### PR TITLE
Fix: Ensure ChatOllama correctly forces tool calls in Serialize phase

### DIFF
--- a/src/questfoundry/providers/langchain_wrapper.py
+++ b/src/questfoundry/providers/langchain_wrapper.py
@@ -144,8 +144,8 @@ class LangChainProvider:
         elif tool_choice == "none":
             return "none"
         else:
-            # Specific tool name - format for forced function call
-            return {"type": "function", "function": {"name": tool_choice}}
+            # Specific tool name - LangChain/Ollama prefer the simple string name
+            return tool_choice
 
     def _to_langchain_message(self, msg: Message) -> Any:
         """Convert our Message to LangChain message."""


### PR DESCRIPTION
The LangChainProvider's _map_tool_choice method was returning an OpenAI-style dictionary for 'tool_choice' when a specific tool was requested. However, ChatOllama's integration requires a simple string (the tool name) in this scenario to correctly force a tool call.

This change modifies _map_tool_choice to return the tool name string directly when 'tool_choice' specifies a single tool, resolving the issue where Ollama models were failing to make tool calls in the Serialize phase despite being instructed to do so.

## Summary

<!-- Brief description of changes -->

## Related Issues

<!-- Link to related issues: Closes #123, Related to #456 -->

## Changes

<!-- List key changes -->

-

## Test Plan

<!-- How were these changes tested? -->

- [ ] Unit tests pass
- [ ] Integration tests pass (if applicable)
- [ ] Manual testing performed

## Checklist

- [ ] Code follows project conventions
- [ ] Tests added/updated for changes
- [ ] Documentation updated (if applicable)
- [ ] No TODO stubs in committed code
- [ ] Type hints added for new code
