### PR TITLE
feat(artifacts): implement artifact schema module

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,84 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+        with:
+          version: "latest"
+
+      - name: Set up Python
+        run: uv python install 3.13
+
+      - name: Install dependencies
+        run: uv sync --all-extras
+
+      - name: Run ruff check
+        run: uv run ruff check src/ tests/
+
+      - name: Run ruff format check
+        run: uv run ruff format --check src/ tests/
+
+  typecheck:
+    name: Type Check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+        with:
+          version: "latest"
+
+      - name: Set up Python
+        run: uv python install 3.13
+
+      - name: Install dependencies
+        run: uv sync --all-extras
+
+      - name: Run mypy
+        run: uv run mypy src/
+
+  test:
+    name: Test (Python ${{ matrix.python-version }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.11", "3.12", "3.13"]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+        with:
+          version: "latest"
+
+      - name: Set up Python ${{ matrix.python-version }}
+        run: uv python install ${{ matrix.python-version }}
+
+      - name: Install dependencies
+        run: uv sync --all-extras
+
+      - name: Run tests with coverage
+        run: uv run pytest --cov --cov-report=xml --cov-fail-under=70
+
+      - name: Upload coverage to Codecov
+        if: matrix.python-version == '3.13'
+        uses: codecov/codecov-action@v4
+        with:
+          files: ./coverage.xml
+          fail_ci_if_error: false
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,7 @@ dev = [
     "mypy>=1.11",
     "ruff>=0.6",
     "pre-commit>=3.8",
+    "types-jsonschema>=4.0",
 ]
 viz = [
     "networkx>=3.0",

--- a/schemas/dream.schema.json
+++ b/schemas/dream.schema.json
@@ -22,12 +22,14 @@
     },
     "subgenre": {
       "type": "string",
+      "minLength": 1,
       "description": "Optional genre refinement"
     },
     "tone": {
       "type": "array",
       "items": {
-        "type": "string"
+        "type": "string",
+        "minLength": 1
       },
       "minItems": 1,
       "description": "Tone descriptors"
@@ -40,13 +42,15 @@
     "themes": {
       "type": "array",
       "items": {
-        "type": "string"
+        "type": "string",
+        "minLength": 1
       },
       "minItems": 1,
       "description": "Thematic elements"
     },
     "style_notes": {
       "type": "string",
+      "minLength": 1,
       "description": "Style guidance"
     },
     "scope": {
@@ -80,14 +84,16 @@
         "includes": {
           "type": "array",
           "items": {
-            "type": "string"
+            "type": "string",
+            "minLength": 1
           },
           "description": "Content included"
         },
         "excludes": {
           "type": "array",
           "items": {
-            "type": "string"
+            "type": "string",
+            "minLength": 1
           },
           "description": "Content excluded"
         }

--- a/schemas/dream.schema.json
+++ b/schemas/dream.schema.json
@@ -1,0 +1,97 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://questfoundry.dev/schemas/dream.schema.json",
+  "title": "DREAM Artifact",
+  "description": "Creative vision and constraints for the story",
+  "type": "object",
+  "required": ["type", "version", "genre", "tone", "audience", "themes"],
+  "properties": {
+    "type": {
+      "const": "dream",
+      "description": "Artifact type identifier"
+    },
+    "version": {
+      "type": "integer",
+      "minimum": 1,
+      "description": "Schema version number"
+    },
+    "genre": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Primary genre"
+    },
+    "subgenre": {
+      "type": "string",
+      "description": "Optional genre refinement"
+    },
+    "tone": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "minItems": 1,
+      "description": "Tone descriptors"
+    },
+    "audience": {
+      "type": "string",
+      "enum": ["adult", "young_adult", "all_ages"],
+      "description": "Target audience"
+    },
+    "themes": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "minItems": 1,
+      "description": "Thematic elements"
+    },
+    "style_notes": {
+      "type": "string",
+      "description": "Style guidance"
+    },
+    "scope": {
+      "type": "object",
+      "properties": {
+        "target_word_count": {
+          "type": "integer",
+          "minimum": 1000,
+          "description": "Approximate final length"
+        },
+        "estimated_passages": {
+          "type": "integer",
+          "minimum": 5,
+          "description": "Target scene count"
+        },
+        "branching_depth": {
+          "type": "string",
+          "enum": ["light", "moderate", "heavy"],
+          "description": "Branching complexity"
+        },
+        "estimated_playtime_minutes": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "Target reading time"
+        }
+      }
+    },
+    "content_notes": {
+      "type": "object",
+      "properties": {
+        "includes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Content included"
+        },
+        "excludes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Content excluded"
+        }
+      }
+    }
+  }
+}

--- a/src/questfoundry/artifacts/__init__.py
+++ b/src/questfoundry/artifacts/__init__.py
@@ -1,1 +1,34 @@
 """Artifact reading, writing, and validation."""
+
+from questfoundry.artifacts.models import (
+    ArtifactType,
+    ContentNotes,
+    DreamArtifact,
+    Scope,
+)
+from questfoundry.artifacts.reader import (
+    ArtifactNotFoundError,
+    ArtifactParseError,
+    ArtifactReader,
+)
+from questfoundry.artifacts.validator import (
+    ArtifactValidationError,
+    ArtifactValidator,
+    SchemaNotFoundError,
+)
+from questfoundry.artifacts.writer import ArtifactWriteError, ArtifactWriter
+
+__all__ = [
+    "ArtifactNotFoundError",
+    "ArtifactParseError",
+    "ArtifactReader",
+    "ArtifactType",
+    "ArtifactValidationError",
+    "ArtifactValidator",
+    "ArtifactWriteError",
+    "ArtifactWriter",
+    "ContentNotes",
+    "DreamArtifact",
+    "SchemaNotFoundError",
+    "Scope",
+]

--- a/src/questfoundry/artifacts/models.py
+++ b/src/questfoundry/artifacts/models.py
@@ -2,9 +2,12 @@
 
 from __future__ import annotations
 
-from typing import Literal
+from typing import Annotated, Literal
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, StringConstraints
+
+# Non-empty string type for list items
+NonEmptyStr = Annotated[str, StringConstraints(min_length=1)]
 
 
 class Scope(BaseModel):
@@ -23,8 +26,8 @@ class Scope(BaseModel):
 class ContentNotes(BaseModel):
     """Content boundaries for the story."""
 
-    includes: list[str] = Field(default_factory=list, description="Content included")
-    excludes: list[str] = Field(default_factory=list, description="Content excluded")
+    includes: list[NonEmptyStr] = Field(default_factory=list, description="Content included")
+    excludes: list[NonEmptyStr] = Field(default_factory=list, description="Content excluded")
 
 
 class DreamArtifact(BaseModel):
@@ -35,13 +38,13 @@ class DreamArtifact(BaseModel):
 
     # Core creative direction
     genre: str = Field(min_length=1, description="Primary genre")
-    subgenre: str | None = Field(default=None, description="Optional refinement")
-    tone: list[str] = Field(min_length=1, description="Tone descriptors")
+    subgenre: str | None = Field(default=None, min_length=1, description="Optional refinement")
+    tone: list[NonEmptyStr] = Field(min_length=1, description="Tone descriptors")
     audience: Literal["adult", "young_adult", "all_ages"] = Field(description="Target audience")
-    themes: list[str] = Field(min_length=1, description="Thematic elements")
+    themes: list[NonEmptyStr] = Field(min_length=1, description="Thematic elements")
 
     # Optional fields
-    style_notes: str | None = Field(default=None, description="Style guidance")
+    style_notes: str | None = Field(default=None, min_length=1, description="Style guidance")
     scope: Scope | None = Field(default=None, description="Scope constraints")
     content_notes: ContentNotes | None = Field(default=None, description="Content boundaries")
 

--- a/src/questfoundry/artifacts/models.py
+++ b/src/questfoundry/artifacts/models.py
@@ -1,0 +1,50 @@
+"""Pydantic models for pipeline artifacts."""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import BaseModel, Field
+
+
+class Scope(BaseModel):
+    """Story scope constraints."""
+
+    target_word_count: int = Field(ge=1000, description="Approximate final length")
+    estimated_passages: int = Field(ge=5, description="Target scene count")
+    branching_depth: Literal["light", "moderate", "heavy"] = Field(
+        default="moderate", description="Branching complexity"
+    )
+    estimated_playtime_minutes: int | None = Field(
+        default=None, ge=1, description="Target reading time"
+    )
+
+
+class ContentNotes(BaseModel):
+    """Content boundaries for the story."""
+
+    includes: list[str] = Field(default_factory=list, description="Content included")
+    excludes: list[str] = Field(default_factory=list, description="Content excluded")
+
+
+class DreamArtifact(BaseModel):
+    """DREAM stage artifact - creative vision for the story."""
+
+    type: Literal["dream"] = "dream"
+    version: int = Field(default=1, ge=1)
+
+    # Core creative direction
+    genre: str = Field(min_length=1, description="Primary genre")
+    subgenre: str | None = Field(default=None, description="Optional refinement")
+    tone: list[str] = Field(min_length=1, description="Tone descriptors")
+    audience: Literal["adult", "young_adult", "all_ages"] = Field(description="Target audience")
+    themes: list[str] = Field(min_length=1, description="Thematic elements")
+
+    # Optional fields
+    style_notes: str | None = Field(default=None, description="Style guidance")
+    scope: Scope | None = Field(default=None, description="Scope constraints")
+    content_notes: ContentNotes | None = Field(default=None, description="Content boundaries")
+
+
+# Type alias for artifact types
+ArtifactType = DreamArtifact

--- a/src/questfoundry/artifacts/reader.py
+++ b/src/questfoundry/artifacts/reader.py
@@ -1,0 +1,114 @@
+"""Artifact reading from YAML files."""
+
+from __future__ import annotations
+
+from pathlib import Path  # noqa: TC003 - used at runtime
+from typing import TypeVar
+
+from pydantic import BaseModel
+from ruamel.yaml import YAML
+
+T = TypeVar("T", bound=BaseModel)
+
+
+class ArtifactNotFoundError(Exception):
+    """Raised when an artifact file doesn't exist."""
+
+    def __init__(self, stage_name: str, path: Path) -> None:
+        self.stage_name = stage_name
+        self.path = path
+        super().__init__(f"Artifact not found: {stage_name} at {path}")
+
+
+class ArtifactParseError(Exception):
+    """Raised when an artifact file can't be parsed."""
+
+    def __init__(self, stage_name: str, path: Path, reason: str) -> None:
+        self.stage_name = stage_name
+        self.path = path
+        self.reason = reason
+        super().__init__(f"Failed to parse {stage_name} artifact at {path}: {reason}")
+
+
+class ArtifactReader:
+    """Read artifacts from the project artifacts directory."""
+
+    def __init__(self, project_path: Path) -> None:
+        """Initialize reader with project path.
+
+        Args:
+            project_path: Path to the project root directory.
+        """
+        self.project_path = project_path
+        self.artifacts_path = project_path / "artifacts"
+        self._yaml = YAML()
+        self._yaml.preserve_quotes = True
+
+    def _get_artifact_path(self, stage_name: str) -> Path:
+        """Get the path to an artifact file.
+
+        Args:
+            stage_name: Name of the stage (e.g., "dream", "seed").
+
+        Returns:
+            Path to the artifact YAML file.
+        """
+        return self.artifacts_path / f"{stage_name}.yaml"
+
+    def exists(self, stage_name: str) -> bool:
+        """Check if an artifact exists.
+
+        Args:
+            stage_name: Name of the stage.
+
+        Returns:
+            True if the artifact file exists.
+        """
+        return self._get_artifact_path(stage_name).exists()
+
+    def read(self, stage_name: str) -> dict[str, object]:
+        """Read an artifact as a raw dictionary.
+
+        Args:
+            stage_name: Name of the stage.
+
+        Returns:
+            Dictionary containing the artifact data.
+
+        Raises:
+            ArtifactNotFoundError: If the artifact doesn't exist.
+            ArtifactParseError: If the artifact can't be parsed.
+        """
+        path = self._get_artifact_path(stage_name)
+
+        if not path.exists():
+            raise ArtifactNotFoundError(stage_name, path)
+
+        try:
+            with path.open("r", encoding="utf-8") as f:
+                data = self._yaml.load(f)
+                if data is None:
+                    raise ArtifactParseError(stage_name, path, "Empty file")
+                return dict(data)
+        except Exception as e:
+            if isinstance(e, (ArtifactNotFoundError, ArtifactParseError)):
+                raise
+            raise ArtifactParseError(stage_name, path, str(e)) from e
+
+    def read_validated(self, stage_name: str, model: type[T]) -> T:
+        """Read and validate an artifact against a Pydantic model.
+
+        Args:
+            stage_name: Name of the stage.
+            model: Pydantic model class to validate against.
+
+        Returns:
+            Validated Pydantic model instance.
+
+        Raises:
+            ArtifactNotFoundError: If the artifact doesn't exist.
+            ArtifactParseError: If the artifact can't be parsed.
+            pydantic.ValidationError: If validation fails.
+        """
+        data = self.read(stage_name)
+        return model.model_validate(data)

--- a/src/questfoundry/artifacts/validator.py
+++ b/src/questfoundry/artifacts/validator.py
@@ -1,0 +1,180 @@
+"""Artifact validation using JSON Schema and Pydantic."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import jsonschema
+from pydantic import BaseModel, ValidationError
+
+from questfoundry.artifacts.models import DreamArtifact
+
+
+class SchemaNotFoundError(Exception):
+    """Raised when a JSON schema file doesn't exist."""
+
+    def __init__(self, schema_name: str, path: Path) -> None:
+        self.schema_name = schema_name
+        self.path = path
+        super().__init__(f"Schema not found: {schema_name} at {path}")
+
+
+class ArtifactValidationError(Exception):
+    """Raised when artifact validation fails."""
+
+    def __init__(self, stage_name: str, errors: list[str]) -> None:
+        self.stage_name = stage_name
+        self.errors = errors
+        error_list = "\n  - ".join(errors)
+        super().__init__(f"Validation failed for {stage_name}:\n  - {error_list}")
+
+
+# Mapping from stage names to Pydantic models
+STAGE_MODELS: dict[str, type[BaseModel]] = {
+    "dream": DreamArtifact,
+}
+
+
+class ArtifactValidator:
+    """Validate artifacts using JSON Schema and Pydantic models."""
+
+    def __init__(self, schemas_path: Path | None = None) -> None:
+        """Initialize validator.
+
+        Args:
+            schemas_path: Path to the schemas directory. If None, uses
+                the schemas directory in the package root.
+        """
+        if schemas_path is None:
+            # Default to project root schemas directory
+            self.schemas_path = Path(__file__).parent.parent.parent.parent / "schemas"
+        else:
+            self.schemas_path = schemas_path
+
+        self._schema_cache: dict[str, dict[str, object]] = {}
+
+    def _load_schema(self, stage_name: str) -> dict[str, object]:
+        """Load a JSON schema from disk.
+
+        Args:
+            stage_name: Name of the stage.
+
+        Returns:
+            The JSON schema as a dictionary.
+
+        Raises:
+            SchemaNotFoundError: If the schema file doesn't exist.
+        """
+        if stage_name in self._schema_cache:
+            return self._schema_cache[stage_name]
+
+        schema_path = self.schemas_path / f"{stage_name}.schema.json"
+
+        if not schema_path.exists():
+            raise SchemaNotFoundError(stage_name, schema_path)
+
+        with schema_path.open("r", encoding="utf-8") as f:
+            schema: dict[str, object] = json.load(f)
+
+        self._schema_cache[stage_name] = schema
+        return schema
+
+    def validate_with_schema(self, data: dict[str, Any], stage_name: str) -> list[str]:
+        """Validate data against a JSON schema.
+
+        Args:
+            data: The artifact data to validate.
+            stage_name: Name of the stage.
+
+        Returns:
+            List of validation error messages (empty if valid).
+        """
+        try:
+            schema = self._load_schema(stage_name)
+        except SchemaNotFoundError:
+            # No schema file, skip JSON Schema validation
+            return []
+
+        errors: list[str] = []
+        validator = jsonschema.Draft7Validator(schema)
+
+        for error in validator.iter_errors(data):
+            path = ".".join(str(p) for p in error.absolute_path)
+            if path:
+                errors.append(f"{path}: {error.message}")
+            else:
+                errors.append(error.message)
+
+        return errors
+
+    def validate_with_model(self, data: dict[str, Any], stage_name: str) -> list[str]:
+        """Validate data against a Pydantic model.
+
+        Args:
+            data: The artifact data to validate.
+            stage_name: Name of the stage.
+
+        Returns:
+            List of validation error messages (empty if valid).
+        """
+        model = STAGE_MODELS.get(stage_name)
+        if model is None:
+            return []
+
+        errors: list[str] = []
+
+        try:
+            model.model_validate(data)
+        except ValidationError as e:
+            for error in e.errors():
+                loc = ".".join(str(part) for part in error["loc"])
+                msg = error["msg"]
+                if loc:
+                    errors.append(f"{loc}: {msg}")
+                else:
+                    errors.append(msg)
+
+        return errors
+
+    def validate(
+        self, data: dict[str, Any], stage_name: str, *, raise_on_error: bool = False
+    ) -> list[str]:
+        """Validate artifact data using both JSON Schema and Pydantic.
+
+        Args:
+            data: The artifact data to validate.
+            stage_name: Name of the stage.
+            raise_on_error: If True, raise ArtifactValidationError on failure.
+
+        Returns:
+            List of all validation error messages (empty if valid).
+
+        Raises:
+            ArtifactValidationError: If raise_on_error is True and validation fails.
+        """
+        errors: list[str] = []
+
+        # Validate with JSON Schema
+        errors.extend(self.validate_with_schema(data, stage_name))
+
+        # Validate with Pydantic model
+        errors.extend(self.validate_with_model(data, stage_name))
+
+        if errors and raise_on_error:
+            raise ArtifactValidationError(stage_name, errors)
+
+        return errors
+
+    def is_valid(self, data: dict[str, Any], stage_name: str) -> bool:
+        """Check if artifact data is valid.
+
+        Args:
+            data: The artifact data to validate.
+            stage_name: Name of the stage.
+
+        Returns:
+            True if the artifact is valid.
+        """
+        return len(self.validate(data, stage_name)) == 0

--- a/src/questfoundry/artifacts/writer.py
+++ b/src/questfoundry/artifacts/writer.py
@@ -1,0 +1,98 @@
+"""Artifact writing to YAML files."""
+
+from __future__ import annotations
+
+from pathlib import Path  # noqa: TC003 - used at runtime
+from typing import Any
+
+from pydantic import BaseModel
+from ruamel.yaml import YAML
+
+
+class ArtifactWriteError(Exception):
+    """Raised when an artifact file can't be written."""
+
+    def __init__(self, stage_name: str, path: Path, reason: str) -> None:
+        self.stage_name = stage_name
+        self.path = path
+        self.reason = reason
+        super().__init__(f"Failed to write {stage_name} artifact at {path}: {reason}")
+
+
+class ArtifactWriter:
+    """Write artifacts to the project artifacts directory."""
+
+    def __init__(self, project_path: Path) -> None:
+        """Initialize writer with project path.
+
+        Args:
+            project_path: Path to the project root directory.
+        """
+        self.project_path = project_path
+        self.artifacts_path = project_path / "artifacts"
+        self._yaml = YAML()
+        self._yaml.default_flow_style = False
+        self._yaml.preserve_quotes = True
+        self._yaml.indent(mapping=2, sequence=4, offset=2)
+
+    def _ensure_artifacts_dir(self) -> None:
+        """Ensure the artifacts directory exists."""
+        self.artifacts_path.mkdir(parents=True, exist_ok=True)
+
+    def _get_artifact_path(self, stage_name: str) -> Path:
+        """Get the path to an artifact file.
+
+        Args:
+            stage_name: Name of the stage (e.g., "dream", "seed").
+
+        Returns:
+            Path to the artifact YAML file.
+        """
+        return self.artifacts_path / f"{stage_name}.yaml"
+
+    def write(self, artifact: BaseModel | dict[str, Any], stage_name: str) -> Path:
+        """Write an artifact to disk.
+
+        Args:
+            artifact: Pydantic model or dictionary to write.
+            stage_name: Name of the stage.
+
+        Returns:
+            Path to the written artifact file.
+
+        Raises:
+            ArtifactWriteError: If the artifact can't be written.
+        """
+        path = self._get_artifact_path(stage_name)
+
+        try:
+            self._ensure_artifacts_dir()
+
+            # Convert Pydantic model to dict if needed
+            if isinstance(artifact, BaseModel):
+                data = artifact.model_dump(exclude_none=True)
+            else:
+                data = artifact
+
+            with path.open("w", encoding="utf-8") as f:
+                self._yaml.dump(data, f)
+
+            return path
+        except Exception as e:
+            if isinstance(e, ArtifactWriteError):
+                raise
+            raise ArtifactWriteError(stage_name, path, str(e)) from e
+
+    def write_raw(self, data: dict[str, Any], stage_name: str) -> Path:
+        """Write raw dictionary data to disk.
+
+        This is an alias for write() that makes intent clearer.
+
+        Args:
+            data: Dictionary to write.
+            stage_name: Name of the stage.
+
+        Returns:
+            Path to the written artifact file.
+        """
+        return self.write(data, stage_name)

--- a/tests/unit/test_artifacts.py
+++ b/tests/unit/test_artifacts.py
@@ -1,0 +1,408 @@
+"""Tests for artifact reading, writing, and validation."""
+
+from pathlib import Path
+
+import pytest
+from pydantic import ValidationError
+
+from questfoundry.artifacts import (
+    ArtifactNotFoundError,
+    ArtifactReader,
+    ArtifactValidationError,
+    ArtifactValidator,
+    ArtifactWriter,
+    DreamArtifact,
+    Scope,
+)
+
+# --- DreamArtifact Model Tests ---
+
+
+def test_dream_artifact_valid_minimal() -> None:
+    """Minimal valid DREAM artifact."""
+    artifact = DreamArtifact(
+        genre="mystery",
+        tone=["dark"],
+        audience="adult",
+        themes=["betrayal"],
+    )
+    assert artifact.type == "dream"
+    assert artifact.version == 1
+    assert artifact.genre == "mystery"
+    assert artifact.subgenre is None
+    assert artifact.scope is None
+
+
+def test_dream_artifact_valid_full() -> None:
+    """Full DREAM artifact with all fields."""
+    artifact = DreamArtifact(
+        genre="mystery",
+        subgenre="noir",
+        tone=["dark", "atmospheric"],
+        audience="adult",
+        themes=["betrayal", "redemption"],
+        style_notes="Hard-boiled narration",
+        scope=Scope(
+            target_word_count=15000,
+            estimated_passages=40,
+            branching_depth="moderate",
+            estimated_playtime_minutes=30,
+        ),
+    )
+    assert artifact.subgenre == "noir"
+    assert artifact.scope is not None
+    assert artifact.scope.target_word_count == 15000
+
+
+def test_dream_artifact_invalid_empty_genre() -> None:
+    """Empty genre should fail validation."""
+    with pytest.raises(ValidationError) as exc_info:
+        DreamArtifact(
+            genre="",
+            tone=["dark"],
+            audience="adult",
+            themes=["betrayal"],
+        )
+    assert "genre" in str(exc_info.value)
+
+
+def test_dream_artifact_invalid_empty_tone() -> None:
+    """Empty tone list should fail validation."""
+    with pytest.raises(ValidationError) as exc_info:
+        DreamArtifact(
+            genre="mystery",
+            tone=[],
+            audience="adult",
+            themes=["betrayal"],
+        )
+    assert "tone" in str(exc_info.value)
+
+
+def test_dream_artifact_invalid_audience() -> None:
+    """Invalid audience value should fail validation."""
+    with pytest.raises(ValidationError) as exc_info:
+        DreamArtifact(
+            genre="mystery",
+            tone=["dark"],
+            audience="invalid",  # type: ignore[arg-type]
+            themes=["betrayal"],
+        )
+    assert "audience" in str(exc_info.value)
+
+
+def test_dream_artifact_invalid_empty_themes() -> None:
+    """Empty themes list should fail validation."""
+    with pytest.raises(ValidationError) as exc_info:
+        DreamArtifact(
+            genre="mystery",
+            tone=["dark"],
+            audience="adult",
+            themes=[],
+        )
+    assert "themes" in str(exc_info.value)
+
+
+def test_scope_invalid_word_count() -> None:
+    """Word count below minimum should fail."""
+    with pytest.raises(ValidationError) as exc_info:
+        Scope(
+            target_word_count=500,  # Below 1000 minimum
+            estimated_passages=10,
+        )
+    assert "target_word_count" in str(exc_info.value)
+
+
+def test_scope_invalid_branching_depth() -> None:
+    """Invalid branching depth should fail."""
+    with pytest.raises(ValidationError) as exc_info:
+        Scope(
+            target_word_count=10000,
+            estimated_passages=10,
+            branching_depth="extreme",  # type: ignore[arg-type]
+        )
+    assert "branching_depth" in str(exc_info.value)
+
+
+# --- ArtifactWriter Tests ---
+
+
+def test_writer_creates_artifact_file(tmp_path: Path) -> None:
+    """Writer creates artifact YAML file."""
+    writer = ArtifactWriter(tmp_path)
+    artifact = DreamArtifact(
+        genre="mystery",
+        tone=["dark"],
+        audience="adult",
+        themes=["betrayal"],
+    )
+
+    path = writer.write(artifact, "dream")
+
+    assert path.exists()
+    assert path == tmp_path / "artifacts" / "dream.yaml"
+
+
+def test_writer_creates_artifacts_directory(tmp_path: Path) -> None:
+    """Writer creates artifacts directory if missing."""
+    writer = ArtifactWriter(tmp_path)
+    artifact = DreamArtifact(
+        genre="mystery",
+        tone=["dark"],
+        audience="adult",
+        themes=["betrayal"],
+    )
+
+    writer.write(artifact, "dream")
+
+    assert (tmp_path / "artifacts").is_dir()
+
+
+def test_writer_writes_dict(tmp_path: Path) -> None:
+    """Writer can write raw dictionaries."""
+    writer = ArtifactWriter(tmp_path)
+    data = {
+        "type": "dream",
+        "version": 1,
+        "genre": "mystery",
+        "tone": ["dark"],
+        "audience": "adult",
+        "themes": ["betrayal"],
+    }
+
+    path = writer.write(data, "dream")
+
+    assert path.exists()
+
+
+def test_writer_excludes_none_values(tmp_path: Path) -> None:
+    """Writer excludes None values from output."""
+    writer = ArtifactWriter(tmp_path)
+    artifact = DreamArtifact(
+        genre="mystery",
+        tone=["dark"],
+        audience="adult",
+        themes=["betrayal"],
+        subgenre=None,  # Should not appear in output
+    )
+
+    path = writer.write(artifact, "dream")
+    content = path.read_text()
+
+    assert "subgenre" not in content
+
+
+# --- ArtifactReader Tests ---
+
+
+def test_reader_reads_artifact(tmp_path: Path) -> None:
+    """Reader reads artifact from YAML file."""
+    # Write first
+    writer = ArtifactWriter(tmp_path)
+    artifact = DreamArtifact(
+        genre="mystery",
+        tone=["dark"],
+        audience="adult",
+        themes=["betrayal"],
+    )
+    writer.write(artifact, "dream")
+
+    # Read back
+    reader = ArtifactReader(tmp_path)
+    data = reader.read("dream")
+
+    assert data["genre"] == "mystery"
+    assert data["tone"] == ["dark"]
+
+
+def test_reader_read_validated(tmp_path: Path) -> None:
+    """Reader validates against Pydantic model."""
+    # Write first
+    writer = ArtifactWriter(tmp_path)
+    artifact = DreamArtifact(
+        genre="mystery",
+        subgenre="noir",
+        tone=["dark", "atmospheric"],
+        audience="adult",
+        themes=["betrayal"],
+    )
+    writer.write(artifact, "dream")
+
+    # Read validated
+    reader = ArtifactReader(tmp_path)
+    loaded = reader.read_validated("dream", DreamArtifact)
+
+    assert isinstance(loaded, DreamArtifact)
+    assert loaded.genre == "mystery"
+    assert loaded.subgenre == "noir"
+
+
+def test_reader_not_found(tmp_path: Path) -> None:
+    """Reader raises error for missing artifact."""
+    reader = ArtifactReader(tmp_path)
+
+    with pytest.raises(ArtifactNotFoundError) as exc_info:
+        reader.read("nonexistent")
+
+    assert exc_info.value.stage_name == "nonexistent"
+
+
+def test_reader_exists(tmp_path: Path) -> None:
+    """Reader checks artifact existence."""
+    writer = ArtifactWriter(tmp_path)
+    artifact = DreamArtifact(
+        genre="mystery",
+        tone=["dark"],
+        audience="adult",
+        themes=["betrayal"],
+    )
+    writer.write(artifact, "dream")
+
+    reader = ArtifactReader(tmp_path)
+
+    assert reader.exists("dream")
+    assert not reader.exists("nonexistent")
+
+
+# --- ArtifactValidator Tests ---
+
+
+def test_validator_valid_data() -> None:
+    """Validator accepts valid data."""
+    validator = ArtifactValidator()
+    data = {
+        "type": "dream",
+        "version": 1,
+        "genre": "mystery",
+        "tone": ["dark"],
+        "audience": "adult",
+        "themes": ["betrayal"],
+    }
+
+    errors = validator.validate(data, "dream")
+
+    assert errors == []
+
+
+def test_validator_is_valid() -> None:
+    """is_valid returns boolean."""
+    validator = ArtifactValidator()
+    valid_data = {
+        "type": "dream",
+        "version": 1,
+        "genre": "mystery",
+        "tone": ["dark"],
+        "audience": "adult",
+        "themes": ["betrayal"],
+    }
+    invalid_data = {
+        "type": "dream",
+        "version": 1,
+        "genre": "mystery",
+        "tone": [],  # Invalid: empty
+        "audience": "adult",
+        "themes": ["betrayal"],
+    }
+
+    assert validator.is_valid(valid_data, "dream")
+    assert not validator.is_valid(invalid_data, "dream")
+
+
+def test_validator_invalid_data_pydantic() -> None:
+    """Validator catches Pydantic validation errors."""
+    validator = ArtifactValidator()
+    data = {
+        "type": "dream",
+        "version": 1,
+        "genre": "mystery",
+        "tone": [],  # Invalid: must have at least 1
+        "audience": "adult",
+        "themes": ["betrayal"],
+    }
+
+    errors = validator.validate(data, "dream")
+
+    assert len(errors) > 0
+    assert any("tone" in e for e in errors)
+
+
+def test_validator_invalid_data_schema() -> None:
+    """Validator catches JSON Schema validation errors."""
+    validator = ArtifactValidator()
+    data = {
+        "type": "dream",
+        "version": 1,
+        "genre": "mystery",
+        "tone": ["dark"],
+        "audience": "invalid_audience",  # Invalid enum value
+        "themes": ["betrayal"],
+    }
+
+    errors = validator.validate(data, "dream")
+
+    assert len(errors) > 0
+
+
+def test_validator_raise_on_error() -> None:
+    """Validator raises exception when requested."""
+    validator = ArtifactValidator()
+    data = {
+        "type": "dream",
+        "version": 1,
+        "genre": "mystery",
+        "tone": [],
+        "audience": "adult",
+        "themes": ["betrayal"],
+    }
+
+    with pytest.raises(ArtifactValidationError) as exc_info:
+        validator.validate(data, "dream", raise_on_error=True)
+
+    assert exc_info.value.stage_name == "dream"
+    assert len(exc_info.value.errors) > 0
+
+
+def test_validator_missing_schema_graceful() -> None:
+    """Validator handles missing schema gracefully."""
+    validator = ArtifactValidator()
+    data = {"type": "unknown", "version": 1}
+
+    # Should not raise, just skip JSON Schema validation
+    errors = validator.validate(data, "unknown_stage")
+
+    # Only Pydantic errors (no model for unknown_stage)
+    assert errors == []
+
+
+# --- Round-trip Tests ---
+
+
+def test_roundtrip_preserves_data(tmp_path: Path) -> None:
+    """Writing then reading preserves all data."""
+    original = DreamArtifact(
+        genre="mystery",
+        subgenre="noir",
+        tone=["dark", "atmospheric", "melancholic"],
+        audience="adult",
+        themes=["betrayal", "redemption"],
+        style_notes="Hard-boiled narration in first person.",
+        scope=Scope(
+            target_word_count=15000,
+            estimated_passages=40,
+            branching_depth="moderate",
+        ),
+    )
+
+    writer = ArtifactWriter(tmp_path)
+    writer.write(original, "dream")
+
+    reader = ArtifactReader(tmp_path)
+    loaded = reader.read_validated("dream", DreamArtifact)
+
+    assert loaded.genre == original.genre
+    assert loaded.subgenre == original.subgenre
+    assert loaded.tone == original.tone
+    assert loaded.audience == original.audience
+    assert loaded.themes == original.themes
+    assert loaded.style_notes == original.style_notes
+    assert loaded.scope is not None
+    assert loaded.scope.target_word_count == original.scope.target_word_count

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -1,0 +1,30 @@
+"""Test CLI commands."""
+
+from typer.testing import CliRunner
+
+from questfoundry import __version__
+from questfoundry.cli import app
+
+runner = CliRunner()
+
+
+def test_version_command() -> None:
+    """Test qf version command."""
+    result = runner.invoke(app, ["version"])
+    assert result.exit_code == 0
+    assert f"v{__version__}" in result.stdout
+
+
+def test_status_command() -> None:
+    """Test qf status command (stub)."""
+    result = runner.invoke(app, ["status"])
+    assert result.exit_code == 0
+    assert "Not implemented" in result.stdout
+
+
+def test_no_args_shows_help() -> None:
+    """Test that no arguments shows help."""
+    result = runner.invoke(app, [])
+    # Typer returns exit code 0 for --help, but 2 for no_args_is_help
+    # The important thing is that help text is shown
+    assert "QuestFoundry" in result.stdout

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -25,6 +25,6 @@ def test_status_command() -> None:
 def test_no_args_shows_help() -> None:
     """Test that no arguments shows help."""
     result = runner.invoke(app, [])
-    # Typer returns exit code 0 for --help, but 2 for no_args_is_help
-    # The important thing is that help text is shown
+    # no_args_is_help=True returns exit code 2 (not 0 like --help)
+    assert result.exit_code == 2
     assert "QuestFoundry" in result.stdout

--- a/tests/unit/test_version.py
+++ b/tests/unit/test_version.py
@@ -16,7 +16,7 @@ def test_version_matches_pyproject() -> None:
     from pathlib import Path
 
     pyproject_path = Path(__file__).parent.parent.parent / "pyproject.toml"
-    with open(pyproject_path, "rb") as f:
+    with pyproject_path.open("rb") as f:
         pyproject = tomllib.load(f)
 
     assert __version__ == pyproject["project"]["version"]

--- a/uv.lock
+++ b/uv.lock
@@ -938,6 +938,7 @@ dev = [
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
     { name = "ruff" },
+    { name = "types-jsonschema" },
 ]
 ollama = [
     { name = "ollama" },
@@ -972,6 +973,7 @@ requires-dist = [
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.6" },
     { name = "tiktoken", specifier = ">=0.5" },
     { name = "typer", specifier = ">=0.12" },
+    { name = "types-jsonschema", marker = "extra == 'dev'", specifier = ">=4.0" },
 ]
 provides-extras = ["ollama", "openai", "all-providers", "dev", "viz"]
 
@@ -1407,6 +1409,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/85/30/ff9ede605e3bd086b4dd842499814e128500621f7951ca1e5ce84bbf61b1/typer-0.21.0.tar.gz", hash = "sha256:c87c0d2b6eee3b49c5c64649ec92425492c14488096dfbc8a0c2799b2f6f9c53", size = 106781, upload-time = "2025-12-25T09:54:53.651Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e1/e4/5ebc1899d31d2b1601b32d21cfb4bba022ae6fce323d365f0448031b1660/typer-0.21.0-py3-none-any.whl", hash = "sha256:c79c01ca6b30af9fd48284058a7056ba0d3bf5cf10d0ff3d0c5b11b68c258ac6", size = 47109, upload-time = "2025-12-25T09:54:51.918Z" },
+]
+
+[[package]]
+name = "types-jsonschema"
+version = "4.25.1.20251009"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "referencing" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ef/da/5b901088da5f710690b422137e8ae74197fb1ca471e4aa84dd3ef0d6e295/types_jsonschema-4.25.1.20251009.tar.gz", hash = "sha256:75d0f5c5dd18dc23b664437a0c1a625743e8d2e665ceaf3aecb29841f3a5f97f", size = 15661, upload-time = "2025-10-09T02:54:36.963Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7f/6a/e5146754c0dfc272f176db9c245bc43cc19030262d891a5a85d472797e60/types_jsonschema-4.25.1.20251009-py3-none-any.whl", hash = "sha256:f30b329037b78e7a60146b1146feb0b6fb0b71628637584409bada83968dad3e", size = 15925, upload-time = "2025-10-09T02:54:35.847Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Implements the artifact schema module for Slice 1, providing:

- **Pydantic models** for DREAM artifact (`models.py`)
- **YAML reader** with validation support (`reader.py`)
- **YAML writer** with Pydantic serialization (`writer.py`)
- **Validator** combining JSON Schema and Pydantic (`validator.py`)
- **JSON Schema** for DREAM artifact (`schemas/dream.schema.json`)

## Key Interfaces

```python
# Models
class DreamArtifact(BaseModel):
    type: Literal["dream"] = "dream"
    version: int = 1
    genre: str
    subgenre: str | None = None
    tone: list[str]  # min 1
    audience: Literal["adult", "young_adult", "all_ages"]
    themes: list[str]  # min 1
    style_notes: str | None = None
    scope: Scope | None = None
    content_notes: ContentNotes | None = None

# Reader/Writer
reader = ArtifactReader(project_path)
artifact = reader.read_validated("dream", DreamArtifact)

writer = ArtifactWriter(project_path)
writer.write(artifact, "dream")

# Validator
validator = ArtifactValidator()
errors = validator.validate(data, "dream")
```

## Test Plan

- [x] Pydantic model validation (valid/invalid cases)
- [x] Writer creates files in correct location
- [x] Reader loads and validates YAML
- [x] Validator combines JSON Schema and Pydantic checks
- [x] Round-trip preserves all data
- [x] 87% test coverage (23 tests)

## Design Reference

- [docs/design/02-artifact-schemas.md](docs/design/02-artifact-schemas.md)

Closes #4

---

**Stacked PR**: This PR is based on `feat/ci-setup` (#12). Merge that PR first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)