### PR TITLE
feat(pipeline): add BRAINSTORM stage with models and CLI

### DIFF
--- a/prompts/templates/discuss_brainstorm.yaml
+++ b/prompts/templates/discuss_brainstorm.yaml
@@ -1,0 +1,49 @@
+name: discuss_brainstorm
+description: Creative exploration phase for generating story entities and tensions
+
+system: |
+  You are a creative collaborator helping to brainstorm story elements for an interactive fiction project.
+
+  ## Creative Vision Context
+  {vision_context}
+
+  ## Your Goal
+  Generate raw creative material that will seed the story structure:
+
+  1. **Entities** - Characters, locations, objects, and factions that could exist in this world
+     - Characters: Individual people/sentient beings
+     - Locations: Places, settings, venues
+     - Objects: Artifacts, devices, significant things
+     - Factions: Groups, organizations, collectives
+
+  2. **Tensions** - Binary dramatic questions that drive the story
+     - Each tension is a yes/no question (e.g., "Can the mentor be trusted?")
+     - Each tension has exactly TWO alternatives (not more, not less)
+     - One alternative should be marked as "canonical" (the default story path)
+     - For nuanced concepts, use MULTIPLE binary tensions rather than one multi-way choice
+
+  ## Guidelines
+  - Be expansive! Generate MORE material than needed (15-25 entities, 4-8 tensions is good)
+  - Include rich notes from discussion - preserve creative context
+  - Every tension must explicitly list which entities are involved
+  - Every tension needs a "why_it_matters" explaining thematic stakes
+  - Don't self-censor - SEED stage will filter later
+  {research_tools_section}
+
+  ## Binary Tension Examples
+  Good: "Is the mentor benevolent or self-serving?" (yes/no)
+  Good: "Is the archive's knowledge salvation or corruption?" (binary choice)
+  Bad: "What is the mentor's alignment?" (open-ended, not binary)
+
+research_tools_section: |
+  ## Research Tools Available
+  You have access to research tools to find relevant examples and techniques:
+  - search_corpus: Search IF Craft Corpus for techniques and examples
+  - get_document: Retrieve full documents from the corpus
+  - list_clusters: Discover available topic clusters
+  - web_search: Search the web for information
+  - web_fetch: Fetch content from URLs
+
+  Use these tools when helpful, but focus on creative brainstorming.
+
+components: []

--- a/prompts/templates/summarize_brainstorm.yaml
+++ b/prompts/templates/summarize_brainstorm.yaml
@@ -18,9 +18,9 @@ system: |
   For each tension capture:
   - id: short identifier (e.g., "mentor_trust")
   - question: binary dramatic question ending with "?"
-  - alternatives: EXACTLY TWO options
-    - First: canonical path (default story)
-    - Second: alternate path (branch if explored)
+  - alternatives: EXACTLY TWO options (order doesn't matter)
+    - One marked canonical: true (the default story path)
+    - One marked canonical: false (the alternate branch)
   - involves: list of entity IDs central to this tension
   - why_it_matters: thematic stakes and consequences
 

--- a/prompts/templates/summarize_brainstorm.yaml
+++ b/prompts/templates/summarize_brainstorm.yaml
@@ -1,0 +1,39 @@
+name: summarize_brainstorm
+description: Summarize brainstorm discussion into structured entities and tensions
+
+system: |
+  You are summarizing a brainstorming discussion about story elements.
+
+  ## Your Task
+  Condense the conversation into a structured summary of ALL entities and tensions discussed:
+
+  ### Entities (aim for 15-25)
+  For each entity capture:
+  - id: short identifier (e.g., "kay", "mentor", "archive")
+  - type: character, location, object, or faction
+  - concept: one-line essence
+  - notes: rich context from discussion
+
+  ### Tensions (aim for 4-8)
+  For each tension capture:
+  - id: short identifier (e.g., "mentor_trust")
+  - question: binary dramatic question ending with "?"
+  - alternatives: EXACTLY TWO options
+    - First: canonical path (default story)
+    - Second: alternate path (branch if explored)
+  - involves: list of entity IDs central to this tension
+  - why_it_matters: thematic stakes and consequences
+
+  ## Guidelines
+  - Extract ALL entities mentioned, even minor ones
+  - Ensure every tension has exactly TWO alternatives
+  - Preserve rich notes - this context helps later stages
+  - Mark which alternative is "canonical" (default path)
+  - Include entity IDs in tension "involves" lists
+  - Be complete - everything discussed should appear in the summary
+
+  ## Output Format
+  Provide a structured summary with clear entity and tension sections.
+  Use consistent formatting so the next phase can serialize it accurately.
+
+components: []

--- a/src/questfoundry/agents/__init__.py
+++ b/src/questfoundry/agents/__init__.py
@@ -2,6 +2,8 @@
 
 from questfoundry.agents.discuss import create_discuss_agent, run_discuss_phase
 from questfoundry.agents.prompts import (
+    get_brainstorm_discuss_prompt,
+    get_brainstorm_summarize_prompt,
     get_discuss_prompt,
     get_serialize_prompt,
     get_summarize_prompt,
@@ -12,6 +14,8 @@ from questfoundry.agents.summarize import summarize_discussion
 __all__ = [
     "SerializationError",
     "create_discuss_agent",
+    "get_brainstorm_discuss_prompt",
+    "get_brainstorm_summarize_prompt",
     "get_discuss_prompt",
     "get_serialize_prompt",
     "get_summarize_prompt",

--- a/src/questfoundry/agents/prompts.py
+++ b/src/questfoundry/agents/prompts.py
@@ -121,6 +121,10 @@ def get_brainstorm_discuss_prompt(
 ) -> str:
     """Build the BRAINSTORM discuss prompt with vision context.
 
+    Uses _load_raw_template() instead of _get_loader() because we need access
+    to the 'research_tools_section' field which isn't in the PromptTemplate
+    dataclass. Summarize prompts use _get_loader() since they only need system.
+
     Args:
         vision_context: Formatted vision from DREAM stage.
         research_tools_available: Whether research tools are available.

--- a/src/questfoundry/agents/prompts.py
+++ b/src/questfoundry/agents/prompts.py
@@ -113,3 +113,43 @@ def _load_raw_template(template_name: str) -> dict[str, Any]:
     yaml = YAML()
     with path.open("r", encoding="utf-8") as f:
         return dict(yaml.load(f))
+
+
+def get_brainstorm_discuss_prompt(
+    vision_context: str,
+    research_tools_available: bool = True,
+) -> str:
+    """Build the BRAINSTORM discuss prompt with vision context.
+
+    Args:
+        vision_context: Formatted vision from DREAM stage.
+        research_tools_available: Whether research tools are available.
+
+    Returns:
+        System prompt string for the BRAINSTORM discuss agent.
+    """
+    raw_data = _load_raw_template("discuss_brainstorm")
+
+    # Build research tools section
+    research_section = ""
+    if research_tools_available:
+        research_section = raw_data.get("research_tools_section", "")
+
+    # Render the system template
+    system_template = raw_data.get("system", "")
+    prompt = ChatPromptTemplate.from_template(system_template)
+    return prompt.format(
+        vision_context=vision_context,
+        research_tools_section=research_section,
+    )
+
+
+def get_brainstorm_summarize_prompt() -> str:
+    """Build the BRAINSTORM summarize prompt.
+
+    Returns:
+        System prompt string for the BRAINSTORM summarize call.
+    """
+    loader = _get_loader()
+    template = loader.load("summarize_brainstorm")
+    return template.system

--- a/src/questfoundry/models/__init__.py
+++ b/src/questfoundry/models/__init__.py
@@ -1,0 +1,22 @@
+"""Pydantic models for stage outputs.
+
+These models define the structured output format for each pipeline stage.
+The LLM produces output matching these schemas, which is then validated
+and applied to the unified graph.
+"""
+
+from questfoundry.models.brainstorm import (
+    Alternative,
+    BrainstormOutput,
+    Entity,
+    EntityType,
+    Tension,
+)
+
+__all__ = [
+    "Alternative",
+    "BrainstormOutput",
+    "Entity",
+    "EntityType",
+    "Tension",
+]

--- a/src/questfoundry/models/brainstorm.py
+++ b/src/questfoundry/models/brainstorm.py
@@ -1,0 +1,118 @@
+"""Pydantic models for BRAINSTORM stage output.
+
+BRAINSTORM is the expansive exploration phase that generates raw creative
+material: entities (characters, locations, objects, factions) and tensions
+(binary dramatic questions with two alternatives each).
+
+See docs/design/00-spec.md and docs/design/procedures/brainstorm.md for details.
+"""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import BaseModel, Field, model_validator
+
+EntityType = Literal["character", "location", "object", "faction"]
+
+
+class Entity(BaseModel):
+    """A story entity: character, location, object, or faction.
+
+    Entities are the raw building blocks generated during BRAINSTORM.
+    SEED will later decide which to retain, cut, or modify.
+
+    Attributes:
+        id: Short identifier (e.g., "kay", "mentor", "archive").
+        type: Entity category.
+        concept: One-line essence capturing what makes it interesting.
+        notes: Freeform context from discussion (rich detail allowed).
+    """
+
+    id: str = Field(min_length=1, description="Short identifier for the entity")
+    type: EntityType = Field(description="Entity category")
+    concept: str = Field(min_length=1, description="One-line essence of the entity")
+    notes: str | None = Field(default=None, description="Freeform notes from discussion")
+
+
+class Alternative(BaseModel):
+    """One possible answer to a tension's binary question.
+
+    Each tension has exactly two alternatives. One is marked canonical
+    (the default story path), and one is the alternate (becomes a branch
+    only if explicitly explored in SEED).
+
+    Attributes:
+        id: Short identifier (e.g., "mentor_protector").
+        description: Full description of this answer/path.
+        canonical: True if this is the default story path.
+    """
+
+    id: str = Field(min_length=1, description="Short identifier for the alternative")
+    description: str = Field(min_length=1, description="Full description of this path")
+    canonical: bool = Field(description="True if this is the default/spine path")
+
+
+class Tension(BaseModel):
+    """A binary dramatic question with two alternative answers.
+
+    Tensions represent meaningful story choices. The binary constraint
+    keeps contrasts crisp and meaningful. For nuanced concepts, use
+    multiple binary tensions instead of a single multi-way choice.
+
+    Attributes:
+        id: Short identifier (e.g., "mentor_trust").
+        question: The dramatic question (must end with "?").
+        alternatives: Exactly two possible answers.
+        involves: Entity IDs central to this tension.
+        why_it_matters: Thematic stakes and consequences.
+    """
+
+    id: str = Field(min_length=1, description="Short identifier for the tension")
+    question: str = Field(min_length=1, description="Dramatic question (should end with ?)")
+    alternatives: list[Alternative] = Field(
+        min_length=2,
+        max_length=2,
+        description="Exactly two alternative answers",
+    )
+    involves: list[str] = Field(
+        default_factory=list,
+        description="Entity IDs central to this tension",
+    )
+    why_it_matters: str = Field(
+        min_length=1,
+        description="Thematic stakes and narrative consequences",
+    )
+
+    @model_validator(mode="after")
+    def validate_exactly_one_canonical(self) -> Tension:
+        """Ensure exactly one alternative is marked canonical."""
+        canonical_count = sum(1 for alt in self.alternatives if alt.canonical)
+        if canonical_count != 1:
+            msg = f"Tension '{self.id}' must have exactly one canonical alternative, found {canonical_count}"
+            raise ValueError(msg)
+        return self
+
+
+class BrainstormOutput(BaseModel):
+    """Complete output of the BRAINSTORM stage.
+
+    This structured output is produced by the LLM after the Discuss phase.
+    It contains all generated entities and tensions that will be triaged
+    by SEED into committed story structure.
+
+    Good BRAINSTORM produces 15-25 entities and 4-8 tensions.
+
+    Attributes:
+        entities: All generated story entities.
+        tensions: All generated dramatic tensions.
+    """
+
+    entities: list[Entity] = Field(
+        default_factory=list,
+        description="Generated story entities",
+    )
+    tensions: list[Tension] = Field(
+        default_factory=list,
+        description="Generated dramatic tensions",
+    )

--- a/src/questfoundry/pipeline/orchestrator.py
+++ b/src/questfoundry/pipeline/orchestrator.py
@@ -267,6 +267,7 @@ class PipelineOrchestrator:
                 on_assistant_message=on_assistant_message,
                 on_llm_start=on_llm_start,
                 on_llm_end=on_llm_end,
+                project_path=self.project_path,
             )
 
             # Validate artifact

--- a/src/questfoundry/pipeline/stages/__init__.py
+++ b/src/questfoundry/pipeline/stages/__init__.py
@@ -8,14 +8,25 @@ from questfoundry.pipeline.stages.base import (
     list_stages,
     register_stage,
 )
+from questfoundry.pipeline.stages.brainstorm import (
+    BrainstormStage,
+    BrainstormStageError,
+    brainstorm_stage,
+    create_brainstorm_stage,
+)
 from questfoundry.pipeline.stages.dream import DreamStage, dream_stage
 
 # Register built-in stages
 register_stage(dream_stage)
+register_stage(brainstorm_stage)
 
 __all__ = [
+    "BrainstormStage",
+    "BrainstormStageError",
     "DreamStage",
     "Stage",
+    "brainstorm_stage",
+    "create_brainstorm_stage",
     "dream_stage",
     "get_stage",
     "list_stages",

--- a/src/questfoundry/pipeline/stages/brainstorm.py
+++ b/src/questfoundry/pipeline/stages/brainstorm.py
@@ -1,0 +1,285 @@
+"""BRAINSTORM stage implementation.
+
+The BRAINSTORM stage generates raw creative material: entities (characters,
+locations, objects, factions) and tensions (binary dramatic questions).
+
+Uses the LangChain-native 3-phase pattern:
+Discuss → Summarize → Serialize.
+
+Requires DREAM stage to have completed (reads vision from graph).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path  # noqa: TC003 - used at runtime for Graph.load()
+from typing import TYPE_CHECKING, Any
+
+from questfoundry.agents import (
+    get_brainstorm_discuss_prompt,
+    get_brainstorm_summarize_prompt,
+    run_discuss_phase,
+    serialize_to_artifact,
+    summarize_discussion,
+)
+from questfoundry.graph import Graph
+from questfoundry.models import BrainstormOutput
+from questfoundry.observability.logging import get_logger
+from questfoundry.observability.tracing import get_current_run_tree, traceable
+from questfoundry.tools.langchain_tools import get_all_research_tools
+
+log = get_logger(__name__)
+
+if TYPE_CHECKING:
+    from langchain_core.language_models import BaseChatModel
+
+    from questfoundry.agents.discuss import (
+        AssistantMessageFn,
+        LLMCallbackFn,
+        UserInputFn,
+    )
+
+
+class BrainstormStageError(Exception):
+    """Raised when BRAINSTORM stage cannot proceed."""
+
+    pass
+
+
+def _format_vision_context(vision_node: dict[str, Any]) -> str:
+    """Format vision node data as readable context for brainstorming.
+
+    Args:
+        vision_node: Vision node data from graph.
+
+    Returns:
+        Formatted string describing the creative vision.
+    """
+    parts = []
+
+    if genre := vision_node.get("genre"):
+        subgenre = vision_node.get("subgenre", "")
+        genre_line = f"**Genre**: {genre}"
+        if subgenre:
+            genre_line += f" ({subgenre})"
+        parts.append(genre_line)
+
+    if tone := vision_node.get("tone"):
+        if isinstance(tone, list):
+            parts.append(f"**Tone**: {', '.join(tone)}")
+        else:
+            parts.append(f"**Tone**: {tone}")
+
+    if themes := vision_node.get("themes"):
+        if isinstance(themes, list):
+            parts.append(f"**Themes**: {', '.join(themes)}")
+        else:
+            parts.append(f"**Themes**: {themes}")
+
+    if audience := vision_node.get("audience"):
+        parts.append(f"**Audience**: {audience}")
+
+    if style_notes := vision_node.get("style_notes"):
+        parts.append(f"**Style**: {style_notes}")
+
+    if scope := vision_node.get("scope"):
+        parts.append(f"**Scope**: {scope}")
+
+    return "\n".join(parts) if parts else "No creative vision available."
+
+
+class BrainstormStage:
+    """BRAINSTORM stage - generate entities and tensions.
+
+    This stage takes the creative vision from DREAM and generates raw
+    creative material: entities (characters, locations, objects, factions)
+    and tensions (binary dramatic questions with two alternatives each).
+
+    Uses the LangChain-native 3-phase pattern:
+    - Discuss: Brainstorm entities and tensions with research tools
+    - Summarize: Condense discussion into structured summary
+    - Serialize: Convert to BrainstormOutput artifact
+
+    Attributes:
+        name: Stage identifier ("brainstorm").
+        project_path: Path to project directory for graph access.
+    """
+
+    name = "brainstorm"
+
+    def __init__(self, project_path: Path | None = None) -> None:
+        """Initialize BRAINSTORM stage.
+
+        Args:
+            project_path: Path to project directory. Required for loading
+                vision context from graph. If None, must be provided via
+                context in execute().
+        """
+        self.project_path = project_path
+
+    def _get_vision_context(self, project_path: Path) -> str:
+        """Load and format vision from graph.
+
+        Args:
+            project_path: Path to project directory.
+
+        Returns:
+            Formatted vision context string.
+
+        Raises:
+            BrainstormStageError: If vision not found in graph.
+        """
+        graph = Graph.load(project_path)
+        vision_node = graph.get_node("vision")
+
+        if vision_node is None:
+            raise BrainstormStageError(
+                "BRAINSTORM requires DREAM stage to complete first. "
+                "No vision found in graph. Run 'qf dream' first."
+            )
+
+        return _format_vision_context(vision_node)
+
+    @traceable(name="BRAINSTORM Stage", run_type="chain", tags=["stage:brainstorm"])
+    async def execute(
+        self,
+        model: BaseChatModel,
+        user_prompt: str,
+        provider_name: str | None = None,
+        *,
+        interactive: bool = False,
+        user_input_fn: UserInputFn | None = None,
+        on_assistant_message: AssistantMessageFn | None = None,
+        on_llm_start: LLMCallbackFn | None = None,
+        on_llm_end: LLMCallbackFn | None = None,
+        project_path: Path | None = None,
+    ) -> tuple[dict[str, Any], int, int]:
+        """Execute the BRAINSTORM stage using the 3-phase pattern.
+
+        Args:
+            model: LangChain chat model for all phases.
+            user_prompt: Additional guidance for brainstorming (optional).
+            provider_name: Provider name for structured output strategy selection.
+            interactive: Enable interactive multi-turn discussion mode.
+            user_input_fn: Async function to get user input (for interactive mode).
+            on_assistant_message: Callback when assistant responds.
+            on_llm_start: Callback when LLM call starts.
+            on_llm_end: Callback when LLM call ends.
+            project_path: Override for project path (uses self.project_path if None).
+
+        Returns:
+            Tuple of (artifact_data, llm_calls, tokens_used).
+
+        Raises:
+            BrainstormStageError: If vision not found in graph.
+            SerializationError: If serialization fails after all retries.
+        """
+        # Resolve project path
+        resolved_path = project_path or self.project_path
+        if resolved_path is None:
+            raise BrainstormStageError(
+                "project_path is required for BRAINSTORM stage. "
+                "Provide it in constructor or execute() call."
+            )
+
+        # Add dynamic metadata to the trace
+        if rt := get_current_run_tree():
+            rt.metadata["provider"] = provider_name
+            rt.metadata["prompt_length"] = len(user_prompt)
+            rt.metadata["interactive"] = interactive
+
+        log.info(
+            "brainstorm_stage_started",
+            prompt_length=len(user_prompt),
+            interactive=interactive,
+        )
+
+        total_llm_calls = 0
+        total_tokens = 0
+
+        # Load vision context from graph
+        vision_context = self._get_vision_context(resolved_path)
+        log.debug("brainstorm_vision_loaded", context_length=len(vision_context))
+
+        # Get research tools
+        tools = get_all_research_tools()
+
+        # Build discuss prompt with vision context
+        discuss_prompt = get_brainstorm_discuss_prompt(
+            vision_context=vision_context,
+            research_tools_available=bool(tools),
+        )
+
+        # Phase 1: Discuss
+        log.debug("brainstorm_phase", phase="discuss")
+        messages, discuss_calls, discuss_tokens = await run_discuss_phase(
+            model=model,
+            tools=tools,
+            user_prompt=user_prompt
+            or "Let's brainstorm story elements based on this creative vision.",
+            interactive=interactive,
+            user_input_fn=user_input_fn,
+            on_assistant_message=on_assistant_message,
+            on_llm_start=on_llm_start,
+            on_llm_end=on_llm_end,
+            system_prompt=discuss_prompt,
+            stage_name="brainstorm",
+        )
+        total_llm_calls += discuss_calls
+        total_tokens += discuss_tokens
+
+        # Phase 2: Summarize
+        log.debug("brainstorm_phase", phase="summarize")
+        summarize_prompt = get_brainstorm_summarize_prompt()
+        brief, summarize_tokens = await summarize_discussion(
+            model=model,
+            messages=messages,
+            system_prompt=summarize_prompt,
+            stage_name="brainstorm",
+        )
+        total_llm_calls += 1
+        total_tokens += summarize_tokens
+
+        # Phase 3: Serialize
+        log.debug("brainstorm_phase", phase="serialize")
+        artifact, serialize_tokens = await serialize_to_artifact(
+            model=model,
+            brief=brief,
+            schema=BrainstormOutput,
+            provider_name=provider_name,
+        )
+        total_llm_calls += 1
+        total_tokens += serialize_tokens
+
+        # Convert to dict for return
+        artifact_data = artifact.model_dump()
+
+        # Log summary statistics
+        entity_count = len(artifact_data.get("entities", []))
+        tension_count = len(artifact_data.get("tensions", []))
+
+        log.info(
+            "brainstorm_stage_completed",
+            llm_calls=total_llm_calls,
+            tokens=total_tokens,
+            entities=entity_count,
+            tensions=tension_count,
+        )
+
+        return artifact_data, total_llm_calls, total_tokens
+
+
+# Factory function to create stage with project path
+def create_brainstorm_stage(project_path: Path | None = None) -> BrainstormStage:
+    """Create a BRAINSTORM stage instance.
+
+    Args:
+        project_path: Path to project directory for graph access.
+
+    Returns:
+        Configured BrainstormStage instance.
+    """
+    return BrainstormStage(project_path)
+
+
+# Create singleton instance for registration (project_path provided at execution)
+brainstorm_stage = BrainstormStage()

--- a/src/questfoundry/pipeline/stages/brainstorm.py
+++ b/src/questfoundry/pipeline/stages/brainstorm.py
@@ -45,6 +45,11 @@ class BrainstormStageError(Exception):
     pass
 
 
+def _format_list_or_str(value: list[str] | str) -> str:
+    """Format a value that may be a list or string as comma-separated text."""
+    return ", ".join(value) if isinstance(value, list) else value
+
+
 def _format_vision_context(vision_node: dict[str, Any]) -> str:
     """Format vision node data as readable context for brainstorming.
 
@@ -64,16 +69,10 @@ def _format_vision_context(vision_node: dict[str, Any]) -> str:
         parts.append(genre_line)
 
     if tone := vision_node.get("tone"):
-        if isinstance(tone, list):
-            parts.append(f"**Tone**: {', '.join(tone)}")
-        else:
-            parts.append(f"**Tone**: {tone}")
+        parts.append(f"**Tone**: {_format_list_or_str(tone)}")
 
     if themes := vision_node.get("themes"):
-        if isinstance(themes, list):
-            parts.append(f"**Themes**: {', '.join(themes)}")
-        else:
-            parts.append(f"**Themes**: {themes}")
+        parts.append(f"**Themes**: {_format_list_or_str(themes)}")
 
     if audience := vision_node.get("audience"):
         parts.append(f"**Audience**: {audience}")

--- a/src/questfoundry/pipeline/stages/dream.py
+++ b/src/questfoundry/pipeline/stages/dream.py
@@ -24,6 +24,8 @@ from questfoundry.tools.langchain_tools import get_all_research_tools
 log = get_logger(__name__)
 
 if TYPE_CHECKING:
+    from pathlib import Path
+
     from langchain_core.language_models import BaseChatModel
 
     from questfoundry.agents.discuss import (
@@ -62,6 +64,7 @@ class DreamStage:
         on_assistant_message: AssistantMessageFn | None = None,
         on_llm_start: LLMCallbackFn | None = None,
         on_llm_end: LLMCallbackFn | None = None,
+        project_path: Path | None = None,  # noqa: ARG002 - API consistency
     ) -> tuple[dict[str, Any], int, int]:
         """Execute the DREAM stage using the 3-phase pattern.
 
@@ -74,6 +77,7 @@ class DreamStage:
             on_assistant_message: Callback when assistant responds.
             on_llm_start: Callback when LLM call starts.
             on_llm_end: Callback when LLM call ends.
+            project_path: Path to project directory (unused by DREAM, for API consistency).
 
         Returns:
             Tuple of (artifact_data, llm_calls, tokens_used).

--- a/tests/unit/test_brainstorm_stage.py
+++ b/tests/unit/test_brainstorm_stage.py
@@ -1,0 +1,411 @@
+"""Tests for BRAINSTORM stage implementation."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+from langchain_core.messages import AIMessage, HumanMessage
+
+from questfoundry.models import BrainstormOutput
+from questfoundry.pipeline.stages import BrainstormStage, BrainstormStageError, get_stage
+
+# --- Stage Registration Tests ---
+
+
+def test_brainstorm_stage_registered() -> None:
+    """Brainstorm stage is registered automatically."""
+    stage = get_stage("brainstorm")
+    assert stage is not None
+    assert stage.name == "brainstorm"
+
+
+def test_brainstorm_stage_name() -> None:
+    """BrainstormStage has correct name."""
+    stage = BrainstormStage()
+    assert stage.name == "brainstorm"
+
+
+# --- Execute Tests ---
+
+
+@pytest.mark.asyncio
+async def test_execute_requires_project_path() -> None:
+    """Execute raises error when project_path is not provided."""
+    stage = BrainstormStage()  # No project_path
+
+    mock_model = MagicMock()
+
+    with pytest.raises(BrainstormStageError, match="project_path is required"):
+        await stage.execute(model=mock_model, user_prompt="test")
+
+
+@pytest.mark.asyncio
+async def test_execute_requires_vision_in_graph() -> None:
+    """Execute raises error when vision is not found in graph."""
+    stage = BrainstormStage()
+
+    mock_model = MagicMock()
+    mock_graph = MagicMock()
+    mock_graph.get_node.return_value = None  # No vision node
+
+    with (
+        patch("questfoundry.pipeline.stages.brainstorm.Graph") as MockGraph,
+    ):
+        MockGraph.load.return_value = mock_graph
+
+        with pytest.raises(BrainstormStageError, match="BRAINSTORM requires DREAM"):
+            await stage.execute(
+                model=mock_model,
+                user_prompt="test",
+                project_path=Path("/test/project"),
+            )
+
+
+@pytest.mark.asyncio
+async def test_execute_calls_all_three_phases() -> None:
+    """Execute calls discuss, summarize, and serialize phases."""
+    stage = BrainstormStage()
+
+    mock_model = MagicMock()
+    mock_graph = MagicMock()
+    mock_graph.get_node.return_value = {
+        "genre": "fantasy",
+        "tone": ["epic"],
+        "themes": ["heroism"],
+    }
+
+    with (
+        patch("questfoundry.pipeline.stages.brainstorm.Graph") as MockGraph,
+        patch("questfoundry.pipeline.stages.brainstorm.run_discuss_phase") as mock_discuss,
+        patch("questfoundry.pipeline.stages.brainstorm.summarize_discussion") as mock_summarize,
+        patch("questfoundry.pipeline.stages.brainstorm.serialize_to_artifact") as mock_serialize,
+        patch("questfoundry.pipeline.stages.brainstorm.get_all_research_tools") as mock_tools,
+    ):
+        MockGraph.load.return_value = mock_graph
+        mock_tools.return_value = []
+        mock_discuss.return_value = (
+            [HumanMessage(content="hi"), AIMessage(content="hello")],
+            2,  # llm_calls
+            500,  # tokens
+        )
+        mock_summarize.return_value = ("Brief summary", 100)
+        mock_artifact = BrainstormOutput(
+            entities=[{"id": "hero", "type": "character", "concept": "A brave warrior"}],
+            tensions=[
+                {
+                    "id": "quest",
+                    "question": "Will the hero succeed?",
+                    "alternatives": [
+                        {"id": "success", "description": "Hero wins", "canonical": True},
+                        {"id": "failure", "description": "Hero fails", "canonical": False},
+                    ],
+                    "involves": ["hero"],
+                    "why_it_matters": "Core story tension",
+                }
+            ],
+        )
+        mock_serialize.return_value = (mock_artifact, 200)
+
+        artifact, llm_calls, tokens = await stage.execute(
+            model=mock_model,
+            user_prompt="Let's brainstorm",
+            project_path=Path("/test/project"),
+        )
+
+        # Verify all phases were called
+        mock_discuss.assert_called_once()
+        mock_summarize.assert_called_once()
+        mock_serialize.assert_called_once()
+
+        # Verify result
+        assert len(artifact["entities"]) == 1
+        assert len(artifact["tensions"]) == 1
+        assert llm_calls == 4  # 2 discuss + 1 summarize + 1 serialize
+        assert tokens == 800  # 500 + 100 + 200
+
+
+@pytest.mark.asyncio
+async def test_execute_passes_vision_context_to_discuss() -> None:
+    """Execute passes formatted vision context to discuss phase."""
+    stage = BrainstormStage()
+
+    mock_model = MagicMock()
+    mock_graph = MagicMock()
+    mock_graph.get_node.return_value = {
+        "genre": "noir",
+        "subgenre": "detective",
+        "tone": ["dark", "moody"],
+        "themes": ["corruption", "justice"],
+    }
+
+    with (
+        patch("questfoundry.pipeline.stages.brainstorm.Graph") as MockGraph,
+        patch("questfoundry.pipeline.stages.brainstorm.run_discuss_phase") as mock_discuss,
+        patch("questfoundry.pipeline.stages.brainstorm.summarize_discussion") as mock_summarize,
+        patch("questfoundry.pipeline.stages.brainstorm.serialize_to_artifact") as mock_serialize,
+        patch("questfoundry.pipeline.stages.brainstorm.get_all_research_tools") as mock_tools,
+        patch(
+            "questfoundry.pipeline.stages.brainstorm.get_brainstorm_discuss_prompt"
+        ) as mock_prompt,
+    ):
+        MockGraph.load.return_value = mock_graph
+        mock_tools.return_value = []
+        mock_prompt.return_value = "System prompt with vision"
+        mock_discuss.return_value = ([], 1, 100)
+        mock_summarize.return_value = ("Brief", 50)
+        mock_artifact = BrainstormOutput(entities=[], tensions=[])
+        mock_serialize.return_value = (mock_artifact, 100)
+
+        await stage.execute(
+            model=mock_model,
+            user_prompt="test",
+            project_path=Path("/test/project"),
+        )
+
+        # Verify get_brainstorm_discuss_prompt was called with vision context
+        mock_prompt.assert_called_once()
+        call_kwargs = mock_prompt.call_args.kwargs
+        assert "vision_context" in call_kwargs
+        # Vision context should include genre info
+        assert "noir" in call_kwargs["vision_context"]
+
+
+@pytest.mark.asyncio
+async def test_execute_passes_brainstorm_output_schema() -> None:
+    """Execute passes BrainstormOutput schema to serialize."""
+    stage = BrainstormStage()
+
+    mock_model = MagicMock()
+    mock_graph = MagicMock()
+    mock_graph.get_node.return_value = {"genre": "fantasy"}
+
+    with (
+        patch("questfoundry.pipeline.stages.brainstorm.Graph") as MockGraph,
+        patch("questfoundry.pipeline.stages.brainstorm.run_discuss_phase") as mock_discuss,
+        patch("questfoundry.pipeline.stages.brainstorm.summarize_discussion") as mock_summarize,
+        patch("questfoundry.pipeline.stages.brainstorm.serialize_to_artifact") as mock_serialize,
+        patch("questfoundry.pipeline.stages.brainstorm.get_all_research_tools") as mock_tools,
+    ):
+        MockGraph.load.return_value = mock_graph
+        mock_tools.return_value = []
+        mock_discuss.return_value = ([], 1, 100)
+        mock_summarize.return_value = ("Brief", 50)
+        mock_artifact = BrainstormOutput(entities=[], tensions=[])
+        mock_serialize.return_value = (mock_artifact, 100)
+
+        await stage.execute(
+            model=mock_model,
+            user_prompt="test",
+            project_path=Path("/test/project"),
+        )
+
+        assert mock_serialize.call_args.kwargs["schema"] is BrainstormOutput
+
+
+@pytest.mark.asyncio
+async def test_execute_uses_brainstorm_summarize_prompt() -> None:
+    """Execute uses brainstorm-specific summarize prompt."""
+    stage = BrainstormStage()
+
+    mock_model = MagicMock()
+    mock_graph = MagicMock()
+    mock_graph.get_node.return_value = {"genre": "fantasy"}
+
+    with (
+        patch("questfoundry.pipeline.stages.brainstorm.Graph") as MockGraph,
+        patch("questfoundry.pipeline.stages.brainstorm.run_discuss_phase") as mock_discuss,
+        patch("questfoundry.pipeline.stages.brainstorm.summarize_discussion") as mock_summarize,
+        patch("questfoundry.pipeline.stages.brainstorm.serialize_to_artifact") as mock_serialize,
+        patch("questfoundry.pipeline.stages.brainstorm.get_all_research_tools") as mock_tools,
+        patch(
+            "questfoundry.pipeline.stages.brainstorm.get_brainstorm_summarize_prompt"
+        ) as mock_prompt,
+    ):
+        MockGraph.load.return_value = mock_graph
+        mock_tools.return_value = []
+        mock_prompt.return_value = "Brainstorm summarize prompt"
+        mock_discuss.return_value = ([], 1, 100)
+        mock_summarize.return_value = ("Brief", 50)
+        mock_artifact = BrainstormOutput(entities=[], tensions=[])
+        mock_serialize.return_value = (mock_artifact, 100)
+
+        await stage.execute(
+            model=mock_model,
+            user_prompt="test",
+            project_path=Path("/test/project"),
+        )
+
+        # Verify summarize was called with brainstorm prompt
+        mock_prompt.assert_called_once()
+        assert mock_summarize.call_args.kwargs["system_prompt"] == "Brainstorm summarize prompt"
+
+
+@pytest.mark.asyncio
+async def test_execute_returns_artifact_as_dict() -> None:
+    """Execute returns artifact as dictionary, not Pydantic model."""
+    stage = BrainstormStage()
+
+    mock_model = MagicMock()
+    mock_graph = MagicMock()
+    mock_graph.get_node.return_value = {"genre": "fantasy"}
+
+    with (
+        patch("questfoundry.pipeline.stages.brainstorm.Graph") as MockGraph,
+        patch("questfoundry.pipeline.stages.brainstorm.run_discuss_phase") as mock_discuss,
+        patch("questfoundry.pipeline.stages.brainstorm.summarize_discussion") as mock_summarize,
+        patch("questfoundry.pipeline.stages.brainstorm.serialize_to_artifact") as mock_serialize,
+        patch("questfoundry.pipeline.stages.brainstorm.get_all_research_tools") as mock_tools,
+    ):
+        MockGraph.load.return_value = mock_graph
+        mock_tools.return_value = []
+        mock_discuss.return_value = ([], 1, 100)
+        mock_summarize.return_value = ("Brief", 50)
+        mock_artifact = BrainstormOutput(
+            entities=[{"id": "kay", "type": "character", "concept": "Protagonist"}],
+            tensions=[
+                {
+                    "id": "trust",
+                    "question": "Can Kay trust the mentor?",
+                    "alternatives": [
+                        {"id": "yes", "description": "Trust", "canonical": True},
+                        {"id": "no", "description": "Betray", "canonical": False},
+                    ],
+                    "involves": ["kay"],
+                    "why_it_matters": "Theme of trust",
+                }
+            ],
+        )
+        mock_serialize.return_value = (mock_artifact, 100)
+
+        artifact, _, _ = await stage.execute(
+            model=mock_model,
+            user_prompt="test",
+            project_path=Path("/test/project"),
+        )
+
+        assert isinstance(artifact, dict)
+        assert artifact["entities"][0]["id"] == "kay"
+        assert artifact["tensions"][0]["id"] == "trust"
+
+
+# --- Vision Context Formatting Tests ---
+
+
+def test_format_vision_context_includes_genre() -> None:
+    """_format_vision_context includes genre in output."""
+    from questfoundry.pipeline.stages.brainstorm import _format_vision_context
+
+    vision = {"genre": "fantasy", "subgenre": "epic"}
+    result = _format_vision_context(vision)
+
+    assert "fantasy" in result
+    assert "epic" in result
+
+
+def test_format_vision_context_includes_tone() -> None:
+    """_format_vision_context includes tone in output."""
+    from questfoundry.pipeline.stages.brainstorm import _format_vision_context
+
+    vision = {"tone": ["dark", "gritty"]}
+    result = _format_vision_context(vision)
+
+    assert "dark" in result
+    assert "gritty" in result
+
+
+def test_format_vision_context_includes_themes() -> None:
+    """_format_vision_context includes themes in output."""
+    from questfoundry.pipeline.stages.brainstorm import _format_vision_context
+
+    vision = {"themes": ["redemption", "sacrifice"]}
+    result = _format_vision_context(vision)
+
+    assert "redemption" in result
+    assert "sacrifice" in result
+
+
+def test_format_vision_context_handles_empty() -> None:
+    """_format_vision_context handles empty vision node."""
+    from questfoundry.pipeline.stages.brainstorm import _format_vision_context
+
+    vision: dict[str, str] = {}
+    result = _format_vision_context(vision)
+
+    assert "No creative vision available" in result
+
+
+# --- Model Tests ---
+
+
+def test_brainstorm_output_model_validates() -> None:
+    """BrainstormOutput model validates correctly."""
+    output = BrainstormOutput(
+        entities=[{"id": "hero", "type": "character", "concept": "The protagonist"}],
+        tensions=[
+            {
+                "id": "quest",
+                "question": "Will the hero complete the quest?",
+                "alternatives": [
+                    {"id": "success", "description": "Quest complete", "canonical": True},
+                    {"id": "failure", "description": "Quest failed", "canonical": False},
+                ],
+                "involves": ["hero"],
+                "why_it_matters": "Central narrative tension",
+            }
+        ],
+    )
+
+    assert len(output.entities) == 1
+    assert len(output.tensions) == 1
+    assert output.entities[0].id == "hero"
+    assert output.tensions[0].id == "quest"
+
+
+def test_tension_requires_two_alternatives() -> None:
+    """Tension model requires exactly two alternatives."""
+    from pydantic import ValidationError
+
+    from questfoundry.models.brainstorm import Tension
+
+    with pytest.raises(ValidationError, match="List should have at least 2 items"):
+        Tension(
+            id="test",
+            question="Test?",
+            alternatives=[{"id": "one", "description": "Only one", "canonical": True}],
+            involves=[],
+            why_it_matters="Test",
+        )
+
+
+def test_tension_requires_one_canonical() -> None:
+    """Tension model requires exactly one canonical alternative."""
+    from pydantic import ValidationError
+
+    from questfoundry.models.brainstorm import Tension
+
+    with pytest.raises(ValidationError, match=r"one.*canonical"):
+        Tension(
+            id="test",
+            question="Test?",
+            alternatives=[
+                {"id": "one", "description": "First", "canonical": True},
+                {"id": "two", "description": "Second", "canonical": True},
+            ],
+            involves=[],
+            why_it_matters="Test",
+        )
+
+
+def test_entity_types() -> None:
+    """Entity model accepts all valid types."""
+    from questfoundry.models.brainstorm import Entity
+
+    for entity_type in ["character", "location", "object", "faction"]:
+        entity = Entity(
+            id="test",
+            type=entity_type,
+            concept="Test concept",
+        )
+        assert entity.type == entity_type


### PR DESCRIPTION
## Problem

Issue #9 (Slice 2) requires implementing BRAINSTORM and SEED stages to build the DREAM → SEED pipeline. This PR implements the BRAINSTORM stage, which takes the creative vision from DREAM and generates entities (characters, locations, objects, factions) and tensions (binary dramatic questions).

## Changes

- Add Pydantic models for BRAINSTORM output (`src/questfoundry/models/brainstorm.py`):
  - `Entity` model with id, type, concept, notes
  - `Alternative` model for tension answers
  - `Tension` model with validation for exactly 2 alternatives and 1 canonical
  - `BrainstormOutput` combining entities and tensions

- Extend agents module to support stage-specific prompts:
  - Add `system_prompt` and `stage_name` parameters to `run_discuss_phase`
  - Add `system_prompt` and `stage_name` parameters to `summarize_discussion`
  - Add `get_brainstorm_discuss_prompt()` and `get_brainstorm_summarize_prompt()`

- Create prompt templates:
  - `prompts/templates/discuss_brainstorm.yaml` - brainstorming system prompt with vision context
  - `prompts/templates/summarize_brainstorm.yaml` - summarization prompt for entities/tensions

- Implement BrainstormStage (`src/questfoundry/pipeline/stages/brainstorm.py`):
  - Loads vision from graph (requires DREAM to complete first)
  - Uses 3-phase pattern: Discuss → Summarize → Serialize
  - Passes vision context to discuss prompt
  - Uses brainstorm-specific prompts for both discuss and summarize

- Add CLI command `qf brainstorm`:
  - Same interface as `qf dream` (prompt, project, provider, interactive)
  - Shows entity count by type and tension questions on completion

- Update orchestrator to pass `project_path` to stages (needed by BRAINSTORM to load graph)

## Not Included / Future PRs

- SEED stage implementation (PR#4 per plan)
- Artifact validator for brainstorm schema
- Integration with apply_mutations (already wired up via `has_mutation_handler`)

## Test Plan

```bash
# Run unit tests
uv run pytest tests/unit/test_brainstorm_stage.py -v
# All 17 tests pass

# Run full unit test suite
uv run pytest tests/unit -q
# All 502 tests pass

# Type check
uv run mypy src/questfoundry/pipeline/stages/brainstorm.py
# No errors

# Lint
uv run ruff check src/questfoundry/pipeline/stages/brainstorm.py
# All checks passed
```

## Risk / Rollback

- Low risk: New stage, doesn't modify existing behavior
- DREAM stage unchanged (just added optional `project_path` parameter)
- Can be disabled by removing from stage registration

🤖 Generated with [Claude Code](https://claude.com/claude-code)