### PR TITLE
feat(tools): add research tools for informed stage decisions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,6 +55,16 @@ all-providers = [
 tracing = [
     "langsmith>=0.2",
 ]
+research = [
+    "ifcraftcorpus @ git+https://github.com/pvliesdonk/if-craft-corpus.git",
+    "pvl-webtools @ git+https://github.com/pvliesdonk/pvl-webtools.git",
+]
+research-corpus = [
+    "ifcraftcorpus @ git+https://github.com/pvliesdonk/if-craft-corpus.git",
+]
+research-web = [
+    "pvl-webtools @ git+https://github.com/pvliesdonk/pvl-webtools.git",
+]
 dev = [
     "pytest>=8.0",
     "pytest-asyncio>=0.24",
@@ -81,6 +91,9 @@ Issues = "https://github.com/pvliesdonk/questfoundry/issues"
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"
+
+[tool.hatch.metadata]
+allow-direct-references = true
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/questfoundry"]
@@ -134,6 +147,8 @@ module = [
     "langchain_ollama.*",
     "langchain_openai.*",
     "langchain_anthropic.*",
+    "ifcraftcorpus.*",
+    "pvlwebtools.*",
 ]
 ignore_missing_imports = true
 

--- a/src/questfoundry/observability/llm_logger.py
+++ b/src/questfoundry/observability/llm_logger.py
@@ -36,8 +36,9 @@ class LLMLogEntry:
     finish_reason: str
     duration_seconds: float
 
-    # Optional metadata
+    # Optional fields
     error: str | None = None
+    tool_calls: list[dict[str, Any]] | None = None
     metadata: dict[str, Any] = field(default_factory=dict)
 
 
@@ -88,6 +89,7 @@ class LLMLogger:
         temperature: float = 0.7,
         max_tokens: int = 4096,
         error: str | None = None,
+        tool_calls: list[dict[str, Any]] | None = None,
         **metadata: Any,
     ) -> LLMLogEntry:
         """Create a log entry with current timestamp.
@@ -103,6 +105,7 @@ class LLMLogger:
             temperature: Sampling temperature.
             max_tokens: Maximum tokens allowed.
             error: Error message if call failed.
+            tool_calls: List of tool calls from response (if any).
             **metadata: Additional metadata.
 
         Returns:
@@ -120,6 +123,7 @@ class LLMLogger:
             finish_reason=finish_reason,
             duration_seconds=duration_seconds,
             error=error,
+            tool_calls=tool_calls,
             metadata=dict(metadata),
         )
 

--- a/src/questfoundry/pipeline/config.py
+++ b/src/questfoundry/pipeline/config.py
@@ -31,6 +31,40 @@ class GateConfig:
 
 
 @dataclass
+class ResearchToolsConfig:
+    """Configuration for research tools.
+
+    Controls which research tools are available to pipeline stages.
+    Tools can be enabled/disabled independently.
+
+    Attributes:
+        corpus: Enable IF Craft Corpus tools (search, get_document, list_clusters).
+        web_search: Enable web search tool (requires SEARXNG_URL).
+        web_fetch: Enable web fetch tool.
+    """
+
+    corpus: bool = True
+    web_search: bool = True
+    web_fetch: bool = True
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> ResearchToolsConfig:
+        """Create config from dictionary.
+
+        Args:
+            data: Dictionary with corpus, web_search, web_fetch bool fields.
+
+        Returns:
+            ResearchToolsConfig instance.
+        """
+        return cls(
+            corpus=data.get("corpus", True),
+            web_search=data.get("web_search", True),
+            web_fetch=data.get("web_fetch", True),
+        )
+
+
+@dataclass
 class ProjectConfig:
     """Configuration for a QuestFoundry project."""
 
@@ -39,6 +73,7 @@ class ProjectConfig:
     provider: ProviderConfig = field(default_factory=ProviderConfig)
     stages: list[str] = field(default_factory=lambda: list(DEFAULT_STAGES))
     gates: list[GateConfig] = field(default_factory=list)
+    research_tools: ResearchToolsConfig = field(default_factory=ResearchToolsConfig)
 
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> ProjectConfig:
@@ -71,12 +106,17 @@ class ProjectConfig:
             for stage, value in gates_data.items()
         ]
 
+        # Parse research tools config
+        research_tools_data = data.get("research_tools", {})
+        research_tools = ResearchToolsConfig.from_dict(research_tools_data)
+
         return cls(
             name=data.get("name", "unnamed"),
             version=data.get("version", 1),
             provider=provider,
             stages=stages,
             gates=gates,
+            research_tools=research_tools,
         )
 
 

--- a/src/questfoundry/pipeline/config.py
+++ b/src/questfoundry/pipeline/config.py
@@ -37,10 +37,17 @@ class ResearchToolsConfig:
     Controls which research tools are available to pipeline stages.
     Tools can be enabled/disabled independently.
 
+    Note:
+        Setting a tool to True means "enabled if available". The tool will
+        only be loaded if its dependencies are installed. If the dependency
+        is missing, a warning is logged but execution continues without
+        the tool. This allows graceful degradation when optional packages
+        are not installed.
+
     Attributes:
-        corpus: Enable IF Craft Corpus tools (search, get_document, list_clusters).
-        web_search: Enable web search tool (requires SEARXNG_URL).
-        web_fetch: Enable web fetch tool.
+        corpus: Enable IF Craft Corpus tools if ifcraftcorpus is installed.
+        web_search: Enable web search tool if pvl-webtools is installed and SEARXNG_URL set.
+        web_fetch: Enable web fetch tool if pvl-webtools is installed.
     """
 
     corpus: bool = True

--- a/src/questfoundry/pipeline/orchestrator.py
+++ b/src/questfoundry/pipeline/orchestrator.py
@@ -184,39 +184,36 @@ class PipelineOrchestrator:
 
         # Get corpus tools if enabled
         if config.corpus:
-            try:
-                from questfoundry.tools.research import get_corpus_tools
+            from questfoundry.tools.research import get_corpus_tools
 
-                corpus_tools = get_corpus_tools()
-                if corpus_tools:
-                    logger.debug("Loaded %d corpus tools", len(corpus_tools))
-                    tools.extend(corpus_tools)
-                else:
-                    logger.info("IF Craft Corpus not installed, corpus tools disabled")
-            except ImportError:
-                logger.info("IF Craft Corpus not installed, corpus tools disabled")
+            corpus_tools = get_corpus_tools()
+            if corpus_tools:
+                logger.debug("Loaded %d corpus tools", len(corpus_tools))
+                tools.extend(corpus_tools)
+            else:
+                # Log at warning since user explicitly enabled but deps unavailable
+                logger.warning("IF Craft Corpus not installed, corpus tools disabled")
 
         # Get web tools if enabled
         if config.web_search or config.web_fetch:
-            try:
-                from questfoundry.tools.research import get_web_tools
+            from questfoundry.tools.research import get_web_tools
 
-                # Only require SEARXNG if web_search is enabled
-                web_tools = get_web_tools(require_searxng=config.web_search)
-                if web_tools:
-                    # Filter based on config
-                    filtered = []
-                    for tool in web_tools:
-                        tool_name = tool.definition.name
-                        if (tool_name == "web_search" and config.web_search) or (
-                            tool_name == "web_fetch" and config.web_fetch
-                        ):
-                            filtered.append(tool)
-                    if filtered:
-                        logger.debug("Loaded %d web tools", len(filtered))
-                        tools.extend(filtered)
-            except ImportError:
-                logger.info("pvl-webtools not installed, web tools disabled")
+            # Only require SEARXNG if web_search is enabled
+            web_tools = get_web_tools(require_searxng=config.web_search)
+            if web_tools:
+                # Filter based on config
+                filtered = [
+                    tool
+                    for tool in web_tools
+                    if (tool.definition.name == "web_search" and config.web_search)
+                    or (tool.definition.name == "web_fetch" and config.web_fetch)
+                ]
+                if filtered:
+                    logger.debug("Loaded %d web tools", len(filtered))
+                    tools.extend(filtered)
+            else:
+                # Log at warning since user explicitly enabled but deps unavailable
+                logger.warning("pvl-webtools not installed, web tools disabled")
 
         return tools
 

--- a/src/questfoundry/providers/logging_wrapper.py
+++ b/src/questfoundry/providers/logging_wrapper.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import time
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from questfoundry.observability import LLMLogger
@@ -99,6 +99,14 @@ class LoggingProvider:
 
         duration = time.perf_counter() - start_time
 
+        # Serialize tool calls for logging
+        tool_calls_data: list[dict[str, Any]] | None = None
+        if response.tool_calls:
+            tool_calls_data = [
+                {"id": tc.id, "name": tc.name, "arguments": tc.arguments}
+                for tc in response.tool_calls
+            ]
+
         # Log successful call (including tool calls if present)
         entry = self._logger.create_entry(
             stage=self._stage,
@@ -110,6 +118,7 @@ class LoggingProvider:
             duration_seconds=duration,
             temperature=temperature,
             max_tokens=max_tokens,
+            tool_calls=tool_calls_data,
         )
         self._logger.log(entry)
 

--- a/src/questfoundry/tools/research/__init__.py
+++ b/src/questfoundry/tools/research/__init__.py
@@ -1,0 +1,31 @@
+"""Research tools for informed stage decisions.
+
+This package provides tools for accessing external knowledge during
+stage execution, enabling LLMs to make informed decisions about:
+- Genre conventions and craft techniques (via IF Craft Corpus)
+- Current trends and references (via web search/fetch)
+
+Tools are stage-agnostic and injected at the orchestrator level.
+"""
+
+from questfoundry.tools.research.corpus_tools import (
+    GetDocumentTool,
+    ListClustersTool,
+    SearchCorpusTool,
+    get_corpus_tools,
+)
+from questfoundry.tools.research.web_tools import (
+    WebFetchTool,
+    WebSearchTool,
+    get_web_tools,
+)
+
+__all__ = [
+    "GetDocumentTool",
+    "ListClustersTool",
+    "SearchCorpusTool",
+    "WebFetchTool",
+    "WebSearchTool",
+    "get_corpus_tools",
+    "get_web_tools",
+]

--- a/src/questfoundry/tools/research/corpus_tools.py
+++ b/src/questfoundry/tools/research/corpus_tools.py
@@ -1,0 +1,305 @@
+"""IF Craft Corpus tools for writing guidance.
+
+This module provides LangChain-compatible tools for searching the
+IF Craft Corpus, a curated knowledge base for interactive fiction writing.
+
+Tools:
+    SearchCorpusTool: Search for craft guidance by topic/query
+    GetDocumentTool: Get full document by name
+    ListClustersTool: Discover available topic clusters
+
+The corpus is a singleton to avoid repeated index building.
+"""
+
+from __future__ import annotations
+
+import logging
+from functools import lru_cache
+from typing import TYPE_CHECKING, Any
+
+from questfoundry.tools.base import Tool, ToolDefinition
+
+if TYPE_CHECKING:
+    from ifcraftcorpus import Corpus
+
+logger = logging.getLogger(__name__)
+
+# Maximum tokens (approx chars / 4) for tool output
+MAX_OUTPUT_CHARS = 4000  # ~1000 tokens
+
+
+class CorpusNotAvailableError(Exception):
+    """Raised when IF Craft Corpus is not installed."""
+
+    def __init__(self) -> None:
+        super().__init__("IF Craft Corpus not available. Install with: uv add ifcraftcorpus")
+
+
+def _corpus_available() -> bool:
+    """Check if IF Craft Corpus is installed."""
+    try:
+        import ifcraftcorpus  # noqa: F401
+
+        return True
+    except ImportError:
+        return False
+
+
+@lru_cache(maxsize=1)
+def _get_corpus() -> Corpus:
+    """Get singleton corpus instance.
+
+    Returns:
+        Corpus instance (lazily initialized).
+
+    Raises:
+        CorpusNotAvailableError: If ifcraftcorpus not installed.
+    """
+    if not _corpus_available():
+        raise CorpusNotAvailableError()
+
+    from ifcraftcorpus import Corpus
+
+    return Corpus()
+
+
+class SearchCorpusTool:
+    """Search IF craft knowledge base for guidance.
+
+    Returns formatted markdown results with source, score,
+    and content excerpts. Results are truncated to avoid
+    context overflow.
+    """
+
+    @property
+    def definition(self) -> ToolDefinition:
+        """Return the tool definition for LLM binding."""
+        return ToolDefinition(
+            name="search_corpus",
+            description="Search IF craft knowledge base. Returns curated writing guidance.",
+            parameters={
+                "type": "object",
+                "properties": {
+                    "query": {
+                        "type": "string",
+                        "description": "Topic to search (e.g., 'cozy mystery', 'dialogue')",
+                    },
+                    "cluster": {
+                        "type": "string",
+                        "description": "Filter by cluster: genre-conventions, narrative-structure, "
+                        "prose-and-language, emotional-design, scope-and-planning, craft-foundations",
+                    },
+                    "limit": {
+                        "type": "integer",
+                        "description": "Max results (default 5)",
+                    },
+                },
+                "required": ["query"],
+            },
+        )
+
+    def execute(self, arguments: dict[str, Any]) -> str:
+        """Execute corpus search.
+
+        Args:
+            arguments: query (required), cluster (optional), limit (optional)
+
+        Returns:
+            Formatted markdown results or error message.
+        """
+        query = arguments["query"]
+        cluster = arguments.get("cluster")
+        limit = arguments.get("limit", 5)
+
+        try:
+            corpus = _get_corpus()
+        except CorpusNotAvailableError as e:
+            return f"Error: {e}"
+
+        try:
+            results = corpus.search(query, cluster=cluster, limit=limit)
+        except Exception as e:
+            logger.warning("Corpus search failed: %s", e)
+            return f"Search failed: {e}"
+
+        if not results:
+            return f"No craft guidance found for '{query}'. Try broader terms."
+
+        # Format results as markdown
+        formatted = []
+        total_chars = 0
+
+        for r in results:
+            # Build result entry
+            source = r.source if hasattr(r, "source") else r.document_name
+            topics = ", ".join(r.topics) if hasattr(r, "topics") and r.topics else ""
+            score = f"{r.score:.2f}" if hasattr(r, "score") else ""
+
+            # Truncate content to fit within budget
+            content = r.content[:1500] if len(r.content) > 1500 else r.content
+
+            entry = f"### {source}"
+            if score:
+                entry += f" (score: {score})"
+            entry += "\n"
+            if topics:
+                entry += f"*Topics: {topics}*\n\n"
+            else:
+                entry += "\n"
+            entry += f"{content}\n"
+
+            # Check total output size
+            if total_chars + len(entry) > MAX_OUTPUT_CHARS:
+                formatted.append("\n*...additional results truncated*")
+                break
+
+            formatted.append(entry)
+            total_chars += len(entry)
+
+        return "\n---\n".join(formatted)
+
+
+class GetDocumentTool:
+    """Get full document from IF Craft Corpus.
+
+    Retrieves complete document content by name, useful when
+    search results indicate a document needs deeper reading.
+    """
+
+    @property
+    def definition(self) -> ToolDefinition:
+        """Return the tool definition for LLM binding."""
+        return ToolDefinition(
+            name="get_document",
+            description="Get full craft document by name. Use after search identifies relevant doc.",
+            parameters={
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "type": "string",
+                        "description": "Document name (e.g., 'dialogue_craft', 'cozy_mystery')",
+                    },
+                },
+                "required": ["name"],
+            },
+        )
+
+    def execute(self, arguments: dict[str, Any]) -> str:
+        """Execute document retrieval.
+
+        Args:
+            arguments: name (required)
+
+        Returns:
+            Formatted document or error message.
+        """
+        name = arguments["name"]
+
+        try:
+            corpus = _get_corpus()
+        except CorpusNotAvailableError as e:
+            return f"Error: {e}"
+
+        try:
+            doc = corpus.get_document(name)
+        except Exception as e:
+            logger.warning("Document retrieval failed: %s", e)
+            return f"Failed to get document: {e}"
+
+        if not doc:
+            return f"Document '{name}' not found. Use list_clusters to see available topics."
+
+        # Format document
+        title = doc.get("title", name)
+        cluster = doc.get("cluster", "unknown")
+        content = doc.get("content", "")
+
+        # Truncate if too long
+        if len(content) > MAX_OUTPUT_CHARS:
+            content = content[:MAX_OUTPUT_CHARS] + "\n\n*...content truncated*"
+
+        return f"# {title}\n*Cluster: {cluster}*\n\n{content}"
+
+
+class ListClustersTool:
+    """List available topic clusters in IF Craft Corpus.
+
+    Helps discover what craft knowledge is available for
+    targeted searches.
+    """
+
+    @property
+    def definition(self) -> ToolDefinition:
+        """Return the tool definition for LLM binding."""
+        return ToolDefinition(
+            name="list_clusters",
+            description="List available craft topic clusters for targeted searches.",
+            parameters={
+                "type": "object",
+                "properties": {},
+            },
+        )
+
+    def execute(self, arguments: dict[str, Any]) -> str:  # noqa: ARG002
+        """Execute cluster listing.
+
+        Args:
+            arguments: Not used.
+
+        Returns:
+            Formatted list of clusters.
+        """
+        try:
+            corpus = _get_corpus()
+        except CorpusNotAvailableError as e:
+            return f"Error: {e}"
+
+        try:
+            clusters = corpus.list_clusters()
+        except Exception as e:
+            logger.warning("Cluster listing failed: %s", e)
+            return f"Failed to list clusters: {e}"
+
+        if not clusters:
+            return "No clusters available."
+
+        # Format as bullet list with descriptions
+        cluster_descriptions = {
+            "craft-foundations": "Core craft concepts, workflow, tools",
+            "narrative-structure": "Story arcs, pacing, branching, endings",
+            "prose-and-language": "Dialogue, voice, POV, exposition",
+            "genre-conventions": "Genre-specific patterns and expectations",
+            "world-and-setting": "Worldbuilding, immersion, locations",
+            "emotional-design": "Tone, atmosphere, emotional resonance",
+            "game-design": "Mechanics, interaction patterns, player agency",
+            "agent-design": "NPC behavior, dialogue systems",
+            "scope-and-planning": "Project scope, planning, estimation",
+            "audience-and-access": "Target audience, accessibility",
+        }
+
+        formatted = ["**Available Clusters:**\n"]
+        for cluster in clusters:
+            desc = cluster_descriptions.get(cluster, "")
+            if desc:
+                formatted.append(f"- **{cluster}**: {desc}")
+            else:
+                formatted.append(f"- **{cluster}**")
+
+        return "\n".join(formatted)
+
+
+def get_corpus_tools() -> list[Tool]:
+    """Get all corpus tools if library is available.
+
+    Returns:
+        List of corpus tools, or empty list if not available.
+    """
+    if not _corpus_available():
+        logger.info("IF Craft Corpus not installed, corpus tools disabled")
+        return []
+
+    return [
+        SearchCorpusTool(),
+        GetDocumentTool(),
+        ListClustersTool(),
+    ]

--- a/src/questfoundry/tools/research/web_tools.py
+++ b/src/questfoundry/tools/research/web_tools.py
@@ -111,13 +111,22 @@ class WebSearchTool:
             from pvlwebtools import web_search
 
             # Run async function in sync context
-            results = asyncio.run(
-                web_search(
-                    query,
-                    max_results=max_results,
-                    recency=recency,
-                )
-            )
+            # Try to get running loop first (if called from async context),
+            # otherwise create a new one
+            try:
+                asyncio.get_running_loop()
+                # We're in an async context - run in thread to avoid blocking
+                import concurrent.futures
+
+                with concurrent.futures.ThreadPoolExecutor() as executor:
+                    future = executor.submit(
+                        asyncio.run,
+                        web_search(query, max_results=max_results, recency=recency),
+                    )
+                    results = future.result()
+            except RuntimeError:
+                # No running loop - safe to use asyncio.run()
+                results = asyncio.run(web_search(query, max_results=max_results, recency=recency))
         except Exception as e:
             logger.warning("Web search failed: %s", e)
             return f"Search failed: {e}"
@@ -125,13 +134,22 @@ class WebSearchTool:
         if not results:
             return f"No results found for '{query}'."
 
-        # Format results
+        # Format results with output size tracking
         formatted = []
+        total_chars = 0
+
         for r in results:
             entry = f"**{r.title}**\n{r.url}\n{r.snippet}"
             if hasattr(r, "published_date") and r.published_date:
                 entry += f"\n*Published: {r.published_date}*"
+
+            # Check total output size
+            if total_chars + len(entry) > MAX_OUTPUT_CHARS:
+                formatted.append("\n*...additional results truncated*")
+                break
+
             formatted.append(entry)
+            total_chars += len(entry)
 
         return "\n\n---\n\n".join(formatted)
 
@@ -188,12 +206,22 @@ class WebFetchTool:
             from pvlwebtools import web_fetch
 
             # Run async function in sync context
-            result = asyncio.run(
-                web_fetch(
-                    url,
-                    extract_mode=extract_mode,
-                )
-            )
+            # Try to get running loop first (if called from async context),
+            # otherwise create a new one
+            try:
+                asyncio.get_running_loop()
+                # We're in an async context - run in thread to avoid blocking
+                import concurrent.futures
+
+                with concurrent.futures.ThreadPoolExecutor() as executor:
+                    future = executor.submit(
+                        asyncio.run,
+                        web_fetch(url, extract_mode=extract_mode),
+                    )
+                    result = future.result()
+            except RuntimeError:
+                # No running loop - safe to use asyncio.run()
+                result = asyncio.run(web_fetch(url, extract_mode=extract_mode))
         except Exception as e:
             logger.warning("Web fetch failed for %s: %s", url, e)
             return f"Fetch failed: {e}"

--- a/src/questfoundry/tools/research/web_tools.py
+++ b/src/questfoundry/tools/research/web_tools.py
@@ -1,0 +1,237 @@
+"""Web research tools for current information.
+
+This module provides LangChain-compatible tools for web research:
+- WebSearchTool: Search the web via SearXNG
+- WebFetchTool: Fetch and extract content from URLs
+
+Requires:
+    - SEARXNG_URL environment variable for web search
+    - pvl-webtools package: uv add pvl-webtools
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+from typing import Any
+
+from questfoundry.tools.base import Tool, ToolDefinition
+
+logger = logging.getLogger(__name__)
+
+# Maximum characters for tool output
+MAX_OUTPUT_CHARS = 4000  # ~1000 tokens
+
+
+class WebToolsNotAvailableError(Exception):
+    """Raised when pvl-webtools is not installed."""
+
+    def __init__(self) -> None:
+        super().__init__("pvl-webtools not available. Install with: uv add pvl-webtools")
+
+
+class SearXNGNotConfiguredError(Exception):
+    """Raised when SEARXNG_URL is not configured."""
+
+    def __init__(self) -> None:
+        super().__init__("SEARXNG_URL not configured. Set environment variable for web search.")
+
+
+def _web_tools_available() -> bool:
+    """Check if pvl-webtools is installed."""
+    try:
+        import pvlwebtools  # noqa: F401
+
+        return True
+    except ImportError:
+        return False
+
+
+def _searxng_configured() -> bool:
+    """Check if SEARXNG_URL is configured."""
+    return bool(os.environ.get("SEARXNG_URL"))
+
+
+class WebSearchTool:
+    """Search the web for current information.
+
+    Uses SearXNG metasearch engine. Requires SEARXNG_URL
+    environment variable to be configured.
+
+    Returns title, URL, and snippet for each result.
+    """
+
+    @property
+    def definition(self) -> ToolDefinition:
+        """Return the tool definition for LLM binding."""
+        return ToolDefinition(
+            name="web_search",
+            description="Search the web for current information and trends.",
+            parameters={
+                "type": "object",
+                "properties": {
+                    "query": {
+                        "type": "string",
+                        "description": "Search query",
+                    },
+                    "max_results": {
+                        "type": "integer",
+                        "description": "Max results (default 5)",
+                    },
+                    "recency": {
+                        "type": "string",
+                        "description": "Filter by time: all_time, day, week, month, year",
+                    },
+                },
+                "required": ["query"],
+            },
+        )
+
+    def execute(self, arguments: dict[str, Any]) -> str:
+        """Execute web search.
+
+        Args:
+            arguments: query (required), max_results (optional), recency (optional)
+
+        Returns:
+            Formatted search results or error message.
+        """
+        if not _web_tools_available():
+            return "Error: pvl-webtools not installed. Install with: uv add pvl-webtools"
+
+        if not _searxng_configured():
+            return "Error: SEARXNG_URL not configured. Set environment variable for web search."
+
+        query = arguments["query"]
+        max_results = arguments.get("max_results", 5)
+        recency = arguments.get("recency", "all_time")
+
+        try:
+            from pvlwebtools import web_search
+
+            # Run async function in sync context
+            results = asyncio.run(
+                web_search(
+                    query,
+                    max_results=max_results,
+                    recency=recency,
+                )
+            )
+        except Exception as e:
+            logger.warning("Web search failed: %s", e)
+            return f"Search failed: {e}"
+
+        if not results:
+            return f"No results found for '{query}'."
+
+        # Format results
+        formatted = []
+        for r in results:
+            entry = f"**{r.title}**\n{r.url}\n{r.snippet}"
+            if hasattr(r, "published_date") and r.published_date:
+                entry += f"\n*Published: {r.published_date}*"
+            formatted.append(entry)
+
+        return "\n\n---\n\n".join(formatted)
+
+
+class WebFetchTool:
+    """Fetch and extract content from a URL.
+
+    Retrieves web page content with intelligent extraction:
+    - Strips navigation, ads, and boilerplate
+    - Extracts main content as markdown
+    - Truncates to fit context window
+
+    Rate-limited to avoid overloading servers.
+    """
+
+    @property
+    def definition(self) -> ToolDefinition:
+        """Return the tool definition for LLM binding."""
+        return ToolDefinition(
+            name="web_fetch",
+            description="Fetch page content from URL. Extracts main text as markdown.",
+            parameters={
+                "type": "object",
+                "properties": {
+                    "url": {
+                        "type": "string",
+                        "description": "URL to fetch",
+                    },
+                    "extract_mode": {
+                        "type": "string",
+                        "description": "Extraction: markdown (default), article, metadata",
+                    },
+                },
+                "required": ["url"],
+            },
+        )
+
+    def execute(self, arguments: dict[str, Any]) -> str:
+        """Execute web fetch.
+
+        Args:
+            arguments: url (required), extract_mode (optional)
+
+        Returns:
+            Extracted content or error message.
+        """
+        if not _web_tools_available():
+            return "Error: pvl-webtools not installed. Install with: uv add pvl-webtools"
+
+        url = arguments["url"]
+        extract_mode = arguments.get("extract_mode", "markdown")
+
+        try:
+            from pvlwebtools import web_fetch
+
+            # Run async function in sync context
+            result = asyncio.run(
+                web_fetch(
+                    url,
+                    extract_mode=extract_mode,
+                )
+            )
+        except Exception as e:
+            logger.warning("Web fetch failed for %s: %s", url, e)
+            return f"Fetch failed: {e}"
+
+        content = result.content
+
+        # Truncate if too long
+        if len(content) > MAX_OUTPUT_CHARS:
+            content = content[:MAX_OUTPUT_CHARS] + "\n\n*...content truncated*"
+
+        return f"**Source:** {result.url}\n**Mode:** {result.extract_mode}\n\n{content}"
+
+
+def get_web_tools(require_searxng: bool = True) -> list[Tool]:
+    """Get all web tools if library is available.
+
+    Args:
+        require_searxng: If True, only return tools if SEARXNG_URL is configured.
+
+    Returns:
+        List of web tools, or empty list if not available.
+    """
+    if not _web_tools_available():
+        logger.info("pvl-webtools not installed, web tools disabled")
+        return []
+
+    tools: list[Tool] = []
+
+    # WebSearch requires SEARXNG_URL
+    if _searxng_configured():
+        tools.append(WebSearchTool())
+    elif require_searxng:
+        logger.info("SEARXNG_URL not configured, web search disabled")
+    else:
+        # Still add it - will return helpful error message if called
+        tools.append(WebSearchTool())
+
+    # WebFetch doesn't require SEARXNG
+    tools.append(WebFetchTool())
+
+    return tools

--- a/tests/unit/test_corpus_tools.py
+++ b/tests/unit/test_corpus_tools.py
@@ -1,0 +1,323 @@
+"""Tests for IF Craft Corpus research tools."""
+
+from __future__ import annotations
+
+import sys
+from dataclasses import dataclass
+from unittest.mock import MagicMock, patch
+
+from questfoundry.tools.research.corpus_tools import (
+    CorpusNotAvailableError,
+    GetDocumentTool,
+    ListClustersTool,
+    SearchCorpusTool,
+    get_corpus_tools,
+)
+
+
+@dataclass
+class MockCorpusResult:
+    """Mock corpus search result."""
+
+    document_name: str
+    title: str
+    cluster: str
+    section_heading: str | None
+    content: str
+    score: float
+    topics: list[str]
+    search_type: str = "keyword"
+
+    @property
+    def source(self) -> str:
+        if self.section_heading:
+            return f"{self.document_name} > {self.section_heading}"
+        return self.document_name
+
+
+class TestSearchCorpusTool:
+    """Tests for SearchCorpusTool."""
+
+    def test_definition_has_required_fields(self) -> None:
+        """Tool definition should have name, description, and parameters."""
+        tool = SearchCorpusTool()
+        defn = tool.definition
+
+        assert defn.name == "search_corpus"
+        assert "craft" in defn.description.lower()
+        assert defn.parameters["type"] == "object"
+        assert "query" in defn.parameters["properties"]
+        assert "query" in defn.parameters["required"]
+
+    def test_execute_without_corpus_installed(self) -> None:
+        """Should return error when corpus not installed."""
+        tool = SearchCorpusTool()
+
+        with patch(
+            "questfoundry.tools.research.corpus_tools._corpus_available",
+            return_value=False,
+        ):
+            # Clear the lru_cache
+            from questfoundry.tools.research.corpus_tools import _get_corpus
+
+            _get_corpus.cache_clear()
+
+            result = tool.execute({"query": "test"})
+
+        assert "not available" in result.lower() or "not installed" in result.lower()
+
+    def test_execute_with_results(self) -> None:
+        """Should return formatted results when search succeeds."""
+        from questfoundry.tools.research.corpus_tools import _get_corpus
+
+        _get_corpus.cache_clear()
+
+        tool = SearchCorpusTool()
+
+        mock_results = [
+            MockCorpusResult(
+                document_name="dialogue_craft",
+                title="Dialogue Craft",
+                cluster="prose-and-language",
+                section_heading="Subtext",
+                content="Subtext is what characters don't say directly.",
+                score=0.85,
+                topics=["dialogue", "subtext", "craft"],
+            ),
+        ]
+
+        mock_corpus = MagicMock()
+        mock_corpus.search.return_value = mock_results
+
+        # Create mock ifcraftcorpus module
+        mock_module = MagicMock()
+        mock_module.Corpus.return_value = mock_corpus
+
+        with (
+            patch.dict(sys.modules, {"ifcraftcorpus": mock_module}),
+            patch(
+                "questfoundry.tools.research.corpus_tools._corpus_available",
+                return_value=True,
+            ),
+        ):
+            _get_corpus.cache_clear()
+            result = tool.execute({"query": "dialogue"})
+
+        assert "dialogue_craft" in result
+        assert "0.85" in result
+        assert "subtext" in result.lower()
+        mock_corpus.search.assert_called_once_with("dialogue", cluster=None, limit=5)
+
+    def test_execute_with_cluster_filter(self) -> None:
+        """Should pass cluster filter to search."""
+        from questfoundry.tools.research.corpus_tools import _get_corpus
+
+        _get_corpus.cache_clear()
+
+        tool = SearchCorpusTool()
+
+        mock_corpus = MagicMock()
+        mock_corpus.search.return_value = []
+
+        # Create mock ifcraftcorpus module
+        mock_module = MagicMock()
+        mock_module.Corpus.return_value = mock_corpus
+
+        with (
+            patch.dict(sys.modules, {"ifcraftcorpus": mock_module}),
+            patch(
+                "questfoundry.tools.research.corpus_tools._corpus_available",
+                return_value=True,
+            ),
+        ):
+            _get_corpus.cache_clear()
+            tool.execute({"query": "mystery", "cluster": "genre-conventions", "limit": 3})
+
+        mock_corpus.search.assert_called_once_with("mystery", cluster="genre-conventions", limit=3)
+
+    def test_execute_no_results(self) -> None:
+        """Should return helpful message when no results found."""
+        from questfoundry.tools.research.corpus_tools import _get_corpus
+
+        _get_corpus.cache_clear()
+
+        tool = SearchCorpusTool()
+
+        mock_corpus = MagicMock()
+        mock_corpus.search.return_value = []
+
+        # Create mock ifcraftcorpus module
+        mock_module = MagicMock()
+        mock_module.Corpus.return_value = mock_corpus
+
+        with (
+            patch.dict(sys.modules, {"ifcraftcorpus": mock_module}),
+            patch(
+                "questfoundry.tools.research.corpus_tools._corpus_available",
+                return_value=True,
+            ),
+        ):
+            _get_corpus.cache_clear()
+            result = tool.execute({"query": "xyz123"})
+
+        assert "no craft guidance found" in result.lower()
+        assert "xyz123" in result
+
+
+class TestGetDocumentTool:
+    """Tests for GetDocumentTool."""
+
+    def test_definition_has_required_fields(self) -> None:
+        """Tool definition should have name, description, and parameters."""
+        tool = GetDocumentTool()
+        defn = tool.definition
+
+        assert defn.name == "get_document"
+        assert "document" in defn.description.lower()
+        assert "name" in defn.parameters["properties"]
+        assert "name" in defn.parameters["required"]
+
+    def test_execute_document_found(self) -> None:
+        """Should return formatted document when found."""
+        tool = GetDocumentTool()
+
+        mock_doc = {
+            "title": "Horror Atmosphere",
+            "cluster": "emotional-design",
+            "content": "Building dread through pacing...",
+        }
+
+        mock_corpus = MagicMock()
+        mock_corpus.get_document.return_value = mock_doc
+
+        with (
+            patch(
+                "questfoundry.tools.research.corpus_tools._corpus_available",
+                return_value=True,
+            ),
+            patch(
+                "questfoundry.tools.research.corpus_tools._get_corpus",
+                return_value=mock_corpus,
+            ),
+        ):
+            result = tool.execute({"name": "horror_atmosphere"})
+
+        assert "Horror Atmosphere" in result
+        assert "emotional-design" in result
+        assert "dread" in result
+        mock_corpus.get_document.assert_called_once_with("horror_atmosphere")
+
+    def test_execute_document_not_found(self) -> None:
+        """Should return helpful message when document not found."""
+        tool = GetDocumentTool()
+
+        mock_corpus = MagicMock()
+        mock_corpus.get_document.return_value = None
+
+        with (
+            patch(
+                "questfoundry.tools.research.corpus_tools._corpus_available",
+                return_value=True,
+            ),
+            patch(
+                "questfoundry.tools.research.corpus_tools._get_corpus",
+                return_value=mock_corpus,
+            ),
+        ):
+            result = tool.execute({"name": "nonexistent"})
+
+        assert "not found" in result.lower()
+
+
+class TestListClustersTool:
+    """Tests for ListClustersTool."""
+
+    def test_definition_has_required_fields(self) -> None:
+        """Tool definition should have name and description."""
+        tool = ListClustersTool()
+        defn = tool.definition
+
+        assert defn.name == "list_clusters"
+        assert "cluster" in defn.description.lower()
+        assert defn.parameters["type"] == "object"
+
+    def test_execute_returns_formatted_clusters(self) -> None:
+        """Should return formatted cluster list with descriptions."""
+        tool = ListClustersTool()
+
+        mock_clusters = ["genre-conventions", "narrative-structure", "prose-and-language"]
+
+        mock_corpus = MagicMock()
+        mock_corpus.list_clusters.return_value = mock_clusters
+
+        with (
+            patch(
+                "questfoundry.tools.research.corpus_tools._corpus_available",
+                return_value=True,
+            ),
+            patch(
+                "questfoundry.tools.research.corpus_tools._get_corpus",
+                return_value=mock_corpus,
+            ),
+        ):
+            result = tool.execute({})
+
+        assert "genre-conventions" in result
+        assert "narrative-structure" in result
+        # Should include descriptions
+        assert "Genre-specific patterns" in result or "patterns" in result.lower()
+
+
+class TestGetCorpusTools:
+    """Tests for get_corpus_tools factory."""
+
+    def test_returns_empty_when_not_available(self) -> None:
+        """Should return empty list when corpus not installed."""
+        with patch(
+            "questfoundry.tools.research.corpus_tools._corpus_available",
+            return_value=False,
+        ):
+            tools = get_corpus_tools()
+
+        assert tools == []
+
+    def test_returns_all_tools_when_available(self) -> None:
+        """Should return all tools when corpus is installed."""
+        mock_corpus = MagicMock()
+
+        with (
+            patch(
+                "questfoundry.tools.research.corpus_tools._corpus_available",
+                return_value=True,
+            ),
+            patch(
+                "questfoundry.tools.research.corpus_tools._get_corpus",
+                return_value=mock_corpus,
+            ),
+        ):
+            tools = get_corpus_tools()
+
+        assert len(tools) == 3
+        tool_names = {t.definition.name for t in tools}
+        assert tool_names == {"search_corpus", "get_document", "list_clusters"}
+
+
+class TestCorpusAvailable:
+    """Tests for _corpus_available helper."""
+
+    def test_returns_false_when_import_fails(self) -> None:
+        """Should return False when ifcraftcorpus not installed."""
+        # This test relies on the actual import behavior
+        # When ifcraftcorpus is not installed, it should return False
+        # We can't easily test this without uninstalling the package
+        pass  # Covered by integration tests
+
+
+class TestCorpusNotAvailableError:
+    """Tests for CorpusNotAvailableError exception."""
+
+    def test_message_includes_install_instructions(self) -> None:
+        """Should include installation instructions in message."""
+        error = CorpusNotAvailableError()
+        assert "ifcraftcorpus" in str(error)
+        assert "uv add" in str(error) or "install" in str(error).lower()

--- a/tests/unit/test_web_tools.py
+++ b/tests/unit/test_web_tools.py
@@ -1,0 +1,379 @@
+"""Tests for web research tools."""
+
+from __future__ import annotations
+
+import sys
+from dataclasses import dataclass
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from questfoundry.tools.research.web_tools import (
+    WebFetchTool,
+    WebSearchTool,
+    _searxng_configured,
+    get_web_tools,
+)
+
+
+@dataclass
+class MockSearchResult:
+    """Mock web search result."""
+
+    title: str
+    url: str
+    snippet: str
+    published_date: str | None = None
+
+
+@dataclass
+class MockFetchResult:
+    """Mock web fetch result."""
+
+    url: str
+    content: str
+    content_length: int
+    extract_mode: str
+
+
+class TestWebSearchTool:
+    """Tests for WebSearchTool."""
+
+    def test_definition_has_required_fields(self) -> None:
+        """Tool definition should have name, description, and parameters."""
+        tool = WebSearchTool()
+        defn = tool.definition
+
+        assert defn.name == "web_search"
+        assert "search" in defn.description.lower()
+        assert defn.parameters["type"] == "object"
+        assert "query" in defn.parameters["properties"]
+        assert "query" in defn.parameters["required"]
+
+    def test_execute_without_webtools_installed(self) -> None:
+        """Should return error when pvl-webtools not installed."""
+        tool = WebSearchTool()
+
+        with patch(
+            "questfoundry.tools.research.web_tools._web_tools_available",
+            return_value=False,
+        ):
+            result = tool.execute({"query": "test"})
+
+        assert "not installed" in result.lower() or "not available" in result.lower()
+
+    def test_execute_without_searxng_configured(self) -> None:
+        """Should return error when SEARXNG_URL not set."""
+        tool = WebSearchTool()
+
+        with (
+            patch(
+                "questfoundry.tools.research.web_tools._web_tools_available",
+                return_value=True,
+            ),
+            patch(
+                "questfoundry.tools.research.web_tools._searxng_configured",
+                return_value=False,
+            ),
+        ):
+            result = tool.execute({"query": "test"})
+
+        assert "searxng" in result.lower() or "not configured" in result.lower()
+
+    def test_execute_with_results(self) -> None:
+        """Should return formatted results when search succeeds."""
+        tool = WebSearchTool()
+
+        mock_results = [
+            MockSearchResult(
+                title="Interactive Fiction Guide",
+                url="https://example.com/if-guide",
+                snippet="A comprehensive guide to writing IF...",
+                published_date="2025-01-01",
+            ),
+        ]
+
+        # Create mock pvlwebtools module
+        mock_module = MagicMock()
+        mock_web_search = AsyncMock(return_value=mock_results)
+        mock_module.web_search = mock_web_search
+
+        with (
+            patch.dict(sys.modules, {"pvlwebtools": mock_module}),
+            patch(
+                "questfoundry.tools.research.web_tools._web_tools_available",
+                return_value=True,
+            ),
+            patch(
+                "questfoundry.tools.research.web_tools._searxng_configured",
+                return_value=True,
+            ),
+        ):
+            result = tool.execute({"query": "interactive fiction guide"})
+
+        assert "Interactive Fiction Guide" in result
+        assert "example.com" in result
+        assert "comprehensive guide" in result
+
+    def test_execute_no_results(self) -> None:
+        """Should return helpful message when no results found."""
+        tool = WebSearchTool()
+
+        # Create mock pvlwebtools module
+        mock_module = MagicMock()
+        mock_web_search = AsyncMock(return_value=[])
+        mock_module.web_search = mock_web_search
+
+        with (
+            patch.dict(sys.modules, {"pvlwebtools": mock_module}),
+            patch(
+                "questfoundry.tools.research.web_tools._web_tools_available",
+                return_value=True,
+            ),
+            patch(
+                "questfoundry.tools.research.web_tools._searxng_configured",
+                return_value=True,
+            ),
+        ):
+            result = tool.execute({"query": "xyz123unique"})
+
+        assert "no results" in result.lower()
+
+    def test_execute_handles_exception(self) -> None:
+        """Should return error message when search fails."""
+        tool = WebSearchTool()
+
+        # Create mock pvlwebtools module that raises exception
+        mock_module = MagicMock()
+        mock_web_search = AsyncMock(side_effect=Exception("Connection timeout"))
+        mock_module.web_search = mock_web_search
+
+        with (
+            patch.dict(sys.modules, {"pvlwebtools": mock_module}),
+            patch(
+                "questfoundry.tools.research.web_tools._web_tools_available",
+                return_value=True,
+            ),
+            patch(
+                "questfoundry.tools.research.web_tools._searxng_configured",
+                return_value=True,
+            ),
+        ):
+            result = tool.execute({"query": "test"})
+
+        assert "failed" in result.lower()
+        assert "timeout" in result.lower()
+
+
+class TestWebFetchTool:
+    """Tests for WebFetchTool."""
+
+    def test_definition_has_required_fields(self) -> None:
+        """Tool definition should have name, description, and parameters."""
+        tool = WebFetchTool()
+        defn = tool.definition
+
+        assert defn.name == "web_fetch"
+        assert "fetch" in defn.description.lower()
+        assert "url" in defn.parameters["properties"]
+        assert "url" in defn.parameters["required"]
+
+    def test_execute_without_webtools_installed(self) -> None:
+        """Should return error when pvl-webtools not installed."""
+        tool = WebFetchTool()
+
+        with patch(
+            "questfoundry.tools.research.web_tools._web_tools_available",
+            return_value=False,
+        ):
+            result = tool.execute({"url": "https://example.com"})
+
+        assert "not installed" in result.lower()
+
+    def test_execute_success(self) -> None:
+        """Should return formatted content when fetch succeeds."""
+        tool = WebFetchTool()
+
+        mock_result = MockFetchResult(
+            url="https://example.com/article",
+            content="# Article Title\n\nThis is the article content...",
+            content_length=500,
+            extract_mode="markdown",
+        )
+
+        # Create mock pvlwebtools module
+        mock_module = MagicMock()
+        mock_web_fetch = AsyncMock(return_value=mock_result)
+        mock_module.web_fetch = mock_web_fetch
+
+        with (
+            patch.dict(sys.modules, {"pvlwebtools": mock_module}),
+            patch(
+                "questfoundry.tools.research.web_tools._web_tools_available",
+                return_value=True,
+            ),
+        ):
+            result = tool.execute({"url": "https://example.com/article"})
+
+        assert "example.com/article" in result
+        assert "Article Title" in result
+        assert "markdown" in result.lower()
+
+    def test_execute_with_extract_mode(self) -> None:
+        """Should pass extract_mode to fetch."""
+        tool = WebFetchTool()
+
+        mock_result = MockFetchResult(
+            url="https://example.com",
+            content="Metadata only",
+            content_length=100,
+            extract_mode="metadata",
+        )
+
+        # Create mock pvlwebtools module
+        mock_module = MagicMock()
+        mock_web_fetch = AsyncMock(return_value=mock_result)
+        mock_module.web_fetch = mock_web_fetch
+
+        with (
+            patch.dict(sys.modules, {"pvlwebtools": mock_module}),
+            patch(
+                "questfoundry.tools.research.web_tools._web_tools_available",
+                return_value=True,
+            ),
+        ):
+            result = tool.execute({"url": "https://example.com", "extract_mode": "metadata"})
+
+        # Verify web_fetch was called
+        assert mock_web_fetch.called
+        assert "Metadata" in result
+
+    def test_execute_truncates_long_content(self) -> None:
+        """Should truncate content that exceeds limit."""
+        tool = WebFetchTool()
+
+        long_content = "x" * 10000  # Longer than MAX_OUTPUT_CHARS
+        mock_result = MockFetchResult(
+            url="https://example.com",
+            content=long_content,
+            content_length=len(long_content),
+            extract_mode="markdown",
+        )
+
+        # Create mock pvlwebtools module
+        mock_module = MagicMock()
+        mock_web_fetch = AsyncMock(return_value=mock_result)
+        mock_module.web_fetch = mock_web_fetch
+
+        with (
+            patch.dict(sys.modules, {"pvlwebtools": mock_module}),
+            patch(
+                "questfoundry.tools.research.web_tools._web_tools_available",
+                return_value=True,
+            ),
+        ):
+            result = tool.execute({"url": "https://example.com"})
+
+        assert "truncated" in result.lower()
+        assert len(result) < len(long_content)
+
+    def test_execute_handles_exception(self) -> None:
+        """Should return error message when fetch fails."""
+        tool = WebFetchTool()
+
+        # Create mock pvlwebtools module that raises exception
+        mock_module = MagicMock()
+        mock_web_fetch = AsyncMock(side_effect=Exception("404 Not Found"))
+        mock_module.web_fetch = mock_web_fetch
+
+        with (
+            patch.dict(sys.modules, {"pvlwebtools": mock_module}),
+            patch(
+                "questfoundry.tools.research.web_tools._web_tools_available",
+                return_value=True,
+            ),
+        ):
+            result = tool.execute({"url": "https://example.com/missing"})
+
+        assert "failed" in result.lower()
+        assert "404" in result
+
+
+class TestGetWebTools:
+    """Tests for get_web_tools factory."""
+
+    def test_returns_empty_when_not_available(self) -> None:
+        """Should return empty list when pvl-webtools not installed."""
+        with patch(
+            "questfoundry.tools.research.web_tools._web_tools_available",
+            return_value=False,
+        ):
+            tools = get_web_tools()
+
+        assert tools == []
+
+    def test_returns_fetch_only_without_searxng(self) -> None:
+        """Should return only fetch tool when SEARXNG not configured."""
+        with (
+            patch(
+                "questfoundry.tools.research.web_tools._web_tools_available",
+                return_value=True,
+            ),
+            patch(
+                "questfoundry.tools.research.web_tools._searxng_configured",
+                return_value=False,
+            ),
+        ):
+            tools = get_web_tools(require_searxng=True)
+
+        tool_names = {t.definition.name for t in tools}
+        # web_fetch doesn't require SEARXNG
+        assert "web_fetch" in tool_names
+        assert "web_search" not in tool_names
+
+    def test_returns_both_when_fully_configured(self) -> None:
+        """Should return both tools when fully configured."""
+        with (
+            patch(
+                "questfoundry.tools.research.web_tools._web_tools_available",
+                return_value=True,
+            ),
+            patch(
+                "questfoundry.tools.research.web_tools._searxng_configured",
+                return_value=True,
+            ),
+        ):
+            tools = get_web_tools()
+
+        tool_names = {t.definition.name for t in tools}
+        assert tool_names == {"web_search", "web_fetch"}
+
+
+class TestSearxngConfigured:
+    """Tests for _searxng_configured helper."""
+
+    def test_returns_true_when_env_set(self) -> None:
+        """Should return True when SEARXNG_URL is set."""
+        with patch.dict("os.environ", {"SEARXNG_URL": "http://localhost:8080"}):
+            assert _searxng_configured() is True
+
+    def test_returns_false_when_env_missing(self) -> None:
+        """Should return False when SEARXNG_URL is not set."""
+        with patch.dict("os.environ", {}, clear=True):
+            # Remove SEARXNG_URL if it exists
+            import os
+
+            original = os.environ.pop("SEARXNG_URL", None)
+            try:
+                assert _searxng_configured() is False
+            finally:
+                if original is not None:
+                    os.environ["SEARXNG_URL"] = original
+
+
+class TestWebToolsAvailable:
+    """Tests for _web_tools_available helper."""
+
+    def test_returns_false_when_import_fails(self) -> None:
+        """Should return False when pvlwebtools not installed."""
+        # This test relies on actual import behavior
+        # We can't easily test this without manipulating imports
+        pass  # Covered by integration tests

--- a/uv.lock
+++ b/uv.lock
@@ -357,6 +357,14 @@ wheels = [
 ]
 
 [[package]]
+name = "ifcraftcorpus"
+version = "1.2.0"
+source = { git = "https://github.com/pvliesdonk/if-craft-corpus.git#e24a717e0ca91f3aead7a343f86944497f260354" }
+dependencies = [
+    { name = "pyyaml" },
+]
+
+[[package]]
 name = "iniconfig"
 version = "2.3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -880,6 +888,14 @@ wheels = [
 ]
 
 [[package]]
+name = "pvl-webtools"
+version = "0.1.3"
+source = { git = "https://github.com/pvliesdonk/pvl-webtools.git#791d87971085e2085f657c2b1af15fbc78da3f8c" }
+dependencies = [
+    { name = "httpx" },
+]
+
+[[package]]
 name = "pydantic"
 version = "2.12.5"
 source = { registry = "https://pypi.org/simple" }
@@ -1148,6 +1164,16 @@ ollama = [
 openai = [
     { name = "langchain-openai" },
 ]
+research = [
+    { name = "ifcraftcorpus" },
+    { name = "pvl-webtools" },
+]
+research-corpus = [
+    { name = "ifcraftcorpus" },
+]
+research-web = [
+    { name = "pvl-webtools" },
+]
 tracing = [
     { name = "langsmith" },
 ]
@@ -1166,6 +1192,8 @@ dev = [
 requires-dist = [
     { name = "graphviz", marker = "extra == 'viz'", specifier = ">=0.20" },
     { name = "httpx", specifier = ">=0.27" },
+    { name = "ifcraftcorpus", marker = "extra == 'research'", git = "https://github.com/pvliesdonk/if-craft-corpus.git" },
+    { name = "ifcraftcorpus", marker = "extra == 'research-corpus'", git = "https://github.com/pvliesdonk/if-craft-corpus.git" },
     { name = "jsonschema", specifier = ">=4.0" },
     { name = "langchain-anthropic", marker = "extra == 'all-providers'", specifier = ">=0.3" },
     { name = "langchain-anthropic", marker = "extra == 'anthropic'", specifier = ">=0.3" },
@@ -1178,6 +1206,8 @@ requires-dist = [
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.11" },
     { name = "networkx", marker = "extra == 'viz'", specifier = ">=3.0" },
     { name = "pre-commit", marker = "extra == 'dev'", specifier = ">=3.8" },
+    { name = "pvl-webtools", marker = "extra == 'research'", git = "https://github.com/pvliesdonk/pvl-webtools.git" },
+    { name = "pvl-webtools", marker = "extra == 'research-web'", git = "https://github.com/pvliesdonk/pvl-webtools.git" },
     { name = "pydantic", specifier = ">=2.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.24" },
@@ -1191,7 +1221,7 @@ requires-dist = [
     { name = "typer", specifier = ">=0.12" },
     { name = "types-jsonschema", marker = "extra == 'dev'", specifier = ">=4.0" },
 ]
-provides-extras = ["ollama", "openai", "anthropic", "all-providers", "tracing", "dev", "viz"]
+provides-extras = ["ollama", "openai", "anthropic", "all-providers", "tracing", "research", "research-corpus", "research-web", "dev", "viz"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
## Problem

Pipeline stages currently operate without access to external knowledge resources, limiting informed decision-making during creative processes like the DREAM stage. This implementation adds research tools for corpus knowledge and web research.

## Changes

- Add `questfoundry.tools.research` package with two tool sets:
  - **Corpus Tools**: `SearchCorpusTool`, `GetDocumentTool`, `ListClustersTool` for IF Craft Corpus access
  - **Web Tools**: `WebSearchTool`, `WebFetchTool` for web research via SearXNG/pvl-webtools
- Add `ResearchToolsConfig` dataclass to `pipeline/config.py` for enabling/disabling tools
- Integrate `_get_research_tools()` in `PipelineOrchestrator` to inject tools into stage context
- Add optional dependencies (`ifcraftcorpus`, `pvl-webtools`) to pyproject.toml
- Follow graceful degradation pattern - tools return helpful errors when dependencies unavailable
- Output truncation to ~1000 tokens (4000 chars) to avoid context overflow

## Not Included / Future PRs

- UI for research tool configuration (qf doctor integration)
- Rate limiting for web tools
- Token budget tracking for tool output

## Test Plan

- Added `tests/unit/test_corpus_tools.py` (14 tests)
- Added `tests/unit/test_web_tools.py` (18 tests)
- All 375 tests pass: `uv run pytest`
- Type checking passes: `uv run mypy src/`
- Linting passes: `uv run ruff check src/`

```bash
uv run pytest tests/unit/test_corpus_tools.py tests/unit/test_web_tools.py -v
```

## Risk / Rollback

- Low risk - tools are additive and disabled by default when dependencies unavailable
- No breaking changes to existing functionality
- Git URLs in pyproject.toml require `allow-direct-references = true` in hatch metadata

## Review Guide

Suggested review order:
1. `src/questfoundry/tools/research/corpus_tools.py` - Core corpus tool implementations
2. `src/questfoundry/tools/research/web_tools.py` - Web tool implementations
3. `src/questfoundry/pipeline/config.py` - ResearchToolsConfig addition
4. `src/questfoundry/pipeline/orchestrator.py` - Integration point
5. Tests files for behavior verification

Closes #31