### PR TITLE
chore(agents): add model configuration to agent definitions

### DIFF
--- a/.claude/agents/architect-reviewer.md
+++ b/.claude/agents/architect-reviewer.md
@@ -2,6 +2,7 @@
 name: architect-reviewer
 description: Use this agent for architecture review tasks including evaluating design decisions, reviewing pipeline structure, assessing scalability, and ensuring alignment with QuestFoundry's design principles.
 tools: Read, Grep, Glob
+model: opus
 ---
 
 You are a senior architecture reviewer. You are evaluating QuestFoundry's architecture.

--- a/.claude/agents/cli-developer.md
+++ b/.claude/agents/cli-developer.md
@@ -2,6 +2,7 @@
 name: cli-developer
 description: Use this agent for CLI development tasks including adding new commands, improving user experience, progress indicators, and terminal output formatting.
 tools: Read, Write, Edit, Bash, Glob, Grep
+model: inherit
 ---
 
 You are a senior CLI developer specializing in developer tools. You are working on QuestFoundry's command-line interface.

--- a/.claude/agents/code-reviewer.md
+++ b/.claude/agents/code-reviewer.md
@@ -2,6 +2,7 @@
 name: code-reviewer
 description: Use this agent for code review tasks including PR reviews, identifying quality issues, security concerns, and suggesting improvements.
 tools: Read, Grep, Glob
+model: inherit
 ---
 
 You are a senior code reviewer. You are reviewing code for QuestFoundry, a Python 3.11+ project.

--- a/.claude/agents/llm-architect.md
+++ b/.claude/agents/llm-architect.md
@@ -2,6 +2,7 @@
 name: llm-architect
 description: Use this agent for LLM system design including provider integration, tool calling patterns, multi-turn conversation design, and production LLM considerations.
 tools: Read, Write, Edit, Bash, Glob, Grep
+model: opus
 ---
 
 You are a senior LLM architect specializing in building production LLM applications. You are working on QuestFoundry's LLM integration layer.

--- a/.claude/agents/prompt-engineer.md
+++ b/.claude/agents/prompt-engineer.md
@@ -2,6 +2,7 @@
 name: prompt-engineer
 description: Use this agent for prompt engineering tasks including designing stage prompts, optimizing LLM output quality, debugging validation failures, and improving the Discuss-Freeze-Serialize pattern.
 tools: Read, Write, Edit, Bash, Glob, Grep
+model: inherit
 ---
 
 You are a senior prompt engineer specializing in structured output generation from LLMs. You are working on QuestFoundry's prompt system.

--- a/.claude/agents/python-pro.md
+++ b/.claude/agents/python-pro.md
@@ -2,6 +2,7 @@
 name: python-pro
 description: Use this agent for Python development tasks including implementing new features, fixing bugs, writing tests, and optimizing code. Specializes in Python 3.11+, pydantic, typer, async patterns, and pytest.
 tools: Read, Write, Edit, Bash, Glob, Grep
+model: inherit
 ---
 
 You are a senior Python developer with mastery of Python 3.11+ and its ecosystem. You are working on QuestFoundry, a pipeline-driven interactive fiction generation system.

--- a/.claude/agents/qa-expert.md
+++ b/.claude/agents/qa-expert.md
@@ -2,6 +2,7 @@
 name: qa-expert
 description: Use this agent for testing strategy, test design, coverage analysis, and quality assurance tasks. Specializes in pytest, fixtures, and achieving the 70%+ coverage target.
 tools: Read, Grep, Glob, Bash
+model: inherit
 ---
 
 You are a senior QA expert specializing in Python testing. You are working on QuestFoundry's test suite.


### PR DESCRIPTION
## Problem
Agent definitions lacked explicit model configuration, defaulting to inherited model for all agents.

## Changes
- Add `model: opus` to architect-reviewer and llm-architect (complex reasoning tasks)
- Add `model: inherit` to other agents (cli-developer, code-reviewer, prompt-engineer, python-pro, qa-expert)

## Not Included / Future PRs
- N/A - complete change

## Test Plan
- Agent definitions are configuration only; no runtime tests needed

## Risk / Rollback
- Low risk - configuration change only
- Rollback: revert commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)