### PR TITLE
fix(pipeline): resolve entity extraction and serialize issues in BRAINSTORM/SEED

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -543,25 +543,26 @@ The `ConversationRunner` orchestrates all three phases and handles:
 
 ### Provider Strategies for Structured Output
 
-When serializing structured output (phase 3), strategy depends on provider:
+When serializing structured output (phase 3), all providers use the same strategy:
 
 ```python
-# Ollama: Use ToolStrategy (more reliable for qwen3:8b)
-model_with_tools = model.with_structured_output(
-    schema=DreamArtifact,
-    method="tool",  # Force tool-based schema
-)
-
-# OpenAI: Use ProviderStrategy (native JSON mode)
-model_with_json = model.with_structured_output(
-    schema=DreamArtifact,
-    method="json_mode",  # Use native JSON schema support
+# All providers use JSON_MODE (json_schema method)
+structured_model = model.with_structured_output(
+    schema=BrainstormOutput,
+    method="json_schema",  # Native JSON mode
 )
 ```
 
-**Why two strategies?**
-- Ollama's JSON mode is inconsistent; tool-based forcing is more reliable
-- OpenAI's JSON mode is native and faster; tool overhead is unnecessary
+**Why JSON_MODE for all providers?**
+- Works reliably with complex nested schemas (BrainstormOutput, SeedOutput)
+- The TOOL strategy (function_calling) was tried but returns None for complex schemas on Ollama
+- Native JSON mode is efficient and consistent across providers
+
+**The two available strategies (for reference):**
+- `method="json_schema"` (JSON_MODE): Uses provider's native JSON mode to constrain output
+- `method="function_calling"` (TOOL): Creates a fake tool with the schema, forces model to call it
+
+The strategy selection is handled by `with_structured_output()` in `providers/structured_output.py`.
 
 ### Prompt Management
 

--- a/prompts/templates/serialize_brainstorm.yaml
+++ b/prompts/templates/serialize_brainstorm.yaml
@@ -30,7 +30,7 @@ system: |
     - `id`: Short identifier
     - `description`: Full description
     - `canonical`: true for ONE alternative (the default path), false for the other
-  - `involves`: List of entity IDs related to this tension
+  - `involves`: List of entity IDs related to this tension (use the same IDs you assigned to entities above)
   - `why_it_matters`: Thematic stakes
 
   ## Guidelines

--- a/prompts/templates/serialize_brainstorm.yaml
+++ b/prompts/templates/serialize_brainstorm.yaml
@@ -1,0 +1,52 @@
+name: serialize_brainstorm
+description: Convert brainstorm brief into BrainstormOutput artifact
+
+system: |
+  You are converting a brainstorming brief into a structured BrainstormOutput artifact.
+
+  ## Entity Mapping (CRITICAL)
+
+  The brief describes story elements in categories. Map them to entities with the correct `type`:
+
+  | Brief Category | Entity Type      |
+  |----------------|------------------|
+  | Characters     | "character"      |
+  | Locations      | "location"       |
+  | Objects        | "object"         |
+  | Factions       | "faction"        |
+
+  Each entity needs:
+  - `id`: Short snake_case identifier (e.g., "lady_beatrice", "vane_manor")
+  - `type`: One of "character", "location", "object", "faction"
+  - `concept`: One-line essence from the brief
+  - `notes`: Optional additional context from the brief
+
+  ## Tension Structure
+
+  Tensions represent binary dramatic questions with exactly TWO alternatives:
+  - `id`: Short snake_case identifier
+  - `question`: The dramatic question (should end with "?")
+  - `alternatives`: Exactly 2 items, each with:
+    - `id`: Short identifier
+    - `description`: Full description
+    - `canonical`: true for ONE alternative (the default path), false for the other
+  - `involves`: List of entity IDs related to this tension
+  - `why_it_matters`: Thematic stakes
+
+  ## Guidelines
+
+  - Extract ALL characters, locations, objects, and factions from the brief as entities
+  - Extract ALL tensions/dramatic questions mentioned
+  - Do NOT invent new details - only structure what's in the brief
+  - Use snake_case for all IDs (lowercase with underscores)
+  - Each tension must have exactly ONE canonical alternative
+
+  ## Output
+
+  Return ONLY valid JSON matching BrainstormOutput schema:
+  {
+    "entities": [...],
+    "tensions": [...]
+  }
+
+components: []

--- a/prompts/templates/serialize_seed.yaml
+++ b/prompts/templates/serialize_seed.yaml
@@ -1,0 +1,112 @@
+name: serialize_seed
+description: Convert seed brief into SeedOutput artifact
+
+system: |
+  You are converting a SEED stage brief into a structured SeedOutput artifact.
+
+  ## Schema Overview
+
+  SeedOutput contains six main sections that must be populated from the brief:
+
+  ### 1. entities (Entity Decisions)
+  For each entity from brainstorm, create an EntityDecision:
+  ```json
+  {
+    "id": "entity_id_from_brainstorm",
+    "disposition": "retained" or "cut"
+  }
+  ```
+
+  ### 2. tensions (Tension Decisions)
+  For each tension from brainstorm, create a TensionDecision:
+  ```json
+  {
+    "tension_id": "tension_id_from_brainstorm",
+    "explored": ["alt_id_1", "alt_id_2"],  // Alternatives that become threads
+    "implicit": ["alt_id_3"]                // Alternatives NOT explored
+  }
+  ```
+  NOTE: The canonical alternative MUST be in "explored", never in "implicit".
+
+  ### 3. threads (Plot Threads)
+  For each explored alternative, create a Thread:
+  ```json
+  {
+    "id": "unique_thread_id",
+    "name": "Human Readable Thread Name",
+    "tension_id": "which_tension",
+    "alternative_id": "which_alternative_this_explores",
+    "shadows": ["unexplored_alt_ids"],  // Implicit alternatives
+    "tier": "major" or "minor",
+    "description": "What this thread is about",
+    "consequences": ["consequence_id_1", "consequence_id_2"]
+  }
+  ```
+
+  ### 4. consequences (Narrative Consequences)
+  For each thread, create its Consequences:
+  ```json
+  {
+    "id": "unique_consequence_id",
+    "thread_id": "which_thread_this_belongs_to",
+    "description": "What happens narratively",
+    "ripples": ["story effect 1", "story effect 2"]
+  }
+  ```
+
+  ### 5. initial_beats (Opening Beats)
+  Create InitialBeat objects for story openings:
+  ```json
+  {
+    "id": "unique_beat_id",
+    "summary": "What happens in this beat",
+    "threads": ["thread_id_1", "thread_id_2"],
+    "tension_impacts": [
+      {
+        "tension_id": "which_tension",
+        "effect": "advances" or "reveals" or "commits" or "complicates",
+        "note": "Explanation of the impact"
+      }
+    ],
+    "entities": ["entity_id_1", "entity_id_2"],
+    "location": "location_entity_id" or null,
+    "location_alternatives": ["other_location_id"]
+  }
+  ```
+
+  ### 6. convergence_sketch
+  ```json
+  {
+    "convergence_points": ["where threads should merge"],
+    "residue_notes": ["differences that persist after convergence"]
+  }
+  ```
+
+  ## Mapping Rules
+
+  | Brief Section      | SeedOutput Field    |
+  |--------------------|---------------------|
+  | Entity Decisions   | entities            |
+  | Tension Decisions  | tensions            |
+  | Threads            | threads             |
+  | Consequences       | consequences        |
+  | Initial Beats      | initial_beats       |
+  | Convergence Sketch | convergence_sketch  |
+
+  ## Guidelines
+
+  - Extract ALL information from the brief - do not invent new details
+  - Use snake_case for all IDs
+  - Entity and tension IDs must match those from brainstorm
+  - Every thread must reference a valid tension_id and alternative_id
+  - Every consequence must reference a valid thread_id
+  - Every initial_beat must reference valid thread IDs
+  - tier must be exactly "major" or "minor" (lowercase)
+  - effect must be exactly "advances", "reveals", "commits", or "complicates"
+  - disposition must be exactly "retained" or "cut"
+
+  ## Output
+
+  Return ONLY valid JSON matching SeedOutput schema with all six sections.
+
+components: []

--- a/prompts/templates/serialize_seed.yaml
+++ b/prompts/templates/serialize_seed.yaml
@@ -97,7 +97,7 @@ system: |
 
   - Extract ALL information from the brief - do not invent new details
   - Use snake_case for all IDs
-  - Entity and tension IDs must match those from brainstorm
+  - Entity and tension IDs must match those shown in the brief (use the IDs as displayed)
   - Every thread must reference a valid tension_id and alternative_id
   - Every consequence must reference a valid thread_id
   - Every initial_beat must reference valid thread IDs

--- a/prompts/templates/summarize_brainstorm.yaml
+++ b/prompts/templates/summarize_brainstorm.yaml
@@ -1,39 +1,52 @@
 name: summarize_brainstorm
-description: Summarize brainstorm discussion into structured entities and tensions
+description: Summarize brainstorm discussion into prose brief for serialization
 
 system: |
   You are summarizing a brainstorming discussion about story elements.
 
   ## Your Task
-  Condense the conversation into a structured summary of ALL entities and tensions discussed:
+  Condense the conversation into a **prose brief** that captures all discussed story elements.
+  Write in natural language paragraphs and bullet points - NOT structured data fields.
 
-  ### Entities (aim for 15-25)
-  For each entity capture:
-  - id: short identifier (e.g., "kay", "mentor", "archive")
-  - type: character, location, object, or faction
-  - concept: one-line essence
-  - notes: rich context from discussion
+  ### Characters (aim for 5-10)
+  Describe each character discussed:
+  - Who they are and their role in the story
+  - Key traits, motivations, or secrets
+  - Any relationships or conflicts mentioned
 
-  ### Tensions (aim for 4-8)
-  For each tension capture:
-  - id: short identifier (e.g., "mentor_trust")
-  - question: binary dramatic question ending with "?"
-  - alternatives: EXACTLY TWO options (order doesn't matter)
-    - One marked canonical: true (the default story path)
-    - One marked canonical: false (the alternate branch)
-  - involves: list of entity IDs central to this tension
-  - why_it_matters: thematic stakes and consequences
+  ### Locations (aim for 3-6)
+  Describe each location discussed:
+  - What the place is and its atmosphere
+  - Why it matters to the story
+  - Any secrets or special features
+
+  ### Objects (aim for 3-5)
+  Describe significant objects discussed:
+  - What the object is
+  - Why it's important (clue, macguffin, symbol, etc.)
+
+  ### Factions (if any)
+  Describe any groups or organizations:
+  - What they are and their goals
+  - Key members or relationships
+
+  ### Dramatic Tensions (aim for 4-8)
+  For each tension, describe in prose:
+  - The central question or conflict
+  - The two possible answers/outcomes (one being the "default" story path)
+  - Which characters or elements are involved
+  - Why this tension matters thematically
 
   ## Guidelines
-  - Extract ALL entities mentioned, even minor ones
-  - Ensure every tension has exactly TWO alternatives
-  - Preserve rich notes - this context helps later stages
-  - Mark which alternative is "canonical" (default path)
-  - Include entity IDs in tension "involves" lists
-  - Be complete - everything discussed should appear in the summary
+  - Write in flowing prose, not schema fields
+  - Capture ALL entities and tensions mentioned in discussion
+  - Preserve rich context and reasoning - this helps the serializer
+  - Be specific about which alternative is the "canonical" (default) path
+  - If something wasn't discussed, don't invent it
 
   ## Output Format
-  Provide a structured summary with clear entity and tension sections.
-  Use consistent formatting so the next phase can serialize it accurately.
+  Write a narrative summary organized by the sections above.
+  Use paragraphs and bullet points for readability.
+  The next phase will convert this prose into structured data.
 
 components: []

--- a/src/questfoundry/agents/__init__.py
+++ b/src/questfoundry/agents/__init__.py
@@ -3,9 +3,11 @@
 from questfoundry.agents.discuss import create_discuss_agent, run_discuss_phase
 from questfoundry.agents.prompts import (
     get_brainstorm_discuss_prompt,
+    get_brainstorm_serialize_prompt,
     get_brainstorm_summarize_prompt,
     get_discuss_prompt,
     get_seed_discuss_prompt,
+    get_seed_serialize_prompt,
     get_seed_summarize_prompt,
     get_serialize_prompt,
     get_summarize_prompt,
@@ -17,9 +19,11 @@ __all__ = [
     "SerializationError",
     "create_discuss_agent",
     "get_brainstorm_discuss_prompt",
+    "get_brainstorm_serialize_prompt",
     "get_brainstorm_summarize_prompt",
     "get_discuss_prompt",
     "get_seed_discuss_prompt",
+    "get_seed_serialize_prompt",
     "get_seed_summarize_prompt",
     "get_serialize_prompt",
     "get_summarize_prompt",

--- a/src/questfoundry/agents/prompts.py
+++ b/src/questfoundry/agents/prompts.py
@@ -199,3 +199,33 @@ def get_seed_summarize_prompt() -> str:
     loader = _get_loader()
     template = loader.load("summarize_seed")
     return template.system
+
+
+def get_brainstorm_serialize_prompt() -> str:
+    """Build the BRAINSTORM serialize prompt.
+
+    This prompt includes explicit instructions for mapping prose categories
+    (Characters, Locations, Objects, Factions) to Entity objects with the
+    correct type field.
+
+    Returns:
+        System prompt string for the BRAINSTORM serialize call.
+    """
+    loader = _get_loader()
+    template = loader.load("serialize_brainstorm")
+    return template.system
+
+
+def get_seed_serialize_prompt() -> str:
+    """Build the SEED serialize prompt.
+
+    This prompt includes explicit instructions for mapping the complex
+    SEED brief sections (Entity Decisions, Tension Decisions, Threads,
+    Consequences, Initial Beats, Convergence Sketch) to the SeedOutput schema.
+
+    Returns:
+        System prompt string for the SEED serialize call.
+    """
+    loader = _get_loader()
+    template = loader.load("serialize_seed")
+    return template.system

--- a/src/questfoundry/agents/serialize.py
+++ b/src/questfoundry/agents/serialize.py
@@ -51,6 +51,7 @@ async def serialize_to_artifact(
     provider_name: str | None = None,
     strategy: StructuredOutputStrategy | None = None,
     max_retries: int = 3,
+    system_prompt: str | None = None,
 ) -> tuple[T, int]:
     """Serialize a brief into a structured artifact.
 
@@ -65,6 +66,7 @@ async def serialize_to_artifact(
         provider_name: Provider name for strategy auto-detection.
         strategy: Output strategy (auto-selected if None).
         max_retries: Maximum total attempts (default 3).
+        system_prompt: Stage-specific serialize prompt. If None, uses generic prompt.
 
     Returns:
         Tuple of (validated_artifact, tokens_used).
@@ -86,9 +88,10 @@ async def serialize_to_artifact(
         provider_name=provider_name,
     )
 
-    system_prompt = get_serialize_prompt()
+    # Use provided prompt or fall back to generic
+    serialize_prompt = system_prompt if system_prompt is not None else get_serialize_prompt()
     messages: list[BaseMessage] = [
-        SystemMessage(content=system_prompt),
+        SystemMessage(content=serialize_prompt),
         HumanMessage(content=f"Convert this brief into the required structure:\n\n{brief}"),
     ]
 

--- a/src/questfoundry/graph/mutations.py
+++ b/src/questfoundry/graph/mutations.py
@@ -125,11 +125,32 @@ def apply_dream_mutations(graph: Graph, output: dict[str, Any]) -> None:
     graph.set_node("vision", vision_data)
 
 
+def _prefix_id(node_type: str, raw_id: str) -> str:
+    """Prefix a raw ID with its node type for namespace isolation.
+
+    This allows entities and tensions to have the same raw ID without collision.
+    E.g., both can use "cipher_journal" -> "entity::cipher_journal", "tension::cipher_journal"
+
+    Args:
+        node_type: Node type prefix (entity, tension, thread, etc.)
+        raw_id: Raw ID from LLM output.
+
+    Returns:
+        Prefixed ID in format "type::raw_id".
+    """
+    return f"{node_type}::{raw_id}"
+
+
 def apply_brainstorm_mutations(graph: Graph, output: dict[str, Any]) -> None:
     """Apply BRAINSTORM stage output to graph.
 
     Creates entity nodes and tension nodes with their alternatives.
     Tensions are linked to their alternatives via has_alternative edges.
+
+    Node IDs are prefixed by type to avoid collisions:
+    - entity::raw_id
+    - tension::raw_id
+    - tension::tension_id::alt::alt_id (for alternatives)
 
     Args:
         graph: Graph to mutate.
@@ -140,9 +161,11 @@ def apply_brainstorm_mutations(graph: Graph, output: dict[str, Any]) -> None:
     """
     # Add entities
     for i, entity in enumerate(output.get("entities", [])):
-        entity_id = _require_field(entity, "id", f"Entity at index {i}")
+        raw_id = _require_field(entity, "id", f"Entity at index {i}")
+        entity_id = _prefix_id("entity", raw_id)
         node_data = {
             "type": "entity",
+            "raw_id": raw_id,  # Store original ID for reference
             "entity_type": entity.get("type"),  # character, location, object, faction
             "concept": entity.get("concept"),
             "notes": entity.get("notes"),
@@ -154,27 +177,34 @@ def apply_brainstorm_mutations(graph: Graph, output: dict[str, Any]) -> None:
 
     # Add tensions with alternatives
     for i, tension in enumerate(output.get("tensions", [])):
-        tension_id = _require_field(tension, "id", f"Tension at index {i}")
+        raw_id = _require_field(tension, "id", f"Tension at index {i}")
+        tension_id = _prefix_id("tension", raw_id)
+
+        # Prefix entity references in involves list
+        raw_involves = tension.get("involves", [])
+        prefixed_involves = [_prefix_id("entity", eid) for eid in raw_involves]
 
         # Create tension node
         tension_data = {
             "type": "tension",
+            "raw_id": raw_id,  # Store original ID for reference
             "question": tension.get("question"),
-            "involves": tension.get("involves", []),
+            "involves": prefixed_involves,
             "why_it_matters": tension.get("why_it_matters"),
         }
         tension_data = _clean_dict(tension_data)
         graph.add_node(tension_id, tension_data)
 
         # Create alternative nodes and edges
-        # Use '::' separator to avoid collisions (e.g., t1::a1 vs t1_a1)
         for j, alt in enumerate(tension.get("alternatives", [])):
             alt_local_id = _require_field(
-                alt, "id", f"Alternative at index {j} in tension '{tension_id}'"
+                alt, "id", f"Alternative at index {j} in tension '{raw_id}'"
             )
-            alt_id = f"{tension_id}::{alt_local_id}"
+            # Alternative ID format: tension::tension_raw_id::alt::alt_local_id
+            alt_id = f"{tension_id}::alt::{alt_local_id}"
             alt_data = {
                 "type": "alternative",
+                "raw_id": alt_local_id,
                 "description": alt.get("description"),
                 "canonical": alt.get("canonical", False),
             }
@@ -189,6 +219,13 @@ def apply_seed_mutations(graph: Graph, output: dict[str, Any]) -> None:
     Updates entity dispositions, creates threads from explored tensions,
     creates consequences, and creates initial beats.
 
+    Node IDs are prefixed by type to match BRAINSTORM's namespacing:
+    - thread::raw_id
+    - consequence::raw_id
+    - beat::raw_id
+
+    References to entities/tensions from LLM output are prefixed for lookup.
+
     Args:
         graph: Graph to mutate.
         output: SEED stage output (SeedOutput fields).
@@ -198,7 +235,8 @@ def apply_seed_mutations(graph: Graph, output: dict[str, Any]) -> None:
     """
     # Update entity dispositions
     for i, entity_decision in enumerate(output.get("entities", [])):
-        entity_id = _require_field(entity_decision, "id", f"Entity decision at index {i}")
+        raw_id = _require_field(entity_decision, "id", f"Entity decision at index {i}")
+        entity_id = _prefix_id("entity", raw_id)
         if graph.has_node(entity_id):
             graph.update_node(
                 entity_id,
@@ -207,9 +245,8 @@ def apply_seed_mutations(graph: Graph, output: dict[str, Any]) -> None:
 
     # Update tension exploration decisions
     for i, tension_decision in enumerate(output.get("tensions", [])):
-        tension_id = _require_field(
-            tension_decision, "tension_id", f"Tension decision at index {i}"
-        )
+        raw_id = _require_field(tension_decision, "tension_id", f"Tension decision at index {i}")
+        tension_id = _prefix_id("tension", raw_id)
         if graph.has_node(tension_id):
             graph.update_node(
                 tension_id,
@@ -221,12 +258,19 @@ def apply_seed_mutations(graph: Graph, output: dict[str, Any]) -> None:
 
     # Create threads from explored tensions (must be created before consequences)
     for i, thread in enumerate(output.get("threads", [])):
-        thread_id = _require_field(thread, "id", f"Thread at index {i}")
+        raw_id = _require_field(thread, "id", f"Thread at index {i}")
+        thread_id = _prefix_id("thread", raw_id)
+
+        # Store prefixed tension reference
+        raw_tension_id = thread.get("tension_id")
+        prefixed_tension_id = _prefix_id("tension", raw_tension_id) if raw_tension_id else None
+
         thread_data = {
             "type": "thread",
+            "raw_id": raw_id,
             "name": thread.get("name"),
-            "tension_id": thread.get("tension_id"),
-            "alternative_id": thread.get("alternative_id"),
+            "tension_id": prefixed_tension_id,
+            "alternative_id": thread.get("alternative_id"),  # Local alt ID, not prefixed
             "shadows": thread.get("shadows", []),
             "tier": thread.get("tier"),
             "description": thread.get("description"),
@@ -236,20 +280,25 @@ def apply_seed_mutations(graph: Graph, output: dict[str, Any]) -> None:
         graph.add_node(thread_id, thread_data)
 
         # Link thread to the alternative it explores
-        if "alternative_id" in thread:
-            # Alternative IDs in graph use tension_id::alt_id format
-            tension_id = thread.get("tension_id")
+        if "alternative_id" in thread and prefixed_tension_id:
             alt_local_id = thread["alternative_id"]
-            if tension_id:
-                full_alt_id = f"{tension_id}::{alt_local_id}"
-                graph.add_edge("explores", thread_id, full_alt_id)
+            # Alternative ID format: tension::tension_id::alt::alt_id
+            full_alt_id = f"{prefixed_tension_id}::alt::{alt_local_id}"
+            graph.add_edge("explores", thread_id, full_alt_id)
 
     # Create consequences (after threads so edges can be created)
     for i, consequence in enumerate(output.get("consequences", [])):
-        consequence_id = _require_field(consequence, "id", f"Consequence at index {i}")
+        raw_id = _require_field(consequence, "id", f"Consequence at index {i}")
+        consequence_id = _prefix_id("consequence", raw_id)
+
+        # Prefix thread reference
+        raw_thread_id = consequence.get("thread_id")
+        prefixed_thread_id = _prefix_id("thread", raw_thread_id) if raw_thread_id else None
+
         consequence_data = {
             "type": "consequence",
-            "thread_id": consequence.get("thread_id"),
+            "raw_id": raw_id,
+            "thread_id": prefixed_thread_id,
             "description": consequence.get("description"),
             "ripples": consequence.get("ripples", []),
         }
@@ -257,26 +306,38 @@ def apply_seed_mutations(graph: Graph, output: dict[str, Any]) -> None:
         graph.add_node(consequence_id, consequence_data)
 
         # Link consequence to its thread (thread must exist)
-        if "thread_id" in consequence and graph.has_node(consequence["thread_id"]):
-            graph.add_edge("has_consequence", consequence["thread_id"], consequence_id)
+        if prefixed_thread_id and graph.has_node(prefixed_thread_id):
+            graph.add_edge("has_consequence", prefixed_thread_id, consequence_id)
 
     # Create initial beats
     for i, beat in enumerate(output.get("initial_beats", [])):
-        beat_id = _require_field(beat, "id", f"Beat at index {i}")
+        raw_id = _require_field(beat, "id", f"Beat at index {i}")
+        beat_id = _prefix_id("beat", raw_id)
+
+        # Prefix entity references
+        raw_entities = beat.get("entities", [])
+        prefixed_entities = [_prefix_id("entity", eid) for eid in raw_entities]
+
+        # Prefix location reference (location is an entity)
+        raw_location = beat.get("location")
+        prefixed_location = _prefix_id("entity", raw_location) if raw_location else None
+
         beat_data = {
             "type": "beat",
+            "raw_id": raw_id,
             "summary": beat.get("summary"),
             "tension_impacts": beat.get("tension_impacts", []),
-            "entities": beat.get("entities", []),
-            "location": beat.get("location"),
+            "entities": prefixed_entities,
+            "location": prefixed_location,
             "location_alternatives": beat.get("location_alternatives", []),
         }
         beat_data = _clean_dict(beat_data)
         graph.add_node(beat_id, beat_data)
 
         # Link beat to threads it belongs to
-        for thread_id in beat.get("threads", []):
-            graph.add_edge("belongs_to", beat_id, thread_id)
+        for raw_thread_id in beat.get("threads", []):
+            prefixed_thread_id = _prefix_id("thread", raw_thread_id)
+            graph.add_edge("belongs_to", beat_id, prefixed_thread_id)
 
     # Store convergence sketch as metadata
     if "convergence_sketch" in output:

--- a/src/questfoundry/pipeline/stages/brainstorm.py
+++ b/src/questfoundry/pipeline/stages/brainstorm.py
@@ -16,6 +16,7 @@ from typing import TYPE_CHECKING, Any
 
 from questfoundry.agents import (
     get_brainstorm_discuss_prompt,
+    get_brainstorm_serialize_prompt,
     get_brainstorm_summarize_prompt,
     run_discuss_phase,
     serialize_to_artifact,
@@ -240,11 +241,13 @@ class BrainstormStage:
 
         # Phase 3: Serialize
         log.debug("brainstorm_phase", phase="serialize")
+        serialize_prompt = get_brainstorm_serialize_prompt()
         artifact, serialize_tokens = await serialize_to_artifact(
             model=model,
             brief=brief,
             schema=BrainstormOutput,
             provider_name=provider_name,
+            system_prompt=serialize_prompt,
         )
         total_llm_calls += 1
         total_tokens += serialize_tokens

--- a/src/questfoundry/pipeline/stages/seed.py
+++ b/src/questfoundry/pipeline/stages/seed.py
@@ -92,7 +92,10 @@ def _format_tension(tension_id: str, tension_data: dict[str, Any], graph: Graph)
     involves_display = []
     for ref in involves:
         # References are prefixed like "entity::raw_id", extract raw_id part
-        if "::" in ref:
+        if ref.startswith("entity::"):
+            involves_display.append(ref[8:])  # Skip "entity::" prefix
+        elif "::" in ref:
+            # Fallback for other prefixed formats
             involves_display.append(ref.split("::")[-1])
         else:
             involves_display.append(ref)

--- a/src/questfoundry/providers/structured_output.py
+++ b/src/questfoundry/providers/structured_output.py
@@ -31,9 +31,12 @@ class StructuredOutputStrategy(str, Enum):
 def get_default_strategy(provider_name: str) -> StructuredOutputStrategy:
     """Get default structured output strategy for a provider.
 
-    Different providers have different native structured output capabilities:
-    - Ollama: Tool calling is more reliable with local models
-    - OpenAI/Anthropic: Native JSON mode is faster and more reliable
+    All known providers use JSON_MODE (json_schema method) for structured output.
+    This uses the provider's native JSON mode to constrain output to match the schema.
+
+    The alternative TOOL strategy (function_calling method) creates a fake tool
+    with the schema and forces the model to call it. This was tried for Ollama
+    but returned None for complex nested schemas like BrainstormOutput.
 
     Args:
         provider_name: Provider name (ollama, openai, anthropic).
@@ -43,14 +46,14 @@ def get_default_strategy(provider_name: str) -> StructuredOutputStrategy:
     """
     provider_lower = provider_name.lower()
 
-    # Ollama: ToolStrategy is more reliable with local models
-    # OpenAI: Native json_mode (gpt-4-turbo, gpt-4o support structured output)
-    # Anthropic: Native JSON mode via raw_mode parameter
-    if provider_lower == "ollama":
-        return StructuredOutputStrategy.TOOL
-    elif provider_lower in ("openai", "anthropic"):
+    # All known providers use JSON_MODE:
+    # - Ollama: JSON_MODE works for complex nested schemas (TOOL returns None)
+    # - OpenAI: Native json_mode (gpt-4-turbo, gpt-4o support structured output)
+    # - Anthropic: Native JSON mode
+    if provider_lower in ("ollama", "openai", "anthropic"):
         return StructuredOutputStrategy.JSON_MODE
-    # Default to TOOL for unknown providers (safest option)
+
+    # Default to TOOL for unknown providers (safest fallback)
     return StructuredOutputStrategy.TOOL
 
 

--- a/src/questfoundry/providers/structured_output.py
+++ b/src/questfoundry/providers/structured_output.py
@@ -53,8 +53,9 @@ def get_default_strategy(provider_name: str) -> StructuredOutputStrategy:
     if provider_lower in ("ollama", "openai", "anthropic"):
         return StructuredOutputStrategy.JSON_MODE
 
-    # Default to TOOL for unknown providers (safest fallback)
-    return StructuredOutputStrategy.TOOL
+    # Default to JSON_MODE for unknown providers
+    # (TOOL strategy can return None for complex nested schemas)
+    return StructuredOutputStrategy.JSON_MODE
 
 
 def with_structured_output(

--- a/tests/unit/test_provider_factory.py
+++ b/tests/unit/test_provider_factory.py
@@ -240,7 +240,9 @@ def test_create_model_structured_ollama_with_schema() -> None:
     mock_chat.with_structured_output.assert_called_once()
     call_args = mock_chat.with_structured_output.call_args
     assert call_args[0][0] is SampleSchema
-    assert call_args[1]["method"] == "function_calling"  # Tool strategy for Ollama
+    assert (
+        call_args[1]["method"] == "json_schema"
+    )  # JSON_MODE for Ollama (better for complex schemas)
 
 
 def test_create_model_structured_openai_with_schema() -> None:

--- a/tests/unit/test_structured_output.py
+++ b/tests/unit/test_structured_output.py
@@ -36,9 +36,9 @@ class TestGetDefaultStrategy:
         assert get_default_strategy("anthropic") == StructuredOutputStrategy.JSON_MODE
 
     def test_get_default_strategy_unknown(self) -> None:
-        """Should return TOOL (safe default) for unknown providers."""
-        assert get_default_strategy("unknown") == StructuredOutputStrategy.TOOL
-        assert get_default_strategy("custom-provider") == StructuredOutputStrategy.TOOL
+        """Should return JSON_MODE for unknown providers (TOOL can fail on complex schemas)."""
+        assert get_default_strategy("unknown") == StructuredOutputStrategy.JSON_MODE
+        assert get_default_strategy("custom-provider") == StructuredOutputStrategy.JSON_MODE
 
     def test_get_default_strategy_case_insensitive(self) -> None:
         """Should handle uppercase provider names."""

--- a/tests/unit/test_structured_output.py
+++ b/tests/unit/test_structured_output.py
@@ -24,8 +24,8 @@ class TestGetDefaultStrategy:
     """Test get_default_strategy function."""
 
     def test_get_default_strategy_ollama(self) -> None:
-        """Should return TOOL strategy for Ollama."""
-        assert get_default_strategy("ollama") == StructuredOutputStrategy.TOOL
+        """Should return JSON_MODE strategy for Ollama (better for complex schemas)."""
+        assert get_default_strategy("ollama") == StructuredOutputStrategy.JSON_MODE
 
     def test_get_default_strategy_openai(self) -> None:
         """Should return JSON_MODE strategy for OpenAI."""
@@ -42,7 +42,7 @@ class TestGetDefaultStrategy:
 
     def test_get_default_strategy_case_insensitive(self) -> None:
         """Should handle uppercase provider names."""
-        assert get_default_strategy("OLLAMA") == StructuredOutputStrategy.TOOL
+        assert get_default_strategy("OLLAMA") == StructuredOutputStrategy.JSON_MODE
         assert get_default_strategy("OpenAI") == StructuredOutputStrategy.JSON_MODE
         assert get_default_strategy("ANTHROPIC") == StructuredOutputStrategy.JSON_MODE
 
@@ -105,7 +105,7 @@ class TestWithStructuredOutput:
         mock_model = MagicMock()
         mock_model.with_structured_output = MagicMock(return_value=mock_model)
 
-        # Test Ollama (TOOL)
+        # Test Ollama (JSON_MODE - better for complex schemas)
         with_structured_output(
             mock_model,
             SampleSchema,
@@ -114,7 +114,7 @@ class TestWithStructuredOutput:
         )
         mock_model.with_structured_output.assert_called_with(
             SampleSchema,
-            method="function_calling",
+            method="json_schema",
         )
 
         # Test OpenAI (JSON_MODE)


### PR DESCRIPTION
## Problem

Testing BRAINSTORM and SEED stages revealed several issues preventing proper artifact generation:

1. **Graph ID collision**: Entities and tensions could share the same raw ID, causing `Node already exists` errors during mutations
2. **BRAINSTORM summarize**: Produced JSON-like output instead of prose brief
3. **BRAINSTORM serialize**: Returned `entities: []` despite prose containing all entity data
4. **SEED serialize**: Returned empty arrays for all fields
5. **Ollama strategy**: TOOL method returned `None` for complex nested schemas

## Changes

- Add type-prefixed node IDs for namespace isolation (`entity::`, `tension::`, `thread::`, `beat::`, `consequence::`)
- Rewrite `summarize_brainstorm.yaml` to request prose paragraphs/bullets instead of structured fields
- Create `serialize_brainstorm.yaml` with explicit entity type mapping (Characters→character, etc.)
- Create `serialize_seed.yaml` with full schema documentation for all 6 output sections
- Add `system_prompt` parameter to `serialize_to_artifact()` for stage-specific prompts
- Change Ollama from TOOL to JSON_MODE strategy in `structured_output.py`
- Update `_format_entity()` and `_format_tension()` to display `raw_id` to LLM
- Update all mutation tests for prefixed IDs

## Not Included / Future PRs

- Improving entity ID generation (currently produces numeric IDs like "1", "2" instead of descriptive snake_case)
- Adding `involves` references in tension decisions

## Test Plan

```bash
# Full pipeline test
uv run qf init test-graph-1
uv run qf dream --project test-graph-1 "A Clue style murder mystery"
uv run qf brainstorm --project test-graph-1 "Generate characters, locations, objects, factions"
uv run qf seed --project test-graph-1 "Triage into story structure"

# Results:
# BRAINSTORM: 6 entities, 5 tensions ✓
# SEED: 8 entities retained, 5 threads, 9 consequences, 2 initial beats ✓

# Unit tests
uv run pytest tests/unit/test_mutations.py -v  # 27 passed
uv run pytest tests/unit/test_structured_output.py -v  # 4 passed
```

## Risk / Rollback

- ID prefixing is a breaking change for any existing graph.json files (none in production)
- Serialize prompt changes are additive (stage-specific prompts, generic still available)

🤖 Generated with [Claude Code](https://claude.ai/code)