### PR TITLE
fix(prompts): ensure central_entity_ids flows through brainstorm phases

### DIFF
--- a/prompts/templates/discuss_brainstorm.yaml
+++ b/prompts/templates/discuss_brainstorm.yaml
@@ -19,13 +19,14 @@ system: |
   2. **Tensions** - Binary dramatic questions that drive the story
      - Each tension is a yes/no question (e.g., "Can the mentor be trusted?")
      - Each tension has exactly TWO alternatives (not more, not less)
-     - One alternative should be marked as "canonical" (the default story path)
+     - One alternative should be marked as the "default path" (the canonical story outcome)
      - For nuanced concepts, use MULTIPLE binary tensions rather than one multi-way choice
+     - Each tension must list its **central entities by ID** (e.g., "Central entities: host, butler")
 
   ## Guidelines
   - Be expansive! Generate MORE material than needed (15-25 entities, 4-8 tensions is good)
   - Include rich notes from discussion - preserve creative context
-  - Every tension must explicitly list which entities are involved
+  - Every tension must explicitly list central entity IDs (use the same IDs you gave the entities)
   - Every tension needs a "why_it_matters" explaining thematic stakes
   - Don't self-censor - SEED stage will filter later
   {research_tools_section}

--- a/prompts/templates/discuss_brainstorm.yaml
+++ b/prompts/templates/discuss_brainstorm.yaml
@@ -21,7 +21,7 @@ system: |
      - Each tension has exactly TWO alternatives (not more, not less)
      - One alternative should be marked as the "default path" (the canonical story outcome)
      - For nuanced concepts, use MULTIPLE binary tensions rather than one multi-way choice
-     - Each tension must list its **central entities by ID** (e.g., "Central entities: host, butler")
+     - Each tension must list its **central entities by ID** (e.g., "Central entities: the_host, the_butler")
 
   ## Guidelines
   - Be expansive! Generate MORE material than needed (15-25 entities, 4-8 tensions is good)

--- a/prompts/templates/summarize_brainstorm.yaml
+++ b/prompts/templates/summarize_brainstorm.yaml
@@ -33,15 +33,16 @@ system: |
   ### Dramatic Tensions (aim for 4-8)
   For each tension, describe in prose:
   - The central question or conflict
-  - The two possible answers/outcomes (one being the "default" story path)
-  - Which characters or elements are involved
+  - The two possible answers/outcomes (one being the "default path")
+  - **Central entity IDs**: List the exact entity IDs involved (e.g., "host, butler, manor")
   - Why this tension matters thematically
 
   ## Guidelines
   - Write in flowing prose, not schema fields
   - Capture ALL entities and tensions mentioned in discussion
   - Preserve rich context and reasoning - this helps the serializer
-  - Be specific about which alternative is the "canonical" (default) path
+  - Be specific about which alternative is the "default path"
+  - IMPORTANT: For each tension, list the central entity IDs exactly as defined in the entities section
   - If something wasn't discussed, don't invent it
 
   ## Output Format

--- a/prompts/templates/summarize_brainstorm.yaml
+++ b/prompts/templates/summarize_brainstorm.yaml
@@ -34,7 +34,7 @@ system: |
   For each tension, describe in prose:
   - The central question or conflict
   - The two possible answers/outcomes (one being the "default path")
-  - **Central entity IDs**: List the exact entity IDs involved (e.g., "host, butler, manor")
+  - **Central entity IDs**: List the exact entity IDs involved (e.g., "the_host, the_butler, vane_manor")
   - Why this tension matters thematically
 
   ## Guidelines

--- a/prompts/templates/summarize_seed.yaml
+++ b/prompts/templates/summarize_seed.yaml
@@ -5,6 +5,9 @@ system: |
   You are summarizing a story architecture discussion into structured output.
   This is the SEED stage output - the committed foundation for the story.
 
+  ## Brainstorm Reference
+  {brainstorm_context}
+
   ## Your Task
   Condense the discussion into a complete story structure:
 

--- a/src/questfoundry/agents/prompts.py
+++ b/src/questfoundry/agents/prompts.py
@@ -190,15 +190,22 @@ def get_seed_discuss_prompt(
     )
 
 
-def get_seed_summarize_prompt() -> str:
+def get_seed_summarize_prompt(brainstorm_context: str = "") -> str:
     """Build the SEED summarize prompt.
+
+    Args:
+        brainstorm_context: YAML representation of brainstorm entities/tensions.
+            Required for the summarizer to know what IDs to reference.
 
     Returns:
         System prompt string for the SEED summarize call.
     """
-    loader = _get_loader()
-    template = loader.load("summarize_seed")
-    return template.system
+    raw_data = _load_raw_template("summarize_seed")
+
+    # Render the system template with brainstorm context
+    system_template = raw_data.get("system", "")
+    prompt = ChatPromptTemplate.from_template(system_template)
+    return prompt.format(brainstorm_context=brainstorm_context)
 
 
 def get_brainstorm_serialize_prompt() -> str:

--- a/src/questfoundry/pipeline/stages/seed.py
+++ b/src/questfoundry/pipeline/stages/seed.py
@@ -298,7 +298,7 @@ class SeedStage:
 
         # Phase 2: Summarize
         log.debug("seed_phase", phase="summarize")
-        summarize_prompt = get_seed_summarize_prompt()
+        summarize_prompt = get_seed_summarize_prompt(brainstorm_context=brainstorm_context)
         brief, summarize_tokens = await summarize_discussion(
             model=model,
             messages=messages,


### PR DESCRIPTION
## Problem
After PR #119 (semantic field renames), pipeline tests revealed two issues:
1. All tensions had empty `central_entity_ids` arrays
2. SEED stage produced empty output because summarize phase lacked brainstorm context

## Changes

### Fix 1: central_entity_ids in BRAINSTORM
- **discuss_brainstorm.yaml**: Add explicit instruction to list "central entities by ID" with example format
- **summarize_brainstorm.yaml**: Add "Central entity IDs" as explicit field to extract with example format
- Align both prompts on "default path" terminology (was inconsistently "canonical")

### Fix 2: SEED summarize context injection
- **summarize_seed.yaml**: Add `{brainstorm_context}` placeholder
- **prompts.py**: Update `get_seed_summarize_prompt()` to accept and inject brainstorm context
- **seed.py**: Pass brainstorm_context when calling summarize prompt

## Test Plan
- [x] All 538 unit tests pass
- [x] Full pipeline test: DREAM → BRAINSTORM → SEED completes successfully
- [x] Brainstorm tensions now have populated `central_entity_ids`
- [x] SEED produces meaningful output (4 entities, 2 threads, 1 beat)

**Before fix:**
- SEED summarize: 343 chars, 0 entities, 0 threads
- central_entity_ids: all empty

**After fix:**
- SEED summarize: 8130 chars, 4 entities, 2 threads, 1 beat
- central_entity_ids: populated with actual IDs

## Risk / Rollback
- Low risk - prompt template and context injection changes only
- If prompts don't work well, revert or iterate on wording

🤖 Generated with [Claude Code](https://claude.com/claude-code)