### PR TITLE
fix(cli): add default prompts for non-interactive brainstorm/seed

### DIFF
--- a/src/questfoundry/agents/serialize.py
+++ b/src/questfoundry/agents/serialize.py
@@ -174,6 +174,7 @@ async def serialize_to_artifact(
                     "serialize_validation_failed",
                     attempt=attempt,
                     error_count=len(last_errors),
+                    errors=last_errors,
                 )
 
                 # Add error feedback for retry

--- a/src/questfoundry/cli.py
+++ b/src/questfoundry/cli.py
@@ -323,7 +323,7 @@ def dream(
             raise typer.Exit(1)
 
     log.info("stage_start", stage="dream")
-    log.debug("user_prompt", prompt=prompt)
+    log.debug("user_prompt", prompt=prompt[:100] + "..." if len(prompt) > 100 else prompt)
 
     # Build context
     context: dict[str, object] = {"user_prompt": prompt, "interactive": use_interactive}
@@ -526,7 +526,7 @@ def brainstorm(
             prompt = DEFAULT_NONINTERACTIVE_BRAINSTORM_PROMPT
 
     log.info("stage_start", stage="brainstorm")
-    log.debug("user_prompt", prompt=prompt)
+    log.debug("user_prompt", prompt=prompt[:100] + "..." if len(prompt) > 100 else prompt)
 
     # Build context
     context: dict[str, object] = {"user_prompt": prompt, "interactive": use_interactive}
@@ -743,7 +743,7 @@ def seed(
             prompt = DEFAULT_NONINTERACTIVE_SEED_PROMPT
 
     log.info("stage_start", stage="seed")
-    log.debug("user_prompt", prompt=prompt)
+    log.debug("user_prompt", prompt=prompt[:100] + "..." if len(prompt) > 100 else prompt)
 
     # Build context
     context: dict[str, object] = {"user_prompt": prompt, "interactive": use_interactive}

--- a/src/questfoundry/cli.py
+++ b/src/questfoundry/cli.py
@@ -323,7 +323,7 @@ def dream(
             raise typer.Exit(1)
 
     log.info("stage_start", stage="dream")
-    log.debug("user_prompt", prompt=prompt[:100] + "..." if len(prompt) > 100 else prompt)
+    log.debug("user_prompt", prompt=prompt)
 
     # Build context
     context: dict[str, object] = {"user_prompt": prompt, "interactive": use_interactive}
@@ -526,7 +526,7 @@ def brainstorm(
             prompt = DEFAULT_NONINTERACTIVE_BRAINSTORM_PROMPT
 
     log.info("stage_start", stage="brainstorm")
-    log.debug("user_prompt", prompt=prompt[:100] + "..." if len(prompt) > 100 else prompt)
+    log.debug("user_prompt", prompt=prompt)
 
     # Build context
     context: dict[str, object] = {"user_prompt": prompt, "interactive": use_interactive}
@@ -743,7 +743,7 @@ def seed(
             prompt = DEFAULT_NONINTERACTIVE_SEED_PROMPT
 
     log.info("stage_start", stage="seed")
-    log.debug("user_prompt", prompt=prompt[:100] + "..." if len(prompt) > 100 else prompt)
+    log.debug("user_prompt", prompt=prompt)
 
     # Build context
     context: dict[str, object] = {"user_prompt": prompt, "interactive": use_interactive}

--- a/src/questfoundry/cli.py
+++ b/src/questfoundry/cli.py
@@ -57,10 +57,21 @@ DEFAULT_INTERACTIVE_BRAINSTORM_PROMPT = (
     "Help me develop characters, locations, and dramatic tensions."
 )
 
+DEFAULT_NONINTERACTIVE_BRAINSTORM_PROMPT = (
+    "Generate characters, locations, objects, factions, and dramatic tensions "
+    "based on the creative vision from the DREAM stage."
+)
+
 DEFAULT_INTERACTIVE_SEED_PROMPT = (
     "Let's triage this brainstorm into a committed story structure. "
     "Help me decide which entities to keep, which tensions to explore, "
     "and what the initial beats should be."
+)
+
+DEFAULT_NONINTERACTIVE_SEED_PROMPT = (
+    "Triage the brainstorm into committed story structure: curate entities, "
+    "decide which tensions to explore as threads, create initial beats, "
+    "and sketch convergence points."
 )
 
 # Global state for logging flags (set by callback, used by commands)
@@ -507,14 +518,12 @@ def brainstorm(
     # Determine interactive mode: explicit flag > TTY detection
     use_interactive = interactive if interactive is not None else _is_interactive_tty()
 
-    # Handle prompt: if not provided, interactive mode uses default, non-interactive fails
+    # Handle prompt: if not provided, use appropriate default for mode
     if prompt is None:
         if use_interactive:
             prompt = DEFAULT_INTERACTIVE_BRAINSTORM_PROMPT
         else:
-            console.print("[red]Error:[/red] Prompt required in non-interactive mode.")
-            console.print("Provide a prompt argument or use --interactive/-i flag.")
-            raise typer.Exit(1)
+            prompt = DEFAULT_NONINTERACTIVE_BRAINSTORM_PROMPT
 
     log.info("stage_start", stage="brainstorm")
     log.debug("user_prompt", prompt=prompt[:100] + "..." if len(prompt) > 100 else prompt)
@@ -726,14 +735,12 @@ def seed(
     # Determine interactive mode: explicit flag > TTY detection
     use_interactive = interactive if interactive is not None else _is_interactive_tty()
 
-    # Handle prompt: if not provided, interactive mode uses default, non-interactive fails
+    # Handle prompt: if not provided, use appropriate default for mode
     if prompt is None:
         if use_interactive:
             prompt = DEFAULT_INTERACTIVE_SEED_PROMPT
         else:
-            console.print("[red]Error:[/red] Prompt required in non-interactive mode.")
-            console.print("Provide a prompt argument or use --interactive/-i flag.")
-            raise typer.Exit(1)
+            prompt = DEFAULT_NONINTERACTIVE_SEED_PROMPT
 
     log.info("stage_start", stage="seed")
     log.debug("user_prompt", prompt=prompt[:100] + "..." if len(prompt) > 100 else prompt)


### PR DESCRIPTION
## Problem

BRAINSTORM and SEED stages fail in non-interactive mode if no prompt is provided:
```
Error: Prompt required in non-interactive mode.
```

But these stages read context from previous stages (DREAM → BRAINSTORM → SEED), so they should work without explicit user prompts.

## Changes

- Add `DEFAULT_NONINTERACTIVE_BRAINSTORM_PROMPT` - generates entities and tensions based on DREAM vision
- Add `DEFAULT_NONINTERACTIVE_SEED_PROMPT` - triages brainstorm into story structure
- Fix serialize logging to include actual validation errors (not just count) - fixes #112

## Test Plan

```bash
# This now works without a prompt:
uv run qf --log brainstorm --no-interactive --project test-project

# All tests pass
uv run pytest tests/unit/test_cli.py tests/unit/test_serialize.py -v
```

## Risk / Rollback

Low risk - adds default prompts without changing any existing behavior when prompts are provided.

🤖 Generated with [Claude Code](https://claude.com/claude-code)