### PR TITLE
feat(validation): add structured validation feedback with expected_fields

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.8.6
+    rev: v0.14.0
     hooks:
       - id: ruff
         args: [--fix]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,6 +19,9 @@ repos:
           - rich
           - ruamel.yaml
           - jsonschema
+          - langchain-core
+          - langchain-openai
+          - langchain-anthropic
         args: [--ignore-missing-imports]
 
   - repo: https://github.com/pre-commit/pre-commit-hooks

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,6 +10,8 @@ repos:
     rev: v1.14.1
     hooks:
       - id: mypy
+        # Only run on src/ to match CI behavior (tests have untyped pytest decorators)
+        files: ^src/
         additional_dependencies:
           - httpx
           - pydantic

--- a/src/questfoundry/artifacts/__init__.py
+++ b/src/questfoundry/artifacts/__init__.py
@@ -15,6 +15,7 @@ from questfoundry.artifacts.validator import (
     ArtifactValidationError,
     ArtifactValidator,
     SchemaNotFoundError,
+    pydantic_errors_to_details,
 )
 from questfoundry.artifacts.writer import ArtifactWriteError, ArtifactWriter
 
@@ -31,4 +32,5 @@ __all__ = [
     "DreamArtifact",
     "SchemaNotFoundError",
     "Scope",
+    "pydantic_errors_to_details",
 ]

--- a/src/questfoundry/artifacts/validator.py
+++ b/src/questfoundry/artifacts/validator.py
@@ -292,7 +292,7 @@ def pydantic_errors_to_details(
         data: The original data that was validated (for extracting provided values).
 
     Returns:
-        List of ValidationErrorDetail with field, issue, and provided value.
+        List of ValidationErrorDetail with field, issue, provided value, and error_type.
 
     Example:
         >>> from pydantic import ValidationError
@@ -300,8 +300,8 @@ def pydantic_errors_to_details(
         ...     DreamArtifact.model_validate({"genre": ""})
         ... except ValidationError as e:
         ...     details = pydantic_errors_to_details(e.errors(), {"genre": ""})
-        ...     print(details[0].field, details[0].provided)
-        genre
+        ...     print(details[0].field, details[0].error_type)
+        genre string_too_short
     """
     from questfoundry.conversation import ValidationErrorDetail
 
@@ -312,7 +312,15 @@ def pydantic_errors_to_details(
         field = _path_to_field_name(path)
         issue = error["msg"]
         provided = _get_nested_value(data, path)
+        error_type = error.get("type")  # Pydantic error type code
 
-        result.append(ValidationErrorDetail(field=field, issue=issue, provided=provided))
+        result.append(
+            ValidationErrorDetail(
+                field=field,
+                issue=issue,
+                provided=provided,
+                error_type=error_type,
+            )
+        )
 
     return result

--- a/src/questfoundry/artifacts/validator.py
+++ b/src/questfoundry/artifacts/validator.py
@@ -4,12 +4,17 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import jsonschema
 from pydantic import BaseModel, ValidationError
 
-from questfoundry.artifacts.models import DreamArtifact
+from questfoundry.artifacts import DreamArtifact
+
+if TYPE_CHECKING:
+    from pydantic_core import ErrorDetails
+
+    from questfoundry.conversation import ValidationErrorDetail
 
 
 class SchemaNotFoundError(Exception):
@@ -197,3 +202,85 @@ class ArtifactValidator:
                 return False
 
         return True
+
+
+def _get_nested_value(data: dict[str, Any], path: tuple[str | int, ...]) -> Any:
+    """Get a value from nested data using a path tuple.
+
+    Args:
+        data: The data dictionary to traverse.
+        path: Tuple of keys/indices from Pydantic error location.
+
+    Returns:
+        The value at the path, or None if path doesn't exist.
+    """
+    current: Any = data
+    for key in path:
+        if current is None:
+            return None
+        if isinstance(key, int):
+            # List index - skip for value extraction (get parent list)
+            if isinstance(current, list) and key < len(current):
+                current = current[key]
+            else:
+                return None
+        elif isinstance(current, dict):
+            current = current.get(key)
+        else:
+            return None
+    return current
+
+
+def _path_to_field_name(path: tuple[str | int, ...]) -> str:
+    """Convert Pydantic error path to field name string.
+
+    Strips list indices to show field name only.
+    E.g., ('scope', 'target_word_count') -> "scope.target_word_count"
+    E.g., ('themes', 0) -> "themes"
+
+    Args:
+        path: Tuple of keys/indices from Pydantic error location.
+
+    Returns:
+        Dot-separated field path string.
+    """
+    # Filter out integer indices for cleaner field names
+    str_parts = [str(p) for p in path if not isinstance(p, int)]
+    return ".".join(str_parts) if str_parts else "(root)"
+
+
+def pydantic_errors_to_details(
+    errors: list[ErrorDetails],
+    data: dict[str, Any],
+) -> list[ValidationErrorDetail]:
+    """Convert Pydantic ValidationError details to structured ValidationErrorDetail list.
+
+    Args:
+        errors: List of error dicts from ValidationError.errors().
+        data: The original data that was validated (for extracting provided values).
+
+    Returns:
+        List of ValidationErrorDetail with field, issue, and provided value.
+
+    Example:
+        >>> from pydantic import ValidationError
+        >>> try:
+        ...     DreamArtifact.model_validate({"genre": ""})
+        ... except ValidationError as e:
+        ...     details = pydantic_errors_to_details(e.errors(), {"genre": ""})
+        ...     print(details[0].field, details[0].provided)
+        genre
+    """
+    from questfoundry.conversation import ValidationErrorDetail
+
+    result: list[ValidationErrorDetail] = []
+
+    for error in errors:
+        path = error["loc"]
+        field = _path_to_field_name(path)
+        issue = error["msg"]
+        provided = _get_nested_value(data, path)
+
+        result.append(ValidationErrorDetail(field=field, issue=issue, provided=provided))
+
+    return result

--- a/src/questfoundry/pipeline/stages/dream.py
+++ b/src/questfoundry/pipeline/stages/dream.py
@@ -208,11 +208,14 @@ class DreamStage:
         if not result.valid:
             raise DreamParseError(f"Validation failed: {result.error}", str(artifact_data))
 
-        # Add required fields
-        artifact_data["type"] = "dream"
-        artifact_data["version"] = artifact_data.get("version", 1)
+        # Use validated data (may have defaults/transformations applied)
+        validated_data = result.data if result.data is not None else artifact_data
 
-        return artifact_data, 1, response.tokens_used
+        # Add required fields
+        validated_data["type"] = "dream"
+        validated_data["version"] = validated_data.get("version", 1)
+
+        return validated_data, 1, response.tokens_used
 
     def _build_direct_user_message(self, user_prompt: str) -> str:
         """Build user message for direct mode with YAML format spec.

--- a/src/questfoundry/providers/factory.py
+++ b/src/questfoundry/providers/factory.py
@@ -84,7 +84,7 @@ def _create_openai(model: str, **kwargs: Any) -> LangChainProvider:
 
     chat_model = ChatOpenAI(
         model=model,
-        api_key=api_key,  # type: ignore[arg-type]
+        api_key=api_key,
         temperature=kwargs.get("temperature", 0.7),
     )
 
@@ -108,9 +108,9 @@ def _create_anthropic(model: str, **kwargs: Any) -> LangChainProvider:
             "API key required. Set ANTHROPIC_API_KEY environment variable.",
         )
 
-    chat_model = ChatAnthropic(  # type: ignore[call-arg]
+    chat_model = ChatAnthropic(
         model=model,
-        api_key=api_key,  # type: ignore[arg-type]
+        api_key=api_key,
         temperature=kwargs.get("temperature", 0.7),
     )
 

--- a/src/questfoundry/providers/factory.py
+++ b/src/questfoundry/providers/factory.py
@@ -84,7 +84,7 @@ def _create_openai(model: str, **kwargs: Any) -> LangChainProvider:
 
     chat_model = ChatOpenAI(
         model=model,
-        api_key=api_key,
+        api_key=api_key,  # type: ignore[arg-type]
         temperature=kwargs.get("temperature", 0.7),
     )
 
@@ -109,8 +109,8 @@ def _create_anthropic(model: str, **kwargs: Any) -> LangChainProvider:
         )
 
     chat_model = ChatAnthropic(
-        model=model,
-        api_key=api_key,
+        model=model,  # type: ignore[call-arg]
+        api_key=api_key,  # type: ignore[arg-type]
         temperature=kwargs.get("temperature", 0.7),
     )
 

--- a/tests/unit/test_conversation_runner.py
+++ b/tests/unit/test_conversation_runner.py
@@ -567,3 +567,138 @@ def test_conversation_error_without_state() -> None:
 
     assert str(error) == "Something failed"
     assert error.state is None
+
+
+# --- expected_fields in Feedback Tests ---
+
+
+def test_validation_result_expected_fields() -> None:
+    """ValidationResult supports expected_fields attribute."""
+    result = ValidationResult(
+        valid=False,
+        error="Missing fields",
+        expected_fields=["name", "age", "email"],
+    )
+
+    assert result.expected_fields == ["name", "age", "email"]
+
+
+def test_validation_result_expected_fields_default() -> None:
+    """ValidationResult defaults expected_fields to None."""
+    result = ValidationResult(valid=True)
+
+    assert result.expected_fields is None
+
+
+@pytest.mark.asyncio
+async def test_runner_feedback_includes_expected_fields() -> None:
+    """Runner includes expected_fields in validation feedback when provided."""
+    import json
+
+    # First attempt fails with expected_fields, second succeeds
+    first_call = ToolCall(id="call_1", name="submit_test", arguments={"value": ""})
+    second_call = ToolCall(id="call_2", name="submit_test", arguments={"value": "fixed"})
+
+    first_response = LLMResponse(
+        content="",
+        model="test",
+        tokens_used=50,
+        finish_reason="tool_calls",
+        tool_calls=[first_call],
+    )
+    second_response = LLMResponse(
+        content="",
+        model="test",
+        tokens_used=50,
+        finish_reason="tool_calls",
+        tool_calls=[second_call],
+    )
+    provider = create_mock_provider([first_response, second_response])
+
+    def validator(data: dict[str, Any]) -> ValidationResult:
+        if data.get("value") == "":
+            return ValidationResult(
+                valid=False,
+                errors=[ValidationErrorDetail(field="value", issue="cannot be empty", provided="")],
+                expected_fields=["value", "description", "priority"],
+            )
+        return ValidationResult(valid=True, data=data)
+
+    runner = ConversationRunner(
+        provider=provider,
+        tools=[FinalizationTool()],
+        finalization_tool="submit_test",
+    )
+
+    _result, state = await runner.run(
+        initial_messages=[{"role": "user", "content": "Start"}],
+        validator=validator,
+    )
+
+    # Find the tool result message with feedback
+    tool_results = [m for m in state.messages if m.get("role") == "tool"]
+    assert len(tool_results) >= 1
+
+    # Parse the feedback JSON
+    feedback_msg = tool_results[0]["content"]
+    feedback = json.loads(feedback_msg)
+
+    assert "expected_fields" in feedback
+    assert feedback["expected_fields"] == ["value", "description", "priority"]
+
+
+@pytest.mark.asyncio
+async def test_runner_feedback_omits_expected_fields_when_none() -> None:
+    """Runner omits expected_fields from feedback when validator doesn't provide it."""
+    import json
+
+    # First attempt fails without expected_fields, second succeeds
+    first_call = ToolCall(id="call_1", name="submit_test", arguments={"value": ""})
+    second_call = ToolCall(id="call_2", name="submit_test", arguments={"value": "fixed"})
+
+    first_response = LLMResponse(
+        content="",
+        model="test",
+        tokens_used=50,
+        finish_reason="tool_calls",
+        tool_calls=[first_call],
+    )
+    second_response = LLMResponse(
+        content="",
+        model="test",
+        tokens_used=50,
+        finish_reason="tool_calls",
+        tool_calls=[second_call],
+    )
+    provider = create_mock_provider([first_response, second_response])
+
+    def validator(data: dict[str, Any]) -> ValidationResult:
+        if data.get("value") == "":
+            return ValidationResult(
+                valid=False,
+                errors=[ValidationErrorDetail(field="value", issue="cannot be empty", provided="")],
+                # No expected_fields
+            )
+        return ValidationResult(valid=True, data=data)
+
+    runner = ConversationRunner(
+        provider=provider,
+        tools=[FinalizationTool()],
+        finalization_tool="submit_test",
+    )
+
+    _result, state = await runner.run(
+        initial_messages=[{"role": "user", "content": "Start"}],
+        validator=validator,
+    )
+
+    # Find the tool result message with feedback
+    tool_results = [m for m in state.messages if m.get("role") == "tool"]
+    assert len(tool_results) >= 1
+
+    # Parse the feedback JSON
+    feedback_msg = tool_results[0]["content"]
+    feedback = json.loads(feedback_msg)
+
+    # expected_fields should not be present when not provided
+    assert "expected_fields" not in feedback

--- a/tests/unit/test_conversation_runner.py
+++ b/tests/unit/test_conversation_runner.py
@@ -648,6 +648,82 @@ async def test_runner_feedback_includes_expected_fields() -> None:
 
 
 @pytest.mark.asyncio
+async def test_runner_categorizes_unknown_error_type_via_string_fallback() -> None:
+    """Runner uses string matching fallback for unknown error types."""
+    import json
+
+    # Simulate an unknown/future Pydantic error type that contains "required" in message
+    first_call = ToolCall(id="call_1", name="submit_test", arguments={"value": ""})
+    second_call = ToolCall(id="call_2", name="submit_test", arguments={"value": "fixed"})
+
+    first_response = LLMResponse(
+        content="",
+        model="test",
+        tokens_used=50,
+        finish_reason="tool_calls",
+        tool_calls=[first_call],
+    )
+    second_response = LLMResponse(
+        content="",
+        model="test",
+        tokens_used=50,
+        finish_reason="tool_calls",
+        tool_calls=[second_call],
+    )
+    provider = create_mock_provider([first_response, second_response])
+
+    def validator(data: dict[str, Any]) -> ValidationResult:
+        if data.get("value") == "":
+            # Unknown error type but "required" in issue text
+            return ValidationResult(
+                valid=False,
+                errors=[
+                    ValidationErrorDetail(
+                        field="value",
+                        issue="Field is required",
+                        provided=None,
+                        error_type="unknown_future_type",  # Unknown to our set
+                    ),
+                    ValidationErrorDetail(
+                        field="count",
+                        issue="Must be positive",
+                        provided=-1,
+                        error_type="greater_than",  # Known invalid type
+                    ),
+                ],
+            )
+        return ValidationResult(valid=True, data=data)
+
+    runner = ConversationRunner(
+        provider=provider,
+        tools=[FinalizationTool()],
+        finalization_tool="submit_test",
+    )
+
+    _result, state = await runner.run(
+        initial_messages=[{"role": "user", "content": "Start"}],
+        validator=validator,
+    )
+
+    # Find the tool result message with feedback
+    tool_results = [m for m in state.messages if m.get("role") == "tool"]
+    assert len(tool_results) >= 1
+
+    # Parse the feedback JSON
+    feedback_msg = tool_results[0]["content"]
+    feedback = json.loads(feedback_msg)
+
+    # "value" should be in missing_fields (fallback to string "required")
+    assert "value" in feedback["missing_fields"], (
+        "Unknown error type with 'required' in issue should be categorized as missing"
+    )
+    # "count" should be in invalid_fields (no "required"/"missing" in issue)
+    assert any(f["field"] == "count" for f in feedback["invalid_fields"]), (
+        "Error without 'required'/'missing' in issue should be categorized as invalid"
+    )
+
+
+@pytest.mark.asyncio
 async def test_runner_feedback_omits_expected_fields_when_none() -> None:
     """Runner omits expected_fields from feedback when validator doesn't provide it."""
     import json

--- a/tests/unit/test_dream_stage.py
+++ b/tests/unit/test_dream_stage.py
@@ -470,14 +470,14 @@ def test_validate_dream_handles_nested_errors() -> None:
     fields = {e.field for e in result.errors}
 
     # target_word_count=100 is below minimum of 1000
-    assert (
-        "scope.target_word_count" in fields
-    ), f"Expected scope.target_word_count error, got: {fields}"
+    assert "scope.target_word_count" in fields, (
+        f"Expected scope.target_word_count error, got: {fields}"
+    )
 
     # estimated_passages is required when scope is provided
-    assert (
-        "scope.estimated_passages" in fields
-    ), f"Expected scope.estimated_passages error, got: {fields}"
+    assert "scope.estimated_passages" in fields, (
+        f"Expected scope.estimated_passages error, got: {fields}"
+    )
 
     # Verify provided values are captured correctly
     word_count_error = next(e for e in result.errors if e.field == "scope.target_word_count")

--- a/tests/unit/test_validator_helpers.py
+++ b/tests/unit/test_validator_helpers.py
@@ -259,9 +259,9 @@ class TestDreamArtifactErrors:
 
         # Verify indices are stripped (field should be exactly "tone", not "tone.1")
         for err in tone_errors:
-            assert (
-                err.field == "tone"
-            ), f"Expected 'tone' but got '{err.field}' - indices should be stripped"
+            assert err.field == "tone", (
+                f"Expected 'tone' but got '{err.field}' - indices should be stripped"
+            )
 
         # Verify the provided value is captured (the empty string at index 1)
         assert any(err.provided == "" for err in tone_errors)

--- a/tests/unit/test_validator_helpers.py
+++ b/tests/unit/test_validator_helpers.py
@@ -1,0 +1,254 @@
+"""Tests for validator helper functions."""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import BaseModel, Field, ValidationError
+
+from questfoundry.artifacts.validator import (
+    _get_nested_value,
+    _path_to_field_name,
+    pydantic_errors_to_details,
+)
+from questfoundry.conversation import ValidationErrorDetail
+
+# --- Helper Function Tests ---
+
+
+class TestPathToFieldName:
+    """Tests for _path_to_field_name helper."""
+
+    def test_single_field(self) -> None:
+        """Single field path."""
+        assert _path_to_field_name(("genre",)) == "genre"
+
+    def test_nested_field(self) -> None:
+        """Nested field path with dot notation."""
+        assert _path_to_field_name(("scope", "target_word_count")) == "scope.target_word_count"
+
+    def test_strips_list_indices(self) -> None:
+        """List indices are stripped from path."""
+        assert _path_to_field_name(("themes", 0)) == "themes"
+        assert _path_to_field_name(("items", 2, "name")) == "items.name"
+
+    def test_empty_path(self) -> None:
+        """Empty path returns root indicator."""
+        assert _path_to_field_name(()) == "(root)"
+
+    def test_only_indices(self) -> None:
+        """Path with only indices returns root."""
+        assert _path_to_field_name((0, 1)) == "(root)"
+
+
+class TestGetNestedValue:
+    """Tests for _get_nested_value helper."""
+
+    def test_simple_field(self) -> None:
+        """Get simple field value."""
+        data = {"genre": "fantasy"}
+        assert _get_nested_value(data, ("genre",)) == "fantasy"
+
+    def test_nested_field(self) -> None:
+        """Get nested field value."""
+        data = {"scope": {"target_word_count": 5000}}
+        assert _get_nested_value(data, ("scope", "target_word_count")) == 5000
+
+    def test_list_index(self) -> None:
+        """Get list item by index."""
+        data = {"themes": ["adventure", "friendship"]}
+        assert _get_nested_value(data, ("themes", 0)) == "adventure"
+        assert _get_nested_value(data, ("themes", 1)) == "friendship"
+
+    def test_missing_field(self) -> None:
+        """Missing field returns None."""
+        data = {"genre": "fantasy"}
+        assert _get_nested_value(data, ("missing",)) is None
+
+    def test_missing_nested_field(self) -> None:
+        """Missing nested field returns None."""
+        data = {"scope": {}}
+        assert _get_nested_value(data, ("scope", "missing")) is None
+
+    def test_none_in_path(self) -> None:
+        """None value in path returns None."""
+        data = {"scope": None}
+        assert _get_nested_value(data, ("scope", "target_word_count")) is None
+
+    def test_list_index_out_of_bounds(self) -> None:
+        """Out of bounds list index returns None."""
+        data = {"themes": ["one"]}
+        assert _get_nested_value(data, ("themes", 5)) is None
+
+    def test_empty_path(self) -> None:
+        """Empty path returns the data itself."""
+        data = {"genre": "fantasy"}
+        assert _get_nested_value(data, ()) == data
+
+
+# --- pydantic_errors_to_details Tests ---
+
+
+class SampleModel(BaseModel):
+    """Sample model for testing error conversion."""
+
+    name: str = Field(min_length=1)
+    age: int = Field(ge=0)
+    tags: list[str] = Field(default_factory=list)
+
+
+class NestedModel(BaseModel):
+    """Model with nested objects for testing."""
+
+    meta: SampleModel
+
+
+class TestPydanticErrorsToDetails:
+    """Tests for pydantic_errors_to_details function."""
+
+    def test_missing_required_field(self) -> None:
+        """Missing required field produces correct error detail."""
+        data = {"age": 25}
+        try:
+            SampleModel.model_validate(data)
+            pytest.fail("Expected ValidationError")
+        except ValidationError as e:
+            details = pydantic_errors_to_details(e.errors(), data)
+
+        assert len(details) == 1
+        assert details[0].field == "name"
+        assert "required" in details[0].issue.lower() or "missing" in details[0].issue.lower()
+        assert details[0].provided is None
+
+    def test_invalid_value(self) -> None:
+        """Invalid value produces correct error detail with provided value."""
+        data = {"name": "", "age": 25}
+        try:
+            SampleModel.model_validate(data)
+            pytest.fail("Expected ValidationError")
+        except ValidationError as e:
+            details = pydantic_errors_to_details(e.errors(), data)
+
+        assert len(details) == 1
+        assert details[0].field == "name"
+        assert details[0].provided == ""
+
+    def test_constraint_violation(self) -> None:
+        """Constraint violation includes provided value."""
+        data = {"name": "Test", "age": -5}
+        try:
+            SampleModel.model_validate(data)
+            pytest.fail("Expected ValidationError")
+        except ValidationError as e:
+            details = pydantic_errors_to_details(e.errors(), data)
+
+        assert len(details) == 1
+        assert details[0].field == "age"
+        assert details[0].provided == -5
+
+    def test_multiple_errors(self) -> None:
+        """Multiple errors produce multiple details."""
+        data = {"name": "", "age": -5}
+        try:
+            SampleModel.model_validate(data)
+            pytest.fail("Expected ValidationError")
+        except ValidationError as e:
+            details = pydantic_errors_to_details(e.errors(), data)
+
+        assert len(details) == 2
+        fields = {d.field for d in details}
+        assert "name" in fields
+        assert "age" in fields
+
+    def test_nested_error(self) -> None:
+        """Nested field error produces dot-notation field path."""
+        data = {"meta": {"name": "", "age": 25}}
+        try:
+            NestedModel.model_validate(data)
+            pytest.fail("Expected ValidationError")
+        except ValidationError as e:
+            details = pydantic_errors_to_details(e.errors(), data)
+
+        assert len(details) == 1
+        assert details[0].field == "meta.name"
+        assert details[0].provided == ""
+
+    def test_empty_errors_list(self) -> None:
+        """Empty errors list produces empty details list."""
+        details = pydantic_errors_to_details([], {})
+        assert details == []
+
+    def test_returns_validation_error_detail_instances(self) -> None:
+        """Results are ValidationErrorDetail instances."""
+        data = {"age": 25}
+        try:
+            SampleModel.model_validate(data)
+            pytest.fail("Expected ValidationError")
+        except ValidationError as e:
+            details = pydantic_errors_to_details(e.errors(), data)
+
+        assert all(isinstance(d, ValidationErrorDetail) for d in details)
+
+
+# --- Integration with DreamArtifact ---
+
+
+class TestDreamArtifactErrors:
+    """Test error conversion with actual DreamArtifact model."""
+
+    def test_dream_missing_required_fields(self) -> None:
+        """Missing required DreamArtifact fields."""
+        from questfoundry.artifacts import DreamArtifact
+
+        data = {}
+        try:
+            DreamArtifact.model_validate(data)
+            pytest.fail("Expected ValidationError")
+        except ValidationError as e:
+            details = pydantic_errors_to_details(e.errors(), data)
+
+        fields = {d.field for d in details}
+        # Required fields: genre, tone, audience, themes
+        assert "genre" in fields
+        assert "tone" in fields
+        assert "audience" in fields
+        assert "themes" in fields
+
+    def test_dream_nested_scope_error(self) -> None:
+        """Nested scope field errors have correct path."""
+        from questfoundry.artifacts import DreamArtifact
+
+        data = {
+            "genre": "fantasy",
+            "tone": ["epic"],
+            "audience": "adult",
+            "themes": ["heroism"],
+            "scope": {"target_word_count": 100},  # Below minimum of 1000
+        }
+        try:
+            DreamArtifact.model_validate(data)
+            pytest.fail("Expected ValidationError")
+        except ValidationError as e:
+            details = pydantic_errors_to_details(e.errors(), data)
+
+        # Should have error for scope.target_word_count and missing estimated_passages
+        fields = {d.field for d in details}
+        assert "scope.target_word_count" in fields or "scope.estimated_passages" in fields
+
+    def test_dream_list_item_error(self) -> None:
+        """List item validation errors reference parent field."""
+        from questfoundry.artifacts import DreamArtifact
+
+        data = {
+            "genre": "fantasy",
+            "tone": ["epic", ""],  # Empty string not allowed
+            "audience": "adult",
+            "themes": ["heroism"],
+        }
+        try:
+            DreamArtifact.model_validate(data)
+            pytest.fail("Expected ValidationError")
+        except ValidationError as e:
+            details = pydantic_errors_to_details(e.errors(), data)
+
+        # Should reference "tone" without index
+        assert any(d.field == "tone" for d in details)


### PR DESCRIPTION
## Problem

When validation fails during the LLM retry loop, the error feedback is a simple string. This makes it harder for the LLM to understand:
1. What fields are invalid vs missing
2. What values were provided that failed
3. What fields are actually valid/expected

## Changes

- **`pydantic_errors_to_details()` helper** in `validator.py`: Converts Pydantic ValidationError to structured `ValidationErrorDetail` objects with field path, issue description, provided value, and error_type
- **`error_type` field** in `ValidationErrorDetail`: Captures Pydantic error type code for reliable categorization
- **`_validate_dream()` updated**: Now returns structured `errors` list alongside the legacy error string for backwards compatibility
- **`expected_fields` in `ValidationResult`**: Validators can now provide the list of valid field names
- **Feedback JSON enhanced**: Includes `expected_fields` when provided by validator
- **Defensive fallback**: Unknown error types fall back to string matching on issue text for future-proofing

### Pre-commit Config Fixes

- **mypy scope aligned with CI**: Pre-commit now only runs mypy on `src/` (not `tests/`) to match CI behavior. Tests have untyped pytest decorators that mypy complains about but aren't worth fixing.
- **ruff version updated**: Pre-commit ruff updated from v0.8.6 to v0.14.0 to match project dependency (0.14.10). Different versions have different formatting rules which caused CI failures.

### Example Feedback JSON (before)

```json
{
  "success": false,
  "error": "Validation failed for submitted artifact",
  "error_count": 2,
  "invalid_fields": [],
  "missing_fields": ["genre", "themes"],
  "submitted_data": {...},
  "hint": "Call submit_dream() again with corrected data."
}
```

### Example Feedback JSON (after)

```json
{
  "success": false,
  "error": "Validation failed for submitted artifact",
  "error_count": 3,
  "invalid_fields": [
    {
      "field": "genre",
      "provided": "",
      "issue": "String should have at least 1 character"
    },
    {
      "field": "scope.target_word_count",
      "provided": 100,
      "issue": "Input should be greater than or equal to 1000"
    }
  ],
  "missing_fields": ["themes"],
  "expected_fields": ["type", "version", "genre", "subgenre", "tone", "audience", "themes", "style_notes", "scope", "content_notes"],
  "submitted_data": {...},
  "hint": "Call submit_dream() again with corrected data. Fix only the errors listed."
}
```

## Not Included / Future PRs

- Fuzzy field matching (synonym detection) - deferred, expected_fields should provide sufficient guidance
- Validation feedback for other stages (will follow same pattern when implemented)
- Move ValidationErrorDetail to shared types module (deferred - current TYPE_CHECKING pattern is acceptable)

## Test Plan

```bash
# All tests pass
uv run pytest --cov --cov-fail-under=70
# Result: 297 passed, 79% coverage

# New tests specifically
uv run pytest tests/unit/test_validator_helpers.py tests/unit/test_dream_stage.py::test_validate_dream tests/unit/test_conversation_runner.py::test_runner_categorizes_unknown_error_type -v
# Result: 27 tests pass (including new unknown error type fallback test)
```

## Risk / Rollback

- Low risk: Backwards compatible (legacy `error` string still provided)
- To rollback: Revert this PR, validators still return just error string

🤖 Generated with [Claude Code](https://claude.com/claude-code)