### PR TITLE
feat(agents): add serialize phase with validation loop (#73)

### DIFF
--- a/prompts/templates/serialize.yaml
+++ b/prompts/templates/serialize.yaml
@@ -9,7 +9,7 @@ system: |
 
   ## Guidelines
   - Extract ALL information from the brief - do not invent new details
-  - If a field is required and not mentioned in the brief, make a reasonable inference
+  - If a field is required and not mentioned in the brief, use a minimal/neutral value appropriate for the type (e.g., short placeholder text, 1 for integers)
   - If a field is optional and not mentioned, omit it
   - Use the exact field names and types specified
   - For arrays, include at least one item for required fields

--- a/prompts/templates/serialize.yaml
+++ b/prompts/templates/serialize.yaml
@@ -1,0 +1,23 @@
+name: serialize
+description: Convert discussion brief into structured artifact
+
+system: |
+  You are converting a creative brief into a structured artifact.
+
+  ## Your Task
+  Transform the brief into the exact JSON structure required.
+
+  ## Guidelines
+  - Extract ALL information from the brief - do not invent new details
+  - If a field is required and not mentioned in the brief, make a reasonable inference
+  - If a field is optional and not mentioned, omit it
+  - Use the exact field names and types specified
+  - For arrays, include at least one item for required fields
+  - Be precise with numeric values (word counts, passage counts)
+
+  ## Important
+  - Do NOT add commentary or explanations
+  - Output ONLY the structured JSON
+  - Follow the schema exactly
+
+components: []

--- a/src/questfoundry/agents/__init__.py
+++ b/src/questfoundry/agents/__init__.py
@@ -1,13 +1,21 @@
 """LangChain agents for QuestFoundry stages."""
 
 from questfoundry.agents.discuss import create_discuss_agent, run_discuss_phase
-from questfoundry.agents.prompts import get_discuss_prompt, get_summarize_prompt
+from questfoundry.agents.prompts import (
+    get_discuss_prompt,
+    get_serialize_prompt,
+    get_summarize_prompt,
+)
+from questfoundry.agents.serialize import SerializationError, serialize_to_artifact
 from questfoundry.agents.summarize import summarize_discussion
 
 __all__ = [
+    "SerializationError",
     "create_discuss_agent",
     "get_discuss_prompt",
+    "get_serialize_prompt",
     "get_summarize_prompt",
     "run_discuss_phase",
+    "serialize_to_artifact",
     "summarize_discussion",
 ]

--- a/src/questfoundry/agents/prompts.py
+++ b/src/questfoundry/agents/prompts.py
@@ -85,6 +85,20 @@ def get_summarize_prompt() -> str:
     return template.system
 
 
+def get_serialize_prompt() -> str:
+    """Build the Serialize phase prompt as a system message string.
+
+    Loads the prompt template from prompts/templates/serialize.yaml.
+    The serialize phase takes a brief and produces a structured artifact.
+
+    Returns:
+        System prompt string for the Serialize call
+    """
+    loader = _get_loader()
+    template = loader.load("serialize")
+    return template.system
+
+
 def _load_raw_template(template_name: str) -> dict[str, Any]:
     """Load raw template data without parsing into PromptTemplate.
 

--- a/src/questfoundry/agents/serialize.py
+++ b/src/questfoundry/agents/serialize.py
@@ -1,0 +1,229 @@
+"""Serialize phase for converting brief to structured artifact."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, TypeVar
+
+from langchain_core.messages import BaseMessage, HumanMessage, SystemMessage
+from pydantic import BaseModel, ValidationError
+
+from questfoundry.agents.prompts import get_serialize_prompt
+from questfoundry.artifacts.validator import strip_null_values
+from questfoundry.observability.logging import get_logger
+from questfoundry.providers.structured_output import (
+    StructuredOutputStrategy,
+    with_structured_output,
+)
+
+if TYPE_CHECKING:
+    from langchain_core.language_models import BaseChatModel
+
+log = get_logger(__name__)
+
+T = TypeVar("T", bound=BaseModel)
+
+
+class SerializationError(Exception):
+    """Raised when serialization fails after all retries."""
+
+    def __init__(
+        self,
+        message: str,
+        attempts: int,
+        last_errors: list[str],
+    ) -> None:
+        self.attempts = attempts
+        self.last_errors = last_errors
+        super().__init__(message)
+
+
+async def serialize_to_artifact(
+    model: BaseChatModel,
+    brief: str,
+    schema: type[T],
+    provider_name: str | None = None,
+    strategy: StructuredOutputStrategy | None = None,
+    max_retries: int = 3,
+) -> tuple[T, int]:
+    """Serialize a brief into a structured artifact.
+
+    Uses LangChain's structured output with a validation/repair loop.
+    If the initial output fails validation, error feedback is provided
+    to the model for retry (up to max_retries attempts).
+
+    Args:
+        model: Chat model to use for generation.
+        brief: The summary brief from the Summarize phase.
+        schema: Pydantic model class for the output.
+        provider_name: Provider name for strategy auto-detection.
+        strategy: Output strategy (auto-selected if None).
+        max_retries: Maximum total attempts (default 3).
+
+    Returns:
+        Tuple of (validated_artifact, tokens_used).
+
+    Raises:
+        SerializationError: If all attempts fail validation.
+    """
+    log.info(
+        "serialize_started",
+        schema=schema.__name__,
+        max_retries=max_retries,
+    )
+
+    # Configure model for structured output
+    structured_model = with_structured_output(
+        model,
+        schema,
+        strategy=strategy,
+        provider_name=provider_name,
+    )
+
+    system_prompt = get_serialize_prompt()
+    messages: list[BaseMessage] = [
+        SystemMessage(content=system_prompt),
+        HumanMessage(content=f"Convert this brief into the required structure:\n\n{brief}"),
+    ]
+
+    total_tokens = 0
+    last_errors: list[str] = []
+
+    for attempt in range(1, max_retries + 1):
+        log.debug("serialize_attempt", attempt=attempt, max_retries=max_retries)
+
+        try:
+            # Invoke structured output
+            result = await structured_model.ainvoke(messages)
+
+            # Extract token usage from response if available
+            tokens = _extract_tokens(result)
+            total_tokens += tokens
+
+            # If result is already a Pydantic model, validate succeeded
+            if isinstance(result, schema):
+                log.info(
+                    "serialize_completed",
+                    attempt=attempt,
+                    tokens=total_tokens,
+                )
+                return result, total_tokens
+
+            # If result is a dict, validate and convert
+            if isinstance(result, dict):
+                # Strip null values (LLMs often send null for optional fields)
+                cleaned = strip_null_values(result)
+                artifact = schema.model_validate(cleaned)
+                log.info(
+                    "serialize_completed",
+                    attempt=attempt,
+                    tokens=total_tokens,
+                )
+                return artifact, total_tokens
+
+            # Unexpected result type
+            last_errors = [f"Unexpected result type: {type(result).__name__}"]
+            log.warning(
+                "serialize_unexpected_type",
+                attempt=attempt,
+                result_type=type(result).__name__,
+            )
+
+        except ValidationError as e:
+            last_errors = _format_validation_errors(e)
+            log.debug(
+                "serialize_validation_failed",
+                attempt=attempt,
+                error_count=len(last_errors),
+            )
+
+            # Add error feedback for retry
+            if attempt < max_retries:
+                error_feedback = _build_error_feedback(last_errors)
+                messages.append(HumanMessage(content=error_feedback))
+
+        except Exception as e:
+            last_errors = [str(e)]
+            log.warning(
+                "serialize_error",
+                attempt=attempt,
+                error=str(e),
+            )
+
+            # Add error feedback for retry
+            if attempt < max_retries:
+                messages.append(
+                    HumanMessage(
+                        content=f"The previous attempt failed with an error: {e}\n\n"
+                        "Please try again, ensuring you output valid JSON matching the schema."
+                    )
+                )
+
+    # All retries exhausted
+    log.error(
+        "serialize_failed",
+        attempts=max_retries,
+        error_count=len(last_errors),
+    )
+    raise SerializationError(
+        f"Failed to serialize after {max_retries} attempts",
+        attempts=max_retries,
+        last_errors=last_errors,
+    )
+
+
+def _extract_tokens(result: object) -> int:
+    """Extract token usage from response metadata.
+
+    Args:
+        result: Response from model invocation.
+
+    Returns:
+        Total tokens used, or 0 if not available.
+    """
+    if not hasattr(result, "response_metadata"):
+        return 0
+
+    metadata = getattr(result, "response_metadata", None) or {}
+    if "token_usage" in metadata:
+        return metadata["token_usage"].get("total_tokens") or 0
+    if "usage_metadata" in metadata:
+        return metadata["usage_metadata"].get("total_tokens") or 0
+    return 0
+
+
+def _format_validation_errors(error: ValidationError) -> list[str]:
+    """Format Pydantic validation errors for feedback.
+
+    Args:
+        error: Pydantic ValidationError.
+
+    Returns:
+        List of human-readable error messages.
+    """
+    errors = []
+    for e in error.errors():
+        loc = ".".join(str(part) for part in e["loc"])
+        msg = e["msg"]
+        if loc:
+            errors.append(f"{loc}: {msg}")
+        else:
+            errors.append(msg)
+    return errors
+
+
+def _build_error_feedback(errors: list[str]) -> str:
+    """Build error feedback message for retry.
+
+    Args:
+        errors: List of validation error messages.
+
+    Returns:
+        Formatted feedback message for the model.
+    """
+    error_list = "\n".join(f"  - {e}" for e in errors)
+    return (
+        "The output had validation errors:\n"
+        f"{error_list}\n\n"
+        "Please fix these issues and try again. "
+        "Ensure all required fields are present and have valid values."
+    )

--- a/tests/unit/test_serialize.py
+++ b/tests/unit/test_serialize.py
@@ -1,0 +1,328 @@
+"""Tests for Serialize phase."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from pydantic import BaseModel, Field, ValidationError
+
+from questfoundry.agents.prompts import get_serialize_prompt
+from questfoundry.agents.serialize import (
+    SerializationError,
+    _build_error_feedback,
+    _extract_tokens,
+    _format_validation_errors,
+    serialize_to_artifact,
+)
+
+
+class SimpleSchema(BaseModel):
+    """Simple schema for testing."""
+
+    title: str = Field(min_length=1)
+    count: int = Field(ge=1)
+
+
+class TestGetSerializePrompt:
+    """Test serialize prompt loading."""
+
+    def test_prompt_loads_from_template(self) -> None:
+        """Prompt should load from external template file."""
+        prompt = get_serialize_prompt()
+
+        assert isinstance(prompt, str)
+        assert len(prompt) > 50
+
+    def test_prompt_includes_task_description(self) -> None:
+        """Prompt should describe the serialization task."""
+        prompt = get_serialize_prompt()
+
+        assert "brief" in prompt.lower()
+        assert "json" in prompt.lower()
+
+
+class TestSerializeToArtifact:
+    """Test serialize_to_artifact function."""
+
+    @pytest.mark.asyncio
+    async def test_serialize_returns_artifact_when_model_returns_pydantic(self) -> None:
+        """serialize_to_artifact should return Pydantic model directly."""
+        mock_model = MagicMock()
+        expected = SimpleSchema(title="Test", count=5)
+        mock_model.with_structured_output.return_value.ainvoke = AsyncMock(return_value=expected)
+
+        artifact, _tokens = await serialize_to_artifact(
+            mock_model,
+            "A test brief",
+            SimpleSchema,
+        )
+
+        assert artifact == expected
+
+    @pytest.mark.asyncio
+    async def test_serialize_returns_artifact_when_model_returns_dict(self) -> None:
+        """serialize_to_artifact should validate and convert dict results."""
+        mock_model = MagicMock()
+        mock_model.with_structured_output.return_value.ainvoke = AsyncMock(
+            return_value={"title": "Test", "count": 5}
+        )
+
+        artifact, _tokens = await serialize_to_artifact(
+            mock_model,
+            "A test brief",
+            SimpleSchema,
+        )
+
+        assert isinstance(artifact, SimpleSchema)
+        assert artifact.title == "Test"
+        assert artifact.count == 5
+
+    @pytest.mark.asyncio
+    async def test_serialize_strips_null_values_from_dict(self) -> None:
+        """serialize_to_artifact should strip null values before validation."""
+        mock_model = MagicMock()
+        # Simulate LLM sending null for optional field
+        mock_model.with_structured_output.return_value.ainvoke = AsyncMock(
+            return_value={"title": "Test", "count": 5, "optional_field": None}
+        )
+
+        artifact, _tokens = await serialize_to_artifact(
+            mock_model,
+            "A test brief",
+            SimpleSchema,
+        )
+
+        assert isinstance(artifact, SimpleSchema)
+        assert artifact.title == "Test"
+
+    @pytest.mark.asyncio
+    async def test_serialize_retries_on_validation_failure(self) -> None:
+        """serialize_to_artifact should retry with error feedback."""
+        mock_model = MagicMock()
+        mock_invoke = AsyncMock(
+            side_effect=[
+                {"title": "", "count": 5},  # Invalid: title too short
+                {"title": "Valid", "count": 5},  # Valid on retry
+            ]
+        )
+        mock_model.with_structured_output.return_value.ainvoke = mock_invoke
+
+        artifact, _tokens = await serialize_to_artifact(
+            mock_model,
+            "A test brief",
+            SimpleSchema,
+        )
+
+        assert artifact.title == "Valid"
+        assert mock_invoke.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_serialize_raises_after_max_retries(self) -> None:
+        """serialize_to_artifact should raise SerializationError after exhausting retries."""
+        mock_model = MagicMock()
+        mock_model.with_structured_output.return_value.ainvoke = AsyncMock(
+            return_value={"title": "", "count": 0}  # Always invalid
+        )
+
+        with pytest.raises(SerializationError) as exc_info:
+            await serialize_to_artifact(
+                mock_model,
+                "A test brief",
+                SimpleSchema,
+                max_retries=2,
+            )
+
+        assert exc_info.value.attempts == 2
+        assert len(exc_info.value.last_errors) > 0
+
+    @pytest.mark.asyncio
+    async def test_serialize_extracts_tokens_from_response(self) -> None:
+        """serialize_to_artifact should call _extract_tokens on response."""
+        from unittest.mock import patch
+
+        mock_model = MagicMock()
+        mock_model.with_structured_output.return_value.ainvoke = AsyncMock(
+            return_value={"title": "Test", "count": 5}
+        )
+
+        # Patch _extract_tokens to return a known value
+        with patch(
+            "questfoundry.agents.serialize._extract_tokens", return_value=150
+        ) as mock_extract:
+            _artifact, tokens = await serialize_to_artifact(
+                mock_model,
+                "A test brief",
+                SimpleSchema,
+            )
+
+        mock_extract.assert_called_once()
+        assert tokens == 150
+
+    @pytest.mark.asyncio
+    async def test_serialize_accumulates_tokens_on_retry(self) -> None:
+        """serialize_to_artifact should accumulate tokens across retries."""
+        from unittest.mock import patch
+
+        mock_model = MagicMock()
+        mock_invoke = AsyncMock(
+            side_effect=[
+                {"title": "", "count": 5},  # Invalid first attempt
+                {"title": "Valid", "count": 5},  # Valid on retry
+            ]
+        )
+        mock_model.with_structured_output.return_value.ainvoke = mock_invoke
+
+        # Return 100 tokens per call
+        with patch("questfoundry.agents.serialize._extract_tokens", return_value=100):
+            _artifact, tokens = await serialize_to_artifact(
+                mock_model,
+                "A test brief",
+                SimpleSchema,
+            )
+
+        assert tokens == 200  # 100 tokens x 2 attempts
+
+    @pytest.mark.asyncio
+    async def test_serialize_handles_exception_with_retry(self) -> None:
+        """serialize_to_artifact should retry on general exceptions."""
+        mock_model = MagicMock()
+        mock_invoke = AsyncMock(
+            side_effect=[
+                RuntimeError("Parse error"),
+                SimpleSchema(title="Success", count=1),
+            ]
+        )
+        mock_model.with_structured_output.return_value.ainvoke = mock_invoke
+
+        artifact, _tokens = await serialize_to_artifact(
+            mock_model,
+            "A test brief",
+            SimpleSchema,
+        )
+
+        assert artifact.title == "Success"
+        assert mock_invoke.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_serialize_handles_unexpected_result_type(self) -> None:
+        """serialize_to_artifact should handle unexpected result types."""
+        mock_model = MagicMock()
+        mock_model.with_structured_output.return_value.ainvoke = AsyncMock(
+            return_value="unexpected string"  # Not dict or Pydantic
+        )
+
+        with pytest.raises(SerializationError) as exc_info:
+            await serialize_to_artifact(
+                mock_model,
+                "A test brief",
+                SimpleSchema,
+                max_retries=1,
+            )
+
+        assert "Unexpected result type" in exc_info.value.last_errors[0]
+
+    @pytest.mark.asyncio
+    async def test_serialize_passes_strategy_to_structured_output(self) -> None:
+        """serialize_to_artifact should pass strategy parameter."""
+        from questfoundry.providers.structured_output import StructuredOutputStrategy
+
+        mock_model = MagicMock()
+        mock_model.with_structured_output.return_value.ainvoke = AsyncMock(
+            return_value=SimpleSchema(title="Test", count=1)
+        )
+
+        await serialize_to_artifact(
+            mock_model,
+            "A test brief",
+            SimpleSchema,
+            provider_name="openai",
+            strategy=StructuredOutputStrategy.JSON_MODE,
+        )
+
+        mock_model.with_structured_output.assert_called_once()
+
+
+class TestHelperFunctions:
+    """Test helper functions."""
+
+    def test_extract_tokens_from_token_usage(self) -> None:
+        """_extract_tokens should extract from token_usage key."""
+        mock_result = MagicMock()
+        mock_result.response_metadata = {"token_usage": {"total_tokens": 100}}
+
+        assert _extract_tokens(mock_result) == 100
+
+    def test_extract_tokens_from_usage_metadata(self) -> None:
+        """_extract_tokens should extract from usage_metadata key."""
+        mock_result = MagicMock()
+        mock_result.response_metadata = {"usage_metadata": {"total_tokens": 200}}
+
+        assert _extract_tokens(mock_result) == 200
+
+    def test_extract_tokens_returns_zero_when_no_metadata(self) -> None:
+        """_extract_tokens should return 0 when no metadata."""
+        mock_result = MagicMock(spec=[])  # No response_metadata attribute
+
+        assert _extract_tokens(mock_result) == 0
+
+    def test_extract_tokens_handles_none_total_tokens(self) -> None:
+        """_extract_tokens should handle None total_tokens."""
+        mock_result = MagicMock()
+        mock_result.response_metadata = {"token_usage": {"total_tokens": None}}
+
+        assert _extract_tokens(mock_result) == 0
+
+    def test_format_validation_errors_with_location(self) -> None:
+        """_format_validation_errors should include field location."""
+        try:
+            SimpleSchema(title="", count=0)
+        except ValidationError as e:
+            errors = _format_validation_errors(e)
+
+        assert len(errors) >= 2
+        assert any("title" in err for err in errors)
+        assert any("count" in err for err in errors)
+
+    def test_format_validation_errors_without_location(self) -> None:
+        """_format_validation_errors should handle errors without location."""
+
+        class RootValidated(BaseModel):
+            value: int
+
+            def __init__(self, **data: object) -> None:
+                super().__init__(**data)
+
+        try:
+            RootValidated(value="not_an_int")  # type: ignore[arg-type]
+        except ValidationError as e:
+            errors = _format_validation_errors(e)
+
+        assert len(errors) >= 1
+
+    def test_build_error_feedback_formats_errors(self) -> None:
+        """_build_error_feedback should format errors for model."""
+        errors = ["title: String should have at least 1 character", "count: Input should be >= 1"]
+
+        feedback = _build_error_feedback(errors)
+
+        assert "validation errors" in feedback.lower()
+        assert "title" in feedback
+        assert "count" in feedback
+        assert "fix" in feedback.lower()
+
+
+class TestSerializationError:
+    """Test SerializationError exception."""
+
+    def test_error_contains_attempts_and_errors(self) -> None:
+        """SerializationError should contain attempts and last errors."""
+        error = SerializationError(
+            "Failed to serialize",
+            attempts=3,
+            last_errors=["error1", "error2"],
+        )
+
+        assert error.attempts == 3
+        assert error.last_errors == ["error1", "error2"]
+        assert "Failed to serialize" in str(error)


### PR DESCRIPTION
## Problem
The pipeline needs to convert the summarized brief from the Discuss phase into a structured artifact. This requires using LangChain's structured output with a validation/repair loop to handle model errors gracefully.

## Changes
- Add `src/questfoundry/agents/serialize.py`:
  - `serialize_to_artifact()`: Main function using `with_structured_output`
  - Validation/repair loop (max 3 retries with error feedback)
  - `SerializationError` exception for exhausted retries
  - Token usage tracking across attempts
  - `_extract_tokens()`, `_format_validation_errors()`, `_build_error_feedback()` helpers

- Add `prompts/templates/serialize.yaml`: Prompt template for serialization

- Update `src/questfoundry/agents/prompts.py`:
  - Add `get_serialize_prompt()` function

- Update `src/questfoundry/agents/__init__.py`:
  - Export `serialize_to_artifact` and `SerializationError`

- Add `tests/unit/test_serialize.py`: 20 tests covering all scenarios

## Not Included / Future PRs
- CLI integration (PR8)
- Artifact persistence to disk (will use existing ArtifactWriter in PR8)
- Integration tests (PR9)

## Test Plan
```bash
uv run pytest tests/unit/test_serialize.py -v  # All 20 tests pass
uv run pytest --tb=short -q  # All 473 tests pass
```

## Risk / Rollback
- Low risk: New functionality, no existing code modified
- Depends on PR5 (feat/summarize-call) being merged first

Closes #73

🤖 Generated with [Claude Code](https://claude.com/claude-code)