### PR TITLE
feat(conversation): add ConversationRunner for interactive stages

### DIFF
--- a/src/questfoundry/conversation/__init__.py
+++ b/src/questfoundry/conversation/__init__.py
@@ -1,0 +1,19 @@
+"""Conversation management for interactive stages.
+
+This package provides the ConversationRunner for managing multi-turn
+LLM interactions with tool calling support.
+"""
+
+from questfoundry.conversation.runner import (
+    ConversationError,
+    ConversationRunner,
+    ValidationResult,
+)
+from questfoundry.conversation.state import ConversationState
+
+__all__ = [
+    "ConversationError",
+    "ConversationRunner",
+    "ConversationState",
+    "ValidationResult",
+]

--- a/src/questfoundry/conversation/__init__.py
+++ b/src/questfoundry/conversation/__init__.py
@@ -7,6 +7,7 @@ LLM interactions with tool calling support.
 from questfoundry.conversation.runner import (
     ConversationError,
     ConversationRunner,
+    ValidationErrorDetail,
     ValidationResult,
 )
 from questfoundry.conversation.state import ConversationState
@@ -15,5 +16,6 @@ __all__ = [
     "ConversationError",
     "ConversationRunner",
     "ConversationState",
+    "ValidationErrorDetail",
     "ValidationResult",
 ]

--- a/src/questfoundry/conversation/runner.py
+++ b/src/questfoundry/conversation/runner.py
@@ -282,9 +282,7 @@ class ConversationRunner:
                         # LLM didn't provide expected tool call - fail fast
                         # Continuing would revalidate same stale data (infinite loop)
                         if response.content:
-                            state.add_message(
-                                {"role": "assistant", "content": response.content}
-                            )
+                            state.add_message({"role": "assistant", "content": response.content})
                         raise ConversationError(
                             f"LLM failed to call {self._finalization_tool} on retry {retries}",
                             state,

--- a/src/questfoundry/conversation/runner.py
+++ b/src/questfoundry/conversation/runner.py
@@ -1,0 +1,268 @@
+"""Conversation runner for interactive stages.
+
+This module provides the ConversationRunner class that manages
+multi-turn LLM interactions with tool calling support, enabling
+conversational refinement before structured output.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+from questfoundry.conversation.state import ConversationState
+
+if TYPE_CHECKING:
+    from collections.abc import Awaitable, Callable
+
+    from questfoundry.providers.base import LLMProvider, Message
+    from questfoundry.tools import Tool, ToolCall
+
+
+class ConversationError(Exception):
+    """Raised when conversation fails.
+
+    Attributes:
+        message: Error description.
+        state: Conversation state at time of failure.
+    """
+
+    def __init__(self, message: str, state: ConversationState | None = None) -> None:
+        self.state = state
+        super().__init__(message)
+
+
+@dataclass
+class ValidationResult:
+    """Result of validating tool call arguments.
+
+    Attributes:
+        valid: Whether validation passed.
+        error: Error message if validation failed.
+        data: Validated/transformed data if validation passed.
+    """
+
+    valid: bool
+    error: str | None = None
+    data: dict[str, Any] | None = None
+
+
+class ConversationRunner:
+    """Manages multi-turn LLM conversations with tool calling.
+
+    The runner implements the Discuss → Freeze → Serialize pattern:
+    1. Conversation phase: LLM discusses with user, uses research tools
+    2. Finalization: LLM calls finalization tool with structured data
+    3. Validation: Data is validated with optional retry loop
+
+    Attributes:
+        finalization_tool: Name of the tool that signals completion.
+        max_turns: Maximum conversation turns before timeout.
+        validation_retries: Maximum validation retry attempts.
+
+    Example:
+        >>> runner = ConversationRunner(
+        ...     provider=provider,
+        ...     tools=[SubmitDreamTool(), SearchCorpusTool()],
+        ...     finalization_tool="submit_dream",
+        ... )
+        >>> artifact, state = await runner.run(
+        ...     initial_messages=[system_msg, user_msg],
+        ...     user_input_fn=lambda: input("> "),
+        ...     validator=validate_dream,
+        ... )
+    """
+
+    def __init__(
+        self,
+        provider: LLMProvider,
+        tools: list[Tool],
+        finalization_tool: str,
+        max_turns: int = 10,
+        validation_retries: int = 3,
+    ) -> None:
+        """Initialize the conversation runner.
+
+        Args:
+            provider: LLM provider for completions.
+            tools: List of tools available during conversation.
+            finalization_tool: Name of the tool that ends the conversation.
+            max_turns: Maximum turns before timeout (default 10).
+            validation_retries: Max validation retries (default 3).
+        """
+        self._provider = provider
+        self._tools = {t.definition.name: t for t in tools}
+        self._tool_definitions = [t.definition for t in tools]
+        self._finalization_tool = finalization_tool
+        self._max_turns = max_turns
+        self._validation_retries = validation_retries
+
+    async def run(
+        self,
+        initial_messages: list[Message],
+        user_input_fn: Callable[[], Awaitable[str | None]] | None = None,
+        validator: Callable[[dict[str, Any]], ValidationResult] | None = None,
+    ) -> tuple[dict[str, Any], ConversationState]:
+        """Run the conversation until finalization.
+
+        Args:
+            initial_messages: Starting messages (typically system + user).
+            user_input_fn: Async function to get user input. If None or
+                returns None/empty, conversation continues without user input.
+            validator: Optional function to validate finalization data.
+                Called with tool arguments, returns ValidationResult.
+
+        Returns:
+            Tuple of (artifact_data, conversation_state).
+
+        Raises:
+            ConversationError: If max turns exceeded or validation fails
+                after all retries.
+        """
+        state = ConversationState(messages=list(initial_messages))
+
+        while state.turn_count < self._max_turns:
+            # Call LLM with tools
+            response = await self._provider.complete(
+                messages=state.messages,
+                tools=self._tool_definitions,
+                tool_choice="auto",
+            )
+            state.llm_calls += 1
+            state.tokens_used += response.tokens_used
+
+            # Handle tool calls
+            if response.has_tool_calls:
+                result = await self._handle_tool_calls(
+                    response.tool_calls or [],
+                    state,
+                    validator,
+                )
+                if result is not None:
+                    # Finalization tool was called and validated
+                    return result, state
+
+            # Add assistant message if there's content
+            if response.content:
+                state.add_message({"role": "assistant", "content": response.content})
+
+            # Check if we should get user input
+            if user_input_fn is not None:
+                user_input = await user_input_fn()
+                if user_input:
+                    state.add_message({"role": "user", "content": user_input})
+
+            state.turn_count += 1
+
+        raise ConversationError(
+            f"Maximum turns ({self._max_turns}) exceeded without finalization",
+            state,
+        )
+
+    async def _handle_tool_calls(
+        self,
+        tool_calls: list[ToolCall],
+        state: ConversationState,
+        validator: Callable[[dict[str, Any]], ValidationResult] | None,
+    ) -> dict[str, Any] | None:
+        """Process tool calls from LLM response.
+
+        Args:
+            tool_calls: List of tool calls from LLM.
+            state: Current conversation state.
+            validator: Optional validator for finalization tool.
+
+        Returns:
+            Finalization data if finalization tool was called successfully,
+            None otherwise.
+        """
+        for tc in tool_calls:
+            if tc.name == self._finalization_tool:
+                # Handle finalization with validation
+                return await self._handle_finalization(tc, state, validator)
+            else:
+                # Execute research tool
+                result = self._execute_tool(tc)
+                state.add_tool_result(tc.id, result)
+
+        return None
+
+    async def _handle_finalization(
+        self,
+        tool_call: ToolCall,
+        state: ConversationState,
+        validator: Callable[[dict[str, Any]], ValidationResult] | None,
+    ) -> dict[str, Any]:
+        """Handle finalization tool call with validation retry.
+
+        Args:
+            tool_call: The finalization tool call.
+            state: Current conversation state.
+            validator: Optional validator function.
+
+        Returns:
+            Validated artifact data.
+
+        Raises:
+            ConversationError: If validation fails after all retries.
+        """
+        data = tool_call.arguments
+        retries = 0
+
+        while retries < self._validation_retries:
+            # Validate if validator provided
+            if validator is not None:
+                result = validator(data)
+                if not result.valid:
+                    # Add error feedback to conversation
+                    error_msg = f"Validation failed: {result.error}. Please fix and try again."
+                    state.add_tool_result(tool_call.id, error_msg)
+
+                    # Request retry from LLM
+                    response = await self._provider.complete(
+                        messages=state.messages,
+                        tools=self._tool_definitions,
+                        tool_choice=self._finalization_tool,  # Force retry of same tool
+                    )
+                    state.llm_calls += 1
+                    state.tokens_used += response.tokens_used
+
+                    # Extract new tool call
+                    if response.has_tool_calls and response.tool_calls:
+                        for tc in response.tool_calls:
+                            if tc.name == self._finalization_tool:
+                                data = tc.arguments
+                                tool_call = tc
+                                break
+                    retries += 1
+                    continue
+                else:
+                    # Use validated/transformed data if provided
+                    data = result.data if result.data is not None else data
+
+            # Validation passed or no validator
+            state.add_tool_result(tool_call.id, "Artifact submitted successfully.")
+            return data
+
+        raise ConversationError(
+            f"Validation failed after {self._validation_retries} retries",
+            state,
+        )
+
+    def _execute_tool(self, tool_call: ToolCall) -> str:
+        """Execute a non-finalization tool.
+
+        Args:
+            tool_call: The tool call to execute.
+
+        Returns:
+            Tool execution result as string.
+        """
+        tool = self._tools.get(tool_call.name)
+        if tool is None:
+            return f"Error: Unknown tool '{tool_call.name}'"
+
+        try:
+            return tool.execute(tool_call.arguments)
+        except Exception as e:
+            return f"Error executing {tool_call.name}: {e}"

--- a/src/questfoundry/conversation/state.py
+++ b/src/questfoundry/conversation/state.py
@@ -1,0 +1,52 @@
+"""Conversation state tracking.
+
+This module provides the ConversationState dataclass for tracking
+the state of a conversation during interactive stage execution.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from questfoundry.providers.base import Message
+
+
+@dataclass
+class ConversationState:
+    """Tracks state during a conversation loop.
+
+    Maintains the message history, turn count, and resource usage
+    metrics for a conversation session.
+
+    Attributes:
+        messages: List of all messages in the conversation.
+        turn_count: Number of completed conversation turns.
+        llm_calls: Total LLM API calls made.
+        tokens_used: Total tokens consumed across all calls.
+
+    Example:
+        >>> state = ConversationState()
+        >>> state.messages.append({"role": "user", "content": "Hello"})
+        >>> state.turn_count += 1
+        >>> state.llm_calls += 1
+        >>> state.tokens_used += 150
+    """
+
+    messages: list[Message] = field(default_factory=list)
+    turn_count: int = 0
+    llm_calls: int = 0
+    tokens_used: int = 0
+
+    def add_message(self, message: Message) -> None:
+        """Add a message to the conversation history."""
+        self.messages.append(message)
+
+    def add_tool_result(self, tool_call_id: str, content: str) -> None:
+        """Add a tool result message to the conversation."""
+        self.messages.append({
+            "role": "tool",
+            "content": content,
+            "tool_call_id": tool_call_id,
+        })

--- a/src/questfoundry/conversation/state.py
+++ b/src/questfoundry/conversation/state.py
@@ -45,8 +45,10 @@ class ConversationState:
 
     def add_tool_result(self, tool_call_id: str, content: str) -> None:
         """Add a tool result message to the conversation."""
-        self.messages.append({
-            "role": "tool",
-            "content": content,
-            "tool_call_id": tool_call_id,
-        })
+        self.messages.append(
+            {
+                "role": "tool",
+                "content": content,
+                "tool_call_id": tool_call_id,
+            }
+        )

--- a/src/questfoundry/tools/__init__.py
+++ b/src/questfoundry/tools/__init__.py
@@ -1,13 +1,22 @@
 """Tools for LLM interactions.
 
-This package provides the tool protocol and base types for
-LLM tool calling.
+This package provides the tool protocol and implementations for
+LLM tool calling, including finalization tools for structured output
+and research tools for context retrieval.
 """
 
 from questfoundry.tools.base import Tool, ToolCall, ToolDefinition
+from questfoundry.tools.finalization import (
+    SubmitBrainstormTool,
+    SubmitDreamTool,
+    get_finalization_tool,
+)
 
 __all__ = [
+    "SubmitBrainstormTool",
+    "SubmitDreamTool",
     "Tool",
     "ToolCall",
     "ToolDefinition",
+    "get_finalization_tool",
 ]

--- a/src/questfoundry/tools/base.py
+++ b/src/questfoundry/tools/base.py
@@ -9,7 +9,7 @@ This module defines the core abstractions for tool calling:
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Any, Protocol
+from typing import Any, Protocol, runtime_checkable
 
 
 @dataclass
@@ -61,11 +61,14 @@ class ToolCall:
     arguments: dict[str, Any]
 
 
+@runtime_checkable
 class Tool(Protocol):
     """Protocol for executable tools.
 
     Tools must provide a definition (for LLM binding) and an
     execute method (for handling invocations).
+
+    This protocol is runtime-checkable, allowing isinstance() checks.
 
     Example:
         >>> class SearchCorpusTool:

--- a/src/questfoundry/tools/finalization.py
+++ b/src/questfoundry/tools/finalization.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from questfoundry.tools.base import ToolDefinition
+from questfoundry.tools.base import Tool, ToolDefinition
 
 
 class SubmitDreamTool:
@@ -188,14 +188,15 @@ class SubmitBrainstormTool:
 
 
 # Registry of finalization tools by stage name
-FINALIZATION_TOOLS: dict[str, type] = {
+# Each value is a callable that returns a Tool-compatible instance
+FINALIZATION_TOOLS: dict[str, type[SubmitDreamTool] | type[SubmitBrainstormTool]] = {
     "dream": SubmitDreamTool,
     "brainstorm": SubmitBrainstormTool,
     # Future stages: seed, grow, fill, ship
 }
 
 
-def get_finalization_tool(stage: str) -> SubmitDreamTool | SubmitBrainstormTool | None:
+def get_finalization_tool(stage: str) -> Tool | None:
     """Get the finalization tool for a stage.
 
     Args:
@@ -206,8 +207,5 @@ def get_finalization_tool(stage: str) -> SubmitDreamTool | SubmitBrainstormTool 
     """
     tool_class = FINALIZATION_TOOLS.get(stage)
     if tool_class is not None:
-        tool = tool_class()
-        # Cast to the known return types
-        if isinstance(tool, (SubmitDreamTool, SubmitBrainstormTool)):
-            return tool
+        return tool_class()
     return None

--- a/src/questfoundry/tools/finalization.py
+++ b/src/questfoundry/tools/finalization.py
@@ -1,0 +1,213 @@
+"""Finalization tools for structured output.
+
+This module provides tools that signal completion of a stage's
+conversation phase and capture structured artifact data.
+
+Each stage has its own finalization tool (submit_dream, submit_brainstorm, etc.)
+that validates and captures the structured output.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from questfoundry.tools.base import ToolDefinition
+
+
+class SubmitDreamTool:
+    """Tool for finalizing DREAM stage output.
+
+    When called, signals that the creative vision has been finalized
+    and provides the structured artifact data for validation.
+
+    The tool schema matches the dream.schema.json artifact format,
+    ensuring the LLM produces valid structured output.
+    """
+
+    @property
+    def definition(self) -> ToolDefinition:
+        """Return the tool definition for LLM binding."""
+        return ToolDefinition(
+            name="submit_dream",
+            description=(
+                "Submit the finalized creative vision. Call this when you have "
+                "discussed and refined the story concept with the user and are "
+                "ready to lock in the creative direction."
+            ),
+            parameters={
+                "type": "object",
+                "properties": {
+                    "genre": {
+                        "type": "string",
+                        "description": "Primary genre (e.g., 'fantasy', 'mystery', 'sci-fi', 'horror')",
+                    },
+                    "subgenre": {
+                        "type": "string",
+                        "description": "Optional genre refinement (e.g., 'urban fantasy', 'cozy mystery')",
+                    },
+                    "tone": {
+                        "type": "array",
+                        "items": {"type": "string"},
+                        "description": "Tone descriptors (e.g., ['dark', 'suspenseful', 'romantic'])",
+                    },
+                    "audience": {
+                        "type": "string",
+                        "description": "Target audience: 'all ages', 'young adult', 'adult', or 'mature'",
+                    },
+                    "themes": {
+                        "type": "array",
+                        "items": {"type": "string"},
+                        "description": "Core thematic elements (e.g., ['redemption', 'found family'])",
+                    },
+                    "style_notes": {
+                        "type": "string",
+                        "description": "Prose style guidance (e.g., 'flowery and descriptive' or 'terse and punchy')",
+                    },
+                    "scope": {
+                        "type": "object",
+                        "description": "Story scope parameters",
+                        "properties": {
+                            "target_word_count": {
+                                "type": "integer",
+                                "description": "Approximate total word count (e.g., 15000)",
+                            },
+                            "estimated_passages": {
+                                "type": "integer",
+                                "description": "Target number of scenes/passages (e.g., 25)",
+                            },
+                            "branching_depth": {
+                                "type": "string",
+                                "description": "Branching complexity: 'light', 'moderate', 'heavy', 'extensive'",
+                            },
+                            "estimated_playtime_minutes": {
+                                "type": "integer",
+                                "description": "Target reading/play time in minutes",
+                            },
+                        },
+                    },
+                    "content_notes": {
+                        "type": "object",
+                        "description": "Content guidance",
+                        "properties": {
+                            "includes": {
+                                "type": "array",
+                                "items": {"type": "string"},
+                                "description": "Content to include (e.g., ['mild violence', 'romance'])",
+                            },
+                            "excludes": {
+                                "type": "array",
+                                "items": {"type": "string"},
+                                "description": "Content to avoid (e.g., ['graphic violence', 'explicit content'])",
+                            },
+                        },
+                    },
+                },
+                "required": ["genre", "tone", "audience", "themes"],
+            },
+        )
+
+    def execute(self, arguments: dict[str, Any]) -> str:  # noqa: ARG002
+        """Execute the finalization tool.
+
+        Note: Actual validation happens in ConversationRunner.
+        This method is called after successful validation.
+
+        Args:
+            arguments: The finalized artifact data.
+
+        Returns:
+            Confirmation message.
+        """
+        return "Creative vision submitted for validation."
+
+
+class SubmitBrainstormTool:
+    """Tool for finalizing BRAINSTORM stage output.
+
+    Captures raw creative material including characters, settings,
+    plot hooks, and other story elements.
+    """
+
+    @property
+    def definition(self) -> ToolDefinition:
+        """Return the tool definition for LLM binding."""
+        return ToolDefinition(
+            name="submit_brainstorm",
+            description=(
+                "Submit the brainstorm results. Call this when you have "
+                "generated sufficient raw creative material for the story."
+            ),
+            parameters={
+                "type": "object",
+                "properties": {
+                    "characters": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "name": {"type": "string"},
+                                "role": {"type": "string"},
+                                "description": {"type": "string"},
+                            },
+                        },
+                        "description": "Character concepts",
+                    },
+                    "settings": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "name": {"type": "string"},
+                                "description": {"type": "string"},
+                            },
+                        },
+                        "description": "Setting/location concepts",
+                    },
+                    "plot_hooks": {
+                        "type": "array",
+                        "items": {"type": "string"},
+                        "description": "Potential plot hooks and story seeds",
+                    },
+                    "conflicts": {
+                        "type": "array",
+                        "items": {"type": "string"},
+                        "description": "Conflict ideas",
+                    },
+                    "notes": {
+                        "type": "string",
+                        "description": "Additional creative notes",
+                    },
+                },
+                "required": ["characters", "plot_hooks"],
+            },
+        )
+
+    def execute(self, arguments: dict[str, Any]) -> str:  # noqa: ARG002
+        """Execute the finalization tool."""
+        return "Brainstorm material submitted for validation."
+
+
+# Registry of finalization tools by stage name
+FINALIZATION_TOOLS: dict[str, type] = {
+    "dream": SubmitDreamTool,
+    "brainstorm": SubmitBrainstormTool,
+    # Future stages: seed, grow, fill, ship
+}
+
+
+def get_finalization_tool(stage: str) -> SubmitDreamTool | SubmitBrainstormTool | None:
+    """Get the finalization tool for a stage.
+
+    Args:
+        stage: Stage name (e.g., "dream", "brainstorm").
+
+    Returns:
+        Instantiated finalization tool, or None if stage not found.
+    """
+    tool_class = FINALIZATION_TOOLS.get(stage)
+    if tool_class is not None:
+        tool = tool_class()
+        # Cast to the known return types
+        if isinstance(tool, (SubmitDreamTool, SubmitBrainstormTool)):
+            return tool
+    return None

--- a/tests/unit/test_conversation_runner.py
+++ b/tests/unit/test_conversation_runner.py
@@ -1,0 +1,570 @@
+"""Tests for ConversationRunner and related types."""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+
+from questfoundry.conversation import (
+    ConversationError,
+    ConversationRunner,
+    ConversationState,
+    ValidationErrorDetail,
+    ValidationResult,
+)
+from questfoundry.providers.base import LLMResponse
+from questfoundry.tools import Tool, ToolCall, ToolDefinition
+
+
+# --- Test Fixtures ---
+
+
+class MockTool:
+    """A simple mock tool for testing."""
+
+    def __init__(self, name: str = "mock_tool", result: str = "Mock result") -> None:
+        self._name = name
+        self._result = result
+
+    @property
+    def definition(self) -> ToolDefinition:
+        return ToolDefinition(
+            name=self._name,
+            description="A mock tool for testing",
+            parameters={"type": "object", "properties": {}},
+        )
+
+    def execute(self, arguments: dict[str, Any]) -> str:  # noqa: ARG002
+        return self._result
+
+
+class FinalizationTool:
+    """A mock finalization tool for testing."""
+
+    @property
+    def definition(self) -> ToolDefinition:
+        return ToolDefinition(
+            name="submit_test",
+            description="Submit test data",
+            parameters={
+                "type": "object",
+                "properties": {"value": {"type": "string"}},
+                "required": ["value"],
+            },
+        )
+
+    def execute(self, arguments: dict[str, Any]) -> str:  # noqa: ARG002
+        return "Test submitted successfully."
+
+
+def create_mock_provider(responses: list[LLMResponse]) -> Mock:
+    """Create a mock LLM provider that returns given responses in sequence."""
+    provider = Mock()
+    provider.complete = AsyncMock(side_effect=responses)
+    provider.default_model = "test-model"
+    return provider
+
+
+# --- ConversationState Tests ---
+
+
+def test_conversation_state_init() -> None:
+    """ConversationState initializes with given messages."""
+    messages = [{"role": "system", "content": "Hello"}]
+    state = ConversationState(messages=messages)
+
+    assert state.messages == messages
+    assert state.turn_count == 0
+    assert state.tokens_used == 0
+    assert state.llm_calls == 0
+
+
+def test_conversation_state_add_message() -> None:
+    """add_message appends to messages list."""
+    state = ConversationState(messages=[])
+    state.add_message({"role": "user", "content": "Test"})
+
+    assert len(state.messages) == 1
+    assert state.messages[0]["content"] == "Test"
+
+
+def test_conversation_state_add_tool_result() -> None:
+    """add_tool_result adds tool message with call_id."""
+    state = ConversationState(messages=[])
+    state.add_tool_result("call_123", "Result text")
+
+    assert len(state.messages) == 1
+    assert state.messages[0]["role"] == "tool"
+    assert state.messages[0]["content"] == "Result text"
+    assert state.messages[0]["tool_call_id"] == "call_123"
+
+
+# --- ValidationResult Tests ---
+
+
+def test_validation_result_valid() -> None:
+    """ValidationResult with valid=True and data."""
+    result = ValidationResult(valid=True, data={"key": "value"})
+
+    assert result.valid
+    assert result.data == {"key": "value"}
+    assert result.error is None
+    assert result.errors is None
+
+
+def test_validation_result_invalid_with_error() -> None:
+    """ValidationResult with valid=False and error string."""
+    result = ValidationResult(valid=False, error="Something went wrong")
+
+    assert not result.valid
+    assert result.error == "Something went wrong"
+
+
+def test_validation_result_invalid_with_structured_errors() -> None:
+    """ValidationResult with valid=False and structured errors."""
+    errors = [
+        ValidationErrorDetail(field="name", issue="is required", provided=None),
+        ValidationErrorDetail(field="age", issue="must be positive", provided=-5),
+    ]
+    result = ValidationResult(valid=False, errors=errors)
+
+    assert not result.valid
+    assert len(result.errors) == 2
+    assert result.errors[0].field == "name"
+    assert result.errors[1].provided == -5
+
+
+# --- ValidationErrorDetail Tests ---
+
+
+def test_validation_error_detail() -> None:
+    """ValidationErrorDetail holds field, issue, and provided value."""
+    error = ValidationErrorDetail(field="genre", issue="cannot be empty", provided="")
+
+    assert error.field == "genre"
+    assert error.issue == "cannot be empty"
+    assert error.provided == ""
+
+
+def test_validation_error_detail_default_provided() -> None:
+    """ValidationErrorDetail defaults provided to None."""
+    error = ValidationErrorDetail(field="test", issue="error")
+
+    assert error.provided is None
+
+
+# --- ConversationRunner Initialization Tests ---
+
+
+def test_runner_init_validates_tools() -> None:
+    """ConversationRunner validates tools implement Tool protocol."""
+    provider = create_mock_provider([])
+
+    # Valid tool should work
+    runner = ConversationRunner(
+        provider=provider,
+        tools=[MockTool()],
+        finalization_tool="submit_test",
+    )
+    assert runner._finalization_tool == "submit_test"
+
+
+def test_runner_init_rejects_invalid_tool() -> None:
+    """ConversationRunner rejects tools that don't implement protocol."""
+    provider = create_mock_provider([])
+
+    class InvalidTool:
+        pass  # Missing definition and execute
+
+    with pytest.raises(TypeError, match="doesn't implement Tool protocol"):
+        ConversationRunner(
+            provider=provider,
+            tools=[InvalidTool()],  # type: ignore[list-item]
+            finalization_tool="submit_test",
+        )
+
+
+def test_runner_init_default_config() -> None:
+    """ConversationRunner uses default max_turns and validation_retries."""
+    provider = create_mock_provider([])
+    runner = ConversationRunner(
+        provider=provider,
+        tools=[MockTool()],
+        finalization_tool="submit_test",
+    )
+
+    assert runner._max_turns == 10
+    assert runner._validation_retries == 3
+
+
+def test_runner_init_custom_config() -> None:
+    """ConversationRunner accepts custom max_turns and validation_retries."""
+    provider = create_mock_provider([])
+    runner = ConversationRunner(
+        provider=provider,
+        tools=[MockTool()],
+        finalization_tool="submit_test",
+        max_turns=5,
+        validation_retries=2,
+    )
+
+    assert runner._max_turns == 5
+    assert runner._validation_retries == 2
+
+
+# --- ConversationRunner.run() Tests ---
+
+
+@pytest.mark.asyncio
+async def test_runner_simple_finalization() -> None:
+    """Runner completes when finalization tool is called with valid data."""
+    tool_call = ToolCall(id="call_1", name="submit_test", arguments={"value": "test"})
+    response = LLMResponse(
+        content="Here's my submission",
+        model="test",
+        tokens_used=100,
+        finish_reason="tool_calls",
+        tool_calls=[tool_call],
+    )
+    provider = create_mock_provider([response])
+
+    runner = ConversationRunner(
+        provider=provider,
+        tools=[FinalizationTool()],
+        finalization_tool="submit_test",
+    )
+
+    result, state = await runner.run(
+        initial_messages=[{"role": "user", "content": "Start"}],
+    )
+
+    assert result == {"value": "test"}
+    assert state.llm_calls == 1
+    assert state.tokens_used == 100
+
+
+@pytest.mark.asyncio
+async def test_runner_with_validation_success() -> None:
+    """Runner validates finalization data when validator provided."""
+    tool_call = ToolCall(id="call_1", name="submit_test", arguments={"value": "test"})
+    response = LLMResponse(
+        content="",
+        model="test",
+        tokens_used=50,
+        finish_reason="tool_calls",
+        tool_calls=[tool_call],
+    )
+    provider = create_mock_provider([response])
+
+    def validator(data: dict[str, Any]) -> ValidationResult:
+        return ValidationResult(valid=True, data=data)
+
+    runner = ConversationRunner(
+        provider=provider,
+        tools=[FinalizationTool()],
+        finalization_tool="submit_test",
+    )
+
+    result, state = await runner.run(
+        initial_messages=[{"role": "user", "content": "Start"}],
+        validator=validator,
+    )
+
+    assert result == {"value": "test"}
+
+
+@pytest.mark.asyncio
+async def test_runner_validation_retry_success() -> None:
+    """Runner retries validation when it fails, then succeeds."""
+    # First attempt fails, second succeeds
+    first_call = ToolCall(id="call_1", name="submit_test", arguments={"value": ""})
+    second_call = ToolCall(id="call_2", name="submit_test", arguments={"value": "fixed"})
+
+    first_response = LLMResponse(
+        content="",
+        model="test",
+        tokens_used=50,
+        finish_reason="tool_calls",
+        tool_calls=[first_call],
+    )
+    second_response = LLMResponse(
+        content="",
+        model="test",
+        tokens_used=50,
+        finish_reason="tool_calls",
+        tool_calls=[second_call],
+    )
+    provider = create_mock_provider([first_response, second_response])
+
+    call_count = 0
+
+    def validator(data: dict[str, Any]) -> ValidationResult:
+        nonlocal call_count
+        call_count += 1
+        if data.get("value") == "":
+            return ValidationResult(
+                valid=False,
+                errors=[ValidationErrorDetail(field="value", issue="cannot be empty", provided="")],
+            )
+        return ValidationResult(valid=True, data=data)
+
+    runner = ConversationRunner(
+        provider=provider,
+        tools=[FinalizationTool()],
+        finalization_tool="submit_test",
+    )
+
+    result, state = await runner.run(
+        initial_messages=[{"role": "user", "content": "Start"}],
+        validator=validator,
+    )
+
+    assert result == {"value": "fixed"}
+    assert call_count == 2
+    assert state.llm_calls == 2
+
+
+@pytest.mark.asyncio
+async def test_runner_validation_exhausts_retries() -> None:
+    """Runner raises ConversationError after exhausting validation retries."""
+    tool_call = ToolCall(id="call_1", name="submit_test", arguments={"value": ""})
+    response = LLMResponse(
+        content="",
+        model="test",
+        tokens_used=50,
+        finish_reason="tool_calls",
+        tool_calls=[tool_call],
+    )
+    # Always return failing response
+    provider = create_mock_provider([response, response, response, response])
+
+    def validator(data: dict[str, Any]) -> ValidationResult:
+        return ValidationResult(
+            valid=False,
+            errors=[ValidationErrorDetail(field="value", issue="cannot be empty", provided="")],
+        )
+
+    runner = ConversationRunner(
+        provider=provider,
+        tools=[FinalizationTool()],
+        finalization_tool="submit_test",
+        validation_retries=2,
+    )
+
+    with pytest.raises(ConversationError, match="Validation failed after 2 retries"):
+        await runner.run(
+            initial_messages=[{"role": "user", "content": "Start"}],
+            validator=validator,
+        )
+
+
+@pytest.mark.asyncio
+async def test_runner_max_turns_exceeded() -> None:
+    """Runner raises ConversationError when max turns exceeded."""
+    # Response without tool calls - conversation continues
+    response = LLMResponse(
+        content="Let me think...",
+        model="test",
+        tokens_used=20,
+        finish_reason="stop",
+        tool_calls=None,
+    )
+    provider = create_mock_provider([response] * 5)
+
+    runner = ConversationRunner(
+        provider=provider,
+        tools=[FinalizationTool()],
+        finalization_tool="submit_test",
+        max_turns=3,
+    )
+
+    with pytest.raises(ConversationError, match="Maximum turns.*exceeded"):
+        await runner.run(
+            initial_messages=[{"role": "user", "content": "Start"}],
+        )
+
+
+@pytest.mark.asyncio
+async def test_runner_llm_fails_to_call_tool() -> None:
+    """Runner raises ConversationError when LLM doesn't call finalization on retry."""
+    first_call = ToolCall(id="call_1", name="submit_test", arguments={"value": ""})
+    first_response = LLMResponse(
+        content="",
+        model="test",
+        tokens_used=50,
+        finish_reason="tool_calls",
+        tool_calls=[first_call],
+    )
+    # Second response has no tool calls
+    second_response = LLMResponse(
+        content="I can't do that",
+        model="test",
+        tokens_used=30,
+        finish_reason="stop",
+        tool_calls=None,
+    )
+    provider = create_mock_provider([first_response, second_response])
+
+    def validator(data: dict[str, Any]) -> ValidationResult:
+        return ValidationResult(
+            valid=False,
+            errors=[ValidationErrorDetail(field="value", issue="error", provided="")],
+        )
+
+    runner = ConversationRunner(
+        provider=provider,
+        tools=[FinalizationTool()],
+        finalization_tool="submit_test",
+    )
+
+    with pytest.raises(ConversationError, match="LLM failed to call"):
+        await runner.run(
+            initial_messages=[{"role": "user", "content": "Start"}],
+            validator=validator,
+        )
+
+
+@pytest.mark.asyncio
+async def test_runner_executes_research_tool() -> None:
+    """Runner executes non-finalization tools and continues."""
+    research_call = ToolCall(id="call_1", name="research", arguments={"query": "test"})
+    finalization_call = ToolCall(id="call_2", name="submit_test", arguments={"value": "done"})
+
+    first_response = LLMResponse(
+        content="Let me research",
+        model="test",
+        tokens_used=30,
+        finish_reason="tool_calls",
+        tool_calls=[research_call],
+    )
+    second_response = LLMResponse(
+        content="",
+        model="test",
+        tokens_used=40,
+        finish_reason="tool_calls",
+        tool_calls=[finalization_call],
+    )
+    provider = create_mock_provider([first_response, second_response])
+
+    research_tool = MockTool(name="research", result="Research results")
+
+    runner = ConversationRunner(
+        provider=provider,
+        tools=[research_tool, FinalizationTool()],
+        finalization_tool="submit_test",
+    )
+
+    result, state = await runner.run(
+        initial_messages=[{"role": "user", "content": "Start"}],
+    )
+
+    assert result == {"value": "done"}
+    assert state.llm_calls == 2
+    # Check research tool result was added
+    tool_results = [m for m in state.messages if m.get("role") == "tool"]
+    assert len(tool_results) >= 1
+
+
+@pytest.mark.asyncio
+async def test_runner_calls_on_assistant_message() -> None:
+    """Runner calls on_assistant_message callback with content."""
+    tool_call = ToolCall(id="call_1", name="submit_test", arguments={"value": "test"})
+    response = LLMResponse(
+        content="Here's my response",
+        model="test",
+        tokens_used=50,
+        finish_reason="tool_calls",
+        tool_calls=[tool_call],
+    )
+    provider = create_mock_provider([response])
+
+    messages_received: list[str] = []
+
+    def on_message(content: str) -> None:
+        messages_received.append(content)
+
+    runner = ConversationRunner(
+        provider=provider,
+        tools=[FinalizationTool()],
+        finalization_tool="submit_test",
+    )
+
+    await runner.run(
+        initial_messages=[{"role": "user", "content": "Start"}],
+        on_assistant_message=on_message,
+    )
+
+    assert "Here's my response" in messages_received
+
+
+@pytest.mark.asyncio
+async def test_runner_tool_execution_error() -> None:
+    """Runner handles tool execution errors gracefully."""
+
+    class FailingTool:
+        @property
+        def definition(self) -> ToolDefinition:
+            return ToolDefinition(name="failing", description="Fails", parameters={})
+
+        def execute(self, arguments: dict[str, Any]) -> str:
+            raise RuntimeError("Tool crashed")
+
+    failing_call = ToolCall(id="call_1", name="failing", arguments={})
+    finalization_call = ToolCall(id="call_2", name="submit_test", arguments={"value": "done"})
+
+    first_response = LLMResponse(
+        content="",
+        model="test",
+        tokens_used=30,
+        finish_reason="tool_calls",
+        tool_calls=[failing_call],
+    )
+    second_response = LLMResponse(
+        content="",
+        model="test",
+        tokens_used=40,
+        finish_reason="tool_calls",
+        tool_calls=[finalization_call],
+    )
+    provider = create_mock_provider([first_response, second_response])
+
+    runner = ConversationRunner(
+        provider=provider,
+        tools=[FailingTool(), FinalizationTool()],
+        finalization_tool="submit_test",
+    )
+
+    result, state = await runner.run(
+        initial_messages=[{"role": "user", "content": "Start"}],
+    )
+
+    # Should complete despite tool error
+    assert result == {"value": "done"}
+    # Error should be in tool results
+    tool_results = [m for m in state.messages if m.get("role") == "tool"]
+    assert any("Error executing" in m.get("content", "") for m in tool_results)
+
+
+# --- ConversationError Tests ---
+
+
+def test_conversation_error_with_state() -> None:
+    """ConversationError preserves state."""
+    state = ConversationState(messages=[{"role": "user", "content": "Test"}])
+    state.llm_calls = 5
+
+    error = ConversationError("Something failed", state)
+
+    assert str(error) == "Something failed"
+    assert error.state is not None
+    assert error.state.llm_calls == 5
+
+
+def test_conversation_error_without_state() -> None:
+    """ConversationError works without state."""
+    error = ConversationError("Something failed")
+
+    assert str(error) == "Something failed"
+    assert error.state is None

--- a/tests/unit/test_conversation_runner.py
+++ b/tests/unit/test_conversation_runner.py
@@ -15,8 +15,7 @@ from questfoundry.conversation import (
     ValidationResult,
 )
 from questfoundry.providers.base import LLMResponse
-from questfoundry.tools import Tool, ToolCall, ToolDefinition
-
+from questfoundry.tools import ToolCall, ToolDefinition
 
 # --- Test Fixtures ---
 
@@ -267,7 +266,7 @@ async def test_runner_with_validation_success() -> None:
         finalization_tool="submit_test",
     )
 
-    result, state = await runner.run(
+    result, _state = await runner.run(
         initial_messages=[{"role": "user", "content": "Start"}],
         validator=validator,
     )
@@ -340,7 +339,7 @@ async def test_runner_validation_exhausts_retries() -> None:
     # Always return failing response
     provider = create_mock_provider([response, response, response, response])
 
-    def validator(data: dict[str, Any]) -> ValidationResult:
+    def validator(_data: dict[str, Any]) -> ValidationResult:
         return ValidationResult(
             valid=False,
             errors=[ValidationErrorDetail(field="value", issue="cannot be empty", provided="")],
@@ -380,7 +379,7 @@ async def test_runner_max_turns_exceeded() -> None:
         max_turns=3,
     )
 
-    with pytest.raises(ConversationError, match="Maximum turns.*exceeded"):
+    with pytest.raises(ConversationError, match=r"Maximum turns.*exceeded"):
         await runner.run(
             initial_messages=[{"role": "user", "content": "Start"}],
         )
@@ -407,7 +406,7 @@ async def test_runner_llm_fails_to_call_tool() -> None:
     )
     provider = create_mock_provider([first_response, second_response])
 
-    def validator(data: dict[str, Any]) -> ValidationResult:
+    def validator(_data: dict[str, Any]) -> ValidationResult:
         return ValidationResult(
             valid=False,
             errors=[ValidationErrorDetail(field="value", issue="error", provided="")],
@@ -419,7 +418,7 @@ async def test_runner_llm_fails_to_call_tool() -> None:
         finalization_tool="submit_test",
     )
 
-    with pytest.raises(ConversationError, match="LLM failed to call"):
+    with pytest.raises(ConversationError, match=r"LLM failed to call"):
         await runner.run(
             initial_messages=[{"role": "user", "content": "Start"}],
             validator=validator,
@@ -508,7 +507,7 @@ async def test_runner_tool_execution_error() -> None:
         def definition(self) -> ToolDefinition:
             return ToolDefinition(name="failing", description="Fails", parameters={})
 
-        def execute(self, arguments: dict[str, Any]) -> str:
+        def execute(self, _arguments: dict[str, Any]) -> str:
             raise RuntimeError("Tool crashed")
 
     failing_call = ToolCall(id="call_1", name="failing", arguments={})

--- a/tests/unit/test_finalization_tools.py
+++ b/tests/unit/test_finalization_tools.py
@@ -1,0 +1,181 @@
+"""Tests for finalization tools."""
+
+from __future__ import annotations
+
+from questfoundry.tools import Tool, ToolDefinition
+from questfoundry.tools.finalization import (
+    FINALIZATION_TOOLS,
+    SubmitBrainstormTool,
+    SubmitDreamTool,
+    get_finalization_tool,
+)
+
+
+# --- SubmitDreamTool Tests ---
+
+
+def test_submit_dream_tool_definition() -> None:
+    """SubmitDreamTool has correct name and description."""
+    tool = SubmitDreamTool()
+    definition = tool.definition
+
+    assert definition.name == "submit_dream"
+    assert "creative vision" in definition.description.lower()
+
+
+def test_submit_dream_tool_parameters() -> None:
+    """SubmitDreamTool has expected required parameters."""
+    tool = SubmitDreamTool()
+    params = tool.definition.parameters
+
+    assert params["type"] == "object"
+    assert "genre" in params["properties"]
+    assert "tone" in params["properties"]
+    assert "audience" in params["properties"]
+    assert "themes" in params["properties"]
+
+    required = params.get("required", [])
+    assert "genre" in required
+    assert "tone" in required
+    assert "audience" in required
+    assert "themes" in required
+
+
+def test_submit_dream_tool_optional_parameters() -> None:
+    """SubmitDreamTool has optional parameters for scope and content_notes."""
+    tool = SubmitDreamTool()
+    params = tool.definition.parameters
+
+    assert "scope" in params["properties"]
+    assert "content_notes" in params["properties"]
+    assert "style_notes" in params["properties"]
+    assert "subgenre" in params["properties"]
+
+
+def test_submit_dream_tool_execute() -> None:
+    """SubmitDreamTool.execute returns confirmation message."""
+    tool = SubmitDreamTool()
+    result = tool.execute({"genre": "fantasy", "tone": ["dark"]})
+
+    assert "submitted" in result.lower() or "validation" in result.lower()
+
+
+def test_submit_dream_tool_implements_protocol() -> None:
+    """SubmitDreamTool implements the Tool protocol."""
+    tool = SubmitDreamTool()
+
+    # Should be an instance of Tool (runtime_checkable protocol)
+    assert isinstance(tool, Tool)
+
+
+# --- SubmitBrainstormTool Tests ---
+
+
+def test_submit_brainstorm_tool_definition() -> None:
+    """SubmitBrainstormTool has correct name and description."""
+    tool = SubmitBrainstormTool()
+    definition = tool.definition
+
+    assert definition.name == "submit_brainstorm"
+    assert "brainstorm" in definition.description.lower()
+
+
+def test_submit_brainstorm_tool_parameters() -> None:
+    """SubmitBrainstormTool has expected required parameters."""
+    tool = SubmitBrainstormTool()
+    params = tool.definition.parameters
+
+    assert params["type"] == "object"
+    assert "characters" in params["properties"]
+    assert "plot_hooks" in params["properties"]
+
+    required = params.get("required", [])
+    assert "characters" in required
+    assert "plot_hooks" in required
+
+
+def test_submit_brainstorm_tool_optional_parameters() -> None:
+    """SubmitBrainstormTool has optional parameters."""
+    tool = SubmitBrainstormTool()
+    params = tool.definition.parameters
+
+    assert "settings" in params["properties"]
+    assert "conflicts" in params["properties"]
+    assert "notes" in params["properties"]
+
+
+def test_submit_brainstorm_tool_execute() -> None:
+    """SubmitBrainstormTool.execute returns confirmation message."""
+    tool = SubmitBrainstormTool()
+    result = tool.execute({"characters": [], "plot_hooks": []})
+
+    assert "submitted" in result.lower() or "validation" in result.lower()
+
+
+def test_submit_brainstorm_tool_implements_protocol() -> None:
+    """SubmitBrainstormTool implements the Tool protocol."""
+    tool = SubmitBrainstormTool()
+
+    assert isinstance(tool, Tool)
+
+
+# --- get_finalization_tool Tests ---
+
+
+def test_get_finalization_tool_dream() -> None:
+    """get_finalization_tool returns SubmitDreamTool for 'dream' stage."""
+    tool = get_finalization_tool("dream")
+
+    assert tool is not None
+    assert isinstance(tool, SubmitDreamTool)
+    assert tool.definition.name == "submit_dream"
+
+
+def test_get_finalization_tool_brainstorm() -> None:
+    """get_finalization_tool returns SubmitBrainstormTool for 'brainstorm' stage."""
+    tool = get_finalization_tool("brainstorm")
+
+    assert tool is not None
+    assert isinstance(tool, SubmitBrainstormTool)
+    assert tool.definition.name == "submit_brainstorm"
+
+
+def test_get_finalization_tool_unknown() -> None:
+    """get_finalization_tool returns None for unknown stage."""
+    tool = get_finalization_tool("unknown_stage")
+
+    assert tool is None
+
+
+def test_get_finalization_tool_returns_tool_protocol() -> None:
+    """get_finalization_tool return type is Tool protocol compatible."""
+    tool = get_finalization_tool("dream")
+
+    # Return value should be usable as Tool
+    assert tool is not None
+    assert isinstance(tool, Tool)
+    assert isinstance(tool.definition, ToolDefinition)
+
+
+# --- FINALIZATION_TOOLS Registry Tests ---
+
+
+def test_finalization_tools_registry_contains_dream() -> None:
+    """FINALIZATION_TOOLS registry contains 'dream' entry."""
+    assert "dream" in FINALIZATION_TOOLS
+    assert FINALIZATION_TOOLS["dream"] is SubmitDreamTool
+
+
+def test_finalization_tools_registry_contains_brainstorm() -> None:
+    """FINALIZATION_TOOLS registry contains 'brainstorm' entry."""
+    assert "brainstorm" in FINALIZATION_TOOLS
+    assert FINALIZATION_TOOLS["brainstorm"] is SubmitBrainstormTool
+
+
+def test_finalization_tools_registry_tools_are_callable() -> None:
+    """All entries in FINALIZATION_TOOLS are callable and return tools."""
+    for stage, tool_class in FINALIZATION_TOOLS.items():
+        tool = tool_class()
+        assert isinstance(tool, Tool), f"Tool for stage '{stage}' doesn't implement Tool protocol"
+        assert hasattr(tool, "definition")
+        assert hasattr(tool, "execute")

--- a/tests/unit/test_finalization_tools.py
+++ b/tests/unit/test_finalization_tools.py
@@ -10,7 +10,6 @@ from questfoundry.tools.finalization import (
     get_finalization_tool,
 )
 
-
 # --- SubmitDreamTool Tests ---
 
 


### PR DESCRIPTION
## Summary
- Add finalization tools (`SubmitDreamTool`, `SubmitBrainstormTool`)
- Add `ConversationRunner` for multi-turn LLM conversations
- Implement validation retry loop with structured feedback
- Fix infinite loop in validation retry (fail fast if no tool call)

This is **Part 2 of 3** of the interactive REPL mode feature, split from #32 for easier review.

## Stack
1. #35 (tool protocol) → main
2. **This PR** → #35
3. #37 (stage implementation) → this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)