### PR TITLE
feat(seed): implement iterative serialization to prevent output truncation

### DIFF
--- a/prompts/templates/serialize_seed_sections.yaml
+++ b/prompts/templates/serialize_seed_sections.yaml
@@ -1,0 +1,184 @@
+name: serialize_seed_sections
+description: Section-specific prompts for iterative SEED serialization
+
+# Common preamble injected into all section prompts
+common_context: |
+  You are extracting ONE SECTION from a SEED stage brief into structured JSON.
+  Focus ONLY on the section requested. Extract ALL items for that section.
+  Use snake_case for all IDs. Do not invent details not in the brief.
+
+# Section 1: Entity Decisions
+entities_prompt: |
+  You are extracting ENTITY DECISIONS from a SEED stage brief.
+
+  ## Schema
+  Return a JSON object with an "entities" array. Each item is an EntityDecision:
+  ```json
+  {
+    "entities": [
+      {
+        "entity_id": "entity_id_from_brainstorm",
+        "disposition": "retained" or "cut"
+      }
+    ]
+  }
+  ```
+
+  ## Rules
+  - disposition must be exactly "retained" or "cut" (lowercase)
+  - entity_id must match the ID shown in the brief
+  - Include ALL entities mentioned in the Entity Decisions section
+  - Do NOT include entities not listed in Entity Decisions
+
+  ## Output
+  Return ONLY valid JSON with the "entities" array.
+
+# Section 2: Tension Decisions
+tensions_prompt: |
+  You are extracting TENSION DECISIONS from a SEED stage brief.
+
+  ## Schema
+  Return a JSON object with a "tensions" array. Each item is a TensionDecision:
+  ```json
+  {
+    "tensions": [
+      {
+        "tension_id": "tension_id_from_brainstorm",
+        "explored": ["alt_id_1", "alt_id_2"],
+        "implicit": ["alt_id_3"]
+      }
+    ]
+  }
+  ```
+
+  ## Rules
+  - tension_id must match the ID shown in the brief
+  - explored: Alternative IDs that become threads (MUST include the default path)
+  - implicit: Alternative IDs NOT explored (become shadows)
+  - Include ALL tensions mentioned in the Tension Decisions section
+
+  ## Output
+  Return ONLY valid JSON with the "tensions" array.
+
+# Section 3: Threads
+threads_prompt: |
+  You are extracting THREADS from a SEED stage brief.
+
+  ## Schema
+  Return a JSON object with a "threads" array. Each item is a Thread:
+  ```json
+  {
+    "threads": [
+      {
+        "thread_id": "unique_thread_id",
+        "name": "Human Readable Thread Name",
+        "tension_id": "which_tension",
+        "alternative_id": "which_alternative_this_explores",
+        "unexplored_alternative_ids": ["unexplored_alt_ids"],
+        "thread_importance": "major" or "minor",
+        "description": "What this thread is about",
+        "consequence_ids": ["consequence_id_1"]
+      }
+    ]
+  }
+  ```
+
+  ## Rules
+  - thread_importance must be exactly "major" or "minor" (lowercase)
+  - unexplored_alternative_ids: IDs of alternatives NOT explored (implicit ones)
+  - consequence_ids: References to consequences for this thread
+  - Include ALL threads mentioned in the Threads section
+
+  ## Output
+  Return ONLY valid JSON with the "threads" array.
+
+# Section 4: Consequences
+consequences_prompt: |
+  You are extracting CONSEQUENCES from a SEED stage brief.
+
+  ## Schema
+  Return a JSON object with a "consequences" array. Each item is a Consequence:
+  ```json
+  {
+    "consequences": [
+      {
+        "consequence_id": "unique_consequence_id",
+        "thread_id": "which_thread_this_belongs_to",
+        "description": "What happens narratively",
+        "narrative_effects": ["story effect 1", "story effect 2"]
+      }
+    ]
+  }
+  ```
+
+  ## Rules
+  - consequence_id must be unique
+  - thread_id must reference a valid thread
+  - narrative_effects: Array of story effects this consequence implies
+  - Include ALL consequences mentioned in the Consequences section
+
+  ## Output
+  Return ONLY valid JSON with the "consequences" array.
+
+# Section 5: Initial Beats
+beats_prompt: |
+  You are extracting INITIAL BEATS from a SEED stage brief.
+
+  ## Schema
+  Return a JSON object with an "initial_beats" array. Each item is an InitialBeat:
+  ```json
+  {
+    "initial_beats": [
+      {
+        "beat_id": "unique_beat_id",
+        "summary": "What happens in this beat",
+        "threads": ["thread_id_1", "thread_id_2"],
+        "tension_impacts": [
+          {
+            "tension_id": "which_tension",
+            "effect": "advances",
+            "note": "Explanation of the impact"
+          }
+        ],
+        "entities": ["entity_id_1", "entity_id_2"],
+        "location": "location_entity_id",
+        "location_alternatives": ["other_location_id"]
+      }
+    ]
+  }
+  ```
+
+  ## Rules
+  - effect must be exactly "advances", "reveals", "commits", or "complicates"
+  - threads: Array of thread IDs this beat serves
+  - location: Primary location entity ID (can be null)
+  - location_alternatives: Other valid locations (can be empty array)
+  - Include ALL initial beats mentioned in the Initial Beats section
+
+  ## Output
+  Return ONLY valid JSON with the "initial_beats" array.
+
+# Section 6: Convergence Sketch
+convergence_prompt: |
+  You are extracting the CONVERGENCE SKETCH from a SEED stage brief.
+
+  ## Schema
+  Return a JSON object with a "convergence_sketch" object:
+  ```json
+  {
+    "convergence_sketch": {
+      "convergence_points": ["where threads should merge"],
+      "residue_notes": ["differences that persist after convergence"]
+    }
+  }
+  ```
+
+  ## Rules
+  - convergence_points: Where threads should merge (e.g., "by act 2 climax")
+  - residue_notes: What differences persist after convergence
+  - Both can be empty arrays if not specified in brief
+
+  ## Output
+  Return ONLY valid JSON with the "convergence_sketch" object.
+
+components: []

--- a/prompts/templates/serialize_seed_sections.yaml
+++ b/prompts/templates/serialize_seed_sections.yaml
@@ -1,12 +1,6 @@
 name: serialize_seed_sections
 description: Section-specific prompts for iterative SEED serialization
 
-# Common preamble injected into all section prompts
-common_context: |
-  You are extracting ONE SECTION from a SEED stage brief into structured JSON.
-  Focus ONLY on the section requested. Extract ALL items for that section.
-  Use snake_case for all IDs. Do not invent details not in the brief.
-
 # Section 1: Entity Decisions
 entities_prompt: |
   You are extracting ENTITY DECISIONS from a SEED stage brief.

--- a/src/questfoundry/agents/__init__.py
+++ b/src/questfoundry/agents/__init__.py
@@ -12,7 +12,11 @@ from questfoundry.agents.prompts import (
     get_serialize_prompt,
     get_summarize_prompt,
 )
-from questfoundry.agents.serialize import SerializationError, serialize_to_artifact
+from questfoundry.agents.serialize import (
+    SerializationError,
+    serialize_seed_iteratively,
+    serialize_to_artifact,
+)
 from questfoundry.agents.summarize import summarize_discussion
 
 __all__ = [
@@ -28,6 +32,7 @@ __all__ = [
     "get_serialize_prompt",
     "get_summarize_prompt",
     "run_discuss_phase",
+    "serialize_seed_iteratively",
     "serialize_to_artifact",
     "summarize_discussion",
 ]

--- a/src/questfoundry/models/seed.py
+++ b/src/questfoundry/models/seed.py
@@ -248,3 +248,61 @@ class SeedOutput(BaseModel):
         default_factory=ConvergenceSketch,
         description="Guidance for GROW about thread convergence",
     )
+
+
+# Section wrapper models for iterative serialization
+# These allow serializing SEED output in chunks to avoid output truncation
+
+
+class EntitiesSection(BaseModel):
+    """Wrapper for serializing entity decisions separately."""
+
+    entities: list[EntityDecision] = Field(
+        default_factory=list,
+        description="Entity curation decisions",
+    )
+
+
+class TensionsSection(BaseModel):
+    """Wrapper for serializing tension decisions separately."""
+
+    tensions: list[TensionDecision] = Field(
+        default_factory=list,
+        description="Tension exploration decisions",
+    )
+
+
+class ThreadsSection(BaseModel):
+    """Wrapper for serializing threads separately."""
+
+    threads: list[Thread] = Field(
+        default_factory=list,
+        description="Created plot threads",
+    )
+
+
+class ConsequencesSection(BaseModel):
+    """Wrapper for serializing consequences separately."""
+
+    consequences: list[Consequence] = Field(
+        default_factory=list,
+        description="Narrative consequences for threads",
+    )
+
+
+class BeatsSection(BaseModel):
+    """Wrapper for serializing initial beats separately."""
+
+    initial_beats: list[InitialBeat] = Field(
+        default_factory=list,
+        description="Initial beats for each thread",
+    )
+
+
+class ConvergenceSection(BaseModel):
+    """Wrapper for serializing convergence sketch separately."""
+
+    convergence_sketch: ConvergenceSketch = Field(
+        default_factory=ConvergenceSketch,
+        description="Guidance for GROW about thread convergence",
+    )

--- a/tests/unit/test_seed_stage.py
+++ b/tests/unit/test_seed_stage.py
@@ -83,7 +83,7 @@ async def test_execute_calls_all_three_phases() -> None:
         patch("questfoundry.pipeline.stages.seed.Graph") as MockGraph,
         patch("questfoundry.pipeline.stages.seed.run_discuss_phase") as mock_discuss,
         patch("questfoundry.pipeline.stages.seed.summarize_discussion") as mock_summarize,
-        patch("questfoundry.pipeline.stages.seed.serialize_to_artifact") as mock_serialize,
+        patch("questfoundry.pipeline.stages.seed.serialize_seed_iteratively") as mock_serialize,
         patch("questfoundry.pipeline.stages.seed.get_all_research_tools") as mock_tools,
     ):
         MockGraph.load.return_value = mock_graph
@@ -132,7 +132,7 @@ async def test_execute_calls_all_three_phases() -> None:
         assert len(artifact["entities"]) == 1
         assert len(artifact["threads"]) == 1
         assert len(artifact["initial_beats"]) == 1
-        assert llm_calls == 4  # 2 discuss + 1 summarize + 1 serialize
+        assert llm_calls == 9  # 2 discuss + 1 summarize + 6 serialize (iterative)
         assert tokens == 800  # 500 + 100 + 200
 
 
@@ -154,7 +154,7 @@ async def test_execute_passes_brainstorm_context_to_discuss() -> None:
         patch("questfoundry.pipeline.stages.seed.Graph") as MockGraph,
         patch("questfoundry.pipeline.stages.seed.run_discuss_phase") as mock_discuss,
         patch("questfoundry.pipeline.stages.seed.summarize_discussion") as mock_summarize,
-        patch("questfoundry.pipeline.stages.seed.serialize_to_artifact") as mock_serialize,
+        patch("questfoundry.pipeline.stages.seed.serialize_seed_iteratively") as mock_serialize,
         patch("questfoundry.pipeline.stages.seed.get_all_research_tools") as mock_tools,
         patch("questfoundry.pipeline.stages.seed.get_seed_discuss_prompt") as mock_prompt,
     ):
@@ -181,8 +181,8 @@ async def test_execute_passes_brainstorm_context_to_discuss() -> None:
 
 
 @pytest.mark.asyncio
-async def test_execute_passes_seed_output_schema() -> None:
-    """Execute passes SeedOutput schema to serialize."""
+async def test_execute_uses_iterative_serialization() -> None:
+    """Execute uses iterative serialization for SEED output."""
     stage = SeedStage()
 
     mock_model = MagicMock()
@@ -196,7 +196,7 @@ async def test_execute_passes_seed_output_schema() -> None:
         patch("questfoundry.pipeline.stages.seed.Graph") as MockGraph,
         patch("questfoundry.pipeline.stages.seed.run_discuss_phase") as mock_discuss,
         patch("questfoundry.pipeline.stages.seed.summarize_discussion") as mock_summarize,
-        patch("questfoundry.pipeline.stages.seed.serialize_to_artifact") as mock_serialize,
+        patch("questfoundry.pipeline.stages.seed.serialize_seed_iteratively") as mock_serialize,
         patch("questfoundry.pipeline.stages.seed.get_all_research_tools") as mock_tools,
     ):
         MockGraph.load.return_value = mock_graph
@@ -212,7 +212,9 @@ async def test_execute_passes_seed_output_schema() -> None:
             project_path=Path("/test/project"),
         )
 
-        assert mock_serialize.call_args.kwargs["schema"] is SeedOutput
+        # Verify iterative serialization is used with the brief
+        mock_serialize.assert_called_once()
+        assert mock_serialize.call_args.kwargs["brief"] == "Brief"
 
 
 @pytest.mark.asyncio
@@ -231,7 +233,7 @@ async def test_execute_uses_seed_summarize_prompt() -> None:
         patch("questfoundry.pipeline.stages.seed.Graph") as MockGraph,
         patch("questfoundry.pipeline.stages.seed.run_discuss_phase") as mock_discuss,
         patch("questfoundry.pipeline.stages.seed.summarize_discussion") as mock_summarize,
-        patch("questfoundry.pipeline.stages.seed.serialize_to_artifact") as mock_serialize,
+        patch("questfoundry.pipeline.stages.seed.serialize_seed_iteratively") as mock_serialize,
         patch("questfoundry.pipeline.stages.seed.get_all_research_tools") as mock_tools,
         patch("questfoundry.pipeline.stages.seed.get_seed_summarize_prompt") as mock_prompt,
     ):
@@ -270,7 +272,7 @@ async def test_execute_returns_artifact_as_dict() -> None:
         patch("questfoundry.pipeline.stages.seed.Graph") as MockGraph,
         patch("questfoundry.pipeline.stages.seed.run_discuss_phase") as mock_discuss,
         patch("questfoundry.pipeline.stages.seed.summarize_discussion") as mock_summarize,
-        patch("questfoundry.pipeline.stages.seed.serialize_to_artifact") as mock_serialize,
+        patch("questfoundry.pipeline.stages.seed.serialize_seed_iteratively") as mock_serialize,
         patch("questfoundry.pipeline.stages.seed.get_all_research_tools") as mock_tools,
     ):
         MockGraph.load.return_value = mock_graph

--- a/tests/unit/test_seed_stage.py
+++ b/tests/unit/test_seed_stage.py
@@ -132,7 +132,9 @@ async def test_execute_calls_all_three_phases() -> None:
         assert len(artifact["entities"]) == 1
         assert len(artifact["threads"]) == 1
         assert len(artifact["initial_beats"]) == 1
-        assert llm_calls == 9  # 2 discuss + 1 summarize + 6 serialize (iterative)
+        # Stage counts: 2 discuss + 1 summarize + 6 (hardcoded for iterative serialize)
+        # Note: This tests the stage's call accounting, not internal serialize behavior
+        assert llm_calls == 9
         assert tokens == 800  # 500 + 100 + 200
 
 


### PR DESCRIPTION
## Problem

SEED output was being truncated (4 entities, 2 threads, 1 beat) despite rich input from BRAINSTORM (16+ entities, 5+ tensions). This was caused by output token limits when serializing the complex nested `SeedOutput` schema in a single LLM call with smaller models like qwen3:8b.

## Changes

Implemented iterative serialization that serializes SEED output in 6 separate sections, then merges:

1. **entities** (EntityDecision list)
2. **tensions** (TensionDecision list)
3. **threads** (Thread list)
4. **consequences** (Consequence list)
5. **initial_beats** (InitialBeat list)
6. **convergence_sketch** (ConvergenceSketch)

### Files changed:
- `src/questfoundry/models/seed.py` - Add 6 section wrapper models
- `prompts/templates/serialize_seed_sections.yaml` - Section-specific prompts
- `src/questfoundry/agents/serialize.py` - Add `serialize_seed_iteratively()` function
- `src/questfoundry/agents/__init__.py` - Export new function
- `src/questfoundry/pipeline/stages/seed.py` - Use iterative serialization
- `tests/unit/test_seed_stage.py` - Update tests for new approach

## Not Included / Future PRs

- Similar iterative serialization for BRAINSTORM (not currently needed)
- Configurable section order or parallel section serialization

## Test Plan

- All 538 unit tests pass
- Full pipeline test verified:

| Metric | Before | After |
|--------|--------|-------|
| Entities | 4 | 17 (12 retained, 5 cut) |
| Tensions | 2 | 8 |
| Threads | 2 | 7 |
| Consequences | 0 | 7 |
| Initial Beats | 1 | 5 |

```bash
uv run pytest tests/unit/ -v  # All 538 tests pass
uv run qf run --to seed --no-interactive --provider ollama --project run-2-ni  # Full pipeline test
```

## Risk / Rollback

- Low risk: Additive change with new function, old `serialize_to_artifact` unchanged
- SEED stage now makes 6 serialize calls instead of 1 (more LLM calls but better output)
- Rollback: Revert to using `serialize_to_artifact` with `SeedOutput` schema

🤖 Generated with [Claude Code](https://claude.com/claude-code)