### PR TITLE
feat(agents): add Summarize phase for discussion condensation

### DIFF
--- a/prompts/templates/summarize.yaml
+++ b/prompts/templates/summarize.yaml
@@ -1,0 +1,29 @@
+name: summarize
+description: Summarize creative discussion into compact brief for serialization
+
+system: |
+  You are summarizing a creative discussion about an interactive fiction project.
+
+  ## Your Task
+  Condense the conversation into a compact brief that captures all key decisions:
+  - Genre and subgenre
+  - Tone and atmosphere descriptors
+  - Target audience
+  - Core themes to explore
+  - Style guidance for writing
+  - Scope constraints (word count range, passage count, branching complexity)
+  - Content notes (what to include/exclude)
+
+  ## Guidelines
+  - Extract concrete decisions, not vague ideas
+  - Preserve specific details like word counts, themes, tone descriptors
+  - Be concise but complete - this brief guides the next stage
+  - Do not add new ideas - only summarize what was discussed
+  - Use bullet points or structured format for clarity
+  - If something wasn't discussed, note it as "not specified" rather than inventing
+
+  ## Output Format
+  Provide a structured summary covering all the categories above.
+  Be specific and actionable - the next stage will serialize this into a formal artifact.
+
+components: []

--- a/src/questfoundry/agents/__init__.py
+++ b/src/questfoundry/agents/__init__.py
@@ -1,6 +1,13 @@
 """LangChain agents for QuestFoundry stages."""
 
 from questfoundry.agents.discuss import create_discuss_agent, run_discuss_phase
-from questfoundry.agents.prompts import get_discuss_prompt
+from questfoundry.agents.prompts import get_discuss_prompt, get_summarize_prompt
+from questfoundry.agents.summarize import summarize_discussion
 
-__all__ = ["create_discuss_agent", "get_discuss_prompt", "run_discuss_phase"]
+__all__ = [
+    "create_discuss_agent",
+    "get_discuss_prompt",
+    "get_summarize_prompt",
+    "run_discuss_phase",
+    "summarize_discussion",
+]

--- a/src/questfoundry/agents/prompts.py
+++ b/src/questfoundry/agents/prompts.py
@@ -9,6 +9,9 @@ from jinja2 import Template
 
 from questfoundry.prompts.loader import PromptLoader
 
+# Module-level loader for caching efficiency
+_prompt_loader: PromptLoader | None = None
+
 
 def _get_prompts_path() -> Path:
     """Get the prompts directory path.
@@ -22,6 +25,17 @@ def _get_prompts_path() -> Path:
 
     # Project root fallback (development)
     return Path.cwd() / "prompts"
+
+
+def _get_loader() -> PromptLoader:
+    """Get or create the module-level PromptLoader.
+
+    Uses lazy initialization to allow path detection at first use.
+    """
+    global _prompt_loader
+    if _prompt_loader is None:
+        _prompt_loader = PromptLoader(_get_prompts_path())
+    return _prompt_loader
 
 
 def get_discuss_prompt(
@@ -41,7 +55,7 @@ def get_discuss_prompt(
     Returns:
         System prompt string for the Discuss agent
     """
-    loader = PromptLoader(_get_prompts_path())
+    loader = _get_loader()
     template = loader.load("discuss")
 
     # Build the research tools section if tools are available
@@ -66,7 +80,7 @@ def get_summarize_prompt() -> str:
     Returns:
         System prompt string for the Summarize call
     """
-    loader = PromptLoader(_get_prompts_path())
+    loader = _get_loader()
     template = loader.load("summarize")
     return template.system
 

--- a/src/questfoundry/agents/prompts.py
+++ b/src/questfoundry/agents/prompts.py
@@ -56,6 +56,21 @@ def get_discuss_prompt(
     return str(jinja_template.render(research_tools_section=research_section))
 
 
+def get_summarize_prompt() -> str:
+    """Build the Summarize phase prompt as a system message string.
+
+    Loads the prompt template from prompts/templates/summarize.yaml.
+    The summarize phase takes a conversation history and produces a
+    compact brief for the serialize phase.
+
+    Returns:
+        System prompt string for the Summarize call
+    """
+    loader = PromptLoader(_get_prompts_path())
+    template = loader.load("summarize")
+    return template.system
+
+
 def _load_raw_template(template_name: str) -> dict[str, Any]:
     """Load raw template data without parsing into PromptTemplate.
 

--- a/src/questfoundry/agents/summarize.py
+++ b/src/questfoundry/agents/summarize.py
@@ -1,0 +1,102 @@
+"""Summarize phase for condensing discussion into brief."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from langchain_core.messages import AIMessage, BaseMessage, HumanMessage, SystemMessage
+
+from questfoundry.agents.prompts import get_summarize_prompt
+from questfoundry.observability.logging import get_logger
+
+if TYPE_CHECKING:
+    from langchain_core.language_models import BaseChatModel
+
+log = get_logger(__name__)
+
+
+async def summarize_discussion(
+    model: BaseChatModel,
+    messages: list[BaseMessage],
+) -> tuple[str, int]:
+    """Summarize a discussion into a compact brief.
+
+    This is a single LLM call (not an agent) that takes the conversation
+    history from the Discuss phase and produces a compact summary for
+    the Serialize phase.
+
+    Uses lower temperature (0.3) for more focused, consistent output.
+
+    Args:
+        model: Chat model to use (will be invoked with low temperature)
+        messages: Conversation history from Discuss phase
+
+    Returns:
+        Tuple of (summary_text, tokens_used)
+    """
+    log.info("summarize_started", message_count=len(messages))
+
+    system_prompt = get_summarize_prompt()
+
+    # Build the messages for the summarize call
+    # We include the system prompt, then the conversation as context,
+    # then ask for the summary
+    summarize_messages: list[BaseMessage] = [
+        SystemMessage(content=system_prompt),
+        HumanMessage(
+            content="Here is the discussion to summarize:\n\n"
+            + _format_messages_for_summary(messages)
+        ),
+    ]
+
+    # Use lower temperature for summarization - we want consistent, focused output
+    # Clone the model with lower temperature if supported
+    try:
+        summarize_model = model.bind(temperature=0.3)
+    except (AttributeError, TypeError):
+        # Fallback if model doesn't support bind
+        summarize_model = model
+
+    response = await summarize_model.ainvoke(summarize_messages)
+
+    # Extract the summary text
+    summary = response.content if isinstance(response.content, str) else str(response.content)
+
+    # Extract token usage
+    tokens = 0
+    if isinstance(response, AIMessage) and hasattr(response, "response_metadata"):
+        metadata = response.response_metadata or {}
+        if "token_usage" in metadata:
+            tokens = metadata["token_usage"].get("total_tokens") or 0
+        elif "usage_metadata" in metadata:
+            tokens = metadata["usage_metadata"].get("total_tokens") or 0
+
+    log.info("summarize_completed", summary_length=len(summary), tokens=tokens)
+
+    return summary, tokens
+
+
+def _format_messages_for_summary(messages: list[BaseMessage]) -> str:
+    """Format conversation messages for the summary prompt.
+
+    Args:
+        messages: List of conversation messages
+
+    Returns:
+        Formatted string representation of the conversation
+    """
+    formatted_parts = []
+    for msg in messages:
+        if isinstance(msg, HumanMessage):
+            prefix = "User"
+        elif isinstance(msg, AIMessage):
+            prefix = "Assistant"
+        elif isinstance(msg, SystemMessage):
+            prefix = "System"
+        else:
+            prefix = "Message"
+
+        content = msg.content if isinstance(msg.content, str) else str(msg.content)
+        formatted_parts.append(f"{prefix}: {content}")
+
+    return "\n\n".join(formatted_parts)

--- a/src/questfoundry/agents/summarize.py
+++ b/src/questfoundry/agents/summarize.py
@@ -60,7 +60,7 @@ async def summarize_discussion(
     response = await summarize_model.ainvoke(summarize_messages)
 
     # Extract the summary text
-    summary = response.content if isinstance(response.content, str) else str(response.content)
+    summary = str(response.content)
 
     # Extract token usage
     tokens = 0

--- a/tests/unit/test_summarize.py
+++ b/tests/unit/test_summarize.py
@@ -75,10 +75,25 @@ class TestSummarizeDiscussion:
         mock_model.bind.assert_called_once_with(temperature=0.3)
 
     @pytest.mark.asyncio
-    async def test_summarize_fallback_when_bind_fails(self) -> None:
+    async def test_summarize_fallback_when_bind_raises_attribute_error(self) -> None:
         """summarize_discussion should fallback when bind not supported."""
         mock_model = MagicMock()
         mock_model.bind.side_effect = AttributeError("no bind")
+        mock_response = AIMessage(content="Summary")
+        mock_model.ainvoke = AsyncMock(return_value=mock_response)
+
+        messages = [HumanMessage(content="Test")]
+
+        summary, _tokens = await summarize_discussion(mock_model, messages)
+
+        assert summary == "Summary"
+        mock_model.ainvoke.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_summarize_fallback_when_bind_raises_type_error(self) -> None:
+        """summarize_discussion should fallback when bind raises TypeError."""
+        mock_model = MagicMock()
+        mock_model.bind.side_effect = TypeError("bad args")
         mock_response = AIMessage(content="Summary")
         mock_model.ainvoke = AsyncMock(return_value=mock_response)
 

--- a/tests/unit/test_summarize.py
+++ b/tests/unit/test_summarize.py
@@ -1,0 +1,207 @@
+"""Tests for Summarize phase."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from langchain_core.messages import AIMessage, HumanMessage, SystemMessage
+
+from questfoundry.agents.prompts import get_summarize_prompt
+from questfoundry.agents.summarize import summarize_discussion
+
+
+class TestGetSummarizePrompt:
+    """Test summarize prompt loading."""
+
+    def test_prompt_loads_from_template(self) -> None:
+        """Prompt should load from external template file."""
+        prompt = get_summarize_prompt()
+
+        assert isinstance(prompt, str)
+        assert len(prompt) > 100
+
+    def test_prompt_includes_task_description(self) -> None:
+        """Prompt should describe the summarization task."""
+        prompt = get_summarize_prompt()
+
+        assert "summariz" in prompt.lower()
+        assert "brief" in prompt.lower()
+
+    def test_prompt_includes_categories(self) -> None:
+        """Prompt should mention key categories to extract."""
+        prompt = get_summarize_prompt()
+
+        assert "Genre" in prompt
+        assert "Tone" in prompt
+        assert "audience" in prompt.lower()
+        assert "themes" in prompt.lower()
+
+
+class TestSummarizeDiscussion:
+    """Test summarize_discussion function."""
+
+    @pytest.mark.asyncio
+    async def test_summarize_returns_summary_and_tokens(self) -> None:
+        """summarize_discussion should return summary text and token count."""
+        mock_model = MagicMock()
+        mock_response = AIMessage(content="Summary of discussion")
+        mock_response.response_metadata = {"token_usage": {"total_tokens": 100}}
+        mock_model.bind.return_value.ainvoke = AsyncMock(return_value=mock_response)
+
+        messages = [
+            HumanMessage(content="I want to write a mystery"),
+            AIMessage(content="Great! Tell me more about the setting."),
+        ]
+
+        summary, tokens = await summarize_discussion(mock_model, messages)
+
+        assert summary == "Summary of discussion"
+        assert tokens == 100
+
+    @pytest.mark.asyncio
+    async def test_summarize_uses_lower_temperature(self) -> None:
+        """summarize_discussion should bind model with lower temperature."""
+        mock_model = MagicMock()
+        mock_bound = MagicMock()
+        mock_response = AIMessage(content="Summary")
+        mock_bound.ainvoke = AsyncMock(return_value=mock_response)
+        mock_model.bind.return_value = mock_bound
+
+        messages = [HumanMessage(content="Test")]
+
+        await summarize_discussion(mock_model, messages)
+
+        mock_model.bind.assert_called_once_with(temperature=0.3)
+
+    @pytest.mark.asyncio
+    async def test_summarize_fallback_when_bind_fails(self) -> None:
+        """summarize_discussion should fallback when bind not supported."""
+        mock_model = MagicMock()
+        mock_model.bind.side_effect = AttributeError("no bind")
+        mock_response = AIMessage(content="Summary")
+        mock_model.ainvoke = AsyncMock(return_value=mock_response)
+
+        messages = [HumanMessage(content="Test")]
+
+        summary, _tokens = await summarize_discussion(mock_model, messages)
+
+        assert summary == "Summary"
+        mock_model.ainvoke.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_summarize_includes_conversation_in_prompt(self) -> None:
+        """summarize_discussion should include formatted conversation."""
+        mock_model = MagicMock()
+        mock_response = AIMessage(content="Summary")
+        mock_model.bind.return_value.ainvoke = AsyncMock(return_value=mock_response)
+
+        messages = [
+            HumanMessage(content="User message"),
+            AIMessage(content="Assistant response"),
+        ]
+
+        await summarize_discussion(mock_model, messages)
+
+        # Check the call to ainvoke included the conversation
+        call_args = mock_model.bind.return_value.ainvoke.call_args
+        invoke_messages = call_args[0][0]
+
+        # Should have system message and human message with conversation
+        assert len(invoke_messages) == 2
+        assert isinstance(invoke_messages[0], SystemMessage)
+        assert isinstance(invoke_messages[1], HumanMessage)
+        assert "User message" in invoke_messages[1].content
+        assert "Assistant response" in invoke_messages[1].content
+
+    @pytest.mark.asyncio
+    async def test_summarize_handles_missing_metadata(self) -> None:
+        """summarize_discussion should handle responses without metadata."""
+        mock_model = MagicMock()
+        mock_response = AIMessage(content="Summary")
+        # No response_metadata
+        mock_model.bind.return_value.ainvoke = AsyncMock(return_value=mock_response)
+
+        messages = [HumanMessage(content="Test")]
+
+        summary, tokens = await summarize_discussion(mock_model, messages)
+
+        assert summary == "Summary"
+        assert tokens == 0
+
+    @pytest.mark.asyncio
+    async def test_summarize_handles_null_token_values(self) -> None:
+        """summarize_discussion should handle None token values."""
+        mock_model = MagicMock()
+        mock_response = AIMessage(content="Summary")
+        mock_response.response_metadata = {"token_usage": {"total_tokens": None}}
+        mock_model.bind.return_value.ainvoke = AsyncMock(return_value=mock_response)
+
+        messages = [HumanMessage(content="Test")]
+
+        summary, tokens = await summarize_discussion(mock_model, messages)
+
+        assert summary == "Summary"
+        assert tokens == 0
+
+    @pytest.mark.asyncio
+    async def test_summarize_handles_usage_metadata_key(self) -> None:
+        """summarize_discussion should extract tokens from usage_metadata."""
+        mock_model = MagicMock()
+        mock_response = AIMessage(content="Summary")
+        mock_response.response_metadata = {"usage_metadata": {"total_tokens": 200}}
+        mock_model.bind.return_value.ainvoke = AsyncMock(return_value=mock_response)
+
+        messages = [HumanMessage(content="Test")]
+
+        _summary, tokens = await summarize_discussion(mock_model, messages)
+
+        assert tokens == 200
+
+    @pytest.mark.asyncio
+    async def test_summarize_handles_empty_messages(self) -> None:
+        """summarize_discussion should handle empty message list."""
+        mock_model = MagicMock()
+        mock_response = AIMessage(content="Nothing to summarize")
+        mock_model.bind.return_value.ainvoke = AsyncMock(return_value=mock_response)
+
+        summary, _tokens = await summarize_discussion(mock_model, [])
+
+        assert summary == "Nothing to summarize"
+
+    @pytest.mark.asyncio
+    async def test_summarize_handles_non_string_content(self) -> None:
+        """summarize_discussion should handle non-string response content."""
+        mock_model = MagicMock()
+        mock_response = AIMessage(content=["list", "content"])  # type: ignore[arg-type]
+        mock_model.bind.return_value.ainvoke = AsyncMock(return_value=mock_response)
+
+        messages = [HumanMessage(content="Test")]
+
+        summary, _tokens = await summarize_discussion(mock_model, messages)
+
+        # Should convert to string
+        assert isinstance(summary, str)
+
+    @pytest.mark.asyncio
+    async def test_summarize_formats_all_message_types(self) -> None:
+        """summarize_discussion should format different message types."""
+        mock_model = MagicMock()
+        mock_response = AIMessage(content="Summary")
+        mock_model.bind.return_value.ainvoke = AsyncMock(return_value=mock_response)
+
+        messages = [
+            SystemMessage(content="System context"),
+            HumanMessage(content="User input"),
+            AIMessage(content="AI response"),
+        ]
+
+        await summarize_discussion(mock_model, messages)
+
+        call_args = mock_model.bind.return_value.ainvoke.call_args
+        invoke_messages = call_args[0][0]
+        conversation_text = invoke_messages[1].content
+
+        assert "System: System context" in conversation_text
+        assert "User: User input" in conversation_text
+        assert "Assistant: AI response" in conversation_text


### PR DESCRIPTION
## Problem
The Discuss phase produces a conversation history, but the Serialize phase needs a compact brief to work from. We need a Summarize phase to condense the discussion into structured output.

## Changes
- Add `prompts/templates/summarize.yaml` - externalized prompt template
- Add `src/questfoundry/agents/summarize.py` with `summarize_discussion()` function
- Add `src/questfoundry/agents/prompts.py` update with `get_summarize_prompt()`
- Export new functions from `src/questfoundry/agents/__init__.py`
- Add `tests/unit/test_summarize.py` with 13 tests covering edge cases

## Implementation Details
- Single LLM call (not an agent) - takes conversation history, produces summary
- Uses lower temperature (0.3) for focused, consistent output
- Formats conversation history into readable format for context
- Extracts token usage from response metadata (handles both `token_usage` and `usage_metadata` keys)
- Handles missing/null token values safely with `or 0` pattern
- Falls back gracefully if model doesn't support `.bind()`

## Not Included / Future PRs
- Serialize phase (PR6 #73) - uses this summary to produce final artifact
- Integration with CLI - will come in PR8

## Test Plan
```bash
uv run pytest tests/unit/test_summarize.py -v  # 13 tests pass
uv run pytest --tb=short -q                    # 452 total tests pass
```

## Risk / Rollback
- Low risk - adds new functionality, doesn't modify existing code paths
- No breaking changes

Closes #72

🤖 Generated with [Claude Code](https://claude.com/claude-code)