### PR TITLE
feat(pipeline): add pipeline orchestrator and gates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,84 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+        with:
+          version: "latest"
+
+      - name: Set up Python
+        run: uv python install 3.13
+
+      - name: Install dependencies
+        run: uv sync --all-extras
+
+      - name: Run ruff check
+        run: uv run ruff check src/ tests/
+
+      - name: Run ruff format check
+        run: uv run ruff format --check src/ tests/
+
+  typecheck:
+    name: Type Check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+        with:
+          version: "latest"
+
+      - name: Set up Python
+        run: uv python install 3.13
+
+      - name: Install dependencies
+        run: uv sync --all-extras
+
+      - name: Run mypy
+        run: uv run mypy src/
+
+  test:
+    name: Test (Python ${{ matrix.python-version }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.11", "3.12", "3.13"]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+        with:
+          version: "latest"
+
+      - name: Set up Python ${{ matrix.python-version }}
+        run: uv python install ${{ matrix.python-version }}
+
+      - name: Install dependencies
+        run: uv sync --all-extras
+
+      - name: Run tests with coverage
+        run: uv run pytest --cov --cov-report=xml --cov-fail-under=70
+
+      - name: Upload coverage to Codecov
+        if: matrix.python-version == '3.13'
+        uses: codecov/codecov-action@v4
+        with:
+          files: ./coverage.xml
+          fail_ci_if_error: false
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/prompts/templates/dream.yaml
+++ b/prompts/templates/dream.yaml
@@ -1,0 +1,49 @@
+name: dream
+description: Generate creative vision for a story
+
+system: |
+  You are a creative director for interactive fiction.
+  Your task is to establish the creative vision for a new story.
+
+  Generate a DREAM artifact that captures:
+  - Genre and subgenre
+  - Tone and atmosphere
+  - Target audience
+  - Core themes to explore
+  - Style guidance for writing
+  - Scope constraints (word count, passages, branching complexity)
+
+  Be specific and evocative. The DREAM artifact guides all subsequent stages.
+
+user: |
+  Create a creative vision for this story idea:
+
+  {{ user_prompt }}
+
+  Output valid YAML with these fields:
+
+  type: dream
+  version: 1
+  genre: <primary genre>
+  subgenre: <optional refinement>
+  tone:
+    - <tone descriptor 1>
+    - <tone descriptor 2>
+    - <tone descriptor 3>
+  audience: <adult | young_adult | all_ages>
+  themes:
+    - <theme 1>
+    - <theme 2>
+    - <theme 3>
+  style_notes: |
+    <writing style guidance>
+  scope:
+    target_word_count: <number>
+    estimated_passages: <number>
+    branching_depth: <light | moderate | heavy>
+
+  Be creative but grounded. Make choices that serve the story.
+
+components:
+  - role_setup
+  - output_format

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,7 @@ dev = [
     "mypy>=1.11",
     "ruff>=0.6",
     "pre-commit>=3.8",
+    "types-jsonschema>=4.0",
 ]
 viz = [
     "networkx>=3.0",

--- a/schemas/dream.schema.json
+++ b/schemas/dream.schema.json
@@ -22,12 +22,14 @@
     },
     "subgenre": {
       "type": "string",
+      "minLength": 1,
       "description": "Optional genre refinement"
     },
     "tone": {
       "type": "array",
       "items": {
-        "type": "string"
+        "type": "string",
+        "minLength": 1
       },
       "minItems": 1,
       "description": "Tone descriptors"
@@ -40,13 +42,15 @@
     "themes": {
       "type": "array",
       "items": {
-        "type": "string"
+        "type": "string",
+        "minLength": 1
       },
       "minItems": 1,
       "description": "Thematic elements"
     },
     "style_notes": {
       "type": "string",
+      "minLength": 1,
       "description": "Style guidance"
     },
     "scope": {
@@ -80,14 +84,16 @@
         "includes": {
           "type": "array",
           "items": {
-            "type": "string"
+            "type": "string",
+            "minLength": 1
           },
           "description": "Content included"
         },
         "excludes": {
           "type": "array",
           "items": {
-            "type": "string"
+            "type": "string",
+            "minLength": 1
           },
           "description": "Content excluded"
         }

--- a/schemas/dream.schema.json
+++ b/schemas/dream.schema.json
@@ -1,0 +1,97 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://questfoundry.dev/schemas/dream.schema.json",
+  "title": "DREAM Artifact",
+  "description": "Creative vision and constraints for the story",
+  "type": "object",
+  "required": ["type", "version", "genre", "tone", "audience", "themes"],
+  "properties": {
+    "type": {
+      "const": "dream",
+      "description": "Artifact type identifier"
+    },
+    "version": {
+      "type": "integer",
+      "minimum": 1,
+      "description": "Schema version number"
+    },
+    "genre": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Primary genre"
+    },
+    "subgenre": {
+      "type": "string",
+      "description": "Optional genre refinement"
+    },
+    "tone": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "minItems": 1,
+      "description": "Tone descriptors"
+    },
+    "audience": {
+      "type": "string",
+      "enum": ["adult", "young_adult", "all_ages"],
+      "description": "Target audience"
+    },
+    "themes": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "minItems": 1,
+      "description": "Thematic elements"
+    },
+    "style_notes": {
+      "type": "string",
+      "description": "Style guidance"
+    },
+    "scope": {
+      "type": "object",
+      "properties": {
+        "target_word_count": {
+          "type": "integer",
+          "minimum": 1000,
+          "description": "Approximate final length"
+        },
+        "estimated_passages": {
+          "type": "integer",
+          "minimum": 5,
+          "description": "Target scene count"
+        },
+        "branching_depth": {
+          "type": "string",
+          "enum": ["light", "moderate", "heavy"],
+          "description": "Branching complexity"
+        },
+        "estimated_playtime_minutes": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "Target reading time"
+        }
+      }
+    },
+    "content_notes": {
+      "type": "object",
+      "properties": {
+        "includes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Content included"
+        },
+        "excludes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Content excluded"
+        }
+      }
+    }
+  }
+}

--- a/src/questfoundry/artifacts/__init__.py
+++ b/src/questfoundry/artifacts/__init__.py
@@ -1,1 +1,34 @@
 """Artifact reading, writing, and validation."""
+
+from questfoundry.artifacts.models import (
+    ArtifactType,
+    ContentNotes,
+    DreamArtifact,
+    Scope,
+)
+from questfoundry.artifacts.reader import (
+    ArtifactNotFoundError,
+    ArtifactParseError,
+    ArtifactReader,
+)
+from questfoundry.artifacts.validator import (
+    ArtifactValidationError,
+    ArtifactValidator,
+    SchemaNotFoundError,
+)
+from questfoundry.artifacts.writer import ArtifactWriteError, ArtifactWriter
+
+__all__ = [
+    "ArtifactNotFoundError",
+    "ArtifactParseError",
+    "ArtifactReader",
+    "ArtifactType",
+    "ArtifactValidationError",
+    "ArtifactValidator",
+    "ArtifactWriteError",
+    "ArtifactWriter",
+    "ContentNotes",
+    "DreamArtifact",
+    "SchemaNotFoundError",
+    "Scope",
+]

--- a/src/questfoundry/artifacts/models.py
+++ b/src/questfoundry/artifacts/models.py
@@ -2,9 +2,12 @@
 
 from __future__ import annotations
 
-from typing import Literal
+from typing import Annotated, Literal
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, StringConstraints
+
+# Non-empty string type for list items
+NonEmptyStr = Annotated[str, StringConstraints(min_length=1)]
 
 
 class Scope(BaseModel):
@@ -23,8 +26,8 @@ class Scope(BaseModel):
 class ContentNotes(BaseModel):
     """Content boundaries for the story."""
 
-    includes: list[str] = Field(default_factory=list, description="Content included")
-    excludes: list[str] = Field(default_factory=list, description="Content excluded")
+    includes: list[NonEmptyStr] = Field(default_factory=list, description="Content included")
+    excludes: list[NonEmptyStr] = Field(default_factory=list, description="Content excluded")
 
 
 class DreamArtifact(BaseModel):
@@ -35,13 +38,13 @@ class DreamArtifact(BaseModel):
 
     # Core creative direction
     genre: str = Field(min_length=1, description="Primary genre")
-    subgenre: str | None = Field(default=None, description="Optional refinement")
-    tone: list[str] = Field(min_length=1, description="Tone descriptors")
+    subgenre: str | None = Field(default=None, min_length=1, description="Optional refinement")
+    tone: list[NonEmptyStr] = Field(min_length=1, description="Tone descriptors")
     audience: Literal["adult", "young_adult", "all_ages"] = Field(description="Target audience")
-    themes: list[str] = Field(min_length=1, description="Thematic elements")
+    themes: list[NonEmptyStr] = Field(min_length=1, description="Thematic elements")
 
     # Optional fields
-    style_notes: str | None = Field(default=None, description="Style guidance")
+    style_notes: str | None = Field(default=None, min_length=1, description="Style guidance")
     scope: Scope | None = Field(default=None, description="Scope constraints")
     content_notes: ContentNotes | None = Field(default=None, description="Content boundaries")
 

--- a/src/questfoundry/artifacts/models.py
+++ b/src/questfoundry/artifacts/models.py
@@ -1,0 +1,50 @@
+"""Pydantic models for pipeline artifacts."""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import BaseModel, Field
+
+
+class Scope(BaseModel):
+    """Story scope constraints."""
+
+    target_word_count: int = Field(ge=1000, description="Approximate final length")
+    estimated_passages: int = Field(ge=5, description="Target scene count")
+    branching_depth: Literal["light", "moderate", "heavy"] = Field(
+        default="moderate", description="Branching complexity"
+    )
+    estimated_playtime_minutes: int | None = Field(
+        default=None, ge=1, description="Target reading time"
+    )
+
+
+class ContentNotes(BaseModel):
+    """Content boundaries for the story."""
+
+    includes: list[str] = Field(default_factory=list, description="Content included")
+    excludes: list[str] = Field(default_factory=list, description="Content excluded")
+
+
+class DreamArtifact(BaseModel):
+    """DREAM stage artifact - creative vision for the story."""
+
+    type: Literal["dream"] = "dream"
+    version: int = Field(default=1, ge=1)
+
+    # Core creative direction
+    genre: str = Field(min_length=1, description="Primary genre")
+    subgenre: str | None = Field(default=None, description="Optional refinement")
+    tone: list[str] = Field(min_length=1, description="Tone descriptors")
+    audience: Literal["adult", "young_adult", "all_ages"] = Field(description="Target audience")
+    themes: list[str] = Field(min_length=1, description="Thematic elements")
+
+    # Optional fields
+    style_notes: str | None = Field(default=None, description="Style guidance")
+    scope: Scope | None = Field(default=None, description="Scope constraints")
+    content_notes: ContentNotes | None = Field(default=None, description="Content boundaries")
+
+
+# Type alias for artifact types
+ArtifactType = DreamArtifact

--- a/src/questfoundry/artifacts/reader.py
+++ b/src/questfoundry/artifacts/reader.py
@@ -1,0 +1,114 @@
+"""Artifact reading from YAML files."""
+
+from __future__ import annotations
+
+from pathlib import Path  # noqa: TC003 - used at runtime
+from typing import TypeVar
+
+from pydantic import BaseModel
+from ruamel.yaml import YAML
+
+T = TypeVar("T", bound=BaseModel)
+
+
+class ArtifactNotFoundError(Exception):
+    """Raised when an artifact file doesn't exist."""
+
+    def __init__(self, stage_name: str, path: Path) -> None:
+        self.stage_name = stage_name
+        self.path = path
+        super().__init__(f"Artifact not found: {stage_name} at {path}")
+
+
+class ArtifactParseError(Exception):
+    """Raised when an artifact file can't be parsed."""
+
+    def __init__(self, stage_name: str, path: Path, reason: str) -> None:
+        self.stage_name = stage_name
+        self.path = path
+        self.reason = reason
+        super().__init__(f"Failed to parse {stage_name} artifact at {path}: {reason}")
+
+
+class ArtifactReader:
+    """Read artifacts from the project artifacts directory."""
+
+    def __init__(self, project_path: Path) -> None:
+        """Initialize reader with project path.
+
+        Args:
+            project_path: Path to the project root directory.
+        """
+        self.project_path = project_path
+        self.artifacts_path = project_path / "artifacts"
+        self._yaml = YAML()
+        self._yaml.preserve_quotes = True
+
+    def _get_artifact_path(self, stage_name: str) -> Path:
+        """Get the path to an artifact file.
+
+        Args:
+            stage_name: Name of the stage (e.g., "dream", "seed").
+
+        Returns:
+            Path to the artifact YAML file.
+        """
+        return self.artifacts_path / f"{stage_name}.yaml"
+
+    def exists(self, stage_name: str) -> bool:
+        """Check if an artifact exists.
+
+        Args:
+            stage_name: Name of the stage.
+
+        Returns:
+            True if the artifact file exists.
+        """
+        return self._get_artifact_path(stage_name).exists()
+
+    def read(self, stage_name: str) -> dict[str, object]:
+        """Read an artifact as a raw dictionary.
+
+        Args:
+            stage_name: Name of the stage.
+
+        Returns:
+            Dictionary containing the artifact data.
+
+        Raises:
+            ArtifactNotFoundError: If the artifact doesn't exist.
+            ArtifactParseError: If the artifact can't be parsed.
+        """
+        path = self._get_artifact_path(stage_name)
+
+        if not path.exists():
+            raise ArtifactNotFoundError(stage_name, path)
+
+        try:
+            with path.open("r", encoding="utf-8") as f:
+                data = self._yaml.load(f)
+                if data is None:
+                    raise ArtifactParseError(stage_name, path, "Empty file")
+                return dict(data)
+        except Exception as e:
+            if isinstance(e, (ArtifactNotFoundError, ArtifactParseError)):
+                raise
+            raise ArtifactParseError(stage_name, path, str(e)) from e
+
+    def read_validated(self, stage_name: str, model: type[T]) -> T:
+        """Read and validate an artifact against a Pydantic model.
+
+        Args:
+            stage_name: Name of the stage.
+            model: Pydantic model class to validate against.
+
+        Returns:
+            Validated Pydantic model instance.
+
+        Raises:
+            ArtifactNotFoundError: If the artifact doesn't exist.
+            ArtifactParseError: If the artifact can't be parsed.
+            pydantic.ValidationError: If validation fails.
+        """
+        data = self.read(stage_name)
+        return model.model_validate(data)

--- a/src/questfoundry/artifacts/validator.py
+++ b/src/questfoundry/artifacts/validator.py
@@ -1,0 +1,180 @@
+"""Artifact validation using JSON Schema and Pydantic."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import jsonschema
+from pydantic import BaseModel, ValidationError
+
+from questfoundry.artifacts.models import DreamArtifact
+
+
+class SchemaNotFoundError(Exception):
+    """Raised when a JSON schema file doesn't exist."""
+
+    def __init__(self, schema_name: str, path: Path) -> None:
+        self.schema_name = schema_name
+        self.path = path
+        super().__init__(f"Schema not found: {schema_name} at {path}")
+
+
+class ArtifactValidationError(Exception):
+    """Raised when artifact validation fails."""
+
+    def __init__(self, stage_name: str, errors: list[str]) -> None:
+        self.stage_name = stage_name
+        self.errors = errors
+        error_list = "\n  - ".join(errors)
+        super().__init__(f"Validation failed for {stage_name}:\n  - {error_list}")
+
+
+# Mapping from stage names to Pydantic models
+STAGE_MODELS: dict[str, type[BaseModel]] = {
+    "dream": DreamArtifact,
+}
+
+
+class ArtifactValidator:
+    """Validate artifacts using JSON Schema and Pydantic models."""
+
+    def __init__(self, schemas_path: Path | None = None) -> None:
+        """Initialize validator.
+
+        Args:
+            schemas_path: Path to the schemas directory. If None, uses
+                the schemas directory in the package root.
+        """
+        if schemas_path is None:
+            # Default to project root schemas directory
+            self.schemas_path = Path(__file__).parent.parent.parent.parent / "schemas"
+        else:
+            self.schemas_path = schemas_path
+
+        self._schema_cache: dict[str, dict[str, object]] = {}
+
+    def _load_schema(self, stage_name: str) -> dict[str, object]:
+        """Load a JSON schema from disk.
+
+        Args:
+            stage_name: Name of the stage.
+
+        Returns:
+            The JSON schema as a dictionary.
+
+        Raises:
+            SchemaNotFoundError: If the schema file doesn't exist.
+        """
+        if stage_name in self._schema_cache:
+            return self._schema_cache[stage_name]
+
+        schema_path = self.schemas_path / f"{stage_name}.schema.json"
+
+        if not schema_path.exists():
+            raise SchemaNotFoundError(stage_name, schema_path)
+
+        with schema_path.open("r", encoding="utf-8") as f:
+            schema: dict[str, object] = json.load(f)
+
+        self._schema_cache[stage_name] = schema
+        return schema
+
+    def validate_with_schema(self, data: dict[str, Any], stage_name: str) -> list[str]:
+        """Validate data against a JSON schema.
+
+        Args:
+            data: The artifact data to validate.
+            stage_name: Name of the stage.
+
+        Returns:
+            List of validation error messages (empty if valid).
+        """
+        try:
+            schema = self._load_schema(stage_name)
+        except SchemaNotFoundError:
+            # No schema file, skip JSON Schema validation
+            return []
+
+        errors: list[str] = []
+        validator = jsonschema.Draft7Validator(schema)
+
+        for error in validator.iter_errors(data):
+            path = ".".join(str(p) for p in error.absolute_path)
+            if path:
+                errors.append(f"{path}: {error.message}")
+            else:
+                errors.append(error.message)
+
+        return errors
+
+    def validate_with_model(self, data: dict[str, Any], stage_name: str) -> list[str]:
+        """Validate data against a Pydantic model.
+
+        Args:
+            data: The artifact data to validate.
+            stage_name: Name of the stage.
+
+        Returns:
+            List of validation error messages (empty if valid).
+        """
+        model = STAGE_MODELS.get(stage_name)
+        if model is None:
+            return []
+
+        errors: list[str] = []
+
+        try:
+            model.model_validate(data)
+        except ValidationError as e:
+            for error in e.errors():
+                loc = ".".join(str(part) for part in error["loc"])
+                msg = error["msg"]
+                if loc:
+                    errors.append(f"{loc}: {msg}")
+                else:
+                    errors.append(msg)
+
+        return errors
+
+    def validate(
+        self, data: dict[str, Any], stage_name: str, *, raise_on_error: bool = False
+    ) -> list[str]:
+        """Validate artifact data using both JSON Schema and Pydantic.
+
+        Args:
+            data: The artifact data to validate.
+            stage_name: Name of the stage.
+            raise_on_error: If True, raise ArtifactValidationError on failure.
+
+        Returns:
+            List of all validation error messages (empty if valid).
+
+        Raises:
+            ArtifactValidationError: If raise_on_error is True and validation fails.
+        """
+        errors: list[str] = []
+
+        # Validate with JSON Schema
+        errors.extend(self.validate_with_schema(data, stage_name))
+
+        # Validate with Pydantic model
+        errors.extend(self.validate_with_model(data, stage_name))
+
+        if errors and raise_on_error:
+            raise ArtifactValidationError(stage_name, errors)
+
+        return errors
+
+    def is_valid(self, data: dict[str, Any], stage_name: str) -> bool:
+        """Check if artifact data is valid.
+
+        Args:
+            data: The artifact data to validate.
+            stage_name: Name of the stage.
+
+        Returns:
+            True if the artifact is valid.
+        """
+        return len(self.validate(data, stage_name)) == 0

--- a/src/questfoundry/artifacts/writer.py
+++ b/src/questfoundry/artifacts/writer.py
@@ -1,0 +1,98 @@
+"""Artifact writing to YAML files."""
+
+from __future__ import annotations
+
+from pathlib import Path  # noqa: TC003 - used at runtime
+from typing import Any
+
+from pydantic import BaseModel
+from ruamel.yaml import YAML
+
+
+class ArtifactWriteError(Exception):
+    """Raised when an artifact file can't be written."""
+
+    def __init__(self, stage_name: str, path: Path, reason: str) -> None:
+        self.stage_name = stage_name
+        self.path = path
+        self.reason = reason
+        super().__init__(f"Failed to write {stage_name} artifact at {path}: {reason}")
+
+
+class ArtifactWriter:
+    """Write artifacts to the project artifacts directory."""
+
+    def __init__(self, project_path: Path) -> None:
+        """Initialize writer with project path.
+
+        Args:
+            project_path: Path to the project root directory.
+        """
+        self.project_path = project_path
+        self.artifacts_path = project_path / "artifacts"
+        self._yaml = YAML()
+        self._yaml.default_flow_style = False
+        self._yaml.preserve_quotes = True
+        self._yaml.indent(mapping=2, sequence=4, offset=2)
+
+    def _ensure_artifacts_dir(self) -> None:
+        """Ensure the artifacts directory exists."""
+        self.artifacts_path.mkdir(parents=True, exist_ok=True)
+
+    def _get_artifact_path(self, stage_name: str) -> Path:
+        """Get the path to an artifact file.
+
+        Args:
+            stage_name: Name of the stage (e.g., "dream", "seed").
+
+        Returns:
+            Path to the artifact YAML file.
+        """
+        return self.artifacts_path / f"{stage_name}.yaml"
+
+    def write(self, artifact: BaseModel | dict[str, Any], stage_name: str) -> Path:
+        """Write an artifact to disk.
+
+        Args:
+            artifact: Pydantic model or dictionary to write.
+            stage_name: Name of the stage.
+
+        Returns:
+            Path to the written artifact file.
+
+        Raises:
+            ArtifactWriteError: If the artifact can't be written.
+        """
+        path = self._get_artifact_path(stage_name)
+
+        try:
+            self._ensure_artifacts_dir()
+
+            # Convert Pydantic model to dict if needed
+            if isinstance(artifact, BaseModel):
+                data = artifact.model_dump(exclude_none=True)
+            else:
+                data = artifact
+
+            with path.open("w", encoding="utf-8") as f:
+                self._yaml.dump(data, f)
+
+            return path
+        except Exception as e:
+            if isinstance(e, ArtifactWriteError):
+                raise
+            raise ArtifactWriteError(stage_name, path, str(e)) from e
+
+    def write_raw(self, data: dict[str, Any], stage_name: str) -> Path:
+        """Write raw dictionary data to disk.
+
+        This is an alias for write() that makes intent clearer.
+
+        Args:
+            data: Dictionary to write.
+            stage_name: Name of the stage.
+
+        Returns:
+            Path to the written artifact file.
+        """
+        return self.write(data, stage_name)

--- a/src/questfoundry/pipeline/__init__.py
+++ b/src/questfoundry/pipeline/__init__.py
@@ -1,1 +1,37 @@
 """Pipeline orchestration and stage execution."""
+
+from questfoundry.pipeline.config import (
+    GateConfig,
+    ProjectConfig,
+    ProjectConfigError,
+    ProviderConfig,
+    create_default_config,
+    load_project_config,
+)
+from questfoundry.pipeline.gates import AutoApproveGate, GateHook, RequireSuccessGate
+from questfoundry.pipeline.orchestrator import (
+    PipelineError,
+    PipelineOrchestrator,
+    PipelineStatus,
+    StageInfo,
+    StageNotFoundError,
+    StageResult,
+)
+
+__all__ = [
+    "AutoApproveGate",
+    "GateConfig",
+    "GateHook",
+    "PipelineError",
+    "PipelineOrchestrator",
+    "PipelineStatus",
+    "ProjectConfig",
+    "ProjectConfigError",
+    "ProviderConfig",
+    "RequireSuccessGate",
+    "StageInfo",
+    "StageNotFoundError",
+    "StageResult",
+    "create_default_config",
+    "load_project_config",
+]

--- a/src/questfoundry/pipeline/config.py
+++ b/src/questfoundry/pipeline/config.py
@@ -1,0 +1,132 @@
+"""Project configuration loading."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path  # noqa: TC003 - used at runtime
+from typing import Any
+
+from ruamel.yaml import YAML
+
+
+@dataclass
+class ProviderConfig:
+    """Configuration for LLM provider."""
+
+    name: str = "ollama"
+    model: str = "qwen3:8b"
+
+
+@dataclass
+class GateConfig:
+    """Configuration for stage gates."""
+
+    stage: str
+    required: bool = False
+
+
+@dataclass
+class ProjectConfig:
+    """Configuration for a QuestFoundry project."""
+
+    name: str
+    version: int = 1
+    provider: ProviderConfig = field(default_factory=ProviderConfig)
+    stages: list[str] = field(
+        default_factory=lambda: ["dream", "brainstorm", "seed", "grow", "fill", "ship"]
+    )
+    gates: list[GateConfig] = field(default_factory=list)
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> ProjectConfig:
+        """Create config from dictionary.
+
+        Args:
+            data: Dictionary containing config fields.
+
+        Returns:
+            ProjectConfig instance.
+        """
+        # Parse provider
+        provider_data = data.get("providers", {})
+        default_provider = provider_data.get("default", "ollama/qwen3:8b")
+        if "/" in default_provider:
+            provider_name, model = default_provider.split("/", 1)
+        else:
+            provider_name, model = default_provider, "qwen3:8b"
+
+        provider = ProviderConfig(name=provider_name, model=model)
+
+        # Parse stages
+        pipeline_data = data.get("pipeline", {})
+        stages = pipeline_data.get(
+            "stages", ["dream", "brainstorm", "seed", "grow", "fill", "ship"]
+        )
+
+        # Parse gates
+        gates_data = pipeline_data.get("gates", {})
+        gates = [
+            GateConfig(stage=stage, required=(value == "required"))
+            for stage, value in gates_data.items()
+        ]
+
+        return cls(
+            name=data.get("name", "unnamed"),
+            version=data.get("version", 1),
+            provider=provider,
+            stages=stages,
+            gates=gates,
+        )
+
+
+class ProjectConfigError(Exception):
+    """Raised when project configuration cannot be loaded."""
+
+    def __init__(self, path: Path, reason: str) -> None:
+        self.path = path
+        self.reason = reason
+        super().__init__(f"Failed to load project config at {path}: {reason}")
+
+
+def load_project_config(project_path: Path) -> ProjectConfig:
+    """Load project configuration from project.yaml.
+
+    Args:
+        project_path: Path to the project root directory.
+
+    Returns:
+        ProjectConfig instance.
+
+    Raises:
+        ProjectConfigError: If config cannot be loaded.
+    """
+    config_path = project_path / "project.yaml"
+
+    if not config_path.exists():
+        raise ProjectConfigError(config_path, "File not found")
+
+    yaml = YAML()
+    try:
+        with config_path.open("r", encoding="utf-8") as f:
+            data = yaml.load(f)
+
+        if data is None:
+            raise ProjectConfigError(config_path, "Empty file")
+
+        return ProjectConfig.from_dict(dict(data))
+    except Exception as e:
+        if isinstance(e, ProjectConfigError):
+            raise
+        raise ProjectConfigError(config_path, str(e)) from e
+
+
+def create_default_config(name: str) -> ProjectConfig:
+    """Create a default project configuration.
+
+    Args:
+        name: Project name.
+
+    Returns:
+        ProjectConfig with default values.
+    """
+    return ProjectConfig(name=name)

--- a/src/questfoundry/pipeline/config.py
+++ b/src/questfoundry/pipeline/config.py
@@ -8,13 +8,18 @@ from typing import Any
 
 from ruamel.yaml import YAML
 
+# Default configuration values
+DEFAULT_PROVIDER = "ollama"
+DEFAULT_MODEL = "qwen3:8b"
+DEFAULT_STAGES = ["dream", "brainstorm", "seed", "grow", "fill", "ship"]
+
 
 @dataclass
 class ProviderConfig:
     """Configuration for LLM provider."""
 
-    name: str = "ollama"
-    model: str = "qwen3:8b"
+    name: str = DEFAULT_PROVIDER
+    model: str = DEFAULT_MODEL
 
 
 @dataclass
@@ -32,9 +37,7 @@ class ProjectConfig:
     name: str
     version: int = 1
     provider: ProviderConfig = field(default_factory=ProviderConfig)
-    stages: list[str] = field(
-        default_factory=lambda: ["dream", "brainstorm", "seed", "grow", "fill", "ship"]
-    )
+    stages: list[str] = field(default_factory=lambda: list(DEFAULT_STAGES))
     gates: list[GateConfig] = field(default_factory=list)
 
     @classmethod
@@ -49,19 +52,17 @@ class ProjectConfig:
         """
         # Parse provider
         provider_data = data.get("providers", {})
-        default_provider = provider_data.get("default", "ollama/qwen3:8b")
+        default_provider = provider_data.get("default", f"{DEFAULT_PROVIDER}/{DEFAULT_MODEL}")
         if "/" in default_provider:
             provider_name, model = default_provider.split("/", 1)
         else:
-            provider_name, model = default_provider, "qwen3:8b"
+            provider_name, model = default_provider, DEFAULT_MODEL
 
         provider = ProviderConfig(name=provider_name, model=model)
 
         # Parse stages
         pipeline_data = data.get("pipeline", {})
-        stages = pipeline_data.get(
-            "stages", ["dream", "brainstorm", "seed", "grow", "fill", "ship"]
-        )
+        stages = pipeline_data.get("stages", list(DEFAULT_STAGES))
 
         # Parse gates
         gates_data = pipeline_data.get("gates", {})

--- a/src/questfoundry/pipeline/gates.py
+++ b/src/questfoundry/pipeline/gates.py
@@ -1,0 +1,77 @@
+"""Gate hooks for pipeline stage transitions."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Literal, Protocol
+
+if TYPE_CHECKING:
+    from questfoundry.pipeline.orchestrator import StageResult
+
+
+class GateHook(Protocol):
+    """Protocol for gate hooks that approve/reject stage transitions."""
+
+    async def on_stage_complete(
+        self,
+        stage: str,
+        result: StageResult,
+    ) -> Literal["approve", "reject"]:
+        """Called when a stage completes.
+
+        Args:
+            stage: Name of the completed stage.
+            result: Result of the stage execution.
+
+        Returns:
+            "approve" to continue or "reject" to halt pipeline.
+        """
+        ...
+
+
+class AutoApproveGate:
+    """Gate that automatically approves all stage transitions.
+
+    This is the default gate for Slice 1 where human review
+    is not yet implemented.
+    """
+
+    async def on_stage_complete(
+        self,
+        _stage: str,
+        _result: StageResult,
+    ) -> Literal["approve", "reject"]:
+        """Automatically approve all completed stages.
+
+        Args:
+            _stage: Name of the completed stage (unused).
+            _result: Result of the stage execution (unused).
+
+        Returns:
+            Always returns "approve".
+        """
+        return "approve"
+
+
+class RequireSuccessGate:
+    """Gate that only approves successful stage completions.
+
+    Rejects any stage that completed with errors.
+    """
+
+    async def on_stage_complete(
+        self,
+        _stage: str,
+        result: StageResult,
+    ) -> Literal["approve", "reject"]:
+        """Approve only if stage completed without errors.
+
+        Args:
+            _stage: Name of the completed stage (unused).
+            result: Result of the stage execution.
+
+        Returns:
+            "approve" if no errors, "reject" otherwise.
+        """
+        if result.errors:
+            return "reject"
+        return "approve"

--- a/src/questfoundry/pipeline/orchestrator.py
+++ b/src/questfoundry/pipeline/orchestrator.py
@@ -1,0 +1,276 @@
+"""Pipeline orchestrator for stage execution."""
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass, field
+from datetime import datetime
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, Literal
+
+from questfoundry.artifacts import ArtifactReader, ArtifactValidator, ArtifactWriter
+from questfoundry.pipeline.config import ProjectConfigError, load_project_config
+from questfoundry.pipeline.gates import AutoApproveGate, GateHook
+from questfoundry.prompts import PromptCompiler
+from questfoundry.providers import OllamaProvider, OpenAIProvider
+
+if TYPE_CHECKING:
+    from questfoundry.providers import LLMProvider
+
+
+@dataclass
+class StageResult:
+    """Result of a stage execution."""
+
+    stage: str
+    status: Literal["completed", "failed", "pending_review"]
+    artifact_path: Path | None = None
+    llm_calls: int = 0
+    tokens_used: int = 0
+    errors: list[str] = field(default_factory=list)
+    duration_seconds: float = 0.0
+
+
+@dataclass
+class StageInfo:
+    """Information about a stage's current state."""
+
+    status: Literal["pending", "completed", "failed"]
+    artifact_path: Path | None = None
+    last_run: datetime | None = None
+
+
+@dataclass
+class PipelineStatus:
+    """Overall pipeline status."""
+
+    project_name: str
+    stages: dict[str, StageInfo] = field(default_factory=dict)
+
+
+class PipelineError(Exception):
+    """Raised when pipeline execution fails."""
+
+    def __init__(self, stage: str, message: str) -> None:
+        self.stage = stage
+        super().__init__(f"Pipeline error in stage '{stage}': {message}")
+
+
+class StageNotFoundError(PipelineError):
+    """Raised when a stage is not found."""
+
+    def __init__(self, stage: str) -> None:
+        super().__init__(stage, f"Stage '{stage}' not found")
+
+
+class PipelineOrchestrator:
+    """Orchestrate pipeline stage execution.
+
+    The orchestrator manages:
+    - Loading project configuration
+    - Initializing LLM providers
+    - Executing stages in sequence
+    - Validating and writing artifacts
+    - Calling gate hooks for stage transitions
+
+    Attributes:
+        project_path: Path to the project root.
+        config: Loaded project configuration.
+    """
+
+    def __init__(
+        self,
+        project_path: Path,
+        gate: GateHook | None = None,
+    ) -> None:
+        """Initialize the orchestrator.
+
+        Args:
+            project_path: Path to the project root directory.
+            gate: Optional gate hook for stage transitions.
+                Defaults to AutoApproveGate.
+
+        Raises:
+            ProjectConfigError: If project.yaml cannot be loaded.
+        """
+        self.project_path = project_path
+        self._gate = gate or AutoApproveGate()
+
+        # Load configuration
+        try:
+            self.config = load_project_config(project_path)
+        except ProjectConfigError:
+            # Use default config if no project.yaml
+            from questfoundry.pipeline.config import create_default_config
+
+            self.config = create_default_config("unnamed")
+
+        # Initialize components
+        self._reader = ArtifactReader(project_path)
+        self._writer = ArtifactWriter(project_path)
+        self._validator = ArtifactValidator()
+        self._prompts_path = project_path.parent / "prompts"  # Default prompts location
+        if not self._prompts_path.exists():
+            # Try project root prompts
+            self._prompts_path = Path(__file__).parent.parent.parent.parent / "prompts"
+
+        # Provider will be lazily initialized
+        self._provider: LLMProvider | None = None
+
+    def _get_provider(self) -> LLMProvider:
+        """Get or create the LLM provider.
+
+        Returns:
+            Configured LLM provider.
+        """
+        if self._provider is not None:
+            return self._provider
+
+        provider_name = self.config.provider.name.lower()
+        model = self.config.provider.model
+
+        if provider_name == "ollama":
+            self._provider = OllamaProvider(default_model=model)
+        elif provider_name == "openai":
+            self._provider = OpenAIProvider(default_model=model)
+        else:
+            # Default to Ollama
+            self._provider = OllamaProvider(default_model=model)
+
+        return self._provider
+
+    def _get_stage_implementation(self, stage_name: str) -> Any:
+        """Get the stage implementation.
+
+        Args:
+            stage_name: Name of the stage.
+
+        Returns:
+            Stage instance.
+
+        Raises:
+            StageNotFoundError: If stage is not implemented.
+        """
+        # Import stages lazily to avoid circular imports
+        from questfoundry.pipeline.stages import get_stage
+
+        stage = get_stage(stage_name)
+        if stage is None:
+            raise StageNotFoundError(stage_name)
+        return stage
+
+    async def run_stage(
+        self,
+        stage_name: str,
+        context: dict[str, Any] | None = None,
+    ) -> StageResult:
+        """Execute a single pipeline stage.
+
+        Args:
+            stage_name: Name of the stage to execute.
+            context: Additional context for the stage.
+
+        Returns:
+            StageResult with execution details.
+        """
+        start_time = time.perf_counter()
+        context = context or {}
+        errors: list[str] = []
+
+        try:
+            # Get stage implementation
+            stage = self._get_stage_implementation(stage_name)
+
+            # Get provider
+            provider = self._get_provider()
+
+            # Create prompt compiler
+            compiler = PromptCompiler(self._prompts_path)
+
+            # Execute stage
+            artifact_data, llm_calls, tokens_used = await stage.execute(
+                context=context,
+                provider=provider,
+                compiler=compiler,
+            )
+
+            # Validate artifact
+            validation_errors = self._validator.validate(artifact_data, stage_name)
+            if validation_errors:
+                errors.extend(validation_errors)
+
+            # Write artifact
+            artifact_path = self._writer.write(artifact_data, stage_name)
+
+            # Calculate duration
+            duration = time.perf_counter() - start_time
+
+            result = StageResult(
+                stage=stage_name,
+                status="completed" if not errors else "failed",
+                artifact_path=artifact_path,
+                llm_calls=llm_calls,
+                tokens_used=tokens_used,
+                errors=errors,
+                duration_seconds=duration,
+            )
+
+            # Call gate hook
+            gate_decision = await self._gate.on_stage_complete(stage_name, result)
+            if gate_decision == "reject":
+                result.status = "pending_review"
+
+            return result
+
+        except StageNotFoundError:
+            raise
+        except Exception as e:
+            duration = time.perf_counter() - start_time
+            return StageResult(
+                stage=stage_name,
+                status="failed",
+                errors=[str(e)],
+                duration_seconds=duration,
+            )
+
+    def get_status(self) -> PipelineStatus:
+        """Get the current pipeline status.
+
+        Returns:
+            PipelineStatus with stage information.
+        """
+        stages: dict[str, StageInfo] = {}
+
+        for stage_name in self.config.stages:
+            stage_artifact_path = self.project_path / "artifacts" / f"{stage_name}.yaml"
+
+            if stage_artifact_path.exists():
+                # Get last modified time
+                mtime = stage_artifact_path.stat().st_mtime
+                last_run: datetime | None = datetime.fromtimestamp(mtime)
+                status: Literal["pending", "completed", "failed"] = "completed"
+                info_artifact_path: Path | None = stage_artifact_path
+            else:
+                info_artifact_path = None
+                last_run = None
+                status = "pending"
+
+            stages[stage_name] = StageInfo(
+                status=status,
+                artifact_path=info_artifact_path,
+                last_run=last_run,
+            )
+
+        return PipelineStatus(
+            project_name=self.config.name,
+            stages=stages,
+        )
+
+    async def close(self) -> None:
+        """Close the orchestrator and release resources."""
+        if self._provider is not None:
+            # Providers with async close
+            if hasattr(self._provider, "close"):
+                close_method = self._provider.close
+                await close_method()
+            self._provider = None

--- a/src/questfoundry/pipeline/stages/__init__.py
+++ b/src/questfoundry/pipeline/stages/__init__.py
@@ -1,1 +1,75 @@
 """Pipeline stage implementations."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, Protocol
+
+if TYPE_CHECKING:
+    from questfoundry.prompts import PromptCompiler
+    from questfoundry.providers import LLMProvider
+
+
+class Stage(Protocol):
+    """Protocol for pipeline stage implementations."""
+
+    name: str
+
+    async def execute(
+        self,
+        context: dict[str, Any],
+        provider: LLMProvider,
+        compiler: PromptCompiler,
+    ) -> tuple[dict[str, Any], int, int]:
+        """Execute the stage.
+
+        Args:
+            context: Context dictionary with user inputs and prior artifacts.
+            provider: LLM provider for completions.
+            compiler: Prompt compiler for template assembly.
+
+        Returns:
+            Tuple of (artifact_data, llm_calls, tokens_used).
+        """
+        ...
+
+
+# Stage registry - populated by stage modules
+_STAGE_REGISTRY: dict[str, Stage] = {}
+
+
+def register_stage(stage: Stage) -> None:
+    """Register a stage implementation.
+
+    Args:
+        stage: Stage instance to register.
+    """
+    _STAGE_REGISTRY[stage.name] = stage
+
+
+def get_stage(name: str) -> Stage | None:
+    """Get a registered stage by name.
+
+    Args:
+        name: Stage name.
+
+    Returns:
+        Stage instance or None if not found.
+    """
+    return _STAGE_REGISTRY.get(name)
+
+
+def list_stages() -> list[str]:
+    """List registered stage names.
+
+    Returns:
+        List of stage names.
+    """
+    return list(_STAGE_REGISTRY.keys())
+
+
+__all__ = [
+    "Stage",
+    "get_stage",
+    "list_stages",
+    "register_stage",
+]

--- a/src/questfoundry/prompts/__init__.py
+++ b/src/questfoundry/prompts/__init__.py
@@ -1,1 +1,25 @@
 """Prompt compiler and template loading."""
+
+from questfoundry.prompts.compiler import (
+    BudgetExceededError,
+    CompiledPrompt,
+    PromptCompileError,
+    PromptCompiler,
+)
+from questfoundry.prompts.loader import (
+    PromptLoader,
+    PromptTemplate,
+    TemplateNotFoundError,
+    TemplateParseError,
+)
+
+__all__ = [
+    "BudgetExceededError",
+    "CompiledPrompt",
+    "PromptCompileError",
+    "PromptCompiler",
+    "PromptLoader",
+    "PromptTemplate",
+    "TemplateNotFoundError",
+    "TemplateParseError",
+]

--- a/src/questfoundry/prompts/compiler.py
+++ b/src/questfoundry/prompts/compiler.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import re
 from dataclasses import dataclass, field
 from pathlib import Path  # noqa: TC003 - used at runtime
@@ -136,8 +137,6 @@ class PromptCompiler:
         # Convert to string
         if isinstance(value, (list, dict)):
             # Format lists/dicts nicely
-            import json
-
             return json.dumps(value, indent=2)
         return str(value)
 

--- a/src/questfoundry/prompts/compiler.py
+++ b/src/questfoundry/prompts/compiler.py
@@ -1,0 +1,216 @@
+"""Prompt compiler for assembling stage prompts."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from pathlib import Path  # noqa: TC003 - used at runtime
+from typing import Any
+
+from questfoundry.prompts.loader import PromptLoader, TemplateNotFoundError
+
+
+@dataclass
+class CompiledPrompt:
+    """A compiled prompt ready for LLM submission."""
+
+    system: str
+    user: str
+    token_count: int
+    template_name: str
+    included_components: list[str] = field(default_factory=list)
+
+    @property
+    def total_tokens(self) -> int:
+        """Alias for token_count for clarity."""
+        return self.token_count
+
+
+class PromptCompileError(Exception):
+    """Raised when prompt compilation fails."""
+
+    def __init__(self, template_name: str, message: str) -> None:
+        self.template_name = template_name
+        super().__init__(f"Failed to compile template '{template_name}': {message}")
+
+
+class BudgetExceededError(Exception):
+    """Raised when compiled prompt exceeds token budget."""
+
+    def __init__(self, required: int, budget: int, template_name: str) -> None:
+        self.required = required
+        self.budget = budget
+        self.template_name = template_name
+        super().__init__(
+            f"Prompt '{template_name}' requires {required} tokens but budget is {budget}"
+        )
+
+
+class PromptCompiler:
+    """Compile prompts from templates with variable substitution.
+
+    This is a simplified implementation for Slice 1:
+    - Simple {{ variable }} substitution (no Jinja2)
+    - No compression strategies (all content must fit)
+    - Token counting with tiktoken, fallback to heuristic
+
+    Attributes:
+        prompts_path: Path to the prompts directory.
+        token_budget: Maximum tokens for compiled prompts.
+    """
+
+    # Pattern for {{ variable }} substitution
+    _VAR_PATTERN = re.compile(r"\{\{\s*(\w+(?:\.\w+)*)\s*\}\}")
+
+    def __init__(
+        self,
+        prompts_path: Path,
+        token_budget: int = 4000,
+    ) -> None:
+        """Initialize the prompt compiler.
+
+        Args:
+            prompts_path: Path to the prompts directory containing templates/.
+            token_budget: Maximum tokens for compiled prompts.
+        """
+        self.prompts_path = prompts_path
+        self.token_budget = token_budget
+        self._loader = PromptLoader(prompts_path)
+        self._tokenizer: Any | None = None
+
+    def _get_tokenizer(self) -> Any:
+        """Lazy-load tiktoken encoder."""
+        if self._tokenizer is None:
+            try:
+                import tiktoken
+
+                self._tokenizer = tiktoken.get_encoding("cl100k_base")
+            except ImportError:
+                self._tokenizer = None
+        return self._tokenizer
+
+    def estimate_tokens(self, text: str) -> int:
+        """Estimate token count for text.
+
+        Uses tiktoken if available, otherwise falls back to
+        character heuristic (4 chars ≈ 1 token).
+
+        Args:
+            text: Text to estimate tokens for.
+
+        Returns:
+            Estimated token count.
+        """
+        tokenizer = self._get_tokenizer()
+        if tokenizer is not None:
+            return len(tokenizer.encode(text))
+        # Fallback: ~4 characters per token
+        return len(text) // 4
+
+    def _resolve_variable(self, path: str, context: dict[str, Any]) -> str:
+        """Resolve a dotted variable path from context.
+
+        Args:
+            path: Dotted path like 'user_prompt' or 'dream.genre'.
+            context: Context dictionary.
+
+        Returns:
+            String representation of the value.
+
+        Raises:
+            KeyError: If the path cannot be resolved.
+        """
+        parts = path.split(".")
+        value: Any = context
+
+        for part in parts:
+            if isinstance(value, dict):
+                if part not in value:
+                    raise KeyError(f"Key '{part}' not found in context path '{path}'")
+                value = value[part]
+            elif hasattr(value, part):
+                value = getattr(value, part)
+            else:
+                raise KeyError(f"Cannot resolve '{part}' in context path '{path}'")
+
+        # Convert to string
+        if isinstance(value, (list, dict)):
+            # Format lists/dicts nicely
+            import json
+
+            return json.dumps(value, indent=2)
+        return str(value)
+
+    def _substitute_variables(self, text: str, context: dict[str, Any]) -> str:
+        """Substitute {{ variable }} placeholders with context values.
+
+        Args:
+            text: Text containing placeholders.
+            context: Context dictionary for substitution.
+
+        Returns:
+            Text with placeholders replaced.
+        """
+
+        def replace_match(match: re.Match[str]) -> str:
+            path = match.group(1)
+            try:
+                return self._resolve_variable(path, context)
+            except KeyError:
+                # Leave unresolved variables as-is
+                return match.group(0)
+
+        return self._VAR_PATTERN.sub(replace_match, text)
+
+    def compile(
+        self,
+        template_name: str,
+        context: dict[str, Any] | None = None,
+    ) -> CompiledPrompt:
+        """Compile a prompt from a template with context substitution.
+
+        Args:
+            template_name: Name of the template (e.g., 'dream').
+            context: Context dictionary for variable substitution.
+
+        Returns:
+            CompiledPrompt ready for LLM submission.
+
+        Raises:
+            PromptCompileError: If template cannot be loaded or compiled.
+            BudgetExceededError: If compiled prompt exceeds token budget.
+        """
+        context = context or {}
+
+        # Load template
+        try:
+            template = self._loader.load(template_name)
+        except TemplateNotFoundError as e:
+            raise PromptCompileError(template_name, str(e)) from e
+
+        # Substitute variables
+        system = self._substitute_variables(template.system, context)
+        user = self._substitute_variables(template.user, context)
+
+        # Calculate token count
+        token_count = self.estimate_tokens(system) + self.estimate_tokens(user)
+
+        # Check budget
+        if token_count > self.token_budget:
+            raise BudgetExceededError(token_count, self.token_budget, template_name)
+
+        return CompiledPrompt(
+            system=system,
+            user=user,
+            token_count=token_count,
+            template_name=template_name,
+            included_components=template.components,
+        )
+
+    def list_templates(self) -> list[str]:
+        """List available template names.
+
+        Returns:
+            List of template names that can be compiled.
+        """
+        return self._loader.list_templates()

--- a/src/questfoundry/prompts/loader.py
+++ b/src/questfoundry/prompts/loader.py
@@ -1,0 +1,157 @@
+"""Template loading for prompt compiler."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path  # noqa: TC003 - used at runtime
+from typing import Any
+
+from ruamel.yaml import YAML
+
+
+@dataclass
+class PromptTemplate:
+    """A loaded prompt template."""
+
+    name: str
+    description: str
+    system: str
+    user: str
+    components: list[str] = field(default_factory=list)
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any], name: str) -> PromptTemplate:
+        """Create a template from dictionary data.
+
+        Args:
+            data: Dictionary containing template fields.
+            name: Template name (usually from filename).
+
+        Returns:
+            PromptTemplate instance.
+
+        Raises:
+            KeyError: If required fields are missing.
+        """
+        return cls(
+            name=data.get("name", name),
+            description=data.get("description", ""),
+            system=data.get("system", ""),
+            user=data.get("user", ""),
+            components=data.get("components", []),
+        )
+
+
+class TemplateNotFoundError(Exception):
+    """Raised when a template file cannot be found."""
+
+    def __init__(self, template_name: str, path: Path) -> None:
+        self.template_name = template_name
+        self.path = path
+        super().__init__(f"Template not found: {template_name} at {path}")
+
+
+class TemplateParseError(Exception):
+    """Raised when a template file cannot be parsed."""
+
+    def __init__(self, template_name: str, reason: str) -> None:
+        self.template_name = template_name
+        self.reason = reason
+        super().__init__(f"Failed to parse template '{template_name}': {reason}")
+
+
+class PromptLoader:
+    """Load prompt templates from disk.
+
+    Templates are YAML files in the templates/ subdirectory.
+
+    Attributes:
+        prompts_path: Path to the prompts directory.
+    """
+
+    def __init__(self, prompts_path: Path) -> None:
+        """Initialize the loader.
+
+        Args:
+            prompts_path: Path to the prompts directory.
+        """
+        self.prompts_path = prompts_path
+        self.templates_path = prompts_path / "templates"
+        self._yaml = YAML()
+        self._yaml.preserve_quotes = True
+        self._cache: dict[str, PromptTemplate] = {}
+
+    def _get_template_path(self, template_name: str) -> Path:
+        """Get the path to a template file.
+
+        Args:
+            template_name: Name of the template.
+
+        Returns:
+            Path to the template YAML file.
+        """
+        return self.templates_path / f"{template_name}.yaml"
+
+    def load(self, template_name: str) -> PromptTemplate:
+        """Load a template by name.
+
+        Args:
+            template_name: Name of the template (without .yaml extension).
+
+        Returns:
+            Loaded PromptTemplate.
+
+        Raises:
+            TemplateNotFoundError: If the template file doesn't exist.
+            TemplateParseError: If the template cannot be parsed.
+        """
+        # Check cache
+        if template_name in self._cache:
+            return self._cache[template_name]
+
+        path = self._get_template_path(template_name)
+
+        if not path.exists():
+            raise TemplateNotFoundError(template_name, path)
+
+        try:
+            with path.open("r", encoding="utf-8") as f:
+                data = self._yaml.load(f)
+
+            if data is None:
+                raise TemplateParseError(template_name, "Empty file")
+
+            template = PromptTemplate.from_dict(dict(data), template_name)
+            self._cache[template_name] = template
+            return template
+
+        except Exception as e:
+            if isinstance(e, (TemplateNotFoundError, TemplateParseError)):
+                raise
+            raise TemplateParseError(template_name, str(e)) from e
+
+    def exists(self, template_name: str) -> bool:
+        """Check if a template exists.
+
+        Args:
+            template_name: Name of the template.
+
+        Returns:
+            True if the template file exists.
+        """
+        return self._get_template_path(template_name).exists()
+
+    def list_templates(self) -> list[str]:
+        """List available template names.
+
+        Returns:
+            List of template names (without .yaml extension).
+        """
+        if not self.templates_path.exists():
+            return []
+
+        return sorted(p.stem for p in self.templates_path.glob("*.yaml") if p.is_file())
+
+    def clear_cache(self) -> None:
+        """Clear the template cache."""
+        self._cache.clear()

--- a/src/questfoundry/prompts/loader.py
+++ b/src/questfoundry/prompts/loader.py
@@ -29,9 +29,6 @@ class PromptTemplate:
 
         Returns:
             PromptTemplate instance.
-
-        Raises:
-            KeyError: If required fields are missing.
         """
         return cls(
             name=data.get("name", name),

--- a/src/questfoundry/providers/__init__.py
+++ b/src/questfoundry/providers/__init__.py
@@ -1,1 +1,25 @@
 """LLM provider integrations (Ollama, OpenAI)."""
+
+from questfoundry.providers.base import (
+    LLMProvider,
+    LLMResponse,
+    Message,
+    ProviderConnectionError,
+    ProviderError,
+    ProviderModelError,
+    ProviderRateLimitError,
+)
+from questfoundry.providers.ollama import OllamaProvider
+from questfoundry.providers.openai_provider import OpenAIProvider
+
+__all__ = [
+    "LLMProvider",
+    "LLMResponse",
+    "Message",
+    "OllamaProvider",
+    "OpenAIProvider",
+    "ProviderConnectionError",
+    "ProviderError",
+    "ProviderModelError",
+    "ProviderRateLimitError",
+]

--- a/src/questfoundry/providers/base.py
+++ b/src/questfoundry/providers/base.py
@@ -1,0 +1,86 @@
+"""Base protocol and types for LLM providers."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal, Protocol, TypedDict
+
+
+class Message(TypedDict):
+    """A single message in a conversation."""
+
+    role: Literal["system", "user", "assistant"]
+    content: str
+
+
+@dataclass
+class LLMResponse:
+    """Response from an LLM completion request."""
+
+    content: str
+    model: str
+    tokens_used: int
+    finish_reason: str
+
+    @property
+    def is_complete(self) -> bool:
+        """Check if the response completed successfully."""
+        return self.finish_reason in ("stop", "end_turn")
+
+
+class LLMProvider(Protocol):
+    """Protocol for LLM providers."""
+
+    @property
+    def default_model(self) -> str:
+        """Return the default model for this provider."""
+        ...
+
+    async def complete(
+        self,
+        messages: list[Message],
+        model: str | None = None,
+        temperature: float = 0.7,
+        max_tokens: int = 4096,
+    ) -> LLMResponse:
+        """Generate a completion from the given messages.
+
+        Args:
+            messages: List of conversation messages.
+            model: Model to use. If None, uses the provider's default.
+            temperature: Sampling temperature (0.0 to 2.0).
+            max_tokens: Maximum tokens to generate.
+
+        Returns:
+            LLMResponse containing the generated text and metadata.
+
+        Raises:
+            ProviderError: If the completion request fails.
+        """
+        ...
+
+
+class ProviderError(Exception):
+    """Base exception for provider errors."""
+
+    def __init__(self, provider: str, message: str) -> None:
+        self.provider = provider
+        super().__init__(f"[{provider}] {message}")
+
+
+class ProviderConnectionError(ProviderError):
+    """Raised when connection to the provider fails."""
+
+    pass
+
+
+class ProviderRateLimitError(ProviderError):
+    """Raised when rate limit is exceeded."""
+
+    pass
+
+
+class ProviderModelError(ProviderError):
+    """Raised when the requested model is unavailable."""
+
+    pass

--- a/src/questfoundry/providers/ollama.py
+++ b/src/questfoundry/providers/ollama.py
@@ -75,7 +75,7 @@ class OllamaProvider:
 
         payload = {
             "model": model,
-            "messages": [dict(m) for m in messages],
+            "messages": messages,
             "stream": False,
             "options": {
                 "temperature": temperature,
@@ -126,9 +126,14 @@ class OllamaProvider:
         prompt_eval_count = data.get("prompt_eval_count", 0)
         tokens_used = eval_count + prompt_eval_count
 
-        # Determine finish reason
-        done_reason = data.get("done_reason", "unknown")
-        finish_reason = "stop" if done_reason == "stop" or data.get("done", False) else done_reason
+        # Determine finish reason - prioritize done_reason over done flag
+        done_reason = data.get("done_reason", "")
+        if done_reason:
+            finish_reason = done_reason
+        elif data.get("done", False):
+            finish_reason = "stop"
+        else:
+            finish_reason = "unknown"
 
         return LLMResponse(
             content=content,

--- a/src/questfoundry/providers/ollama.py
+++ b/src/questfoundry/providers/ollama.py
@@ -1,0 +1,187 @@
+"""Ollama LLM provider implementation."""
+
+from __future__ import annotations
+
+import os
+
+import httpx
+
+from questfoundry.providers.base import (
+    LLMResponse,
+    Message,
+    ProviderConnectionError,
+    ProviderError,
+    ProviderModelError,
+)
+
+
+class OllamaProvider:
+    """Ollama LLM provider.
+
+    Uses the Ollama API to generate completions. The Ollama server
+    must be running locally or at the configured host.
+
+    Attributes:
+        host: Ollama server URL.
+        default_model: Default model to use for completions.
+    """
+
+    def __init__(
+        self,
+        host: str | None = None,
+        default_model: str = "qwen3:8b",
+    ) -> None:
+        """Initialize the Ollama provider.
+
+        Args:
+            host: Ollama server URL. Defaults to OLLAMA_HOST env var
+                or http://localhost:11434.
+            default_model: Default model for completions.
+        """
+        self.host = host or os.getenv("OLLAMA_HOST", "http://localhost:11434")
+        self._default_model = default_model
+        self._client = httpx.AsyncClient(timeout=300.0)
+
+    @property
+    def default_model(self) -> str:
+        """Return the default model for this provider."""
+        return self._default_model
+
+    async def complete(
+        self,
+        messages: list[Message],
+        model: str | None = None,
+        temperature: float = 0.7,
+        max_tokens: int = 4096,
+    ) -> LLMResponse:
+        """Generate a completion from the given messages.
+
+        Args:
+            messages: List of conversation messages.
+            model: Model to use. If None, uses the provider's default.
+            temperature: Sampling temperature (0.0 to 2.0).
+            max_tokens: Maximum tokens to generate.
+
+        Returns:
+            LLMResponse containing the generated text and metadata.
+
+        Raises:
+            ProviderConnectionError: If connection to Ollama fails.
+            ProviderModelError: If the model is not available.
+            ProviderError: For other API errors.
+        """
+        model = model or self._default_model
+        url = f"{self.host}/api/chat"
+
+        payload = {
+            "model": model,
+            "messages": [dict(m) for m in messages],
+            "stream": False,
+            "options": {
+                "temperature": temperature,
+                "num_predict": max_tokens,
+            },
+        }
+
+        try:
+            response = await self._client.post(url, json=payload)
+        except httpx.ConnectError as e:
+            raise ProviderConnectionError(
+                "ollama",
+                f"Failed to connect to Ollama at {self.host}: {e}",
+            ) from e
+        except httpx.TimeoutException as e:
+            raise ProviderConnectionError(
+                "ollama",
+                f"Request to Ollama timed out: {e}",
+            ) from e
+
+        if response.status_code == 404:
+            raise ProviderModelError(
+                "ollama",
+                f"Model '{model}' not found. Run 'ollama pull {model}' first.",
+            )
+
+        if response.status_code != 200:
+            raise ProviderError(
+                "ollama",
+                f"API error (status {response.status_code}): {response.text}",
+            )
+
+        try:
+            data = response.json()
+        except ValueError as e:
+            raise ProviderError(
+                "ollama",
+                f"Invalid JSON response: {e}",
+            ) from e
+
+        # Extract response content
+        message = data.get("message", {})
+        content = message.get("content", "")
+
+        # Calculate token usage
+        # Ollama provides eval_count (output) and prompt_eval_count (input)
+        eval_count = data.get("eval_count", 0)
+        prompt_eval_count = data.get("prompt_eval_count", 0)
+        tokens_used = eval_count + prompt_eval_count
+
+        # Determine finish reason
+        done_reason = data.get("done_reason", "unknown")
+        finish_reason = "stop" if done_reason == "stop" or data.get("done", False) else done_reason
+
+        return LLMResponse(
+            content=content,
+            model=model,
+            tokens_used=tokens_used,
+            finish_reason=finish_reason,
+        )
+
+    async def close(self) -> None:
+        """Close the HTTP client."""
+        await self._client.aclose()
+
+    async def __aenter__(self) -> OllamaProvider:
+        """Enter async context."""
+        return self
+
+    async def __aexit__(self, *_: object) -> None:
+        """Exit async context and close client."""
+        await self.close()
+
+    async def list_models(self) -> list[str]:
+        """List available models on the Ollama server.
+
+        Returns:
+            List of model names.
+
+        Raises:
+            ProviderConnectionError: If connection to Ollama fails.
+            ProviderError: For other API errors.
+        """
+        url = f"{self.host}/api/tags"
+
+        try:
+            response = await self._client.get(url)
+        except httpx.ConnectError as e:
+            raise ProviderConnectionError(
+                "ollama",
+                f"Failed to connect to Ollama at {self.host}: {e}",
+            ) from e
+
+        if response.status_code != 200:
+            raise ProviderError(
+                "ollama",
+                f"API error (status {response.status_code}): {response.text}",
+            )
+
+        try:
+            data = response.json()
+        except ValueError as e:
+            raise ProviderError(
+                "ollama",
+                f"Invalid JSON response: {e}",
+            ) from e
+
+        models = data.get("models", [])
+        return [m.get("name", "") for m in models if m.get("name")]

--- a/src/questfoundry/providers/openai_provider.py
+++ b/src/questfoundry/providers/openai_provider.py
@@ -1,0 +1,168 @@
+"""OpenAI LLM provider implementation."""
+
+from __future__ import annotations
+
+import os
+
+import httpx
+
+from questfoundry.providers.base import (
+    LLMResponse,
+    Message,
+    ProviderConnectionError,
+    ProviderError,
+    ProviderRateLimitError,
+)
+
+
+class OpenAIProvider:
+    """OpenAI LLM provider.
+
+    Uses the OpenAI API to generate completions. Requires an API key.
+
+    Attributes:
+        default_model: Default model to use for completions.
+    """
+
+    def __init__(
+        self,
+        api_key: str | None = None,
+        default_model: str = "gpt-4o-mini",
+        base_url: str | None = None,
+    ) -> None:
+        """Initialize the OpenAI provider.
+
+        Args:
+            api_key: OpenAI API key. Defaults to OPENAI_API_KEY env var.
+            default_model: Default model for completions.
+            base_url: Custom API base URL (for compatible endpoints).
+        """
+        self._api_key = api_key or os.getenv("OPENAI_API_KEY")
+        if not self._api_key:
+            raise ProviderError(
+                "openai",
+                "API key required. Set OPENAI_API_KEY environment variable.",
+            )
+
+        self._default_model = default_model
+        self._base_url = base_url or "https://api.openai.com/v1"
+        self._client = httpx.AsyncClient(
+            timeout=300.0,
+            headers={
+                "Authorization": f"Bearer {self._api_key}",
+                "Content-Type": "application/json",
+            },
+        )
+
+    @property
+    def default_model(self) -> str:
+        """Return the default model for this provider."""
+        return self._default_model
+
+    async def complete(
+        self,
+        messages: list[Message],
+        model: str | None = None,
+        temperature: float = 0.7,
+        max_tokens: int = 4096,
+    ) -> LLMResponse:
+        """Generate a completion from the given messages.
+
+        Args:
+            messages: List of conversation messages.
+            model: Model to use. If None, uses the provider's default.
+            temperature: Sampling temperature (0.0 to 2.0).
+            max_tokens: Maximum tokens to generate.
+
+        Returns:
+            LLMResponse containing the generated text and metadata.
+
+        Raises:
+            ProviderConnectionError: If connection fails.
+            ProviderRateLimitError: If rate limit is exceeded.
+            ProviderError: For other API errors.
+        """
+        model = model or self._default_model
+        url = f"{self._base_url}/chat/completions"
+
+        payload = {
+            "model": model,
+            "messages": [dict(m) for m in messages],
+            "temperature": temperature,
+            "max_tokens": max_tokens,
+        }
+
+        try:
+            response = await self._client.post(url, json=payload)
+        except httpx.ConnectError as e:
+            raise ProviderConnectionError(
+                "openai",
+                f"Failed to connect to OpenAI API: {e}",
+            ) from e
+        except httpx.TimeoutException as e:
+            raise ProviderConnectionError(
+                "openai",
+                f"Request to OpenAI timed out: {e}",
+            ) from e
+
+        if response.status_code == 429:
+            raise ProviderRateLimitError(
+                "openai",
+                "Rate limit exceeded. Please wait before retrying.",
+            )
+
+        if response.status_code == 401:
+            raise ProviderError(
+                "openai",
+                "Invalid API key. Check your OPENAI_API_KEY.",
+            )
+
+        if response.status_code != 200:
+            raise ProviderError(
+                "openai",
+                f"API error (status {response.status_code}): {response.text}",
+            )
+
+        try:
+            data = response.json()
+        except ValueError as e:
+            raise ProviderError(
+                "openai",
+                f"Invalid JSON response: {e}",
+            ) from e
+
+        # Extract response
+        choices = data.get("choices", [])
+        if not choices:
+            raise ProviderError(
+                "openai",
+                "Empty response from API",
+            )
+
+        choice = choices[0]
+        message = choice.get("message", {})
+        content = message.get("content", "")
+        finish_reason = choice.get("finish_reason", "unknown")
+
+        # Calculate token usage
+        usage = data.get("usage", {})
+        tokens_used = usage.get("total_tokens", 0)
+
+        return LLMResponse(
+            content=content,
+            model=model,
+            tokens_used=tokens_used,
+            finish_reason=finish_reason,
+        )
+
+    async def close(self) -> None:
+        """Close the HTTP client."""
+        await self._client.aclose()
+
+    async def __aenter__(self) -> OpenAIProvider:
+        """Enter async context."""
+        return self
+
+    async def __aexit__(self, *_: object) -> None:
+        """Exit async context and close client."""
+        await self.close()

--- a/src/questfoundry/providers/openai_provider.py
+++ b/src/questfoundry/providers/openai_provider.py
@@ -87,7 +87,7 @@ class OpenAIProvider:
 
         payload = {
             "model": model,
-            "messages": [dict(m) for m in messages],
+            "messages": messages,
             "temperature": temperature,
             "max_tokens": max_tokens,
         }

--- a/tests/unit/test_artifacts.py
+++ b/tests/unit/test_artifacts.py
@@ -1,0 +1,408 @@
+"""Tests for artifact reading, writing, and validation."""
+
+from pathlib import Path
+
+import pytest
+from pydantic import ValidationError
+
+from questfoundry.artifacts import (
+    ArtifactNotFoundError,
+    ArtifactReader,
+    ArtifactValidationError,
+    ArtifactValidator,
+    ArtifactWriter,
+    DreamArtifact,
+    Scope,
+)
+
+# --- DreamArtifact Model Tests ---
+
+
+def test_dream_artifact_valid_minimal() -> None:
+    """Minimal valid DREAM artifact."""
+    artifact = DreamArtifact(
+        genre="mystery",
+        tone=["dark"],
+        audience="adult",
+        themes=["betrayal"],
+    )
+    assert artifact.type == "dream"
+    assert artifact.version == 1
+    assert artifact.genre == "mystery"
+    assert artifact.subgenre is None
+    assert artifact.scope is None
+
+
+def test_dream_artifact_valid_full() -> None:
+    """Full DREAM artifact with all fields."""
+    artifact = DreamArtifact(
+        genre="mystery",
+        subgenre="noir",
+        tone=["dark", "atmospheric"],
+        audience="adult",
+        themes=["betrayal", "redemption"],
+        style_notes="Hard-boiled narration",
+        scope=Scope(
+            target_word_count=15000,
+            estimated_passages=40,
+            branching_depth="moderate",
+            estimated_playtime_minutes=30,
+        ),
+    )
+    assert artifact.subgenre == "noir"
+    assert artifact.scope is not None
+    assert artifact.scope.target_word_count == 15000
+
+
+def test_dream_artifact_invalid_empty_genre() -> None:
+    """Empty genre should fail validation."""
+    with pytest.raises(ValidationError) as exc_info:
+        DreamArtifact(
+            genre="",
+            tone=["dark"],
+            audience="adult",
+            themes=["betrayal"],
+        )
+    assert "genre" in str(exc_info.value)
+
+
+def test_dream_artifact_invalid_empty_tone() -> None:
+    """Empty tone list should fail validation."""
+    with pytest.raises(ValidationError) as exc_info:
+        DreamArtifact(
+            genre="mystery",
+            tone=[],
+            audience="adult",
+            themes=["betrayal"],
+        )
+    assert "tone" in str(exc_info.value)
+
+
+def test_dream_artifact_invalid_audience() -> None:
+    """Invalid audience value should fail validation."""
+    with pytest.raises(ValidationError) as exc_info:
+        DreamArtifact(
+            genre="mystery",
+            tone=["dark"],
+            audience="invalid",  # type: ignore[arg-type]
+            themes=["betrayal"],
+        )
+    assert "audience" in str(exc_info.value)
+
+
+def test_dream_artifact_invalid_empty_themes() -> None:
+    """Empty themes list should fail validation."""
+    with pytest.raises(ValidationError) as exc_info:
+        DreamArtifact(
+            genre="mystery",
+            tone=["dark"],
+            audience="adult",
+            themes=[],
+        )
+    assert "themes" in str(exc_info.value)
+
+
+def test_scope_invalid_word_count() -> None:
+    """Word count below minimum should fail."""
+    with pytest.raises(ValidationError) as exc_info:
+        Scope(
+            target_word_count=500,  # Below 1000 minimum
+            estimated_passages=10,
+        )
+    assert "target_word_count" in str(exc_info.value)
+
+
+def test_scope_invalid_branching_depth() -> None:
+    """Invalid branching depth should fail."""
+    with pytest.raises(ValidationError) as exc_info:
+        Scope(
+            target_word_count=10000,
+            estimated_passages=10,
+            branching_depth="extreme",  # type: ignore[arg-type]
+        )
+    assert "branching_depth" in str(exc_info.value)
+
+
+# --- ArtifactWriter Tests ---
+
+
+def test_writer_creates_artifact_file(tmp_path: Path) -> None:
+    """Writer creates artifact YAML file."""
+    writer = ArtifactWriter(tmp_path)
+    artifact = DreamArtifact(
+        genre="mystery",
+        tone=["dark"],
+        audience="adult",
+        themes=["betrayal"],
+    )
+
+    path = writer.write(artifact, "dream")
+
+    assert path.exists()
+    assert path == tmp_path / "artifacts" / "dream.yaml"
+
+
+def test_writer_creates_artifacts_directory(tmp_path: Path) -> None:
+    """Writer creates artifacts directory if missing."""
+    writer = ArtifactWriter(tmp_path)
+    artifact = DreamArtifact(
+        genre="mystery",
+        tone=["dark"],
+        audience="adult",
+        themes=["betrayal"],
+    )
+
+    writer.write(artifact, "dream")
+
+    assert (tmp_path / "artifacts").is_dir()
+
+
+def test_writer_writes_dict(tmp_path: Path) -> None:
+    """Writer can write raw dictionaries."""
+    writer = ArtifactWriter(tmp_path)
+    data = {
+        "type": "dream",
+        "version": 1,
+        "genre": "mystery",
+        "tone": ["dark"],
+        "audience": "adult",
+        "themes": ["betrayal"],
+    }
+
+    path = writer.write(data, "dream")
+
+    assert path.exists()
+
+
+def test_writer_excludes_none_values(tmp_path: Path) -> None:
+    """Writer excludes None values from output."""
+    writer = ArtifactWriter(tmp_path)
+    artifact = DreamArtifact(
+        genre="mystery",
+        tone=["dark"],
+        audience="adult",
+        themes=["betrayal"],
+        subgenre=None,  # Should not appear in output
+    )
+
+    path = writer.write(artifact, "dream")
+    content = path.read_text()
+
+    assert "subgenre" not in content
+
+
+# --- ArtifactReader Tests ---
+
+
+def test_reader_reads_artifact(tmp_path: Path) -> None:
+    """Reader reads artifact from YAML file."""
+    # Write first
+    writer = ArtifactWriter(tmp_path)
+    artifact = DreamArtifact(
+        genre="mystery",
+        tone=["dark"],
+        audience="adult",
+        themes=["betrayal"],
+    )
+    writer.write(artifact, "dream")
+
+    # Read back
+    reader = ArtifactReader(tmp_path)
+    data = reader.read("dream")
+
+    assert data["genre"] == "mystery"
+    assert data["tone"] == ["dark"]
+
+
+def test_reader_read_validated(tmp_path: Path) -> None:
+    """Reader validates against Pydantic model."""
+    # Write first
+    writer = ArtifactWriter(tmp_path)
+    artifact = DreamArtifact(
+        genre="mystery",
+        subgenre="noir",
+        tone=["dark", "atmospheric"],
+        audience="adult",
+        themes=["betrayal"],
+    )
+    writer.write(artifact, "dream")
+
+    # Read validated
+    reader = ArtifactReader(tmp_path)
+    loaded = reader.read_validated("dream", DreamArtifact)
+
+    assert isinstance(loaded, DreamArtifact)
+    assert loaded.genre == "mystery"
+    assert loaded.subgenre == "noir"
+
+
+def test_reader_not_found(tmp_path: Path) -> None:
+    """Reader raises error for missing artifact."""
+    reader = ArtifactReader(tmp_path)
+
+    with pytest.raises(ArtifactNotFoundError) as exc_info:
+        reader.read("nonexistent")
+
+    assert exc_info.value.stage_name == "nonexistent"
+
+
+def test_reader_exists(tmp_path: Path) -> None:
+    """Reader checks artifact existence."""
+    writer = ArtifactWriter(tmp_path)
+    artifact = DreamArtifact(
+        genre="mystery",
+        tone=["dark"],
+        audience="adult",
+        themes=["betrayal"],
+    )
+    writer.write(artifact, "dream")
+
+    reader = ArtifactReader(tmp_path)
+
+    assert reader.exists("dream")
+    assert not reader.exists("nonexistent")
+
+
+# --- ArtifactValidator Tests ---
+
+
+def test_validator_valid_data() -> None:
+    """Validator accepts valid data."""
+    validator = ArtifactValidator()
+    data = {
+        "type": "dream",
+        "version": 1,
+        "genre": "mystery",
+        "tone": ["dark"],
+        "audience": "adult",
+        "themes": ["betrayal"],
+    }
+
+    errors = validator.validate(data, "dream")
+
+    assert errors == []
+
+
+def test_validator_is_valid() -> None:
+    """is_valid returns boolean."""
+    validator = ArtifactValidator()
+    valid_data = {
+        "type": "dream",
+        "version": 1,
+        "genre": "mystery",
+        "tone": ["dark"],
+        "audience": "adult",
+        "themes": ["betrayal"],
+    }
+    invalid_data = {
+        "type": "dream",
+        "version": 1,
+        "genre": "mystery",
+        "tone": [],  # Invalid: empty
+        "audience": "adult",
+        "themes": ["betrayal"],
+    }
+
+    assert validator.is_valid(valid_data, "dream")
+    assert not validator.is_valid(invalid_data, "dream")
+
+
+def test_validator_invalid_data_pydantic() -> None:
+    """Validator catches Pydantic validation errors."""
+    validator = ArtifactValidator()
+    data = {
+        "type": "dream",
+        "version": 1,
+        "genre": "mystery",
+        "tone": [],  # Invalid: must have at least 1
+        "audience": "adult",
+        "themes": ["betrayal"],
+    }
+
+    errors = validator.validate(data, "dream")
+
+    assert len(errors) > 0
+    assert any("tone" in e for e in errors)
+
+
+def test_validator_invalid_data_schema() -> None:
+    """Validator catches JSON Schema validation errors."""
+    validator = ArtifactValidator()
+    data = {
+        "type": "dream",
+        "version": 1,
+        "genre": "mystery",
+        "tone": ["dark"],
+        "audience": "invalid_audience",  # Invalid enum value
+        "themes": ["betrayal"],
+    }
+
+    errors = validator.validate(data, "dream")
+
+    assert len(errors) > 0
+
+
+def test_validator_raise_on_error() -> None:
+    """Validator raises exception when requested."""
+    validator = ArtifactValidator()
+    data = {
+        "type": "dream",
+        "version": 1,
+        "genre": "mystery",
+        "tone": [],
+        "audience": "adult",
+        "themes": ["betrayal"],
+    }
+
+    with pytest.raises(ArtifactValidationError) as exc_info:
+        validator.validate(data, "dream", raise_on_error=True)
+
+    assert exc_info.value.stage_name == "dream"
+    assert len(exc_info.value.errors) > 0
+
+
+def test_validator_missing_schema_graceful() -> None:
+    """Validator handles missing schema gracefully."""
+    validator = ArtifactValidator()
+    data = {"type": "unknown", "version": 1}
+
+    # Should not raise, just skip JSON Schema validation
+    errors = validator.validate(data, "unknown_stage")
+
+    # Only Pydantic errors (no model for unknown_stage)
+    assert errors == []
+
+
+# --- Round-trip Tests ---
+
+
+def test_roundtrip_preserves_data(tmp_path: Path) -> None:
+    """Writing then reading preserves all data."""
+    original = DreamArtifact(
+        genre="mystery",
+        subgenre="noir",
+        tone=["dark", "atmospheric", "melancholic"],
+        audience="adult",
+        themes=["betrayal", "redemption"],
+        style_notes="Hard-boiled narration in first person.",
+        scope=Scope(
+            target_word_count=15000,
+            estimated_passages=40,
+            branching_depth="moderate",
+        ),
+    )
+
+    writer = ArtifactWriter(tmp_path)
+    writer.write(original, "dream")
+
+    reader = ArtifactReader(tmp_path)
+    loaded = reader.read_validated("dream", DreamArtifact)
+
+    assert loaded.genre == original.genre
+    assert loaded.subgenre == original.subgenre
+    assert loaded.tone == original.tone
+    assert loaded.audience == original.audience
+    assert loaded.themes == original.themes
+    assert loaded.style_notes == original.style_notes
+    assert loaded.scope is not None
+    assert loaded.scope.target_word_count == original.scope.target_word_count

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -1,0 +1,30 @@
+"""Test CLI commands."""
+
+from typer.testing import CliRunner
+
+from questfoundry import __version__
+from questfoundry.cli import app
+
+runner = CliRunner()
+
+
+def test_version_command() -> None:
+    """Test qf version command."""
+    result = runner.invoke(app, ["version"])
+    assert result.exit_code == 0
+    assert f"v{__version__}" in result.stdout
+
+
+def test_status_command() -> None:
+    """Test qf status command (stub)."""
+    result = runner.invoke(app, ["status"])
+    assert result.exit_code == 0
+    assert "Not implemented" in result.stdout
+
+
+def test_no_args_shows_help() -> None:
+    """Test that no arguments shows help."""
+    result = runner.invoke(app, [])
+    # Typer returns exit code 0 for --help, but 2 for no_args_is_help
+    # The important thing is that help text is shown
+    assert "QuestFoundry" in result.stdout

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -25,6 +25,6 @@ def test_status_command() -> None:
 def test_no_args_shows_help() -> None:
     """Test that no arguments shows help."""
     result = runner.invoke(app, [])
-    # Typer returns exit code 0 for --help, but 2 for no_args_is_help
-    # The important thing is that help text is shown
+    # no_args_is_help=True returns exit code 2 (not 0 like --help)
+    assert result.exit_code == 2
     assert "QuestFoundry" in result.stdout

--- a/tests/unit/test_orchestrator.py
+++ b/tests/unit/test_orchestrator.py
@@ -1,0 +1,316 @@
+"""Tests for pipeline orchestrator."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from questfoundry.pipeline import (
+    AutoApproveGate,
+    PipelineOrchestrator,
+    ProjectConfig,
+    RequireSuccessGate,
+    StageNotFoundError,
+    StageResult,
+    create_default_config,
+    load_project_config,
+)
+from questfoundry.pipeline.config import ProjectConfigError
+from questfoundry.pipeline.stages import get_stage, list_stages, register_stage
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+# --- ProjectConfig Tests ---
+
+
+def test_create_default_config() -> None:
+    """create_default_config returns config with defaults."""
+    config = create_default_config("test_project")
+
+    assert config.name == "test_project"
+    assert config.version == 1
+    assert config.provider.name == "ollama"
+    assert config.provider.model == "qwen3:8b"
+    assert "dream" in config.stages
+
+
+def test_config_from_dict_minimal() -> None:
+    """ProjectConfig.from_dict handles minimal config."""
+    data = {"name": "minimal"}
+    config = ProjectConfig.from_dict(data)
+
+    assert config.name == "minimal"
+    assert config.provider.name == "ollama"
+
+
+def test_config_from_dict_full() -> None:
+    """ProjectConfig.from_dict parses full config."""
+    data = {
+        "name": "full",
+        "version": 2,
+        "pipeline": {
+            "stages": ["dream", "seed"],
+            "gates": {
+                "dream": "optional",
+                "seed": "required",
+            },
+        },
+        "providers": {
+            "default": "openai/gpt-4o",
+        },
+    }
+    config = ProjectConfig.from_dict(data)
+
+    assert config.name == "full"
+    assert config.version == 2
+    assert config.provider.name == "openai"
+    assert config.provider.model == "gpt-4o"
+    assert config.stages == ["dream", "seed"]
+    assert len(config.gates) == 2
+    assert any(g.stage == "seed" and g.required for g in config.gates)
+
+
+def test_load_project_config(tmp_path: Path) -> None:
+    """load_project_config loads from project.yaml."""
+    config_file = tmp_path / "project.yaml"
+    config_file.write_text(
+        """
+name: loaded
+version: 1
+providers:
+  default: ollama/llama3
+"""
+    )
+
+    config = load_project_config(tmp_path)
+
+    assert config.name == "loaded"
+    assert config.provider.model == "llama3"
+
+
+def test_load_project_config_not_found(tmp_path: Path) -> None:
+    """load_project_config raises error for missing file."""
+    with pytest.raises(ProjectConfigError) as exc_info:
+        load_project_config(tmp_path)
+
+    assert "File not found" in str(exc_info.value)
+
+
+# --- Gate Tests ---
+
+
+@pytest.mark.asyncio
+async def test_auto_approve_gate() -> None:
+    """AutoApproveGate always approves."""
+    gate = AutoApproveGate()
+    result = StageResult(stage="test", status="completed")
+
+    decision = await gate.on_stage_complete("test", result)
+
+    assert decision == "approve"
+
+
+@pytest.mark.asyncio
+async def test_require_success_gate_approves_success() -> None:
+    """RequireSuccessGate approves stages without errors."""
+    gate = RequireSuccessGate()
+    result = StageResult(stage="test", status="completed", errors=[])
+
+    decision = await gate.on_stage_complete("test", result)
+
+    assert decision == "approve"
+
+
+@pytest.mark.asyncio
+async def test_require_success_gate_rejects_errors() -> None:
+    """RequireSuccessGate rejects stages with errors."""
+    gate = RequireSuccessGate()
+    result = StageResult(stage="test", status="completed", errors=["Something went wrong"])
+
+    decision = await gate.on_stage_complete("test", result)
+
+    assert decision == "reject"
+
+
+# --- Stage Registry Tests ---
+
+
+def test_register_and_get_stage() -> None:
+    """Stages can be registered and retrieved."""
+    # Create a mock stage
+    mock_stage = MagicMock()
+    mock_stage.name = "test_stage"
+
+    register_stage(mock_stage)
+
+    assert get_stage("test_stage") is mock_stage
+
+
+def test_get_stage_not_found() -> None:
+    """get_stage returns None for unknown stages."""
+    assert get_stage("nonexistent_stage") is None
+
+
+def test_list_stages() -> None:
+    """list_stages returns registered stage names."""
+    # Register a stage for the test
+    mock_stage = MagicMock()
+    mock_stage.name = "listed_stage"
+    register_stage(mock_stage)
+
+    stages = list_stages()
+
+    assert "listed_stage" in stages
+
+
+# --- PipelineOrchestrator Tests ---
+
+
+def test_orchestrator_initialization(tmp_path: Path) -> None:
+    """Orchestrator initializes without project.yaml."""
+    orchestrator = PipelineOrchestrator(tmp_path)
+
+    assert orchestrator.config.name == "unnamed"
+
+
+def test_orchestrator_with_config(tmp_path: Path) -> None:
+    """Orchestrator loads project configuration."""
+    config_file = tmp_path / "project.yaml"
+    config_file.write_text(
+        """
+name: test_project
+providers:
+  default: ollama/qwen3:8b
+"""
+    )
+
+    orchestrator = PipelineOrchestrator(tmp_path)
+
+    assert orchestrator.config.name == "test_project"
+
+
+@pytest.mark.asyncio
+async def test_orchestrator_run_stage_not_found(tmp_path: Path) -> None:
+    """Orchestrator raises error for unknown stage."""
+    orchestrator = PipelineOrchestrator(tmp_path)
+
+    with pytest.raises(StageNotFoundError):
+        await orchestrator.run_stage("nonexistent")
+
+
+@pytest.mark.asyncio
+async def test_orchestrator_run_stage_with_mock(tmp_path: Path) -> None:
+    """Orchestrator executes stage with mocked components."""
+    # Register a mock stage
+    mock_stage = MagicMock()
+    mock_stage.name = "mock"
+    mock_stage.execute = AsyncMock(
+        return_value=(
+            {"type": "mock", "version": 1},
+            1,
+            100,
+        )
+    )
+    register_stage(mock_stage)
+
+    orchestrator = PipelineOrchestrator(tmp_path)
+
+    # Run stage
+    result = await orchestrator.run_stage("mock", {"test": "context"})
+
+    assert result.stage == "mock"
+    assert result.llm_calls == 1
+    assert result.tokens_used == 100
+    assert result.artifact_path is not None
+    assert result.artifact_path.exists()
+
+
+@pytest.mark.asyncio
+async def test_orchestrator_run_stage_with_errors(tmp_path: Path) -> None:
+    """Orchestrator handles stage execution errors."""
+    # Register a stage that raises an error
+    mock_stage = MagicMock()
+    mock_stage.name = "failing"
+    mock_stage.execute = AsyncMock(side_effect=RuntimeError("Stage failed"))
+    register_stage(mock_stage)
+
+    orchestrator = PipelineOrchestrator(tmp_path)
+
+    result = await orchestrator.run_stage("failing")
+
+    assert result.stage == "failing"
+    assert result.status == "failed"
+    assert "Stage failed" in result.errors[0]
+
+
+def test_orchestrator_get_status(tmp_path: Path) -> None:
+    """Orchestrator reports pipeline status."""
+    # Create project.yaml
+    config_file = tmp_path / "project.yaml"
+    config_file.write_text(
+        """
+name: status_test
+pipeline:
+  stages:
+    - dream
+    - seed
+"""
+    )
+
+    # Create one artifact
+    artifacts_dir = tmp_path / "artifacts"
+    artifacts_dir.mkdir()
+    (artifacts_dir / "dream.yaml").write_text("type: dream\nversion: 1")
+
+    orchestrator = PipelineOrchestrator(tmp_path)
+    status = orchestrator.get_status()
+
+    assert status.project_name == "status_test"
+    assert status.stages["dream"].status == "completed"
+    assert status.stages["dream"].artifact_path is not None
+    assert status.stages["seed"].status == "pending"
+    assert status.stages["seed"].artifact_path is None
+
+
+@pytest.mark.asyncio
+async def test_orchestrator_gate_rejection(tmp_path: Path) -> None:
+    """Orchestrator respects gate rejection."""
+    # Register mock stage
+    mock_stage = MagicMock()
+    mock_stage.name = "gated"
+    mock_stage.execute = AsyncMock(
+        return_value=(
+            {"type": "gated", "version": 1},
+            1,
+            50,
+        )
+    )
+    register_stage(mock_stage)
+
+    # Create rejecting gate
+    class RejectGate:
+        async def on_stage_complete(self, _stage: str, _result: StageResult) -> str:
+            return "reject"
+
+    orchestrator = PipelineOrchestrator(tmp_path, gate=RejectGate())
+    result = await orchestrator.run_stage("gated")
+
+    assert result.status == "pending_review"
+
+
+@pytest.mark.asyncio
+async def test_orchestrator_close(tmp_path: Path) -> None:
+    """Orchestrator closes provider on close."""
+    orchestrator = PipelineOrchestrator(tmp_path)
+
+    # Initialize provider
+    _ = orchestrator._get_provider()
+
+    # Close orchestrator
+    await orchestrator.close()
+
+    assert orchestrator._provider is None

--- a/tests/unit/test_prompt_compiler.py
+++ b/tests/unit/test_prompt_compiler.py
@@ -1,0 +1,330 @@
+"""Tests for prompt compiler and loader."""
+
+from pathlib import Path
+
+import pytest
+
+from questfoundry.prompts import (
+    BudgetExceededError,
+    CompiledPrompt,
+    PromptCompileError,
+    PromptCompiler,
+    PromptLoader,
+    PromptTemplate,
+    TemplateNotFoundError,
+)
+
+# --- PromptTemplate Tests ---
+
+
+def test_prompt_template_from_dict() -> None:
+    """PromptTemplate created from dictionary."""
+    data = {
+        "name": "test",
+        "description": "A test template",
+        "system": "You are a helper.",
+        "user": "Help me with {{ task }}.",
+        "components": ["role", "output"],
+    }
+    template = PromptTemplate.from_dict(data, "test")
+
+    assert template.name == "test"
+    assert template.description == "A test template"
+    assert "helper" in template.system
+    assert "{{ task }}" in template.user
+    assert template.components == ["role", "output"]
+
+
+def test_prompt_template_defaults() -> None:
+    """PromptTemplate uses defaults for missing fields."""
+    template = PromptTemplate.from_dict({}, "minimal")
+
+    assert template.name == "minimal"
+    assert template.description == ""
+    assert template.system == ""
+    assert template.user == ""
+    assert template.components == []
+
+
+# --- PromptLoader Tests ---
+
+
+def test_loader_load_template(tmp_path: Path) -> None:
+    """PromptLoader loads a template from disk."""
+    templates_dir = tmp_path / "templates"
+    templates_dir.mkdir()
+
+    template_file = templates_dir / "test.yaml"
+    template_file.write_text(
+        """
+name: test
+description: Test template
+system: System prompt
+user: User prompt
+"""
+    )
+
+    loader = PromptLoader(tmp_path)
+    template = loader.load("test")
+
+    assert template.name == "test"
+    assert template.system == "System prompt"
+    assert template.user == "User prompt"
+
+
+def test_loader_not_found(tmp_path: Path) -> None:
+    """PromptLoader raises error for missing template."""
+    loader = PromptLoader(tmp_path)
+
+    with pytest.raises(TemplateNotFoundError) as exc_info:
+        loader.load("nonexistent")
+
+    assert exc_info.value.template_name == "nonexistent"
+
+
+def test_loader_exists(tmp_path: Path) -> None:
+    """PromptLoader checks template existence."""
+    templates_dir = tmp_path / "templates"
+    templates_dir.mkdir()
+    (templates_dir / "exists.yaml").write_text("name: exists")
+
+    loader = PromptLoader(tmp_path)
+
+    assert loader.exists("exists")
+    assert not loader.exists("missing")
+
+
+def test_loader_list_templates(tmp_path: Path) -> None:
+    """PromptLoader lists available templates."""
+    templates_dir = tmp_path / "templates"
+    templates_dir.mkdir()
+    (templates_dir / "one.yaml").write_text("name: one")
+    (templates_dir / "two.yaml").write_text("name: two")
+    (templates_dir / "not_yaml.txt").write_text("ignore me")
+
+    loader = PromptLoader(tmp_path)
+    templates = loader.list_templates()
+
+    assert templates == ["one", "two"]
+
+
+def test_loader_caches_templates(tmp_path: Path) -> None:
+    """PromptLoader caches loaded templates."""
+    templates_dir = tmp_path / "templates"
+    templates_dir.mkdir()
+    (templates_dir / "cached.yaml").write_text("name: cached\nuser: original")
+
+    loader = PromptLoader(tmp_path)
+
+    # Load template
+    template1 = loader.load("cached")
+    assert template1.user == "original"
+
+    # Modify file (shouldn't affect cached version)
+    (templates_dir / "cached.yaml").write_text("name: cached\nuser: modified")
+
+    # Should still return cached version
+    template2 = loader.load("cached")
+    assert template2.user == "original"
+    assert template1 is template2  # Same object
+
+    # Clear cache and reload
+    loader.clear_cache()
+    template3 = loader.load("cached")
+    assert template3.user == "modified"
+
+
+# --- PromptCompiler Tests ---
+
+
+def test_compiler_compile_simple(tmp_path: Path) -> None:
+    """PromptCompiler compiles a simple template."""
+    templates_dir = tmp_path / "templates"
+    templates_dir.mkdir()
+    (templates_dir / "simple.yaml").write_text(
+        """
+name: simple
+system: You are a helper.
+user: Help me.
+"""
+    )
+
+    compiler = PromptCompiler(tmp_path)
+    prompt = compiler.compile("simple")
+
+    assert isinstance(prompt, CompiledPrompt)
+    assert prompt.system == "You are a helper."
+    assert prompt.user == "Help me."
+    assert prompt.template_name == "simple"
+    assert prompt.token_count > 0
+
+
+def test_compiler_variable_substitution(tmp_path: Path) -> None:
+    """PromptCompiler substitutes {{ variables }}."""
+    templates_dir = tmp_path / "templates"
+    templates_dir.mkdir()
+    (templates_dir / "vars.yaml").write_text(
+        """
+name: vars
+system: You are a {{ role }}.
+user: Help me with {{ task }}.
+"""
+    )
+
+    compiler = PromptCompiler(tmp_path)
+    context = {"role": "teacher", "task": "math homework"}
+    prompt = compiler.compile("vars", context)
+
+    assert prompt.system == "You are a teacher."
+    assert prompt.user == "Help me with math homework."
+
+
+def test_compiler_nested_variable(tmp_path: Path) -> None:
+    """PromptCompiler resolves nested variables like {{ dream.genre }}."""
+    templates_dir = tmp_path / "templates"
+    templates_dir.mkdir()
+    (templates_dir / "nested.yaml").write_text(
+        """
+name: nested
+system: Genre is {{ dream.genre }}.
+user: Themes are {{ dream.themes }}.
+"""
+    )
+
+    compiler = PromptCompiler(tmp_path)
+    context = {
+        "dream": {
+            "genre": "mystery",
+            "themes": ["betrayal", "redemption"],
+        }
+    }
+    prompt = compiler.compile("nested", context)
+
+    assert prompt.system == "Genre is mystery."
+    assert "betrayal" in prompt.user
+    assert "redemption" in prompt.user
+
+
+def test_compiler_missing_variable_unchanged(tmp_path: Path) -> None:
+    """PromptCompiler leaves unresolved variables unchanged."""
+    templates_dir = tmp_path / "templates"
+    templates_dir.mkdir()
+    (templates_dir / "missing.yaml").write_text(
+        """
+name: missing
+system: Hello {{ name }}.
+user: Value is {{ undefined }}.
+"""
+    )
+
+    compiler = PromptCompiler(tmp_path)
+    context = {"name": "World"}
+    prompt = compiler.compile("missing", context)
+
+    assert prompt.system == "Hello World."
+    assert prompt.user == "Value is {{ undefined }}."
+
+
+def test_compiler_template_not_found(tmp_path: Path) -> None:
+    """PromptCompiler raises error for missing template."""
+    compiler = PromptCompiler(tmp_path)
+
+    with pytest.raises(PromptCompileError) as exc_info:
+        compiler.compile("nonexistent")
+
+    assert exc_info.value.template_name == "nonexistent"
+
+
+def test_compiler_budget_exceeded(tmp_path: Path) -> None:
+    """PromptCompiler raises error when budget exceeded."""
+    templates_dir = tmp_path / "templates"
+    templates_dir.mkdir()
+
+    # Create a template with lots of text
+    long_content = "word " * 1000  # ~1000 tokens
+    (templates_dir / "long.yaml").write_text(
+        f"""
+name: long
+system: |
+  {long_content}
+user: |
+  {long_content}
+"""
+    )
+
+    compiler = PromptCompiler(tmp_path, token_budget=100)
+
+    with pytest.raises(BudgetExceededError) as exc_info:
+        compiler.compile("long")
+
+    assert exc_info.value.budget == 100
+    assert exc_info.value.required > 100
+
+
+def test_compiler_estimate_tokens(tmp_path: Path) -> None:
+    """PromptCompiler estimates tokens."""
+    compiler = PromptCompiler(tmp_path)
+
+    # Short text
+    short = compiler.estimate_tokens("Hello world")
+    assert short > 0
+
+    # Longer text should have more tokens
+    long = compiler.estimate_tokens("Hello world " * 100)
+    assert long > short
+
+
+def test_compiler_list_templates(tmp_path: Path) -> None:
+    """PromptCompiler lists available templates."""
+    templates_dir = tmp_path / "templates"
+    templates_dir.mkdir()
+    (templates_dir / "alpha.yaml").write_text("name: alpha")
+    (templates_dir / "beta.yaml").write_text("name: beta")
+
+    compiler = PromptCompiler(tmp_path)
+    templates = compiler.list_templates()
+
+    assert templates == ["alpha", "beta"]
+
+
+# --- Integration with Project Templates ---
+
+
+def test_dream_template_exists() -> None:
+    """DREAM template exists in project prompts."""
+    project_root = Path(__file__).parent.parent.parent
+    prompts_path = project_root / "prompts"
+
+    compiler = PromptCompiler(prompts_path)
+    templates = compiler.list_templates()
+
+    assert "dream" in templates
+
+
+def test_dream_template_compiles() -> None:
+    """DREAM template compiles with context."""
+    project_root = Path(__file__).parent.parent.parent
+    prompts_path = project_root / "prompts"
+
+    compiler = PromptCompiler(prompts_path)
+    context = {"user_prompt": "A noir mystery in 1940s Los Angeles"}
+    prompt = compiler.compile("dream", context)
+
+    assert "creative director" in prompt.system.lower()
+    assert "noir mystery" in prompt.user
+    assert "1940s Los Angeles" in prompt.user
+    assert prompt.token_count > 0
+    assert prompt.template_name == "dream"
+
+
+def test_compiled_prompt_total_tokens() -> None:
+    """CompiledPrompt.total_tokens is alias for token_count."""
+    prompt = CompiledPrompt(
+        system="System",
+        user="User",
+        token_count=100,
+        template_name="test",
+    )
+
+    assert prompt.total_tokens == 100
+    assert prompt.total_tokens == prompt.token_count

--- a/tests/unit/test_providers.py
+++ b/tests/unit/test_providers.py
@@ -1,0 +1,331 @@
+"""Tests for LLM providers."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+
+from questfoundry.providers import (
+    LLMResponse,
+    Message,
+    OllamaProvider,
+    OpenAIProvider,
+    ProviderConnectionError,
+    ProviderError,
+    ProviderModelError,
+    ProviderRateLimitError,
+)
+
+# --- LLMResponse Tests ---
+
+
+def test_llm_response_is_complete_stop() -> None:
+    """Response with 'stop' finish reason is complete."""
+    response = LLMResponse(
+        content="Hello",
+        model="test",
+        tokens_used=10,
+        finish_reason="stop",
+    )
+    assert response.is_complete
+
+
+def test_llm_response_is_complete_end_turn() -> None:
+    """Response with 'end_turn' finish reason is complete."""
+    response = LLMResponse(
+        content="Hello",
+        model="test",
+        tokens_used=10,
+        finish_reason="end_turn",
+    )
+    assert response.is_complete
+
+
+def test_llm_response_not_complete_length() -> None:
+    """Response with 'length' finish reason is not complete."""
+    response = LLMResponse(
+        content="Hello",
+        model="test",
+        tokens_used=10,
+        finish_reason="length",
+    )
+    assert not response.is_complete
+
+
+# --- OllamaProvider Tests ---
+
+
+def test_ollama_default_host() -> None:
+    """OllamaProvider uses default host."""
+    with patch.dict("os.environ", {}, clear=True):
+        provider = OllamaProvider()
+        assert provider.host == "http://localhost:11434"
+
+
+def test_ollama_env_host() -> None:
+    """OllamaProvider uses OLLAMA_HOST env var."""
+    with patch.dict("os.environ", {"OLLAMA_HOST": "http://custom:8080"}):
+        provider = OllamaProvider()
+        assert provider.host == "http://custom:8080"
+
+
+def test_ollama_custom_host() -> None:
+    """OllamaProvider uses custom host parameter."""
+    provider = OllamaProvider(host="http://myhost:1234")
+    assert provider.host == "http://myhost:1234"
+
+
+def test_ollama_default_model() -> None:
+    """OllamaProvider has correct default model."""
+    provider = OllamaProvider()
+    assert provider.default_model == "qwen3:8b"
+
+
+def test_ollama_custom_model() -> None:
+    """OllamaProvider uses custom default model."""
+    provider = OllamaProvider(default_model="llama3:8b")
+    assert provider.default_model == "llama3:8b"
+
+
+@pytest.mark.asyncio
+async def test_ollama_complete_success() -> None:
+    """OllamaProvider successfully completes a request."""
+    provider = OllamaProvider()
+
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = {
+        "message": {"content": "Hello, world!"},
+        "eval_count": 10,
+        "prompt_eval_count": 5,
+        "done": True,
+        "done_reason": "stop",
+    }
+
+    with patch.object(provider._client, "post", new=AsyncMock(return_value=mock_response)):
+        messages: list[Message] = [{"role": "user", "content": "Hi"}]
+        result = await provider.complete(messages)
+
+        assert result.content == "Hello, world!"
+        assert result.model == "qwen3:8b"
+        assert result.tokens_used == 15
+        assert result.finish_reason == "stop"
+        assert result.is_complete
+
+
+@pytest.mark.asyncio
+async def test_ollama_complete_custom_model() -> None:
+    """OllamaProvider uses custom model when specified."""
+    provider = OllamaProvider()
+
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = {
+        "message": {"content": "Response"},
+        "done": True,
+        "done_reason": "stop",
+    }
+
+    with patch.object(
+        provider._client, "post", new=AsyncMock(return_value=mock_response)
+    ) as mock_post:
+        messages: list[Message] = [{"role": "user", "content": "Hi"}]
+        result = await provider.complete(messages, model="llama3:70b")
+
+        assert result.model == "llama3:70b"
+        # Verify the model was passed in the request
+        call_args = mock_post.call_args
+        assert call_args[1]["json"]["model"] == "llama3:70b"
+
+
+@pytest.mark.asyncio
+async def test_ollama_complete_connection_error() -> None:
+    """OllamaProvider raises ProviderConnectionError on connection failure."""
+    provider = OllamaProvider()
+
+    with patch.object(
+        provider._client, "post", new=AsyncMock(side_effect=httpx.ConnectError("Failed"))
+    ):
+        messages: list[Message] = [{"role": "user", "content": "Hi"}]
+        with pytest.raises(ProviderConnectionError) as exc_info:
+            await provider.complete(messages)
+
+        assert exc_info.value.provider == "ollama"
+        assert "Failed to connect" in str(exc_info.value)
+
+
+@pytest.mark.asyncio
+async def test_ollama_complete_timeout() -> None:
+    """OllamaProvider raises ProviderConnectionError on timeout."""
+    provider = OllamaProvider()
+
+    with patch.object(
+        provider._client, "post", new=AsyncMock(side_effect=httpx.TimeoutException("Timeout"))
+    ):
+        messages: list[Message] = [{"role": "user", "content": "Hi"}]
+        with pytest.raises(ProviderConnectionError) as exc_info:
+            await provider.complete(messages)
+
+        assert "timed out" in str(exc_info.value)
+
+
+@pytest.mark.asyncio
+async def test_ollama_complete_model_not_found() -> None:
+    """OllamaProvider raises ProviderModelError when model not found."""
+    provider = OllamaProvider()
+
+    mock_response = MagicMock()
+    mock_response.status_code = 404
+    mock_response.text = "model not found"
+
+    with patch.object(provider._client, "post", new=AsyncMock(return_value=mock_response)):
+        messages: list[Message] = [{"role": "user", "content": "Hi"}]
+        with pytest.raises(ProviderModelError) as exc_info:
+            await provider.complete(messages, model="nonexistent")
+
+        assert "not found" in str(exc_info.value)
+
+
+@pytest.mark.asyncio
+async def test_ollama_complete_api_error() -> None:
+    """OllamaProvider raises ProviderError on API error."""
+    provider = OllamaProvider()
+
+    mock_response = MagicMock()
+    mock_response.status_code = 500
+    mock_response.text = "Internal Server Error"
+
+    with patch.object(provider._client, "post", new=AsyncMock(return_value=mock_response)):
+        messages: list[Message] = [{"role": "user", "content": "Hi"}]
+        with pytest.raises(ProviderError) as exc_info:
+            await provider.complete(messages)
+
+        assert "status 500" in str(exc_info.value)
+
+
+@pytest.mark.asyncio
+async def test_ollama_context_manager() -> None:
+    """OllamaProvider works as async context manager."""
+    async with OllamaProvider() as provider:
+        assert provider.default_model == "qwen3:8b"
+
+
+@pytest.mark.asyncio
+async def test_ollama_list_models() -> None:
+    """OllamaProvider lists available models."""
+    provider = OllamaProvider()
+
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = {
+        "models": [
+            {"name": "llama3:8b"},
+            {"name": "qwen3:8b"},
+            {"name": "mistral:7b"},
+        ]
+    }
+
+    with patch.object(provider._client, "get", new=AsyncMock(return_value=mock_response)):
+        models = await provider.list_models()
+
+        assert "llama3:8b" in models
+        assert "qwen3:8b" in models
+        assert len(models) == 3
+
+
+# --- OpenAIProvider Tests ---
+
+
+def test_openai_requires_api_key() -> None:
+    """OpenAIProvider raises error without API key."""
+    with patch.dict("os.environ", {}, clear=True):
+        with pytest.raises(ProviderError) as exc_info:
+            OpenAIProvider()
+
+        assert "API key required" in str(exc_info.value)
+
+
+def test_openai_uses_env_key() -> None:
+    """OpenAIProvider uses OPENAI_API_KEY env var."""
+    with patch.dict("os.environ", {"OPENAI_API_KEY": "test-key"}):
+        provider = OpenAIProvider()
+        assert provider.default_model == "gpt-4o-mini"
+
+
+def test_openai_custom_model() -> None:
+    """OpenAIProvider uses custom default model."""
+    with patch.dict("os.environ", {"OPENAI_API_KEY": "test-key"}):
+        provider = OpenAIProvider(default_model="gpt-4o")
+        assert provider.default_model == "gpt-4o"
+
+
+@pytest.mark.asyncio
+async def test_openai_complete_success() -> None:
+    """OpenAIProvider successfully completes a request."""
+    with patch.dict("os.environ", {"OPENAI_API_KEY": "test-key"}):
+        provider = OpenAIProvider()
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "choices": [
+                {
+                    "message": {"content": "Hello from GPT!"},
+                    "finish_reason": "stop",
+                }
+            ],
+            "usage": {"total_tokens": 25},
+        }
+
+        with patch.object(provider._client, "post", new=AsyncMock(return_value=mock_response)):
+            messages: list[Message] = [{"role": "user", "content": "Hi"}]
+            result = await provider.complete(messages)
+
+            assert result.content == "Hello from GPT!"
+            assert result.model == "gpt-4o-mini"
+            assert result.tokens_used == 25
+            assert result.finish_reason == "stop"
+
+
+@pytest.mark.asyncio
+async def test_openai_complete_rate_limit() -> None:
+    """OpenAIProvider raises ProviderRateLimitError on 429."""
+    with patch.dict("os.environ", {"OPENAI_API_KEY": "test-key"}):
+        provider = OpenAIProvider()
+
+        mock_response = MagicMock()
+        mock_response.status_code = 429
+        mock_response.text = "Rate limit exceeded"
+
+        with patch.object(provider._client, "post", new=AsyncMock(return_value=mock_response)):
+            messages: list[Message] = [{"role": "user", "content": "Hi"}]
+            with pytest.raises(ProviderRateLimitError):
+                await provider.complete(messages)
+
+
+@pytest.mark.asyncio
+async def test_openai_complete_auth_error() -> None:
+    """OpenAIProvider raises ProviderError on 401."""
+    with patch.dict("os.environ", {"OPENAI_API_KEY": "invalid-key"}):
+        provider = OpenAIProvider()
+
+        mock_response = MagicMock()
+        mock_response.status_code = 401
+        mock_response.text = "Invalid API key"
+
+        with patch.object(provider._client, "post", new=AsyncMock(return_value=mock_response)):
+            messages: list[Message] = [{"role": "user", "content": "Hi"}]
+            with pytest.raises(ProviderError) as exc_info:
+                await provider.complete(messages)
+
+            assert "Invalid API key" in str(exc_info.value)
+
+
+@pytest.mark.asyncio
+async def test_openai_context_manager() -> None:
+    """OpenAIProvider works as async context manager."""
+    with patch.dict("os.environ", {"OPENAI_API_KEY": "test-key"}):
+        async with OpenAIProvider() as provider:
+            assert provider.default_model == "gpt-4o-mini"

--- a/tests/unit/test_version.py
+++ b/tests/unit/test_version.py
@@ -16,7 +16,7 @@ def test_version_matches_pyproject() -> None:
     from pathlib import Path
 
     pyproject_path = Path(__file__).parent.parent.parent / "pyproject.toml"
-    with open(pyproject_path, "rb") as f:
+    with pyproject_path.open("rb") as f:
         pyproject = tomllib.load(f)
 
     assert __version__ == pyproject["project"]["version"]

--- a/uv.lock
+++ b/uv.lock
@@ -938,6 +938,7 @@ dev = [
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
     { name = "ruff" },
+    { name = "types-jsonschema" },
 ]
 ollama = [
     { name = "ollama" },
@@ -972,6 +973,7 @@ requires-dist = [
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.6" },
     { name = "tiktoken", specifier = ">=0.5" },
     { name = "typer", specifier = ">=0.12" },
+    { name = "types-jsonschema", marker = "extra == 'dev'", specifier = ">=4.0" },
 ]
 provides-extras = ["ollama", "openai", "all-providers", "dev", "viz"]
 
@@ -1407,6 +1409,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/85/30/ff9ede605e3bd086b4dd842499814e128500621f7951ca1e5ce84bbf61b1/typer-0.21.0.tar.gz", hash = "sha256:c87c0d2b6eee3b49c5c64649ec92425492c14488096dfbc8a0c2799b2f6f9c53", size = 106781, upload-time = "2025-12-25T09:54:53.651Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e1/e4/5ebc1899d31d2b1601b32d21cfb4bba022ae6fce323d365f0448031b1660/typer-0.21.0-py3-none-any.whl", hash = "sha256:c79c01ca6b30af9fd48284058a7056ba0d3bf5cf10d0ff3d0c5b11b68c258ac6", size = 47109, upload-time = "2025-12-25T09:54:51.918Z" },
+]
+
+[[package]]
+name = "types-jsonschema"
+version = "4.25.1.20251009"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "referencing" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ef/da/5b901088da5f710690b422137e8ae74197fb1ca471e4aa84dd3ef0d6e295/types_jsonschema-4.25.1.20251009.tar.gz", hash = "sha256:75d0f5c5dd18dc23b664437a0c1a625743e8d2e665ceaf3aecb29841f3a5f97f", size = 15661, upload-time = "2025-10-09T02:54:36.963Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7f/6a/e5146754c0dfc272f176db9c245bc43cc19030262d891a5a85d472797e60/types_jsonschema-4.25.1.20251009-py3-none-any.whl", hash = "sha256:f30b329037b78e7a60146b1146feb0b6fb0b71628637584409bada83968dad3e", size = 15925, upload-time = "2025-10-09T02:54:35.847Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Implements `PipelineOrchestrator` for stage execution with lazy provider initialization
- Adds `GateHook` protocol with `AutoApproveGate` and `RequireSuccessGate` implementations
- Creates `ProjectConfig` loading from `project.yaml` with sensible defaults
- Establishes `Stage` protocol and registry for pluggable stage implementations
- Provides `StageResult` and `PipelineStatus` dataclasses for execution tracking

## Test plan
- [x] Unit tests for ProjectConfig parsing (5 tests)
- [x] Unit tests for gate hooks (3 tests)
- [x] Unit tests for stage registry (3 tests)  
- [x] Unit tests for orchestrator (8 tests)
- [x] All 88 tests pass with 88% coverage
- [x] Lint and type checks pass

Closes #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)