### PR TITLE
fix(cli): wire interactive mode through to discuss phase

### DIFF
--- a/src/questfoundry/agents/discuss.py
+++ b/src/questfoundry/agents/discuss.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Awaitable, Callable
 from typing import TYPE_CHECKING, Any
 
 from langchain_core.messages import AIMessage, BaseMessage, HumanMessage
@@ -14,6 +15,11 @@ if TYPE_CHECKING:
     from langchain_core.tools import BaseTool
 
 log = get_logger(__name__)
+
+# Type aliases for callbacks
+UserInputFn = Callable[[], Awaitable[str | None]]
+AssistantMessageFn = Callable[[str], None]
+LLMCallbackFn = Callable[[str], None]
 
 
 def create_discuss_agent(
@@ -55,61 +61,121 @@ async def run_discuss_phase(
     tools: list[BaseTool],
     user_prompt: str,
     max_iterations: int = 25,
+    *,
+    interactive: bool = False,
+    user_input_fn: UserInputFn | None = None,
+    on_assistant_message: AssistantMessageFn | None = None,
+    on_llm_start: LLMCallbackFn | None = None,
+    on_llm_end: LLMCallbackFn | None = None,
 ) -> tuple[list[BaseMessage], int, int]:
     """Run the Discuss phase to completion.
 
     Creates a Discuss agent and runs it with the user's initial prompt.
     The agent will use research tools as needed and return when complete.
 
+    In interactive mode, allows multi-turn conversation until user types
+    '/done' or provides empty input.
+
     Args:
         model: Chat model to use
         tools: Research tools
         user_prompt: User's initial story idea
-        max_iterations: Maximum agent iterations (default 25)
+        max_iterations: Maximum agent iterations per turn (default 25)
+        interactive: Whether to enable interactive multi-turn mode
+        user_input_fn: Async function to get user input (required for interactive)
+        on_assistant_message: Callback when assistant responds
+        on_llm_start: Callback when LLM call starts
+        on_llm_end: Callback when LLM call ends
 
     Returns:
         Tuple of (messages, llm_call_count, total_tokens)
     """
     agent = create_discuss_agent(model, tools)
 
-    log.info("discuss_phase_started", user_prompt_length=len(user_prompt))
-
-    # Initial message from user - the agent will respond to this
-    initial_message = HumanMessage(content=user_prompt)
-
-    result = await agent.ainvoke(
-        {"messages": [initial_message]},
-        config={"recursion_limit": max_iterations},
+    log.info(
+        "discuss_phase_started",
+        user_prompt_length=len(user_prompt),
+        interactive=interactive,
     )
 
-    messages: list[BaseMessage] = result.get("messages", [])
-
-    # Extract metrics from response metadata
-    # LangChain tracks token usage in different places:
-    # - OpenAI: response_metadata["token_usage"]
-    # - Ollama: usage_metadata attribute on AIMessage
-    llm_calls = 0
+    # Track all messages and metrics across turns
+    all_messages: list[BaseMessage] = []
+    total_llm_calls = 0
     total_tokens = 0
-    for msg in messages:
-        if isinstance(msg, AIMessage):
-            llm_calls += 1
-            # First check usage_metadata attribute (Ollama, newer providers)
-            if hasattr(msg, "usage_metadata") and msg.usage_metadata:
-                tokens = msg.usage_metadata.get("total_tokens")
-                total_tokens += tokens if tokens is not None else 0
-            # Then check response_metadata (OpenAI)
-            elif hasattr(msg, "response_metadata") and msg.response_metadata:
-                metadata = msg.response_metadata
-                if "token_usage" in metadata:
-                    usage = metadata["token_usage"]
-                    tokens = usage.get("total_tokens")
+
+    # Initial message from user
+    current_messages: list[BaseMessage] = [HumanMessage(content=user_prompt)]
+
+    while True:
+        # Signal LLM start
+        if on_llm_start:
+            on_llm_start("")
+
+        # Run agent for this turn
+        result = await agent.ainvoke(
+            {"messages": current_messages},
+            config={"recursion_limit": max_iterations},
+        )
+
+        # Signal LLM end
+        if on_llm_end:
+            on_llm_end("")
+
+        turn_messages: list[BaseMessage] = result.get("messages", [])
+
+        # Extract metrics and find the last assistant message
+        last_ai_content = ""
+        for msg in turn_messages:
+            if isinstance(msg, AIMessage):
+                total_llm_calls += 1
+                last_ai_content = str(msg.content)
+                # Extract tokens
+                if hasattr(msg, "usage_metadata") and msg.usage_metadata:
+                    tokens = msg.usage_metadata.get("total_tokens")
                     total_tokens += tokens if tokens is not None else 0
+                elif hasattr(msg, "response_metadata") and msg.response_metadata:
+                    metadata = msg.response_metadata
+                    if "token_usage" in metadata:
+                        usage = metadata["token_usage"]
+                        tokens = usage.get("total_tokens")
+                        total_tokens += tokens if tokens is not None else 0
+
+        # Store messages
+        all_messages.extend(turn_messages)
+
+        # Display assistant response
+        if on_assistant_message and last_ai_content:
+            on_assistant_message(last_ai_content)
+
+        # If not interactive, we're done after one turn
+        if not interactive:
+            break
+
+        # Interactive mode: get next user input
+        if user_input_fn is None:
+            log.warning("interactive_mode_no_input_fn")
+            break
+
+        user_input = await user_input_fn()
+
+        # Check for exit conditions
+        if user_input is None or user_input.strip() == "":
+            log.debug("interactive_exit", reason="empty_input")
+            break
+
+        if user_input.strip().lower() in ("/done", "/quit", "/exit"):
+            log.debug("interactive_exit", reason="user_command")
+            break
+
+        # Continue conversation with user's new input
+        current_messages = [*all_messages, HumanMessage(content=user_input)]
 
     log.info(
         "discuss_phase_completed",
-        message_count=len(messages),
-        llm_calls=llm_calls,
+        message_count=len(all_messages),
+        llm_calls=total_llm_calls,
         total_tokens=total_tokens,
+        interactive=interactive,
     )
 
-    return messages, llm_calls, total_tokens
+    return all_messages, total_llm_calls, total_tokens

--- a/src/questfoundry/agents/discuss.py
+++ b/src/questfoundry/agents/discuss.py
@@ -17,8 +17,11 @@ if TYPE_CHECKING:
 log = get_logger(__name__)
 
 # Type aliases for callbacks
+#: Async function to get user input; returns None or empty string to exit
 UserInputFn = Callable[[], Awaitable[str | None]]
+#: Callback when assistant responds; receives the response content
 AssistantMessageFn = Callable[[str], None]
+#: Callback for LLM start/end events; receives the phase name (e.g., "discuss")
 LLMCallbackFn = Callable[[str], None]
 
 
@@ -175,7 +178,8 @@ async def run_discuss_phase(
             break
 
         # Interactive mode: get next user input
-        user_input = await user_input_fn()  # type: ignore[misc]
+        assert user_input_fn is not None  # Validated at line 112
+        user_input = await user_input_fn()
 
         # Check for exit conditions
         if user_input is None or user_input.strip() == "":

--- a/src/questfoundry/cli.py
+++ b/src/questfoundry/cli.py
@@ -386,6 +386,7 @@ def dream(
         # Interactive mode: no spinner, direct output
         console.print("[dim]Starting interactive DREAM stage...[/dim]")
         console.print("[dim]The AI will discuss your story idea with you.[/dim]")
+        console.print("[dim]Type [bold]/done[/bold] or press Enter on empty line to finish.[/dim]")
         console.print()
         result = asyncio.run(_run_dream())
     else:

--- a/src/questfoundry/pipeline/orchestrator.py
+++ b/src/questfoundry/pipeline/orchestrator.py
@@ -242,10 +242,23 @@ class PipelineOrchestrator:
 
             # Execute stage with new LangChain-native protocol
             log.debug("stage_execute", stage=stage_name)
+
+            # Extract interactive mode callbacks from context
+            interactive = bool(context.get("interactive", False))
+            user_input_fn = context.get("user_input_fn")
+            on_assistant_message = context.get("on_assistant_message")
+            on_llm_start = context.get("on_llm_start")
+            on_llm_end = context.get("on_llm_end")
+
             artifact_data, llm_calls, tokens_used = await stage.execute(
                 model=model,
                 user_prompt=user_prompt,
                 provider_name=self._provider_name or "unknown",
+                interactive=interactive,
+                user_input_fn=user_input_fn,
+                on_assistant_message=on_assistant_message,
+                on_llm_start=on_llm_start,
+                on_llm_end=on_llm_end,
             )
 
             # Validate artifact

--- a/src/questfoundry/pipeline/stages/dream.py
+++ b/src/questfoundry/pipeline/stages/dream.py
@@ -16,11 +16,6 @@ from questfoundry.agents import (
     serialize_to_artifact,
     summarize_discussion,
 )
-from questfoundry.agents.discuss import (
-    AssistantMessageFn,
-    LLMCallbackFn,
-    UserInputFn,
-)
 from questfoundry.artifacts import DreamArtifact
 from questfoundry.observability.logging import get_logger
 from questfoundry.tools.langchain_tools import get_all_research_tools
@@ -29,6 +24,12 @@ log = get_logger(__name__)
 
 if TYPE_CHECKING:
     from langchain_core.language_models import BaseChatModel
+
+    from questfoundry.agents.discuss import (
+        AssistantMessageFn,
+        LLMCallbackFn,
+        UserInputFn,
+    )
 
 
 class DreamStage:

--- a/src/questfoundry/pipeline/stages/dream.py
+++ b/src/questfoundry/pipeline/stages/dream.py
@@ -16,6 +16,11 @@ from questfoundry.agents import (
     serialize_to_artifact,
     summarize_discussion,
 )
+from questfoundry.agents.discuss import (
+    AssistantMessageFn,
+    LLMCallbackFn,
+    UserInputFn,
+)
 from questfoundry.artifacts import DreamArtifact
 from questfoundry.observability.logging import get_logger
 from questfoundry.tools.langchain_tools import get_all_research_tools
@@ -50,10 +55,10 @@ class DreamStage:
         provider_name: str | None = None,
         *,
         interactive: bool = False,
-        user_input_fn: Any | None = None,
-        on_assistant_message: Any | None = None,
-        on_llm_start: Any | None = None,
-        on_llm_end: Any | None = None,
+        user_input_fn: UserInputFn | None = None,
+        on_assistant_message: AssistantMessageFn | None = None,
+        on_llm_start: LLMCallbackFn | None = None,
+        on_llm_end: LLMCallbackFn | None = None,
     ) -> tuple[dict[str, Any], int, int]:
         """Execute the DREAM stage using the 3-phase pattern.
 

--- a/src/questfoundry/pipeline/stages/dream.py
+++ b/src/questfoundry/pipeline/stages/dream.py
@@ -48,6 +48,12 @@ class DreamStage:
         model: BaseChatModel,
         user_prompt: str,
         provider_name: str | None = None,
+        *,
+        interactive: bool = False,
+        user_input_fn: Any | None = None,
+        on_assistant_message: Any | None = None,
+        on_llm_start: Any | None = None,
+        on_llm_end: Any | None = None,
     ) -> tuple[dict[str, Any], int, int]:
         """Execute the DREAM stage using the 3-phase pattern.
 
@@ -55,6 +61,11 @@ class DreamStage:
             model: LangChain chat model for all phases.
             user_prompt: The user's story idea.
             provider_name: Provider name for structured output strategy selection.
+            interactive: Enable interactive multi-turn discussion mode.
+            user_input_fn: Async function to get user input (for interactive mode).
+            on_assistant_message: Callback when assistant responds.
+            on_llm_start: Callback when LLM call starts.
+            on_llm_end: Callback when LLM call ends.
 
         Returns:
             Tuple of (artifact_data, llm_calls, tokens_used).
@@ -65,6 +76,7 @@ class DreamStage:
         log.info(
             "dream_stage_started",
             prompt_length=len(user_prompt),
+            interactive=interactive,
         )
 
         total_llm_calls = 0
@@ -79,6 +91,11 @@ class DreamStage:
             model=model,
             tools=tools,
             user_prompt=user_prompt,
+            interactive=interactive,
+            user_input_fn=user_input_fn,
+            on_assistant_message=on_assistant_message,
+            on_llm_start=on_llm_start,
+            on_llm_end=on_llm_end,
         )
         total_llm_calls += discuss_calls
         total_tokens += discuss_tokens


### PR DESCRIPTION
## Problem
The `--interactive` flag in `qf dream` was set up in the CLI but the callbacks were never passed through to the discuss phase. This meant interactive mode didn't actually allow multi-turn conversation.

## Changes
- Add interactive callback parameters to `run_discuss_phase()`:
  - `user_input_fn`: async callback to get user input
  - `on_assistant_message`: callback when assistant responds
  - `on_llm_start`/`on_llm_end`: thinking indicator callbacks
- Update `DreamStage.execute()` to accept and forward callbacks
- Update orchestrator to extract callbacks from context and pass to stage
- Implement multi-turn conversation loop in discuss phase
- Add helpful message about `/done` command in interactive mode

## Not Included / Future PRs
- N/A

## Test Plan
- `uv run pytest tests/unit/test_discuss_agent.py` - all 17 tests pass
- `uv run pytest tests/unit/` - all 400 tests pass
- Manual test: `rm -Rf projects/test0 && uv run qf --log init test0 && uv run qf --log dream --interactive --provider ollama --project test0`

## Risk / Rollback
- Low risk - adds optional parameters with defaults that preserve existing behavior
- Non-interactive mode unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)