### PR TITLE
feat(graph): add SEED semantic validation

### DIFF
--- a/src/questfoundry/graph/__init__.py
+++ b/src/questfoundry/graph/__init__.py
@@ -10,11 +10,14 @@ See docs/architecture/graph-storage.md for architecture details.
 from questfoundry.graph.graph import Graph
 from questfoundry.graph.mutations import (
     MutationError,
+    SeedMutationError,
+    SeedValidationError,
     apply_brainstorm_mutations,
     apply_dream_mutations,
     apply_mutations,
     apply_seed_mutations,
     has_mutation_handler,
+    validate_seed_mutations,
 )
 from questfoundry.graph.snapshots import (
     list_snapshots,
@@ -25,6 +28,8 @@ from questfoundry.graph.snapshots import (
 __all__ = [
     "Graph",
     "MutationError",
+    "SeedMutationError",
+    "SeedValidationError",
     "apply_brainstorm_mutations",
     "apply_dream_mutations",
     "apply_mutations",
@@ -33,4 +38,5 @@ __all__ = [
     "list_snapshots",
     "rollback_to_snapshot",
     "save_snapshot",
+    "validate_seed_mutations",
 ]


### PR DESCRIPTION
## Problem

Current SEED validation is purely structural (Pydantic). Cannot catch semantic errors like:
- Tension IDs renamed (should match BRAINSTORM exactly)
- Alternative IDs that don't exist in BRAINSTORM
- Entity ID mismatches in beats
- Thread references to non-existent threads

## Changes

- Add `validate_seed_mutations()` to check cross-references against BRAINSTORM data in graph
- Add `SeedValidationError` dataclass with structured feedback (field_path, issue, available, provided)
- Add `SeedMutationError` exception that formats errors for LLM retry
- Export new types from graph package
- Update tests to set up proper BRAINSTORM data with `raw_id` fields

### Validation Checks

1. Entity IDs in decisions exist in graph
2. Tension IDs in decisions exist in graph
3. Thread tension_ids reference valid tensions
4. Thread alternative_ids exist for their tension
5. Beat entity/location references exist
6. Beat thread references exist (within SEED output)
7. Consequence thread references exist (within SEED output)
8. Tension impacts reference valid tensions

## Not Included / Future PRs

- Integrate with SEED stage retry loop (can be added when serialization retry is implemented)

## Test Plan

```bash
# All tests pass
uv run pytest tests/unit/test_mutations.py -v
# 27 passed

# Full test suite
uv run pytest tests/unit/ -v
# 538 passed
```

## Risk / Rollback

- Medium risk: validation now raises errors that were previously silently accepted
- Existing pipelines may need BRAINSTORM data regenerated if entities lack `raw_id`

**Stacked on #122** - merge that PR first

🤖 Generated with [Claude Code](https://claude.com/claude-code)