### PR TITLE
fix(schema): align JSON schema with Pydantic model requirements

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -35,5 +35,5 @@ repos:
         name: Check schema/model sync
         entry: uv run python scripts/check_schema_model_sync.py
         language: system
-        files: ^(schemas/.*\.schema\.json|src/questfoundry/artifacts/models\.py)$
+        files: ^(schemas/.*\.schema\.json|src/questfoundry/artifacts/models\.py|src/questfoundry/tools/finalization\.py)$
         pass_filenames: false

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,3 +26,14 @@ repos:
       - id: end-of-file-fixer
       - id: check-yaml
       - id: check-added-large-files
+      - id: check-json
+        files: ^schemas/.*\.json$
+
+  - repo: local
+    hooks:
+      - id: check-schema-model-sync
+        name: Check schema/model sync
+        entry: uv run python scripts/check_schema_model_sync.py
+        language: system
+        files: ^(schemas/.*\.schema\.json|src/questfoundry/artifacts/models\.py)$
+        pass_filenames: false

--- a/docs/design/02-artifact-schemas.md
+++ b/docs/design/02-artifact-schemas.md
@@ -99,7 +99,7 @@ content_notes:
     },
     "audience": {
       "type": "string",
-      "enum": ["adult", "young_adult", "all_ages"]
+      "minLength": 1
     },
     "themes": {
       "type": "array",
@@ -109,12 +109,13 @@ content_notes:
     "style_notes": { "type": "string" },
     "scope": {
       "type": "object",
+      "required": ["target_word_count", "estimated_passages"],
       "properties": {
         "target_word_count": { "type": "integer", "minimum": 1000 },
         "estimated_passages": { "type": "integer", "minimum": 5 },
         "branching_depth": {
           "type": "string",
-          "enum": ["light", "moderate", "heavy"]
+          "minLength": 1
         }
       }
     }

--- a/schemas/dream.schema.json
+++ b/schemas/dream.schema.json
@@ -55,6 +55,7 @@
     },
     "scope": {
       "type": "object",
+      "required": ["target_word_count", "estimated_passages"],
       "properties": {
         "target_word_count": {
           "type": "integer",

--- a/scripts/check_schema_model_sync.py
+++ b/scripts/check_schema_model_sync.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+"""Check that JSON schemas and Pydantic models are in sync.
+
+This pre-commit hook validates that schema required fields match
+the corresponding Pydantic model requirements.
+
+Usage:
+    python scripts/check_schema_model_sync.py
+
+Exit codes:
+    0: All schemas in sync with models
+    1: Mismatch detected between schema and model
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+
+def check_dream_schema_sync() -> list[str]:
+    """Check dream.schema.json matches DreamArtifact model.
+
+    Returns:
+        List of error messages (empty if in sync).
+    """
+    errors: list[str] = []
+
+    # Load schema
+    schema_path = Path(__file__).parent.parent / "schemas" / "dream.schema.json"
+    if not schema_path.exists():
+        errors.append(f"Schema not found: {schema_path}")
+        return errors
+
+    with schema_path.open() as f:
+        schema = json.load(f)
+
+    # Import Pydantic models (deferred to avoid import errors in minimal envs)
+    try:
+        from questfoundry.artifacts import DreamArtifact, Scope
+    except ImportError as e:
+        errors.append(f"Cannot import models: {e}")
+        return errors
+
+    # Check top-level required fields
+    schema_required = set(schema.get("required", []))
+    model_required = {
+        name for name, field in DreamArtifact.model_fields.items() if field.is_required()
+    }
+    missing_from_schema = model_required - schema_required
+    if missing_from_schema:
+        errors.append(
+            f"DreamArtifact requires {missing_from_schema} but schema doesn't. "
+            "Update schemas/dream.schema.json required array."
+        )
+
+    # Check scope required fields
+    scope_schema = schema.get("properties", {}).get("scope", {})
+    scope_schema_required = set(scope_schema.get("required", []))
+    scope_model_required = {
+        name for name, field in Scope.model_fields.items() if field.is_required()
+    }
+    missing_scope_fields = scope_model_required - scope_schema_required
+    if missing_scope_fields:
+        errors.append(
+            f"Scope model requires {missing_scope_fields} but schema.scope doesn't. "
+            "Update schemas/dream.schema.json scope.required array."
+        )
+
+    return errors
+
+
+def main() -> int:
+    """Run all schema sync checks.
+
+    Returns:
+        Exit code (0 for success, 1 for failure).
+    """
+    all_errors: list[str] = []
+
+    # Check dream schema
+    all_errors.extend(check_dream_schema_sync())
+
+    # Add checks for other schemas here as they're added
+    # all_errors.extend(check_brainstorm_schema_sync())
+    # all_errors.extend(check_seed_schema_sync())
+
+    if all_errors:
+        print("Schema/Model sync errors found:", file=sys.stderr)
+        for error in all_errors:
+            print(f"  - {error}", file=sys.stderr)
+        print(
+            "\nNote: When PR #2 (code generation) is merged, run "
+            "'uv run python scripts/generate_models.py' to fix drift.",
+            file=sys.stderr,
+        )
+        return 1
+
+    print("All schemas in sync with Pydantic models.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check_schema_model_sync.py
+++ b/scripts/check_schema_model_sync.py
@@ -51,8 +51,8 @@ def check_dream_schema_sync() -> list[str]:
     missing_from_schema = model_required - schema_required
     if missing_from_schema:
         errors.append(
-            f"DreamArtifact requires {missing_from_schema} but schema doesn't. "
-            "Update schemas/dream.schema.json required array."
+            f"{DreamArtifact.__name__} requires {missing_from_schema} but schema doesn't. "
+            f"Update {schema_path.name} required array."
         )
 
     # Check scope required fields
@@ -64,8 +64,8 @@ def check_dream_schema_sync() -> list[str]:
     missing_scope_fields = scope_model_required - scope_schema_required
     if missing_scope_fields:
         errors.append(
-            f"Scope model requires {missing_scope_fields} but schema.scope doesn't. "
-            "Update schemas/dream.schema.json scope.required array."
+            f"{Scope.__name__} model requires {missing_scope_fields} but schema.scope doesn't. "
+            f"Update {schema_path.name} scope.required array."
         )
 
     return errors
@@ -90,11 +90,6 @@ def main() -> int:
         print("Schema/Model sync errors found:", file=sys.stderr)
         for error in all_errors:
             print(f"  - {error}", file=sys.stderr)
-        print(
-            "\nNote: When PR #2 (code generation) is merged, run "
-            "'uv run python scripts/generate_models.py' to fix drift.",
-            file=sys.stderr,
-        )
         return 1
 
     print("All schemas in sync with Pydantic models.")

--- a/src/questfoundry/tools/finalization.py
+++ b/src/questfoundry/tools/finalization.py
@@ -66,6 +66,7 @@ class SubmitDreamTool:
                     "scope": {
                         "type": "object",
                         "description": "Story scope parameters",
+                        "required": ["target_word_count", "estimated_passages"],
                         "properties": {
                             "target_word_count": {
                                 "type": "integer",


### PR DESCRIPTION
## Problem

The JSON schema and Pydantic model for `scope` had a contract mismatch:
- Pydantic `Scope` class requires `target_word_count` and `estimated_passages`
- JSON schema and tool definition had no required fields for scope

This caused validation inconsistency between external tools (using JSON schema) and internal code (using Pydantic).

## Changes

**Schema alignment:**
- Add `required: ["target_word_count", "estimated_passages"]` to `schemas/dream.schema.json` scope object
- Add same required fields to `SubmitDreamTool.definition.parameters.scope`
- Update `docs/design/02-artifact-schemas.md` schema example to match
- Replace enum constraints with `minLength=1` for `audience`/`branching_depth` (per CLAUDE.md guidance on LLM flexibility)

**Pre-commit hooks:**
- Add `check-json` hook for schema file validation
- Add `check-schema-model-sync` hook to detect schema/model drift
- Create `scripts/check_schema_model_sync.py` validation script

## Not Included / Future PRs

- Code generation from schema (PR #2)
- Structured validation feedback (PR #3)
- Cleanup and migration from models.py (PR #4)

## Test Plan

```bash
uv run pytest tests/unit/test_artifacts.py -v
# 30 passed

uv run python scripts/check_schema_model_sync.py
# All schemas in sync with Pydantic models.

uv run pytest --tb=short -q
# 231 passed
```

New tests:
- `test_schema_model_required_fields_match` - Schema covers Pydantic required
- `test_scope_required_fields_in_schema` - Scope has correct required fields
- `test_scope_requires_word_count_and_passages` - Explicit Scope validation
- `test_optional_scope_is_none_by_default` - DreamArtifact.scope defaults
- `test_tool_schema_matches_json_schema_scope_required` - Tool/schema sync

## Risk / Rollback

- Low risk: Only adds required fields that were already enforced by Pydantic
- Breaking change: External tools using the schema may fail if not providing scope.target_word_count/estimated_passages (but this was already required by the model)

## Review Guide

Suggested order:
1. `schemas/dream.schema.json` - The core fix (1 line)
2. `src/questfoundry/tools/finalization.py` - Tool alignment (1 line)
3. `docs/design/02-artifact-schemas.md` - Doc update (3 lines)
4. `scripts/check_schema_model_sync.py` - New validation script
5. `tests/unit/test_artifacts.py` - New contract tests
6. `.pre-commit-config.yaml` - Hook configuration