### PR TITLE
refactor: fix semantic ambiguities in model field names

### DIFF
--- a/prompts/templates/serialize_brainstorm.yaml
+++ b/prompts/templates/serialize_brainstorm.yaml
@@ -16,21 +16,21 @@ system: |
   | Factions       | "faction"        |
 
   Each entity needs:
-  - `id`: Short snake_case identifier (e.g., "lady_beatrice", "vane_manor")
-  - `type`: One of "character", "location", "object", "faction"
+  - `entity_id`: Short snake_case identifier (e.g., "lady_beatrice", "vane_manor")
+  - `entity_category`: One of "character", "location", "object", "faction"
   - `concept`: One-line essence from the brief
   - `notes`: Optional additional context from the brief
 
   ## Tension Structure
 
   Tensions represent binary dramatic questions with exactly TWO alternatives:
-  - `id`: Short snake_case identifier
+  - `tension_id`: Short snake_case identifier
   - `question`: The dramatic question (should end with "?")
   - `alternatives`: Exactly 2 items, each with:
-    - `id`: Short identifier
+    - `alternative_id`: Unique short identifier for THIS alternative (e.g., "guilty", "framed", "dagger", "poison")
     - `description`: Full description
-    - `canonical`: true for ONE alternative (the default path), false for the other
-  - `involves`: List of entity IDs related to this tension (use the same IDs you assigned to entities above)
+    - `is_default_path`: true for ONE alternative (the default path), false for the other
+  - `central_entity_ids`: List of entity_id values related to this tension
   - `why_it_matters`: Thematic stakes
 
   ## Guidelines
@@ -39,7 +39,8 @@ system: |
   - Extract ALL tensions/dramatic questions mentioned
   - Do NOT invent new details - only structure what's in the brief
   - Use snake_case for all IDs (lowercase with underscores)
-  - Each tension must have exactly ONE canonical alternative
+  - Each tension must have exactly ONE alternative with is_default_path=true
+  - CRITICAL: alternative_id must be UNIQUE identifiers (e.g., "guilty", "framed"), NOT entity references
 
   ## Output
 

--- a/prompts/templates/serialize_seed.yaml
+++ b/prompts/templates/serialize_seed.yaml
@@ -12,7 +12,7 @@ system: |
   For each entity from brainstorm, create an EntityDecision:
   ```json
   {
-    "id": "entity_id_from_brainstorm",
+    "entity_id": "entity_id_from_brainstorm",
     "disposition": "retained" or "cut"
   }
   ```
@@ -26,20 +26,20 @@ system: |
     "implicit": ["alt_id_3"]                // Alternatives NOT explored
   }
   ```
-  NOTE: The canonical alternative MUST be in "explored", never in "implicit".
+  NOTE: The default path alternative (is_default_path=true) MUST be in "explored", never in "implicit".
 
   ### 3. threads (Plot Threads)
   For each explored alternative, create a Thread:
   ```json
   {
-    "id": "unique_thread_id",
+    "thread_id": "unique_thread_id",
     "name": "Human Readable Thread Name",
     "tension_id": "which_tension",
     "alternative_id": "which_alternative_this_explores",
-    "shadows": ["unexplored_alt_ids"],  // Implicit alternatives
-    "tier": "major" or "minor",
+    "unexplored_alternative_ids": ["unexplored_alt_ids"],  // Implicit alternatives
+    "thread_importance": "major" or "minor",
     "description": "What this thread is about",
-    "consequences": ["consequence_id_1", "consequence_id_2"]
+    "consequence_ids": ["consequence_id_1", "consequence_id_2"]
   }
   ```
 
@@ -47,10 +47,10 @@ system: |
   For each thread, create its Consequences:
   ```json
   {
-    "id": "unique_consequence_id",
+    "consequence_id": "unique_consequence_id",
     "thread_id": "which_thread_this_belongs_to",
     "description": "What happens narratively",
-    "ripples": ["story effect 1", "story effect 2"]
+    "narrative_effects": ["story effect 1", "story effect 2"]
   }
   ```
 
@@ -58,7 +58,7 @@ system: |
   Create InitialBeat objects for story openings:
   ```json
   {
-    "id": "unique_beat_id",
+    "beat_id": "unique_beat_id",
     "summary": "What happens in this beat",
     "threads": ["thread_id_1", "thread_id_2"],
     "tension_impacts": [
@@ -101,7 +101,7 @@ system: |
   - Every thread must reference a valid tension_id and alternative_id
   - Every consequence must reference a valid thread_id
   - Every initial_beat must reference valid thread IDs
-  - tier must be exactly "major" or "minor" (lowercase)
+  - thread_importance must be exactly "major" or "minor" (lowercase)
   - effect must be exactly "advances", "reveals", "commits", or "complicates"
   - disposition must be exactly "retained" or "cut"
 

--- a/src/questfoundry/cli.py
+++ b/src/questfoundry/cli.py
@@ -476,17 +476,17 @@ def _preview_brainstorm_artifact(artifact: dict[str, Any]) -> None:
 
     console.print(f"  Entities: [bold]{len(entities)}[/bold]")
 
-    # Group entities by type
-    entity_types: dict[str, list[str]] = {}
+    # Group entities by category
+    entity_categories: dict[str, list[str]] = {}
     for entity in entities:
-        etype = entity.get("type", "unknown")
-        entity_types.setdefault(etype, []).append(entity.get("id", "?"))
+        category = entity.get("entity_category", "unknown")
+        entity_categories.setdefault(category, []).append(entity.get("entity_id", "?"))
 
-    for etype, ids in entity_types.items():
+    for category, ids in entity_categories.items():
         ids_display = ", ".join(ids[:5])
         if len(ids) > 5:
             ids_display += f", +{len(ids) - 5} more"
-        console.print(f"    {etype}: {ids_display}")
+        console.print(f"    {category}: {ids_display}")
 
     console.print(f"  Tensions: [bold]{len(tensions)}[/bold]")
     for tension in tensions[:3]:
@@ -509,9 +509,11 @@ def _preview_seed_artifact(artifact: dict[str, Any]) -> None:
 
     console.print(f"  Threads: [bold]{len(threads)}[/bold]")
     for thread in threads[:3]:
-        tier = thread.get("tier", "?")
-        tier_style = "bold green" if tier == "major" else "dim"
-        console.print(f"    • [{tier_style}]{tier}[/{tier_style}] {thread.get('name', '?')}")
+        importance = thread.get("thread_importance", "?")
+        importance_style = "bold green" if importance == "major" else "dim"
+        console.print(
+            f"    • [{importance_style}]{importance}[/{importance_style}] {thread.get('name', '?')}"
+        )
     if len(threads) > 3:
         console.print(f"    ... and {len(threads) - 3} more")
 

--- a/src/questfoundry/models/seed.py
+++ b/src/questfoundry/models/seed.py
@@ -29,11 +29,13 @@ class EntityDecision(BaseModel):
     ideas make it into the final story.
 
     Attributes:
-        id: Entity ID from BRAINSTORM.
+        entity_id: Entity ID from BRAINSTORM.
         disposition: Whether to keep (retained) or discard (cut).
     """
 
-    id: str = Field(min_length=1, description="Entity ID from BRAINSTORM")
+    entity_id: str = Field(
+        min_length=1, description="Entity ID from BRAINSTORM (references entity_id)"
+    )
     disposition: EntityDisposition = Field(
         default="retained",
         description="Whether to keep or discard the entity",
@@ -72,18 +74,20 @@ class Consequence(BaseModel):
     consequences become active.
 
     Attributes:
-        id: Unique identifier for the consequence.
+        consequence_id: Unique identifier for the consequence.
         thread_id: Thread this consequence belongs to.
         description: What happens narratively.
-        ripples: Story effects this implies.
+        narrative_effects: Story effects this implies.
     """
 
-    id: str = Field(min_length=1, description="Unique identifier")
-    thread_id: str = Field(min_length=1, description="Thread this belongs to")
+    consequence_id: str = Field(min_length=1, description="Unique identifier for this consequence")
+    thread_id: str = Field(
+        min_length=1, description="Thread this belongs to (references thread_id)"
+    )
     description: str = Field(min_length=1, description="Narrative meaning of this path")
-    ripples: list[str] = Field(
+    narrative_effects: list[str] = Field(
         default_factory=list,
-        description="Story effects this consequence implies",
+        description="Story effects this consequence implies (cascading impacts)",
     )
 
 
@@ -95,29 +99,35 @@ class Thread(BaseModel):
     not choosing the other).
 
     Attributes:
-        id: Unique identifier for the thread.
+        thread_id: Unique identifier for the thread.
         name: Human-readable name.
         tension_id: The tension this thread explores.
         alternative_id: The specific alternative this thread explores.
-        shadows: Unexplored alternatives (context for FILL).
-        tier: Major threads interweave; minor threads support.
+        unexplored_alternative_ids: IDs of unexplored alternatives (context for FILL).
+        thread_importance: Major threads interweave; minor threads support.
         description: What this thread is about.
-        consequences: IDs of consequences for this thread.
+        consequence_ids: IDs of consequences for this thread.
     """
 
-    id: str = Field(min_length=1, description="Unique identifier")
+    thread_id: str = Field(min_length=1, description="Unique identifier for this thread")
     name: str = Field(min_length=1, description="Human-readable name")
-    tension_id: str = Field(min_length=1, description="Tension this explores")
-    alternative_id: str = Field(min_length=1, description="Alternative this explores")
-    shadows: list[str] = Field(
-        default_factory=list,
-        description="Unexplored alternative IDs (context for FILL)",
+    tension_id: str = Field(
+        min_length=1, description="Tension this explores (references tension_id)"
     )
-    tier: ThreadTier = Field(description="Major or minor thread")
-    description: str = Field(min_length=1, description="What this thread is about")
-    consequences: list[str] = Field(
+    alternative_id: str = Field(
+        min_length=1, description="Alternative this explores (references alternative_id)"
+    )
+    unexplored_alternative_ids: list[str] = Field(
         default_factory=list,
-        description="Consequence IDs for this thread",
+        description="IDs of unexplored alternatives from same tension (context for FILL)",
+    )
+    thread_importance: ThreadTier = Field(
+        description="Thread importance: major (interweaves) or minor (supports)"
+    )
+    description: str = Field(min_length=1, description="What this thread is about")
+    consequence_ids: list[str] = Field(
+        default_factory=list,
+        description="Consequence IDs for this thread (references consequence_id)",
     )
 
 
@@ -154,7 +164,7 @@ class InitialBeat(BaseModel):
         location_alternatives: Other valid locations (enables knot flexibility).
     """
 
-    id: str = Field(min_length=1, description="Unique identifier")
+    beat_id: str = Field(min_length=1, description="Unique identifier for this beat")
     summary: str = Field(min_length=1, description="What happens in this beat")
     threads: list[str] = Field(
         min_length=1,

--- a/src/questfoundry/pipeline/stages/seed.py
+++ b/src/questfoundry/pipeline/stages/seed.py
@@ -72,9 +72,9 @@ def _format_alternative(alt: dict[str, Any]) -> str:
     Uses raw_id for display (what the LLM should reference).
     """
     # Use raw_id for display
-    display_id = alt.get("raw_id", alt.get("id", "unknown"))
-    canonical = " (canonical)" if alt.get("canonical") else ""
-    return f"  - {display_id}: {alt.get('description', '')}{canonical}"
+    display_id = alt.get("raw_id", "unknown")
+    default_marker = " (default path)" if alt.get("is_default_path") else ""
+    return f"  - {display_id}: {alt.get('description', '')}{default_marker}"
 
 
 def _format_tension(tension_id: str, tension_data: dict[str, Any], graph: Graph) -> str:
@@ -85,25 +85,23 @@ def _format_tension(tension_id: str, tension_data: dict[str, Any], graph: Graph)
     # Use raw_id for display
     display_id = tension_data.get("raw_id", tension_id)
     question = tension_data.get("question", "")
-    involves = tension_data.get("involves", [])
+    central_entities = tension_data.get("central_entity_ids", [])
     why_it_matters = tension_data.get("why_it_matters", "")
 
-    # Format involves list - extract raw IDs from prefixed references
-    involves_display = []
-    for ref in involves:
+    # Format central entities list - extract raw IDs from prefixed references
+    entities_display = []
+    for ref in central_entities:
         # References are prefixed like "entity::raw_id", extract raw_id part
         if ref.startswith("entity::"):
-            involves_display.append(ref[8:])  # Skip "entity::" prefix
+            entities_display.append(ref[8:])  # Skip "entity::" prefix
         elif "::" in ref:
             # Fallback for other prefixed formats
-            involves_display.append(ref.split("::")[-1])
+            entities_display.append(ref.split("::")[-1])
         else:
-            involves_display.append(ref)
+            entities_display.append(ref)
 
     result = f"- **{display_id}**: {question}\n"
-    result += (
-        f"  Involves: {', '.join(involves_display) if involves_display else 'none specified'}\n"
-    )
+    result += f"  Central entities: {', '.join(entities_display) if entities_display else 'none specified'}\n"
     result += f"  Stakes: {why_it_matters}\n"
     result += "  Alternatives:\n"
 


### PR DESCRIPTION
## Problem

LLMs interpret generic field names ambiguously. The BRAINSTORM→SEED handover failed in `projects/run-1-ni/` because the LLM filled `Alternative.id` with entity references (`lady_eleanor_vane`) instead of unique alternative identifiers, causing duplicate node IDs that aborted the graph update.

Root cause: `id` is too generic—the LLM interpreted it as "entity reference" rather than "unique identifier for this alternative."

## Changes

Renamed ambiguous fields to semantically-clear names that LLMs can't misinterpret:

### Critical Renames
| Old | New |
|-----|-----|
| `Alternative.id` | `alternative_id` |
| `Alternative.canonical` | `is_default_path` |
| `Entity.id` | `entity_id` |
| `Entity.type` | `entity_category` |
| `Tension.id` | `tension_id` |
| `Tension.involves` | `central_entity_ids` |

### SEED Model Renames
| Old | New |
|-----|-----|
| `Thread.id` | `thread_id` |
| `Thread.shadows` | `unexplored_alternative_ids` |
| `Thread.tier` | `thread_importance` |
| `Thread.consequences` | `consequence_ids` |
| `Consequence.id` | `consequence_id` |
| `Consequence.ripples` | `narrative_effects` |
| `InitialBeat.id` | `beat_id` |

### Files Modified
- `src/questfoundry/models/brainstorm.py` - Model field renames
- `src/questfoundry/models/seed.py` - Model field renames
- `src/questfoundry/graph/mutations.py` - Updated field reads
- `src/questfoundry/pipeline/stages/seed.py` - Updated graph access
- `src/questfoundry/cli.py` - Updated preview functions
- `prompts/templates/serialize_brainstorm.yaml` - Updated examples
- `prompts/templates/serialize_seed.yaml` - Updated examples
- `tests/unit/test_brainstorm_stage.py` - Updated fixtures
- `tests/unit/test_seed_stage.py` - Updated fixtures
- `tests/unit/test_mutations.py` - Updated fixtures

## Not Included / Future PRs

- Tool response renames (`result` → `outcome`, `content` → `formatted_output`) - separate concern
- Documentation updates in `docs/architecture/decisions.md`

## Test Plan

- [x] `uv run pytest tests/unit/` - 538 tests pass
- [x] `uv run mypy src/` - passes
- [x] `uv run ruff check src/` - passes

## Risk / Rollback

- Breaking change for any existing project artifacts using old field names
- No migration path needed since pipeline always regenerates from LLM output
- Rollback: revert all commits on this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)