### PR TITLE
feat(ci): add GitHub Actions CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,84 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+        with:
+          version: "latest"
+
+      - name: Set up Python
+        run: uv python install 3.13
+
+      - name: Install dependencies
+        run: uv sync --all-extras
+
+      - name: Run ruff check
+        run: uv run ruff check src/ tests/
+
+      - name: Run ruff format check
+        run: uv run ruff format --check src/ tests/
+
+  typecheck:
+    name: Type Check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+        with:
+          version: "latest"
+
+      - name: Set up Python
+        run: uv python install 3.13
+
+      - name: Install dependencies
+        run: uv sync --all-extras
+
+      - name: Run mypy
+        run: uv run mypy src/
+
+  test:
+    name: Test (Python ${{ matrix.python-version }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.11", "3.12", "3.13"]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+        with:
+          version: "latest"
+
+      - name: Set up Python ${{ matrix.python-version }}
+        run: uv python install ${{ matrix.python-version }}
+
+      - name: Install dependencies
+        run: uv sync --all-extras
+
+      - name: Run tests with coverage
+        run: uv run pytest --cov --cov-report=xml --cov-fail-under=70
+
+      - name: Upload coverage to Codecov
+        if: matrix.python-version == '3.13'
+        uses: codecov/codecov-action@v4
+        with:
+          files: ./coverage.xml
+          fail_ci_if_error: false
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -1,0 +1,30 @@
+"""Test CLI commands."""
+
+from typer.testing import CliRunner
+
+from questfoundry import __version__
+from questfoundry.cli import app
+
+runner = CliRunner()
+
+
+def test_version_command() -> None:
+    """Test qf version command."""
+    result = runner.invoke(app, ["version"])
+    assert result.exit_code == 0
+    assert f"v{__version__}" in result.stdout
+
+
+def test_status_command() -> None:
+    """Test qf status command (stub)."""
+    result = runner.invoke(app, ["status"])
+    assert result.exit_code == 0
+    assert "Not implemented" in result.stdout
+
+
+def test_no_args_shows_help() -> None:
+    """Test that no arguments shows help."""
+    result = runner.invoke(app, [])
+    # Typer returns exit code 0 for --help, but 2 for no_args_is_help
+    # The important thing is that help text is shown
+    assert "QuestFoundry" in result.stdout

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -25,6 +25,6 @@ def test_status_command() -> None:
 def test_no_args_shows_help() -> None:
     """Test that no arguments shows help."""
     result = runner.invoke(app, [])
-    # Typer returns exit code 0 for --help, but 2 for no_args_is_help
-    # The important thing is that help text is shown
+    # no_args_is_help=True returns exit code 2 (not 0 like --help)
+    assert result.exit_code == 2
     assert "QuestFoundry" in result.stdout

--- a/tests/unit/test_version.py
+++ b/tests/unit/test_version.py
@@ -16,7 +16,7 @@ def test_version_matches_pyproject() -> None:
     from pathlib import Path
 
     pyproject_path = Path(__file__).parent.parent.parent / "pyproject.toml"
-    with open(pyproject_path, "rb") as f:
+    with pyproject_path.open("rb") as f:
         pyproject = tomllib.load(f)
 
     assert __version__ == pyproject["project"]["version"]


### PR DESCRIPTION
## Summary

- Add GitHub Actions CI workflow with lint, typecheck, and test jobs
- Configure ruff for linting and formatting checks
- Configure mypy for type checking
- Run pytest with coverage threshold (70%)
- Test matrix: Python 3.11, 3.12, 3.13
- Add CLI tests to achieve coverage threshold

Closes #8

## Changes

- `.github/workflows/ci.yml` - CI workflow configuration
- `tests/unit/test_cli.py` - CLI command tests
- `tests/unit/test_version.py` - Fix ruff PTH123 lint error

## Test Plan

- [x] `uv run ruff check src/ tests/` passes
- [x] `uv run ruff format --check src/ tests/` passes  
- [x] `uv run mypy src/` passes
- [x] `uv run pytest --cov --cov-fail-under=70` passes (100% coverage)

## Checklist

- [x] Code follows project conventions
- [x] Tests added/updated for changes
- [x] No TODO stubs in committed code
- [x] Type hints added for new code

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)