### PR TITLE
feat(validation): improve tool validation feedback quality

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,6 +22,8 @@ repos:
           - langchain-core
           - langchain-openai
           - langchain-anthropic
+          - pyyaml
+          - types-pyyaml
         args: [--ignore-missing-imports]
 
   - repo: https://github.com/pre-commit/pre-commit-hooks

--- a/src/questfoundry/artifacts/__init__.py
+++ b/src/questfoundry/artifacts/__init__.py
@@ -15,6 +15,7 @@ from questfoundry.artifacts.validator import (
     ArtifactValidationError,
     ArtifactValidator,
     SchemaNotFoundError,
+    get_all_field_paths,
     pydantic_errors_to_details,
 )
 from questfoundry.artifacts.writer import ArtifactWriteError, ArtifactWriter
@@ -32,5 +33,6 @@ __all__ = [
     "DreamArtifact",
     "SchemaNotFoundError",
     "Scope",
+    "get_all_field_paths",
     "pydantic_errors_to_details",
 ]

--- a/src/questfoundry/conversation/runner.py
+++ b/src/questfoundry/conversation/runner.py
@@ -452,15 +452,18 @@ class ConversationRunner:
         if expected_fields is None:
             return []
 
+        # Pre-compute parent prefixes for O(1) lookup instead of O(m) per field
+        parent_prefixes = {ef.rsplit(".", 1)[0] for ef in expected_fields if "." in ef}
+
         unknown: list[str] = []
 
         for key, value in data.items():
-            field_path = f"{prefix}{key}" if not prefix else f"{prefix}.{key}"
+            field_path = f"{prefix}.{key}" if prefix else key
 
             # Check if this exact path or a parent path is expected
             # e.g., "scope" is expected if "scope.target_word_count" is in expected_fields
             path_is_expected = field_path in expected_fields
-            is_parent_of_expected = any(ef.startswith(f"{field_path}.") for ef in expected_fields)
+            is_parent_of_expected = field_path in parent_prefixes
 
             if not path_is_expected and not is_parent_of_expected:
                 unknown.append(field_path)

--- a/src/questfoundry/conversation/runner.py
+++ b/src/questfoundry/conversation/runner.py
@@ -44,16 +44,19 @@ class ValidationErrorDetail:
 
     Attributes:
         field: The field path that failed validation (e.g., "genre", "scope.target_word_count").
-        issue: Description of what went wrong.
+        issue: Description of what went wrong (used as "problem" in feedback).
         provided: The value that was provided (if any).
         error_type: Pydantic error type code (e.g., "missing", "string_too_short").
             Used for reliable categorization instead of string matching on issue text.
+        requirement: Human-readable description of what the field requires.
+            Derived from error type and schema constraints.
     """
 
     field: str
     issue: str
     provided: Any = None
     error_type: str | None = None
+    requirement: str | None = None
 
 
 @dataclass
@@ -65,14 +68,14 @@ class ValidationResult:
         error: Error message if validation failed (for display/logging).
         errors: Structured list of validation errors (preferred over error string).
         data: Validated/transformed data if validation passed.
-        expected_fields: List of valid field names (for LLM guidance on retry).
+        expected_fields: Set of valid field names (for detecting unknown fields).
     """
 
     valid: bool
     error: str | None = None
     errors: list[ValidationErrorDetail] | None = None
     data: dict[str, Any] | None = None
-    expected_fields: list[str] | None = None
+    expected_fields: set[str] | None = None
 
 
 class ConversationRunner:
@@ -259,70 +262,10 @@ class ConversationRunner:
             if validator is not None:
                 result = validator(data)
                 if not result.valid:
-                    # Validate-with-feedback pattern: structured error response
-                    # Lets LLM understand exactly what failed and how to fix it
-                    missing_fields: list[str] = []
-                    invalid_fields: list[dict[str, Any]] = []
-
-                    # Use structured errors if available (preferred)
-                    # Known Pydantic v2 error types for missing fields.
-                    # See: https://docs.pydantic.dev/latest/errors/validation_errors/
-                    missing_error_types = {"missing", "value_error.missing"}
-                    if result.errors:
-                        for err in result.errors:
-                            # Primary: use error_type for reliable categorization
-                            # Fallback: string match on issue for unknown/future error types
-                            if err.error_type in missing_error_types:
-                                is_missing = True
-                            else:
-                                # Defensive fallback for unknown error types
-                                issue_lower = err.issue.lower()
-                                is_missing = "required" in issue_lower or "missing" in issue_lower
-
-                            if is_missing:
-                                missing_fields.append(err.field)
-                            else:
-                                invalid_fields.append(
-                                    {
-                                        "field": err.field,
-                                        "provided": err.provided,
-                                        "issue": err.issue,
-                                    }
-                                )
-                    # Fallback: parse error string (legacy support)
-                    elif result.error:
-                        for err_str in result.error.replace("Validation errors: ", "").split("; "):
-                            if ": " in err_str:
-                                field, issue = err_str.split(": ", 1)
-                                if "required" in issue.lower() or "missing" in issue.lower():
-                                    missing_fields.append(field)
-                                else:
-                                    invalid_fields.append(
-                                        {
-                                            "field": field,
-                                            "provided": data.get(field.split(".")[0]),
-                                            "issue": issue,
-                                        }
-                                    )
-
-                    error_count = (
-                        len(result.errors)
-                        if result.errors
-                        else (len(result.error.split(";")) if result.error else 1)
+                    # Build structured feedback per ADR-007
+                    feedback = self._build_validation_feedback(
+                        data, result, self._finalization_tool
                     )
-                    feedback: dict[str, Any] = {
-                        "success": False,
-                        "error": "Validation failed for submitted artifact",
-                        "error_count": error_count,
-                        "invalid_fields": invalid_fields,
-                        "missing_fields": missing_fields,
-                        "submitted_data": data,
-                        "hint": f"Call {self._finalization_tool}() again with corrected data. Fix only the errors listed.",
-                    }
-
-                    # Include expected fields if provided by validator
-                    if result.expected_fields:
-                        feedback["expected_fields"] = result.expected_fields
 
                     # Check if we've exhausted retries BEFORE making another LLM call
                     retries += 1
@@ -400,3 +343,130 @@ class ConversationRunner:
             raise  # Don't catch system signals
         except Exception as e:
             return f"Error executing {tool_call.name}: {e}"
+
+    def _build_validation_feedback(
+        self,
+        data: dict[str, Any],
+        result: ValidationResult,
+        tool_name: str,
+    ) -> dict[str, Any]:
+        """Build structured validation feedback per ADR-007.
+
+        Creates feedback optimized for LLM comprehension with:
+        - Semantic result enum (not boolean)
+        - Categorized issues (invalid/missing/unknown)
+        - Field-specific requirements
+        - Action instruction last (recency effect)
+
+        Args:
+            data: The submitted data that failed validation.
+            result: ValidationResult with structured errors.
+            tool_name: Name of the finalization tool for action text.
+
+        Returns:
+            Structured feedback dict ready for JSON serialization.
+        """
+        # Categorize errors into invalid vs missing
+        invalid_fields: list[dict[str, Any]] = []
+        missing_fields: list[dict[str, Any]] = []
+
+        # Known Pydantic v2 error types for missing fields
+        missing_error_types = {"missing", "value_error.missing"}
+
+        if result.errors:
+            for err in result.errors:
+                # Determine if this is a "missing" or "invalid" error
+                if err.error_type in missing_error_types:
+                    is_missing = True
+                else:
+                    # Defensive fallback for unknown error types
+                    issue_lower = err.issue.lower()
+                    is_missing = "required" in issue_lower or "missing" in issue_lower
+
+                if is_missing:
+                    missing_fields.append(
+                        {
+                            "field": err.field,
+                            "requirement": err.requirement or "required field",
+                        }
+                    )
+                else:
+                    invalid_fields.append(
+                        {
+                            "field": err.field,
+                            "provided": err.provided,
+                            "problem": err.issue,
+                            "requirement": err.requirement or "see tool definition",
+                        }
+                    )
+
+        # Detect unknown fields (submitted but not in expected schema)
+        unknown_fields = self._detect_unknown_fields(data, result.expected_fields)
+
+        # Calculate total issue count
+        issue_count = len(invalid_fields) + len(missing_fields) + len(unknown_fields)
+
+        # Build action text
+        action_parts = [f"Call {tool_name}() with corrected data."]
+        if unknown_fields:
+            unknown_list = ", ".join(f"'{f}'" for f in unknown_fields[:3])
+            if len(unknown_fields) > 3:
+                unknown_list += f" and {len(unknown_fields) - 3} more"
+            action_parts.append(
+                f"Unknown fields {unknown_list} may be typos - check tool definition for correct names."
+            )
+
+        # Build feedback structure (ordered per ADR-007: result → issues → action)
+        feedback: dict[str, Any] = {
+            "result": "validation_failed",
+            "issues": {
+                "invalid": invalid_fields,
+                "missing": missing_fields,
+                "unknown": unknown_fields,
+            },
+            "issue_count": issue_count,
+            "action": " ".join(action_parts),
+        }
+
+        return feedback
+
+    def _detect_unknown_fields(
+        self,
+        data: dict[str, Any],
+        expected_fields: set[str] | None,
+        prefix: str = "",
+    ) -> list[str]:
+        """Detect fields in data that are not in the expected schema.
+
+        Recursively checks nested objects. Helps identify wrong field names
+        (e.g., 'passages' instead of 'estimated_passages').
+
+        Args:
+            data: Submitted data to check.
+            expected_fields: Set of valid field paths (e.g., {"genre", "scope.target_word_count"}).
+            prefix: Current field path prefix for recursion.
+
+        Returns:
+            List of unknown field paths.
+        """
+        if expected_fields is None:
+            return []
+
+        unknown: list[str] = []
+
+        for key, value in data.items():
+            field_path = f"{prefix}{key}" if not prefix else f"{prefix}.{key}"
+
+            # Check if this exact path or a parent path is expected
+            # e.g., "scope" is expected if "scope.target_word_count" is in expected_fields
+            path_is_expected = field_path in expected_fields
+            is_parent_of_expected = any(ef.startswith(f"{field_path}.") for ef in expected_fields)
+
+            if not path_is_expected and not is_parent_of_expected:
+                unknown.append(field_path)
+            elif isinstance(value, dict) and is_parent_of_expected:
+                # Recurse into nested objects
+                nested_unknown = self._detect_unknown_fields(value, expected_fields, field_path)
+                unknown.extend(nested_unknown)
+
+        return unknown

--- a/src/questfoundry/pipeline/stages/dream.py
+++ b/src/questfoundry/pipeline/stages/dream.py
@@ -274,10 +274,14 @@ Be creative but grounded. Make choices that serve the story."""
         """
         from pydantic import ValidationError
 
-        from questfoundry.artifacts import DreamArtifact, pydantic_errors_to_details
+        from questfoundry.artifacts import (
+            DreamArtifact,
+            get_all_field_paths,
+            pydantic_errors_to_details,
+        )
 
-        # Get expected field names from model for LLM guidance
-        expected_fields = list(DreamArtifact.model_fields.keys())
+        # Get all expected field paths (including nested) for unknown field detection
+        expected_fields = get_all_field_paths(DreamArtifact)
 
         try:
             # Validate using Pydantic model

--- a/tests/unit/test_dream_stage.py
+++ b/tests/unit/test_dream_stage.py
@@ -407,8 +407,8 @@ def test_validate_dream_returns_structured_errors() -> None:
 
 
 def test_validate_dream_returns_expected_fields() -> None:
-    """_validate_dream returns expected_fields matching DreamArtifact.model_fields."""
-    from questfoundry.artifacts import DreamArtifact
+    """_validate_dream returns expected_fields including nested paths."""
+    from questfoundry.artifacts import DreamArtifact, get_all_field_paths
 
     stage = DreamStage()
 
@@ -417,14 +417,18 @@ def test_validate_dream_returns_expected_fields() -> None:
     assert not result.valid
     assert result.expected_fields is not None
 
-    # expected_fields should match all DreamArtifact model fields exactly
-    model_fields = set(DreamArtifact.model_fields.keys())
+    # expected_fields should include all paths including nested (scope.target_word_count, etc.)
+    expected_paths = get_all_field_paths(DreamArtifact)
     returned_fields = set(result.expected_fields)
-    assert returned_fields == model_fields, (
+    assert returned_fields == expected_paths, (
         f"expected_fields mismatch: "
-        f"missing={model_fields - returned_fields}, "
-        f"extra={returned_fields - model_fields}"
+        f"missing={expected_paths - returned_fields}, "
+        f"extra={returned_fields - expected_paths}"
     )
+
+    # Verify nested paths are included (key feature for unknown field detection)
+    assert "scope.target_word_count" in returned_fields
+    assert "content_notes.includes" in returned_fields
 
 
 def test_validate_dream_includes_provided_values() -> None:


### PR DESCRIPTION
## Problem

Issue #47 identified that validation feedback from tool calls wasn't structured well for LLM comprehension. The existing feedback lacked:
- Clear categorization of error types (invalid vs missing vs unknown)
- Field-specific requirement descriptions
- Detection of unknown/typo field names
- Proper ordering based on primacy/recency effects

## Changes

Implements ADR-007 for structured validation feedback:

- **Semantic result enum**: Use `"result": "validation_failed"` instead of boolean
- **Categorized issues**: Separate `invalid`, `missing`, and `unknown` field arrays
- **Field-specific requirements**: Derive human-readable requirements from Pydantic error types
- **Recency effect**: Place action instruction last for better LLM recall
- **Unknown field detection**: Identify fields not in schema (helps catch typos)
- **PEP 604 union support**: Fix `get_all_field_paths` for `X | None` syntax

**New feedback structure:**
```json
{
  "result": "validation_failed",
  "issues": {
    "invalid": [{"field": "...", "provided": "...", "problem": "...", "requirement": "..."}],
    "missing": [{"field": "...", "requirement": "..."}],
    "unknown": ["field1", "field2"]
  },
  "issue_count": 3,
  "action": "Call submit_dream() with corrected data..."
}
```

**Files changed:**
- `src/questfoundry/conversation/runner.py` - Add `_build_validation_feedback()`, `_detect_unknown_fields()`
- `src/questfoundry/artifacts/validator.py` - Add `_generate_requirement_text()`, `get_all_field_paths()`
- `src/questfoundry/pipeline/stages/dream.py` - Use new field path extraction
- `docs/architecture/decisions.md` - Add ADR-007
- `docs/architecture/interactive-stages.md` - Add feedback format spec
- `.pre-commit-config.yaml` - Add pyyaml types for mypy

## Not Included / Future PRs

- Fuzzy matching for field name suggestions (#47 comment - may not be needed with unknown field detection)
- Multi-stage feedback patterns (future stages can reuse this infrastructure)

## Test Plan

```bash
# All tests pass with 82% coverage
uv run pytest --cov --cov-fail-under=70  # 332 passed

# Specific test files:
# - test_conversation_runner.py: 31 tests for feedback structure
# - test_validator_helpers.py: 40 tests for helpers
# - test_dream_stage.py: 76 tests including validation
```

Coverage for changed modules:
- `conversation/runner.py`: 90%
- `artifacts/validator.py`: 93%

## Risk / Rollback

- **Breaking change**: Feedback structure changed from flat to nested
  - Tests updated to use new structure
  - No external consumers of this internal API
- **Rollback**: Revert commit, no migration needed

Closes #47

🤖 Generated with [Claude Code](https://claude.com/claude-code)