### PR TITLE
docs: clarify 3-phase stage execution pattern

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,7 +25,7 @@ DRESS stage (art direction) is deferred for later implementation.
 ### Key Design Principles
 
 1. **No Persistent Agent State** - Each stage starts fresh; context from artifacts
-2. **One LLM Call Per Stage** - Predictable, bounded calls
+2. **Bounded Stage Execution** - Each stage follows 3-phase pattern: discuss → summarize → serialize
 3. **Human Gates Between Stages** - Review and approval checkpoints
 4. **Prompts as Visible Artifacts** - All prompts in `/prompts/`, not in code
 5. **No Backflow** - Later stages cannot modify earlier artifacts

--- a/docs/architecture/interactive-stages.md
+++ b/docs/architecture/interactive-stages.md
@@ -186,10 +186,12 @@ The tool schema matches the artifact schema, ensuring structured output.
 ### Direct Mode (Non-TTY or `--no-interactive`)
 
 1. LLM receives system prompt with direct generation instructions
-2. Single LLM call with `tool_choice="submit_dream"`
-3. Falls back to YAML parsing for legacy providers
-4. Validation with error on failure
+2. Same conversation loop as interactive, but `max_turns=1` and no user input
+3. Research tools available, finalization tool for completion
+4. Validation with retry on failure
 5. Artifact written
+
+Both modes use the same `ConversationRunner` with identical 3-phase flow (discuss with research tools → summarize → serialize with finalization tool). The only differences are turn limits and whether user input is collected.
 
 ## Prompt Architecture
 
@@ -263,7 +265,7 @@ result = await orchestrator.run_stage("dream", {
 
 ### Adding Research Tools
 
-Research tools can be injected into the conversation:
+Research tools are loaded by the orchestrator and available during discussion:
 
 ```python
 context = {
@@ -272,7 +274,10 @@ context = {
 }
 ```
 
-These are available alongside the finalization tool during conversation.
+Research tools and finalization tools are **not** available simultaneously. The 3-phase pattern uses different tool sets per phase:
+- **Discuss phase**: Research tools only
+- **Summarize phase**: No tools
+- **Serialize phase**: Finalization tool only
 
 ### Adding New Stages
 


### PR DESCRIPTION
## Problem
Documentation described "One LLM Call Per Stage" which contradicts the 3-phase execution pattern (discuss → summarize → serialize). The direct mode section also described the shortcut implementation rather than the correct architecture.

## Changes
- Update CLAUDE.md key design principle #2: "Bounded Stage Execution" with 3-phase pattern
- Fix direct mode description in interactive-stages.md: same ConversationRunner, different config
- Clarify research tools are phase-separated (discuss only), not available alongside finalization tool

## Not Included / Future PRs
- Actual implementation of unified 3-phase pattern (see #57)

## Test Plan
- Documentation only, no code changes

## Risk / Rollback
- None, documentation only

🤖 Generated with [Claude Code](https://claude.com/claude-code)