### PR TITLE
fix(cli): load dotenv and add provider override

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -183,10 +183,9 @@ qf status                     # Show pipeline state
 Configuration follows a strict precedence order (highest to lowest):
 
 1. **CLI flags** - `--provider ollama/qwen3:8b`
-2. **Environment variables** - `QF_PROVIDER=openai/gpt-4o`
+2. **Environment variables** - `QF_PROVIDER=openai/gpt-4o` (can be set in your shell or a `.env` file)
 3. **Project config** - `project.yaml` providers.default
-4. **.env file** - loaded at CLI startup via python-dotenv
-5. **Defaults** - ollama/qwen3:8b
+4. **Defaults** - `ollama/qwen3:8b`
 
 ### Environment Variables
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -178,13 +178,29 @@ qf status                     # Show pipeline state
 - Target **70% coverage** initially, increase later
 - Use pytest fixtures for common test data
 
-## Environment Variables
+## Configuration
+
+Configuration follows a strict precedence order (highest to lowest):
+
+1. **CLI flags** - `--provider ollama/qwen3:8b`
+2. **Environment variables** - `QF_PROVIDER=openai/gpt-4o`
+3. **Project config** - `project.yaml` providers.default
+4. **.env file** - loaded at CLI startup via python-dotenv
+5. **Defaults** - ollama/qwen3:8b
+
+### Environment Variables
 
 ```bash
-OLLAMA_HOST=http://athena.int.liesdonk.nl:11434
-OPENAI_API_KEY=sk-...
-LANGSMITH_TRACING=true  # Optional observability
+# Provider configuration
+QF_PROVIDER=ollama/qwen3:8b    # Override default provider
+OLLAMA_HOST=http://athena.int.liesdonk.nl:11434  # Required for Ollama
+OPENAI_API_KEY=sk-...          # Required for OpenAI
+
+# Optional observability
+LANGSMITH_TRACING=true
 ```
+
+**Note**: `OLLAMA_HOST` and `OPENAI_API_KEY` are required for their respective providers. There are no defaults - you must explicitly configure them.
 
 ## Related Resources
 

--- a/src/questfoundry/cli.py
+++ b/src/questfoundry/cli.py
@@ -7,8 +7,12 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Annotated
 
 import typer
+from dotenv import load_dotenv
 from rich.console import Console
 from rich.table import Table
+
+# Load environment variables from .env file
+load_dotenv()
 
 if TYPE_CHECKING:
     from questfoundry.pipeline import PipelineOrchestrator, StageResult
@@ -35,18 +39,19 @@ def _require_project(project_path: Path) -> None:
         raise typer.Exit(1)
 
 
-def _get_orchestrator(project_path: Path) -> PipelineOrchestrator:
+def _get_orchestrator(project_path: Path, provider_override: str | None = None) -> PipelineOrchestrator:
     """Get a pipeline orchestrator for the project.
 
     Args:
         project_path: Path to the project directory.
+        provider_override: Optional provider string (e.g., "openai/gpt-4o") to override config.
 
     Returns:
         Configured PipelineOrchestrator.
     """
     from questfoundry.pipeline import PipelineOrchestrator
 
-    return PipelineOrchestrator(project_path)
+    return PipelineOrchestrator(project_path, provider_override=provider_override)
 
 
 @app.command()
@@ -117,6 +122,9 @@ def init(
 def dream(
     prompt: Annotated[str | None, typer.Argument(help="Story idea or concept")] = None,
     project: Annotated[Path, typer.Option("--project", "-p", help="Project directory")] = Path(),
+    provider: Annotated[
+        str | None, typer.Option("--provider", help="LLM provider (e.g., ollama/qwen3:8b, openai/gpt-4o)")
+    ] = None,
 ) -> None:
     """Run DREAM stage - establish creative vision.
 
@@ -134,7 +142,7 @@ def dream(
 
     async def _run_dream() -> StageResult:
         """Run DREAM stage and close orchestrator."""
-        orchestrator = _get_orchestrator(project)
+        orchestrator = _get_orchestrator(project, provider_override=provider)
         try:
             return await orchestrator.run_stage("dream", {"user_prompt": prompt})
         finally:

--- a/src/questfoundry/cli.py
+++ b/src/questfoundry/cli.py
@@ -39,7 +39,9 @@ def _require_project(project_path: Path) -> None:
         raise typer.Exit(1)
 
 
-def _get_orchestrator(project_path: Path, provider_override: str | None = None) -> PipelineOrchestrator:
+def _get_orchestrator(
+    project_path: Path, provider_override: str | None = None
+) -> PipelineOrchestrator:
     """Get a pipeline orchestrator for the project.
 
     Args:
@@ -123,7 +125,8 @@ def dream(
     prompt: Annotated[str | None, typer.Argument(help="Story idea or concept")] = None,
     project: Annotated[Path, typer.Option("--project", "-p", help="Project directory")] = Path(),
     provider: Annotated[
-        str | None, typer.Option("--provider", help="LLM provider (e.g., ollama/qwen3:8b, openai/gpt-4o)")
+        str | None,
+        typer.Option("--provider", help="LLM provider (e.g., ollama/qwen3:8b, openai/gpt-4o)"),
     ] = None,
 ) -> None:
     """Run DREAM stage - establish creative vision.

--- a/src/questfoundry/providers/ollama.py
+++ b/src/questfoundry/providers/ollama.py
@@ -34,11 +34,19 @@ class OllamaProvider:
         """Initialize the Ollama provider.
 
         Args:
-            host: Ollama server URL. Defaults to OLLAMA_HOST env var
-                or http://localhost:11434.
+            host: Ollama server URL. If not provided, reads from OLLAMA_HOST env var.
             default_model: Default model for completions.
+
+        Raises:
+            ProviderError: If OLLAMA_HOST is not configured.
         """
-        self.host = host or os.getenv("OLLAMA_HOST", "http://localhost:11434")
+        self.host = host or os.getenv("OLLAMA_HOST")
+        if not self.host:
+            raise ProviderError(
+                "ollama",
+                "OLLAMA_HOST not configured. Set OLLAMA_HOST environment variable "
+                "or add it to your .env file.",
+            )
         self._default_model = default_model
         self._client = httpx.AsyncClient(timeout=300.0)
 

--- a/tests/unit/test_providers.py
+++ b/tests/unit/test_providers.py
@@ -57,11 +57,13 @@ def test_llm_response_not_complete_length() -> None:
 # --- OllamaProvider Tests ---
 
 
-def test_ollama_default_host() -> None:
-    """OllamaProvider uses default host."""
+def test_ollama_requires_host() -> None:
+    """OllamaProvider raises error without OLLAMA_HOST."""
     with patch.dict("os.environ", {}, clear=True):
-        provider = OllamaProvider()
-        assert provider.host == "http://localhost:11434"
+        with pytest.raises(ProviderError) as exc_info:
+            OllamaProvider()
+
+        assert "OLLAMA_HOST not configured" in str(exc_info.value)
 
 
 def test_ollama_env_host() -> None:
@@ -79,20 +81,20 @@ def test_ollama_custom_host() -> None:
 
 def test_ollama_default_model() -> None:
     """OllamaProvider has correct default model."""
-    provider = OllamaProvider()
+    provider = OllamaProvider(host="http://test:11434")
     assert provider.default_model == "qwen3:8b"
 
 
 def test_ollama_custom_model() -> None:
     """OllamaProvider uses custom default model."""
-    provider = OllamaProvider(default_model="llama3:8b")
+    provider = OllamaProvider(host="http://test:11434", default_model="llama3:8b")
     assert provider.default_model == "llama3:8b"
 
 
 @pytest.mark.asyncio
 async def test_ollama_complete_success() -> None:
     """OllamaProvider successfully completes a request."""
-    provider = OllamaProvider()
+    provider = OllamaProvider(host="http://test:11434")
 
     mock_response = MagicMock()
     mock_response.status_code = 200
@@ -118,7 +120,7 @@ async def test_ollama_complete_success() -> None:
 @pytest.mark.asyncio
 async def test_ollama_complete_custom_model() -> None:
     """OllamaProvider uses custom model when specified."""
-    provider = OllamaProvider()
+    provider = OllamaProvider(host="http://test:11434")
 
     mock_response = MagicMock()
     mock_response.status_code = 200
@@ -143,7 +145,7 @@ async def test_ollama_complete_custom_model() -> None:
 @pytest.mark.asyncio
 async def test_ollama_complete_connection_error() -> None:
     """OllamaProvider raises ProviderConnectionError on connection failure."""
-    provider = OllamaProvider()
+    provider = OllamaProvider(host="http://test:11434")
 
     with patch.object(
         provider._client, "post", new=AsyncMock(side_effect=httpx.ConnectError("Failed"))
@@ -159,7 +161,7 @@ async def test_ollama_complete_connection_error() -> None:
 @pytest.mark.asyncio
 async def test_ollama_complete_timeout() -> None:
     """OllamaProvider raises ProviderConnectionError on timeout."""
-    provider = OllamaProvider()
+    provider = OllamaProvider(host="http://test:11434")
 
     with patch.object(
         provider._client, "post", new=AsyncMock(side_effect=httpx.TimeoutException("Timeout"))
@@ -174,7 +176,7 @@ async def test_ollama_complete_timeout() -> None:
 @pytest.mark.asyncio
 async def test_ollama_complete_model_not_found() -> None:
     """OllamaProvider raises ProviderModelError when model not found."""
-    provider = OllamaProvider()
+    provider = OllamaProvider(host="http://test:11434")
 
     mock_response = MagicMock()
     mock_response.status_code = 404
@@ -191,7 +193,7 @@ async def test_ollama_complete_model_not_found() -> None:
 @pytest.mark.asyncio
 async def test_ollama_complete_api_error() -> None:
     """OllamaProvider raises ProviderError on API error."""
-    provider = OllamaProvider()
+    provider = OllamaProvider(host="http://test:11434")
 
     mock_response = MagicMock()
     mock_response.status_code = 500
@@ -208,14 +210,14 @@ async def test_ollama_complete_api_error() -> None:
 @pytest.mark.asyncio
 async def test_ollama_context_manager() -> None:
     """OllamaProvider works as async context manager."""
-    async with OllamaProvider() as provider:
+    async with OllamaProvider(host="http://test:11434") as provider:
         assert provider.default_model == "qwen3:8b"
 
 
 @pytest.mark.asyncio
 async def test_ollama_list_models() -> None:
     """OllamaProvider lists available models."""
-    provider = OllamaProvider()
+    provider = OllamaProvider(host="http://test:11434")
 
     mock_response = MagicMock()
     mock_response.status_code = 200


### PR DESCRIPTION
## Summary

Infrastructure fixes discovered during DREAM stage testing:

- Add `load_dotenv()` to CLI entry point so `.env` variables are read
- Add `--provider` CLI flag to override provider (e.g., `--provider openai/gpt-4o`)
- Add `QF_PROVIDER` environment variable support
- Require explicit `OLLAMA_HOST` configuration (no localhost default)
- Document configuration precedence in CLAUDE.md

## Changes

| File | Change |
|------|--------|
| `src/questfoundry/cli.py` | Add `load_dotenv()`, `--provider` flag |
| `src/questfoundry/pipeline/orchestrator.py` | Add `provider_override` param, `QF_PROVIDER` env support |
| `src/questfoundry/providers/ollama.py` | Require `OLLAMA_HOST` (no default) |
| `tests/unit/test_providers.py` | Update tests for required host |
| `CLAUDE.md` | Document configuration hierarchy |

## Configuration Precedence

```
1. CLI flags        --provider ollama/qwen3:8b
2. Environment      QF_PROVIDER=openai/gpt-4o
3. Project config   project.yaml providers.default
4. .env file        loaded at startup
5. Defaults         ollama/qwen3:8b
```

## Test plan

- [x] All 114 tests pass
- [ ] Manual test: `qf dream` reads from `.env`
- [ ] Manual test: `qf dream --provider openai/gpt-4o` overrides provider
- [ ] Manual test: Missing `OLLAMA_HOST` gives clear error

🤖 Generated with [Claude Code](https://claude.com/claude-code)