### PR TITLE
feat(pipeline): integrate unified graph into orchestrator

### DIFF
--- a/src/questfoundry/graph/__init__.py
+++ b/src/questfoundry/graph/__init__.py
@@ -14,6 +14,7 @@ from questfoundry.graph.mutations import (
     apply_dream_mutations,
     apply_mutations,
     apply_seed_mutations,
+    has_mutation_handler,
 )
 from questfoundry.graph.snapshots import (
     list_snapshots,
@@ -28,6 +29,7 @@ __all__ = [
     "apply_dream_mutations",
     "apply_mutations",
     "apply_seed_mutations",
+    "has_mutation_handler",
     "list_snapshots",
     "rollback_to_snapshot",
     "save_snapshot",

--- a/src/questfoundry/graph/mutations.py
+++ b/src/questfoundry/graph/mutations.py
@@ -39,6 +39,25 @@ def _require_field(item: dict[str, Any], field: str, context: str) -> Any:
     return item[field]
 
 
+# Registry of stages with mutation handlers
+_MUTATION_STAGES = frozenset({"dream", "brainstorm", "seed"})
+
+
+def has_mutation_handler(stage: str) -> bool:
+    """Check if a stage has a mutation handler.
+
+    Use this to determine whether to call apply_mutations() for a stage.
+    This is the single source of truth for which stages support graph mutations.
+
+    Args:
+        stage: Stage name to check.
+
+    Returns:
+        True if the stage has a mutation handler, False otherwise.
+    """
+    return stage in _MUTATION_STAGES
+
+
 def apply_mutations(graph: Graph, stage: str, output: dict[str, Any]) -> None:
     """Apply stage output as graph mutations.
 

--- a/src/questfoundry/pipeline/orchestrator.py
+++ b/src/questfoundry/pipeline/orchestrator.py
@@ -9,7 +9,7 @@ from datetime import datetime
 from typing import TYPE_CHECKING, Any, Literal
 
 from questfoundry.artifacts import ArtifactReader, ArtifactValidator, ArtifactWriter
-from questfoundry.graph import Graph, apply_mutations, save_snapshot
+from questfoundry.graph import Graph, apply_mutations, has_mutation_handler, save_snapshot
 from questfoundry.observability.logging import get_logger
 from questfoundry.observability.tracing import generate_run_id, set_pipeline_run_id
 from questfoundry.pipeline.config import ProjectConfigError, load_project_config
@@ -287,13 +287,18 @@ class PipelineOrchestrator:
                 log.debug("artifact_written", stage=stage_name, path=str(artifact_path))
 
                 # Apply mutations to unified graph (only for stages with mutation handlers)
-                if stage_name in ("dream", "brainstorm", "seed"):
-                    graph = Graph.load(self.project_path)
-                    save_snapshot(graph, self.project_path, stage_name)
-                    apply_mutations(graph, stage_name, artifact_data)
-                    graph.set_last_stage(stage_name)
-                    graph.save(self.project_path / "graph.json")
-                    log.debug("graph_updated", stage=stage_name)
+                if has_mutation_handler(stage_name):
+                    try:
+                        graph = Graph.load(self.project_path)
+                        # Pre-stage snapshot enables rollback if mutations fail or stage is rejected
+                        save_snapshot(graph, self.project_path, stage_name)
+                        apply_mutations(graph, stage_name, artifact_data)
+                        graph.set_last_stage(stage_name)
+                        graph.save(self.project_path / "graph.json")
+                        log.debug("graph_updated", stage=stage_name)
+                    except Exception as e:
+                        # Graph operations are non-critical - artifact was written successfully
+                        log.warning("graph_update_failed", stage=stage_name, error=str(e))
 
             # Calculate duration
             duration = time.perf_counter() - start_time
@@ -348,17 +353,21 @@ class PipelineOrchestrator:
     def get_status(self) -> PipelineStatus:
         """Get the current pipeline status.
 
-        Reads from both graph.json (preferred) and legacy artifact files
-        for backwards compatibility.
+        Stage completion is determined by artifact file existence.
+        Also loads graph.json metadata for debugging if available.
 
         Returns:
             PipelineStatus with stage information.
         """
         stages: dict[str, StageInfo] = {}
 
-        # Load graph for metadata (may not exist for legacy projects)
-        graph = Graph.load(self.project_path)
-        graph_last_stage = graph.get_last_stage()
+        # Load graph for metadata logging (may not exist or be corrupted)
+        graph_last_stage: str | None = None
+        try:
+            graph = Graph.load(self.project_path)
+            graph_last_stage = graph.get_last_stage()
+        except Exception as e:
+            log.warning("graph_load_failed_in_status", error=str(e))
 
         for stage_name in self.config.stages:
             stage_artifact_path = self.project_path / "artifacts" / f"{stage_name}.yaml"

--- a/tests/unit/test_mutations.py
+++ b/tests/unit/test_mutations.py
@@ -10,7 +10,32 @@ from questfoundry.graph.mutations import (
     apply_dream_mutations,
     apply_mutations,
     apply_seed_mutations,
+    has_mutation_handler,
 )
+
+
+class TestHasMutationHandler:
+    """Test the mutation handler check function."""
+
+    def test_returns_true_for_dream(self) -> None:
+        """Dream stage has a mutation handler."""
+        assert has_mutation_handler("dream") is True
+
+    def test_returns_true_for_brainstorm(self) -> None:
+        """Brainstorm stage has a mutation handler."""
+        assert has_mutation_handler("brainstorm") is True
+
+    def test_returns_true_for_seed(self) -> None:
+        """Seed stage has a mutation handler."""
+        assert has_mutation_handler("seed") is True
+
+    def test_returns_false_for_unknown_stage(self) -> None:
+        """Unknown stages don't have mutation handlers."""
+        assert has_mutation_handler("grow") is False
+        assert has_mutation_handler("fill") is False
+        assert has_mutation_handler("ship") is False
+        assert has_mutation_handler("mock") is False
+        assert has_mutation_handler("nonexistent") is False
 
 
 class TestApplyMutations:


### PR DESCRIPTION
## Problem

After merging PR #105 (Graph Infrastructure), the unified graph exists but isn't used by the orchestrator. Stage outputs are still written only to legacy artifact files. This PR integrates the graph into the pipeline to enable the new unified storage architecture.

## Changes

- Import `Graph`, `apply_mutations`, `save_snapshot` from `questfoundry.graph`
- After successful artifact validation in `run_stage()`:
  - Load the graph from `graph.json`
  - Save a pre-stage snapshot for rollback capability
  - Apply stage-specific mutations to the graph
  - Update graph metadata (`set_last_stage`)
  - Save the graph back to `graph.json`
- Only applies mutations for stages with handlers: `dream`, `brainstorm`, `seed`
- Update `get_status()` to load graph and log `last_stage` metadata
- Maintain backwards compatibility: still write legacy artifact files alongside graph

## Not Included / Future PRs

- BRAINSTORM stage implementation (PR#3)
- SEED stage implementation (PR#4)
- CLI commands for graph inspection
- Migration of existing projects from artifact-only to graph

## Test Plan

```bash
# All existing tests pass
uv run pytest tests/unit/test_orchestrator.py -v  # 20 passed
uv run pytest tests/unit/test_graph.py -v         # 23 passed
uv run pytest tests/unit/test_mutations.py -v     # 22 passed
```

## Risk / Rollback

- Low risk: graph operations are additive (artifact files still written)
- Existing projects continue to work with artifact-only storage
- Graph.load() returns empty graph if no graph.json exists
- Only mutation-enabled stages trigger graph operations

Part of #9 (Slice 2: DREAM → SEED)
Depends on: #105 (merged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)