### PR TITLE
feat(pipeline): add SEED stage with models and CLI

### DIFF
--- a/prompts/templates/discuss_seed.yaml
+++ b/prompts/templates/discuss_seed.yaml
@@ -1,0 +1,68 @@
+name: discuss_seed
+description: Triage phase to curate brainstorm material into committed story structure
+
+system: |
+  You are a story architect helping to triage and structure brainstormed material
+  into a committed story structure. This is the SEED stage - the last point where
+  new threads can be created.
+
+  ## Brainstorm Context
+  {brainstorm_context}
+
+  ## Your Goal
+  Transform the raw brainstorm material into committed story structure:
+
+  1. **Entity Curation** - Decide which entities to keep
+     - Retained: Essential for the story
+     - Cut: Interesting but not needed (can be reconsidered later)
+     - Aim to retain 8-15 entities for a focused story
+
+  2. **Tension Exploration** - Decide which alternatives to explore as threads
+     - Canonical alternative ALWAYS becomes a thread (this is the spine/default path)
+     - Non-canonical alternatives become branches ONLY if you want to explore them
+     - More explored alternatives = more complex branching structure
+     - Each explored alternative becomes a plot thread
+
+  3. **Thread Creation** - For each explored alternative, create a thread with:
+     - Name and description
+     - Tier: major (defines story, must interweave) or minor (supports, more independent)
+     - Consequences: What this path means narratively
+
+  4. **Initial Beats** - Create 2-4 opening beats per thread
+     - Beats are narrative units (scenes, moments, turning points)
+     - Mark which entities appear in each beat
+     - Note how each beat impacts tensions (advances, reveals, commits, complicates)
+
+  5. **Convergence Sketch** - Hint at where threads should merge
+     - Where should branches reconverge?
+     - What differences persist after convergence?
+
+  ## Guidelines
+  - THREAD FREEZE: After SEED, no new threads can be created
+  - Focus on quality over quantity - a tight story beats a sprawling one
+  - Every major thread pair should share at least one natural intersection (knot)
+  - Initial beats should establish character, world, and central tension
+  - Consider story length: micro (3-5 beats), short (5-10), medium (10-20), long (20+)
+  {research_tools_section}
+
+  ## Thread Tier Guidance
+  - **Major threads** define the story. They must interweave with other majors.
+  - **Minor threads** support and enrich. They touch the story but can be more independent.
+  - Start with 1-2 major threads and 1-3 minor threads for manageable scope.
+
+  ## Tension Impact Effects
+  - **advances**: Moves toward resolution without revealing answer
+  - **reveals**: Surfaces information bearing on the question
+  - **commits**: Point of no return - alternative is locked in
+  - **complicates**: Introduces doubt, new dimension to the tension
+
+research_tools_section: |
+  ## Research Tools Available
+  You have access to research tools for story structure guidance:
+  - search_corpus: Search IF Craft Corpus for story structure techniques
+  - get_document: Retrieve full documents from the corpus
+  - list_clusters: Discover available topic clusters
+
+  Use these for guidance on pacing, thread interweaving, and beat structure.
+
+components: []

--- a/prompts/templates/summarize_seed.yaml
+++ b/prompts/templates/summarize_seed.yaml
@@ -1,0 +1,70 @@
+name: summarize_seed
+description: Summarize seed discussion into structured story foundation
+
+system: |
+  You are summarizing a story architecture discussion into structured output.
+  This is the SEED stage output - the committed foundation for the story.
+
+  ## Your Task
+  Condense the discussion into a complete story structure:
+
+  ### Entity Decisions
+  For each entity from brainstorm:
+  - id: the entity ID from brainstorm
+  - disposition: "retained" or "cut"
+
+  ### Tension Decisions
+  For each tension from brainstorm:
+  - tension_id: the tension ID from brainstorm
+  - explored: list of alternative IDs that become threads (MUST include canonical)
+  - implicit: list of alternative IDs NOT explored (context for shadows)
+
+  ### Threads
+  For each explored alternative:
+  - id: unique thread identifier
+  - name: human-readable name
+  - tension_id: which tension this explores
+  - alternative_id: which alternative this explores
+  - shadows: IDs of unexplored alternatives (for FILL context)
+  - tier: "major" or "minor"
+  - description: what this thread is about
+  - consequences: list of consequence IDs
+
+  ### Consequences
+  For each thread's narrative consequences:
+  - id: unique consequence identifier
+  - thread_id: which thread this belongs to
+  - description: what happens narratively
+  - ripples: story effects this implies
+
+  ### Initial Beats
+  For each opening beat:
+  - id: unique beat identifier
+  - summary: what happens in this beat
+  - threads: list of thread IDs this beat serves
+  - tension_impacts: how this beat affects tensions
+    - tension_id: which tension
+    - effect: "advances", "reveals", "commits", or "complicates"
+    - note: explanation of the impact
+  - entities: entity IDs present in this beat
+  - location: primary location entity ID (or null)
+  - location_alternatives: other valid location IDs for knot flexibility
+
+  ### Convergence Sketch
+  - convergence_points: where threads should merge
+  - residue_notes: what differences persist after convergence
+
+  ## Guidelines
+  - Be complete - capture ALL decisions discussed
+  - Entity IDs must match those from brainstorm
+  - Every tension must have a decision (explored vs implicit)
+  - Canonical alternative MUST be in the explored list
+  - Every thread needs at least one consequence
+  - Every thread needs at least one initial beat
+  - Use clear, consistent IDs (snake_case recommended)
+
+  ## Output Format
+  Provide a structured summary with all six sections clearly labeled.
+  Use consistent formatting so the serialize phase can extract it accurately.
+
+components: []

--- a/src/questfoundry/agents/__init__.py
+++ b/src/questfoundry/agents/__init__.py
@@ -5,6 +5,8 @@ from questfoundry.agents.prompts import (
     get_brainstorm_discuss_prompt,
     get_brainstorm_summarize_prompt,
     get_discuss_prompt,
+    get_seed_discuss_prompt,
+    get_seed_summarize_prompt,
     get_serialize_prompt,
     get_summarize_prompt,
 )
@@ -17,6 +19,8 @@ __all__ = [
     "get_brainstorm_discuss_prompt",
     "get_brainstorm_summarize_prompt",
     "get_discuss_prompt",
+    "get_seed_discuss_prompt",
+    "get_seed_summarize_prompt",
     "get_serialize_prompt",
     "get_summarize_prompt",
     "run_discuss_phase",

--- a/src/questfoundry/agents/prompts.py
+++ b/src/questfoundry/agents/prompts.py
@@ -157,3 +157,45 @@ def get_brainstorm_summarize_prompt() -> str:
     loader = _get_loader()
     template = loader.load("summarize_brainstorm")
     return template.system
+
+
+def get_seed_discuss_prompt(
+    brainstorm_context: str,
+    research_tools_available: bool = True,
+) -> str:
+    """Build the SEED discuss prompt with brainstorm context.
+
+    Uses _load_raw_template() to access the 'research_tools_section' field.
+
+    Args:
+        brainstorm_context: Formatted brainstorm output from BRAINSTORM stage.
+        research_tools_available: Whether research tools are available.
+
+    Returns:
+        System prompt string for the SEED discuss agent.
+    """
+    raw_data = _load_raw_template("discuss_seed")
+
+    # Build research tools section
+    research_section = ""
+    if research_tools_available:
+        research_section = raw_data.get("research_tools_section", "")
+
+    # Render the system template
+    system_template = raw_data.get("system", "")
+    prompt = ChatPromptTemplate.from_template(system_template)
+    return prompt.format(
+        brainstorm_context=brainstorm_context,
+        research_tools_section=research_section,
+    )
+
+
+def get_seed_summarize_prompt() -> str:
+    """Build the SEED summarize prompt.
+
+    Returns:
+        System prompt string for the SEED summarize call.
+    """
+    loader = _get_loader()
+    template = loader.load("summarize_seed")
+    return template.system

--- a/src/questfoundry/graph/mutations.py
+++ b/src/questfoundry/graph/mutations.py
@@ -175,11 +175,11 @@ def apply_seed_mutations(graph: Graph, output: dict[str, Any]) -> None:
     """Apply SEED stage output to graph.
 
     Updates entity dispositions, creates threads from explored tensions,
-    and creates initial beats.
+    creates consequences, and creates initial beats.
 
     Args:
         graph: Graph to mutate.
-        output: SEED stage output (entities, threads, beats).
+        output: SEED stage output (SeedOutput fields).
 
     Raises:
         MutationError: If required 'id' fields are missing.
@@ -193,12 +193,46 @@ def apply_seed_mutations(graph: Graph, output: dict[str, Any]) -> None:
                 {"disposition": entity_decision.get("disposition", "retained")},
             )
 
+    # Update tension exploration decisions
+    for i, tension_decision in enumerate(output.get("tensions", [])):
+        tension_id = _require_field(
+            tension_decision, "tension_id", f"Tension decision at index {i}"
+        )
+        if graph.has_node(tension_id):
+            graph.update_node(
+                tension_id,
+                {
+                    "explored": tension_decision.get("explored", []),
+                    "implicit": tension_decision.get("implicit", []),
+                },
+            )
+
+    # Create consequences
+    for i, consequence in enumerate(output.get("consequences", [])):
+        consequence_id = _require_field(consequence, "id", f"Consequence at index {i}")
+        consequence_data = {
+            "type": "consequence",
+            "thread_id": consequence.get("thread_id"),
+            "description": consequence.get("description"),
+            "ripples": consequence.get("ripples", []),
+        }
+        consequence_data = {k: v for k, v in consequence_data.items() if v is not None}
+        graph.add_node(consequence_id, consequence_data)
+
+        # Link consequence to its thread
+        if "thread_id" in consequence:
+            graph.add_edge("has_consequence", consequence["thread_id"], consequence_id)
+
     # Create threads from explored tensions
     for i, thread in enumerate(output.get("threads", [])):
         thread_id = _require_field(thread, "id", f"Thread at index {i}")
         thread_data = {
             "type": "thread",
             "name": thread.get("name"),
+            "tension_id": thread.get("tension_id"),
+            "alternative_id": thread.get("alternative_id"),
+            "shadows": thread.get("shadows", []),
+            "tier": thread.get("tier"),
             "description": thread.get("description"),
             "consequences": thread.get("consequences", []),
         }
@@ -207,17 +241,23 @@ def apply_seed_mutations(graph: Graph, output: dict[str, Any]) -> None:
 
         # Link thread to the alternative it explores
         if "alternative_id" in thread:
-            graph.add_edge("explores", thread_id, thread["alternative_id"])
+            # Alternative IDs in graph use tension_id::alt_id format
+            tension_id = thread.get("tension_id")
+            alt_local_id = thread["alternative_id"]
+            if tension_id:
+                full_alt_id = f"{tension_id}::{alt_local_id}"
+                graph.add_edge("explores", thread_id, full_alt_id)
 
     # Create initial beats
-    for i, beat in enumerate(output.get("beats", [])):
+    for i, beat in enumerate(output.get("initial_beats", [])):
         beat_id = _require_field(beat, "id", f"Beat at index {i}")
         beat_data = {
             "type": "beat",
-            "name": beat.get("name"),
-            "description": beat.get("description"),
-            "beat_type": beat.get("beat_type"),
+            "summary": beat.get("summary"),
             "tension_impacts": beat.get("tension_impacts", []),
+            "entities": beat.get("entities", []),
+            "location": beat.get("location"),
+            "location_alternatives": beat.get("location_alternatives", []),
         }
         beat_data = {k: v for k, v in beat_data.items() if v is not None}
         graph.add_node(beat_id, beat_data)
@@ -225,3 +265,15 @@ def apply_seed_mutations(graph: Graph, output: dict[str, Any]) -> None:
         # Link beat to threads it belongs to
         for thread_id in beat.get("threads", []):
             graph.add_edge("belongs_to", beat_id, thread_id)
+
+    # Store convergence sketch as metadata
+    if "convergence_sketch" in output:
+        sketch = output["convergence_sketch"]
+        graph.set_node(
+            "convergence_sketch",
+            {
+                "type": "convergence_sketch",
+                "convergence_points": sketch.get("convergence_points", []),
+                "residue_notes": sketch.get("residue_notes", []),
+            },
+        )

--- a/src/questfoundry/graph/mutations.py
+++ b/src/questfoundry/graph/mutations.py
@@ -39,6 +39,18 @@ def _require_field(item: dict[str, Any], field: str, context: str) -> Any:
     return item[field]
 
 
+def _clean_dict(data: dict[str, Any]) -> dict[str, Any]:
+    """Remove None values from a dictionary for cleaner storage.
+
+    Args:
+        data: Dictionary to clean.
+
+    Returns:
+        New dictionary with None values removed.
+    """
+    return {k: v for k, v in data.items() if v is not None}
+
+
 # Registry of stages with mutation handlers
 _MUTATION_STAGES = frozenset({"dream", "brainstorm", "seed"})
 
@@ -108,7 +120,7 @@ def apply_dream_mutations(graph: Graph, output: dict[str, Any]) -> None:
     }
 
     # Remove None values for cleaner storage
-    vision_data = {k: v for k, v in vision_data.items() if v is not None}
+    vision_data = _clean_dict(vision_data)
 
     graph.set_node("vision", vision_data)
 
@@ -137,7 +149,7 @@ def apply_brainstorm_mutations(graph: Graph, output: dict[str, Any]) -> None:
             "disposition": "proposed",  # All entities start as proposed
         }
         # Remove None values
-        node_data = {k: v for k, v in node_data.items() if v is not None}
+        node_data = _clean_dict(node_data)
         graph.add_node(entity_id, node_data)
 
     # Add tensions with alternatives
@@ -151,7 +163,7 @@ def apply_brainstorm_mutations(graph: Graph, output: dict[str, Any]) -> None:
             "involves": tension.get("involves", []),
             "why_it_matters": tension.get("why_it_matters"),
         }
-        tension_data = {k: v for k, v in tension_data.items() if v is not None}
+        tension_data = _clean_dict(tension_data)
         graph.add_node(tension_id, tension_data)
 
         # Create alternative nodes and edges
@@ -166,7 +178,7 @@ def apply_brainstorm_mutations(graph: Graph, output: dict[str, Any]) -> None:
                 "description": alt.get("description"),
                 "canonical": alt.get("canonical", False),
             }
-            alt_data = {k: v for k, v in alt_data.items() if v is not None}
+            alt_data = _clean_dict(alt_data)
             graph.add_node(alt_id, alt_data)
             graph.add_edge("has_alternative", tension_id, alt_id)
 
@@ -207,23 +219,7 @@ def apply_seed_mutations(graph: Graph, output: dict[str, Any]) -> None:
                 },
             )
 
-    # Create consequences
-    for i, consequence in enumerate(output.get("consequences", [])):
-        consequence_id = _require_field(consequence, "id", f"Consequence at index {i}")
-        consequence_data = {
-            "type": "consequence",
-            "thread_id": consequence.get("thread_id"),
-            "description": consequence.get("description"),
-            "ripples": consequence.get("ripples", []),
-        }
-        consequence_data = {k: v for k, v in consequence_data.items() if v is not None}
-        graph.add_node(consequence_id, consequence_data)
-
-        # Link consequence to its thread
-        if "thread_id" in consequence:
-            graph.add_edge("has_consequence", consequence["thread_id"], consequence_id)
-
-    # Create threads from explored tensions
+    # Create threads from explored tensions (must be created before consequences)
     for i, thread in enumerate(output.get("threads", [])):
         thread_id = _require_field(thread, "id", f"Thread at index {i}")
         thread_data = {
@@ -236,7 +232,7 @@ def apply_seed_mutations(graph: Graph, output: dict[str, Any]) -> None:
             "description": thread.get("description"),
             "consequences": thread.get("consequences", []),
         }
-        thread_data = {k: v for k, v in thread_data.items() if v is not None}
+        thread_data = _clean_dict(thread_data)
         graph.add_node(thread_id, thread_data)
 
         # Link thread to the alternative it explores
@@ -247,6 +243,22 @@ def apply_seed_mutations(graph: Graph, output: dict[str, Any]) -> None:
             if tension_id:
                 full_alt_id = f"{tension_id}::{alt_local_id}"
                 graph.add_edge("explores", thread_id, full_alt_id)
+
+    # Create consequences (after threads so edges can be created)
+    for i, consequence in enumerate(output.get("consequences", [])):
+        consequence_id = _require_field(consequence, "id", f"Consequence at index {i}")
+        consequence_data = {
+            "type": "consequence",
+            "thread_id": consequence.get("thread_id"),
+            "description": consequence.get("description"),
+            "ripples": consequence.get("ripples", []),
+        }
+        consequence_data = _clean_dict(consequence_data)
+        graph.add_node(consequence_id, consequence_data)
+
+        # Link consequence to its thread (thread must exist)
+        if "thread_id" in consequence and graph.has_node(consequence["thread_id"]):
+            graph.add_edge("has_consequence", consequence["thread_id"], consequence_id)
 
     # Create initial beats
     for i, beat in enumerate(output.get("initial_beats", [])):
@@ -259,7 +271,7 @@ def apply_seed_mutations(graph: Graph, output: dict[str, Any]) -> None:
             "location": beat.get("location"),
             "location_alternatives": beat.get("location_alternatives", []),
         }
-        beat_data = {k: v for k, v in beat_data.items() if v is not None}
+        beat_data = _clean_dict(beat_data)
         graph.add_node(beat_id, beat_data)
 
         # Link beat to threads it belongs to

--- a/src/questfoundry/models/__init__.py
+++ b/src/questfoundry/models/__init__.py
@@ -12,11 +12,35 @@ from questfoundry.models.brainstorm import (
     EntityType,
     Tension,
 )
+from questfoundry.models.seed import (
+    Consequence,
+    ConvergenceSketch,
+    EntityDecision,
+    EntityDisposition,
+    InitialBeat,
+    SeedOutput,
+    TensionDecision,
+    TensionEffect,
+    TensionImpact,
+    Thread,
+    ThreadTier,
+)
 
 __all__ = [
     "Alternative",
     "BrainstormOutput",
+    "Consequence",
+    "ConvergenceSketch",
     "Entity",
+    "EntityDecision",
+    "EntityDisposition",
     "EntityType",
+    "InitialBeat",
+    "SeedOutput",
     "Tension",
+    "TensionDecision",
+    "TensionEffect",
+    "TensionImpact",
+    "Thread",
+    "ThreadTier",
 ]

--- a/src/questfoundry/models/seed.py
+++ b/src/questfoundry/models/seed.py
@@ -1,0 +1,240 @@
+"""Pydantic models for SEED stage output.
+
+SEED is the triage stage that transforms expansive brainstorm material into
+committed story structure. It curates entities, decides which alternatives
+to explore as threads, creates consequences, and defines initial beats.
+
+CRITICAL: THREAD FREEZE - No new threads can be created after SEED.
+
+See docs/design/00-spec.md for details.
+"""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import BaseModel, Field
+
+# Type aliases for clarity
+EntityDisposition = Literal["retained", "cut"]
+ThreadTier = Literal["major", "minor"]
+TensionEffect = Literal["advances", "reveals", "commits", "complicates"]
+
+
+class EntityDecision(BaseModel):
+    """Entity curation decision from SEED.
+
+    SEED receives entities from BRAINSTORM and decides which to retain
+    for the story. Entities are the building blocks; not all brainstorm
+    ideas make it into the final story.
+
+    Attributes:
+        id: Entity ID from BRAINSTORM.
+        disposition: Whether to keep (retained) or discard (cut).
+    """
+
+    id: str = Field(min_length=1, description="Entity ID from BRAINSTORM")
+    disposition: EntityDisposition = Field(
+        default="retained",
+        description="Whether to keep or discard the entity",
+    )
+
+
+class TensionDecision(BaseModel):
+    """Tension exploration decision from SEED.
+
+    Each tension has two alternatives. SEED decides which alternatives to
+    explore as threads. The canonical alternative is always explored (spine).
+    Non-canonical alternatives become branches only if explicitly explored.
+
+    Attributes:
+        tension_id: Tension ID from BRAINSTORM.
+        explored: Alternative IDs that become threads.
+        implicit: Alternative IDs not explored (context for FILL shadows).
+    """
+
+    tension_id: str = Field(min_length=1, description="Tension ID from BRAINSTORM")
+    explored: list[str] = Field(
+        min_length=1,
+        description="Alternative IDs to explore as threads (always includes canonical)",
+    )
+    implicit: list[str] = Field(
+        default_factory=list,
+        description="Alternative IDs not explored (become shadows)",
+    )
+
+
+class Consequence(BaseModel):
+    """Narrative consequence of a thread choice.
+
+    Consequences bridge the gap between "what this path represents" (alternative)
+    and "how we track it" (codeword). GROW creates codewords to track when
+    consequences become active.
+
+    Attributes:
+        id: Unique identifier for the consequence.
+        thread_id: Thread this consequence belongs to.
+        description: What happens narratively.
+        ripples: Story effects this implies.
+    """
+
+    id: str = Field(min_length=1, description="Unique identifier")
+    thread_id: str = Field(min_length=1, description="Thread this belongs to")
+    description: str = Field(min_length=1, description="Narrative meaning of this path")
+    ripples: list[str] = Field(
+        default_factory=list,
+        description="Story effects this consequence implies",
+    )
+
+
+class Thread(BaseModel):
+    """Plot thread exploring one alternative from a tension.
+
+    Threads are the core structural units of the branching story. Threads
+    from the same tension are automatically exclusive (choosing one means
+    not choosing the other).
+
+    Attributes:
+        id: Unique identifier for the thread.
+        name: Human-readable name.
+        tension_id: The tension this thread explores.
+        alternative_id: The specific alternative this thread explores.
+        shadows: Unexplored alternatives (context for FILL).
+        tier: Major threads interweave; minor threads support.
+        description: What this thread is about.
+        consequences: IDs of consequences for this thread.
+    """
+
+    id: str = Field(min_length=1, description="Unique identifier")
+    name: str = Field(min_length=1, description="Human-readable name")
+    tension_id: str = Field(min_length=1, description="Tension this explores")
+    alternative_id: str = Field(min_length=1, description="Alternative this explores")
+    shadows: list[str] = Field(
+        default_factory=list,
+        description="Unexplored alternative IDs (context for FILL)",
+    )
+    tier: ThreadTier = Field(description="Major or minor thread")
+    description: str = Field(min_length=1, description="What this thread is about")
+    consequences: list[str] = Field(
+        default_factory=list,
+        description="Consequence IDs for this thread",
+    )
+
+
+class TensionImpact(BaseModel):
+    """How a beat affects a tension.
+
+    Each beat can impact one or more tensions, moving the story forward
+    in various ways.
+
+    Attributes:
+        tension_id: Tension being impacted.
+        effect: How the beat affects the tension.
+        note: Explanation of the impact.
+    """
+
+    tension_id: str = Field(min_length=1, description="Tension being impacted")
+    effect: TensionEffect = Field(description="How the beat affects the tension")
+    note: str = Field(min_length=1, description="Explanation of the impact")
+
+
+class InitialBeat(BaseModel):
+    """Initial beat created by SEED.
+
+    Beats are narrative units belonging to one or more threads. SEED creates
+    the initial beats for each thread; GROW mutates and adds more.
+
+    Attributes:
+        id: Unique identifier for the beat.
+        summary: What happens in this beat.
+        threads: Thread IDs this beat serves.
+        tension_impacts: How this beat affects tensions.
+        entities: Entity IDs present in this beat.
+        location: Primary location entity ID.
+        location_alternatives: Other valid locations (enables knot flexibility).
+    """
+
+    id: str = Field(min_length=1, description="Unique identifier")
+    summary: str = Field(min_length=1, description="What happens in this beat")
+    threads: list[str] = Field(
+        min_length=1,
+        description="Thread IDs this beat serves",
+    )
+    tension_impacts: list[TensionImpact] = Field(
+        default_factory=list,
+        description="How this beat affects tensions",
+    )
+    entities: list[str] = Field(
+        default_factory=list,
+        description="Entity IDs present in this beat",
+    )
+    location: str | None = Field(
+        default=None,
+        description="Primary location entity ID",
+    )
+    location_alternatives: list[str] = Field(
+        default_factory=list,
+        description="Other valid locations for knot flexibility",
+    )
+
+
+class ConvergenceSketch(BaseModel):
+    """Informal guidance for GROW about thread convergence.
+
+    Provides hints about where threads should merge and what differences
+    should persist after convergence.
+
+    Attributes:
+        convergence_points: Where threads should merge.
+        residue_notes: What differences persist after convergence.
+    """
+
+    convergence_points: list[str] = Field(
+        default_factory=list,
+        description="Where threads should merge (e.g., 'by act 2 climax')",
+    )
+    residue_notes: list[str] = Field(
+        default_factory=list,
+        description="Differences that persist after convergence",
+    )
+
+
+class SeedOutput(BaseModel):
+    """Complete output of the SEED stage.
+
+    SEED transforms brainstorm material into committed story structure.
+    After SEED, no new threads can be created (THREAD FREEZE).
+
+    Attributes:
+        entities: Entity curation decisions.
+        tensions: Tension exploration decisions.
+        threads: Created plot threads.
+        consequences: Narrative consequences for threads.
+        initial_beats: Initial beats for each thread.
+        convergence_sketch: Guidance for GROW about convergence.
+    """
+
+    entities: list[EntityDecision] = Field(
+        default_factory=list,
+        description="Entity curation decisions",
+    )
+    tensions: list[TensionDecision] = Field(
+        default_factory=list,
+        description="Tension exploration decisions",
+    )
+    threads: list[Thread] = Field(
+        default_factory=list,
+        description="Created plot threads",
+    )
+    consequences: list[Consequence] = Field(
+        default_factory=list,
+        description="Narrative consequences for threads",
+    )
+    initial_beats: list[InitialBeat] = Field(
+        default_factory=list,
+        description="Initial beats for each thread",
+    )
+    convergence_sketch: ConvergenceSketch = Field(
+        default_factory=ConvergenceSketch,
+        description="Guidance for GROW about thread convergence",
+    )

--- a/src/questfoundry/pipeline/stages/__init__.py
+++ b/src/questfoundry/pipeline/stages/__init__.py
@@ -15,20 +15,31 @@ from questfoundry.pipeline.stages.brainstorm import (
     create_brainstorm_stage,
 )
 from questfoundry.pipeline.stages.dream import DreamStage, dream_stage
+from questfoundry.pipeline.stages.seed import (
+    SeedStage,
+    SeedStageError,
+    create_seed_stage,
+    seed_stage,
+)
 
 # Register built-in stages
 register_stage(dream_stage)
 register_stage(brainstorm_stage)
+register_stage(seed_stage)
 
 __all__ = [
     "BrainstormStage",
     "BrainstormStageError",
     "DreamStage",
+    "SeedStage",
+    "SeedStageError",
     "Stage",
     "brainstorm_stage",
     "create_brainstorm_stage",
+    "create_seed_stage",
     "dream_stage",
     "get_stage",
     "list_stages",
     "register_stage",
+    "seed_stage",
 ]

--- a/src/questfoundry/pipeline/stages/seed.py
+++ b/src/questfoundry/pipeline/stages/seed.py
@@ -80,11 +80,8 @@ def _format_tension(tension_id: str, tension_data: dict[str, Any], graph: Graph)
     # Get alternatives from graph edges
     alt_edges = graph.get_edges(from_id=tension_id, edge_type="has_alternative")
     for edge in alt_edges:
-        alt_id = edge.get("to")
-        if alt_id:
-            alt_node = graph.get_node(alt_id)
-            if alt_node:
-                result += _format_alternative(alt_node) + "\n"
+        if (alt_id := edge.get("to")) and (alt_node := graph.get_node(alt_id)):
+            result += _format_alternative(alt_node) + "\n"
 
     return result
 

--- a/src/questfoundry/pipeline/stages/seed.py
+++ b/src/questfoundry/pipeline/stages/seed.py
@@ -1,0 +1,332 @@
+"""SEED stage implementation.
+
+The SEED stage triages brainstorm material into committed story structure.
+It curates entities, decides which alternatives to explore as threads,
+creates consequences, and defines initial beats.
+
+CRITICAL: THREAD FREEZE - No new threads can be created after SEED.
+
+Uses the LangChain-native 3-phase pattern:
+Discuss → Summarize → Serialize.
+
+Requires BRAINSTORM stage to have completed (reads brainstorm from graph).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path  # noqa: TC003 - used at runtime for Graph.load()
+from typing import TYPE_CHECKING, Any
+
+from questfoundry.agents import (
+    get_seed_discuss_prompt,
+    get_seed_summarize_prompt,
+    run_discuss_phase,
+    serialize_to_artifact,
+    summarize_discussion,
+)
+from questfoundry.graph import Graph
+from questfoundry.models import SeedOutput
+from questfoundry.observability.logging import get_logger
+from questfoundry.observability.tracing import get_current_run_tree, traceable
+from questfoundry.tools.langchain_tools import get_all_research_tools
+
+log = get_logger(__name__)
+
+if TYPE_CHECKING:
+    from langchain_core.language_models import BaseChatModel
+
+    from questfoundry.agents.discuss import (
+        AssistantMessageFn,
+        LLMCallbackFn,
+        UserInputFn,
+    )
+
+
+class SeedStageError(Exception):
+    """Raised when SEED stage cannot proceed."""
+
+    pass
+
+
+def _format_entity(entity: dict[str, Any]) -> str:
+    """Format a single entity for display."""
+    entity_type = entity.get("entity_type", entity.get("type", "unknown"))
+    concept = entity.get("concept", "")
+    notes = entity.get("notes", "")
+
+    result = f"- **{entity.get('id', 'unknown')}** ({entity_type}): {concept}"
+    if notes:
+        result += f"\n  Notes: {notes}"
+    return result
+
+
+def _format_alternative(alt: dict[str, Any]) -> str:
+    """Format a single alternative for display."""
+    canonical = " (canonical)" if alt.get("canonical") else ""
+    return f"  - {alt.get('id', 'unknown')}: {alt.get('description', '')}{canonical}"
+
+
+def _format_tension(tension_id: str, tension_data: dict[str, Any], graph: Graph) -> str:
+    """Format a single tension for display."""
+    question = tension_data.get("question", "")
+    involves = tension_data.get("involves", [])
+    why_it_matters = tension_data.get("why_it_matters", "")
+
+    result = f"- **{tension_id}**: {question}\n"
+    result += f"  Involves: {', '.join(involves) if involves else 'none specified'}\n"
+    result += f"  Stakes: {why_it_matters}\n"
+    result += "  Alternatives:\n"
+
+    # Get alternatives from graph edges
+    alt_edges = graph.get_edges(from_id=tension_id, edge_type="has_alternative")
+    for edge in alt_edges:
+        alt_id = edge.get("to")
+        if alt_id:
+            alt_node = graph.get_node(alt_id)
+            if alt_node:
+                result += _format_alternative(alt_node) + "\n"
+
+    return result
+
+
+def _format_brainstorm_context(graph: Graph) -> str:
+    """Format brainstorm data from graph as context for SEED.
+
+    Args:
+        graph: Graph containing brainstorm output.
+
+    Returns:
+        Formatted string describing entities and tensions from brainstorm.
+    """
+    parts = []
+
+    # Collect entities and tensions using proper Graph API
+    entity_nodes = graph.get_nodes_by_type("entity")
+    tension_nodes = graph.get_nodes_by_type("tension")
+
+    entities = list(entity_nodes.items())
+    tensions = list(tension_nodes.items())
+
+    # Format entities section
+    if entities:
+        parts.append("## Entities from BRAINSTORM")
+        for entity_id, entity_data in entities:
+            entity_with_id = {"id": entity_id, **entity_data}
+            parts.append(_format_entity(entity_with_id))
+        parts.append("")
+
+    # Format tensions section
+    if tensions:
+        parts.append("## Tensions from BRAINSTORM")
+        for tension_id, tension_data in tensions:
+            parts.append(_format_tension(tension_id, tension_data, graph))
+
+    return "\n".join(parts) if parts else "No brainstorm data available."
+
+
+class SeedStage:
+    """SEED stage - triage brainstorm into committed structure.
+
+    This stage takes the entities and tensions from BRAINSTORM and transforms
+    them into committed story structure: curated entities, threads with
+    consequences, and initial beats.
+
+    CRITICAL: After SEED, no new threads can be created (THREAD FREEZE).
+
+    Uses the LangChain-native 3-phase pattern:
+    - Discuss: Triage entities and tensions, plan threads and beats
+    - Summarize: Condense discussion into structured summary
+    - Serialize: Convert to SeedOutput artifact
+
+    Attributes:
+        name: Stage identifier ("seed").
+        project_path: Path to project directory for graph access.
+    """
+
+    name = "seed"
+
+    def __init__(self, project_path: Path | None = None) -> None:
+        """Initialize SEED stage.
+
+        Args:
+            project_path: Path to project directory. Required for loading
+                brainstorm context from graph. If None, must be provided via
+                context in execute().
+        """
+        self.project_path = project_path
+
+    def _get_brainstorm_context(self, project_path: Path) -> str:
+        """Load and format brainstorm from graph.
+
+        Args:
+            project_path: Path to project directory.
+
+        Returns:
+            Formatted brainstorm context string.
+
+        Raises:
+            SeedStageError: If brainstorm not found in graph.
+        """
+        graph = Graph.load(project_path)
+
+        # Check for entities (indicates brainstorm completed)
+        entity_nodes = graph.get_nodes_by_type("entity")
+        tension_nodes = graph.get_nodes_by_type("tension")
+
+        has_entities = bool(entity_nodes)
+        has_tensions = bool(tension_nodes)
+
+        if not has_entities and not has_tensions:
+            raise SeedStageError(
+                "SEED requires BRAINSTORM stage to complete first. "
+                "No entities or tensions found in graph. Run 'qf brainstorm' first."
+            )
+
+        return _format_brainstorm_context(graph)
+
+    @traceable(name="SEED Stage", run_type="chain", tags=["stage:seed"])
+    async def execute(
+        self,
+        model: BaseChatModel,
+        user_prompt: str,
+        provider_name: str | None = None,
+        *,
+        interactive: bool = False,
+        user_input_fn: UserInputFn | None = None,
+        on_assistant_message: AssistantMessageFn | None = None,
+        on_llm_start: LLMCallbackFn | None = None,
+        on_llm_end: LLMCallbackFn | None = None,
+        project_path: Path | None = None,
+    ) -> tuple[dict[str, Any], int, int]:
+        """Execute the SEED stage using the 3-phase pattern.
+
+        Args:
+            model: LangChain chat model for all phases.
+            user_prompt: Additional guidance for seeding (optional).
+            provider_name: Provider name for structured output strategy selection.
+            interactive: Enable interactive multi-turn discussion mode.
+            user_input_fn: Async function to get user input (for interactive mode).
+            on_assistant_message: Callback when assistant responds.
+            on_llm_start: Callback when LLM call starts.
+            on_llm_end: Callback when LLM call ends.
+            project_path: Override for project path (uses self.project_path if None).
+
+        Returns:
+            Tuple of (artifact_data, llm_calls, tokens_used).
+
+        Raises:
+            SeedStageError: If brainstorm not found in graph.
+            SerializationError: If serialization fails after all retries.
+        """
+        # Resolve project path
+        resolved_path = project_path or self.project_path
+        if resolved_path is None:
+            raise SeedStageError(
+                "project_path is required for SEED stage. "
+                "Provide it in constructor or execute() call."
+            )
+
+        # Add dynamic metadata to the trace
+        if rt := get_current_run_tree():
+            rt.metadata["provider"] = provider_name
+            rt.metadata["prompt_length"] = len(user_prompt)
+            rt.metadata["interactive"] = interactive
+
+        log.info(
+            "seed_stage_started",
+            prompt_length=len(user_prompt),
+            interactive=interactive,
+        )
+
+        total_llm_calls = 0
+        total_tokens = 0
+
+        # Load brainstorm context from graph
+        brainstorm_context = self._get_brainstorm_context(resolved_path)
+        log.debug("seed_brainstorm_loaded", context_length=len(brainstorm_context))
+
+        # Get research tools
+        tools = get_all_research_tools()
+
+        # Build discuss prompt with brainstorm context
+        discuss_prompt = get_seed_discuss_prompt(
+            brainstorm_context=brainstorm_context,
+            research_tools_available=bool(tools),
+        )
+
+        # Phase 1: Discuss
+        log.debug("seed_phase", phase="discuss")
+        messages, discuss_calls, discuss_tokens = await run_discuss_phase(
+            model=model,
+            tools=tools,
+            user_prompt=user_prompt
+            or "Let's triage this brainstorm into a committed story structure.",
+            interactive=interactive,
+            user_input_fn=user_input_fn,
+            on_assistant_message=on_assistant_message,
+            on_llm_start=on_llm_start,
+            on_llm_end=on_llm_end,
+            system_prompt=discuss_prompt,
+            stage_name="seed",
+        )
+        total_llm_calls += discuss_calls
+        total_tokens += discuss_tokens
+
+        # Phase 2: Summarize
+        log.debug("seed_phase", phase="summarize")
+        summarize_prompt = get_seed_summarize_prompt()
+        brief, summarize_tokens = await summarize_discussion(
+            model=model,
+            messages=messages,
+            system_prompt=summarize_prompt,
+            stage_name="seed",
+        )
+        total_llm_calls += 1
+        total_tokens += summarize_tokens
+
+        # Phase 3: Serialize
+        log.debug("seed_phase", phase="serialize")
+        artifact, serialize_tokens = await serialize_to_artifact(
+            model=model,
+            brief=brief,
+            schema=SeedOutput,
+            provider_name=provider_name,
+        )
+        total_llm_calls += 1
+        total_tokens += serialize_tokens
+
+        # Convert to dict for return
+        artifact_data = artifact.model_dump()
+
+        # Log summary statistics
+        entity_count = len(artifact_data.get("entities", []))
+        thread_count = len(artifact_data.get("threads", []))
+        beat_count = len(artifact_data.get("initial_beats", []))
+
+        log.info(
+            "seed_stage_completed",
+            llm_calls=total_llm_calls,
+            tokens=total_tokens,
+            entities=entity_count,
+            threads=thread_count,
+            beats=beat_count,
+        )
+
+        return artifact_data, total_llm_calls, total_tokens
+
+
+# Factory function to create stage with project path
+def create_seed_stage(project_path: Path | None = None) -> SeedStage:
+    """Create a SEED stage instance.
+
+    Args:
+        project_path: Path to project directory for graph access.
+
+    Returns:
+        Configured SeedStage instance.
+    """
+    return SeedStage(project_path)
+
+
+# Create singleton instance for registration (project_path provided at execution)
+seed_stage = SeedStage()

--- a/tests/unit/test_seed_stage.py
+++ b/tests/unit/test_seed_stage.py
@@ -1,0 +1,440 @@
+"""Tests for SEED stage implementation."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+from langchain_core.messages import AIMessage, HumanMessage
+
+from questfoundry.models import SeedOutput
+from questfoundry.pipeline.stages import SeedStage, SeedStageError, get_stage
+
+# --- Stage Registration Tests ---
+
+
+def test_seed_stage_registered() -> None:
+    """Seed stage is registered automatically."""
+    stage = get_stage("seed")
+    assert stage is not None
+    assert stage.name == "seed"
+
+
+def test_seed_stage_name() -> None:
+    """SeedStage has correct name."""
+    stage = SeedStage()
+    assert stage.name == "seed"
+
+
+# --- Execute Tests ---
+
+
+@pytest.mark.asyncio
+async def test_execute_requires_project_path() -> None:
+    """Execute raises error when project_path is not provided."""
+    stage = SeedStage()  # No project_path
+
+    mock_model = MagicMock()
+
+    with pytest.raises(SeedStageError, match="project_path is required"):
+        await stage.execute(model=mock_model, user_prompt="test")
+
+
+@pytest.mark.asyncio
+async def test_execute_requires_brainstorm_in_graph() -> None:
+    """Execute raises error when brainstorm is not found in graph."""
+    stage = SeedStage()
+
+    mock_model = MagicMock()
+    mock_graph = MagicMock()
+    mock_graph.get_nodes_by_type.return_value = {}  # No entities or tensions
+
+    with (
+        patch("questfoundry.pipeline.stages.seed.Graph") as MockGraph,
+    ):
+        MockGraph.load.return_value = mock_graph
+
+        with pytest.raises(SeedStageError, match="SEED requires BRAINSTORM"):
+            await stage.execute(
+                model=mock_model,
+                user_prompt="test",
+                project_path=Path("/test/project"),
+            )
+
+
+@pytest.mark.asyncio
+async def test_execute_calls_all_three_phases() -> None:
+    """Execute calls discuss, summarize, and serialize phases."""
+    stage = SeedStage()
+
+    mock_model = MagicMock()
+    mock_graph = MagicMock()
+    mock_graph.get_nodes_by_type.side_effect = lambda t: (
+        {"kay": {"type": "entity", "concept": "Protagonist"}}
+        if t == "entity"
+        else {"trust": {"type": "tension", "question": "?"}}
+        if t == "tension"
+        else {}
+    )
+    mock_graph.get_edges.return_value = []
+
+    with (
+        patch("questfoundry.pipeline.stages.seed.Graph") as MockGraph,
+        patch("questfoundry.pipeline.stages.seed.run_discuss_phase") as mock_discuss,
+        patch("questfoundry.pipeline.stages.seed.summarize_discussion") as mock_summarize,
+        patch("questfoundry.pipeline.stages.seed.serialize_to_artifact") as mock_serialize,
+        patch("questfoundry.pipeline.stages.seed.get_all_research_tools") as mock_tools,
+    ):
+        MockGraph.load.return_value = mock_graph
+        mock_tools.return_value = []
+        mock_discuss.return_value = (
+            [HumanMessage(content="hi"), AIMessage(content="hello")],
+            2,  # llm_calls
+            500,  # tokens
+        )
+        mock_summarize.return_value = ("Brief summary", 100)
+        mock_artifact = SeedOutput(
+            entities=[{"id": "kay", "disposition": "retained"}],
+            tensions=[{"tension_id": "trust", "explored": ["yes"], "implicit": ["no"]}],
+            threads=[
+                {
+                    "id": "thread_trust",
+                    "name": "Trust Arc",
+                    "tension_id": "trust",
+                    "alternative_id": "yes",
+                    "tier": "major",
+                    "description": "The trust thread",
+                }
+            ],
+            initial_beats=[
+                {
+                    "id": "beat1",
+                    "summary": "Opening beat",
+                    "threads": ["thread_trust"],
+                }
+            ],
+        )
+        mock_serialize.return_value = (mock_artifact, 200)
+
+        artifact, llm_calls, tokens = await stage.execute(
+            model=mock_model,
+            user_prompt="Let's seed",
+            project_path=Path("/test/project"),
+        )
+
+        # Verify all phases were called
+        mock_discuss.assert_called_once()
+        mock_summarize.assert_called_once()
+        mock_serialize.assert_called_once()
+
+        # Verify result
+        assert len(artifact["entities"]) == 1
+        assert len(artifact["threads"]) == 1
+        assert len(artifact["initial_beats"]) == 1
+        assert llm_calls == 4  # 2 discuss + 1 summarize + 1 serialize
+        assert tokens == 800  # 500 + 100 + 200
+
+
+@pytest.mark.asyncio
+async def test_execute_passes_brainstorm_context_to_discuss() -> None:
+    """Execute passes formatted brainstorm context to discuss phase."""
+    stage = SeedStage()
+
+    mock_model = MagicMock()
+    mock_graph = MagicMock()
+    mock_graph.get_nodes_by_type.side_effect = lambda t: (
+        {"kay": {"type": "entity", "entity_type": "character", "concept": "Hero"}}
+        if t == "entity"
+        else {}
+    )
+    mock_graph.get_edges.return_value = []
+
+    with (
+        patch("questfoundry.pipeline.stages.seed.Graph") as MockGraph,
+        patch("questfoundry.pipeline.stages.seed.run_discuss_phase") as mock_discuss,
+        patch("questfoundry.pipeline.stages.seed.summarize_discussion") as mock_summarize,
+        patch("questfoundry.pipeline.stages.seed.serialize_to_artifact") as mock_serialize,
+        patch("questfoundry.pipeline.stages.seed.get_all_research_tools") as mock_tools,
+        patch("questfoundry.pipeline.stages.seed.get_seed_discuss_prompt") as mock_prompt,
+    ):
+        MockGraph.load.return_value = mock_graph
+        mock_tools.return_value = []
+        mock_prompt.return_value = "System prompt with brainstorm"
+        mock_discuss.return_value = ([], 1, 100)
+        mock_summarize.return_value = ("Brief", 50)
+        mock_artifact = SeedOutput(entities=[], tensions=[], threads=[], initial_beats=[])
+        mock_serialize.return_value = (mock_artifact, 100)
+
+        await stage.execute(
+            model=mock_model,
+            user_prompt="test",
+            project_path=Path("/test/project"),
+        )
+
+        # Verify get_seed_discuss_prompt was called with brainstorm context
+        mock_prompt.assert_called_once()
+        call_kwargs = mock_prompt.call_args.kwargs
+        assert "brainstorm_context" in call_kwargs
+        # Brainstorm context should include entity info
+        assert "kay" in call_kwargs["brainstorm_context"]
+
+
+@pytest.mark.asyncio
+async def test_execute_passes_seed_output_schema() -> None:
+    """Execute passes SeedOutput schema to serialize."""
+    stage = SeedStage()
+
+    mock_model = MagicMock()
+    mock_graph = MagicMock()
+    mock_graph.get_nodes_by_type.side_effect = lambda t: (
+        {"entity1": {"type": "entity"}} if t == "entity" else {}
+    )
+    mock_graph.get_edges.return_value = []
+
+    with (
+        patch("questfoundry.pipeline.stages.seed.Graph") as MockGraph,
+        patch("questfoundry.pipeline.stages.seed.run_discuss_phase") as mock_discuss,
+        patch("questfoundry.pipeline.stages.seed.summarize_discussion") as mock_summarize,
+        patch("questfoundry.pipeline.stages.seed.serialize_to_artifact") as mock_serialize,
+        patch("questfoundry.pipeline.stages.seed.get_all_research_tools") as mock_tools,
+    ):
+        MockGraph.load.return_value = mock_graph
+        mock_tools.return_value = []
+        mock_discuss.return_value = ([], 1, 100)
+        mock_summarize.return_value = ("Brief", 50)
+        mock_artifact = SeedOutput(entities=[], tensions=[], threads=[], initial_beats=[])
+        mock_serialize.return_value = (mock_artifact, 100)
+
+        await stage.execute(
+            model=mock_model,
+            user_prompt="test",
+            project_path=Path("/test/project"),
+        )
+
+        assert mock_serialize.call_args.kwargs["schema"] is SeedOutput
+
+
+@pytest.mark.asyncio
+async def test_execute_uses_seed_summarize_prompt() -> None:
+    """Execute uses seed-specific summarize prompt."""
+    stage = SeedStage()
+
+    mock_model = MagicMock()
+    mock_graph = MagicMock()
+    mock_graph.get_nodes_by_type.side_effect = lambda t: (
+        {"entity1": {"type": "entity"}} if t == "entity" else {}
+    )
+    mock_graph.get_edges.return_value = []
+
+    with (
+        patch("questfoundry.pipeline.stages.seed.Graph") as MockGraph,
+        patch("questfoundry.pipeline.stages.seed.run_discuss_phase") as mock_discuss,
+        patch("questfoundry.pipeline.stages.seed.summarize_discussion") as mock_summarize,
+        patch("questfoundry.pipeline.stages.seed.serialize_to_artifact") as mock_serialize,
+        patch("questfoundry.pipeline.stages.seed.get_all_research_tools") as mock_tools,
+        patch("questfoundry.pipeline.stages.seed.get_seed_summarize_prompt") as mock_prompt,
+    ):
+        MockGraph.load.return_value = mock_graph
+        mock_tools.return_value = []
+        mock_prompt.return_value = "Seed summarize prompt"
+        mock_discuss.return_value = ([], 1, 100)
+        mock_summarize.return_value = ("Brief", 50)
+        mock_artifact = SeedOutput(entities=[], tensions=[], threads=[], initial_beats=[])
+        mock_serialize.return_value = (mock_artifact, 100)
+
+        await stage.execute(
+            model=mock_model,
+            user_prompt="test",
+            project_path=Path("/test/project"),
+        )
+
+        # Verify summarize was called with seed prompt
+        mock_prompt.assert_called_once()
+        assert mock_summarize.call_args.kwargs["system_prompt"] == "Seed summarize prompt"
+
+
+@pytest.mark.asyncio
+async def test_execute_returns_artifact_as_dict() -> None:
+    """Execute returns artifact as dictionary, not Pydantic model."""
+    stage = SeedStage()
+
+    mock_model = MagicMock()
+    mock_graph = MagicMock()
+    mock_graph.get_nodes_by_type.side_effect = lambda t: (
+        {"entity1": {"type": "entity"}} if t == "entity" else {}
+    )
+    mock_graph.get_edges.return_value = []
+
+    with (
+        patch("questfoundry.pipeline.stages.seed.Graph") as MockGraph,
+        patch("questfoundry.pipeline.stages.seed.run_discuss_phase") as mock_discuss,
+        patch("questfoundry.pipeline.stages.seed.summarize_discussion") as mock_summarize,
+        patch("questfoundry.pipeline.stages.seed.serialize_to_artifact") as mock_serialize,
+        patch("questfoundry.pipeline.stages.seed.get_all_research_tools") as mock_tools,
+    ):
+        MockGraph.load.return_value = mock_graph
+        mock_tools.return_value = []
+        mock_discuss.return_value = ([], 1, 100)
+        mock_summarize.return_value = ("Brief", 50)
+        mock_artifact = SeedOutput(
+            entities=[{"id": "kay", "disposition": "retained"}],
+            tensions=[],
+            threads=[
+                {
+                    "id": "thread1",
+                    "name": "Test",
+                    "tension_id": "t1",
+                    "alternative_id": "a1",
+                    "tier": "major",
+                    "description": "Test thread",
+                }
+            ],
+            initial_beats=[
+                {
+                    "id": "beat1",
+                    "summary": "Test beat",
+                    "threads": ["thread1"],
+                }
+            ],
+        )
+        mock_serialize.return_value = (mock_artifact, 100)
+
+        artifact, _, _ = await stage.execute(
+            model=mock_model,
+            user_prompt="test",
+            project_path=Path("/test/project"),
+        )
+
+        assert isinstance(artifact, dict)
+        assert artifact["entities"][0]["id"] == "kay"
+        assert artifact["threads"][0]["id"] == "thread1"
+        assert artifact["initial_beats"][0]["id"] == "beat1"
+
+
+# --- Brainstorm Context Formatting Tests ---
+
+
+def test_format_brainstorm_context_includes_entities() -> None:
+    """_format_brainstorm_context includes entities in output."""
+    from questfoundry.graph import Graph
+    from questfoundry.pipeline.stages.seed import _format_brainstorm_context
+
+    graph = Graph.empty()
+    graph.add_node("kay", {"type": "entity", "entity_type": "character", "concept": "Hero"})
+
+    result = _format_brainstorm_context(graph)
+
+    assert "kay" in result
+    assert "character" in result
+    assert "Hero" in result
+
+
+def test_format_brainstorm_context_includes_tensions() -> None:
+    """_format_brainstorm_context includes tensions in output."""
+    from questfoundry.graph import Graph
+    from questfoundry.pipeline.stages.seed import _format_brainstorm_context
+
+    graph = Graph.empty()
+    graph.add_node(
+        "trust",
+        {
+            "type": "tension",
+            "question": "Can trust be earned?",
+            "involves": ["kay"],
+            "why_it_matters": "Core theme",
+        },
+    )
+    graph.add_node("trust::yes", {"type": "alternative", "description": "Yes", "canonical": True})
+    graph.add_edge("has_alternative", "trust", "trust::yes")
+
+    result = _format_brainstorm_context(graph)
+
+    assert "trust" in result
+    assert "Can trust be earned?" in result
+
+
+def test_format_brainstorm_context_handles_empty() -> None:
+    """_format_brainstorm_context handles empty graph."""
+    from questfoundry.graph import Graph
+    from questfoundry.pipeline.stages.seed import _format_brainstorm_context
+
+    graph = Graph.empty()
+    result = _format_brainstorm_context(graph)
+
+    assert "No brainstorm data available" in result
+
+
+# --- Model Tests ---
+
+
+def test_seed_output_model_validates() -> None:
+    """SeedOutput model validates correctly."""
+    output = SeedOutput(
+        entities=[{"id": "kay", "disposition": "retained"}],
+        tensions=[{"tension_id": "trust", "explored": ["yes"], "implicit": []}],
+        threads=[
+            {
+                "id": "thread_trust",
+                "name": "Trust Arc",
+                "tension_id": "trust",
+                "alternative_id": "yes",
+                "tier": "major",
+                "description": "The trust thread",
+            }
+        ],
+        initial_beats=[
+            {
+                "id": "beat1",
+                "summary": "Opening scene",
+                "threads": ["thread_trust"],
+            }
+        ],
+    )
+
+    assert len(output.entities) == 1
+    assert len(output.threads) == 1
+    assert len(output.initial_beats) == 1
+    assert output.entities[0].id == "kay"
+    assert output.threads[0].name == "Trust Arc"
+
+
+def test_thread_tier_types() -> None:
+    """Thread model accepts major and minor tiers."""
+    from questfoundry.models.seed import Thread
+
+    for tier in ["major", "minor"]:
+        thread = Thread(
+            id="test",
+            name="Test Thread",
+            tension_id="test_tension",
+            alternative_id="test_alt",
+            tier=tier,  # type: ignore[arg-type]
+            description="Test description",
+        )
+        assert thread.tier == tier
+
+
+def test_tension_effect_types() -> None:
+    """TensionImpact model accepts all effect types."""
+    from questfoundry.models.seed import TensionImpact
+
+    for effect in ["advances", "reveals", "commits", "complicates"]:
+        impact = TensionImpact(
+            tension_id="test",
+            effect=effect,  # type: ignore[arg-type]
+            note="Test note",
+        )
+        assert impact.effect == effect
+
+
+def test_entity_disposition_types() -> None:
+    """EntityDecision model accepts retained and cut dispositions."""
+    from questfoundry.models.seed import EntityDecision
+
+    for disposition in ["retained", "cut"]:
+        decision = EntityDecision(
+            id="test",
+            disposition=disposition,  # type: ignore[arg-type]
+        )
+        assert decision.disposition == disposition


### PR DESCRIPTION
## Problem
Issue #100 - The pipeline needs a SEED stage to transform brainstorm material (entities and tensions) into committed story structure with threads and initial beats. SEED is the "thread creation gate" - after this stage, no new threads can be created (THREAD FREEZE).

## Changes
- Add Pydantic models for SEED output:
  - `EntityDecision` - disposition (retained/cut) for each entity
  - `TensionDecision` - which alternatives are explored vs implicit
  - `Thread` - story thread with tension, alternative, tier (major/minor)
  - `InitialBeat` - opening beats with thread/tension impacts
  - `Consequence`, `TensionImpact`, `ConvergenceSketch`, `SeedOutput`
- Add discuss and summarize prompt templates for SEED stage
- Implement `SeedStage` using 3-phase pattern (Discuss → Summarize → Serialize)
- Add `qf seed` CLI command with interactive mode support
- Add graph mutations for SEED output
- Add 16 unit tests for SEED stage

## Not Included / Future PRs
- GROW stage implementation (next after SEED)
- Convergence validation logic (threads must converge properly)
- Thread continuity enforcement across later stages

## Test Plan
```bash
# All unit tests pass
uv run pytest tests/unit/ -v
# 518 tests pass

# Type checking
uv run mypy src/
# No errors
```

## Risk / Rollback
- Low risk: New stage follows established patterns from DREAM/BRAINSTORM
- No migrations required
- Rollback: revert commit

## Related Issues
- Closes #100
- Part of #9 (Slice 2: DREAM → SEED)

🤖 Generated with [Claude Code](https://claude.com/claude-code)