### PR TITLE
feat(cli): add --projects-dir global option and interactive defaults

### DIFF
--- a/src/questfoundry/cli.py
+++ b/src/questfoundry/cli.py
@@ -38,6 +38,12 @@ console = Console()
 # Default directory for projects
 DEFAULT_PROJECTS_DIR = Path("projects")
 
+# Default prompt for interactive mode when no prompt is provided
+DEFAULT_INTERACTIVE_DREAM_PROMPT = (
+    "I'd like to create a new interactive fiction story. "
+    "Please help me develop the creative vision."
+)
+
 # Global state for logging flags (set by callback, used by commands)
 _verbose: int = 0
 _log_enabled: bool = False
@@ -115,7 +121,7 @@ def _resolve_project_path(project: Path | None) -> Path:
         return project
 
     # If it's a simple name (no path sep), try in projects dir
-    if "/" not in str(project) and "\\" not in str(project):
+    if len(project.parts) == 1:
         projects_path = _projects_dir / project
         if projects_path.exists():
             return projects_path
@@ -279,7 +285,7 @@ def dream(
     if prompt is None:
         if use_interactive:
             # In interactive mode, start with a guiding prompt that invites conversation
-            prompt = "I'd like to create a new interactive fiction story. Please help me develop the creative vision."
+            prompt = DEFAULT_INTERACTIVE_DREAM_PROMPT
         else:
             # Non-interactive requires explicit prompt
             prompt = typer.prompt("Enter your story idea")


### PR DESCRIPTION
## Problem

Several CLI usability issues:
1. `qf init` creates projects in current directory, cluttering the workspace
2. Users must specify `--project path/to/proj` for every command
3. Interactive mode requires a prompt argument even when conversational

## Changes

- Add `--projects-dir` (`-d`) global option with `QF_PROJECTS_DIR` envvar support
- Default projects directory is `./projects/` (already in .gitignore)
- `init` creates projects in the projects dir by default
- `dream`/`status`/`doctor` resolve project names from projects dir
- Add `_resolve_project_path()` helper for flexible project lookup
- Interactive mode uses a default guiding prompt when none provided

## Not Included / Future PRs

Created issues for more complex improvements:
- #51: Rich panels for agent/user messages
- #52: Guided conversation with tool-based options (wall-of-text fix)

## Test Plan

```bash
uv run pytest tests/unit/test_cli.py -v  # 22 passed
uv run pytest -x -q                      # 343 passed
```

## Risk / Rollback

Low risk - backwards compatible:
- Existing workflows with explicit `--project` paths unchanged
- Default behavior only changes for `init` (now uses projects/)
- Can override with `-d .` to use current directory

🤖 Generated with [Claude Code](https://claude.com/claude-code)