### PR TITLE
feat(tools): migrate research tools to LangChain @tool format (#77)

### DIFF
--- a/src/questfoundry/tools/__init__.py
+++ b/src/questfoundry/tools/__init__.py
@@ -12,6 +12,16 @@ from questfoundry.tools.finalization import (
     SubmitDreamTool,
     get_finalization_tool,
 )
+from questfoundry.tools.langchain_tools import (
+    get_all_research_tools,
+    get_corpus_tools,
+    get_document,
+    get_web_tools,
+    list_clusters,
+    search_corpus,
+    web_fetch,
+    web_search,
+)
 
 __all__ = [
     "ReadyToSummarizeTool",
@@ -20,5 +30,13 @@ __all__ = [
     "Tool",
     "ToolCall",
     "ToolDefinition",
+    "get_all_research_tools",
+    "get_corpus_tools",
+    "get_document",
     "get_finalization_tool",
+    "get_web_tools",
+    "list_clusters",
+    "search_corpus",
+    "web_fetch",
+    "web_search",
 ]

--- a/src/questfoundry/tools/langchain_tools.py
+++ b/src/questfoundry/tools/langchain_tools.py
@@ -1,0 +1,176 @@
+"""LangChain tool wrappers for research tools.
+
+This module converts QuestFoundry research tools to LangChain's @tool format
+for use with LangChain agents via create_agent(). Each wrapper delegates to
+the existing Tool protocol implementations.
+
+All tools return JSON strings following ADR-008:
+- result: semantic status (success, no_results, error)
+- data/content: the actual result data
+- action: guidance on what to do next
+
+Usage:
+    from questfoundry.tools.langchain_tools import get_all_research_tools
+    from langchain.agents import create_react_agent
+
+    tools = get_all_research_tools()
+    agent = create_react_agent(llm, tools, prompt)
+"""
+
+from __future__ import annotations
+
+from langchain_core.tools import BaseTool, tool
+
+
+@tool
+def search_corpus(query: str, cluster: str | None = None, limit: int = 5) -> str:
+    """Search the IF Craft Corpus knowledge base for relevant craft guidance.
+
+    The corpus contains curated writing guidance on interactive fiction craft,
+    including genre conventions, narrative structure, prose techniques, and more.
+    Results include source attribution, relevance scores, and content excerpts.
+
+    Args:
+        query: Topic or question to search for (e.g., "cozy mystery", "dialogue")
+        cluster: Optional filter by topic cluster (genre-conventions,
+            narrative-structure, prose-and-language, emotional-design,
+            scope-and-planning, craft-foundations). Use list_clusters to discover.
+        limit: Maximum number of results to return (default 5)
+
+    Returns:
+        JSON string with search results:
+        - {"result": "success", "content": "...", "action": "..."}
+        - {"result": "no_results", "query": "...", "action": "..."}
+        - {"result": "error", "error": "...", "action": "..."}
+    """
+    from questfoundry.tools.research.corpus_tools import SearchCorpusTool
+
+    tool_instance = SearchCorpusTool()
+    arguments = {"query": query, "limit": limit}
+    if cluster is not None:
+        arguments["cluster"] = cluster
+    return tool_instance.execute(arguments)
+
+
+@tool
+def get_document(name: str) -> str:
+    """Retrieve a full document from the IF Craft Corpus by name.
+
+    Use this after search_corpus identifies a relevant document that needs
+    deeper reading. Returns the complete document content with metadata.
+
+    Args:
+        name: Name of the document to retrieve (e.g., "dialogue_craft",
+            "cozy_mystery"). Names are shown in search_corpus results.
+
+    Returns:
+        JSON string with document content:
+        - {"result": "success", "content": "...", "title": "...", "cluster": "..."}
+        - {"result": "no_results", "document": "...", "action": "..."}
+        - {"result": "error", "error": "...", "action": "..."}
+    """
+    from questfoundry.tools.research.corpus_tools import GetDocumentTool
+
+    tool_instance = GetDocumentTool()
+    return tool_instance.execute({"name": name})
+
+
+@tool
+def list_clusters() -> str:
+    """List available topic clusters in the IF Craft Corpus.
+
+    Discovers what categories of craft knowledge are available for targeted
+    searches. Use the cluster names as filters in search_corpus.
+
+    Returns:
+        JSON string with cluster list and descriptions:
+        - {"result": "success", "clusters": [...], "content": "...", "action": "..."}
+        - {"result": "error", "error": "...", "action": "..."}
+    """
+    from questfoundry.tools.research.corpus_tools import ListClustersTool
+
+    tool_instance = ListClustersTool()
+    return tool_instance.execute({})
+
+
+@tool
+def web_search(query: str, max_results: int = 5, recency: str = "all_time") -> str:
+    """Search the web using SearXNG for current information and trends.
+
+    Useful for researching contemporary topics, current events, or information
+    not available in the curated corpus. Results include title, URL, and snippet.
+
+    Requires SEARXNG_URL environment variable to be configured.
+
+    Args:
+        query: Search query
+        max_results: Maximum number of results to return (default 5)
+        recency: Filter by time - "all_time", "day", "week", "month", "year"
+
+    Returns:
+        JSON string with search results:
+        - {"result": "success", "content": "...", "count": N, "action": "..."}
+        - {"result": "no_results", "query": "...", "action": "..."}
+        - {"result": "error", "error": "...", "action": "..."}
+    """
+    from questfoundry.tools.research.web_tools import WebSearchTool
+
+    tool_instance = WebSearchTool()
+    return tool_instance.execute({"query": query, "max_results": max_results, "recency": recency})
+
+
+@tool
+def web_fetch(url: str, extract_mode: str = "markdown") -> str:
+    """Fetch and extract content from a URL as markdown.
+
+    Retrieves web page content with intelligent extraction that strips
+    navigation, ads, and boilerplate. Returns main content as clean markdown.
+
+    Args:
+        url: URL to fetch (must be a valid HTTP/HTTPS URL)
+        extract_mode: Extraction method - "markdown" (default), "article", "metadata"
+
+    Returns:
+        JSON string with extracted content:
+        - {"result": "success", "content": "...", "url": "...", "action": "..."}
+        - {"result": "error", "url": "...", "error": "...", "action": "..."}
+    """
+    from questfoundry.tools.research.web_tools import WebFetchTool
+
+    tool_instance = WebFetchTool()
+    return tool_instance.execute({"url": url, "extract_mode": extract_mode})
+
+
+def get_all_research_tools() -> list[BaseTool]:
+    """Get all available research tools as LangChain tools.
+
+    Returns corpus tools (if ifcraftcorpus is installed) and web tools
+    (if pvl-webtools is installed). Tools that are unavailable will return
+    helpful error messages if invoked.
+
+    Returns:
+        List of LangChain tool functions that can be passed to create_agent.
+
+    Example:
+        >>> tools = get_all_research_tools()
+        >>> agent = create_react_agent(llm, tools, prompt)
+    """
+    return [search_corpus, get_document, list_clusters, web_search, web_fetch]
+
+
+def get_corpus_tools() -> list[BaseTool]:
+    """Get corpus-related tools only.
+
+    Returns:
+        List containing search_corpus, get_document, and list_clusters tools.
+    """
+    return [search_corpus, get_document, list_clusters]
+
+
+def get_web_tools() -> list[BaseTool]:
+    """Get web-related tools only.
+
+    Returns:
+        List containing web_search and web_fetch tools.
+    """
+    return [web_search, web_fetch]

--- a/tests/unit/test_langchain_tools.py
+++ b/tests/unit/test_langchain_tools.py
@@ -83,56 +83,49 @@ class TestToolCollections:
 class TestSearchCorpusExecution:
     """Test search_corpus tool execution."""
 
-    @patch("questfoundry.tools.research.corpus_tools.SearchCorpusTool")
-    def test_search_corpus_delegates(self, mock_class: MagicMock) -> None:
+    @patch("questfoundry.tools.langchain_tools._search_corpus_tool")
+    def test_search_corpus_delegates(self, mock_tool: MagicMock) -> None:
         """search_corpus should delegate to SearchCorpusTool."""
-        mock_instance = MagicMock()
-        mock_instance.execute.return_value = json.dumps(
+        mock_tool.execute.return_value = json.dumps(
             {"result": "success", "content": "test content", "action": "use this"}
         )
-        mock_class.return_value = mock_instance
 
         result = search_corpus.invoke({"query": "test", "limit": 3})
 
-        mock_instance.execute.assert_called_once_with({"query": "test", "limit": 3})
+        mock_tool.execute.assert_called_once_with({"query": "test", "limit": 3, "cluster": None})
         assert "success" in result
         assert "test content" in result
 
-    @patch("questfoundry.tools.research.corpus_tools.SearchCorpusTool")
-    def test_search_corpus_with_cluster(self, mock_class: MagicMock) -> None:
+    @patch("questfoundry.tools.langchain_tools._search_corpus_tool")
+    def test_search_corpus_with_cluster(self, mock_tool: MagicMock) -> None:
         """search_corpus should pass cluster parameter."""
-        mock_instance = MagicMock()
-        mock_instance.execute.return_value = json.dumps({"result": "success"})
-        mock_class.return_value = mock_instance
+        mock_tool.execute.return_value = json.dumps({"result": "success"})
 
         search_corpus.invoke({"query": "mystery", "cluster": "genre-conventions", "limit": 5})
 
-        call_args = mock_instance.execute.call_args[0][0]
+        call_args = mock_tool.execute.call_args[0][0]
         assert call_args["query"] == "mystery"
         assert call_args["cluster"] == "genre-conventions"
         assert call_args["limit"] == 5
 
-    @patch("questfoundry.tools.research.corpus_tools.SearchCorpusTool")
-    def test_search_corpus_default_limit(self, mock_class: MagicMock) -> None:
+    @patch("questfoundry.tools.langchain_tools._search_corpus_tool")
+    def test_search_corpus_default_limit(self, mock_tool: MagicMock) -> None:
         """search_corpus should use default limit of 5."""
-        mock_instance = MagicMock()
-        mock_instance.execute.return_value = json.dumps({"result": "success"})
-        mock_class.return_value = mock_instance
+        mock_tool.execute.return_value = json.dumps({"result": "success"})
 
         search_corpus.invoke({"query": "test"})
 
-        call_args = mock_instance.execute.call_args[0][0]
+        call_args = mock_tool.execute.call_args[0][0]
         assert call_args["limit"] == 5
 
 
 class TestGetDocumentExecution:
     """Test get_document tool execution."""
 
-    @patch("questfoundry.tools.research.corpus_tools.GetDocumentTool")
-    def test_get_document_delegates(self, mock_class: MagicMock) -> None:
+    @patch("questfoundry.tools.langchain_tools._get_document_tool")
+    def test_get_document_delegates(self, mock_tool: MagicMock) -> None:
         """get_document should delegate to GetDocumentTool."""
-        mock_instance = MagicMock()
-        mock_instance.execute.return_value = json.dumps(
+        mock_tool.execute.return_value = json.dumps(
             {
                 "result": "success",
                 "title": "Test Doc",
@@ -140,11 +133,10 @@ class TestGetDocumentExecution:
                 "action": "use this",
             }
         )
-        mock_class.return_value = mock_instance
 
         result = get_document.invoke({"name": "test_doc"})
 
-        mock_instance.execute.assert_called_once_with({"name": "test_doc"})
+        mock_tool.execute.assert_called_once_with({"name": "test_doc"})
         assert "success" in result
         assert "Test Doc" in result
 
@@ -152,11 +144,10 @@ class TestGetDocumentExecution:
 class TestListClustersExecution:
     """Test list_clusters tool execution."""
 
-    @patch("questfoundry.tools.research.corpus_tools.ListClustersTool")
-    def test_list_clusters_delegates(self, mock_class: MagicMock) -> None:
+    @patch("questfoundry.tools.langchain_tools._list_clusters_tool")
+    def test_list_clusters_delegates(self, mock_tool: MagicMock) -> None:
         """list_clusters should delegate to ListClustersTool."""
-        mock_instance = MagicMock()
-        mock_instance.execute.return_value = json.dumps(
+        mock_tool.execute.return_value = json.dumps(
             {
                 "result": "success",
                 "clusters": ["genre-conventions", "narrative-structure"],
@@ -164,11 +155,10 @@ class TestListClustersExecution:
                 "action": "use search_corpus",
             }
         )
-        mock_class.return_value = mock_instance
 
         result = list_clusters.invoke({})
 
-        mock_instance.execute.assert_called_once_with({})
+        mock_tool.execute.assert_called_once_with({})
         assert "success" in result
         assert "genre-conventions" in result
 
@@ -176,44 +166,38 @@ class TestListClustersExecution:
 class TestWebSearchExecution:
     """Test web_search tool execution."""
 
-    @patch("questfoundry.tools.research.web_tools.WebSearchTool")
-    def test_web_search_delegates(self, mock_class: MagicMock) -> None:
+    @patch("questfoundry.tools.langchain_tools._web_search_tool")
+    def test_web_search_delegates(self, mock_tool: MagicMock) -> None:
         """web_search should delegate to WebSearchTool."""
-        mock_instance = MagicMock()
-        mock_instance.execute.return_value = json.dumps(
+        mock_tool.execute.return_value = json.dumps(
             {"result": "success", "content": "search results", "action": "use this"}
         )
-        mock_class.return_value = mock_instance
 
         result = web_search.invoke({"query": "test search", "max_results": 3})
 
-        mock_instance.execute.assert_called_once_with(
+        mock_tool.execute.assert_called_once_with(
             {"query": "test search", "max_results": 3, "recency": "all_time"}
         )
         assert "success" in result
 
-    @patch("questfoundry.tools.research.web_tools.WebSearchTool")
-    def test_web_search_with_recency(self, mock_class: MagicMock) -> None:
+    @patch("questfoundry.tools.langchain_tools._web_search_tool")
+    def test_web_search_with_recency(self, mock_tool: MagicMock) -> None:
         """web_search should pass recency parameter."""
-        mock_instance = MagicMock()
-        mock_instance.execute.return_value = json.dumps({"result": "success"})
-        mock_class.return_value = mock_instance
+        mock_tool.execute.return_value = json.dumps({"result": "success"})
 
         web_search.invoke({"query": "recent news", "max_results": 5, "recency": "week"})
 
-        call_args = mock_instance.execute.call_args[0][0]
+        call_args = mock_tool.execute.call_args[0][0]
         assert call_args["recency"] == "week"
 
-    @patch("questfoundry.tools.research.web_tools.WebSearchTool")
-    def test_web_search_defaults(self, mock_class: MagicMock) -> None:
+    @patch("questfoundry.tools.langchain_tools._web_search_tool")
+    def test_web_search_defaults(self, mock_tool: MagicMock) -> None:
         """web_search should use default values."""
-        mock_instance = MagicMock()
-        mock_instance.execute.return_value = json.dumps({"result": "success"})
-        mock_class.return_value = mock_instance
+        mock_tool.execute.return_value = json.dumps({"result": "success"})
 
         web_search.invoke({"query": "test"})
 
-        call_args = mock_instance.execute.call_args[0][0]
+        call_args = mock_tool.execute.call_args[0][0]
         assert call_args["max_results"] == 5
         assert call_args["recency"] == "all_time"
 
@@ -221,11 +205,10 @@ class TestWebSearchExecution:
 class TestWebFetchExecution:
     """Test web_fetch tool execution."""
 
-    @patch("questfoundry.tools.research.web_tools.WebFetchTool")
-    def test_web_fetch_delegates(self, mock_class: MagicMock) -> None:
+    @patch("questfoundry.tools.langchain_tools._web_fetch_tool")
+    def test_web_fetch_delegates(self, mock_tool: MagicMock) -> None:
         """web_fetch should delegate to WebFetchTool."""
-        mock_instance = MagicMock()
-        mock_instance.execute.return_value = json.dumps(
+        mock_tool.execute.return_value = json.dumps(
             {
                 "result": "success",
                 "url": "https://example.com",
@@ -233,78 +216,65 @@ class TestWebFetchExecution:
                 "action": "use this",
             }
         )
-        mock_class.return_value = mock_instance
 
         result = web_fetch.invoke({"url": "https://example.com"})
 
-        mock_instance.execute.assert_called_once_with(
+        mock_tool.execute.assert_called_once_with(
             {"url": "https://example.com", "extract_mode": "markdown"}
         )
         assert "success" in result
         assert "page content" in result
 
-    @patch("questfoundry.tools.research.web_tools.WebFetchTool")
-    def test_web_fetch_with_extract_mode(self, mock_class: MagicMock) -> None:
+    @patch("questfoundry.tools.langchain_tools._web_fetch_tool")
+    def test_web_fetch_with_extract_mode(self, mock_tool: MagicMock) -> None:
         """web_fetch should pass extract_mode parameter."""
-        mock_instance = MagicMock()
-        mock_instance.execute.return_value = json.dumps({"result": "success"})
-        mock_class.return_value = mock_instance
+        mock_tool.execute.return_value = json.dumps({"result": "success"})
 
         web_fetch.invoke({"url": "https://example.com", "extract_mode": "article"})
 
-        call_args = mock_instance.execute.call_args[0][0]
+        call_args = mock_tool.execute.call_args[0][0]
         assert call_args["extract_mode"] == "article"
 
 
 class TestToolReturnTypes:
     """Test that all tools return strings (required for LangChain)."""
 
-    @patch("questfoundry.tools.research.corpus_tools.SearchCorpusTool")
-    def test_search_corpus_returns_string(self, mock_class: MagicMock) -> None:
+    @patch("questfoundry.tools.langchain_tools._search_corpus_tool")
+    def test_search_corpus_returns_string(self, mock_tool: MagicMock) -> None:
         """search_corpus must return a string."""
-        mock_instance = MagicMock()
-        mock_instance.execute.return_value = '{"result": "success"}'
-        mock_class.return_value = mock_instance
+        mock_tool.execute.return_value = '{"result": "success"}'
 
         result = search_corpus.invoke({"query": "test"})
         assert isinstance(result, str)
 
-    @patch("questfoundry.tools.research.corpus_tools.GetDocumentTool")
-    def test_get_document_returns_string(self, mock_class: MagicMock) -> None:
+    @patch("questfoundry.tools.langchain_tools._get_document_tool")
+    def test_get_document_returns_string(self, mock_tool: MagicMock) -> None:
         """get_document must return a string."""
-        mock_instance = MagicMock()
-        mock_instance.execute.return_value = '{"result": "success"}'
-        mock_class.return_value = mock_instance
+        mock_tool.execute.return_value = '{"result": "success"}'
 
         result = get_document.invoke({"name": "test"})
         assert isinstance(result, str)
 
-    @patch("questfoundry.tools.research.corpus_tools.ListClustersTool")
-    def test_list_clusters_returns_string(self, mock_class: MagicMock) -> None:
+    @patch("questfoundry.tools.langchain_tools._list_clusters_tool")
+    def test_list_clusters_returns_string(self, mock_tool: MagicMock) -> None:
         """list_clusters must return a string."""
-        mock_instance = MagicMock()
-        mock_instance.execute.return_value = '{"result": "success"}'
-        mock_class.return_value = mock_instance
+        mock_tool.execute.return_value = '{"result": "success"}'
 
         result = list_clusters.invoke({})
         assert isinstance(result, str)
 
-    @patch("questfoundry.tools.research.web_tools.WebSearchTool")
-    def test_web_search_returns_string(self, mock_class: MagicMock) -> None:
+    @patch("questfoundry.tools.langchain_tools._web_search_tool")
+    def test_web_search_returns_string(self, mock_tool: MagicMock) -> None:
         """web_search must return a string."""
-        mock_instance = MagicMock()
-        mock_instance.execute.return_value = '{"result": "success"}'
-        mock_class.return_value = mock_instance
+        mock_tool.execute.return_value = '{"result": "success"}'
 
         result = web_search.invoke({"query": "test"})
         assert isinstance(result, str)
 
-    @patch("questfoundry.tools.research.web_tools.WebFetchTool")
-    def test_web_fetch_returns_string(self, mock_class: MagicMock) -> None:
+    @patch("questfoundry.tools.langchain_tools._web_fetch_tool")
+    def test_web_fetch_returns_string(self, mock_tool: MagicMock) -> None:
         """web_fetch must return a string."""
-        mock_instance = MagicMock()
-        mock_instance.execute.return_value = '{"result": "success"}'
-        mock_class.return_value = mock_instance
+        mock_tool.execute.return_value = '{"result": "success"}'
 
         result = web_fetch.invoke({"url": "https://example.com"})
         assert isinstance(result, str)
@@ -313,14 +283,12 @@ class TestToolReturnTypes:
 class TestErrorHandling:
     """Test that tools handle errors gracefully."""
 
-    @patch("questfoundry.tools.research.corpus_tools.SearchCorpusTool")
-    def test_search_corpus_error_propagates(self, mock_class: MagicMock) -> None:
+    @patch("questfoundry.tools.langchain_tools._search_corpus_tool")
+    def test_search_corpus_error_propagates(self, mock_tool: MagicMock) -> None:
         """search_corpus should return error JSON from underlying tool."""
-        mock_instance = MagicMock()
-        mock_instance.execute.return_value = json.dumps(
+        mock_tool.execute.return_value = json.dumps(
             {"result": "error", "error": "Corpus not available", "action": "proceed"}
         )
-        mock_class.return_value = mock_instance
 
         result = search_corpus.invoke({"query": "test"})
 
@@ -328,14 +296,12 @@ class TestErrorHandling:
         assert data["result"] == "error"
         assert "error" in data
 
-    @patch("questfoundry.tools.research.web_tools.WebSearchTool")
-    def test_web_search_error_propagates(self, mock_class: MagicMock) -> None:
+    @patch("questfoundry.tools.langchain_tools._web_search_tool")
+    def test_web_search_error_propagates(self, mock_tool: MagicMock) -> None:
         """web_search should return error JSON from underlying tool."""
-        mock_instance = MagicMock()
-        mock_instance.execute.return_value = json.dumps(
+        mock_tool.execute.return_value = json.dumps(
             {"result": "error", "error": "SEARXNG_URL not configured", "action": "proceed"}
         )
-        mock_class.return_value = mock_instance
 
         result = web_search.invoke({"query": "test"})
 

--- a/tests/unit/test_langchain_tools.py
+++ b/tests/unit/test_langchain_tools.py
@@ -1,0 +1,343 @@
+"""Tests for LangChain tool wrappers."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock, patch
+
+from questfoundry.tools.langchain_tools import (
+    get_all_research_tools,
+    get_corpus_tools,
+    get_document,
+    get_web_tools,
+    list_clusters,
+    search_corpus,
+    web_fetch,
+    web_search,
+)
+
+
+class TestToolMetadata:
+    """Test that tools have proper LangChain metadata."""
+
+    def test_search_corpus_is_tool(self) -> None:
+        """search_corpus should have LangChain tool metadata."""
+        assert hasattr(search_corpus, "name")
+        assert search_corpus.name == "search_corpus"
+        assert hasattr(search_corpus, "description")
+        assert "corpus" in search_corpus.description.lower()
+
+    def test_get_document_is_tool(self) -> None:
+        """get_document should have LangChain tool metadata."""
+        assert hasattr(get_document, "name")
+        assert get_document.name == "get_document"
+
+    def test_list_clusters_is_tool(self) -> None:
+        """list_clusters should have LangChain tool metadata."""
+        assert hasattr(list_clusters, "name")
+        assert list_clusters.name == "list_clusters"
+
+    def test_web_search_is_tool(self) -> None:
+        """web_search should have LangChain tool metadata."""
+        assert hasattr(web_search, "name")
+        assert web_search.name == "web_search"
+
+    def test_web_fetch_is_tool(self) -> None:
+        """web_fetch should have LangChain tool metadata."""
+        assert hasattr(web_fetch, "name")
+        assert web_fetch.name == "web_fetch"
+
+
+class TestToolCollections:
+    """Test tool collection functions."""
+
+    def test_get_all_research_tools(self) -> None:
+        """get_all_research_tools should return all 5 tools."""
+        tools = get_all_research_tools()
+        assert len(tools) == 5
+        names = [t.name for t in tools]
+        assert "search_corpus" in names
+        assert "get_document" in names
+        assert "list_clusters" in names
+        assert "web_search" in names
+        assert "web_fetch" in names
+
+    def test_get_corpus_tools(self) -> None:
+        """get_corpus_tools should return 3 corpus tools."""
+        tools = get_corpus_tools()
+        assert len(tools) == 3
+        names = [t.name for t in tools]
+        assert "search_corpus" in names
+        assert "get_document" in names
+        assert "list_clusters" in names
+
+    def test_get_web_tools(self) -> None:
+        """get_web_tools should return 2 web tools."""
+        tools = get_web_tools()
+        assert len(tools) == 2
+        names = [t.name for t in tools]
+        assert "web_search" in names
+        assert "web_fetch" in names
+
+
+class TestSearchCorpusExecution:
+    """Test search_corpus tool execution."""
+
+    @patch("questfoundry.tools.research.corpus_tools.SearchCorpusTool")
+    def test_search_corpus_delegates(self, mock_class: MagicMock) -> None:
+        """search_corpus should delegate to SearchCorpusTool."""
+        mock_instance = MagicMock()
+        mock_instance.execute.return_value = json.dumps(
+            {"result": "success", "content": "test content", "action": "use this"}
+        )
+        mock_class.return_value = mock_instance
+
+        result = search_corpus.invoke({"query": "test", "limit": 3})
+
+        mock_instance.execute.assert_called_once_with({"query": "test", "limit": 3})
+        assert "success" in result
+        assert "test content" in result
+
+    @patch("questfoundry.tools.research.corpus_tools.SearchCorpusTool")
+    def test_search_corpus_with_cluster(self, mock_class: MagicMock) -> None:
+        """search_corpus should pass cluster parameter."""
+        mock_instance = MagicMock()
+        mock_instance.execute.return_value = json.dumps({"result": "success"})
+        mock_class.return_value = mock_instance
+
+        search_corpus.invoke({"query": "mystery", "cluster": "genre-conventions", "limit": 5})
+
+        call_args = mock_instance.execute.call_args[0][0]
+        assert call_args["query"] == "mystery"
+        assert call_args["cluster"] == "genre-conventions"
+        assert call_args["limit"] == 5
+
+    @patch("questfoundry.tools.research.corpus_tools.SearchCorpusTool")
+    def test_search_corpus_default_limit(self, mock_class: MagicMock) -> None:
+        """search_corpus should use default limit of 5."""
+        mock_instance = MagicMock()
+        mock_instance.execute.return_value = json.dumps({"result": "success"})
+        mock_class.return_value = mock_instance
+
+        search_corpus.invoke({"query": "test"})
+
+        call_args = mock_instance.execute.call_args[0][0]
+        assert call_args["limit"] == 5
+
+
+class TestGetDocumentExecution:
+    """Test get_document tool execution."""
+
+    @patch("questfoundry.tools.research.corpus_tools.GetDocumentTool")
+    def test_get_document_delegates(self, mock_class: MagicMock) -> None:
+        """get_document should delegate to GetDocumentTool."""
+        mock_instance = MagicMock()
+        mock_instance.execute.return_value = json.dumps(
+            {
+                "result": "success",
+                "title": "Test Doc",
+                "content": "document content",
+                "action": "use this",
+            }
+        )
+        mock_class.return_value = mock_instance
+
+        result = get_document.invoke({"name": "test_doc"})
+
+        mock_instance.execute.assert_called_once_with({"name": "test_doc"})
+        assert "success" in result
+        assert "Test Doc" in result
+
+
+class TestListClustersExecution:
+    """Test list_clusters tool execution."""
+
+    @patch("questfoundry.tools.research.corpus_tools.ListClustersTool")
+    def test_list_clusters_delegates(self, mock_class: MagicMock) -> None:
+        """list_clusters should delegate to ListClustersTool."""
+        mock_instance = MagicMock()
+        mock_instance.execute.return_value = json.dumps(
+            {
+                "result": "success",
+                "clusters": ["genre-conventions", "narrative-structure"],
+                "content": "cluster list",
+                "action": "use search_corpus",
+            }
+        )
+        mock_class.return_value = mock_instance
+
+        result = list_clusters.invoke({})
+
+        mock_instance.execute.assert_called_once_with({})
+        assert "success" in result
+        assert "genre-conventions" in result
+
+
+class TestWebSearchExecution:
+    """Test web_search tool execution."""
+
+    @patch("questfoundry.tools.research.web_tools.WebSearchTool")
+    def test_web_search_delegates(self, mock_class: MagicMock) -> None:
+        """web_search should delegate to WebSearchTool."""
+        mock_instance = MagicMock()
+        mock_instance.execute.return_value = json.dumps(
+            {"result": "success", "content": "search results", "action": "use this"}
+        )
+        mock_class.return_value = mock_instance
+
+        result = web_search.invoke({"query": "test search", "max_results": 3})
+
+        mock_instance.execute.assert_called_once_with(
+            {"query": "test search", "max_results": 3, "recency": "all_time"}
+        )
+        assert "success" in result
+
+    @patch("questfoundry.tools.research.web_tools.WebSearchTool")
+    def test_web_search_with_recency(self, mock_class: MagicMock) -> None:
+        """web_search should pass recency parameter."""
+        mock_instance = MagicMock()
+        mock_instance.execute.return_value = json.dumps({"result": "success"})
+        mock_class.return_value = mock_instance
+
+        web_search.invoke({"query": "recent news", "max_results": 5, "recency": "week"})
+
+        call_args = mock_instance.execute.call_args[0][0]
+        assert call_args["recency"] == "week"
+
+    @patch("questfoundry.tools.research.web_tools.WebSearchTool")
+    def test_web_search_defaults(self, mock_class: MagicMock) -> None:
+        """web_search should use default values."""
+        mock_instance = MagicMock()
+        mock_instance.execute.return_value = json.dumps({"result": "success"})
+        mock_class.return_value = mock_instance
+
+        web_search.invoke({"query": "test"})
+
+        call_args = mock_instance.execute.call_args[0][0]
+        assert call_args["max_results"] == 5
+        assert call_args["recency"] == "all_time"
+
+
+class TestWebFetchExecution:
+    """Test web_fetch tool execution."""
+
+    @patch("questfoundry.tools.research.web_tools.WebFetchTool")
+    def test_web_fetch_delegates(self, mock_class: MagicMock) -> None:
+        """web_fetch should delegate to WebFetchTool."""
+        mock_instance = MagicMock()
+        mock_instance.execute.return_value = json.dumps(
+            {
+                "result": "success",
+                "url": "https://example.com",
+                "content": "page content",
+                "action": "use this",
+            }
+        )
+        mock_class.return_value = mock_instance
+
+        result = web_fetch.invoke({"url": "https://example.com"})
+
+        mock_instance.execute.assert_called_once_with(
+            {"url": "https://example.com", "extract_mode": "markdown"}
+        )
+        assert "success" in result
+        assert "page content" in result
+
+    @patch("questfoundry.tools.research.web_tools.WebFetchTool")
+    def test_web_fetch_with_extract_mode(self, mock_class: MagicMock) -> None:
+        """web_fetch should pass extract_mode parameter."""
+        mock_instance = MagicMock()
+        mock_instance.execute.return_value = json.dumps({"result": "success"})
+        mock_class.return_value = mock_instance
+
+        web_fetch.invoke({"url": "https://example.com", "extract_mode": "article"})
+
+        call_args = mock_instance.execute.call_args[0][0]
+        assert call_args["extract_mode"] == "article"
+
+
+class TestToolReturnTypes:
+    """Test that all tools return strings (required for LangChain)."""
+
+    @patch("questfoundry.tools.research.corpus_tools.SearchCorpusTool")
+    def test_search_corpus_returns_string(self, mock_class: MagicMock) -> None:
+        """search_corpus must return a string."""
+        mock_instance = MagicMock()
+        mock_instance.execute.return_value = '{"result": "success"}'
+        mock_class.return_value = mock_instance
+
+        result = search_corpus.invoke({"query": "test"})
+        assert isinstance(result, str)
+
+    @patch("questfoundry.tools.research.corpus_tools.GetDocumentTool")
+    def test_get_document_returns_string(self, mock_class: MagicMock) -> None:
+        """get_document must return a string."""
+        mock_instance = MagicMock()
+        mock_instance.execute.return_value = '{"result": "success"}'
+        mock_class.return_value = mock_instance
+
+        result = get_document.invoke({"name": "test"})
+        assert isinstance(result, str)
+
+    @patch("questfoundry.tools.research.corpus_tools.ListClustersTool")
+    def test_list_clusters_returns_string(self, mock_class: MagicMock) -> None:
+        """list_clusters must return a string."""
+        mock_instance = MagicMock()
+        mock_instance.execute.return_value = '{"result": "success"}'
+        mock_class.return_value = mock_instance
+
+        result = list_clusters.invoke({})
+        assert isinstance(result, str)
+
+    @patch("questfoundry.tools.research.web_tools.WebSearchTool")
+    def test_web_search_returns_string(self, mock_class: MagicMock) -> None:
+        """web_search must return a string."""
+        mock_instance = MagicMock()
+        mock_instance.execute.return_value = '{"result": "success"}'
+        mock_class.return_value = mock_instance
+
+        result = web_search.invoke({"query": "test"})
+        assert isinstance(result, str)
+
+    @patch("questfoundry.tools.research.web_tools.WebFetchTool")
+    def test_web_fetch_returns_string(self, mock_class: MagicMock) -> None:
+        """web_fetch must return a string."""
+        mock_instance = MagicMock()
+        mock_instance.execute.return_value = '{"result": "success"}'
+        mock_class.return_value = mock_instance
+
+        result = web_fetch.invoke({"url": "https://example.com"})
+        assert isinstance(result, str)
+
+
+class TestErrorHandling:
+    """Test that tools handle errors gracefully."""
+
+    @patch("questfoundry.tools.research.corpus_tools.SearchCorpusTool")
+    def test_search_corpus_error_propagates(self, mock_class: MagicMock) -> None:
+        """search_corpus should return error JSON from underlying tool."""
+        mock_instance = MagicMock()
+        mock_instance.execute.return_value = json.dumps(
+            {"result": "error", "error": "Corpus not available", "action": "proceed"}
+        )
+        mock_class.return_value = mock_instance
+
+        result = search_corpus.invoke({"query": "test"})
+
+        data = json.loads(result)
+        assert data["result"] == "error"
+        assert "error" in data
+
+    @patch("questfoundry.tools.research.web_tools.WebSearchTool")
+    def test_web_search_error_propagates(self, mock_class: MagicMock) -> None:
+        """web_search should return error JSON from underlying tool."""
+        mock_instance = MagicMock()
+        mock_instance.execute.return_value = json.dumps(
+            {"result": "error", "error": "SEARXNG_URL not configured", "action": "proceed"}
+        )
+        mock_class.return_value = mock_instance
+
+        result = web_search.invoke({"query": "test"})
+
+        data = json.loads(result)
+        assert data["result"] == "error"


### PR DESCRIPTION
## Problem

Research tools use a custom `Tool` protocol that's incompatible with LangChain's `create_agent`. Need LangChain-compatible wrappers.

## Changes

### New: `src/questfoundry/tools/langchain_tools.py`
- `@tool` wrappers for all 5 research tools:
  - `search_corpus` - Search IF Craft Corpus
  - `get_document` - Retrieve corpus documents
  - `list_clusters` - List topic clusters
  - `web_search` - SearXNG web search
  - `web_fetch` - URL content extraction
- Collection helpers:
  - `get_all_research_tools()` - All 5 tools
  - `get_corpus_tools()` - Corpus tools only
  - `get_web_tools()` - Web tools only
- Delegate to existing Tool implementations (no logic duplication)
- Return JSON strings per ADR-008 format

### Updated: `src/questfoundry/tools/__init__.py`
- Export new LangChain tools and helpers

### New: `tests/unit/test_langchain_tools.py`
- 25 tests covering metadata, collections, delegation, return types, errors

## Not Included / Future PRs

- Discuss agent using these tools (#71 - PR4)
- Removal of old Tool protocol (#74 - PR7)

## Test Plan

```bash
uv run pytest tests/unit/test_langchain_tools.py -v
# 25 passed
```

## Risk / Rollback

- Low risk - adds new wrappers, old tools remain
- Rollback: revert commit

---

Part of epic #68. This is **PR3** in the stacked PR series.
**Base**: `feat/langchain-deps` (PR2 #80)

🤖 Generated with [Claude Code](https://claude.com/claude-code)