### PR TITLE
fix(tools): use thread-local storage for corpus to fix SQLite threading error

### DIFF
--- a/src/questfoundry/tools/research/corpus_tools.py
+++ b/src/questfoundry/tools/research/corpus_tools.py
@@ -22,7 +22,7 @@ import json
 import logging
 import threading
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 
 from questfoundry.tools.base import Tool, ToolDefinition
 
@@ -84,7 +84,7 @@ def _get_corpus() -> Corpus:
     """
     # Check if this thread already has a corpus instance
     if hasattr(_thread_local, "corpus"):
-        return _thread_local.corpus
+        return cast("Corpus", _thread_local.corpus)
 
     if not _corpus_available():
         raise CorpusNotAvailableError()

--- a/src/questfoundry/tools/research/corpus_tools.py
+++ b/src/questfoundry/tools/research/corpus_tools.py
@@ -20,7 +20,7 @@ from __future__ import annotations
 
 import json
 import logging
-from functools import lru_cache
+import threading
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -55,11 +55,24 @@ def _corpus_available() -> bool:
         return False
 
 
-@lru_cache(maxsize=1)
-def _get_corpus() -> Corpus:
-    """Get singleton corpus instance with semantic search enabled.
+# Thread-local storage for corpus instances
+# Each thread gets its own Corpus with its own SQLite connection
+_thread_local = threading.local()
 
-    Configures the corpus with an embedding provider for semantic search.
+
+def _clear_corpus_cache() -> None:
+    """Clear thread-local corpus cache. Used for testing."""
+    if hasattr(_thread_local, "corpus"):
+        delattr(_thread_local, "corpus")
+
+
+def _get_corpus() -> Corpus:
+    """Get thread-local corpus instance with semantic search enabled.
+
+    Uses thread-local storage to ensure each thread has its own Corpus
+    instance with its own SQLite connection. This avoids SQLite's
+    "objects created in a thread can only be used in that same thread" error.
+
     Embeddings are cached in ~/.cache/questfoundry/corpus-embeddings/.
     If embeddings don't exist, they are built on first use.
 
@@ -69,6 +82,10 @@ def _get_corpus() -> Corpus:
     Raises:
         CorpusNotAvailableError: If ifcraftcorpus not installed.
     """
+    # Check if this thread already has a corpus instance
+    if hasattr(_thread_local, "corpus"):
+        return _thread_local.corpus
+
     if not _corpus_available():
         raise CorpusNotAvailableError()
 
@@ -80,7 +97,9 @@ def _get_corpus() -> Corpus:
         provider = get_embedding_provider()
     except Exception as e:
         logger.warning("Could not get embedding provider: %s. Using keyword search only.", e)
-        return Corpus()
+        corpus = Corpus()
+        _thread_local.corpus = corpus
+        return corpus
 
     # Create corpus with embeddings support
     EMBEDDINGS_CACHE_DIR.mkdir(parents=True, exist_ok=True)
@@ -98,6 +117,8 @@ def _get_corpus() -> Corpus:
         except Exception as e:
             logger.warning("Failed to build embeddings: %s. Using keyword search.", e)
 
+    # Store in thread-local storage
+    _thread_local.corpus = corpus
     return corpus
 
 

--- a/tests/unit/test_corpus_tools.py
+++ b/tests/unit/test_corpus_tools.py
@@ -11,6 +11,7 @@ from questfoundry.tools.research.corpus_tools import (
     GetDocumentTool,
     ListClustersTool,
     SearchCorpusTool,
+    _clear_corpus_cache,
     get_corpus_tools,
 )
 
@@ -57,10 +58,8 @@ class TestSearchCorpusTool:
             "questfoundry.tools.research.corpus_tools._corpus_available",
             return_value=False,
         ):
-            # Clear the lru_cache
-            from questfoundry.tools.research.corpus_tools import _get_corpus
-
-            _get_corpus.cache_clear()
+            # Clear thread-local corpus cache
+            _clear_corpus_cache()
 
             result = tool.execute({"query": "test"})
 
@@ -68,9 +67,7 @@ class TestSearchCorpusTool:
 
     def test_execute_with_results(self) -> None:
         """Should return formatted results when search succeeds."""
-        from questfoundry.tools.research.corpus_tools import _get_corpus
-
-        _get_corpus.cache_clear()
+        _clear_corpus_cache()
 
         tool = SearchCorpusTool()
 
@@ -105,7 +102,7 @@ class TestSearchCorpusTool:
                 return_value=True,
             ),
         ):
-            _get_corpus.cache_clear()
+            _clear_corpus_cache()
             result = tool.execute({"query": "dialogue"})
 
         assert "dialogue_craft" in result
@@ -115,9 +112,7 @@ class TestSearchCorpusTool:
 
     def test_execute_with_cluster_filter(self) -> None:
         """Should pass cluster filter to search."""
-        from questfoundry.tools.research.corpus_tools import _get_corpus
-
-        _get_corpus.cache_clear()
+        _clear_corpus_cache()
 
         tool = SearchCorpusTool()
 
@@ -140,7 +135,7 @@ class TestSearchCorpusTool:
                 return_value=True,
             ),
         ):
-            _get_corpus.cache_clear()
+            _clear_corpus_cache()
             tool.execute({"query": "mystery", "cluster": "genre-conventions", "limit": 3})
 
         mock_corpus.search.assert_called_once_with(
@@ -151,9 +146,7 @@ class TestSearchCorpusTool:
         """Should return structured JSON with no_results status (ADR-008)."""
         import json
 
-        from questfoundry.tools.research.corpus_tools import _get_corpus
-
-        _get_corpus.cache_clear()
+        _clear_corpus_cache()
 
         tool = SearchCorpusTool()
 
@@ -176,7 +169,7 @@ class TestSearchCorpusTool:
                 return_value=True,
             ),
         ):
-            _get_corpus.cache_clear()
+            _clear_corpus_cache()
             result = tool.execute({"query": "xyz123"})
 
         # ADR-008: Structured JSON response


### PR DESCRIPTION
## Problem

Corpus search tools fail with SQLite threading errors when used with slower LLM providers (gpt-oss:120b). The error doesn't appear with faster providers (qwen3:8b, openai/gpt-4o).

```
Corpus search failed: SQLite objects created in a thread can only be used in that same thread.
The object was created in thread id 140529811048128 and this is thread id 140528876193472.
```

The issue is that `_get_corpus()` used `@lru_cache` to create a singleton, but SQLite connections aren't thread-safe. When LangChain executes tools on different threads (which happens more with slower providers due to timing), the cached corpus fails.

## Changes

- Replace `@lru_cache` singleton with `threading.local()` for corpus instances
- Each thread now gets its own Corpus with its own SQLite connection
- Add `_clear_corpus_cache()` helper for testing
- Update tests to use new cache clearing function

## Not Included / Future PRs

- No changes to ifcraftcorpus library itself

## Test Plan

- All 14 corpus tool tests pass
- All 538 unit tests pass
- The fix ensures each thread gets its own SQLite connection

```bash
uv run pytest tests/unit/test_corpus_tools.py -v  # 14 passed
uv run pytest tests/unit/ -q                      # 538 passed
```

## Risk / Rollback

- Low risk - isolated change to corpus tool caching strategy
- Each thread creates its own corpus instance (slightly more memory with multiple threads)
- Embeddings are still cached on disk, so no performance regression for embedding loading

Fixes #127

🤖 Generated with [Claude Code](https://claude.com/claude-code)