### PR TITLE
fix(observability): propagate callbacks through RunnableConfig

### DIFF
--- a/src/questfoundry/agents/discuss.py
+++ b/src/questfoundry/agents/discuss.py
@@ -12,6 +12,7 @@ from questfoundry.observability.logging import get_logger
 from questfoundry.observability.tracing import build_runnable_config, traceable
 
 if TYPE_CHECKING:
+    from langchain_core.callbacks import BaseCallbackHandler
     from langchain_core.language_models import BaseChatModel
     from langchain_core.tools import BaseTool
 
@@ -79,6 +80,7 @@ async def run_discuss_phase(
     on_llm_end: LLMCallbackFn | None = None,
     system_prompt: str | None = None,
     stage_name: str = "dream",
+    callbacks: list[BaseCallbackHandler] | None = None,
 ) -> tuple[list[BaseMessage], int, int]:
     """Run the Discuss phase to completion.
 
@@ -100,6 +102,7 @@ async def run_discuss_phase(
         on_llm_end: Callback when LLM call ends
         system_prompt: Optional custom system prompt for the agent
         stage_name: Stage name for logging/tagging (default "dream")
+        callbacks: LangChain callback handlers for logging LLM calls
 
     Returns:
         Tuple of (messages, llm_call_count, total_tokens)
@@ -139,6 +142,7 @@ async def run_discuss_phase(
             tags=[stage_name, "discuss", "agent"],
             metadata={"stage": stage_name, "phase": "discuss"},
             recursion_limit=max_iterations,
+            callbacks=callbacks,
         )
         result = await agent.ainvoke(
             {"messages": current_messages},

--- a/src/questfoundry/agents/serialize.py
+++ b/src/questfoundry/agents/serialize.py
@@ -23,6 +23,7 @@ from questfoundry.providers.structured_output import (
 )
 
 if TYPE_CHECKING:
+    from langchain_core.callbacks import BaseCallbackHandler
     from langchain_core.language_models import BaseChatModel
 
 log = get_logger(__name__)
@@ -53,6 +54,7 @@ async def serialize_to_artifact(
     strategy: StructuredOutputStrategy | None = None,
     max_retries: int = 3,
     system_prompt: str | None = None,
+    callbacks: list[BaseCallbackHandler] | None = None,
 ) -> tuple[T, int]:
     """Serialize a brief into a structured artifact.
 
@@ -68,6 +70,7 @@ async def serialize_to_artifact(
         strategy: Output strategy (auto-selected if None).
         max_retries: Maximum total attempts (default 3).
         system_prompt: Stage-specific serialize prompt. If None, uses generic prompt.
+        callbacks: LangChain callback handlers for logging LLM calls.
 
     Returns:
         Tuple of (validated_artifact, tokens_used).
@@ -125,6 +128,7 @@ async def serialize_to_artifact(
                         "phase": "serialize",
                         "attempt": attempt,
                     },
+                    callbacks=callbacks,
                 )
 
                 # Invoke structured output
@@ -355,6 +359,7 @@ async def serialize_seed_iteratively(
     brief: str,
     provider_name: str | None = None,
     max_retries: int = 3,
+    callbacks: list[BaseCallbackHandler] | None = None,
 ) -> tuple[Any, int]:
     """Serialize SEED brief in sections to avoid output truncation.
 
@@ -375,6 +380,7 @@ async def serialize_seed_iteratively(
         brief: The summary brief from the Summarize phase.
         provider_name: Provider name for strategy auto-detection.
         max_retries: Maximum retries per section.
+        callbacks: LangChain callback handlers for logging LLM calls.
 
     Returns:
         Tuple of (SeedOutput, total_tokens_used).
@@ -420,6 +426,7 @@ async def serialize_seed_iteratively(
             provider_name=provider_name,
             max_retries=max_retries,
             system_prompt=section_prompt,
+            callbacks=callbacks,
         )
         total_tokens += section_tokens
 

--- a/src/questfoundry/agents/summarize.py
+++ b/src/questfoundry/agents/summarize.py
@@ -11,6 +11,7 @@ from questfoundry.observability.logging import get_logger
 from questfoundry.observability.tracing import build_runnable_config, traceable
 
 if TYPE_CHECKING:
+    from langchain_core.callbacks import BaseCallbackHandler
     from langchain_core.language_models import BaseChatModel
 
 log = get_logger(__name__)
@@ -22,6 +23,7 @@ async def summarize_discussion(
     messages: list[BaseMessage],
     system_prompt: str | None = None,
     stage_name: str = "dream",
+    callbacks: list[BaseCallbackHandler] | None = None,
 ) -> tuple[str, int]:
     """Summarize a discussion into a compact brief.
 
@@ -37,6 +39,7 @@ async def summarize_discussion(
         system_prompt: Optional custom system prompt. If not provided,
             uses the default summarize prompt.
         stage_name: Stage name for logging/tagging (default "dream")
+        callbacks: LangChain callback handlers for logging LLM calls
 
     Returns:
         Tuple of (summary_text, tokens_used)
@@ -63,6 +66,7 @@ async def summarize_discussion(
         run_name="Summarize LLM Call",
         tags=[stage_name, "summarize", "llm"],
         metadata={"stage": stage_name, "phase": "summarize", "message_count": len(messages)},
+        callbacks=callbacks,
     )
 
     # Note: We use the model as configured rather than trying to override temperature

--- a/src/questfoundry/pipeline/orchestrator.py
+++ b/src/questfoundry/pipeline/orchestrator.py
@@ -18,6 +18,7 @@ from questfoundry.pipeline.gates import AutoApproveGate, GateHook
 if TYPE_CHECKING:
     from pathlib import Path
 
+    from langchain_core.callbacks import BaseCallbackHandler
     from langchain_core.language_models import BaseChatModel
 
 log = get_logger(__name__)
@@ -131,7 +132,7 @@ class PipelineOrchestrator:
         from questfoundry.observability import LLMLogger
 
         self._llm_logger = LLMLogger(project_path, enabled=enable_llm_logging)
-        self._callbacks: list[Any] | None = None  # Set when model is created
+        self._callbacks: list[BaseCallbackHandler] | None = None  # Set when model is created
 
     def _get_chat_model(self) -> BaseChatModel:
         """Get or create the LangChain chat model.

--- a/src/questfoundry/pipeline/stages/brainstorm.py
+++ b/src/questfoundry/pipeline/stages/brainstorm.py
@@ -31,6 +31,7 @@ from questfoundry.tools.langchain_tools import get_all_research_tools
 log = get_logger(__name__)
 
 if TYPE_CHECKING:
+    from langchain_core.callbacks import BaseCallbackHandler
     from langchain_core.language_models import BaseChatModel
 
     from questfoundry.agents.discuss import (
@@ -152,6 +153,7 @@ class BrainstormStage:
         on_llm_start: LLMCallbackFn | None = None,
         on_llm_end: LLMCallbackFn | None = None,
         project_path: Path | None = None,
+        callbacks: list[BaseCallbackHandler] | None = None,
     ) -> tuple[dict[str, Any], int, int]:
         """Execute the BRAINSTORM stage using the 3-phase pattern.
 
@@ -165,6 +167,7 @@ class BrainstormStage:
             on_llm_start: Callback when LLM call starts.
             on_llm_end: Callback when LLM call ends.
             project_path: Override for project path (uses self.project_path if None).
+            callbacks: LangChain callback handlers for logging LLM calls.
 
         Returns:
             Tuple of (artifact_data, llm_calls, tokens_used).
@@ -223,6 +226,7 @@ class BrainstormStage:
             on_llm_end=on_llm_end,
             system_prompt=discuss_prompt,
             stage_name="brainstorm",
+            callbacks=callbacks,
         )
         total_llm_calls += discuss_calls
         total_tokens += discuss_tokens
@@ -235,6 +239,7 @@ class BrainstormStage:
             messages=messages,
             system_prompt=summarize_prompt,
             stage_name="brainstorm",
+            callbacks=callbacks,
         )
         total_llm_calls += 1
         total_tokens += summarize_tokens
@@ -248,6 +253,7 @@ class BrainstormStage:
             schema=BrainstormOutput,
             provider_name=provider_name,
             system_prompt=serialize_prompt,
+            callbacks=callbacks,
         )
         total_llm_calls += 1
         total_tokens += serialize_tokens

--- a/src/questfoundry/pipeline/stages/seed.py
+++ b/src/questfoundry/pipeline/stages/seed.py
@@ -32,6 +32,7 @@ from questfoundry.tools.langchain_tools import get_all_research_tools
 log = get_logger(__name__)
 
 if TYPE_CHECKING:
+    from langchain_core.callbacks import BaseCallbackHandler
     from langchain_core.language_models import BaseChatModel
 
     from questfoundry.agents.discuss import (
@@ -219,6 +220,7 @@ class SeedStage:
         on_llm_start: LLMCallbackFn | None = None,
         on_llm_end: LLMCallbackFn | None = None,
         project_path: Path | None = None,
+        callbacks: list[BaseCallbackHandler] | None = None,
     ) -> tuple[dict[str, Any], int, int]:
         """Execute the SEED stage using the 3-phase pattern.
 
@@ -232,6 +234,7 @@ class SeedStage:
             on_llm_start: Callback when LLM call starts.
             on_llm_end: Callback when LLM call ends.
             project_path: Override for project path (uses self.project_path if None).
+            callbacks: LangChain callback handlers for logging LLM calls.
 
         Returns:
             Tuple of (artifact_data, llm_calls, tokens_used).
@@ -290,6 +293,7 @@ class SeedStage:
             on_llm_end=on_llm_end,
             system_prompt=discuss_prompt,
             stage_name="seed",
+            callbacks=callbacks,
         )
         total_llm_calls += discuss_calls
         total_tokens += discuss_tokens
@@ -302,6 +306,7 @@ class SeedStage:
             messages=messages,
             system_prompt=summarize_prompt,
             stage_name="seed",
+            callbacks=callbacks,
         )
         total_llm_calls += 1
         total_tokens += summarize_tokens
@@ -312,6 +317,7 @@ class SeedStage:
             model=model,
             brief=brief,
             provider_name=provider_name,
+            callbacks=callbacks,
         )
         # Iterative serialization makes 6 calls (one per section)
         total_llm_calls += 6


### PR DESCRIPTION
## Problem

`llm_calls.jsonl` only captures 3 LLM calls (summarize phase) instead of all ~16+ calls per pipeline run. Callbacks bound via `model.with_config(callbacks=...)` don't propagate through `create_agent()` or `with_structured_output()` wrappers.

## Changes

- Add `callbacks` parameter to `build_runnable_config()` in tracing.py
- Store callbacks in orchestrator and pass through to stage `execute()` calls
- Update `run_discuss_phase()`, `summarize_discussion()`, and serialize functions to accept callbacks
- Update dream, brainstorm, and seed stages to pass callbacks to all phases

## Not Included / Future PRs

- SEED semantic validation (separate PR: feat/seed-validation)

## Test Plan

```bash
# All existing tests pass
uv run pytest tests/unit/ -v
# 538 passed

# Verify logging fix (after merging)
uv run qf --log run --to seed projects/test-logging "A mystery story"
wc -l projects/test-logging/logs/llm_calls.jsonl
# Expected: ~16+ calls (not 3)
```

## Risk / Rollback

- Low risk: adds optional parameter with no behavior change if not provided
- Backwards compatible: all new parameters have defaults

🤖 Generated with [Claude Code](https://claude.com/claude-code)