### PR TITLE
feat: add interactive REPL mode for stages

### DIFF
--- a/docs/architecture/interactive-stages.md
+++ b/docs/architecture/interactive-stages.md
@@ -1,0 +1,247 @@
+# Interactive Stage Architecture
+
+This document describes the architecture for interactive stage execution in QuestFoundry v5, enabling conversational refinement before structured output.
+
+## Overview
+
+Interactive mode enables multi-turn LLM conversations during stage execution. Instead of a single LLM call producing the final artifact, the LLM engages with the user to discuss and refine the creative vision before calling a finalization tool.
+
+### Key Design Decisions
+
+1. **Single Codepath**: Interactive mode is a flag, not separate implementation
+2. **Tool-Gated Finalization**: LLM signals completion by calling a stage-specific tool
+3. **Sandwich Pattern**: Critical instructions appear at prompt start AND end
+4. **TTY Auto-Detection**: Mode defaults based on terminal interactivity
+5. **Validation-Retry Loop**: Failed validation triggers compact feedback for retry
+
+## Architecture Components
+
+### Tool Protocol (`src/questfoundry/tools/base.py`)
+
+```
+┌────────────────────┐
+│  ToolDefinition    │
+│  - name: str       │
+│  - description     │
+│  - parameters      │  (JSON Schema)
+└────────────────────┘
+
+┌────────────────────┐
+│  ToolCall          │
+│  - id: str         │
+│  - name: str       │
+│  - arguments: dict │
+└────────────────────┘
+
+┌────────────────────┐
+│  Tool (Protocol)   │
+│  + definition      │
+│  + execute()       │
+└────────────────────┘
+```
+
+### LLMProvider Extension (`src/questfoundry/providers/base.py`)
+
+The provider interface was extended with tool support:
+
+```python
+async def complete(
+    messages: list[Message],
+    tools: list[ToolDefinition] | None = None,
+    tool_choice: str | None = None,  # "auto", "required", or tool name
+) -> LLMResponse
+```
+
+The `LLMResponse` now includes optional `tool_calls`:
+
+```python
+@dataclass
+class LLMResponse:
+    content: str
+    model: str
+    tokens_used: int
+    finish_reason: str
+    tool_calls: list[ToolCall] | None = None
+```
+
+### ConversationRunner (`src/questfoundry/conversation/runner.py`)
+
+The `ConversationRunner` manages the multi-turn conversation loop:
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                    ConversationRunner                        │
+├─────────────────────────────────────────────────────────────┤
+│ provider: LLMProvider                                        │
+│ tools: list[Tool]                                           │
+│ finalization_tool: str          (e.g., "submit_dream")      │
+│ max_turns: int                  (default: 10)               │
+│ validation_retries: int         (default: 3)                │
+├─────────────────────────────────────────────────────────────┤
+│ run(initial_messages, user_input_fn, validator)             │
+│   → (artifact_data, ConversationState)                      │
+└─────────────────────────────────────────────────────────────┘
+```
+
+**Conversation Flow:**
+
+```
+┌─────────────┐     ┌───────────────┐     ┌──────────────┐
+│   System    │ →   │     User      │ →   │     LLM      │
+│   Prompt    │     │   Message     │     │   Response   │
+└─────────────┘     └───────────────┘     └──────┬───────┘
+                                                  │
+                    ┌─────────────────────────────┘
+                    │
+                    ▼
+        ┌───────────────────────┐
+        │  Tool Call Present?   │
+        └───────────┬───────────┘
+                    │
+         ┌──────────┴──────────┐
+         │                     │
+    finalization           research
+         │                     │
+         ▼                     ▼
+┌─────────────────┐  ┌─────────────────┐
+│   Validate      │  │  Execute Tool   │
+│   Artifact      │  │  Add Result to  │
+└────────┬────────┘  │  Messages       │
+         │           └─────────────────┘
+         │                     │
+    ┌────┴────┐               │
+    │         │               │
+  valid    invalid            │
+    │         │               │
+    ▼         ▼               ▼
+ RETURN    RETRY        CONTINUE
+           (max 3)      CONVERSATION
+```
+
+### Finalization Tools (`src/questfoundry/tools/finalization.py`)
+
+Each stage has a dedicated finalization tool:
+
+| Stage | Tool Name | Purpose |
+|-------|-----------|---------|
+| DREAM | `submit_dream` | Capture creative vision |
+| BRAINSTORM | `submit_brainstorm` | Capture raw material |
+| (future) | `submit_seed` | Capture core elements |
+
+The tool schema matches the artifact schema, ensuring structured output.
+
+## Execution Modes
+
+### Interactive Mode (Default with TTY)
+
+1. LLM receives system prompt with discussion instructions
+2. Conversation loop: LLM ↔ User (via `user_input_fn`)
+3. LLM calls finalization tool when ready
+4. Validation with retry on failure
+5. Artifact written
+
+### Direct Mode (Non-TTY or `--no-interactive`)
+
+1. LLM receives system prompt with direct generation instructions
+2. Single LLM call with `tool_choice="submit_dream"`
+3. Falls back to YAML parsing for legacy providers
+4. Validation with error on failure
+5. Artifact written
+
+## Prompt Architecture
+
+### Sandwich Pattern
+
+Critical instructions appear at both the start and end of the system prompt:
+
+```yaml
+system: |
+  You are a creative director for interactive fiction.
+
+  {{ mode_instructions }}        # START: Mode-specific behavior
+
+  The DREAM artifact captures:
+  - Genre and subgenre
+  - Tone and atmosphere
+  ...
+
+  {{ mode_reminder }}            # END: Reinforce key behavior
+```
+
+### Mode-Specific Content
+
+The stage provides mode-specific content via template variables:
+
+**Interactive Mode:**
+- `mode_instructions`: Engage in conversation, ask clarifying questions
+- `mode_reminder`: Only call submit_dream when vision is refined
+
+**Direct Mode:**
+- `mode_instructions`: Generate directly, call submit_dream
+- `mode_reminder`: (empty)
+
+## Usage
+
+### CLI
+
+```bash
+# Auto-detect (interactive if TTY)
+qf dream "A noir mystery"
+
+# Force interactive
+qf dream -i "A noir mystery"
+
+# Force direct (piped input, scripting)
+qf dream -I "A noir mystery"
+echo "A noir mystery" | qf dream -I
+```
+
+### Programmatic
+
+```python
+from questfoundry.pipeline import PipelineOrchestrator
+
+orchestrator = PipelineOrchestrator(project_path)
+
+# Interactive mode (default)
+result = await orchestrator.run_stage("dream", {
+    "user_prompt": "A noir mystery",
+    # "interactive" not set = TTY auto-detect
+})
+
+# Force direct mode
+result = await orchestrator.run_stage("dream", {
+    "user_prompt": "A noir mystery",
+    "interactive": False,
+})
+```
+
+## Extension Points
+
+### Adding Research Tools
+
+Research tools can be injected into the conversation:
+
+```python
+context = {
+    "user_prompt": "...",
+    "research_tools": [SearchCorpusTool(), WebSearchTool()],
+}
+```
+
+These are available alongside the finalization tool during conversation.
+
+### Adding New Stages
+
+1. Create finalization tool in `tools/finalization.py`
+2. Register in `FINALIZATION_TOOLS` dict
+3. Create stage implementation using `ConversationRunner`
+4. Create prompt template with mode variables
+
+## Testing
+
+- **Unit tests**: Mock provider, verify tool call handling
+- **Integration tests**: Full stage execution with both modes
+- **E2E tests**: Real LLM calls (optional, marked slow)
+
+See `tests/unit/test_conversation_runner.py` and `tests/unit/test_dream_stage.py`.

--- a/prompts/templates/dream.yaml
+++ b/prompts/templates/dream.yaml
@@ -5,44 +5,23 @@ system: |
   You are a creative director for interactive fiction.
   Your task is to establish the creative vision for a new story.
 
-  Generate a DREAM artifact that captures:
+  {{ mode_instructions }}
+
+  The DREAM artifact captures:
   - Genre and subgenre
-  - Tone and atmosphere
+  - Tone and atmosphere (list of descriptors)
   - Target audience
-  - Core themes to explore
+  - Core themes to explore (list)
   - Style guidance for writing
   - Scope constraints (word count, passages, branching complexity)
+  - Content notes (what to include/exclude)
 
   Be specific and evocative. The DREAM artifact guides all subsequent stages.
 
+  {{ mode_reminder }}
+
 user: |
-  Create a creative vision for this story idea:
-
-  {{ user_prompt }}
-
-  Output valid YAML with these fields:
-
-  type: dream
-  version: 1
-  genre: <primary genre, e.g., Mystery, Fantasy, Horror, Romance, Sci-Fi>
-  subgenre: <optional refinement, e.g., Cozy Mystery, Urban Fantasy, Gothic Horror>
-  tone:
-    - <tone descriptor, e.g., dark and brooding>
-    - <tone descriptor, e.g., whimsical>
-    - <tone descriptor, e.g., tense and suspenseful>
-  audience: <target readers, e.g., adult, young adult, all ages, mature>
-  themes:
-    - <thematic element, e.g., redemption>
-    - <thematic element, e.g., the cost of ambition>
-    - <thematic element, e.g., found family>
-  style_notes: |
-    <writing style guidance - describe prose style, pacing, narrative voice>
-  scope:
-    target_word_count: <approximate length, e.g., 50000>
-    estimated_passages: <scene count, e.g., 25>
-    branching_depth: <complexity, e.g., light, moderate, heavy, extensive>
-
-  Be creative but grounded. Make choices that serve the story.
+  {{ user_message }}
 
 components:
   - role_setup

--- a/src/questfoundry/conversation/__init__.py
+++ b/src/questfoundry/conversation/__init__.py
@@ -1,0 +1,19 @@
+"""Conversation management for interactive stages.
+
+This package provides the ConversationRunner for managing multi-turn
+LLM interactions with tool calling support.
+"""
+
+from questfoundry.conversation.runner import (
+    ConversationError,
+    ConversationRunner,
+    ValidationResult,
+)
+from questfoundry.conversation.state import ConversationState
+
+__all__ = [
+    "ConversationError",
+    "ConversationRunner",
+    "ConversationState",
+    "ValidationResult",
+]

--- a/src/questfoundry/conversation/runner.py
+++ b/src/questfoundry/conversation/runner.py
@@ -228,13 +228,22 @@ class ConversationRunner:
                     state.tokens_used += response.tokens_used
 
                     # Extract new tool call
+                    found_new_call = False
                     if response.has_tool_calls and response.tool_calls:
                         for tc in response.tool_calls:
                             if tc.name == self._finalization_tool:
                                 data = tc.arguments
                                 tool_call = tc
+                                found_new_call = True
                                 break
+
                     retries += 1
+                    if not found_new_call:
+                        # LLM didn't provide expected tool call, count as failed attempt
+                        state.add_message({
+                            "role": "assistant",
+                            "content": response.content or "(no tool call provided)",
+                        })
                     continue
                 else:
                     # Use validated/transformed data if provided

--- a/src/questfoundry/conversation/runner.py
+++ b/src/questfoundry/conversation/runner.py
@@ -240,10 +240,12 @@ class ConversationRunner:
                     retries += 1
                     if not found_new_call:
                         # LLM didn't provide expected tool call, count as failed attempt
-                        state.add_message({
-                            "role": "assistant",
-                            "content": response.content or "(no tool call provided)",
-                        })
+                        state.add_message(
+                            {
+                                "role": "assistant",
+                                "content": response.content or "(no tool call provided)",
+                            }
+                        )
                     continue
                 else:
                     # Use validated/transformed data if provided

--- a/src/questfoundry/conversation/runner.py
+++ b/src/questfoundry/conversation/runner.py
@@ -7,6 +7,7 @@ conversational refinement before structured output.
 
 from __future__ import annotations
 
+import json
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
@@ -219,8 +220,18 @@ class ConversationRunner:
             if validator is not None:
                 result = validator(data)
                 if not result.valid:
-                    # Add error feedback to conversation
-                    error_msg = f"Validation failed: {result.error}. Please fix and try again."
+                    # Add error feedback with full context for repair
+                    # Following validate-with-feedback pattern:
+                    # 1. Include previous candidate verbatim
+                    # 2. List validation errors by field
+                    # 3. Give strict repair instructions
+                    error_msg = (
+                        f"Validation failed. Your submitted data:\n\n"
+                        f"```json\n{json.dumps(data, indent=2)}\n```\n\n"
+                        f"Errors:\n{result.error}\n\n"
+                        f"Call {self._finalization_tool}() again with corrected data. "
+                        f"Fix ONLY the errors listed above. Do not change valid fields."
+                    )
                     state.add_tool_result(tool_call.id, error_msg)
 
                     # Request retry from LLM

--- a/src/questfoundry/conversation/runner.py
+++ b/src/questfoundry/conversation/runner.py
@@ -220,19 +220,35 @@ class ConversationRunner:
             if validator is not None:
                 result = validator(data)
                 if not result.valid:
-                    # Add error feedback with full context for repair
-                    # Following validate-with-feedback pattern:
-                    # 1. Include previous candidate verbatim
-                    # 2. List validation errors by field
-                    # 3. Give strict repair instructions
-                    error_msg = (
-                        f"Validation failed. Your submitted data:\n\n"
-                        f"```json\n{json.dumps(data, indent=2)}\n```\n\n"
-                        f"Errors:\n{result.error}\n\n"
-                        f"Call {self._finalization_tool}() again with corrected data. "
-                        f"Fix ONLY the errors listed above. Do not change valid fields."
-                    )
-                    state.add_tool_result(tool_call.id, error_msg)
+                    # Validate-with-feedback pattern: structured error response
+                    # Lets LLM understand exactly what failed and how to fix it
+                    feedback = {
+                        "success": False,
+                        "error": "Validation failed for submitted artifact",
+                        "error_count": len(result.error.split(";")) if result.error else 1,
+                        "invalid_fields": [],
+                        "missing_fields": [],
+                        "submitted_data": data,
+                        "hint": f"Call {self._finalization_tool}() again with corrected data. Fix only the errors listed.",
+                    }
+
+                    # Parse validation errors into structured format
+                    if result.error:
+                        for err in result.error.replace("Validation errors: ", "").split("; "):
+                            if ": " in err:
+                                field, issue = err.split(": ", 1)
+                                if "required" in issue.lower() or "missing" in issue.lower():
+                                    feedback["missing_fields"].append(field)
+                                else:
+                                    feedback["invalid_fields"].append(
+                                        {
+                                            "field": field,
+                                            "provided": data.get(field.split(".")[0]),
+                                            "issue": issue,
+                                        }
+                                    )
+
+                    state.add_tool_result(tool_call.id, json.dumps(feedback, indent=2))
 
                     # Request retry from LLM
                     response = await self._provider.complete(

--- a/src/questfoundry/conversation/runner.py
+++ b/src/questfoundry/conversation/runner.py
@@ -282,9 +282,7 @@ class ConversationRunner:
                         # LLM didn't provide expected tool call - fail fast
                         # Continuing would revalidate same stale data (infinite loop)
                         if response.content:
-                            state.add_message(
-                                {"role": "assistant", "content": response.content}
-                            )
+                            state.add_message({"role": "assistant", "content": response.content})
                         raise ConversationError(
                             f"LLM failed to call {self._finalization_tool} on retry {retries}",
                             state,

--- a/src/questfoundry/conversation/runner.py
+++ b/src/questfoundry/conversation/runner.py
@@ -102,6 +102,7 @@ class ConversationRunner:
         initial_messages: list[Message],
         user_input_fn: Callable[[], Awaitable[str | None]] | None = None,
         validator: Callable[[dict[str, Any]], ValidationResult] | None = None,
+        on_assistant_message: Callable[[str], None] | None = None,
     ) -> tuple[dict[str, Any], ConversationState]:
         """Run the conversation until finalization.
 
@@ -111,6 +112,8 @@ class ConversationRunner:
                 returns None/empty, conversation continues without user input.
             validator: Optional function to validate finalization data.
                 Called with tool arguments, returns ValidationResult.
+            on_assistant_message: Optional callback for assistant messages.
+                Called with the message content for display purposes.
 
         Returns:
             Tuple of (artifact_data, conversation_state).
@@ -145,6 +148,8 @@ class ConversationRunner:
             # Add assistant message if there's content
             if response.content:
                 state.add_message({"role": "assistant", "content": response.content})
+                if on_assistant_message is not None:
+                    on_assistant_message(response.content)
 
             # Check if we should get user input
             if user_input_fn is not None:

--- a/src/questfoundry/conversation/runner.py
+++ b/src/questfoundry/conversation/runner.py
@@ -1,0 +1,268 @@
+"""Conversation runner for interactive stages.
+
+This module provides the ConversationRunner class that manages
+multi-turn LLM interactions with tool calling support, enabling
+conversational refinement before structured output.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+from questfoundry.conversation.state import ConversationState
+
+if TYPE_CHECKING:
+    from collections.abc import Awaitable, Callable
+
+    from questfoundry.providers.base import LLMProvider, Message
+    from questfoundry.tools import Tool, ToolCall
+
+
+class ConversationError(Exception):
+    """Raised when conversation fails.
+
+    Attributes:
+        message: Error description.
+        state: Conversation state at time of failure.
+    """
+
+    def __init__(self, message: str, state: ConversationState | None = None) -> None:
+        self.state = state
+        super().__init__(message)
+
+
+@dataclass
+class ValidationResult:
+    """Result of validating tool call arguments.
+
+    Attributes:
+        valid: Whether validation passed.
+        error: Error message if validation failed.
+        data: Validated/transformed data if validation passed.
+    """
+
+    valid: bool
+    error: str | None = None
+    data: dict[str, Any] | None = None
+
+
+class ConversationRunner:
+    """Manages multi-turn LLM conversations with tool calling.
+
+    The runner implements the Discuss → Freeze → Serialize pattern:
+    1. Conversation phase: LLM discusses with user, uses research tools
+    2. Finalization: LLM calls finalization tool with structured data
+    3. Validation: Data is validated with optional retry loop
+
+    Attributes:
+        finalization_tool: Name of the tool that signals completion.
+        max_turns: Maximum conversation turns before timeout.
+        validation_retries: Maximum validation retry attempts.
+
+    Example:
+        >>> runner = ConversationRunner(
+        ...     provider=provider,
+        ...     tools=[SubmitDreamTool(), SearchCorpusTool()],
+        ...     finalization_tool="submit_dream",
+        ... )
+        >>> artifact, state = await runner.run(
+        ...     initial_messages=[system_msg, user_msg],
+        ...     user_input_fn=lambda: input("> "),
+        ...     validator=validate_dream,
+        ... )
+    """
+
+    def __init__(
+        self,
+        provider: LLMProvider,
+        tools: list[Tool],
+        finalization_tool: str,
+        max_turns: int = 10,
+        validation_retries: int = 3,
+    ) -> None:
+        """Initialize the conversation runner.
+
+        Args:
+            provider: LLM provider for completions.
+            tools: List of tools available during conversation.
+            finalization_tool: Name of the tool that ends the conversation.
+            max_turns: Maximum turns before timeout (default 10).
+            validation_retries: Max validation retries (default 3).
+        """
+        self._provider = provider
+        self._tools = {t.definition.name: t for t in tools}
+        self._tool_definitions = [t.definition for t in tools]
+        self._finalization_tool = finalization_tool
+        self._max_turns = max_turns
+        self._validation_retries = validation_retries
+
+    async def run(
+        self,
+        initial_messages: list[Message],
+        user_input_fn: Callable[[], Awaitable[str | None]] | None = None,
+        validator: Callable[[dict[str, Any]], ValidationResult] | None = None,
+    ) -> tuple[dict[str, Any], ConversationState]:
+        """Run the conversation until finalization.
+
+        Args:
+            initial_messages: Starting messages (typically system + user).
+            user_input_fn: Async function to get user input. If None or
+                returns None/empty, conversation continues without user input.
+            validator: Optional function to validate finalization data.
+                Called with tool arguments, returns ValidationResult.
+
+        Returns:
+            Tuple of (artifact_data, conversation_state).
+
+        Raises:
+            ConversationError: If max turns exceeded or validation fails
+                after all retries.
+        """
+        state = ConversationState(messages=list(initial_messages))
+
+        while state.turn_count < self._max_turns:
+            # Call LLM with tools
+            response = await self._provider.complete(
+                messages=state.messages,
+                tools=self._tool_definitions,
+                tool_choice="auto",
+            )
+            state.llm_calls += 1
+            state.tokens_used += response.tokens_used
+
+            # Handle tool calls
+            if response.has_tool_calls:
+                result = await self._handle_tool_calls(
+                    response.tool_calls or [],
+                    state,
+                    validator,
+                )
+                if result is not None:
+                    # Finalization tool was called and validated
+                    return result, state
+
+            # Add assistant message if there's content
+            if response.content:
+                state.add_message({"role": "assistant", "content": response.content})
+
+            # Check if we should get user input
+            if user_input_fn is not None:
+                user_input = await user_input_fn()
+                if user_input:
+                    state.add_message({"role": "user", "content": user_input})
+
+            state.turn_count += 1
+
+        raise ConversationError(
+            f"Maximum turns ({self._max_turns}) exceeded without finalization",
+            state,
+        )
+
+    async def _handle_tool_calls(
+        self,
+        tool_calls: list[ToolCall],
+        state: ConversationState,
+        validator: Callable[[dict[str, Any]], ValidationResult] | None,
+    ) -> dict[str, Any] | None:
+        """Process tool calls from LLM response.
+
+        Args:
+            tool_calls: List of tool calls from LLM.
+            state: Current conversation state.
+            validator: Optional validator for finalization tool.
+
+        Returns:
+            Finalization data if finalization tool was called successfully,
+            None otherwise.
+        """
+        for tc in tool_calls:
+            if tc.name == self._finalization_tool:
+                # Handle finalization with validation
+                return await self._handle_finalization(tc, state, validator)
+            else:
+                # Execute research tool
+                result = self._execute_tool(tc)
+                state.add_tool_result(tc.id, result)
+
+        return None
+
+    async def _handle_finalization(
+        self,
+        tool_call: ToolCall,
+        state: ConversationState,
+        validator: Callable[[dict[str, Any]], ValidationResult] | None,
+    ) -> dict[str, Any]:
+        """Handle finalization tool call with validation retry.
+
+        Args:
+            tool_call: The finalization tool call.
+            state: Current conversation state.
+            validator: Optional validator function.
+
+        Returns:
+            Validated artifact data.
+
+        Raises:
+            ConversationError: If validation fails after all retries.
+        """
+        data = tool_call.arguments
+        retries = 0
+
+        while retries < self._validation_retries:
+            # Validate if validator provided
+            if validator is not None:
+                result = validator(data)
+                if not result.valid:
+                    # Add error feedback to conversation
+                    error_msg = f"Validation failed: {result.error}. Please fix and try again."
+                    state.add_tool_result(tool_call.id, error_msg)
+
+                    # Request retry from LLM
+                    response = await self._provider.complete(
+                        messages=state.messages,
+                        tools=self._tool_definitions,
+                        tool_choice=self._finalization_tool,  # Force retry of same tool
+                    )
+                    state.llm_calls += 1
+                    state.tokens_used += response.tokens_used
+
+                    # Extract new tool call
+                    if response.has_tool_calls and response.tool_calls:
+                        for tc in response.tool_calls:
+                            if tc.name == self._finalization_tool:
+                                data = tc.arguments
+                                tool_call = tc
+                                break
+                    retries += 1
+                    continue
+                else:
+                    # Use validated/transformed data if provided
+                    data = result.data if result.data is not None else data
+
+            # Validation passed or no validator
+            state.add_tool_result(tool_call.id, "Artifact submitted successfully.")
+            return data
+
+        raise ConversationError(
+            f"Validation failed after {self._validation_retries} retries",
+            state,
+        )
+
+    def _execute_tool(self, tool_call: ToolCall) -> str:
+        """Execute a non-finalization tool.
+
+        Args:
+            tool_call: The tool call to execute.
+
+        Returns:
+            Tool execution result as string.
+        """
+        tool = self._tools.get(tool_call.name)
+        if tool is None:
+            return f"Error: Unknown tool '{tool_call.name}'"
+
+        try:
+            return tool.execute(tool_call.arguments)
+        except Exception as e:
+            return f"Error executing {tool_call.name}: {e}"

--- a/src/questfoundry/conversation/state.py
+++ b/src/questfoundry/conversation/state.py
@@ -1,0 +1,52 @@
+"""Conversation state tracking.
+
+This module provides the ConversationState dataclass for tracking
+the state of a conversation during interactive stage execution.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from questfoundry.providers.base import Message
+
+
+@dataclass
+class ConversationState:
+    """Tracks state during a conversation loop.
+
+    Maintains the message history, turn count, and resource usage
+    metrics for a conversation session.
+
+    Attributes:
+        messages: List of all messages in the conversation.
+        turn_count: Number of completed conversation turns.
+        llm_calls: Total LLM API calls made.
+        tokens_used: Total tokens consumed across all calls.
+
+    Example:
+        >>> state = ConversationState()
+        >>> state.messages.append({"role": "user", "content": "Hello"})
+        >>> state.turn_count += 1
+        >>> state.llm_calls += 1
+        >>> state.tokens_used += 150
+    """
+
+    messages: list[Message] = field(default_factory=list)
+    turn_count: int = 0
+    llm_calls: int = 0
+    tokens_used: int = 0
+
+    def add_message(self, message: Message) -> None:
+        """Add a message to the conversation history."""
+        self.messages.append(message)
+
+    def add_tool_result(self, tool_call_id: str, content: str) -> None:
+        """Add a tool result message to the conversation."""
+        self.messages.append({
+            "role": "tool",
+            "content": content,
+            "tool_call_id": tool_call_id,
+        })

--- a/src/questfoundry/conversation/state.py
+++ b/src/questfoundry/conversation/state.py
@@ -45,8 +45,10 @@ class ConversationState:
 
     def add_tool_result(self, tool_call_id: str, content: str) -> None:
         """Add a tool result message to the conversation."""
-        self.messages.append({
-            "role": "tool",
-            "content": content,
-            "tool_call_id": tool_call_id,
-        })
+        self.messages.append(
+            {
+                "role": "tool",
+                "content": content,
+                "tool_call_id": tool_call_id,
+            }
+        )

--- a/src/questfoundry/pipeline/stages/dream.py
+++ b/src/questfoundry/pipeline/stages/dream.py
@@ -25,6 +25,7 @@ from questfoundry.tools import SubmitDreamTool
 if TYPE_CHECKING:
     from questfoundry.prompts import PromptCompiler
     from questfoundry.providers import LLMProvider
+    from questfoundry.providers.base import Message
     from questfoundry.tools import Tool
 
 
@@ -144,14 +145,14 @@ class DreamStage:
         )
 
         # Build initial messages
-        initial_messages: list[dict[str, str]] = [
+        initial_messages: list[Message] = [
             {"role": "system", "content": prompt.system},
             {"role": "user", "content": prompt.user},
         ]
 
         # Run conversation
         artifact_data, state = await runner.run(
-            initial_messages=initial_messages,  # type: ignore[arg-type]
+            initial_messages=initial_messages,
             user_input_fn=user_input_fn,
             validator=self._validate_dream,
         )

--- a/src/questfoundry/pipeline/stages/dream.py
+++ b/src/questfoundry/pipeline/stages/dream.py
@@ -108,6 +108,7 @@ class DreamStage:
         """
         user_prompt = context.get("user_prompt", "")
         user_input_fn = context.get("user_input_fn")
+        on_assistant_message = context.get("on_assistant_message")
         research_tools: list[Tool] = context.get("research_tools", [])
 
         # Build prompt context for interactive mode (sandwich pattern)
@@ -155,6 +156,7 @@ class DreamStage:
             initial_messages=initial_messages,
             user_input_fn=user_input_fn,
             validator=self._validate_dream,
+            on_assistant_message=on_assistant_message,
         )
 
         # Add required fields

--- a/src/questfoundry/providers/base.py
+++ b/src/questfoundry/providers/base.py
@@ -2,34 +2,66 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
-from typing import Literal, Protocol, TypedDict
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Literal, Protocol, TypedDict
+
+if TYPE_CHECKING:
+    from questfoundry.tools import ToolCall, ToolDefinition
 
 
-class Message(TypedDict):
-    """A single message in a conversation."""
+class Message(TypedDict, total=False):
+    """A single message in a conversation.
 
-    role: Literal["system", "user", "assistant"]
+    Supports regular messages (system/user/assistant) and tool result
+    messages. Tool messages must include tool_call_id to correlate
+    with the original tool call.
+
+    Attributes:
+        role: Message role - "system", "user", "assistant", or "tool".
+        content: Message content text.
+        tool_call_id: ID of the tool call this message responds to (tool role only).
+    """
+
+    role: Literal["system", "user", "assistant", "tool"]
     content: str
+    tool_call_id: str  # Required for role="tool"
 
 
 @dataclass
 class LLMResponse:
-    """Response from an LLM completion request."""
+    """Response from an LLM completion request.
+
+    Attributes:
+        content: Text content from the response.
+        model: Model that generated the response.
+        tokens_used: Total tokens consumed.
+        finish_reason: Why the response ended ("stop", "end_turn", "tool_calls", etc.).
+        tool_calls: List of tool calls requested by the LLM, if any.
+    """
 
     content: str
     model: str
     tokens_used: int
     finish_reason: str
+    tool_calls: list[ToolCall] | None = field(default=None)
 
     @property
     def is_complete(self) -> bool:
-        """Check if the response completed successfully."""
-        return self.finish_reason in ("stop", "end_turn")
+        """Check if the response completed successfully (no pending tool calls)."""
+        return self.finish_reason in ("stop", "end_turn") and not self.tool_calls
+
+    @property
+    def has_tool_calls(self) -> bool:
+        """Check if the response contains tool calls."""
+        return bool(self.tool_calls)
 
 
 class LLMProvider(Protocol):
-    """Protocol for LLM providers."""
+    """Protocol for LLM providers.
+
+    Providers must implement text completion with optional tool calling.
+    Tool support enables structured output via tool-gated finalization.
+    """
 
     @property
     def default_model(self) -> str:
@@ -42,20 +74,34 @@ class LLMProvider(Protocol):
         model: str | None = None,
         temperature: float = 0.7,
         max_tokens: int = 4096,
+        tools: list[ToolDefinition] | None = None,
+        tool_choice: str | None = None,
     ) -> LLMResponse:
         """Generate a completion from the given messages.
 
         Args:
-            messages: List of conversation messages.
+            messages: List of conversation messages (including tool results).
             model: Model to use. If None, uses the provider's default.
             temperature: Sampling temperature (0.0 to 2.0).
             max_tokens: Maximum tokens to generate.
+            tools: Optional list of tools to make available to the LLM.
+            tool_choice: How to handle tool selection:
+                - None or "auto": LLM decides whether to call tools
+                - "required": LLM must call at least one tool
+                - "none": Disable tool calling for this request
+                - "<tool_name>": Force specific tool to be called
 
         Returns:
-            LLMResponse containing the generated text and metadata.
+            LLMResponse containing generated text, metadata, and any tool calls.
 
         Raises:
             ProviderError: If the completion request fails.
+
+        Note:
+            When the response contains tool_calls, the caller should:
+            1. Execute each tool
+            2. Add tool result messages with matching tool_call_id
+            3. Call complete() again with the extended message list
         """
         ...
 

--- a/src/questfoundry/providers/langchain_wrapper.py
+++ b/src/questfoundry/providers/langchain_wrapper.py
@@ -158,7 +158,9 @@ class LangChainProvider:
             return AIMessage(content=content)
         elif role == "tool":
             # Tool result message - needs tool_call_id
-            tool_call_id = msg.get("tool_call_id", "")
+            tool_call_id = msg.get("tool_call_id")
+            if not tool_call_id:
+                raise ValueError("Message with role 'tool' must have a 'tool_call_id'")
             return ToolMessage(content=content, tool_call_id=tool_call_id)
         else:
             raise ValueError(f"Unknown role: {role}")

--- a/src/questfoundry/providers/langchain_wrapper.py
+++ b/src/questfoundry/providers/langchain_wrapper.py
@@ -4,9 +4,10 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
-from langchain_core.messages import AIMessage, HumanMessage, SystemMessage
+from langchain_core.messages import AIMessage, HumanMessage, SystemMessage, ToolMessage
 
 from questfoundry.providers.base import LLMResponse, Message, ProviderError
+from questfoundry.tools import ToolCall, ToolDefinition
 
 if TYPE_CHECKING:
     from langchain_core.language_models import BaseChatModel
@@ -44,6 +45,8 @@ class LangChainProvider:
         model: str | None = None,
         temperature: float = 0.7,  # noqa: ARG002 - set at model construction
         max_tokens: int = 4096,  # noqa: ARG002 - set at model construction
+        tools: list[ToolDefinition] | None = None,
+        tool_choice: str | None = None,
     ) -> LLMResponse:
         """Generate a completion from the given messages.
 
@@ -52,9 +55,11 @@ class LangChainProvider:
             model: Model override for response metadata.
             temperature: Unused - set at model construction.
             max_tokens: Unused - set at model construction.
+            tools: Optional tools to bind to the model.
+            tool_choice: Tool selection mode ("auto", "required", "none", or tool name).
 
         Returns:
-            LLMResponse with content and metadata.
+            LLMResponse with content, metadata, and any tool calls.
 
         Raises:
             ProviderError: If completion fails.
@@ -62,9 +67,17 @@ class LangChainProvider:
         # Convert messages to LangChain format
         lc_messages = [self._to_langchain_message(m) for m in messages]
 
+        # Get model, optionally with tools bound
+        lc_model: Any = self._model
+        if tools:
+            lc_tools = [self._to_langchain_tool(t) for t in tools]
+            lc_model = lc_model.bind_tools(
+                lc_tools, tool_choice=self._map_tool_choice(tool_choice)
+            )
+
         try:
             # Call the model
-            response: AIMessage = await self._model.ainvoke(lc_messages)
+            response: AIMessage = await lc_model.ainvoke(lc_messages)
         except Exception as e:
             raise ProviderError("langchain", f"Completion failed: {e}") from e
 
@@ -73,9 +86,23 @@ class LangChainProvider:
         if hasattr(response, "usage_metadata") and response.usage_metadata:
             tokens_used = response.usage_metadata.get("total_tokens", 0)
 
-        # Extract finish reason (default to "unknown" for safety)
+        # Extract tool calls
+        tool_calls: list[ToolCall] | None = None
+        if hasattr(response, "tool_calls") and response.tool_calls:
+            tool_calls = [
+                ToolCall(
+                    id=str(tc.get("id") or f"call_{i}"),
+                    name=str(tc.get("name") or ""),
+                    arguments=tc.get("args") or {},
+                )
+                for i, tc in enumerate(response.tool_calls)
+            ]
+
+        # Determine finish reason
         finish_reason = "unknown"
-        if hasattr(response, "response_metadata") and response.response_metadata:
+        if tool_calls:
+            finish_reason = "tool_calls"
+        elif hasattr(response, "response_metadata") and response.response_metadata:
             finish_reason = response.response_metadata.get("finish_reason", "unknown")
 
         # Handle content (can be str or list)
@@ -88,7 +115,35 @@ class LangChainProvider:
             model=model or self._default_model,
             tokens_used=tokens_used,
             finish_reason=finish_reason,
+            tool_calls=tool_calls,
         )
+
+    def _to_langchain_tool(self, tool_def: ToolDefinition) -> dict[str, Any]:
+        """Convert ToolDefinition to LangChain tool schema.
+
+        LangChain expects OpenAI-style function definitions with
+        name, description, and parameters.
+        """
+        return {
+            "type": "function",
+            "function": {
+                "name": tool_def.name,
+                "description": tool_def.description,
+                "parameters": tool_def.parameters,
+            },
+        }
+
+    def _map_tool_choice(self, tool_choice: str | None) -> str | dict[str, Any] | None:
+        """Map QuestFoundry tool_choice to LangChain format."""
+        if tool_choice is None or tool_choice == "auto":
+            return "auto"
+        elif tool_choice == "required":
+            return "required"
+        elif tool_choice == "none":
+            return "none"
+        else:
+            # Specific tool name - format for forced function call
+            return {"type": "function", "function": {"name": tool_choice}}
 
     def _to_langchain_message(self, msg: Message) -> Any:
         """Convert our Message to LangChain message."""
@@ -101,6 +156,10 @@ class LangChainProvider:
             return HumanMessage(content=content)
         elif role == "assistant":
             return AIMessage(content=content)
+        elif role == "tool":
+            # Tool result message - needs tool_call_id
+            tool_call_id = msg.get("tool_call_id", "")
+            return ToolMessage(content=content, tool_call_id=tool_call_id)
         else:
             raise ValueError(f"Unknown role: {role}")
 

--- a/src/questfoundry/providers/langchain_wrapper.py
+++ b/src/questfoundry/providers/langchain_wrapper.py
@@ -71,9 +71,7 @@ class LangChainProvider:
         lc_model: Any = self._model
         if tools:
             lc_tools = [self._to_langchain_tool(t) for t in tools]
-            lc_model = lc_model.bind_tools(
-                lc_tools, tool_choice=self._map_tool_choice(tool_choice)
-            )
+            lc_model = lc_model.bind_tools(lc_tools, tool_choice=self._map_tool_choice(tool_choice))
 
         try:
             # Call the model

--- a/src/questfoundry/providers/logging_wrapper.py
+++ b/src/questfoundry/providers/logging_wrapper.py
@@ -9,6 +9,7 @@ if TYPE_CHECKING:
     from questfoundry.observability import LLMLogger
     from questfoundry.providers import LLMProvider
     from questfoundry.providers.base import LLMResponse, Message
+    from questfoundry.tools import ToolDefinition
 
 
 class LoggingProvider:
@@ -49,6 +50,8 @@ class LoggingProvider:
         model: str | None = None,
         temperature: float = 0.7,
         max_tokens: int = 4096,
+        tools: list[ToolDefinition] | None = None,
+        tool_choice: str | None = None,
     ) -> LLMResponse:
         """Generate completion and log the call.
 
@@ -57,6 +60,8 @@ class LoggingProvider:
             model: Optional model override.
             temperature: Sampling temperature.
             max_tokens: Maximum tokens to generate.
+            tools: Optional tools to bind.
+            tool_choice: Tool selection mode.
 
         Returns:
             LLMResponse from underlying provider.
@@ -70,6 +75,8 @@ class LoggingProvider:
                 model=model,
                 temperature=temperature,
                 max_tokens=max_tokens,
+                tools=tools,
+                tool_choice=tool_choice,
             )
         except Exception as e:
             error_msg = str(e)
@@ -92,7 +99,7 @@ class LoggingProvider:
 
         duration = time.perf_counter() - start_time
 
-        # Log successful call
+        # Log successful call (including tool calls if present)
         entry = self._logger.create_entry(
             stage=self._stage,
             model=response.model,

--- a/src/questfoundry/tools/__init__.py
+++ b/src/questfoundry/tools/__init__.py
@@ -1,0 +1,22 @@
+"""Tools for LLM interactions.
+
+This package provides the tool protocol and implementations for
+LLM tool calling, including finalization tools for structured output
+and research tools for context retrieval.
+"""
+
+from questfoundry.tools.base import Tool, ToolCall, ToolDefinition
+from questfoundry.tools.finalization import (
+    SubmitBrainstormTool,
+    SubmitDreamTool,
+    get_finalization_tool,
+)
+
+__all__ = [
+    "SubmitBrainstormTool",
+    "SubmitDreamTool",
+    "Tool",
+    "ToolCall",
+    "ToolDefinition",
+    "get_finalization_tool",
+]

--- a/src/questfoundry/tools/base.py
+++ b/src/questfoundry/tools/base.py
@@ -1,0 +1,103 @@
+"""Base types and protocol for LLM tools.
+
+This module defines the core abstractions for tool calling:
+- ToolDefinition: JSON Schema-based tool specification
+- ToolCall: Represents a tool invocation from LLM
+- Tool: Protocol for implementing executable tools
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Protocol
+
+
+@dataclass
+class ToolDefinition:
+    """Definition of a tool that can be bound to an LLM.
+
+    Uses JSON Schema format for parameter definitions, compatible
+    with OpenAI/Anthropic function calling specifications.
+
+    Attributes:
+        name: Unique tool identifier (e.g., "submit_dream", "search_corpus").
+        description: Concise description for LLM to understand when to use.
+        parameters: JSON Schema object defining accepted arguments.
+
+    Example:
+        >>> ToolDefinition(
+        ...     name="search_corpus",
+        ...     description="Search IF craft knowledge base.",
+        ...     parameters={
+        ...         "type": "object",
+        ...         "properties": {
+        ...             "query": {"type": "string", "description": "Search query"},
+        ...         },
+        ...         "required": ["query"],
+        ...     },
+        ... )
+    """
+
+    name: str
+    description: str
+    parameters: dict[str, Any] = field(default_factory=lambda: {"type": "object", "properties": {}})
+
+
+@dataclass
+class ToolCall:
+    """Represents a tool invocation requested by the LLM.
+
+    Contains the tool name, arguments parsed from LLM response,
+    and a unique ID for correlating with tool results.
+
+    Attributes:
+        id: Unique identifier for this call (from LLM provider).
+        name: Name of the tool being called.
+        arguments: Parsed arguments dictionary.
+    """
+
+    id: str
+    name: str
+    arguments: dict[str, Any]
+
+
+class Tool(Protocol):
+    """Protocol for executable tools.
+
+    Tools must provide a definition (for LLM binding) and an
+    execute method (for handling invocations).
+
+    Example:
+        >>> class SearchCorpusTool:
+        ...     @property
+        ...     def definition(self) -> ToolDefinition:
+        ...         return ToolDefinition(
+        ...             name="search_corpus",
+        ...             description="Search IF craft knowledge.",
+        ...             parameters={...},
+        ...         )
+        ...
+        ...     def execute(self, arguments: dict[str, Any]) -> str:
+        ...         query = arguments["query"]
+        ...         return search_results
+    """
+
+    @property
+    def definition(self) -> ToolDefinition:
+        """Return the tool definition for LLM binding."""
+        ...
+
+    def execute(self, arguments: dict[str, Any]) -> str:
+        """Execute the tool with given arguments.
+
+        Args:
+            arguments: Parsed arguments from LLM tool call.
+
+        Returns:
+            String result to send back to LLM.
+
+        Note:
+            Execute is synchronous. For async operations, use
+            asyncio.get_event_loop().run_until_complete() internally.
+        """
+        ...

--- a/src/questfoundry/tools/finalization.py
+++ b/src/questfoundry/tools/finalization.py
@@ -9,9 +9,14 @@ that validates and captures the structured output.
 
 from __future__ import annotations
 
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from questfoundry.tools.base import ToolDefinition
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from questfoundry.tools.base import Tool
 
 
 class SubmitDreamTool:
@@ -188,14 +193,14 @@ class SubmitBrainstormTool:
 
 
 # Registry of finalization tools by stage name
-FINALIZATION_TOOLS: dict[str, type] = {
+FINALIZATION_TOOLS: dict[str, Callable[[], Tool]] = {
     "dream": SubmitDreamTool,
     "brainstorm": SubmitBrainstormTool,
     # Future stages: seed, grow, fill, ship
 }
 
 
-def get_finalization_tool(stage: str) -> SubmitDreamTool | SubmitBrainstormTool | None:
+def get_finalization_tool(stage: str) -> Tool | None:
     """Get the finalization tool for a stage.
 
     Args:
@@ -206,8 +211,5 @@ def get_finalization_tool(stage: str) -> SubmitDreamTool | SubmitBrainstormTool 
     """
     tool_class = FINALIZATION_TOOLS.get(stage)
     if tool_class is not None:
-        tool = tool_class()
-        # Cast to the known return types
-        if isinstance(tool, (SubmitDreamTool, SubmitBrainstormTool)):
-            return tool
+        return tool_class()
     return None

--- a/src/questfoundry/tools/finalization.py
+++ b/src/questfoundry/tools/finalization.py
@@ -1,0 +1,213 @@
+"""Finalization tools for structured output.
+
+This module provides tools that signal completion of a stage's
+conversation phase and capture structured artifact data.
+
+Each stage has its own finalization tool (submit_dream, submit_brainstorm, etc.)
+that validates and captures the structured output.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from questfoundry.tools.base import ToolDefinition
+
+
+class SubmitDreamTool:
+    """Tool for finalizing DREAM stage output.
+
+    When called, signals that the creative vision has been finalized
+    and provides the structured artifact data for validation.
+
+    The tool schema matches the dream.schema.json artifact format,
+    ensuring the LLM produces valid structured output.
+    """
+
+    @property
+    def definition(self) -> ToolDefinition:
+        """Return the tool definition for LLM binding."""
+        return ToolDefinition(
+            name="submit_dream",
+            description=(
+                "Submit the finalized creative vision. Call this when you have "
+                "discussed and refined the story concept with the user and are "
+                "ready to lock in the creative direction."
+            ),
+            parameters={
+                "type": "object",
+                "properties": {
+                    "genre": {
+                        "type": "string",
+                        "description": "Primary genre (e.g., 'fantasy', 'mystery', 'sci-fi', 'horror')",
+                    },
+                    "subgenre": {
+                        "type": "string",
+                        "description": "Optional genre refinement (e.g., 'urban fantasy', 'cozy mystery')",
+                    },
+                    "tone": {
+                        "type": "array",
+                        "items": {"type": "string"},
+                        "description": "Tone descriptors (e.g., ['dark', 'suspenseful', 'romantic'])",
+                    },
+                    "audience": {
+                        "type": "string",
+                        "description": "Target audience: 'all ages', 'young adult', 'adult', or 'mature'",
+                    },
+                    "themes": {
+                        "type": "array",
+                        "items": {"type": "string"},
+                        "description": "Core thematic elements (e.g., ['redemption', 'found family'])",
+                    },
+                    "style_notes": {
+                        "type": "string",
+                        "description": "Prose style guidance (e.g., 'flowery and descriptive' or 'terse and punchy')",
+                    },
+                    "scope": {
+                        "type": "object",
+                        "description": "Story scope parameters",
+                        "properties": {
+                            "target_word_count": {
+                                "type": "integer",
+                                "description": "Approximate total word count (e.g., 15000)",
+                            },
+                            "estimated_passages": {
+                                "type": "integer",
+                                "description": "Target number of scenes/passages (e.g., 25)",
+                            },
+                            "branching_depth": {
+                                "type": "string",
+                                "description": "Branching complexity: 'light', 'moderate', 'heavy', 'extensive'",
+                            },
+                            "estimated_playtime_minutes": {
+                                "type": "integer",
+                                "description": "Target reading/play time in minutes",
+                            },
+                        },
+                    },
+                    "content_notes": {
+                        "type": "object",
+                        "description": "Content guidance",
+                        "properties": {
+                            "includes": {
+                                "type": "array",
+                                "items": {"type": "string"},
+                                "description": "Content to include (e.g., ['mild violence', 'romance'])",
+                            },
+                            "excludes": {
+                                "type": "array",
+                                "items": {"type": "string"},
+                                "description": "Content to avoid (e.g., ['graphic violence', 'explicit content'])",
+                            },
+                        },
+                    },
+                },
+                "required": ["genre", "tone", "audience", "themes"],
+            },
+        )
+
+    def execute(self, arguments: dict[str, Any]) -> str:  # noqa: ARG002
+        """Execute the finalization tool.
+
+        Note: Actual validation happens in ConversationRunner.
+        This method is called after successful validation.
+
+        Args:
+            arguments: The finalized artifact data.
+
+        Returns:
+            Confirmation message.
+        """
+        return "Creative vision submitted for validation."
+
+
+class SubmitBrainstormTool:
+    """Tool for finalizing BRAINSTORM stage output.
+
+    Captures raw creative material including characters, settings,
+    plot hooks, and other story elements.
+    """
+
+    @property
+    def definition(self) -> ToolDefinition:
+        """Return the tool definition for LLM binding."""
+        return ToolDefinition(
+            name="submit_brainstorm",
+            description=(
+                "Submit the brainstorm results. Call this when you have "
+                "generated sufficient raw creative material for the story."
+            ),
+            parameters={
+                "type": "object",
+                "properties": {
+                    "characters": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "name": {"type": "string"},
+                                "role": {"type": "string"},
+                                "description": {"type": "string"},
+                            },
+                        },
+                        "description": "Character concepts",
+                    },
+                    "settings": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "name": {"type": "string"},
+                                "description": {"type": "string"},
+                            },
+                        },
+                        "description": "Setting/location concepts",
+                    },
+                    "plot_hooks": {
+                        "type": "array",
+                        "items": {"type": "string"},
+                        "description": "Potential plot hooks and story seeds",
+                    },
+                    "conflicts": {
+                        "type": "array",
+                        "items": {"type": "string"},
+                        "description": "Conflict ideas",
+                    },
+                    "notes": {
+                        "type": "string",
+                        "description": "Additional creative notes",
+                    },
+                },
+                "required": ["characters", "plot_hooks"],
+            },
+        )
+
+    def execute(self, arguments: dict[str, Any]) -> str:  # noqa: ARG002
+        """Execute the finalization tool."""
+        return "Brainstorm material submitted for validation."
+
+
+# Registry of finalization tools by stage name
+FINALIZATION_TOOLS: dict[str, type] = {
+    "dream": SubmitDreamTool,
+    "brainstorm": SubmitBrainstormTool,
+    # Future stages: seed, grow, fill, ship
+}
+
+
+def get_finalization_tool(stage: str) -> SubmitDreamTool | SubmitBrainstormTool | None:
+    """Get the finalization tool for a stage.
+
+    Args:
+        stage: Stage name (e.g., "dream", "brainstorm").
+
+    Returns:
+        Instantiated finalization tool, or None if stage not found.
+    """
+    tool_class = FINALIZATION_TOOLS.get(stage)
+    if tool_class is not None:
+        tool = tool_class()
+        # Cast to the known return types
+        if isinstance(tool, (SubmitDreamTool, SubmitBrainstormTool)):
+            return tool
+    return None

--- a/tests/unit/test_conversation_runner.py
+++ b/tests/unit/test_conversation_runner.py
@@ -1,0 +1,587 @@
+"""Tests for ConversationRunner."""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from questfoundry.conversation import (
+    ConversationError,
+    ConversationRunner,
+    ConversationState,
+    ValidationResult,
+)
+from questfoundry.providers.base import LLMResponse
+from questfoundry.tools import ToolCall, ToolDefinition
+
+# --- Helper Classes ---
+
+
+class MockFinalizationTool:
+    """Mock finalization tool for testing."""
+
+    @property
+    def definition(self) -> ToolDefinition:
+        return ToolDefinition(
+            name="submit_test",
+            description="Submit test data",
+            parameters={
+                "type": "object",
+                "properties": {
+                    "data": {"type": "string"},
+                },
+                "required": ["data"],
+            },
+        )
+
+    def execute(self, arguments: dict[str, Any]) -> str:  # noqa: ARG002
+        return "Submitted successfully"
+
+
+class MockResearchTool:
+    """Mock research tool for testing."""
+
+    @property
+    def definition(self) -> ToolDefinition:
+        return ToolDefinition(
+            name="search",
+            description="Search for information",
+            parameters={
+                "type": "object",
+                "properties": {
+                    "query": {"type": "string"},
+                },
+                "required": ["query"],
+            },
+        )
+
+    def execute(self, arguments: dict[str, Any]) -> str:
+        return f"Search results for: {arguments.get('query', '')}"
+
+
+# --- ConversationState Tests ---
+
+
+def test_conversation_state_creation() -> None:
+    """ConversationState can be created with initial messages."""
+    messages = [{"role": "system", "content": "Hello"}]
+    state = ConversationState(messages=messages)
+
+    assert state.messages == messages
+    assert state.turn_count == 0
+    assert state.llm_calls == 0
+    assert state.tokens_used == 0
+
+
+def test_conversation_state_add_message() -> None:
+    """ConversationState.add_message appends to messages."""
+    state = ConversationState(messages=[])
+    state.add_message({"role": "user", "content": "Hello"})
+
+    assert len(state.messages) == 1
+    assert state.messages[0]["content"] == "Hello"
+
+
+def test_conversation_state_add_tool_result() -> None:
+    """ConversationState.add_tool_result adds tool response message."""
+    state = ConversationState(messages=[])
+    state.add_tool_result("call_123", "Tool output")
+
+    assert len(state.messages) == 1
+    assert state.messages[0]["role"] == "tool"
+    assert state.messages[0]["tool_call_id"] == "call_123"
+    assert state.messages[0]["content"] == "Tool output"
+
+
+# --- ValidationResult Tests ---
+
+
+def test_validation_result_valid() -> None:
+    """ValidationResult with valid=True."""
+    result = ValidationResult(valid=True, data={"key": "value"})
+
+    assert result.valid is True
+    assert result.error is None
+    assert result.data == {"key": "value"}
+
+
+def test_validation_result_invalid() -> None:
+    """ValidationResult with valid=False."""
+    result = ValidationResult(valid=False, error="Missing required field")
+
+    assert result.valid is False
+    assert result.error == "Missing required field"
+    assert result.data is None
+
+
+# --- ConversationRunner Initialization Tests ---
+
+
+def test_runner_initialization() -> None:
+    """ConversationRunner can be initialized."""
+    provider = MagicMock()
+    tools = [MockFinalizationTool()]
+
+    runner = ConversationRunner(
+        provider=provider,
+        tools=tools,
+        finalization_tool="submit_test",
+        max_turns=5,
+        validation_retries=2,
+    )
+
+    assert runner._max_turns == 5
+    assert runner._validation_retries == 2
+    assert runner._finalization_tool == "submit_test"
+
+
+def test_runner_builds_tool_definitions() -> None:
+    """ConversationRunner builds tool definitions list."""
+    provider = MagicMock()
+    tools = [MockFinalizationTool(), MockResearchTool()]
+
+    runner = ConversationRunner(
+        provider=provider,
+        tools=tools,
+        finalization_tool="submit_test",
+    )
+
+    assert len(runner._tool_definitions) == 2
+    assert runner._tool_definitions[0].name == "submit_test"
+    assert runner._tool_definitions[1].name == "search"
+
+
+# --- ConversationRunner.run Tests ---
+
+
+@pytest.mark.asyncio
+async def test_runner_immediate_finalization() -> None:
+    """Runner returns immediately when finalization tool is called."""
+    provider = MagicMock()
+    provider.complete = AsyncMock(
+        return_value=LLMResponse(
+            content="",
+            model="test",
+            tokens_used=100,
+            finish_reason="tool_calls",
+            tool_calls=[
+                ToolCall(id="call_1", name="submit_test", arguments={"data": "test_value"})
+            ],
+        )
+    )
+
+    runner = ConversationRunner(
+        provider=provider,
+        tools=[MockFinalizationTool()],
+        finalization_tool="submit_test",
+    )
+
+    initial = [
+        {"role": "system", "content": "System prompt"},
+        {"role": "user", "content": "User message"},
+    ]
+
+    artifact, state = await runner.run(initial)
+
+    assert artifact == {"data": "test_value"}
+    assert state.llm_calls == 1
+    assert state.tokens_used == 100
+
+
+@pytest.mark.asyncio
+async def test_runner_conversation_before_finalization() -> None:
+    """Runner handles conversation turns before finalization."""
+    # First call: assistant message (no tool call)
+    # Second call: finalization tool
+    responses = [
+        LLMResponse(
+            content="Let me think about this...",
+            model="test",
+            tokens_used=50,
+            finish_reason="stop",
+        ),
+        LLMResponse(
+            content="",
+            model="test",
+            tokens_used=100,
+            finish_reason="tool_calls",
+            tool_calls=[
+                ToolCall(id="call_1", name="submit_test", arguments={"data": "final"})
+            ],
+        ),
+    ]
+
+    provider = MagicMock()
+    provider.complete = AsyncMock(side_effect=responses)
+
+    runner = ConversationRunner(
+        provider=provider,
+        tools=[MockFinalizationTool()],
+        finalization_tool="submit_test",
+    )
+
+    # No user input function - auto-continue
+    artifact, state = await runner.run([{"role": "system", "content": "System"}])
+
+    assert artifact == {"data": "final"}
+    assert state.llm_calls == 2
+    assert state.tokens_used == 150
+    assert state.turn_count == 1
+
+
+@pytest.mark.asyncio
+async def test_runner_with_user_input() -> None:
+    """Runner calls user_input_fn for each turn."""
+    responses = [
+        LLMResponse(
+            content="What genre?",
+            model="test",
+            tokens_used=50,
+            finish_reason="stop",
+        ),
+        LLMResponse(
+            content="",
+            model="test",
+            tokens_used=100,
+            finish_reason="tool_calls",
+            tool_calls=[
+                ToolCall(id="call_1", name="submit_test", arguments={"data": "fantasy"})
+            ],
+        ),
+    ]
+
+    provider = MagicMock()
+    provider.complete = AsyncMock(side_effect=responses)
+
+    user_inputs = ["Fantasy", None]  # Second call returns None
+    input_index = [0]
+
+    async def mock_user_input() -> str | None:
+        idx = input_index[0]
+        input_index[0] += 1
+        return user_inputs[idx] if idx < len(user_inputs) else None
+
+    runner = ConversationRunner(
+        provider=provider,
+        tools=[MockFinalizationTool()],
+        finalization_tool="submit_test",
+    )
+
+    _artifact, state = await runner.run(
+        [{"role": "system", "content": "System"}],
+        user_input_fn=mock_user_input,
+    )
+
+    # Check user message was added
+    user_messages = [m for m in state.messages if m.get("role") == "user"]
+    assert len(user_messages) == 1
+    assert user_messages[0]["content"] == "Fantasy"
+
+
+@pytest.mark.asyncio
+async def test_runner_max_turns_exceeded() -> None:
+    """Runner raises ConversationError when max turns exceeded."""
+    # Always return content without tool calls
+    provider = MagicMock()
+    provider.complete = AsyncMock(
+        return_value=LLMResponse(
+            content="Still thinking...",
+            model="test",
+            tokens_used=20,
+            finish_reason="stop",
+        )
+    )
+
+    runner = ConversationRunner(
+        provider=provider,
+        tools=[MockFinalizationTool()],
+        finalization_tool="submit_test",
+        max_turns=3,
+    )
+
+    with pytest.raises(ConversationError) as exc_info:
+        await runner.run([{"role": "system", "content": "System"}])
+
+    assert "Maximum turns" in str(exc_info.value)
+    assert exc_info.value.state is not None
+    assert exc_info.value.state.turn_count == 3
+
+
+@pytest.mark.asyncio
+async def test_runner_research_tool_execution() -> None:
+    """Runner executes research tools and adds results to conversation."""
+    responses = [
+        # First: research tool call
+        LLMResponse(
+            content="",
+            model="test",
+            tokens_used=50,
+            finish_reason="tool_calls",
+            tool_calls=[
+                ToolCall(id="call_search", name="search", arguments={"query": "noir"})
+            ],
+        ),
+        # Second: finalization
+        LLMResponse(
+            content="",
+            model="test",
+            tokens_used=100,
+            finish_reason="tool_calls",
+            tool_calls=[
+                ToolCall(id="call_final", name="submit_test", arguments={"data": "result"})
+            ],
+        ),
+    ]
+
+    provider = MagicMock()
+    provider.complete = AsyncMock(side_effect=responses)
+
+    runner = ConversationRunner(
+        provider=provider,
+        tools=[MockFinalizationTool(), MockResearchTool()],
+        finalization_tool="submit_test",
+    )
+
+    _artifact, state = await runner.run([{"role": "system", "content": "System"}])
+
+    # Check tool result was added
+    tool_messages = [m for m in state.messages if m.get("role") == "tool"]
+    assert len(tool_messages) >= 1
+    assert "Search results for: noir" in tool_messages[0]["content"]
+
+
+@pytest.mark.asyncio
+async def test_runner_validation_success() -> None:
+    """Runner uses validator and returns on success."""
+    provider = MagicMock()
+    provider.complete = AsyncMock(
+        return_value=LLMResponse(
+            content="",
+            model="test",
+            tokens_used=100,
+            finish_reason="tool_calls",
+            tool_calls=[
+                ToolCall(id="call_1", name="submit_test", arguments={"data": "valid"})
+            ],
+        )
+    )
+
+    def validator(data: dict) -> ValidationResult:
+        if data.get("data") == "valid":
+            return ValidationResult(valid=True, data=data)
+        return ValidationResult(valid=False, error="Invalid data")
+
+    runner = ConversationRunner(
+        provider=provider,
+        tools=[MockFinalizationTool()],
+        finalization_tool="submit_test",
+    )
+
+    artifact, _state = await runner.run(
+        [{"role": "system", "content": "System"}],
+        validator=validator,
+    )
+
+    assert artifact == {"data": "valid"}
+
+
+@pytest.mark.asyncio
+async def test_runner_validation_retry() -> None:
+    """Runner retries on validation failure."""
+    # First attempt fails validation, second succeeds
+    responses = [
+        LLMResponse(
+            content="",
+            model="test",
+            tokens_used=100,
+            finish_reason="tool_calls",
+            tool_calls=[
+                ToolCall(id="call_1", name="submit_test", arguments={"data": "invalid"})
+            ],
+        ),
+        LLMResponse(
+            content="",
+            model="test",
+            tokens_used=100,
+            finish_reason="tool_calls",
+            tool_calls=[
+                ToolCall(id="call_2", name="submit_test", arguments={"data": "valid"})
+            ],
+        ),
+    ]
+
+    provider = MagicMock()
+    provider.complete = AsyncMock(side_effect=responses)
+
+    call_count = [0]
+
+    def validator(data: dict) -> ValidationResult:
+        call_count[0] += 1
+        if data.get("data") == "valid":
+            return ValidationResult(valid=True, data=data)
+        return ValidationResult(valid=False, error="Data must be 'valid'")
+
+    runner = ConversationRunner(
+        provider=provider,
+        tools=[MockFinalizationTool()],
+        finalization_tool="submit_test",
+        validation_retries=3,
+    )
+
+    artifact, state = await runner.run(
+        [{"role": "system", "content": "System"}],
+        validator=validator,
+    )
+
+    assert artifact == {"data": "valid"}
+    assert call_count[0] == 2  # Validator called twice
+    assert state.llm_calls == 2  # Two LLM calls
+
+
+@pytest.mark.asyncio
+async def test_runner_validation_exhausted() -> None:
+    """Runner raises ConversationError when validation retries exhausted."""
+    # Always fails validation
+    provider = MagicMock()
+    provider.complete = AsyncMock(
+        return_value=LLMResponse(
+            content="",
+            model="test",
+            tokens_used=100,
+            finish_reason="tool_calls",
+            tool_calls=[
+                ToolCall(id="call_1", name="submit_test", arguments={"data": "always_bad"})
+            ],
+        )
+    )
+
+    def validator(data: dict[str, Any]) -> ValidationResult:  # noqa: ARG001
+        return ValidationResult(valid=False, error="Always fails")
+
+    runner = ConversationRunner(
+        provider=provider,
+        tools=[MockFinalizationTool()],
+        finalization_tool="submit_test",
+        validation_retries=2,
+    )
+
+    with pytest.raises(ConversationError) as exc_info:
+        await runner.run(
+            [{"role": "system", "content": "System"}],
+            validator=validator,
+        )
+
+    assert "Validation failed" in str(exc_info.value)
+    assert "2 retries" in str(exc_info.value)
+
+
+@pytest.mark.asyncio
+async def test_runner_unknown_tool() -> None:
+    """Runner handles unknown tool gracefully."""
+    responses = [
+        LLMResponse(
+            content="",
+            model="test",
+            tokens_used=50,
+            finish_reason="tool_calls",
+            tool_calls=[
+                ToolCall(id="call_1", name="unknown_tool", arguments={})
+            ],
+        ),
+        LLMResponse(
+            content="",
+            model="test",
+            tokens_used=100,
+            finish_reason="tool_calls",
+            tool_calls=[
+                ToolCall(id="call_2", name="submit_test", arguments={"data": "ok"})
+            ],
+        ),
+    ]
+
+    provider = MagicMock()
+    provider.complete = AsyncMock(side_effect=responses)
+
+    runner = ConversationRunner(
+        provider=provider,
+        tools=[MockFinalizationTool()],
+        finalization_tool="submit_test",
+    )
+
+    _artifact, state = await runner.run([{"role": "system", "content": "System"}])
+
+    # Check error message was added
+    tool_messages = [m for m in state.messages if m.get("role") == "tool"]
+    assert any("Unknown tool" in m["content"] for m in tool_messages)
+
+
+@pytest.mark.asyncio
+async def test_runner_tool_execution_error() -> None:
+    """Runner handles tool execution errors gracefully."""
+
+    class FailingTool:
+        @property
+        def definition(self) -> ToolDefinition:
+            return ToolDefinition(name="failing", description="Always fails")
+
+        def execute(self, arguments: dict[str, Any]) -> str:  # noqa: ARG002
+            raise ValueError("Tool error")
+
+    responses = [
+        LLMResponse(
+            content="",
+            model="test",
+            tokens_used=50,
+            finish_reason="tool_calls",
+            tool_calls=[
+                ToolCall(id="call_1", name="failing", arguments={})
+            ],
+        ),
+        LLMResponse(
+            content="",
+            model="test",
+            tokens_used=100,
+            finish_reason="tool_calls",
+            tool_calls=[
+                ToolCall(id="call_2", name="submit_test", arguments={"data": "ok"})
+            ],
+        ),
+    ]
+
+    provider = MagicMock()
+    provider.complete = AsyncMock(side_effect=responses)
+
+    runner = ConversationRunner(
+        provider=provider,
+        tools=[MockFinalizationTool(), FailingTool()],
+        finalization_tool="submit_test",
+    )
+
+    _artifact, state = await runner.run([{"role": "system", "content": "System"}])
+
+    # Check error message was added
+    tool_messages = [m for m in state.messages if m.get("role") == "tool"]
+    assert any("Error executing" in m["content"] for m in tool_messages)
+
+
+# --- ConversationError Tests ---
+
+
+def test_conversation_error_with_state() -> None:
+    """ConversationError preserves state."""
+    state = ConversationState(messages=[{"role": "user", "content": "test"}])
+    error = ConversationError("Test error", state)
+
+    assert str(error) == "Test error"
+    assert error.state is state
+    assert len(error.state.messages) == 1
+
+
+def test_conversation_error_without_state() -> None:
+    """ConversationError works without state."""
+    error = ConversationError("Test error")
+
+    assert str(error) == "Test error"
+    assert error.state is None

--- a/tests/unit/test_conversation_runner.py
+++ b/tests/unit/test_conversation_runner.py
@@ -207,9 +207,7 @@ async def test_runner_conversation_before_finalization() -> None:
             model="test",
             tokens_used=100,
             finish_reason="tool_calls",
-            tool_calls=[
-                ToolCall(id="call_1", name="submit_test", arguments={"data": "final"})
-            ],
+            tool_calls=[ToolCall(id="call_1", name="submit_test", arguments={"data": "final"})],
         ),
     ]
 
@@ -246,9 +244,7 @@ async def test_runner_with_user_input() -> None:
             model="test",
             tokens_used=100,
             finish_reason="tool_calls",
-            tool_calls=[
-                ToolCall(id="call_1", name="submit_test", arguments={"data": "fantasy"})
-            ],
+            tool_calls=[ToolCall(id="call_1", name="submit_test", arguments={"data": "fantasy"})],
         ),
     ]
 
@@ -319,9 +315,7 @@ async def test_runner_research_tool_execution() -> None:
             model="test",
             tokens_used=50,
             finish_reason="tool_calls",
-            tool_calls=[
-                ToolCall(id="call_search", name="search", arguments={"query": "noir"})
-            ],
+            tool_calls=[ToolCall(id="call_search", name="search", arguments={"query": "noir"})],
         ),
         # Second: finalization
         LLMResponse(
@@ -362,9 +356,7 @@ async def test_runner_validation_success() -> None:
             model="test",
             tokens_used=100,
             finish_reason="tool_calls",
-            tool_calls=[
-                ToolCall(id="call_1", name="submit_test", arguments={"data": "valid"})
-            ],
+            tool_calls=[ToolCall(id="call_1", name="submit_test", arguments={"data": "valid"})],
         )
     )
 
@@ -397,18 +389,14 @@ async def test_runner_validation_retry() -> None:
             model="test",
             tokens_used=100,
             finish_reason="tool_calls",
-            tool_calls=[
-                ToolCall(id="call_1", name="submit_test", arguments={"data": "invalid"})
-            ],
+            tool_calls=[ToolCall(id="call_1", name="submit_test", arguments={"data": "invalid"})],
         ),
         LLMResponse(
             content="",
             model="test",
             tokens_used=100,
             finish_reason="tool_calls",
-            tool_calls=[
-                ToolCall(id="call_2", name="submit_test", arguments={"data": "valid"})
-            ],
+            tool_calls=[ToolCall(id="call_2", name="submit_test", arguments={"data": "valid"})],
         ),
     ]
 
@@ -486,18 +474,14 @@ async def test_runner_unknown_tool() -> None:
             model="test",
             tokens_used=50,
             finish_reason="tool_calls",
-            tool_calls=[
-                ToolCall(id="call_1", name="unknown_tool", arguments={})
-            ],
+            tool_calls=[ToolCall(id="call_1", name="unknown_tool", arguments={})],
         ),
         LLMResponse(
             content="",
             model="test",
             tokens_used=100,
             finish_reason="tool_calls",
-            tool_calls=[
-                ToolCall(id="call_2", name="submit_test", arguments={"data": "ok"})
-            ],
+            tool_calls=[ToolCall(id="call_2", name="submit_test", arguments={"data": "ok"})],
         ),
     ]
 
@@ -535,18 +519,14 @@ async def test_runner_tool_execution_error() -> None:
             model="test",
             tokens_used=50,
             finish_reason="tool_calls",
-            tool_calls=[
-                ToolCall(id="call_1", name="failing", arguments={})
-            ],
+            tool_calls=[ToolCall(id="call_1", name="failing", arguments={})],
         ),
         LLMResponse(
             content="",
             model="test",
             tokens_used=100,
             finish_reason="tool_calls",
-            tool_calls=[
-                ToolCall(id="call_2", name="submit_test", arguments={"data": "ok"})
-            ],
+            tool_calls=[ToolCall(id="call_2", name="submit_test", arguments={"data": "ok"})],
         ),
     ]
 

--- a/tests/unit/test_prompt_compiler.py
+++ b/tests/unit/test_prompt_compiler.py
@@ -307,7 +307,12 @@ def test_dream_template_compiles() -> None:
     prompts_path = project_root / "prompts"
 
     compiler = PromptCompiler(prompts_path)
-    context = {"user_prompt": "A noir mystery in 1940s Los Angeles"}
+    # New context structure with mode-aware fields
+    context = {
+        "mode_instructions": "Generate a creative vision directly.",
+        "mode_reminder": "",
+        "user_message": "A noir mystery in 1940s Los Angeles",
+    }
     prompt = compiler.compile("dream", context)
 
     assert "creative director" in prompt.system.lower()

--- a/tests/unit/test_tools.py
+++ b/tests/unit/test_tools.py
@@ -1,0 +1,225 @@
+"""Tests for tool protocol and finalization tools."""
+
+from __future__ import annotations
+
+from questfoundry.tools import (
+    SubmitBrainstormTool,
+    SubmitDreamTool,
+    ToolCall,
+    ToolDefinition,
+    get_finalization_tool,
+)
+
+# --- ToolDefinition Tests ---
+
+
+def test_tool_definition_creation() -> None:
+    """ToolDefinition can be created with required fields."""
+    definition = ToolDefinition(
+        name="test_tool",
+        description="A test tool",
+        parameters={"type": "object", "properties": {}},
+    )
+
+    assert definition.name == "test_tool"
+    assert definition.description == "A test tool"
+    assert definition.parameters == {"type": "object", "properties": {}}
+
+
+def test_tool_definition_default_parameters() -> None:
+    """ToolDefinition has default empty parameters."""
+    definition = ToolDefinition(name="simple", description="Simple tool")
+
+    assert definition.parameters == {"type": "object", "properties": {}}
+
+
+# --- ToolCall Tests ---
+
+
+def test_tool_call_creation() -> None:
+    """ToolCall can be created with all fields."""
+    call = ToolCall(
+        id="call_123",
+        name="submit_dream",
+        arguments={"genre": "fantasy", "tone": ["epic"]},
+    )
+
+    assert call.id == "call_123"
+    assert call.name == "submit_dream"
+    assert call.arguments["genre"] == "fantasy"
+
+
+def test_tool_call_empty_arguments() -> None:
+    """ToolCall works with empty arguments."""
+    call = ToolCall(id="call_456", name="test", arguments={})
+
+    assert call.arguments == {}
+
+
+# --- SubmitDreamTool Tests ---
+
+
+def test_submit_dream_tool_definition() -> None:
+    """SubmitDreamTool has correct definition."""
+    tool = SubmitDreamTool()
+    definition = tool.definition
+
+    assert definition.name == "submit_dream"
+    assert "creative vision" in definition.description.lower()
+    assert definition.parameters["type"] == "object"
+
+    # Check required fields
+    required = definition.parameters.get("required", [])
+    assert "genre" in required
+    assert "tone" in required
+    assert "audience" in required
+    assert "themes" in required
+
+
+def test_submit_dream_tool_properties() -> None:
+    """SubmitDreamTool has expected properties in schema."""
+    tool = SubmitDreamTool()
+    properties = tool.definition.parameters["properties"]
+
+    # Core fields
+    assert "genre" in properties
+    assert "subgenre" in properties
+    assert "tone" in properties
+    assert "audience" in properties
+    assert "themes" in properties
+    assert "style_notes" in properties
+
+    # Nested objects
+    assert "scope" in properties
+    assert "content_notes" in properties
+
+
+def test_submit_dream_tool_execute() -> None:
+    """SubmitDreamTool.execute returns confirmation message."""
+    tool = SubmitDreamTool()
+    result = tool.execute({"genre": "fantasy", "tone": ["epic"]})
+
+    assert isinstance(result, str)
+    assert "validation" in result.lower() or "submitted" in result.lower()
+
+
+# --- SubmitBrainstormTool Tests ---
+
+
+def test_submit_brainstorm_tool_definition() -> None:
+    """SubmitBrainstormTool has correct definition."""
+    tool = SubmitBrainstormTool()
+    definition = tool.definition
+
+    assert definition.name == "submit_brainstorm"
+    assert "brainstorm" in definition.description.lower()
+
+    # Check required fields
+    required = definition.parameters.get("required", [])
+    assert "characters" in required
+    assert "plot_hooks" in required
+
+
+def test_submit_brainstorm_tool_properties() -> None:
+    """SubmitBrainstormTool has expected properties."""
+    tool = SubmitBrainstormTool()
+    properties = tool.definition.parameters["properties"]
+
+    assert "characters" in properties
+    assert "settings" in properties
+    assert "plot_hooks" in properties
+    assert "conflicts" in properties
+    assert "notes" in properties
+
+
+def test_submit_brainstorm_tool_execute() -> None:
+    """SubmitBrainstormTool.execute returns confirmation message."""
+    tool = SubmitBrainstormTool()
+    result = tool.execute({"characters": [], "plot_hooks": []})
+
+    assert isinstance(result, str)
+
+
+# --- get_finalization_tool Tests ---
+
+
+def test_get_finalization_tool_dream() -> None:
+    """get_finalization_tool returns SubmitDreamTool for 'dream'."""
+    tool = get_finalization_tool("dream")
+
+    assert tool is not None
+    assert isinstance(tool, SubmitDreamTool)
+    assert tool.definition.name == "submit_dream"
+
+
+def test_get_finalization_tool_brainstorm() -> None:
+    """get_finalization_tool returns SubmitBrainstormTool for 'brainstorm'."""
+    tool = get_finalization_tool("brainstorm")
+
+    assert tool is not None
+    assert isinstance(tool, SubmitBrainstormTool)
+    assert tool.definition.name == "submit_brainstorm"
+
+
+def test_get_finalization_tool_unknown() -> None:
+    """get_finalization_tool returns None for unknown stage."""
+    tool = get_finalization_tool("unknown_stage")
+
+    assert tool is None
+
+
+def test_get_finalization_tool_case_sensitive() -> None:
+    """get_finalization_tool is case-sensitive."""
+    # Uppercase should not match
+    tool = get_finalization_tool("DREAM")
+
+    assert tool is None
+
+
+# --- Tool Protocol Tests ---
+
+
+class MockTool:
+    """Mock implementation of Tool protocol."""
+
+    @property
+    def definition(self) -> ToolDefinition:
+        return ToolDefinition(
+            name="mock_tool",
+            description="A mock tool for testing",
+            parameters={"type": "object", "properties": {"input": {"type": "string"}}},
+        )
+
+    def execute(self, arguments: dict) -> str:
+        return f"Executed with: {arguments.get('input', 'none')}"
+
+
+def test_tool_protocol_implementation() -> None:
+    """Custom tool implements Tool protocol correctly."""
+    tool = MockTool()
+
+    # Verify protocol compliance
+    assert hasattr(tool, "definition")
+    assert hasattr(tool, "execute")
+
+    definition = tool.definition
+    assert isinstance(definition, ToolDefinition)
+
+    result = tool.execute({"input": "test"})
+    assert "test" in result
+
+
+def test_tool_definition_as_dict() -> None:
+    """ToolDefinition can be converted to dict for LangChain."""
+    tool = SubmitDreamTool()
+    definition = tool.definition
+
+    # These fields are needed for LangChain tool binding
+    assert hasattr(definition, "name")
+    assert hasattr(definition, "description")
+    assert hasattr(definition, "parameters")
+
+    # Parameters should be JSON Schema compatible
+    params = definition.parameters
+    assert params.get("type") == "object"
+    assert "properties" in params


### PR DESCRIPTION
## Summary

Implements interactive REPL mode for stage execution, enabling conversational refinement before structured output via tool-gated finalization.

- Add tool protocol with `ToolDefinition`, `ToolCall`, and `Tool` types
- Extend `LLMProvider` with tool calling support (tools, tool_choice params)
- Implement LangChain tool binding in `LangChainProvider`
- Create `ConversationRunner` for multi-turn LLM conversations
- Add `SubmitDreamTool` and `SubmitBrainstormTool` finalization tools
- Update `DreamStage` with interactive/direct execution modes
- Add TTY auto-detection for mode selection
- Add `--interactive/-i` and `--no-interactive/-I` CLI flags
- Add 35 new tests (197 total passing)
- Add architecture documentation

### Key Design Decisions

- **Tool-gated finalization**: LLM signals completion by calling `submit_dream` tool
- **TTY auto-detection**: Interactive mode when running in terminal, direct when piped
- **Sandwich pattern**: Critical instructions at prompt start AND end
- **Validation retry loop**: Up to 3 retries on validation failure

Closes #30

## Test plan

- [x] All 197 unit tests pass
- [x] Linting passes (`ruff check`)
- [x] Type checking passes (`mypy`)
- [ ] Manual test: `qf dream -I "A noir mystery"` (direct mode)
- [ ] Manual test: `qf dream -i "A noir mystery"` (interactive mode)

🤖 Generated with [Claude Code](https://claude.com/claude-code)