### PR TITLE
refactor(conversation): implement 3-phase Discuss → Summarize → Serialize pattern

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,11 +56,11 @@ tracing = [
     "langsmith>=0.2",
 ]
 research = [
-    "ifcraftcorpus @ git+https://github.com/pvliesdonk/if-craft-corpus.git",
+    "ifcraftcorpus[embeddings-api]",
     "pvl-webtools @ git+https://github.com/pvliesdonk/pvl-webtools.git",
 ]
 research-corpus = [
-    "ifcraftcorpus @ git+https://github.com/pvliesdonk/if-craft-corpus.git",
+    "ifcraftcorpus[embeddings-api]",
 ]
 research-web = [
     "pvl-webtools @ git+https://github.com/pvliesdonk/pvl-webtools.git",

--- a/src/questfoundry/conversation/runner.py
+++ b/src/questfoundry/conversation/runner.py
@@ -1,8 +1,8 @@
 """Conversation runner for interactive stages.
 
 This module provides the ConversationRunner class that manages
-multi-turn LLM interactions with tool calling support, enabling
-conversational refinement before structured output.
+multi-turn LLM interactions with the 3-phase pattern:
+Discuss → Summarize → Serialize.
 """
 
 from __future__ import annotations
@@ -12,11 +12,12 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
 from questfoundry.conversation.state import ConversationState
-from questfoundry.tools import Tool
+from questfoundry.tools import ReadyToSummarizeTool, Tool
 
 # Default configuration values
-DEFAULT_MAX_TURNS = 10
+DEFAULT_MAX_DISCUSS_TURNS = 10
 DEFAULT_VALIDATION_RETRIES = 3
+USER_DONE_SIGNAL = "/done"
 
 if TYPE_CHECKING:
     from collections.abc import Awaitable, Callable
@@ -79,23 +80,28 @@ class ValidationResult:
 
 
 class ConversationRunner:
-    """Manages multi-turn LLM conversations with tool calling.
+    """Manages multi-turn LLM conversations with the 3-phase pattern.
 
-    The runner implements the Discuss → Freeze → Serialize pattern:
-    1. Conversation phase: LLM discusses with user, uses research tools
-    2. Finalization: LLM calls finalization tool with structured data
-    3. Validation: Data is validated with optional retry loop
+    The runner implements the Discuss → Summarize → Serialize pattern:
 
-    Attributes:
-        finalization_tool: Name of the tool that signals completion.
-        max_turns: Maximum conversation turns before timeout.
-        validation_retries: Maximum validation retry attempts.
+    1. **Discuss phase**: LLM discusses with user using research tools.
+       Ends when user types /done, LLM calls ready_to_summarize(), or max turns.
+
+    2. **Summarize phase**: LLM generates a summary with no tools.
+       Distills the conversation into key decisions.
+
+    3. **Serialize phase**: LLM calls finalization tool with structured data.
+       Validation with retry loop; fails explicitly if no tool call.
+
+    Both direct and interactive modes use this same code path:
+    - Direct mode: max_discuss_turns=1, user_input_fn=None
+    - Interactive mode: max_discuss_turns=10, user_input_fn provided
 
     Example:
         >>> runner = ConversationRunner(
         ...     provider=provider,
-        ...     tools=[SubmitDreamTool(), SearchCorpusTool()],
-        ...     finalization_tool="submit_dream",
+        ...     research_tools=[SearchCorpusTool()],
+        ...     finalization_tool=SubmitDreamTool(),
         ... )
         >>> artifact, state = await runner.run(
         ...     initial_messages=[system_msg, user_msg],
@@ -107,243 +113,350 @@ class ConversationRunner:
     def __init__(
         self,
         provider: LLMProvider,
-        tools: list[Tool],
-        finalization_tool: str,
-        max_turns: int = DEFAULT_MAX_TURNS,
+        research_tools: list[Tool],
+        finalization_tool: Tool,
+        max_discuss_turns: int = DEFAULT_MAX_DISCUSS_TURNS,
         validation_retries: int = DEFAULT_VALIDATION_RETRIES,
     ) -> None:
         """Initialize the conversation runner.
 
         Args:
             provider: LLM provider for completions.
-            tools: List of tools available during conversation.
-            finalization_tool: Name of the tool that ends the conversation.
-            max_turns: Maximum turns before timeout (default 10).
-            validation_retries: Max validation retries (default 3).
+            research_tools: Tools available during Discuss phase only.
+            finalization_tool: Tool available during Serialize phase only.
+            max_discuss_turns: Max turns in Discuss phase (1 for direct mode).
+            validation_retries: Max validation retries in Serialize phase.
 
         Raises:
-            TypeError: If any tool doesn't implement the Tool protocol.
+            TypeError: If finalization_tool doesn't implement the Tool protocol.
         """
-        # Validate all tools implement the Tool protocol
-        for tool in tools:
+        # Validate finalization tool implements Tool protocol
+        if not isinstance(finalization_tool, Tool):
+            raise TypeError(
+                f"finalization_tool {finalization_tool!r} doesn't implement Tool protocol"
+            )
+
+        # Validate research tools
+        for tool in research_tools:
             if not isinstance(tool, Tool):
-                raise TypeError(
-                    f"Tool {tool!r} doesn't implement Tool protocol "
-                    f"(missing 'definition' property or 'execute' method)"
-                )
+                raise TypeError(f"Research tool {tool!r} doesn't implement Tool protocol")
 
         self._provider = provider
-        self._tools = {t.definition.name: t for t in tools}
-        self._tool_definitions = [t.definition for t in tools]
+        self._research_tools = research_tools
         self._finalization_tool = finalization_tool
-        self._max_turns = max_turns
+        self._max_discuss_turns = max_discuss_turns
         self._validation_retries = validation_retries
+
+        # Build tool lookup maps for each phase
+        self._ready_tool = ReadyToSummarizeTool()
+        self._discuss_tools = {t.definition.name: t for t in research_tools}
+        self._discuss_tools[self._ready_tool.definition.name] = self._ready_tool
+        self._discuss_tool_defs = [t.definition for t in research_tools] + [
+            self._ready_tool.definition
+        ]
+
+        self._finalization_tool_name = finalization_tool.definition.name
+        self._finalization_tool_def = finalization_tool.definition
 
     async def run(
         self,
         initial_messages: list[Message],
         user_input_fn: Callable[[], Awaitable[str | None]] | None = None,
         validator: Callable[[dict[str, Any]], ValidationResult] | None = None,
+        summary_prompt: str | None = None,
         on_assistant_message: Callable[[str], None] | None = None,
     ) -> tuple[dict[str, Any], ConversationState]:
-        """Run the conversation until finalization.
+        """Run the 3-phase conversation.
 
         Args:
             initial_messages: Starting messages (typically system + user).
-            user_input_fn: Async function to get user input. If None or
-                returns None/empty, conversation continues without user input.
+            user_input_fn: Async function to get user input. If None,
+                runs in direct mode (no user interaction in Discuss).
             validator: Optional function to validate finalization data.
-                Called with tool arguments, returns ValidationResult.
+            summary_prompt: Optional guidance for the Summarize phase.
             on_assistant_message: Optional callback for assistant messages.
-                Called with the message content for display purposes.
 
         Returns:
             Tuple of (artifact_data, conversation_state).
 
         Raises:
-            ConversationError: If max turns exceeded or validation fails
-                after all retries.
+            ConversationError: If any phase fails.
         """
-        state = ConversationState(messages=list(initial_messages))
+        state = ConversationState(messages=list(initial_messages), phase="discuss")
 
-        while state.turn_count < self._max_turns:
-            # Call LLM with tools
+        # Phase 1: Discuss
+        await self._discuss_phase(state, user_input_fn, on_assistant_message)
+
+        # Phase 2: Summarize
+        state.phase = "summarize"
+        summary = await self._summarize_phase(state, summary_prompt, on_assistant_message)
+
+        # Phase 3: Serialize
+        state.phase = "serialize"
+        artifact = await self._serialize_phase(state, summary, validator, on_assistant_message)
+
+        return artifact, state
+
+    async def _discuss_phase(
+        self,
+        state: ConversationState,
+        user_input_fn: Callable[[], Awaitable[str | None]] | None,
+        on_assistant_message: Callable[[str], None] | None,
+    ) -> None:
+        """Run the Discuss phase with research tools only.
+
+        Exit conditions:
+        - User types /done
+        - LLM calls ready_to_summarize()
+        - max_discuss_turns reached (auto-transition)
+
+        Args:
+            state: Conversation state to update.
+            user_input_fn: Function to get user input, or None for direct mode.
+            on_assistant_message: Callback for assistant messages.
+        """
+        while state.turn_count < self._max_discuss_turns:
+            # Call LLM with research tools only
             response = await self._provider.complete(
                 messages=state.messages,
-                tools=self._tool_definitions,
+                tools=self._discuss_tool_defs if self._discuss_tool_defs else None,
                 tool_choice="auto",
             )
             state.llm_calls += 1
             state.tokens_used += response.tokens_used
 
-            # Add assistant message BEFORE processing tool calls
-            # This preserves any explanatory text the LLM provides alongside tool calls
+            # Add assistant message
             if response.content:
                 state.add_message({"role": "assistant", "content": response.content})
                 if on_assistant_message is not None:
                     on_assistant_message(response.content)
 
             # Handle tool calls
-            if response.has_tool_calls:
-                result = await self._handle_tool_calls(
-                    response.tool_calls or [],
-                    state,
-                    validator,
-                )
-                if result is not None:
-                    # Finalization tool was called and validated
-                    return result, state
+            if response.has_tool_calls and response.tool_calls:
+                ready_to_proceed = await self._handle_discuss_tools(response.tool_calls, state)
+                if ready_to_proceed:
+                    return  # LLM signaled ready to summarize
+                # Tool was executed - loop back to see LLM response to tool result
+                # without incrementing turn count (tool calls don't count as turns)
+                continue
 
-            # Check if we should get user input
+            # Get user input (if interactive)
             if user_input_fn is not None:
                 user_input = await user_input_fn()
                 if user_input:
+                    # Check for /done signal
+                    if user_input.strip().lower() == USER_DONE_SIGNAL:
+                        return  # User signaled ready to summarize
                     state.add_message({"role": "user", "content": user_input})
 
             state.turn_count += 1
 
-        raise ConversationError(
-            f"Maximum turns ({self._max_turns}) exceeded without finalization",
-            state,
-        )
+        # Max turns reached - auto-transition to summarize
 
-    async def _handle_tool_calls(
+    async def _handle_discuss_tools(
         self,
         tool_calls: list[ToolCall],
         state: ConversationState,
-        validator: Callable[[dict[str, Any]], ValidationResult] | None,
-    ) -> dict[str, Any] | None:
-        """Process tool calls from LLM response.
+    ) -> bool:
+        """Process tool calls during Discuss phase.
+
+        Only allows research tools and ready_to_summarize.
+        Rejects finalization tool calls (must be in Serialize phase).
 
         Args:
-            tool_calls: List of tool calls from LLM.
-            state: Current conversation state.
-            validator: Optional validator for finalization tool.
+            tool_calls: Tool calls from LLM response.
+            state: Conversation state to update.
 
         Returns:
-            Finalization data if finalization tool was called successfully,
-            None otherwise.
+            True if ready_to_summarize was called, False otherwise.
         """
         for tc in tool_calls:
-            if tc.name == self._finalization_tool:
-                # Handle finalization with validation
-                return await self._handle_finalization(tc, state, validator)
-            else:
-                # Execute research tool
-                result = self._execute_tool(tc)
+            # Check for ready_to_summarize signal
+            if tc.name == "ready_to_summarize":
+                result = self._ready_tool.execute(tc.arguments)
                 state.add_tool_result(tc.id, result)
+                return True
 
-        return None
+            # Reject finalization tool in discuss phase
+            if tc.name == self._finalization_tool_name:
+                state.add_tool_result(
+                    tc.id,
+                    json.dumps(
+                        {
+                            "error": "Cannot call finalization tool during discussion phase. "
+                            "Use ready_to_summarize() when done discussing, then the "
+                            "finalization tool will be available in the serialize phase."
+                        }
+                    ),
+                )
+                continue
 
-    async def _handle_finalization(
+            # Execute research tool
+            tool = self._discuss_tools.get(tc.name)
+            if tool is None:
+                state.add_tool_result(tc.id, f"Error: Unknown tool '{tc.name}'")
+                continue
+
+            try:
+                result = tool.execute(tc.arguments)
+                state.add_tool_result(tc.id, result)
+            except (KeyboardInterrupt, SystemExit):
+                raise
+            except Exception as e:
+                state.add_tool_result(tc.id, f"Error executing {tc.name}: {e}")
+
+        return False
+
+    async def _summarize_phase(
         self,
-        tool_call: ToolCall,
         state: ConversationState,
-        validator: Callable[[dict[str, Any]], ValidationResult] | None,
-    ) -> dict[str, Any]:
-        """Handle finalization tool call with validation retry.
+        summary_prompt: str | None,
+        on_assistant_message: Callable[[str], None] | None,
+    ) -> str:
+        """Run the Summarize phase with no tools.
+
+        Generates a summary of the discussion for the Serialize phase.
 
         Args:
-            tool_call: The finalization tool call.
-            state: Current conversation state.
-            validator: Optional validator function.
+            state: Conversation state to update.
+            summary_prompt: Optional guidance for summarization.
+            on_assistant_message: Callback for assistant messages.
+
+        Returns:
+            The generated summary text.
+
+        Raises:
+            ConversationError: If summarization fails.
+        """
+        # Build summarize prompt
+        if summary_prompt:
+            summarize_instruction = summary_prompt
+        else:
+            summarize_instruction = (
+                "Summarize the key decisions and creative direction from our discussion. "
+                "Be concise but capture the essential elements that should inform the final output."
+            )
+
+        state.add_message({"role": "user", "content": summarize_instruction})
+
+        # Call LLM with no tools
+        response = await self._provider.complete(
+            messages=state.messages,
+            tools=None,
+            tool_choice=None,
+        )
+        state.llm_calls += 1
+        state.tokens_used += response.tokens_used
+
+        if not response.content:
+            raise ConversationError(
+                "Summarize phase produced no content",
+                state,
+            )
+
+        state.add_message({"role": "assistant", "content": response.content})
+        if on_assistant_message is not None:
+            on_assistant_message(response.content)
+
+        return response.content
+
+    async def _serialize_phase(
+        self,
+        state: ConversationState,
+        summary: str,  # noqa: ARG002 - summary already in messages, param kept for API clarity
+        validator: Callable[[dict[str, Any]], ValidationResult] | None,
+        on_assistant_message: Callable[[str], None] | None,
+    ) -> dict[str, Any]:
+        """Run the Serialize phase with finalization tool only.
+
+        Converts the summary to structured output via tool call.
+        Includes validation retry loop.
+
+        Args:
+            state: Conversation state to update.
+            summary: Summary from previous phase.
+            validator: Optional validation function.
+            on_assistant_message: Callback for assistant messages.
 
         Returns:
             Validated artifact data.
 
         Raises:
-            ConversationError: If validation fails after all retries.
+            ConversationError: If serialization or validation fails.
         """
-        data = tool_call.arguments
-        retries = 0
+        # Build serialize instruction
+        serialize_instruction = (
+            f"Based on the summary above, call {self._finalization_tool_name}() "
+            f"with the complete structured data."
+        )
+        state.add_message({"role": "user", "content": serialize_instruction})
 
-        while retries < self._validation_retries:
+        retries = 0
+        while retries <= self._validation_retries:
+            # Call LLM with finalization tool only, forced
+            response = await self._provider.complete(
+                messages=state.messages,
+                tools=[self._finalization_tool_def],
+                tool_choice=self._finalization_tool_name,
+            )
+            state.llm_calls += 1
+            state.tokens_used += response.tokens_used
+
+            # Add any assistant content
+            if response.content:
+                state.add_message({"role": "assistant", "content": response.content})
+                if on_assistant_message is not None:
+                    on_assistant_message(response.content)
+
+            # Extract tool call
+            tool_call = None
+            if response.has_tool_calls and response.tool_calls:
+                for tc in response.tool_calls:
+                    if tc.name == self._finalization_tool_name:
+                        tool_call = tc
+                        break
+
+            # No tool call = explicit failure (no YAML fallback)
+            if tool_call is None:
+                raise ConversationError(
+                    f"Provider did not return {self._finalization_tool_name} tool call. "
+                    "Ensure you are using a tool-capable provider/model.",
+                    state,
+                )
+
+            data = tool_call.arguments
+
             # Validate if validator provided
             if validator is not None:
                 result = validator(data)
                 if not result.valid:
-                    # Build structured feedback per ADR-007
-                    # Include schema to help small models that ignore tool definitions
-                    feedback = self._build_validation_feedback(
-                        data, result, self._finalization_tool, include_schema=True
-                    )
-
-                    # Check if we've exhausted retries BEFORE making another LLM call
                     retries += 1
-                    if retries >= self._validation_retries:
+                    if retries > self._validation_retries:
                         raise ConversationError(
                             f"Validation failed after {self._validation_retries} retries",
                             state,
                         )
 
-                    state.add_tool_result(tool_call.id, json.dumps(feedback, indent=2))
-
-                    # Request retry from LLM
-                    response = await self._provider.complete(
-                        messages=state.messages,
-                        tools=self._tool_definitions,
-                        tool_choice=self._finalization_tool,  # Force retry of same tool
+                    # Build feedback and retry
+                    feedback = self._build_validation_feedback(
+                        data, result, self._finalization_tool_name, include_schema=True
                     )
-                    state.llm_calls += 1
-                    state.tokens_used += response.tokens_used
-
-                    # Extract new tool call
-                    found_new_call = False
-                    if response.has_tool_calls and response.tool_calls:
-                        for tc in response.tool_calls:
-                            if tc.name == self._finalization_tool:
-                                data = tc.arguments
-                                tool_call = tc
-                                found_new_call = True
-                                break
-
-                    if not found_new_call:
-                        # LLM didn't provide expected tool call - fail fast
-                        # Continuing would revalidate same stale data (infinite loop)
-                        if response.content:
-                            state.add_message({"role": "assistant", "content": response.content})
-                        raise ConversationError(
-                            f"LLM failed to call {self._finalization_tool} on retry {retries}",
-                            state,
-                        )
+                    state.add_tool_result(tool_call.id, json.dumps(feedback, indent=2))
                     continue
-                else:
-                    # Use validated/transformed data if provided
-                    data = result.data if result.data is not None else data
 
-            # Validation passed or no validator - call tool.execute() for confirmation
-            tool = self._tools.get(self._finalization_tool)
-            if tool is not None:
-                result_message = tool.execute(data)
-            else:
-                result_message = "Artifact submitted successfully."
+                # Use validated/transformed data if provided
+                data = result.data if result.data is not None else data
+
+            # Validation passed - confirm and return
+            result_message = self._finalization_tool.execute(data)
             state.add_tool_result(tool_call.id, result_message)
             return data
 
+        # Should not reach here, but just in case
         raise ConversationError(
             f"Validation failed after {self._validation_retries} retries",
             state,
         )
-
-    def _execute_tool(self, tool_call: ToolCall) -> str:
-        """Execute a non-finalization tool.
-
-        Args:
-            tool_call: The tool call to execute.
-
-        Returns:
-            Tool execution result as string.
-        """
-        tool = self._tools.get(tool_call.name)
-        if tool is None:
-            return f"Error: Unknown tool '{tool_call.name}'"
-
-        try:
-            return tool.execute(tool_call.arguments)
-        except (KeyboardInterrupt, SystemExit):
-            raise  # Don't catch system signals
-        except Exception as e:
-            return f"Error executing {tool_call.name}: {e}"
 
     def _build_validation_feedback(
         self,
@@ -365,8 +478,7 @@ class ConversationRunner:
             data: The submitted data that failed validation.
             result: ValidationResult with structured errors.
             tool_name: Name of the finalization tool for action text.
-            include_schema: If True, include full schema in feedback for
-                models that struggle with tool definition attention.
+            include_schema: If True, include full schema in feedback.
 
         Returns:
             Structured feedback dict ready for JSON serialization.
@@ -433,11 +545,9 @@ class ConversationRunner:
             "action": " ".join(action_parts),
         }
 
-        # Include schema for serialize phase - helps small models that ignore tool definitions
+        # Include schema for serialize phase - helps small models
         if include_schema:
-            tool_def = next((t for t in self._tool_definitions if t.name == tool_name), None)
-            if tool_def:
-                feedback["schema"] = tool_def.parameters
+            feedback["schema"] = self._finalization_tool_def.parameters
 
         return feedback
 
@@ -454,7 +564,7 @@ class ConversationRunner:
 
         Args:
             data: Submitted data to check.
-            expected_fields: Set of valid field paths (e.g., {"genre", "scope.target_word_count"}).
+            expected_fields: Set of valid field paths.
             prefix: Current field path prefix for recursion.
 
         Returns:
@@ -463,7 +573,7 @@ class ConversationRunner:
         if expected_fields is None:
             return []
 
-        # Pre-compute parent prefixes for O(1) lookup instead of O(m) per field
+        # Pre-compute parent prefixes for O(1) lookup
         parent_prefixes = {ef.rsplit(".", 1)[0] for ef in expected_fields if "." in ef}
 
         unknown: list[str] = []
@@ -472,7 +582,6 @@ class ConversationRunner:
             field_path = f"{prefix}.{key}" if prefix else key
 
             # Check if this exact path or a parent path is expected
-            # e.g., "scope" is expected if "scope.target_word_count" is in expected_fields
             path_is_expected = field_path in expected_fields
             is_parent_of_expected = field_path in parent_prefixes
 

--- a/src/questfoundry/conversation/state.py
+++ b/src/questfoundry/conversation/state.py
@@ -17,27 +17,35 @@ if TYPE_CHECKING:
 class ConversationState:
     """Tracks state during a conversation loop.
 
-    Maintains the message history, turn count, and resource usage
+    Maintains the message history, turn count, phase, and resource usage
     metrics for a conversation session.
+
+    The phase tracks the current stage of the 3-phase conversation pattern:
+    - "discuss": Initial discussion with research tools
+    - "summarize": Generating summary with no tools
+    - "serialize": Converting to structured output with finalization tool
 
     Attributes:
         messages: List of all messages in the conversation.
-        turn_count: Number of completed conversation turns.
+        turn_count: Number of completed conversation turns in discuss phase.
         llm_calls: Total LLM API calls made.
         tokens_used: Total tokens consumed across all calls.
+        phase: Current phase ("discuss", "summarize", or "serialize").
 
     Example:
-        >>> state = ConversationState()
+        >>> state = ConversationState(phase="discuss")
         >>> state.messages.append({"role": "user", "content": "Hello"})
         >>> state.turn_count += 1
         >>> state.llm_calls += 1
         >>> state.tokens_used += 150
+        >>> state.phase = "summarize"
     """
 
     messages: list[Message] = field(default_factory=list)
     turn_count: int = 0
     llm_calls: int = 0
     tokens_used: int = 0
+    phase: str = "discuss"
 
     def add_message(self, message: Message) -> None:
         """Add a message to the conversation history."""

--- a/src/questfoundry/pipeline/stages/__init__.py
+++ b/src/questfoundry/pipeline/stages/__init__.py
@@ -8,13 +8,12 @@ from questfoundry.pipeline.stages.base import (
     list_stages,
     register_stage,
 )
-from questfoundry.pipeline.stages.dream import DreamParseError, DreamStage, dream_stage
+from questfoundry.pipeline.stages.dream import DreamStage, dream_stage
 
 # Register built-in stages
 register_stage(dream_stage)
 
 __all__ = [
-    "DreamParseError",
     "DreamStage",
     "Stage",
     "dream_stage",

--- a/src/questfoundry/pipeline/stages/dream.py
+++ b/src/questfoundry/pipeline/stages/dream.py
@@ -3,19 +3,16 @@
 The DREAM stage establishes the creative vision for the story,
 generating genre, tone, themes, and style direction.
 
-Supports two execution modes:
-- Interactive: Conversational refinement with user before finalization
-- Direct: Single LLM call with tool-gated output (for testing/automation)
+Both interactive and direct modes use the same 3-phase pattern:
+Discuss → Summarize → Serialize.
 
-The caller (CLI) determines the mode via the `interactive` context flag.
+- Interactive: Multi-turn discussion with user, then summarize and serialize
+- Direct: Single-turn discuss (no user), then summarize and serialize
 """
 
 from __future__ import annotations
 
-import re
 from typing import TYPE_CHECKING, Any
-
-import yaml
 
 from questfoundry.conversation import ConversationRunner, ValidationResult
 from questfoundry.tools import SubmitDreamTool
@@ -27,23 +24,16 @@ if TYPE_CHECKING:
     from questfoundry.tools import Tool
 
 
-class DreamParseError(Exception):
-    """Raised when DREAM stage response cannot be parsed."""
-
-    def __init__(self, message: str, raw_content: str) -> None:
-        self.raw_content = raw_content
-        super().__init__(message)
-
-
 class DreamStage:
     """DREAM stage - establish creative vision.
 
     This stage takes a user's story idea and generates a creative
     vision artifact containing genre, tone, themes, and style direction.
 
-    Supports interactive mode (default) where the LLM engages in conversation
-    with the user before finalizing the creative vision, and direct mode
-    for automated/testing scenarios.
+    Both interactive and direct modes follow the same 3-phase pattern,
+    differing only in configuration:
+    - Interactive: max_discuss_turns=10, user_input_fn provided
+    - Direct: max_discuss_turns=1, user_input_fn=None
 
     Attributes:
         name: Stage identifier ("dream").
@@ -57,14 +47,20 @@ class DreamStage:
         provider: LLMProvider,
         compiler: PromptCompiler,
     ) -> tuple[dict[str, Any], int, int]:
-        """Execute the DREAM stage.
+        """Execute the DREAM stage using the 3-phase pattern.
+
+        Both interactive and direct modes use the same code path:
+        Discuss → Summarize → Serialize.
 
         Args:
             context: Context with keys:
                 - user_prompt: The user's story idea (required)
-                - interactive: Enable conversation mode (default: False)
+                - interactive: Enable multi-turn discussion (default: False)
                 - user_input_fn: Async function to get user input (optional)
                 - research_tools: Additional tools for context (optional)
+                - on_assistant_message: Callback for assistant messages (optional)
+                - max_turns: Max discussion turns (default: 10)
+                - validation_retries: Max validation retries (default: 3)
             provider: LLM provider for completions.
             compiler: Prompt compiler for template assembly.
 
@@ -72,70 +68,19 @@ class DreamStage:
             Tuple of (artifact_data, llm_calls, tokens_used).
 
         Raises:
-            DreamParseError: If response cannot be parsed (legacy mode only).
-            ConversationError: If conversation fails (interactive mode).
+            ConversationError: If any phase fails.
         """
-        # Determine interactive mode from context (CLI handles TTY detection)
         interactive = context.get("interactive", False)
-
-        if interactive:
-            return await self._execute_interactive(context, provider, compiler)
-        else:
-            return await self._execute_direct(context, provider, compiler)
-
-    async def _execute_interactive(
-        self,
-        context: dict[str, Any],
-        provider: LLMProvider,
-        compiler: PromptCompiler,
-    ) -> tuple[dict[str, Any], int, int]:
-        """Execute in interactive mode with conversation loop.
-
-        Uses ConversationRunner to manage multi-turn dialogue with the user,
-        finalizing via submit_dream tool call.
-        """
         user_prompt = context.get("user_prompt", "")
         user_input_fn = context.get("user_input_fn")
         on_assistant_message = context.get("on_assistant_message")
         research_tools: list[Tool] = context.get("research_tools") or []
 
-        # Build research tools section if any are available
-        research_tools_section = self._build_research_tools_section(research_tools)
+        # Build prompt context
+        prompt_context = self._build_prompt_context(user_prompt, research_tools, interactive)
 
-        # Build prompt context for interactive mode (sandwich pattern)
-        prompt_context = {
-            "mode_instructions": (
-                "IMPORTANT: You have access to the submit_dream tool. Engage in conversation "
-                "with the user to refine the creative vision. Ask clarifying questions about:\n"
-                "- What genre and tone they envision\n"
-                "- The target audience and themes\n"
-                "- Any content to include or avoid\n"
-                "- The desired scope and complexity\n\n"
-                f"{research_tools_section}"
-                "When the user is satisfied with the direction, call submit_dream() with the "
-                "finalized artifact data."
-            ),
-            "mode_reminder": (
-                "REMEMBER: Discuss the vision with the user first. Only call submit_dream() "
-                "when you have refined the concept together and the user is ready to proceed."
-            ),
-            "user_message": f"I'd like to create an interactive story. Here's my idea:\n\n{user_prompt}",
-        }
-
-        # Compile prompt for interactive mode
+        # Compile prompt
         prompt = compiler.compile("dream", prompt_context)
-
-        # Build tool list: finalization + research tools
-        tools: list[Tool] = [SubmitDreamTool(), *research_tools]
-
-        # Create conversation runner
-        runner = ConversationRunner(
-            provider=provider,
-            tools=tools,
-            finalization_tool="submit_dream",
-            max_turns=context.get("max_turns", 10),
-            validation_retries=context.get("validation_retries", 3),
-        )
 
         # Build initial messages
         initial_messages: list[Message] = [
@@ -143,11 +88,23 @@ class DreamStage:
             {"role": "user", "content": prompt.user},
         ]
 
-        # Run conversation
+        # Create conversation runner with unified configuration
+        # Direct mode: max_discuss_turns=1, no user_input_fn
+        # Interactive mode: max_discuss_turns from context, user_input_fn provided
+        runner = ConversationRunner(
+            provider=provider,
+            research_tools=research_tools,
+            finalization_tool=SubmitDreamTool(),
+            max_discuss_turns=1 if not interactive else context.get("max_turns", 10),
+            validation_retries=context.get("validation_retries", 3),
+        )
+
+        # Run the 3-phase conversation
         artifact_data, state = await runner.run(
             initial_messages=initial_messages,
-            user_input_fn=user_input_fn,
+            user_input_fn=user_input_fn if interactive else None,
             validator=self._validate_dream,
+            summary_prompt=self._get_summary_prompt(),
             on_assistant_message=on_assistant_message,
         )
 
@@ -157,141 +114,98 @@ class DreamStage:
 
         return artifact_data, state.llm_calls, state.tokens_used
 
-    async def _execute_direct(
+    def _build_prompt_context(
         self,
-        context: dict[str, Any],
-        provider: LLMProvider,
-        compiler: PromptCompiler,
-    ) -> tuple[dict[str, Any], int, int]:
-        """Execute in direct mode with single LLM call.
+        user_prompt: str,
+        research_tools: list[Tool],
+        interactive: bool,
+    ) -> dict[str, str]:
+        """Build the prompt context for the DREAM stage.
 
-        Uses tool_choice to force submit_dream call, falling back to
-        YAML parsing for legacy provider compatibility.
+        Args:
+            user_prompt: The user's story idea.
+            research_tools: Available research tools.
+            interactive: Whether interactive mode is enabled.
+
+        Returns:
+            Context dict for prompt compilation.
         """
-        user_prompt = context.get("user_prompt", "")
+        # Build research tools section if any are available
+        research_tools_section = self._build_research_tools_section(research_tools)
 
-        # Build prompt context for direct mode
-        prompt_context = {
-            "mode_instructions": (
-                "Generate a creative vision for the story idea provided. You have the "
-                "submit_dream tool available - call it with the complete artifact data."
-            ),
-            "mode_reminder": "",
-            "user_message": self._build_direct_user_message(user_prompt),
+        if interactive:
+            mode_instructions = (
+                "IMPORTANT: Engage in a creative discussion with the user to refine "
+                "the creative vision. Ask clarifying questions about:\n"
+                "- What genre and tone they envision\n"
+                "- The target audience and themes\n"
+                "- Any content to include or avoid\n"
+                "- The desired scope and complexity\n\n"
+                f"{research_tools_section}"
+                "When the discussion is complete, call ready_to_summarize() to signal "
+                "that you're ready to move to the summarization phase. The user can also "
+                "type /done to signal they're ready."
+            )
+            mode_reminder = (
+                "REMEMBER: Discuss the vision with the user first. Call ready_to_summarize() "
+                "when you have refined the concept together and are ready to proceed."
+            )
+        else:
+            mode_instructions = (
+                "Generate a creative vision for the story idea provided. "
+                f"{research_tools_section}"
+                "Consider the key elements: genre, tone, themes, audience, scope, and style."
+            )
+            mode_reminder = ""
+
+        return {
+            "mode_instructions": mode_instructions,
+            "mode_reminder": mode_reminder,
+            "user_message": f"I'd like to create an interactive story. Here's my idea:\n\n{user_prompt}",
         }
-
-        # Compile prompt for direct mode
-        prompt = compiler.compile("dream", prompt_context)
-
-        # Try tool-gated approach first
-        submit_tool = SubmitDreamTool()
-        response = await provider.complete(
-            [
-                {"role": "system", "content": prompt.system},
-                {"role": "user", "content": prompt.user},
-            ],
-            tools=[submit_tool.definition],
-            tool_choice="submit_dream",
-        )
-
-        # Extract artifact data from tool call or fall back to YAML parsing
-        artifact_data = None
-        if response.has_tool_calls and response.tool_calls:
-            # Prefer the finalization tool call if present
-            for tc in response.tool_calls:
-                if tc.name == "submit_dream":
-                    artifact_data = tc.arguments
-                    break
-
-        # Fallback to YAML parsing for legacy providers or if tool call was missed
-        if artifact_data is None:
-            artifact_data = self._parse_response(response.content)
-
-        # Validate
-        result = self._validate_dream(artifact_data)
-        if not result.valid:
-            raise DreamParseError(f"Validation failed: {result.error}", str(artifact_data))
-
-        # Use validated data (may have defaults/transformations applied)
-        validated_data = result.data if result.data is not None else artifact_data
-
-        # Add required fields
-        validated_data["type"] = "dream"
-        validated_data["version"] = validated_data.get("version", 1)
-
-        return validated_data, 1, response.tokens_used
 
     def _build_research_tools_section(self, tools: list[Tool]) -> str:
         """Build prompt section describing available research tools.
 
         Args:
-            tools: List of research tools (excludes finalization tools).
+            tools: List of research tools.
 
         Returns:
             Formatted string describing tools, or empty string if none.
         """
-        # Filter to research tools only (exclude finalization tools like submit_dream)
-        finalization_tools = {"submit_dream", "submit_brainstorm"}
-        research = [t for t in tools if t.definition.name not in finalization_tools]
-
-        if not research:
+        if not tools:
             return ""
 
         # Build tool descriptions
         tool_lines = []
-        for tool in research:
+        for tool in tools:
             defn = tool.definition
             tool_lines.append(f"- {defn.name}: {defn.description}")
 
         return (
-            "You also have research tools available to gather information:\n"
+            "You have research tools available to gather information:\n"
             + "\n".join(tool_lines)
             + "\n\n"
             "Use these tools to research genre conventions, writing craft, or current trends "
             "that might inform the creative vision.\n\n"
         )
 
-    def _build_direct_user_message(self, user_prompt: str) -> str:
-        """Build user message for direct mode with YAML format spec.
-
-        Includes output format for legacy providers that don't support tools.
-
-        Args:
-            user_prompt: The user's story idea.
+    def _get_summary_prompt(self) -> str:
+        """Get the summary prompt for the DREAM stage.
 
         Returns:
-            Formatted user message with output instructions.
+            Prompt text for the Summarize phase.
         """
-        return f"""Create a creative vision for this story idea:
-
-{user_prompt}
-
-Call submit_dream() with the artifact data, or output valid YAML with these fields:
-
-type: dream
-version: 1
-genre: <primary genre>
-subgenre: <optional refinement>
-tone:
-  - <tone descriptor>
-  - <tone descriptor>
-audience: <target audience>
-themes:
-  - <thematic element>
-  - <thematic element>
-style_notes: |
-  <writing style guidance>
-scope:
-  target_word_count: <approximate length>
-  estimated_passages: <scene count>
-  branching_depth: <light, moderate, heavy, or extensive>
-content_notes:
-  includes:
-    - <content to include>
-  excludes:
-    - <content to avoid>
-
-Be creative but grounded. Make choices that serve the story."""
+        return (
+            "Summarize the creative vision we've developed. Include the key decisions about:\n"
+            "- Genre and subgenre\n"
+            "- Tone and atmosphere\n"
+            "- Target audience\n"
+            "- Core themes\n"
+            "- Scope and complexity\n"
+            "- Any content notes\n\n"
+            "Be concise but capture the essential creative direction."
+        )
 
     def _validate_dream(self, data: dict[str, Any]) -> ValidationResult:
         """Validate dream artifact data using Pydantic model.
@@ -334,114 +248,6 @@ Be creative but grounded. Make choices that serve the story."""
                 errors=error_details,
                 expected_fields=expected_fields,
             )
-
-    def _parse_response(self, content: str) -> dict[str, Any]:
-        """Parse YAML artifact from LLM response.
-
-        Handles various response formats:
-        - Raw YAML
-        - YAML wrapped in ```yaml``` fences
-        - YAML with leading/trailing text
-
-        Args:
-            content: Raw LLM response content.
-
-        Returns:
-            Parsed artifact dictionary.
-
-        Raises:
-            DreamParseError: If no valid YAML can be extracted.
-        """
-        # Try to extract YAML from markdown fences first
-        fence_pattern = r"```(?:yaml|yml)?\s*\n(.*?)```"
-        fence_match = re.search(fence_pattern, content, re.DOTALL | re.IGNORECASE)
-
-        if fence_match:
-            yaml_content = fence_match.group(1).strip()
-        else:
-            # Try to find YAML-like content (starts with key:)
-            # Look for lines starting with common artifact keys
-            yaml_content = self._extract_yaml_block(content)
-
-        if not yaml_content:
-            raise DreamParseError(
-                "No valid YAML found in response",
-                content,
-            )
-
-        try:
-            data = yaml.safe_load(yaml_content)
-            if not isinstance(data, dict):
-                raise DreamParseError(
-                    f"Expected YAML dict, got {type(data).__name__}",
-                    content,
-                )
-            return data
-        except yaml.YAMLError as e:
-            raise DreamParseError(
-                f"YAML parse error: {e}",
-                content,
-            ) from e
-
-    def _extract_yaml_block(self, content: str) -> str:
-        """Extract YAML block from mixed content.
-
-        Looks for content starting with common artifact keys like
-        'type:', 'genre:', etc. and extracts until end or blank line.
-
-        Args:
-            content: Mixed content that may contain YAML.
-
-        Returns:
-            Extracted YAML string, or empty string if not found.
-        """
-        lines = content.split("\n")
-        yaml_lines: list[str] = []
-        in_yaml = False
-
-        # Common starting keys for dream artifacts
-        start_keys = ("type:", "genre:", "version:", "subgenre:", "tone:")
-
-        for line in lines:
-            stripped = line.strip()
-
-            # Start capturing when we see a known key
-            if not in_yaml and any(stripped.startswith(key) for key in start_keys):
-                in_yaml = True
-
-            if in_yaml:
-                # Stop at blank lines after content, or obvious non-YAML
-                if not stripped and yaml_lines:
-                    # Check if next non-blank line is still YAML-like
-                    continue
-                if stripped.startswith("#") and not yaml_lines:
-                    continue
-                # Pass original line to preserve indentation for continuation check
-                if stripped and not self._is_yaml_line(line):
-                    break
-                yaml_lines.append(line)
-
-        return "\n".join(yaml_lines).strip()
-
-    def _is_yaml_line(self, line: str) -> bool:
-        """Check if a line looks like YAML content.
-
-        Args:
-            line: Line to check (may include leading whitespace).
-
-        Returns:
-            True if line appears to be YAML.
-        """
-        # Continuation: starts with whitespace (check first, before stripping)
-        if line.startswith(" ") or line.startswith("\t"):
-            return True
-        # YAML patterns: key:, - item
-        stripped = line.strip()
-        # Key pattern: word characters followed by colon (not just ":" anywhere)
-        if re.match(r"^\w[\w\s]*:", stripped):
-            return True
-        # List item: dash followed by space
-        return stripped.startswith("- ")
 
 
 # Create singleton instance for registration

--- a/src/questfoundry/tools/__init__.py
+++ b/src/questfoundry/tools/__init__.py
@@ -7,12 +7,14 @@ and research tools for context retrieval.
 
 from questfoundry.tools.base import Tool, ToolCall, ToolDefinition
 from questfoundry.tools.finalization import (
+    ReadyToSummarizeTool,
     SubmitBrainstormTool,
     SubmitDreamTool,
     get_finalization_tool,
 )
 
 __all__ = [
+    "ReadyToSummarizeTool",
     "SubmitBrainstormTool",
     "SubmitDreamTool",
     "Tool",

--- a/src/questfoundry/tools/finalization.py
+++ b/src/questfoundry/tools/finalization.py
@@ -58,6 +58,39 @@ class SubmitDreamTool:
         return "Creative vision submitted for validation."
 
 
+class ReadyToSummarizeTool:
+    """Signal tool for LLM to indicate discussion is complete.
+
+    When called during the Discuss phase, signals that the LLM believes
+    the conversation has reached a good stopping point and is ready
+    to move to the Summarize phase.
+
+    This is a no-op tool - it doesn't perform any action, just signals
+    intent to transition phases.
+    """
+
+    @property
+    def definition(self) -> ToolDefinition:
+        """Return the tool definition for LLM binding."""
+        return ToolDefinition(
+            name="ready_to_summarize",
+            description=(
+                "Signal that the discussion is complete and you are ready to "
+                "summarize the creative direction. Call this when you have "
+                "gathered enough information to proceed with summarizing."
+            ),
+            parameters={"type": "object", "properties": {}},
+        )
+
+    def execute(self, arguments: dict[str, Any]) -> str:  # noqa: ARG002
+        """Execute the signal tool.
+
+        Returns:
+            JSON confirmation of the transition signal.
+        """
+        return '{"result": "proceed"}'
+
+
 class SubmitBrainstormTool:
     """Tool for finalizing BRAINSTORM stage output.
 

--- a/tests/unit/test_corpus_tools.py
+++ b/tests/unit/test_corpus_tools.py
@@ -136,7 +136,9 @@ class TestSearchCorpusTool:
         mock_corpus.search.assert_called_once_with("mystery", cluster="genre-conventions", limit=3)
 
     def test_execute_no_results(self) -> None:
-        """Should return helpful message when no results found."""
+        """Should return structured JSON with no_results status (ADR-008)."""
+        import json
+
         from questfoundry.tools.research.corpus_tools import _get_corpus
 
         _get_corpus.cache_clear()
@@ -160,8 +162,12 @@ class TestSearchCorpusTool:
             _get_corpus.cache_clear()
             result = tool.execute({"query": "xyz123"})
 
-        assert "no craft guidance found" in result.lower()
-        assert "xyz123" in result
+        # ADR-008: Structured JSON response
+        data = json.loads(result)
+        assert data["result"] == "no_results"
+        assert data["query"] == "xyz123"
+        assert "action" in data
+        assert "proceed" in data["action"].lower()
 
 
 class TestGetDocumentTool:

--- a/tests/unit/test_corpus_tools.py
+++ b/tests/unit/test_corpus_tools.py
@@ -89,12 +89,17 @@ class TestSearchCorpusTool:
         mock_corpus = MagicMock()
         mock_corpus.search.return_value = mock_results
 
-        # Create mock ifcraftcorpus module
+        # Create mock ifcraftcorpus module and providers submodule
+        mock_providers = MagicMock()
+        mock_providers.get_embedding_provider.return_value = MagicMock()
         mock_module = MagicMock()
         mock_module.Corpus.return_value = mock_corpus
 
         with (
-            patch.dict(sys.modules, {"ifcraftcorpus": mock_module}),
+            patch.dict(
+                sys.modules,
+                {"ifcraftcorpus": mock_module, "ifcraftcorpus.providers": mock_providers},
+            ),
             patch(
                 "questfoundry.tools.research.corpus_tools._corpus_available",
                 return_value=True,
@@ -106,7 +111,7 @@ class TestSearchCorpusTool:
         assert "dialogue_craft" in result
         assert "0.85" in result
         assert "subtext" in result.lower()
-        mock_corpus.search.assert_called_once_with("dialogue", cluster=None, limit=5)
+        mock_corpus.search.assert_called_once_with("dialogue", cluster=None, limit=5, mode="hybrid")
 
     def test_execute_with_cluster_filter(self) -> None:
         """Should pass cluster filter to search."""
@@ -119,12 +124,17 @@ class TestSearchCorpusTool:
         mock_corpus = MagicMock()
         mock_corpus.search.return_value = []
 
-        # Create mock ifcraftcorpus module
+        # Create mock ifcraftcorpus module and providers submodule
+        mock_providers = MagicMock()
+        mock_providers.get_embedding_provider.return_value = MagicMock()
         mock_module = MagicMock()
         mock_module.Corpus.return_value = mock_corpus
 
         with (
-            patch.dict(sys.modules, {"ifcraftcorpus": mock_module}),
+            patch.dict(
+                sys.modules,
+                {"ifcraftcorpus": mock_module, "ifcraftcorpus.providers": mock_providers},
+            ),
             patch(
                 "questfoundry.tools.research.corpus_tools._corpus_available",
                 return_value=True,
@@ -133,7 +143,9 @@ class TestSearchCorpusTool:
             _get_corpus.cache_clear()
             tool.execute({"query": "mystery", "cluster": "genre-conventions", "limit": 3})
 
-        mock_corpus.search.assert_called_once_with("mystery", cluster="genre-conventions", limit=3)
+        mock_corpus.search.assert_called_once_with(
+            "mystery", cluster="genre-conventions", limit=3, mode="hybrid"
+        )
 
     def test_execute_no_results(self) -> None:
         """Should return structured JSON with no_results status (ADR-008)."""
@@ -148,12 +160,17 @@ class TestSearchCorpusTool:
         mock_corpus = MagicMock()
         mock_corpus.search.return_value = []
 
-        # Create mock ifcraftcorpus module
+        # Create mock ifcraftcorpus module and providers submodule
+        mock_providers = MagicMock()
+        mock_providers.get_embedding_provider.return_value = MagicMock()
         mock_module = MagicMock()
         mock_module.Corpus.return_value = mock_corpus
 
         with (
-            patch.dict(sys.modules, {"ifcraftcorpus": mock_module}),
+            patch.dict(
+                sys.modules,
+                {"ifcraftcorpus": mock_module, "ifcraftcorpus.providers": mock_providers},
+            ),
             patch(
                 "questfoundry.tools.research.corpus_tools._corpus_available",
                 return_value=True,

--- a/tests/unit/test_web_tools.py
+++ b/tests/unit/test_web_tools.py
@@ -114,7 +114,9 @@ class TestWebSearchTool:
         assert "comprehensive guide" in result
 
     def test_execute_no_results(self) -> None:
-        """Should return helpful message when no results found."""
+        """Should return structured JSON with no_results status (ADR-008)."""
+        import json
+
         tool = WebSearchTool()
 
         # Create mock pvlwebtools module
@@ -135,7 +137,12 @@ class TestWebSearchTool:
         ):
             result = tool.execute({"query": "xyz123unique"})
 
-        assert "no results" in result.lower()
+        # ADR-008: Structured JSON response
+        data = json.loads(result)
+        assert data["result"] == "no_results"
+        assert data["query"] == "xyz123unique"
+        assert "action" in data
+        assert "proceed" in data["action"].lower()
 
     def test_execute_handles_exception(self) -> None:
         """Should return error message when search fails."""

--- a/uv.lock
+++ b/uv.lock
@@ -359,9 +359,19 @@ wheels = [
 [[package]]
 name = "ifcraftcorpus"
 version = "1.2.0"
-source = { git = "https://github.com/pvliesdonk/if-craft-corpus.git#e24a717e0ca91f3aead7a343f86944497f260354" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyyaml" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c6/35/344998f1e1dac9326ae77f023577014a83ac52a6e166f89b27c4cc177210/ifcraftcorpus-1.2.0.tar.gz", hash = "sha256:3a3405763108b326ff6852aeb014a3e63c069237c658a23cd193d8030d8baf66", size = 214803, upload-time = "2026-01-05T12:44:25.596Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9d/e8/a62c358bce6833fa1108688f9644287423ba336ad6c7fffb3a17fa073555/ifcraftcorpus-1.2.0-py3-none-any.whl", hash = "sha256:b43678785fe8e6e016df9c538ad267a943c0801f634bec1e2f1f0510cc71523d", size = 269688, upload-time = "2026-01-05T12:44:23.859Z" },
+]
+
+[package.optional-dependencies]
+embeddings-api = [
+    { name = "httpx" },
+    { name = "numpy" },
 ]
 
 [[package]]
@@ -733,6 +743,85 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/24/bf/d1bda4f6168e0b2e9e5958945e01910052158313224ada5ce1fb2e1113b8/nodeenv-1.10.0.tar.gz", hash = "sha256:996c191ad80897d076bdfba80a41994c2b47c68e224c542b48feba42ba00f8bb", size = 55611, upload-time = "2025-12-20T14:08:54.006Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/88/b2/d0896bdcdc8d28a7fc5717c305f1a861c26e18c05047949fb371034d98bd/nodeenv-1.10.0-py2.py3-none-any.whl", hash = "sha256:5bb13e3eed2923615535339b3c620e76779af4cb4c6a90deccc9e36b274d3827", size = 23438, upload-time = "2025-12-20T14:08:52.782Z" },
+]
+
+[[package]]
+name = "numpy"
+version = "2.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a4/7a/6a3d14e205d292b738db449d0de649b373a59edb0d0b4493821d0a3e8718/numpy-2.4.0.tar.gz", hash = "sha256:6e504f7b16118198f138ef31ba24d985b124c2c469fe8467007cf30fd992f934", size = 20685720, upload-time = "2025-12-20T16:18:19.023Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/26/7e/7bae7cbcc2f8132271967aa03e03954fc1e48aa1f3bf32b29ca95fbef352/numpy-2.4.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:316b2f2584682318539f0bcaca5a496ce9ca78c88066579ebd11fd06f8e4741e", size = 16940166, upload-time = "2025-12-20T16:15:43.434Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/27/6c13f5b46776d6246ec884ac5817452672156a506d08a1f2abb39961930a/numpy-2.4.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:a2718c1de8504121714234b6f8241d0019450353276c88b9453c9c3d92e101db", size = 12641781, upload-time = "2025-12-20T16:15:45.701Z" },
+    { url = "https://files.pythonhosted.org/packages/14/1c/83b4998d4860d15283241d9e5215f28b40ac31f497c04b12fa7f428ff370/numpy-2.4.0-cp311-cp311-macosx_14_0_arm64.whl", hash = "sha256:21555da4ec4a0c942520ead42c3b0dc9477441e085c42b0fbdd6a084869a6f6b", size = 5470247, upload-time = "2025-12-20T16:15:47.943Z" },
+    { url = "https://files.pythonhosted.org/packages/54/08/cbce72c835d937795571b0464b52069f869c9e78b0c076d416c5269d2718/numpy-2.4.0-cp311-cp311-macosx_14_0_x86_64.whl", hash = "sha256:413aa561266a4be2d06cd2b9665e89d9f54c543f418773076a76adcf2af08bc7", size = 6799807, upload-time = "2025-12-20T16:15:49.795Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/be/2e647961cd8c980591d75cdcd9e8f647d69fbe05e2a25613dc0a2ea5fb1a/numpy-2.4.0-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0feafc9e03128074689183031181fac0897ff169692d8492066e949041096548", size = 14701992, upload-time = "2025-12-20T16:15:51.615Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/fb/e1652fb8b6fd91ce6ed429143fe2e01ce714711e03e5b762615e7b36172c/numpy-2.4.0-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a8fdfed3deaf1928fb7667d96e0567cdf58c2b370ea2ee7e586aa383ec2cb346", size = 16646871, upload-time = "2025-12-20T16:15:54.129Z" },
+    { url = "https://files.pythonhosted.org/packages/62/23/d841207e63c4322842f7cd042ae981cffe715c73376dcad8235fb31debf1/numpy-2.4.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:e06a922a469cae9a57100864caf4f8a97a1026513793969f8ba5b63137a35d25", size = 16487190, upload-time = "2025-12-20T16:15:56.147Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/a0/6a842c8421ebfdec0a230e65f61e0dabda6edbef443d999d79b87c273965/numpy-2.4.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:927ccf5cd17c48f801f4ed43a7e5673a2724bd2171460be3e3894e6e332ef83a", size = 18580762, upload-time = "2025-12-20T16:15:58.524Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/d1/c79e0046641186f2134dde05e6181825b911f8bdcef31b19ddd16e232847/numpy-2.4.0-cp311-cp311-win32.whl", hash = "sha256:882567b7ae57c1b1a0250208cc21a7976d8cbcc49d5a322e607e6f09c9e0bd53", size = 6233359, upload-time = "2025-12-20T16:16:00.938Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/f0/74965001d231f28184d6305b8cdc1b6fcd4bf23033f6cb039cfe76c9fca7/numpy-2.4.0-cp311-cp311-win_amd64.whl", hash = "sha256:8b986403023c8f3bf8f487c2e6186afda156174d31c175f747d8934dfddf3479", size = 12601132, upload-time = "2025-12-20T16:16:02.484Z" },
+    { url = "https://files.pythonhosted.org/packages/65/32/55408d0f46dfebce38017f5bd931affa7256ad6beac1a92a012e1fbc67a7/numpy-2.4.0-cp311-cp311-win_arm64.whl", hash = "sha256:3f3096405acc48887458bbf9f6814d43785ac7ba2a57ea6442b581dedbc60ce6", size = 10573977, upload-time = "2025-12-20T16:16:04.77Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/ff/f6400ffec95de41c74b8e73df32e3fff1830633193a7b1e409be7fb1bb8c/numpy-2.4.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:2a8b6bb8369abefb8bd1801b054ad50e02b3275c8614dc6e5b0373c305291037", size = 16653117, upload-time = "2025-12-20T16:16:06.709Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/28/6c23e97450035072e8d830a3c411bf1abd1f42c611ff9d29e3d8f55c6252/numpy-2.4.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:2e284ca13d5a8367e43734148622caf0b261b275673823593e3e3634a6490f83", size = 12369711, upload-time = "2025-12-20T16:16:08.758Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/af/acbef97b630ab1bb45e6a7d01d1452e4251aa88ce680ac36e56c272120ec/numpy-2.4.0-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:49ff32b09f5aa0cd30a20c2b39db3e669c845589f2b7fc910365210887e39344", size = 5198355, upload-time = "2025-12-20T16:16:10.902Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/c8/4e0d436b66b826f2e53330adaa6311f5cac9871a5b5c31ad773b27f25a74/numpy-2.4.0-cp312-cp312-macosx_14_0_x86_64.whl", hash = "sha256:36cbfb13c152b1c7c184ddac43765db8ad672567e7bafff2cc755a09917ed2e6", size = 6545298, upload-time = "2025-12-20T16:16:12.607Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/27/e1f5d144ab54eac34875e79037011d511ac57b21b220063310cb96c80fbc/numpy-2.4.0-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:35ddc8f4914466e6fc954c76527aa91aa763682a4f6d73249ef20b418fe6effb", size = 14398387, upload-time = "2025-12-20T16:16:14.257Z" },
+    { url = "https://files.pythonhosted.org/packages/67/64/4cb909dd5ab09a9a5d086eff9586e69e827b88a5585517386879474f4cf7/numpy-2.4.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:dc578891de1db95b2a35001b695451767b580bb45753717498213c5ff3c41d63", size = 16363091, upload-time = "2025-12-20T16:16:17.32Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/9c/8efe24577523ec6809261859737cf117b0eb6fdb655abdfdc81b2e468ce4/numpy-2.4.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:98e81648e0b36e325ab67e46b5400a7a6d4a22b8a7c8e8bbfe20e7db7906bf95", size = 16176394, upload-time = "2025-12-20T16:16:19.524Z" },
+    { url = "https://files.pythonhosted.org/packages/61/f0/1687441ece7b47a62e45a1f82015352c240765c707928edd8aef875d5951/numpy-2.4.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:d57b5046c120561ba8fa8e4030fbb8b822f3063910fa901ffadf16e2b7128ad6", size = 18287378, upload-time = "2025-12-20T16:16:22.866Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/6f/f868765d44e6fc466467ed810ba9d8d6db1add7d4a748abfa2a4c99a3194/numpy-2.4.0-cp312-cp312-win32.whl", hash = "sha256:92190db305a6f48734d3982f2c60fa30d6b5ee9bff10f2887b930d7b40119f4c", size = 5955432, upload-time = "2025-12-20T16:16:25.06Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/b5/94c1e79fcbab38d1ca15e13777477b2914dd2d559b410f96949d6637b085/numpy-2.4.0-cp312-cp312-win_amd64.whl", hash = "sha256:680060061adb2d74ce352628cb798cfdec399068aa7f07ba9fb818b2b3305f98", size = 12306201, upload-time = "2025-12-20T16:16:26.979Z" },
+    { url = "https://files.pythonhosted.org/packages/70/09/c39dadf0b13bb0768cd29d6a3aaff1fb7c6905ac40e9aaeca26b1c086e06/numpy-2.4.0-cp312-cp312-win_arm64.whl", hash = "sha256:39699233bc72dd482da1415dcb06076e32f60eddc796a796c5fb6c5efce94667", size = 10308234, upload-time = "2025-12-20T16:16:29.417Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/0d/853fd96372eda07c824d24adf02e8bc92bb3731b43a9b2a39161c3667cc4/numpy-2.4.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:a152d86a3ae00ba5f47b3acf3b827509fd0b6cb7d3259665e63dafbad22a75ea", size = 16649088, upload-time = "2025-12-20T16:16:31.421Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/37/cc636f1f2a9f585434e20a3e6e63422f70bfe4f7f6698e941db52ea1ac9a/numpy-2.4.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:39b19251dec4de8ff8496cd0806cbe27bf0684f765abb1f4809554de93785f2d", size = 12364065, upload-time = "2025-12-20T16:16:33.491Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/69/0b78f37ca3690969beee54103ce5f6021709134e8020767e93ba691a72f1/numpy-2.4.0-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:009bd0ea12d3c784b6639a8457537016ce5172109e585338e11334f6a7bb88ee", size = 5192640, upload-time = "2025-12-20T16:16:35.636Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/2a/08569f8252abf590294dbb09a430543ec8f8cc710383abfb3e75cc73aeda/numpy-2.4.0-cp313-cp313-macosx_14_0_x86_64.whl", hash = "sha256:5fe44e277225fd3dff6882d86d3d447205d43532c3627313d17e754fb3905a0e", size = 6541556, upload-time = "2025-12-20T16:16:37.276Z" },
+    { url = "https://files.pythonhosted.org/packages/93/e9/a949885a4e177493d61519377952186b6cbfdf1d6002764c664ba28349b5/numpy-2.4.0-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f935c4493eda9069851058fa0d9e39dbf6286be690066509305e52912714dbb2", size = 14396562, upload-time = "2025-12-20T16:16:38.953Z" },
+    { url = "https://files.pythonhosted.org/packages/99/98/9d4ad53b0e9ef901c2ef1d550d2136f5ac42d3fd2988390a6def32e23e48/numpy-2.4.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8cfa5f29a695cb7438965e6c3e8d06e0416060cf0d709c1b1c1653a939bf5c2a", size = 16351719, upload-time = "2025-12-20T16:16:41.503Z" },
+    { url = "https://files.pythonhosted.org/packages/28/de/5f3711a38341d6e8dd619f6353251a0cdd07f3d6d101a8fd46f4ef87f895/numpy-2.4.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:ba0cb30acd3ef11c94dc27fbfba68940652492bc107075e7ffe23057f9425681", size = 16176053, upload-time = "2025-12-20T16:16:44.552Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/5b/2a3753dc43916501b4183532e7ace862e13211042bceafa253afb5c71272/numpy-2.4.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:60e8c196cd82cbbd4f130b5290007e13e6de3eca79f0d4d38014769d96a7c475", size = 18277859, upload-time = "2025-12-20T16:16:47.174Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/c5/a18bcdd07a941db3076ef489d036ab16d2bfc2eae0cf27e5a26e29189434/numpy-2.4.0-cp313-cp313-win32.whl", hash = "sha256:5f48cb3e88fbc294dc90e215d86fbaf1c852c63dbdb6c3a3e63f45c4b57f7344", size = 5953849, upload-time = "2025-12-20T16:16:49.554Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/f1/719010ff8061da6e8a26e1980cf090412d4f5f8060b31f0c45d77dd67a01/numpy-2.4.0-cp313-cp313-win_amd64.whl", hash = "sha256:a899699294f28f7be8992853c0c60741f16ff199205e2e6cdca155762cbaa59d", size = 12302840, upload-time = "2025-12-20T16:16:51.227Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/5a/b3d259083ed8b4d335270c76966cb6cf14a5d1b69e1a608994ac57a659e6/numpy-2.4.0-cp313-cp313-win_arm64.whl", hash = "sha256:9198f447e1dc5647d07c9a6bbe2063cc0132728cc7175b39dbc796da5b54920d", size = 10308509, upload-time = "2025-12-20T16:16:53.313Z" },
+    { url = "https://files.pythonhosted.org/packages/31/01/95edcffd1bb6c0633df4e808130545c4f07383ab629ac7e316fb44fff677/numpy-2.4.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:74623f2ab5cc3f7c886add4f735d1031a1d2be4a4ae63c0546cfd74e7a31ddf6", size = 12491815, upload-time = "2025-12-20T16:16:55.496Z" },
+    { url = "https://files.pythonhosted.org/packages/59/ea/5644b8baa92cc1c7163b4b4458c8679852733fa74ca49c942cfa82ded4e0/numpy-2.4.0-cp313-cp313t-macosx_14_0_arm64.whl", hash = "sha256:0804a8e4ab070d1d35496e65ffd3cf8114c136a2b81f61dfab0de4b218aacfd5", size = 5320321, upload-time = "2025-12-20T16:16:57.468Z" },
+    { url = "https://files.pythonhosted.org/packages/26/4e/e10938106d70bc21319bd6a86ae726da37edc802ce35a3a71ecdf1fdfe7f/numpy-2.4.0-cp313-cp313t-macosx_14_0_x86_64.whl", hash = "sha256:02a2038eb27f9443a8b266a66911e926566b5a6ffd1a689b588f7f35b81e7dc3", size = 6641635, upload-time = "2025-12-20T16:16:59.379Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/8d/a8828e3eaf5c0b4ab116924df82f24ce3416fa38d0674d8f708ddc6c8aac/numpy-2.4.0-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1889b3a3f47a7b5bee16bc25a2145bd7cb91897f815ce3499db64c7458b6d91d", size = 14456053, upload-time = "2025-12-20T16:17:01.768Z" },
+    { url = "https://files.pythonhosted.org/packages/68/a1/17d97609d87d4520aa5ae2dcfb32305654550ac6a35effb946d303e594ce/numpy-2.4.0-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:85eef4cb5625c47ee6425c58a3502555e10f45ee973da878ac8248ad58c136f3", size = 16401702, upload-time = "2025-12-20T16:17:04.235Z" },
+    { url = "https://files.pythonhosted.org/packages/18/32/0f13c1b2d22bea1118356b8b963195446f3af124ed7a5adfa8fdecb1b6ca/numpy-2.4.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:6dc8b7e2f4eb184b37655195f421836cfae6f58197b67e3ffc501f1333d993fa", size = 16242493, upload-time = "2025-12-20T16:17:06.856Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/23/48f21e3d309fbc137c068a1475358cbd3a901b3987dcfc97a029ab3068e2/numpy-2.4.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:44aba2f0cafd287871a495fb3163408b0bd25bbce135c6f621534a07f4f7875c", size = 18324222, upload-time = "2025-12-20T16:17:09.392Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/52/41f3d71296a3dcaa4f456aaa3c6fc8e745b43d0552b6bde56571bb4b4a0f/numpy-2.4.0-cp313-cp313t-win32.whl", hash = "sha256:20c115517513831860c573996e395707aa9fb691eb179200125c250e895fcd93", size = 6076216, upload-time = "2025-12-20T16:17:11.437Z" },
+    { url = "https://files.pythonhosted.org/packages/35/ff/46fbfe60ab0710d2a2b16995f708750307d30eccbb4c38371ea9e986866e/numpy-2.4.0-cp313-cp313t-win_amd64.whl", hash = "sha256:b48e35f4ab6f6a7597c46e301126ceba4c44cd3280e3750f85db48b082624fa4", size = 12444263, upload-time = "2025-12-20T16:17:13.182Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/e3/9189ab319c01d2ed556c932ccf55064c5d75bb5850d1df7a482ce0badead/numpy-2.4.0-cp313-cp313t-win_arm64.whl", hash = "sha256:4d1cfce39e511069b11e67cd0bd78ceff31443b7c9e5c04db73c7a19f572967c", size = 10378265, upload-time = "2025-12-20T16:17:15.211Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/ed/52eac27de39d5e5a6c9aadabe672bc06f55e24a3d9010cd1183948055d76/numpy-2.4.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:c95eb6db2884917d86cde0b4d4cf31adf485c8ec36bf8696dd66fa70de96f36b", size = 16647476, upload-time = "2025-12-20T16:17:17.671Z" },
+    { url = "https://files.pythonhosted.org/packages/77/c0/990ce1b7fcd4e09aeaa574e2a0a839589e4b08b2ca68070f1acb1fea6736/numpy-2.4.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:65167da969cd1ec3a1df31cb221ca3a19a8aaa25370ecb17d428415e93c1935e", size = 12374563, upload-time = "2025-12-20T16:17:20.216Z" },
+    { url = "https://files.pythonhosted.org/packages/37/7c/8c5e389c6ae8f5fd2277a988600d79e9625db3fff011a2d87ac80b881a4c/numpy-2.4.0-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:3de19cfecd1465d0dcf8a5b5ea8b3155b42ed0b639dba4b71e323d74f2a3be5e", size = 5203107, upload-time = "2025-12-20T16:17:22.47Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/94/ca5b3bd6a8a70a5eec9a0b8dd7f980c1eff4b8a54970a9a7fef248ef564f/numpy-2.4.0-cp314-cp314-macosx_14_0_x86_64.whl", hash = "sha256:6c05483c3136ac4c91b4e81903cb53a8707d316f488124d0398499a4f8e8ef51", size = 6538067, upload-time = "2025-12-20T16:17:24.001Z" },
+    { url = "https://files.pythonhosted.org/packages/79/43/993eb7bb5be6761dde2b3a3a594d689cec83398e3f58f4758010f3b85727/numpy-2.4.0-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:36667db4d6c1cea79c8930ab72fadfb4060feb4bfe724141cd4bd064d2e5f8ce", size = 14411926, upload-time = "2025-12-20T16:17:25.822Z" },
+    { url = "https://files.pythonhosted.org/packages/03/75/d4c43b61de473912496317a854dac54f1efec3eeb158438da6884b70bb90/numpy-2.4.0-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9a818668b674047fd88c4cddada7ab8f1c298812783e8328e956b78dc4807f9f", size = 16354295, upload-time = "2025-12-20T16:17:28.308Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/0a/b54615b47ee8736a6461a4bb6749128dd3435c5a759d5663f11f0e9af4ac/numpy-2.4.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:1ee32359fb7543b7b7bd0b2f46294db27e29e7bbdf70541e81b190836cd83ded", size = 16190242, upload-time = "2025-12-20T16:17:30.993Z" },
+    { url = "https://files.pythonhosted.org/packages/98/ce/ea207769aacad6246525ec6c6bbd66a2bf56c72443dc10e2f90feed29290/numpy-2.4.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:e493962256a38f58283de033d8af176c5c91c084ea30f15834f7545451c42059", size = 18280875, upload-time = "2025-12-20T16:17:33.327Z" },
+    { url = "https://files.pythonhosted.org/packages/17/ef/ec409437aa962ea372ed601c519a2b141701683ff028f894b7466f0ab42b/numpy-2.4.0-cp314-cp314-win32.whl", hash = "sha256:6bbaebf0d11567fa8926215ae731e1d58e6ec28a8a25235b8a47405d301332db", size = 6002530, upload-time = "2025-12-20T16:17:35.729Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/4a/5cb94c787a3ed1ac65e1271b968686521169a7b3ec0b6544bb3ca32960b0/numpy-2.4.0-cp314-cp314-win_amd64.whl", hash = "sha256:3d857f55e7fdf7c38ab96c4558c95b97d1c685be6b05c249f5fdafcbd6f9899e", size = 12435890, upload-time = "2025-12-20T16:17:37.599Z" },
+    { url = "https://files.pythonhosted.org/packages/48/a0/04b89db963af9de1104975e2544f30de89adbf75b9e75f7dd2599be12c79/numpy-2.4.0-cp314-cp314-win_arm64.whl", hash = "sha256:bb50ce5fb202a26fd5404620e7ef820ad1ab3558b444cb0b55beb7ef66cd2d63", size = 10591892, upload-time = "2025-12-20T16:17:39.649Z" },
+    { url = "https://files.pythonhosted.org/packages/53/e5/d74b5ccf6712c06c7a545025a6a71bfa03bdc7e0568b405b0d655232fd92/numpy-2.4.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:355354388cba60f2132df297e2d53053d4063f79077b67b481d21276d61fc4df", size = 12494312, upload-time = "2025-12-20T16:17:41.714Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/08/3ca9cc2ddf54dfee7ae9a6479c071092a228c68aef08252aa08dac2af002/numpy-2.4.0-cp314-cp314t-macosx_14_0_arm64.whl", hash = "sha256:1d8f9fde5f6dc1b6fc34df8162f3b3079365468703fee7f31d4e0cc8c63baed9", size = 5322862, upload-time = "2025-12-20T16:17:44.145Z" },
+    { url = "https://files.pythonhosted.org/packages/87/74/0bb63a68394c0c1e52670cfff2e309afa41edbe11b3327d9af29e4383f34/numpy-2.4.0-cp314-cp314t-macosx_14_0_x86_64.whl", hash = "sha256:e0434aa22c821f44eeb4c650b81c7fbdd8c0122c6c4b5a576a76d5a35625ecd9", size = 6644986, upload-time = "2025-12-20T16:17:46.203Z" },
+    { url = "https://files.pythonhosted.org/packages/06/8f/9264d9bdbcf8236af2823623fe2f3981d740fc3461e2787e231d97c38c28/numpy-2.4.0-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:40483b2f2d3ba7aad426443767ff5632ec3156ef09742b96913787d13c336471", size = 14457958, upload-time = "2025-12-20T16:17:48.017Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/d9/f9a69ae564bbc7236a35aa883319364ef5fd41f72aa320cc1cbe66148fe2/numpy-2.4.0-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d9e6a7664ddd9746e20b7325351fe1a8408d0a2bf9c63b5e898290ddc8f09544", size = 16398394, upload-time = "2025-12-20T16:17:50.409Z" },
+    { url = "https://files.pythonhosted.org/packages/34/c7/39241501408dde7f885d241a98caba5421061a2c6d2b2197ac5e3aa842d8/numpy-2.4.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:ecb0019d44f4cdb50b676c5d0cb4b1eae8e15d1ed3d3e6639f986fc92b2ec52c", size = 16241044, upload-time = "2025-12-20T16:17:52.661Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/95/cae7effd90e065a95e59fe710eeee05d7328ed169776dfdd9f789e032125/numpy-2.4.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:d0ffd9e2e4441c96a9c91ec1783285d80bf835b677853fc2770a89d50c1e48ac", size = 18321772, upload-time = "2025-12-20T16:17:54.947Z" },
+    { url = "https://files.pythonhosted.org/packages/96/df/3c6c279accd2bfb968a76298e5b276310bd55d243df4fa8ac5816d79347d/numpy-2.4.0-cp314-cp314t-win32.whl", hash = "sha256:77f0d13fa87036d7553bf81f0e1fe3ce68d14c9976c9851744e4d3e91127e95f", size = 6148320, upload-time = "2025-12-20T16:17:57.249Z" },
+    { url = "https://files.pythonhosted.org/packages/92/8d/f23033cce252e7a75cae853d17f582e86534c46404dea1c8ee094a9d6d84/numpy-2.4.0-cp314-cp314t-win_amd64.whl", hash = "sha256:b1f5b45829ac1848893f0ddf5cb326110604d6df96cdc255b0bf9edd154104d4", size = 12623460, upload-time = "2025-12-20T16:17:58.963Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/4f/1f8475907d1a7c4ef9020edf7f39ea2422ec896849245f00688e4b268a71/numpy-2.4.0-cp314-cp314t-win_arm64.whl", hash = "sha256:23a3e9d1a6f360267e8fbb38ba5db355a6a7e9be71d7fce7ab3125e88bb646c8", size = 10661799, upload-time = "2025-12-20T16:18:01.078Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/ef/088e7c7342f300aaf3ee5f2c821c4b9996a1bef2aaf6a49cc8ab4883758e/numpy-2.4.0-pp311-pypy311_pp73-macosx_10_15_x86_64.whl", hash = "sha256:b54c83f1c0c0f1d748dca0af516062b8829d53d1f0c402be24b4257a9c48ada6", size = 16819003, upload-time = "2025-12-20T16:18:03.41Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/ce/a53017b5443b4b84517182d463fc7bcc2adb4faa8b20813f8e5f5aeb5faa/numpy-2.4.0-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:aabb081ca0ec5d39591fc33018cd4b3f96e1a2dd6756282029986d00a785fba4", size = 12567105, upload-time = "2025-12-20T16:18:05.594Z" },
+    { url = "https://files.pythonhosted.org/packages/77/58/5ff91b161f2ec650c88a626c3905d938c89aaadabd0431e6d9c1330c83e2/numpy-2.4.0-pp311-pypy311_pp73-macosx_14_0_arm64.whl", hash = "sha256:8eafe7c36c8430b7794edeab3087dec7bf31d634d92f2af9949434b9d1964cba", size = 5395590, upload-time = "2025-12-20T16:18:08.031Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/4e/f1a084106df8c2df8132fc437e56987308e0524836aa7733721c8429d4fe/numpy-2.4.0-pp311-pypy311_pp73-macosx_14_0_x86_64.whl", hash = "sha256:2f585f52b2baf07ff3356158d9268ea095e221371f1074fadea2f42544d58b4d", size = 6709947, upload-time = "2025-12-20T16:18:09.836Z" },
+    { url = "https://files.pythonhosted.org/packages/63/09/3d8aeb809c0332c3f642da812ac2e3d74fc9252b3021f8c30c82e99e3f3d/numpy-2.4.0-pp311-pypy311_pp73-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:32ed06d0fe9cae27d8fb5f400c63ccee72370599c75e683a6358dd3a4fb50aaf", size = 14535119, upload-time = "2025-12-20T16:18:12.105Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/7f/68f0fc43a2cbdc6bb239160c754d87c922f60fbaa0fa3cd3d312b8a7f5ee/numpy-2.4.0-pp311-pypy311_pp73-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:57c540ed8fb1f05cb997c6761cd56db72395b0d6985e90571ff660452ade4f98", size = 16475815, upload-time = "2025-12-20T16:18:14.433Z" },
+    { url = "https://files.pythonhosted.org/packages/11/73/edeacba3167b1ca66d51b1a5a14697c2c40098b5ffa01811c67b1785a5ab/numpy-2.4.0-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:a39fb973a726e63223287adc6dafe444ce75af952d711e400f3bf2b36ef55a7b", size = 12489376, upload-time = "2025-12-20T16:18:16.524Z" },
 ]
 
 [[package]]
@@ -1165,11 +1254,11 @@ openai = [
     { name = "langchain-openai" },
 ]
 research = [
-    { name = "ifcraftcorpus" },
+    { name = "ifcraftcorpus", extra = ["embeddings-api"] },
     { name = "pvl-webtools" },
 ]
 research-corpus = [
-    { name = "ifcraftcorpus" },
+    { name = "ifcraftcorpus", extra = ["embeddings-api"] },
 ]
 research-web = [
     { name = "pvl-webtools" },
@@ -1192,8 +1281,8 @@ dev = [
 requires-dist = [
     { name = "graphviz", marker = "extra == 'viz'", specifier = ">=0.20" },
     { name = "httpx", specifier = ">=0.27" },
-    { name = "ifcraftcorpus", marker = "extra == 'research'", git = "https://github.com/pvliesdonk/if-craft-corpus.git" },
-    { name = "ifcraftcorpus", marker = "extra == 'research-corpus'", git = "https://github.com/pvliesdonk/if-craft-corpus.git" },
+    { name = "ifcraftcorpus", extras = ["embeddings-api"], marker = "extra == 'research'" },
+    { name = "ifcraftcorpus", extras = ["embeddings-api"], marker = "extra == 'research-corpus'" },
     { name = "jsonschema", specifier = ">=4.0" },
     { name = "langchain-anthropic", marker = "extra == 'all-providers'", specifier = ">=0.3" },
     { name = "langchain-anthropic", marker = "extra == 'anthropic'", specifier = ">=0.3" },


### PR DESCRIPTION
## Problem

The current implementation has two separate code paths in DreamStage:
- `_execute_direct()` - single LLM call, YAML fallback, only finalization tool
- `_execute_interactive()` - conversation loop with all tools

This violates the unified stage execution architecture and causes maintenance issues (e.g., research tools only added to interactive path).

## Changes

Implements the unified 3-phase pattern: **Discuss → Summarize → Serialize**

### ConversationRunner
- Refactored to use 3 distinct phase methods (`_discuss_phase`, `_summarize_phase`, `_serialize_phase`)
- Tool gating per phase:
  - Discuss: research tools + `ready_to_summarize` signal tool
  - Summarize: no tools (generates compact summary)
  - Serialize: finalization tool only with `tool_choice=required`
- User `/done` command transitions from Discuss to Summarize
- LLM `ready_to_summarize()` tool call also transitions phases
- Tool calls in Discuss phase loop back without incrementing turn count

### DreamStage
- Removed `_execute_direct()` and `_execute_interactive()` methods
- Removed YAML parsing fallback (`_parse_response`, `_extract_yaml_block`, `_is_yaml_line`)
- Removed `DreamParseError` exception (no longer needed)
- Single unified `execute()` method using new ConversationRunner API

### New Tools
- `ReadyToSummarizeTool` - signal tool for LLM to indicate discussion complete

### Mode Configuration
| Mode | max_discuss_turns | user_input_fn | Behavior |
|------|-------------------|---------------|----------|
| Direct | 1 | None | Single discuss turn, then auto-proceed |
| Interactive | 10 (default) | Provided | Multi-turn discussion with user |

## Not Included / Future PRs

- No changes to prompt templates (using existing mode_instructions/mode_reminder variables)
- No changes to other stages (BRAINSTORM, SEED, etc.)

## Test Plan

- [x] All 376 tests pass (`uv run pytest`)
- [x] Lint checks pass (`uv run ruff check`)
- [x] Type checks pass (`uv run mypy src/`)
- [x] Updated tests for new 3-phase ConversationRunner API
- [x] Updated tests for unified DreamStage.execute()

## Risk / Rollback

- **Breaking change**: `DreamParseError` removed from public API
- **Breaking change**: YAML fallback removed - requires tool-capable providers
- Rollback: Revert this commit to restore previous behavior

Closes #57

🤖 Generated with [Claude Code](https://claude.com/claude-code)