### PR TITLE
fix: LLM logging, YAML extraction, and schema relaxation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -219,13 +219,20 @@ This creates:
 ### 2. Analyze the Response
 
 ```bash
-# Pretty-print the LLM response
-python3 -c "import json; d=json.load(open('myproject/logs/llm_calls.jsonl')); print(d['content'])"
+# Pretty-print the last LLM response (JSONL = one JSON object per line)
+python3 -c "
+import json
+with open('myproject/logs/llm_calls.jsonl') as f:
+    lines = f.readlines()
+    d = json.loads(lines[-1])  # Get last call
+    print(d['content'])
+"
 
 # Debug YAML parsing
 python3 -c "
 import json, yaml
-d = json.load(open('myproject/logs/llm_calls.jsonl'))
+with open('myproject/logs/llm_calls.jsonl') as f:
+    d = json.loads(f.readlines()[-1])
 parsed = yaml.safe_load(d['content'])
 print(json.dumps(parsed, indent=2))
 "
@@ -241,7 +248,7 @@ print(json.dumps(parsed, indent=2))
 
 ### 4. Prompt Engineering Reference
 
-See `/mnt/code/if-craft-corpus/corpus/agent-design/agent_prompt_engineering.md` for:
+Key patterns for working with LLMs:
 - **Sandwich pattern**: Repeat critical instructions at start AND end of prompt
 - **Validate → Feedback → Repair loop**: For structured output, validate and ask model to fix errors
 - **Discuss → Freeze → Serialize**: Separate conversation from structured output generation

--- a/prompts/templates/dream.yaml
+++ b/prompts/templates/dream.yaml
@@ -24,23 +24,23 @@ user: |
 
   type: dream
   version: 1
-  genre: <primary genre>
-  subgenre: <optional refinement>
+  genre: <primary genre, e.g., Mystery, Fantasy, Horror, Romance, Sci-Fi>
+  subgenre: <optional refinement, e.g., Cozy Mystery, Urban Fantasy, Gothic Horror>
   tone:
-    - <tone descriptor 1>
-    - <tone descriptor 2>
-    - <tone descriptor 3>
-  audience: <adult | young_adult | all_ages>
+    - <tone descriptor, e.g., dark and brooding>
+    - <tone descriptor, e.g., whimsical>
+    - <tone descriptor, e.g., tense and suspenseful>
+  audience: <target readers, e.g., adult, young adult, all ages, mature>
   themes:
-    - <theme 1>
-    - <theme 2>
-    - <theme 3>
+    - <thematic element, e.g., redemption>
+    - <thematic element, e.g., the cost of ambition>
+    - <thematic element, e.g., found family>
   style_notes: |
-    <writing style guidance>
+    <writing style guidance - describe prose style, pacing, narrative voice>
   scope:
-    target_word_count: <number>
-    estimated_passages: <number>
-    branching_depth: <light | moderate | heavy>
+    target_word_count: <approximate length, e.g., 50000>
+    estimated_passages: <scene count, e.g., 25>
+    branching_depth: <complexity, e.g., light, moderate, heavy, extensive>
 
   Be creative but grounded. Make choices that serve the story.
 

--- a/schemas/dream.schema.json
+++ b/schemas/dream.schema.json
@@ -36,8 +36,8 @@
     },
     "audience": {
       "type": "string",
-      "enum": ["adult", "young_adult", "all_ages"],
-      "description": "Target audience"
+      "minLength": 1,
+      "description": "Target audience (e.g., adult, young adult, all ages, mature)"
     },
     "themes": {
       "type": "array",
@@ -68,8 +68,8 @@
         },
         "branching_depth": {
           "type": "string",
-          "enum": ["light", "moderate", "heavy"],
-          "description": "Branching complexity"
+          "minLength": 1,
+          "description": "Branching complexity (e.g., light, moderate, heavy, extensive)"
         },
         "estimated_playtime_minutes": {
           "type": "integer",

--- a/src/questfoundry/artifacts/models.py
+++ b/src/questfoundry/artifacts/models.py
@@ -15,8 +15,10 @@ class Scope(BaseModel):
 
     target_word_count: int = Field(ge=1000, description="Approximate final length")
     estimated_passages: int = Field(ge=5, description="Target scene count")
-    branching_depth: Literal["light", "moderate", "heavy"] = Field(
-        default="moderate", description="Branching complexity"
+    branching_depth: str = Field(
+        default="moderate",
+        min_length=1,
+        description="Branching complexity (e.g., light, moderate, heavy)",
     )
     estimated_playtime_minutes: int | None = Field(
         default=None, ge=1, description="Target reading time"
@@ -40,7 +42,10 @@ class DreamArtifact(BaseModel):
     genre: str = Field(min_length=1, description="Primary genre")
     subgenre: str | None = Field(default=None, min_length=1, description="Optional refinement")
     tone: list[NonEmptyStr] = Field(min_length=1, description="Tone descriptors")
-    audience: Literal["adult", "young_adult", "all_ages"] = Field(description="Target audience")
+    audience: str = Field(
+        min_length=1,
+        description="Target audience (e.g., adult, young_adult, all_ages)",
+    )
     themes: list[NonEmptyStr] = Field(min_length=1, description="Thematic elements")
 
     # Optional fields

--- a/src/questfoundry/pipeline/orchestrator.py
+++ b/src/questfoundry/pipeline/orchestrator.py
@@ -206,8 +206,12 @@ class PipelineOrchestrator:
             # Get stage implementation
             stage = self._get_stage_implementation(stage_name)
 
-            # Get provider
+            # Get provider (with logging wrapper if enabled)
             provider = self._get_provider()
+            if self._enable_llm_logging:
+                from questfoundry.providers import LoggingProvider
+
+                provider = LoggingProvider(provider, self._llm_logger, stage_name)
 
             # Create prompt compiler
             compiler = PromptCompiler(self._prompts_path)

--- a/src/questfoundry/pipeline/orchestrator.py
+++ b/src/questfoundry/pipeline/orchestrator.py
@@ -13,6 +13,7 @@ from questfoundry.artifacts import ArtifactReader, ArtifactValidator, ArtifactWr
 from questfoundry.pipeline.config import ProjectConfigError, load_project_config
 from questfoundry.pipeline.gates import AutoApproveGate, GateHook
 from questfoundry.prompts import PromptCompiler
+from questfoundry.providers import LoggingProvider
 
 if TYPE_CHECKING:
     from questfoundry.providers import LLMProvider
@@ -209,8 +210,6 @@ class PipelineOrchestrator:
             # Get provider (with logging wrapper if enabled)
             provider = self._get_provider()
             if self._enable_llm_logging:
-                from questfoundry.providers import LoggingProvider
-
                 provider = LoggingProvider(provider, self._llm_logger, stage_name)
 
             # Create prompt compiler

--- a/src/questfoundry/pipeline/stages/dream.py
+++ b/src/questfoundry/pipeline/stages/dream.py
@@ -156,7 +156,8 @@ class DreamStage:
                     continue
                 if stripped.startswith("#") and not yaml_lines:
                     continue
-                if stripped and not self._is_yaml_line(stripped):
+                # Pass original line to preserve indentation for continuation check
+                if stripped and not self._is_yaml_line(line):
                     break
                 yaml_lines.append(line)
 
@@ -166,20 +167,23 @@ class DreamStage:
         """Check if a line looks like YAML content.
 
         Args:
-            line: Stripped line to check.
+            line: Line to check (may include leading whitespace).
 
         Returns:
             True if line appears to be YAML.
         """
-        # YAML patterns: key:, - item, continuation indent
+        # Continuation: starts with whitespace (check first, before stripping)
+        if line.startswith(" ") or line.startswith("\t"):
+            return True
+        # YAML patterns: key:, - item
+        stripped = line.strip()
         # Key pattern: word characters followed by colon (not just ":" anywhere)
-        if re.match(r"^\w[\w\s]*:", line):
+        if re.match(r"^\w[\w\s]*:", stripped):
             return True
         # List item: dash followed by space
-        if line.startswith("- "):
+        if stripped.startswith("- "):
             return True
-        # Continuation: starts with whitespace
-        return line.startswith(" ") or line.startswith("\t")
+        return False
 
 
 # Create singleton instance for registration

--- a/src/questfoundry/pipeline/stages/dream.py
+++ b/src/questfoundry/pipeline/stages/dream.py
@@ -181,9 +181,7 @@ class DreamStage:
         if re.match(r"^\w[\w\s]*:", stripped):
             return True
         # List item: dash followed by space
-        if stripped.startswith("- "):
-            return True
-        return False
+        return stripped.startswith("- ")
 
 
 # Create singleton instance for registration

--- a/src/questfoundry/providers/__init__.py
+++ b/src/questfoundry/providers/__init__.py
@@ -11,11 +11,13 @@ from questfoundry.providers.base import (
 )
 from questfoundry.providers.factory import create_provider
 from questfoundry.providers.langchain_wrapper import LangChainProvider
+from questfoundry.providers.logging_wrapper import LoggingProvider
 
 __all__ = [
     "LLMProvider",
     "LLMResponse",
     "LangChainProvider",
+    "LoggingProvider",
     "Message",
     "ProviderConnectionError",
     "ProviderError",

--- a/src/questfoundry/providers/langchain_wrapper.py
+++ b/src/questfoundry/providers/langchain_wrapper.py
@@ -42,8 +42,8 @@ class LangChainProvider:
         self,
         messages: list[Message],
         model: str | None = None,
-        temperature: float = 0.7,
-        max_tokens: int = 4096,
+        temperature: float = 0.7,  # noqa: ARG002 - set at model construction
+        max_tokens: int = 4096,  # noqa: ARG002 - set at model construction
     ) -> LLMResponse:
         """Generate a completion from the given messages.
 

--- a/src/questfoundry/providers/langchain_wrapper.py
+++ b/src/questfoundry/providers/langchain_wrapper.py
@@ -42,16 +42,16 @@ class LangChainProvider:
         self,
         messages: list[Message],
         model: str | None = None,
-        _temperature: float = 0.7,
-        _max_tokens: int = 4096,
+        temperature: float = 0.7,
+        max_tokens: int = 4096,
     ) -> LLMResponse:
         """Generate a completion from the given messages.
 
         Args:
             messages: List of conversation messages.
             model: Model override for response metadata.
-            _temperature: Unused - set at model construction.
-            _max_tokens: Unused - set at model construction.
+            temperature: Unused - set at model construction.
+            max_tokens: Unused - set at model construction.
 
         Returns:
             LLMResponse with content and metadata.

--- a/src/questfoundry/providers/logging_wrapper.py
+++ b/src/questfoundry/providers/logging_wrapper.py
@@ -5,11 +5,10 @@ from __future__ import annotations
 import time
 from typing import TYPE_CHECKING
 
-from questfoundry.providers.base import LLMResponse, Message
-
 if TYPE_CHECKING:
     from questfoundry.observability import LLMLogger
     from questfoundry.providers import LLMProvider
+    from questfoundry.providers.base import LLMResponse, Message
 
 
 class LoggingProvider:
@@ -79,7 +78,7 @@ class LoggingProvider:
             entry = self._logger.create_entry(
                 stage=self._stage,
                 model=model or self.default_model,
-                messages=[dict(m) for m in messages],
+                messages=[{**m} for m in messages],  # type: ignore[dict-item]
                 content="",
                 tokens_used=0,
                 finish_reason="error",
@@ -97,7 +96,7 @@ class LoggingProvider:
         entry = self._logger.create_entry(
             stage=self._stage,
             model=response.model,
-            messages=[dict(m) for m in messages],
+            messages=[{**m} for m in messages],  # type: ignore[dict-item]
             content=response.content,
             tokens_used=response.tokens_used,
             finish_reason=response.finish_reason,
@@ -114,7 +113,7 @@ class LoggingProvider:
         if hasattr(self._provider, "close"):
             await self._provider.close()
 
-    async def __aenter__(self) -> "LoggingProvider":
+    async def __aenter__(self) -> LoggingProvider:
         """Enter async context."""
         return self
 

--- a/src/questfoundry/providers/logging_wrapper.py
+++ b/src/questfoundry/providers/logging_wrapper.py
@@ -48,16 +48,16 @@ class LoggingProvider:
         self,
         messages: list[Message],
         model: str | None = None,
-        _temperature: float = 0.7,
-        _max_tokens: int = 4096,
+        temperature: float = 0.7,
+        max_tokens: int = 4096,
     ) -> LLMResponse:
         """Generate completion and log the call.
 
         Args:
             messages: List of conversation messages.
             model: Optional model override.
-            _temperature: Sampling temperature (logged, may be unused by provider).
-            _max_tokens: Maximum tokens (logged, may be unused by provider).
+            temperature: Sampling temperature.
+            max_tokens: Maximum tokens to generate.
 
         Returns:
             LLMResponse from underlying provider.
@@ -69,6 +69,8 @@ class LoggingProvider:
             response = await self._provider.complete(
                 messages=messages,
                 model=model,
+                temperature=temperature,
+                max_tokens=max_tokens,
             )
         except Exception as e:
             error_msg = str(e)
@@ -82,8 +84,8 @@ class LoggingProvider:
                 tokens_used=0,
                 finish_reason="error",
                 duration_seconds=duration,
-                temperature=_temperature,
-                max_tokens=_max_tokens,
+                temperature=temperature,
+                max_tokens=max_tokens,
                 error=error_msg,
             )
             self._logger.log(entry)
@@ -100,8 +102,8 @@ class LoggingProvider:
             tokens_used=response.tokens_used,
             finish_reason=response.finish_reason,
             duration_seconds=duration,
-            temperature=_temperature,
-            max_tokens=_max_tokens,
+            temperature=temperature,
+            max_tokens=max_tokens,
         )
         self._logger.log(entry)
 

--- a/src/questfoundry/providers/logging_wrapper.py
+++ b/src/questfoundry/providers/logging_wrapper.py
@@ -1,0 +1,121 @@
+"""Logging wrapper for LLM providers."""
+
+from __future__ import annotations
+
+import time
+from typing import TYPE_CHECKING
+
+from questfoundry.providers.base import LLMResponse, Message
+
+if TYPE_CHECKING:
+    from questfoundry.observability import LLMLogger
+    from questfoundry.providers import LLMProvider
+
+
+class LoggingProvider:
+    """Wrapper that logs all LLM calls to the LLMLogger.
+
+    Delegates to an underlying provider and logs request/response details
+    to the configured LLMLogger.
+
+    Attributes:
+        default_model: The model name from the wrapped provider.
+    """
+
+    def __init__(
+        self,
+        provider: LLMProvider,
+        logger: LLMLogger,
+        stage: str,
+    ) -> None:
+        """Initialize logging wrapper.
+
+        Args:
+            provider: Underlying LLM provider to wrap.
+            logger: LLMLogger instance for recording calls.
+            stage: Current pipeline stage name for log entries.
+        """
+        self._provider = provider
+        self._logger = logger
+        self._stage = stage
+
+    @property
+    def default_model(self) -> str:
+        """Return the default model from wrapped provider."""
+        return self._provider.default_model
+
+    async def complete(
+        self,
+        messages: list[Message],
+        model: str | None = None,
+        _temperature: float = 0.7,
+        _max_tokens: int = 4096,
+    ) -> LLMResponse:
+        """Generate completion and log the call.
+
+        Args:
+            messages: List of conversation messages.
+            model: Optional model override.
+            _temperature: Sampling temperature (logged, may be unused by provider).
+            _max_tokens: Maximum tokens (logged, may be unused by provider).
+
+        Returns:
+            LLMResponse from underlying provider.
+        """
+        start_time = time.perf_counter()
+        error_msg: str | None = None
+
+        try:
+            response = await self._provider.complete(
+                messages=messages,
+                model=model,
+            )
+        except Exception as e:
+            error_msg = str(e)
+            duration = time.perf_counter() - start_time
+            # Log the failed call
+            entry = self._logger.create_entry(
+                stage=self._stage,
+                model=model or self.default_model,
+                messages=[dict(m) for m in messages],
+                content="",
+                tokens_used=0,
+                finish_reason="error",
+                duration_seconds=duration,
+                temperature=_temperature,
+                max_tokens=_max_tokens,
+                error=error_msg,
+            )
+            self._logger.log(entry)
+            raise
+
+        duration = time.perf_counter() - start_time
+
+        # Log successful call
+        entry = self._logger.create_entry(
+            stage=self._stage,
+            model=response.model,
+            messages=[dict(m) for m in messages],
+            content=response.content,
+            tokens_used=response.tokens_used,
+            finish_reason=response.finish_reason,
+            duration_seconds=duration,
+            temperature=_temperature,
+            max_tokens=_max_tokens,
+        )
+        self._logger.log(entry)
+
+        return response
+
+    async def close(self) -> None:
+        """Close underlying provider."""
+        if hasattr(self._provider, "close"):
+            await self._provider.close()
+
+    async def __aenter__(self) -> "LoggingProvider":
+        """Enter async context."""
+        return self
+
+    async def __aexit__(self, *_: object) -> None:
+        """Exit async context."""
+        await self.close()

--- a/tests/unit/test_artifacts.py
+++ b/tests/unit/test_artifacts.py
@@ -354,7 +354,7 @@ def test_validator_invalid_data_schema() -> None:
         "version": 1,
         "genre": "mystery",
         "tone": ["dark"],
-        "audience": "invalid_audience",  # Invalid enum value
+        "audience": "",  # Empty string not allowed (minLength=1)
         "themes": ["betrayal"],
     }
 

--- a/tests/unit/test_artifacts.py
+++ b/tests/unit/test_artifacts.py
@@ -79,12 +79,12 @@ def test_dream_artifact_invalid_empty_tone() -> None:
 
 
 def test_dream_artifact_invalid_audience() -> None:
-    """Invalid audience value should fail validation."""
+    """Empty audience should fail validation."""
     with pytest.raises(ValidationError) as exc_info:
         DreamArtifact(
             genre="mystery",
             tone=["dark"],
-            audience="invalid",  # type: ignore[arg-type]
+            audience="",  # Empty string not allowed
             themes=["betrayal"],
         )
     assert "audience" in str(exc_info.value)
@@ -113,14 +113,35 @@ def test_scope_invalid_word_count() -> None:
 
 
 def test_scope_invalid_branching_depth() -> None:
-    """Invalid branching depth should fail."""
+    """Empty branching depth should fail."""
     with pytest.raises(ValidationError) as exc_info:
         Scope(
             target_word_count=10000,
             estimated_passages=10,
-            branching_depth="extreme",  # type: ignore[arg-type]
+            branching_depth="",  # Empty string not allowed
         )
     assert "branching_depth" in str(exc_info.value)
+
+
+def test_dream_artifact_accepts_flexible_audience() -> None:
+    """Audience accepts any non-empty string for LLM flexibility."""
+    artifact = DreamArtifact(
+        genre="mystery",
+        tone=["dark"],
+        audience="adults",  # Not strictly "adult" but valid
+        themes=["betrayal"],
+    )
+    assert artifact.audience == "adults"
+
+
+def test_scope_accepts_flexible_branching_depth() -> None:
+    """Branching depth accepts any non-empty string for LLM flexibility."""
+    scope = Scope(
+        target_word_count=10000,
+        estimated_passages=10,
+        branching_depth="extensive",  # Custom value
+    )
+    assert scope.branching_depth == "extensive"
 
 
 # --- ArtifactWriter Tests ---


### PR DESCRIPTION
## Summary

- Wire up LLM logging to capture full request/response in `logs/llm_calls.jsonl`
- Fix YAML extraction bug that stopped parsing at multi-line content
- Relax schema validation to use strings with examples instead of strict enums

## Changes

### LLM Logging (`feat(observability)`)
- Add `LoggingProvider` wrapper that logs all LLM calls to JSONL
- Enable with `qf --log` flag for debugging prompt engineering issues

### YAML Extraction (`fix(dream)`)
- Fixed `_is_yaml_line()` receiving stripped lines, causing multi-line content (after `|`) to be rejected
- Now passes original line to preserve indentation for continuation detection

### Schema Relaxation (`refactor(schema)`)
- Replace `Literal["adult", ...]` with `str` + examples in descriptions
- Artifacts will be interpreted by other LLMs, so strict validation is unnecessary
- Update Pydantic models, JSON schema, and prompt template with inline examples

## Test plan
- [x] All 162 tests pass
- [x] End-to-end test: `qf dream --project test1 "noir detective story"` succeeds
- [x] Logs captured in `logs/llm_calls.jsonl` when using `--log` flag

🤖 Generated with [Claude Code](https://claude.com/claude-code)