### PR TITLE
feat(stages): add DREAM stage implementation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -154,3 +154,8 @@ known-first-party = ["questfoundry"]
 [tool.ruff.format]
 quote-style = "double"
 indent-style = "space"
+
+[dependency-groups]
+dev = [
+    "types-pyyaml>=6.0.12.20250915",
+]

--- a/src/questfoundry/pipeline/stages/__init__.py
+++ b/src/questfoundry/pipeline/stages/__init__.py
@@ -2,73 +2,22 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Protocol
+from questfoundry.pipeline.stages.base import (
+    Stage,
+    get_stage,
+    list_stages,
+    register_stage,
+)
+from questfoundry.pipeline.stages.dream import DreamParseError, DreamStage, dream_stage
 
-if TYPE_CHECKING:
-    from questfoundry.prompts import PromptCompiler
-    from questfoundry.providers import LLMProvider
-
-
-class Stage(Protocol):
-    """Protocol for pipeline stage implementations."""
-
-    name: str
-
-    async def execute(
-        self,
-        context: dict[str, Any],
-        provider: LLMProvider,
-        compiler: PromptCompiler,
-    ) -> tuple[dict[str, Any], int, int]:
-        """Execute the stage.
-
-        Args:
-            context: Context dictionary with user inputs and prior artifacts.
-            provider: LLM provider for completions.
-            compiler: Prompt compiler for template assembly.
-
-        Returns:
-            Tuple of (artifact_data, llm_calls, tokens_used).
-        """
-        ...
-
-
-# Stage registry - populated by stage modules
-_STAGE_REGISTRY: dict[str, Stage] = {}
-
-
-def register_stage(stage: Stage) -> None:
-    """Register a stage implementation.
-
-    Args:
-        stage: Stage instance to register.
-    """
-    _STAGE_REGISTRY[stage.name] = stage
-
-
-def get_stage(name: str) -> Stage | None:
-    """Get a registered stage by name.
-
-    Args:
-        name: Stage name.
-
-    Returns:
-        Stage instance or None if not found.
-    """
-    return _STAGE_REGISTRY.get(name)
-
-
-def list_stages() -> list[str]:
-    """List registered stage names.
-
-    Returns:
-        List of stage names.
-    """
-    return list(_STAGE_REGISTRY.keys())
-
+# Register built-in stages
+register_stage(dream_stage)
 
 __all__ = [
+    "DreamParseError",
+    "DreamStage",
     "Stage",
+    "dream_stage",
     "get_stage",
     "list_stages",
     "register_stage",

--- a/src/questfoundry/pipeline/stages/base.py
+++ b/src/questfoundry/pipeline/stages/base.py
@@ -1,0 +1,67 @@
+"""Base types and registry for pipeline stages."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, Protocol
+
+if TYPE_CHECKING:
+    from questfoundry.prompts import PromptCompiler
+    from questfoundry.providers import LLMProvider
+
+
+class Stage(Protocol):
+    """Protocol for pipeline stage implementations."""
+
+    name: str
+
+    async def execute(
+        self,
+        context: dict[str, Any],
+        provider: LLMProvider,
+        compiler: PromptCompiler,
+    ) -> tuple[dict[str, Any], int, int]:
+        """Execute the stage.
+
+        Args:
+            context: Context dictionary with user inputs and prior artifacts.
+            provider: LLM provider for completions.
+            compiler: Prompt compiler for template assembly.
+
+        Returns:
+            Tuple of (artifact_data, llm_calls, tokens_used).
+        """
+        ...
+
+
+# Stage registry - populated by stage modules
+_STAGE_REGISTRY: dict[str, Stage] = {}
+
+
+def register_stage(stage: Stage) -> None:
+    """Register a stage implementation.
+
+    Args:
+        stage: Stage instance to register.
+    """
+    _STAGE_REGISTRY[stage.name] = stage
+
+
+def get_stage(name: str) -> Stage | None:
+    """Get a registered stage by name.
+
+    Args:
+        name: Stage name.
+
+    Returns:
+        Stage instance or None if not found.
+    """
+    return _STAGE_REGISTRY.get(name)
+
+
+def list_stages() -> list[str]:
+    """List registered stage names.
+
+    Returns:
+        List of stage names.
+    """
+    return list(_STAGE_REGISTRY.keys())

--- a/src/questfoundry/pipeline/stages/dream.py
+++ b/src/questfoundry/pipeline/stages/dream.py
@@ -172,10 +172,13 @@ class DreamStage:
             True if line appears to be YAML.
         """
         # YAML patterns: key:, - item, continuation indent
-        if ":" in line:
+        # Key pattern: word characters followed by colon (not just ":" anywhere)
+        if re.match(r"^\w[\w\s]*:", line):
             return True
-        if line.startswith("-"):
+        # List item: dash followed by space
+        if line.startswith("- "):
             return True
+        # Continuation: starts with whitespace
         return line.startswith(" ") or line.startswith("\t")
 
 

--- a/src/questfoundry/pipeline/stages/dream.py
+++ b/src/questfoundry/pipeline/stages/dream.py
@@ -1,0 +1,183 @@
+"""DREAM stage implementation.
+
+The DREAM stage establishes the creative vision for the story,
+generating genre, tone, themes, and style direction.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import TYPE_CHECKING, Any
+
+import yaml
+
+if TYPE_CHECKING:
+    from questfoundry.prompts import PromptCompiler
+    from questfoundry.providers import LLMProvider
+
+
+class DreamParseError(Exception):
+    """Raised when DREAM stage response cannot be parsed."""
+
+    def __init__(self, message: str, raw_content: str) -> None:
+        self.raw_content = raw_content
+        super().__init__(message)
+
+
+class DreamStage:
+    """DREAM stage - establish creative vision.
+
+    This stage takes a user's story idea and generates a creative
+    vision artifact containing genre, tone, themes, and style direction.
+    """
+
+    name = "dream"
+
+    async def execute(
+        self,
+        context: dict[str, Any],
+        provider: LLMProvider,
+        compiler: PromptCompiler,
+    ) -> tuple[dict[str, Any], int, int]:
+        """Execute the DREAM stage.
+
+        Args:
+            context: Context with 'user_prompt' key containing the story idea.
+            provider: LLM provider for completions.
+            compiler: Prompt compiler for template assembly.
+
+        Returns:
+            Tuple of (artifact_data, llm_calls, tokens_used).
+
+        Raises:
+            DreamParseError: If the LLM response cannot be parsed as YAML.
+        """
+        # Get user prompt from context
+        user_prompt = context.get("user_prompt", "")
+
+        # Compile the dream prompt template
+        prompt = compiler.compile("dream", {"user_prompt": user_prompt})
+
+        # Call LLM
+        response = await provider.complete(
+            [
+                {"role": "system", "content": prompt.system},
+                {"role": "user", "content": prompt.user},
+            ]
+        )
+
+        # Parse YAML from response
+        artifact_data = self._parse_response(response.content)
+
+        # Ensure required fields
+        artifact_data["type"] = "dream"
+        artifact_data["version"] = artifact_data.get("version", 1)
+
+        return artifact_data, 1, response.tokens_used
+
+    def _parse_response(self, content: str) -> dict[str, Any]:
+        """Parse YAML artifact from LLM response.
+
+        Handles various response formats:
+        - Raw YAML
+        - YAML wrapped in ```yaml``` fences
+        - YAML with leading/trailing text
+
+        Args:
+            content: Raw LLM response content.
+
+        Returns:
+            Parsed artifact dictionary.
+
+        Raises:
+            DreamParseError: If no valid YAML can be extracted.
+        """
+        # Try to extract YAML from markdown fences first
+        fence_pattern = r"```(?:yaml|yml)?\s*\n(.*?)```"
+        fence_match = re.search(fence_pattern, content, re.DOTALL | re.IGNORECASE)
+
+        if fence_match:
+            yaml_content = fence_match.group(1).strip()
+        else:
+            # Try to find YAML-like content (starts with key:)
+            # Look for lines starting with common artifact keys
+            yaml_content = self._extract_yaml_block(content)
+
+        if not yaml_content:
+            raise DreamParseError(
+                "No valid YAML found in response",
+                content,
+            )
+
+        try:
+            data = yaml.safe_load(yaml_content)
+            if not isinstance(data, dict):
+                raise DreamParseError(
+                    f"Expected YAML dict, got {type(data).__name__}",
+                    content,
+                )
+            return data
+        except yaml.YAMLError as e:
+            raise DreamParseError(
+                f"YAML parse error: {e}",
+                content,
+            ) from e
+
+    def _extract_yaml_block(self, content: str) -> str:
+        """Extract YAML block from mixed content.
+
+        Looks for content starting with common artifact keys like
+        'type:', 'genre:', etc. and extracts until end or blank line.
+
+        Args:
+            content: Mixed content that may contain YAML.
+
+        Returns:
+            Extracted YAML string, or empty string if not found.
+        """
+        lines = content.split("\n")
+        yaml_lines: list[str] = []
+        in_yaml = False
+
+        # Common starting keys for dream artifacts
+        start_keys = ("type:", "genre:", "version:", "subgenre:", "tone:")
+
+        for line in lines:
+            stripped = line.strip()
+
+            # Start capturing when we see a known key
+            if not in_yaml and any(stripped.startswith(key) for key in start_keys):
+                in_yaml = True
+
+            if in_yaml:
+                # Stop at blank lines after content, or obvious non-YAML
+                if not stripped and yaml_lines:
+                    # Check if next non-blank line is still YAML-like
+                    continue
+                if stripped.startswith("#") and not yaml_lines:
+                    continue
+                if stripped and not self._is_yaml_line(stripped):
+                    break
+                yaml_lines.append(line)
+
+        return "\n".join(yaml_lines).strip()
+
+    def _is_yaml_line(self, line: str) -> bool:
+        """Check if a line looks like YAML content.
+
+        Args:
+            line: Stripped line to check.
+
+        Returns:
+            True if line appears to be YAML.
+        """
+        # YAML patterns: key:, - item, continuation indent
+        if ":" in line:
+            return True
+        if line.startswith("-"):
+            return True
+        return line.startswith(" ") or line.startswith("\t")
+
+
+# Create singleton instance for registration
+dream_stage = DreamStage()

--- a/tests/unit/test_dream_stage.py
+++ b/tests/unit/test_dream_stage.py
@@ -1,0 +1,378 @@
+"""Tests for DREAM stage implementation."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from questfoundry.pipeline.stages import DreamParseError, DreamStage, get_stage
+from questfoundry.providers.base import LLMResponse
+
+# --- Stage Registration Tests ---
+
+
+def test_dream_stage_registered() -> None:
+    """Dream stage is registered automatically."""
+    stage = get_stage("dream")
+    assert stage is not None
+    assert stage.name == "dream"
+
+
+def test_dream_stage_name() -> None:
+    """DreamStage has correct name."""
+    stage = DreamStage()
+    assert stage.name == "dream"
+
+
+# --- Response Parsing Tests ---
+
+
+def test_parse_raw_yaml() -> None:
+    """Parse raw YAML response."""
+    stage = DreamStage()
+    content = """type: dream
+version: 1
+genre: fantasy
+tone:
+  - epic
+  - adventurous
+audience: adult
+themes:
+  - heroism
+  - sacrifice
+"""
+    result = stage._parse_response(content)
+
+    assert result["type"] == "dream"
+    assert result["genre"] == "fantasy"
+    assert result["tone"] == ["epic", "adventurous"]
+    assert result["themes"] == ["heroism", "sacrifice"]
+
+
+def test_parse_yaml_with_fences() -> None:
+    """Parse YAML wrapped in markdown fences."""
+    stage = DreamStage()
+    content = """Here's the creative vision for your story:
+
+```yaml
+type: dream
+version: 1
+genre: mystery
+subgenre: noir
+tone:
+  - dark
+  - atmospheric
+audience: adult
+themes:
+  - betrayal
+  - redemption
+```
+
+This establishes a classic noir atmosphere.
+"""
+    result = stage._parse_response(content)
+
+    assert result["genre"] == "mystery"
+    assert result["subgenre"] == "noir"
+    assert result["tone"] == ["dark", "atmospheric"]
+
+
+def test_parse_yaml_fences_no_lang() -> None:
+    """Parse YAML in fences without language specifier."""
+    stage = DreamStage()
+    content = """```
+genre: sci-fi
+tone:
+  - philosophical
+audience: adult
+themes:
+  - identity
+```"""
+    result = stage._parse_response(content)
+
+    assert result["genre"] == "sci-fi"
+    assert result["themes"] == ["identity"]
+
+
+def test_parse_yaml_with_leading_text() -> None:
+    """Parse YAML with leading non-YAML text."""
+    stage = DreamStage()
+    content = """I'll create a creative vision based on your noir detective story idea.
+
+genre: mystery
+subgenre: noir
+tone:
+  - gritty
+  - cynical
+audience: adult
+themes:
+  - corruption
+  - justice
+style_notes: Focus on atmospheric descriptions and morally gray characters.
+"""
+    result = stage._parse_response(content)
+
+    assert result["genre"] == "mystery"
+    assert result["subgenre"] == "noir"
+    assert "style_notes" in result
+
+
+def test_parse_invalid_yaml_raises() -> None:
+    """Invalid YAML raises DreamParseError."""
+    stage = DreamStage()
+    # Use truly invalid YAML syntax with mapping in sequence context
+    content = """```yaml
+genre: fantasy
+tone: [
+  - epic
+  unclosed bracket
+```"""
+    with pytest.raises(DreamParseError) as exc_info:
+        stage._parse_response(content)
+
+    assert "YAML parse error" in str(exc_info.value)
+    assert exc_info.value.raw_content == content
+
+
+def test_parse_no_yaml_raises() -> None:
+    """No YAML content raises DreamParseError."""
+    stage = DreamStage()
+    content = "This is just plain text with no YAML structure at all."
+
+    with pytest.raises(DreamParseError) as exc_info:
+        stage._parse_response(content)
+
+    assert "No valid YAML found" in str(exc_info.value)
+
+
+def test_parse_yaml_not_dict_raises() -> None:
+    """YAML that isn't a dict raises DreamParseError."""
+    stage = DreamStage()
+    content = """```yaml
+- item1
+- item2
+- item3
+```"""
+    with pytest.raises(DreamParseError) as exc_info:
+        stage._parse_response(content)
+
+    assert "Expected YAML dict" in str(exc_info.value)
+
+
+def test_parse_yml_fence() -> None:
+    """Parse YAML with 'yml' fence specifier."""
+    stage = DreamStage()
+    content = """```yml
+genre: romance
+tone:
+  - heartwarming
+audience: adult
+themes:
+  - love
+```"""
+    result = stage._parse_response(content)
+
+    assert result["genre"] == "romance"
+
+
+# --- Execute Tests ---
+
+
+@pytest.mark.asyncio
+async def test_execute_with_mock_provider() -> None:
+    """Execute DREAM stage with mocked LLM provider."""
+    stage = DreamStage()
+
+    # Mock provider
+    mock_provider = MagicMock()
+    mock_provider.complete = AsyncMock(
+        return_value=LLMResponse(
+            content="""```yaml
+genre: fantasy
+subgenre: epic
+tone:
+  - adventurous
+  - dramatic
+audience: adult
+themes:
+  - destiny
+  - friendship
+style_notes: Focus on world-building and character growth.
+```""",
+            model="test-model",
+            tokens_used=500,
+            finish_reason="stop",
+        )
+    )
+
+    # Mock compiler
+    mock_compiler = MagicMock()
+    mock_prompt = MagicMock()
+    mock_prompt.system = "You are a creative director."
+    mock_prompt.user = "Create a vision for: epic quest"
+    mock_compiler.compile.return_value = mock_prompt
+
+    # Execute
+    context = {"user_prompt": "An epic quest to save the world"}
+    artifact, llm_calls, tokens = await stage.execute(context, mock_provider, mock_compiler)
+
+    assert artifact["type"] == "dream"
+    assert artifact["version"] == 1
+    assert artifact["genre"] == "fantasy"
+    assert artifact["subgenre"] == "epic"
+    assert llm_calls == 1
+    assert tokens == 500
+
+    # Verify provider was called correctly
+    mock_provider.complete.assert_called_once()
+    call_args = mock_provider.complete.call_args
+    messages = call_args[0][0]
+    assert len(messages) == 2
+    assert messages[0]["role"] == "system"
+    assert messages[1]["role"] == "user"
+
+
+@pytest.mark.asyncio
+async def test_execute_preserves_version() -> None:
+    """Execute preserves version from LLM response."""
+    stage = DreamStage()
+
+    mock_provider = MagicMock()
+    mock_provider.complete = AsyncMock(
+        return_value=LLMResponse(
+            content="""type: dream
+version: 2
+genre: horror
+tone:
+  - terrifying
+audience: adult
+themes:
+  - fear
+""",
+            model="test",
+            tokens_used=100,
+            finish_reason="stop",
+        )
+    )
+
+    mock_compiler = MagicMock()
+    mock_prompt = MagicMock()
+    mock_prompt.system = "system"
+    mock_prompt.user = "user"
+    mock_compiler.compile.return_value = mock_prompt
+
+    artifact, _, _ = await stage.execute({}, mock_provider, mock_compiler)
+
+    assert artifact["version"] == 2
+
+
+@pytest.mark.asyncio
+async def test_execute_empty_context() -> None:
+    """Execute with empty context uses empty user_prompt."""
+    stage = DreamStage()
+
+    mock_provider = MagicMock()
+    mock_provider.complete = AsyncMock(
+        return_value=LLMResponse(
+            content="genre: general\ntone:\n  - neutral\naudience: all_ages\nthemes:\n  - life",
+            model="test",
+            tokens_used=50,
+            finish_reason="stop",
+        )
+    )
+
+    mock_compiler = MagicMock()
+    mock_prompt = MagicMock()
+    mock_prompt.system = "system"
+    mock_prompt.user = "user"
+    mock_compiler.compile.return_value = mock_prompt
+
+    artifact, _, _ = await stage.execute({}, mock_provider, mock_compiler)
+
+    # Compiler should be called with empty user_prompt
+    mock_compiler.compile.assert_called_once_with("dream", {"user_prompt": ""})
+    assert artifact["genre"] == "general"
+
+
+@pytest.mark.asyncio
+async def test_execute_parse_error_propagates() -> None:
+    """Execute propagates parse errors from LLM response."""
+    stage = DreamStage()
+
+    mock_provider = MagicMock()
+    mock_provider.complete = AsyncMock(
+        return_value=LLMResponse(
+            content="I cannot generate that content.",
+            model="test",
+            tokens_used=10,
+            finish_reason="stop",
+        )
+    )
+
+    mock_compiler = MagicMock()
+    mock_prompt = MagicMock()
+    mock_prompt.system = "system"
+    mock_prompt.user = "user"
+    mock_compiler.compile.return_value = mock_prompt
+
+    with pytest.raises(DreamParseError):
+        await stage.execute({}, mock_provider, mock_compiler)
+
+
+# --- Edge Cases ---
+
+
+def test_parse_yaml_with_comments() -> None:
+    """Parse YAML that includes comments."""
+    stage = DreamStage()
+    content = """# Creative vision
+genre: thriller  # Fast-paced
+tone:
+  - suspenseful
+  - tense
+audience: adult
+themes:
+  - survival
+"""
+    result = stage._parse_response(content)
+
+    assert result["genre"] == "thriller"
+    assert result["tone"] == ["suspenseful", "tense"]
+
+
+def test_parse_yaml_multiline_strings() -> None:
+    """Parse YAML with multiline string values in fenced block."""
+    stage = DreamStage()
+    # Use fenced block for reliable multiline parsing
+    content = """```yaml
+genre: literary
+tone:
+  - contemplative
+audience: adult
+themes:
+  - memory
+style_notes: |
+  Focus on introspective narration.
+  Use stream of consciousness techniques.
+  Pay attention to sensory details.
+```"""
+    result = stage._parse_response(content)
+
+    assert "Focus on introspective" in result["style_notes"]
+    assert "sensory details" in result["style_notes"]
+
+
+def test_is_yaml_line_detection() -> None:
+    """Test YAML line detection helper."""
+    stage = DreamStage()
+
+    # YAML-like lines
+    assert stage._is_yaml_line("key: value") is True
+    assert stage._is_yaml_line("- list item") is True
+    assert stage._is_yaml_line("  indented: content") is True
+    assert stage._is_yaml_line("\tcontinuation") is True
+
+    # Non-YAML lines
+    assert stage._is_yaml_line("Just plain text") is False
+    assert stage._is_yaml_line("No colon here") is False

--- a/uv.lock
+++ b/uv.lock
@@ -951,6 +951,11 @@ viz = [
     { name = "networkx" },
 ]
 
+[package.dev-dependencies]
+dev = [
+    { name = "types-pyyaml" },
+]
+
 [package.metadata]
 requires-dist = [
     { name = "graphviz", marker = "extra == 'viz'", specifier = ">=0.20" },
@@ -976,6 +981,9 @@ requires-dist = [
     { name = "types-jsonschema", marker = "extra == 'dev'", specifier = ">=4.0" },
 ]
 provides-extras = ["ollama", "openai", "all-providers", "dev", "viz"]
+
+[package.metadata.requires-dev]
+dev = [{ name = "types-pyyaml", specifier = ">=6.0.12.20250915" }]
 
 [[package]]
 name = "referencing"
@@ -1421,6 +1429,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/ef/da/5b901088da5f710690b422137e8ae74197fb1ca471e4aa84dd3ef0d6e295/types_jsonschema-4.25.1.20251009.tar.gz", hash = "sha256:75d0f5c5dd18dc23b664437a0c1a625743e8d2e665ceaf3aecb29841f3a5f97f", size = 15661, upload-time = "2025-10-09T02:54:36.963Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/7f/6a/e5146754c0dfc272f176db9c245bc43cc19030262d891a5a85d472797e60/types_jsonschema-4.25.1.20251009-py3-none-any.whl", hash = "sha256:f30b329037b78e7a60146b1146feb0b6fb0b71628637584409bada83968dad3e", size = 15925, upload-time = "2025-10-09T02:54:35.847Z" },
+]
+
+[[package]]
+name = "types-pyyaml"
+version = "6.0.12.20250915"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7e/69/3c51b36d04da19b92f9e815be12753125bd8bc247ba0470a982e6979e71c/types_pyyaml-6.0.12.20250915.tar.gz", hash = "sha256:0f8b54a528c303f0e6f7165687dd33fafa81c807fcac23f632b63aa624ced1d3", size = 17522, upload-time = "2025-09-15T03:01:00.728Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bd/e0/1eed384f02555dde685fff1a1ac805c1c7dcb6dd019c916fe659b1c1f9ec/types_pyyaml-6.0.12.20250915-py3-none-any.whl", hash = "sha256:e7d4d9e064e89a3b3cae120b4990cd370874d2bf12fa5f46c97018dd5d3c9ab6", size = 20338, upload-time = "2025-09-15T03:00:59.218Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Implements `DreamStage` that generates creative vision from user prompts
- Robust YAML parsing from LLM responses (handles fenced blocks, raw YAML, mixed content)
- `DreamParseError` for handling malformed LLM responses
- Refactors stage protocol and registry into `base.py` for cleaner imports
- Auto-registers `dream_stage` on module import

## Test plan
- [x] Unit tests for YAML parsing (10 tests) - raw, fenced, mixed content
- [x] Unit tests for stage execution (5 tests) - mock provider/compiler
- [x] Edge case tests (2 tests) - comments, line detection
- [x] All 105 tests pass with 88% coverage
- [x] Lint and type checks pass

Closes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)