### PR TITLE
fix(cli): fail fast when no prompt in non-interactive mode

### DIFF
--- a/src/questfoundry/cli.py
+++ b/src/questfoundry/cli.py
@@ -281,14 +281,16 @@ def dream(
     # Determine interactive mode: explicit flag > TTY detection
     use_interactive = interactive if interactive is not None else _is_interactive_tty()
 
-    # Handle prompt: if not provided, interactive mode uses default, otherwise prompt
+    # Handle prompt: if not provided, interactive mode uses default, non-interactive fails
     if prompt is None:
         if use_interactive:
             # In interactive mode, start with a guiding prompt that invites conversation
             prompt = DEFAULT_INTERACTIVE_DREAM_PROMPT
         else:
-            # Non-interactive requires explicit prompt
-            prompt = typer.prompt("Enter your story idea")
+            # Non-interactive requires explicit prompt (fail fast, don't hang in CI/CD)
+            console.print("[red]Error:[/red] Prompt required in non-interactive mode.")
+            console.print("Provide a prompt argument or use --interactive/-i flag.")
+            raise typer.Exit(1)
 
     log.info("stage_start", stage="dream")
     log.debug("user_prompt", prompt=prompt[:100] + "..." if len(prompt) > 100 else prompt)


### PR DESCRIPTION
## Problem

In non-interactive mode (e.g., CI/CD), if no prompt is provided, the `qf dream` command hangs waiting for `typer.prompt()` input. This is poor UX for automated environments.

## Changes

- Replace `typer.prompt()` with immediate error exit in non-interactive mode
- Clear error message explaining what's needed: provide prompt or use `--interactive` flag
- Update test to verify fail-fast behavior

## Test Plan

```bash
uv run pytest tests/unit/test_cli.py::test_dream_no_prompt_noninteractive_fails_fast -v
```

All 381 tests pass.

## Risk / Rollback

Low risk - changes error behavior from hanging to failing fast, which is strictly better for CI/CD.

🤖 Generated with [Claude Code](https://claude.com/claude-code)