### PR TITLE
feat(tools): add tool protocol and provider support

### DIFF
--- a/src/questfoundry/providers/base.py
+++ b/src/questfoundry/providers/base.py
@@ -2,34 +2,66 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
-from typing import Literal, Protocol, TypedDict
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Literal, Protocol, TypedDict
+
+if TYPE_CHECKING:
+    from questfoundry.tools import ToolCall, ToolDefinition
 
 
-class Message(TypedDict):
-    """A single message in a conversation."""
+class Message(TypedDict, total=False):
+    """A single message in a conversation.
 
-    role: Literal["system", "user", "assistant"]
+    Supports regular messages (system/user/assistant) and tool result
+    messages. Tool messages must include tool_call_id to correlate
+    with the original tool call.
+
+    Attributes:
+        role: Message role - "system", "user", "assistant", or "tool".
+        content: Message content text.
+        tool_call_id: ID of the tool call this message responds to (tool role only).
+    """
+
+    role: Literal["system", "user", "assistant", "tool"]
     content: str
+    tool_call_id: str  # Required for role="tool"
 
 
 @dataclass
 class LLMResponse:
-    """Response from an LLM completion request."""
+    """Response from an LLM completion request.
+
+    Attributes:
+        content: Text content from the response.
+        model: Model that generated the response.
+        tokens_used: Total tokens consumed.
+        finish_reason: Why the response ended ("stop", "end_turn", "tool_calls", etc.).
+        tool_calls: List of tool calls requested by the LLM, if any.
+    """
 
     content: str
     model: str
     tokens_used: int
     finish_reason: str
+    tool_calls: list[ToolCall] | None = field(default=None)
 
     @property
     def is_complete(self) -> bool:
-        """Check if the response completed successfully."""
-        return self.finish_reason in ("stop", "end_turn")
+        """Check if the response completed successfully (no pending tool calls)."""
+        return self.finish_reason in ("stop", "end_turn") and not self.tool_calls
+
+    @property
+    def has_tool_calls(self) -> bool:
+        """Check if the response contains tool calls."""
+        return bool(self.tool_calls)
 
 
 class LLMProvider(Protocol):
-    """Protocol for LLM providers."""
+    """Protocol for LLM providers.
+
+    Providers must implement text completion with optional tool calling.
+    Tool support enables structured output via tool-gated finalization.
+    """
 
     @property
     def default_model(self) -> str:
@@ -42,20 +74,34 @@ class LLMProvider(Protocol):
         model: str | None = None,
         temperature: float = 0.7,
         max_tokens: int = 4096,
+        tools: list[ToolDefinition] | None = None,
+        tool_choice: str | None = None,
     ) -> LLMResponse:
         """Generate a completion from the given messages.
 
         Args:
-            messages: List of conversation messages.
+            messages: List of conversation messages (including tool results).
             model: Model to use. If None, uses the provider's default.
             temperature: Sampling temperature (0.0 to 2.0).
             max_tokens: Maximum tokens to generate.
+            tools: Optional list of tools to make available to the LLM.
+            tool_choice: How to handle tool selection:
+                - None or "auto": LLM decides whether to call tools
+                - "required": LLM must call at least one tool
+                - "none": Disable tool calling for this request
+                - "<tool_name>": Force specific tool to be called
 
         Returns:
-            LLMResponse containing the generated text and metadata.
+            LLMResponse containing generated text, metadata, and any tool calls.
 
         Raises:
             ProviderError: If the completion request fails.
+
+        Note:
+            When the response contains tool_calls, the caller should:
+            1. Execute each tool
+            2. Add tool result messages with matching tool_call_id
+            3. Call complete() again with the extended message list
         """
         ...
 

--- a/src/questfoundry/providers/base.py
+++ b/src/questfoundry/providers/base.py
@@ -9,7 +9,14 @@ if TYPE_CHECKING:
     from questfoundry.tools import ToolCall, ToolDefinition
 
 
-class Message(TypedDict, total=False):
+class _MessageRequired(TypedDict):
+    """Required fields for all messages."""
+
+    role: Literal["system", "user", "assistant", "tool"]
+    content: str
+
+
+class Message(_MessageRequired, total=False):
     """A single message in a conversation.
 
     Supports regular messages (system/user/assistant) and tool result
@@ -22,8 +29,6 @@ class Message(TypedDict, total=False):
         tool_call_id: ID of the tool call this message responds to (tool role only).
     """
 
-    role: Literal["system", "user", "assistant", "tool"]
-    content: str
     tool_call_id: str  # Required for role="tool"
 
 

--- a/src/questfoundry/providers/langchain_wrapper.py
+++ b/src/questfoundry/providers/langchain_wrapper.py
@@ -4,9 +4,10 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
-from langchain_core.messages import AIMessage, HumanMessage, SystemMessage
+from langchain_core.messages import AIMessage, HumanMessage, SystemMessage, ToolMessage
 
 from questfoundry.providers.base import LLMResponse, Message, ProviderError
+from questfoundry.tools import ToolCall, ToolDefinition
 
 if TYPE_CHECKING:
     from langchain_core.language_models import BaseChatModel
@@ -44,6 +45,8 @@ class LangChainProvider:
         model: str | None = None,
         temperature: float = 0.7,  # noqa: ARG002 - set at model construction
         max_tokens: int = 4096,  # noqa: ARG002 - set at model construction
+        tools: list[ToolDefinition] | None = None,
+        tool_choice: str | None = None,
     ) -> LLMResponse:
         """Generate a completion from the given messages.
 
@@ -52,9 +55,11 @@ class LangChainProvider:
             model: Model override for response metadata.
             temperature: Unused - set at model construction.
             max_tokens: Unused - set at model construction.
+            tools: Optional tools to bind to the model.
+            tool_choice: Tool selection mode ("auto", "required", "none", or tool name).
 
         Returns:
-            LLMResponse with content and metadata.
+            LLMResponse with content, metadata, and any tool calls.
 
         Raises:
             ProviderError: If completion fails.
@@ -62,9 +67,17 @@ class LangChainProvider:
         # Convert messages to LangChain format
         lc_messages = [self._to_langchain_message(m) for m in messages]
 
+        # Get model, optionally with tools bound
+        lc_model: Any = self._model
+        if tools:
+            lc_tools = [self._to_langchain_tool(t) for t in tools]
+            lc_model = lc_model.bind_tools(
+                lc_tools, tool_choice=self._map_tool_choice(tool_choice)
+            )
+
         try:
             # Call the model
-            response: AIMessage = await self._model.ainvoke(lc_messages)
+            response: AIMessage = await lc_model.ainvoke(lc_messages)
         except Exception as e:
             raise ProviderError("langchain", f"Completion failed: {e}") from e
 
@@ -73,9 +86,23 @@ class LangChainProvider:
         if hasattr(response, "usage_metadata") and response.usage_metadata:
             tokens_used = response.usage_metadata.get("total_tokens", 0)
 
-        # Extract finish reason (default to "unknown" for safety)
+        # Extract tool calls
+        tool_calls: list[ToolCall] | None = None
+        if hasattr(response, "tool_calls") and response.tool_calls:
+            tool_calls = [
+                ToolCall(
+                    id=str(tc.get("id") or f"call_{i}"),
+                    name=str(tc.get("name") or ""),
+                    arguments=tc.get("args") or {},
+                )
+                for i, tc in enumerate(response.tool_calls)
+            ]
+
+        # Determine finish reason
         finish_reason = "unknown"
-        if hasattr(response, "response_metadata") and response.response_metadata:
+        if tool_calls:
+            finish_reason = "tool_calls"
+        elif hasattr(response, "response_metadata") and response.response_metadata:
             finish_reason = response.response_metadata.get("finish_reason", "unknown")
 
         # Handle content (can be str or list)
@@ -88,7 +115,35 @@ class LangChainProvider:
             model=model or self._default_model,
             tokens_used=tokens_used,
             finish_reason=finish_reason,
+            tool_calls=tool_calls,
         )
+
+    def _to_langchain_tool(self, tool_def: ToolDefinition) -> dict[str, Any]:
+        """Convert ToolDefinition to LangChain tool schema.
+
+        LangChain expects OpenAI-style function definitions with
+        name, description, and parameters.
+        """
+        return {
+            "type": "function",
+            "function": {
+                "name": tool_def.name,
+                "description": tool_def.description,
+                "parameters": tool_def.parameters,
+            },
+        }
+
+    def _map_tool_choice(self, tool_choice: str | None) -> str | dict[str, Any] | None:
+        """Map QuestFoundry tool_choice to LangChain format."""
+        if tool_choice is None or tool_choice == "auto":
+            return "auto"
+        elif tool_choice == "required":
+            return "required"
+        elif tool_choice == "none":
+            return "none"
+        else:
+            # Specific tool name - format for forced function call
+            return {"type": "function", "function": {"name": tool_choice}}
 
     def _to_langchain_message(self, msg: Message) -> Any:
         """Convert our Message to LangChain message."""
@@ -101,6 +156,10 @@ class LangChainProvider:
             return HumanMessage(content=content)
         elif role == "assistant":
             return AIMessage(content=content)
+        elif role == "tool":
+            # Tool result message - needs tool_call_id
+            tool_call_id = msg.get("tool_call_id", "")
+            return ToolMessage(content=content, tool_call_id=tool_call_id)
         else:
             raise ValueError(f"Unknown role: {role}")
 

--- a/src/questfoundry/providers/logging_wrapper.py
+++ b/src/questfoundry/providers/logging_wrapper.py
@@ -9,6 +9,7 @@ if TYPE_CHECKING:
     from questfoundry.observability import LLMLogger
     from questfoundry.providers import LLMProvider
     from questfoundry.providers.base import LLMResponse, Message
+    from questfoundry.tools import ToolDefinition
 
 
 class LoggingProvider:
@@ -49,6 +50,8 @@ class LoggingProvider:
         model: str | None = None,
         temperature: float = 0.7,
         max_tokens: int = 4096,
+        tools: list[ToolDefinition] | None = None,
+        tool_choice: str | None = None,
     ) -> LLMResponse:
         """Generate completion and log the call.
 
@@ -57,6 +60,8 @@ class LoggingProvider:
             model: Optional model override.
             temperature: Sampling temperature.
             max_tokens: Maximum tokens to generate.
+            tools: Optional tools to bind.
+            tool_choice: Tool selection mode.
 
         Returns:
             LLMResponse from underlying provider.
@@ -70,6 +75,8 @@ class LoggingProvider:
                 model=model,
                 temperature=temperature,
                 max_tokens=max_tokens,
+                tools=tools,
+                tool_choice=tool_choice,
             )
         except Exception as e:
             error_msg = str(e)
@@ -92,7 +99,7 @@ class LoggingProvider:
 
         duration = time.perf_counter() - start_time
 
-        # Log successful call
+        # Log successful call (including tool calls if present)
         entry = self._logger.create_entry(
             stage=self._stage,
             model=response.model,

--- a/src/questfoundry/tools/__init__.py
+++ b/src/questfoundry/tools/__init__.py
@@ -1,22 +1,13 @@
 """Tools for LLM interactions.
 
-This package provides the tool protocol and implementations for
-LLM tool calling, including finalization tools for structured output
-and research tools for context retrieval.
+This package provides the tool protocol and base types for
+LLM tool calling.
 """
 
 from questfoundry.tools.base import Tool, ToolCall, ToolDefinition
-from questfoundry.tools.finalization import (
-    SubmitBrainstormTool,
-    SubmitDreamTool,
-    get_finalization_tool,
-)
 
 __all__ = [
-    "SubmitBrainstormTool",
-    "SubmitDreamTool",
     "Tool",
     "ToolCall",
     "ToolDefinition",
-    "get_finalization_tool",
 ]

--- a/src/questfoundry/tools/__init__.py
+++ b/src/questfoundry/tools/__init__.py
@@ -1,0 +1,22 @@
+"""Tools for LLM interactions.
+
+This package provides the tool protocol and implementations for
+LLM tool calling, including finalization tools for structured output
+and research tools for context retrieval.
+"""
+
+from questfoundry.tools.base import Tool, ToolCall, ToolDefinition
+from questfoundry.tools.finalization import (
+    SubmitBrainstormTool,
+    SubmitDreamTool,
+    get_finalization_tool,
+)
+
+__all__ = [
+    "SubmitBrainstormTool",
+    "SubmitDreamTool",
+    "Tool",
+    "ToolCall",
+    "ToolDefinition",
+    "get_finalization_tool",
+]

--- a/src/questfoundry/tools/base.py
+++ b/src/questfoundry/tools/base.py
@@ -1,0 +1,103 @@
+"""Base types and protocol for LLM tools.
+
+This module defines the core abstractions for tool calling:
+- ToolDefinition: JSON Schema-based tool specification
+- ToolCall: Represents a tool invocation from LLM
+- Tool: Protocol for implementing executable tools
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Protocol
+
+
+@dataclass
+class ToolDefinition:
+    """Definition of a tool that can be bound to an LLM.
+
+    Uses JSON Schema format for parameter definitions, compatible
+    with OpenAI/Anthropic function calling specifications.
+
+    Attributes:
+        name: Unique tool identifier (e.g., "submit_dream", "search_corpus").
+        description: Concise description for LLM to understand when to use.
+        parameters: JSON Schema object defining accepted arguments.
+
+    Example:
+        >>> ToolDefinition(
+        ...     name="search_corpus",
+        ...     description="Search IF craft knowledge base.",
+        ...     parameters={
+        ...         "type": "object",
+        ...         "properties": {
+        ...             "query": {"type": "string", "description": "Search query"},
+        ...         },
+        ...         "required": ["query"],
+        ...     },
+        ... )
+    """
+
+    name: str
+    description: str
+    parameters: dict[str, Any] = field(default_factory=lambda: {"type": "object", "properties": {}})
+
+
+@dataclass
+class ToolCall:
+    """Represents a tool invocation requested by the LLM.
+
+    Contains the tool name, arguments parsed from LLM response,
+    and a unique ID for correlating with tool results.
+
+    Attributes:
+        id: Unique identifier for this call (from LLM provider).
+        name: Name of the tool being called.
+        arguments: Parsed arguments dictionary.
+    """
+
+    id: str
+    name: str
+    arguments: dict[str, Any]
+
+
+class Tool(Protocol):
+    """Protocol for executable tools.
+
+    Tools must provide a definition (for LLM binding) and an
+    execute method (for handling invocations).
+
+    Example:
+        >>> class SearchCorpusTool:
+        ...     @property
+        ...     def definition(self) -> ToolDefinition:
+        ...         return ToolDefinition(
+        ...             name="search_corpus",
+        ...             description="Search IF craft knowledge.",
+        ...             parameters={...},
+        ...         )
+        ...
+        ...     def execute(self, arguments: dict[str, Any]) -> str:
+        ...         query = arguments["query"]
+        ...         return search_results
+    """
+
+    @property
+    def definition(self) -> ToolDefinition:
+        """Return the tool definition for LLM binding."""
+        ...
+
+    def execute(self, arguments: dict[str, Any]) -> str:
+        """Execute the tool with given arguments.
+
+        Args:
+            arguments: Parsed arguments from LLM tool call.
+
+        Returns:
+            String result to send back to LLM.
+
+        Note:
+            Execute is synchronous. For async operations, use
+            asyncio.get_event_loop().run_until_complete() internally.
+        """
+        ...

--- a/tests/unit/test_providers.py
+++ b/tests/unit/test_providers.py
@@ -9,6 +9,7 @@ from questfoundry.providers import (
     ProviderModelError,
     ProviderRateLimitError,
 )
+from questfoundry.tools import ToolCall, ToolDefinition
 
 # --- LLMResponse Tests ---
 
@@ -86,3 +87,106 @@ def test_provider_model_error_is_provider_error() -> None:
     error = ProviderModelError("test", "Model not found")
     assert isinstance(error, ProviderError)
     assert error.provider == "test"
+
+
+# --- Tool-Related LLMResponse Tests ---
+
+
+def test_llm_response_with_tool_calls_not_complete() -> None:
+    """Response with tool_calls is not complete even with 'stop' finish_reason."""
+    tool_call = ToolCall(id="call_1", name="test_tool", arguments={})
+    response = LLMResponse(
+        content="Let me call a tool",
+        model="test",
+        tokens_used=10,
+        finish_reason="stop",
+        tool_calls=[tool_call],
+    )
+    assert not response.is_complete
+    assert response.has_tool_calls
+
+
+def test_llm_response_empty_tool_calls_is_complete() -> None:
+    """Response with empty tool_calls list is still complete."""
+    response = LLMResponse(
+        content="Hello",
+        model="test",
+        tokens_used=10,
+        finish_reason="stop",
+        tool_calls=[],
+    )
+    # Empty list is falsy, so is_complete should be True
+    assert response.is_complete
+    assert not response.has_tool_calls
+
+
+def test_llm_response_has_tool_calls_true() -> None:
+    """has_tool_calls returns True when tool_calls is populated."""
+    tool_call = ToolCall(id="call_1", name="submit_dream", arguments={"title": "Test"})
+    response = LLMResponse(
+        content="",
+        model="test",
+        tokens_used=10,
+        finish_reason="tool_calls",
+        tool_calls=[tool_call],
+    )
+    assert response.has_tool_calls
+
+
+def test_llm_response_has_tool_calls_false_none() -> None:
+    """has_tool_calls returns False when tool_calls is None."""
+    response = LLMResponse(
+        content="Hello",
+        model="test",
+        tokens_used=10,
+        finish_reason="stop",
+        tool_calls=None,
+    )
+    assert not response.has_tool_calls
+
+
+# --- ToolDefinition Tests ---
+
+
+def test_tool_definition_creation() -> None:
+    """ToolDefinition can be created with all fields."""
+    tool = ToolDefinition(
+        name="test_tool",
+        description="A test tool",
+        parameters={"type": "object", "properties": {"arg1": {"type": "string"}}},
+    )
+    assert tool.name == "test_tool"
+    assert tool.description == "A test tool"
+    assert "properties" in tool.parameters
+
+
+def test_tool_definition_default_parameters() -> None:
+    """ToolDefinition has sensible default for parameters."""
+    tool = ToolDefinition(
+        name="simple_tool",
+        description="Tool with no params",
+    )
+    assert tool.name == "simple_tool"
+    # Parameters defaults to empty object schema
+    assert tool.parameters == {"type": "object", "properties": {}}
+
+
+# --- ToolCall Tests ---
+
+
+def test_tool_call_creation() -> None:
+    """ToolCall can be created with required fields."""
+    call = ToolCall(
+        id="call_abc123",
+        name="submit_dream",
+        arguments={"title": "My Story", "genre": "Fantasy"},
+    )
+    assert call.id == "call_abc123"
+    assert call.name == "submit_dream"
+    assert call.arguments == {"title": "My Story", "genre": "Fantasy"}
+
+
+def test_tool_call_empty_arguments() -> None:
+    """ToolCall can have empty arguments."""
+    call = ToolCall(id="call_1", name="get_status", arguments={})
+    assert call.arguments == {}


### PR DESCRIPTION
## Summary
- Add tool protocol types (`ToolDefinition`, `ToolCall`, `Tool`)
- Extend `LLMProvider` interface with tool calling support
- Implement LangChain tool binding for Ollama/OpenAI/Anthropic providers

This is **Part 1 of 3** of the interactive REPL mode feature, split from #32 for easier review.

## Stack
1. **This PR** → main
2. #36 (conversation runner) → this PR
3. #37 (stage implementation) → #36

🤖 Generated with [Claude Code](https://claude.com/claude-code)