### PR TITLE
docs: add unified graph architecture to spec and architecture docs

### DIFF
--- a/docs/architecture/graph-storage.md
+++ b/docs/architecture/graph-storage.md
@@ -1,0 +1,361 @@
+# Graph Storage Architecture
+
+**Version**: 1.0.0
+**Status**: Proposed
+
+## Overview
+
+This document describes the runtime implementation of the unified story graph.
+The design principles and ontology are defined in [00-spec.md](../design/00-spec.md);
+this document covers implementation details.
+
+## Design Principles
+
+1. **Docs are truth. Code implements truth.** The ontology lives in design docs.
+   Pydantic models implement the ontology but are not the source of truth.
+
+2. **Single graph, multiple views.** One JSON file stores the graph.
+   Human-readable exports (YAML, Markdown) are generated on demand.
+
+3. **In-memory during stage.** Graph loads at stage start, modifications happen
+   in memory, and the graph persists at stage end.
+
+4. **Stage-level rollback.** Pre-stage snapshots enable reverting failed or
+   rejected stages without complex event sourcing.
+
+## Storage Format
+
+### Primary Storage: JSON
+
+The graph is stored as a single JSON file (`graph.json`) in the project root.
+
+```json
+{
+  "version": "5.0",
+  "meta": {
+    "project_name": "noir_mystery",
+    "last_stage": "seed",
+    "last_modified": "2026-01-13T10:30:00Z",
+    "stage_history": [
+      {"stage": "dream", "completed": "2026-01-13T09:00:00Z"},
+      {"stage": "brainstorm", "completed": "2026-01-13T09:30:00Z"},
+      {"stage": "seed", "completed": "2026-01-13T10:30:00Z"}
+    ]
+  },
+  "nodes": {
+    "vision": {
+      "type": "vision",
+      "genre": "noir mystery",
+      "tone": "gritty, atmospheric",
+      "themes": ["trust", "redemption"],
+      "constraints": ["no explicit violence"],
+      "length": "medium"
+    },
+    "detective_001": {
+      "type": "entity",
+      "entity_type": "character",
+      "concept": "Weary private eye with a dark past",
+      "disposition": "retained",
+      "base": {
+        "name": "Sam Cross",
+        "details": "..."
+      },
+      "overlays": []
+    }
+  },
+  "edges": [
+    {
+      "type": "choice",
+      "from": "opening_001",
+      "to": "investigate_office",
+      "label": "Head to the office",
+      "requires": [],
+      "grants": ["visited_office"]
+    },
+    {
+      "type": "has_alternative",
+      "from": "mentor_trust",
+      "to": "mentor_protector"
+    }
+  ]
+}
+```
+
+### Why JSON over YAML for Storage
+
+| Concern | JSON | YAML |
+|---------|------|------|
+| Parse speed | Fast | Slower |
+| Strictness | Strict (catches errors) | Forgiving (hides errors) |
+| Round-trip safety | Excellent | Risky (comments, formatting) |
+| Tool ecosystem | Universal | Good but quirky |
+| Human editing | Not intended | Better for review |
+
+**Decision:** JSON for storage, YAML for human review exports.
+
+## Graph Operations
+
+### Loading
+
+```python
+class Graph:
+    @classmethod
+    def load(cls, project_path: Path) -> "Graph":
+        """Load graph from project directory."""
+        graph_file = project_path / "graph.json"
+        if not graph_file.exists():
+            return cls.empty(project_path)
+
+        with graph_file.open() as f:
+            data = json.load(f)
+
+        return cls.from_dict(data)
+```
+
+### Saving
+
+```python
+def save(self, project_path: Path) -> None:
+    """Persist graph to storage."""
+    graph_file = project_path / "graph.json"
+
+    # Atomic write: write to temp file, then rename
+    temp_file = graph_file.with_suffix(".tmp")
+    with temp_file.open("w") as f:
+        json.dump(self.to_dict(), f, indent=2)
+    temp_file.rename(graph_file)
+```
+
+### Mutation Pattern
+
+Stages don't modify the graph directly. They produce structured output that
+the runtime interprets:
+
+```python
+async def run_stage(stage: Stage, graph: Graph) -> Graph:
+    # 1. Snapshot before modifications
+    snapshot_path = project_path / "snapshots" / f"pre-{stage.name}.json"
+    graph.save(snapshot_path)
+
+    # 2. Execute stage (produces structured output)
+    stage_output = await stage.execute(graph)
+
+    # 3. Validate output
+    validate_stage_output(stage.name, stage_output)
+
+    # 4. Apply mutations to graph
+    apply_mutations(graph, stage.name, stage_output)
+
+    # 5. Validate graph consistency
+    validate_graph(graph)
+
+    # 6. Persist
+    graph.save(project_path)
+
+    return graph
+```
+
+## Snapshot Strategy
+
+### Pre-Stage Snapshots
+
+Before each stage runs:
+
+```
+project/
+  graph.json              # Current state
+  snapshots/
+    pre-dream.json        # Before DREAM ran
+    pre-brainstorm.json   # Before BRAINSTORM ran
+    pre-seed.json         # Before SEED ran
+```
+
+### Rollback
+
+```python
+def rollback_to_stage(project_path: Path, stage_name: str) -> Graph:
+    """Restore graph to pre-stage snapshot."""
+    snapshot = project_path / "snapshots" / f"pre-{stage_name}.json"
+    if not snapshot.exists():
+        raise ValueError(f"No snapshot for stage {stage_name}")
+
+    # Load snapshot
+    graph = Graph.load_from_file(snapshot)
+
+    # Save as current
+    graph.save(project_path)
+
+    return graph
+```
+
+### Cleanup Policy
+
+Snapshots are kept indefinitely during development. For production:
+- Keep last N stages (configurable, default 3)
+- Archive older snapshots on successful SHIP
+
+## Human Review Exports
+
+When users run `qf review`, generate readable views:
+
+### YAML Export
+
+Full graph in YAML format for detailed review:
+
+```yaml
+# exports/graph.yaml
+version: "5.0"
+last_stage: seed
+
+nodes:
+  vision:
+    type: vision
+    genre: noir mystery
+    # ...
+
+  detective_001:
+    type: entity
+    entity_type: character
+    concept: "Weary private eye with a dark past"
+    # ...
+```
+
+### Markdown Summary
+
+High-level overview for quick review:
+
+```markdown
+# Noir Mystery - Graph Summary
+
+## Stage: SEED (completed 2026-01-13 10:30)
+
+### Entities (5)
+- **detective_001** (character): Weary private eye with a dark past [retained]
+- **femme_001** (character): Mysterious client with secrets [retained]
+- ...
+
+### Threads (2)
+- **mentor_protector_thread**: Trust arc exploring mentor as protector
+- **trust_betrayal_thread**: Trust arc exploring betrayal
+
+### Beats (8)
+- opening_001: First meeting (scene, opening)
+- investigation_001: Search the office (scene)
+- ...
+```
+
+### Export Command
+
+```bash
+qf review              # Generate exports, open for review
+qf review --format yaml
+qf review --format md
+qf export graph.yaml   # Just export, don't open
+```
+
+## Validation
+
+### Structural Validation
+
+After each stage, validate:
+
+1. **Node references**: All edge endpoints exist
+2. **Type consistency**: Edge types match node types
+3. **Required fields**: All required fields present
+4. **Stage ownership**: Only expected nodes created/modified
+
+### Graph Consistency
+
+Cross-cutting validation:
+
+1. **Reachability**: All passages reachable from start
+2. **No orphans**: No disconnected subgraphs (except pending work)
+3. **State coherence**: Codeword references valid
+
+### Validation Timing
+
+| Check | When |
+|-------|------|
+| Node schema | After stage output parsed |
+| Edge validity | After mutations applied |
+| Reachability | Before human gate |
+| Full consistency | Before SHIP |
+
+## Stage Integration
+
+### Stage Contract
+
+Each stage must:
+1. Accept graph as read-only context
+2. Produce stage-specific output (validated against schema)
+3. Not modify graph directly
+
+### Mutation Application
+
+The runtime maps stage output to graph mutations:
+
+```python
+def apply_mutations(graph: Graph, stage: str, output: dict) -> None:
+    """Apply stage output as graph mutations."""
+
+    if stage == "dream":
+        graph.set_node("vision", output["dream"])
+
+    elif stage == "brainstorm":
+        for entity in output["entities"]:
+            graph.add_node(entity["id"], {"type": "entity", **entity})
+        for tension in output["tensions"]:
+            graph.add_node(tension["id"], {"type": "tension", **tension})
+            for alt in tension["alternatives"]:
+                alt_id = f"{tension['id']}_{alt['id']}"
+                graph.add_node(alt_id, {"type": "alternative", **alt})
+                graph.add_edge("has_alternative", tension["id"], alt_id)
+
+    elif stage == "seed":
+        # ... seed mutations
+```
+
+## Performance Considerations
+
+### Memory Usage
+
+For medium-size stories (50-100 passages):
+- Graph in memory: ~1-5 MB
+- JSON on disk: ~100-500 KB
+- Load time: <100ms
+
+### Scaling
+
+If graphs grow larger:
+1. Lazy loading of node details
+2. Index edges by type for faster queries
+3. Consider SQLite for very large projects
+
+**Current decision:** Simple in-memory model is sufficient for v5.0 target scope.
+
+## Future Considerations
+
+### Audit Log
+
+Not implemented in v5.0. Could add:
+- Append-only log of all mutations
+- Enable fine-grained rollback
+- Support multi-user collaboration
+
+### Database Storage
+
+For very large projects or multi-user:
+- SQLite for local persistence
+- PostgreSQL for collaborative editing
+
+### Incremental Persistence
+
+For long-running stages:
+- Checkpoint during stage execution
+- Resume from checkpoint on failure
+
+## See Also
+
+- [00-spec.md](../design/00-spec.md) - Graph ontology and design
+- [schema-first-models.md](./schema-first-models.md) - Pydantic model generation
+- [langchain-dream-pipeline.md](./langchain-dream-pipeline.md) - Stage execution

--- a/docs/design/00-spec.md
+++ b/docs/design/00-spec.md
@@ -300,6 +300,20 @@ illustration:
 
 **Lifecycle:** Created in DRESS. Exported.
 
+#### Codex
+
+Player-facing encyclopedia entries for entities. Provides in-world information without spoilers.
+
+```yaml
+codex_entry:
+  id: string
+  entity_id: string               # which entity this describes
+  visible_when: codeword[]        # player must have these to see entry
+  content: string                 # player-safe, no spoilers
+```
+
+**Lifecycle:** Created in DRESS. Exported.
+
 ---
 
 ### Creative Nodes (created in BRAINSTORM, refined in SEED)
@@ -350,6 +364,20 @@ tensions:
 This yields four combinations (benevolent+capable, benevolent+flawed, etc.) while each tension remains a clear binary contrast.
 
 **Key insight:** "Mentor is a protector" is flat. "Mentor is a protector (not the manipulator they could have been)" has tension—even if we never write the manipulator thread.
+
+#### Alternative
+
+One possible answer to a Tension's question. Extracted as separate nodes in the graph to enable thread/alternative relationships.
+
+```yaml
+alternative:
+  id: string
+  description: string             # "Mentor is genuine protector"
+  canonical: bool                 # true = used for spine arc
+  tension_id: string              # parent tension
+```
+
+**Lifecycle:** Created in BRAINSTORM as part of tension generation. Not exported.
 
 ---
 
@@ -466,6 +494,9 @@ arc:
 ---
 
 ## Edge Types
+
+> **Naming Convention:** Persistent edges use PascalCase (Choice, Appears) as they appear
+> in exports. Working edges use snake_case (belongs_to, has_alternative) as they're internal only.
 
 ### Persistent Edges (survive to export)
 
@@ -1270,7 +1301,7 @@ When users run `qf review`:
 
 | Node | Persistent | Created in | Required for SHIP |
 |------|------------|------------|-------------------|
-| Vision | Yes | DREAM | Yes |
+| Vision | Yes | DREAM | No (context only) |
 | Passage | Yes | GROW | Yes (with prose) |
 | Entity | Yes | BRAINSTORM/SEED | Yes (FILL can update, not create) |
 | Codeword | Yes | GROW | Yes |

--- a/docs/design/00-spec.md
+++ b/docs/design/00-spec.md
@@ -160,6 +160,28 @@ This provides stage-level rollback without complex event sourcing.
 
 ## Node Types
 
+### Metadata Node
+
+#### Vision
+
+Creative direction established in DREAM. Not a graph node in the traditional sense—more like graph-level configuration.
+
+```yaml
+vision:
+  genre: string
+  tone: string[]
+  themes: string[]
+  audience: string
+  scope:
+    length: micro | short | medium | long
+    branches: minimal | moderate | extensive
+  content_notes: string[]
+```
+
+**Lifecycle:** Created in DREAM, read by all subsequent stages for context. Not exported.
+
+---
+
 ### Persistent Nodes (survive to export)
 
 #### Passage
@@ -175,6 +197,8 @@ passage:
 ```
 
 A passage is complete when `prose` exists.
+
+**Lifecycle:** Created in GROW (1:1 from beats), prose added in FILL. Exported.
 
 **Structural properties (derived):**
 - Start passage: no incoming choice edges
@@ -195,6 +219,8 @@ entity:
       details:
         key: value
 ```
+
+**Lifecycle:** Created in BRAINSTORM, curated in SEED, details added in FILL. Exported.
 
 **Creation constraint:** Entities can only be created in BRAINSTORM or SEED. Neither GROW nor FILL can create Entity nodes. Minor characters that appear in a single scene are prose detail, not entities.
 
@@ -237,6 +263,8 @@ codeword:
   condition: string | null         # for derived: e.g., "gold > 50"
 ```
 
+**Lifecycle:** Created in GROW (derived from beat grants and choice edges). Exported.
+
 The `tracks` field links a codeword to its originating consequence from SEED. This makes codewords traceable to their narrative purpose. When GROW creates `mentor_protector_committed`, it links back to the `mentor_ally` consequence.
 
 #### Relationship
@@ -257,9 +285,11 @@ relationship:
         key: value
 ```
 
+**Lifecycle:** Created in BRAINSTORM or SEED, updated in FILL. Exported.
+
 #### Illustration
 
-Art asset with caption. Created in DRESS.
+Art asset with caption.
 
 ```yaml
 illustration:
@@ -268,9 +298,11 @@ illustration:
   caption: string
 ```
 
+**Lifecycle:** Created in DRESS. Exported.
+
 ---
 
-### Creative Nodes (created in BRAINSTORM/SEED)
+### Creative Nodes (created in BRAINSTORM, refined in SEED)
 
 #### Tension
 
@@ -289,7 +321,11 @@ tension:
       canonical: false          # alternate arc if explored
   involves: entity_id[]
   why_it_matters: string        # thematic stakes
+  # Added by SEED:
+  explored: alternative_id[]    # which alternatives become threads
 ```
+
+**Lifecycle:** Created in BRAINSTORM, exploration decisions added in SEED. Not exported.
 
 **Binary constraint:** Exactly two alternatives per tension. This keeps contrasts crisp.
 
@@ -333,7 +369,9 @@ consequence:
     # - "Reveals family connection"
 ```
 
-Consequences are declared in SEED when threads are created. GROW creates codewords to track when consequences become active, and creates entity overlays to implement consequence effects.
+**Lifecycle:** Created in SEED when threads are created. Not exported.
+
+GROW creates codewords to track when consequences become active, and creates entity overlays to implement consequence effects.
 
 #### Plot Thread
 
@@ -350,6 +388,8 @@ thread:
   description: string
   consequences: consequence_id[]    # narrative meaning of this path
 ```
+
+**Lifecycle:** Created in SEED. Not exported. (THREAD FREEZE: no new threads after SEED)
 
 **Tier:**
 - **Major:** Defines the story. Must interweave with other major threads.
@@ -378,6 +418,8 @@ beat:
   location: entity_id | null              # primary location (assigned in SEED)
   location_alternatives: entity_id[]      # other valid locations (enables knot flexibility)
 ```
+
+**Lifecycle:** Initial beats created in SEED, mutated and new beats added in GROW. Not exported.
 
 **Location flexibility:** Beats can specify alternative locations where the same dramatic action could occur. If Beat A (at Market) and Beat B (at Docks) both have `location_alternatives` including each other's location, GROW can merge them by choosing a shared setting. This enables knot formation without constraining BRAINSTORM's creative freedom.
 
@@ -418,6 +460,8 @@ arc:
   diverges_at: beat_id | null
   converges_at: beat_id | null
 ```
+
+**Lifecycle:** Created in GROW during arc enumeration. Not exported.
 
 ---
 

--- a/docs/design/00-spec.md
+++ b/docs/design/00-spec.md
@@ -1292,6 +1292,7 @@ When users run `qf review`:
 | Appears | Yes | GROW | Yes |
 | Involves | Yes | GROW | Yes |
 | Depicts | Yes | DRESS | Yes |
+| involves (tension) | No | BRAINSTORM | No |
 | has_alternative | No | BRAINSTORM | No |
 | explores | No | SEED | No |
 | has_consequence | No | SEED | No |

--- a/docs/design/00-spec.md
+++ b/docs/design/00-spec.md
@@ -1270,6 +1270,7 @@ When users run `qf review`:
 
 | Node | Persistent | Created in | Required for SHIP |
 |------|------------|------------|-------------------|
+| Vision | Yes | DREAM | Yes |
 | Passage | Yes | GROW | Yes (with prose) |
 | Entity | Yes | BRAINSTORM/SEED | Yes (FILL can update, not create) |
 | Codeword | Yes | GROW | Yes |
@@ -1289,6 +1290,9 @@ When users run `qf review`:
 | Appears | Yes | GROW | Yes |
 | Involves | Yes | GROW | Yes |
 | Depicts | Yes | DRESS | Yes |
+| has_alternative | No | BRAINSTORM | No |
+| explores | No | SEED | No |
+| has_consequence | No | SEED | No |
 | belongs_to | No | SEED/GROW | No |
 | requires (beat) | No | SEED/GROW | No |
 | grants (beat) | No | GROW | No |

--- a/docs/design/00-spec.md
+++ b/docs/design/00-spec.md
@@ -1276,6 +1276,7 @@ When users run `qf review`:
 | Codeword | Yes | GROW | Yes |
 | Relationship | Yes | BRAINSTORM/SEED | Yes (FILL can update, not create) |
 | Illustration | Yes | DRESS | Yes |
+| Codex | Yes | DRESS | Yes |
 | Tension | No | BRAINSTORM | No |
 | Alternative | No | BRAINSTORM | No |
 | Consequence | No | SEED | No |

--- a/docs/design/00-spec.md
+++ b/docs/design/00-spec.md
@@ -735,11 +735,11 @@ Every choice has a diegetic label.
 
 #### Phase 0: Voice Determination
 
-Before prose generation, establish the voice document. This synthesizes DREAM's high-level vision with GROW's structural artifacts into concrete stylistic guidance.
+Before prose generation, establish the voice document. This synthesizes DREAM's high-level vision with GROW's structural data into concrete stylistic guidance.
 
 **Input:**
-- DREAM vision (genre, tone, themes)
-- GROW artifacts (arc structures, beat summaries, scene types)
+- Vision node (genre, tone, themes)
+- GROW-created nodes (arcs, beats with scene_type, passages with summaries)
 
 **Voice document schema:**
 ```yaml
@@ -1001,7 +1001,7 @@ Do not allow "keep generating until good." Quality comes from good prompts and h
 
 ### ❌ Backflow
 
-Do not allow later stages to modify earlier artifacts. If GROW reveals a problem with SEED, the human must manually revise SEED and regenerate.
+Do not allow later stages to modify nodes they don't own. Each node type has a creating stage (see Stage Operations table). If GROW reveals a problem with SEED's threads, the human must manually revert to pre-GROW snapshot and revise SEED.
 
 ### ❌ Hidden Prompts
 

--- a/docs/design/00-spec.md
+++ b/docs/design/00-spec.md
@@ -534,6 +534,10 @@ Example: `mentor_trusted` (from alignment tension) and `mentor_ill` (from health
 
 ## Stage Specifications
 
+> **Note on Output Schemas:** The YAML schemas shown below represent **LLM output format**,
+> not storage format. The runtime interprets these and applies graph mutations accordingly.
+> See "LLM Output vs Graph Storage" in the Graph Ontology section.
+
 ### Stage 1: DREAM
 
 **Purpose:** Riff on genre, tone, themes, constraints.

--- a/docs/design/00-spec.md
+++ b/docs/design/00-spec.md
@@ -469,12 +469,12 @@ arc:
 
 ### Persistent Edges (survive to export)
 
-| Edge | From → To | Properties | Purpose |
-|------|-----------|------------|---------|
-| **Choice** | passage → passage | label, requires[], grants[], modifies{} | Player navigation |
-| **Appears** | entity → passage | role | Entity present in scene |
-| **Involves** | relationship → passage | — | Relationship active in scene |
-| **Depicts** | illustration → passage | — | Art shown with passage |
+| Edge | From → To | Properties | Created In | Purpose |
+|------|-----------|------------|------------|---------|
+| **Choice** | passage → passage | label, requires[], grants[], modifies{} | GROW | Player navigation |
+| **Appears** | entity → passage | role | GROW | Entity present in scene |
+| **Involves** | relationship → passage | — | GROW | Relationship active in scene |
+| **Depicts** | illustration → passage | — | DRESS | Art shown with passage |
 
 **Choice properties:**
 ```yaml
@@ -486,15 +486,19 @@ choice:
     state_key: delta
 ```
 
-### Working Edges (consumed by GROW)
+### Working Edges (consumed by GROW, not exported)
 
-| Edge | From → To | Purpose |
-|------|-----------|---------|
-| **belongs_to** | beat → thread | Beat serves this thread |
-| **requires** | beat → beat | Ordering constraint |
-| **grants** | beat → codeword | Beat completion grants codeword |
-| **weaves** | arc → thread | Arc uses this thread |
-| **from_beat** | passage → beat | Traceability |
+| Edge | From → To | Created In | Purpose |
+|------|-----------|------------|---------|
+| **belongs_to** | beat → thread | SEED | Beat serves this thread |
+| **involves** | tension → entity | BRAINSTORM | Tension involves these entities |
+| **has_alternative** | tension → alternative | BRAINSTORM | Tension's possible answers |
+| **explores** | thread → alternative | SEED | Thread explores this alternative |
+| **has_consequence** | thread → consequence | SEED | Thread's narrative consequences |
+| **requires** | beat → beat | SEED, GROW | Ordering constraint |
+| **grants** | beat → codeword | GROW | Beat completion grants codeword |
+| **weaves** | arc → thread | GROW | Arc uses this thread |
+| **from_beat** | passage → beat | GROW | Traceability |
 
 ---
 

--- a/docs/design/00-spec.md
+++ b/docs/design/00-spec.md
@@ -1277,6 +1277,7 @@ When users run `qf review`:
 | Relationship | Yes | BRAINSTORM/SEED | Yes (FILL can update, not create) |
 | Illustration | Yes | DRESS | Yes |
 | Tension | No | BRAINSTORM | No |
+| Alternative | No | BRAINSTORM | No |
 | Consequence | No | SEED | No |
 | Plot Thread | No | SEED | No |
 | Beat | No | SEED/GROW | No |


### PR DESCRIPTION
## Problem

The v5 spec partially described two conflicting models:
1. Separate artifact files per stage (original conception)
2. Single unified graph mutated by stages (spec intent)

This confusion would cause implementation issues as developers wouldn't know which model to follow.

See #102 for the full discussion.

## Changes

### Spec Updates (docs/design/00-spec.md)
- Added "Graph Ontology" section explaining unified graph model
- Added "Stage Operations" table (creates/modifies/reads per stage)
- Added "LLM Output vs Graph Storage" clarification
- Added lifecycle info to all 11 node types and all edge types
- Updated File Structure to show graph-based storage with snapshots
- Updated terminology throughout (artifact → graph concepts)
- Completed Summary Tables with all nodes and edges

### New Architecture Doc (docs/architecture/graph-storage.md)
- JSON storage format and rationale
- Graph operations (load, save, mutation pattern)
- Snapshot strategy for stage-level rollback
- Human review exports (YAML, Markdown on demand)
- Validation timing (per-stage and graph-wide)
- Stage integration contract

## Not Included / Future PRs
- Actual Graph class implementation (this is docs only)
- Schema changes for graph format
- CLI commands for graph operations

## Test Plan
- Documentation only - no tests needed
- Manual review for consistency and completeness

## Risk / Rollback
- No code changes, docs only
- Low risk - can revert if design changes

Closes #102
