### PR TITLE
fix(prompts): add stage-aware non-interactive instructions

### DIFF
--- a/prompts/templates/discuss.yaml
+++ b/prompts/templates/discuss.yaml
@@ -18,6 +18,13 @@ system: |
   - Be conversational and supportive
   - Focus on creative exploration, not implementation details
   {research_tools_section}
+  {mode_section}
+
+non_interactive_section: |
+  ## Mode: Autonomous
+  You are running without user interaction. Make confident creative decisions
+  based on the initial prompt. Do NOT ask clarifying questions - interpret
+  the prompt and commit to choices that best serve the story idea presented.
 
 research_tools_section: |
   ## Research Tools Available

--- a/prompts/templates/discuss_brainstorm.yaml
+++ b/prompts/templates/discuss_brainstorm.yaml
@@ -35,6 +35,13 @@ system: |
   Good: "Is the mentor benevolent or self-serving?" (yes/no)
   Good: "Is the archive's knowledge salvation or corruption?" (binary choice)
   Bad: "What is the mentor's alignment?" (open-ended, not binary)
+  {mode_section}
+
+non_interactive_section: |
+  ## Mode: Autonomous
+  You are running without user interaction. Make confident creative decisions
+  consistent with the creative vision above. Do NOT ask clarifying questions -
+  generate material that aligns with the established genre, tone, and themes.
 
 research_tools_section: |
   ## Research Tools Available

--- a/prompts/templates/discuss_seed.yaml
+++ b/prompts/templates/discuss_seed.yaml
@@ -55,6 +55,13 @@ system: |
   - **reveals**: Surfaces information bearing on the question
   - **commits**: Point of no return - alternative is locked in
   - **complicates**: Introduces doubt, new dimension to the tension
+  {mode_section}
+
+non_interactive_section: |
+  ## Mode: Autonomous
+  You are running without user interaction. Make confident curation decisions
+  consistent with the creative vision and brainstormed material above. Do NOT
+  ask clarifying questions - commit to choices that best serve the story.
 
 research_tools_section: |
   ## Research Tools Available

--- a/src/questfoundry/agents/discuss.py
+++ b/src/questfoundry/agents/discuss.py
@@ -31,6 +31,7 @@ def create_discuss_agent(
     model: BaseChatModel,
     tools: list[BaseTool],
     system_prompt: str | None = None,
+    interactive: bool = True,
 ) -> Any:  # Returns CompiledStateGraph but avoid import issues
     """Create a Discuss phase agent.
 
@@ -42,6 +43,8 @@ def create_discuss_agent(
         tools: Research tools available to the agent
         system_prompt: Optional custom system prompt. If not provided,
             uses the default DREAM discuss prompt.
+        interactive: Whether running in interactive mode. When False,
+            includes instructions for autonomous decision-making.
 
     Returns:
         Compiled agent graph ready for invocation
@@ -55,6 +58,7 @@ def create_discuss_agent(
     if system_prompt is None:
         system_prompt = get_discuss_prompt(
             research_tools_available=has_tools,
+            interactive=interactive,
         )
 
     log.info("discuss_agent_created", tool_count=len(tools) if tools else 0)
@@ -107,7 +111,7 @@ async def run_discuss_phase(
     Returns:
         Tuple of (messages, llm_call_count, total_tokens)
     """
-    agent = create_discuss_agent(model, tools, system_prompt)
+    agent = create_discuss_agent(model, tools, system_prompt, interactive=interactive)
 
     log.info(
         "discuss_phase_started",

--- a/src/questfoundry/agents/prompts.py
+++ b/src/questfoundry/agents/prompts.py
@@ -62,23 +62,11 @@ def get_discuss_prompt(
     Returns:
         System prompt string for the Discuss agent
     """
-    # Load raw data once to avoid double file read
-    raw_data = _load_raw_template("discuss")
-
-    # Build the research tools section if tools are available
-    research_section = ""
-    if research_tools_available:
-        research_section = raw_data.get("research_tools_section", "")
-
-    # Build mode section for non-interactive mode
-    mode_section = ""
-    if not interactive:
-        mode_section = raw_data.get("non_interactive_section", "")
-
-    # Render the system template with ChatPromptTemplate
-    system_template = raw_data.get("system", "")
-    prompt = ChatPromptTemplate.from_template(system_template)
-    return prompt.format(research_tools_section=research_section, mode_section=mode_section)
+    return _render_discuss_template(
+        "discuss",
+        research_tools_available=research_tools_available,
+        interactive=interactive,
+    )
 
 
 def get_summarize_prompt() -> str:
@@ -123,16 +111,50 @@ def _load_raw_template(template_name: str) -> dict[str, Any]:
         return dict(yaml.load(f))
 
 
+def _render_discuss_template(
+    template_name: str,
+    research_tools_available: bool,
+    interactive: bool,
+    **kwargs: Any,
+) -> str:
+    """Render a discuss-style prompt template.
+
+    Common helper for discuss prompts that share the same pattern:
+    load template, build research/mode sections, format with kwargs.
+
+    Args:
+        template_name: Name of the template file (without .yaml).
+        research_tools_available: Whether to include research tools section.
+        interactive: Whether running interactively. When False, includes
+            autonomous decision-making instructions.
+        **kwargs: Additional format arguments for the template.
+
+    Returns:
+        Rendered system prompt string.
+    """
+    raw_data = _load_raw_template(template_name)
+
+    research_section = (
+        raw_data.get("research_tools_section", "") if research_tools_available else ""
+    )
+    mode_section = raw_data.get("non_interactive_section", "") if not interactive else ""
+
+    system_template = raw_data.get("system", "")
+    prompt = ChatPromptTemplate.from_template(system_template)
+
+    return prompt.format(
+        research_tools_section=research_section,
+        mode_section=mode_section,
+        **kwargs,
+    )
+
+
 def get_brainstorm_discuss_prompt(
     vision_context: str,
     research_tools_available: bool = True,
     interactive: bool = True,
 ) -> str:
     """Build the BRAINSTORM discuss prompt with vision context.
-
-    Uses _load_raw_template() instead of _get_loader() because we need access
-    to the 'research_tools_section' field which isn't in the PromptTemplate
-    dataclass. Summarize prompts use _get_loader() since they only need system.
 
     Args:
         vision_context: Formatted vision from DREAM stage.
@@ -143,25 +165,11 @@ def get_brainstorm_discuss_prompt(
     Returns:
         System prompt string for the BRAINSTORM discuss agent.
     """
-    raw_data = _load_raw_template("discuss_brainstorm")
-
-    # Build research tools section
-    research_section = ""
-    if research_tools_available:
-        research_section = raw_data.get("research_tools_section", "")
-
-    # Build mode section for non-interactive mode
-    mode_section = ""
-    if not interactive:
-        mode_section = raw_data.get("non_interactive_section", "")
-
-    # Render the system template
-    system_template = raw_data.get("system", "")
-    prompt = ChatPromptTemplate.from_template(system_template)
-    return prompt.format(
+    return _render_discuss_template(
+        "discuss_brainstorm",
+        research_tools_available=research_tools_available,
+        interactive=interactive,
         vision_context=vision_context,
-        research_tools_section=research_section,
-        mode_section=mode_section,
     )
 
 
@@ -183,8 +191,6 @@ def get_seed_discuss_prompt(
 ) -> str:
     """Build the SEED discuss prompt with brainstorm context.
 
-    Uses _load_raw_template() to access the 'research_tools_section' field.
-
     Args:
         brainstorm_context: Formatted brainstorm output from BRAINSTORM stage.
         research_tools_available: Whether research tools are available.
@@ -194,25 +200,11 @@ def get_seed_discuss_prompt(
     Returns:
         System prompt string for the SEED discuss agent.
     """
-    raw_data = _load_raw_template("discuss_seed")
-
-    # Build research tools section
-    research_section = ""
-    if research_tools_available:
-        research_section = raw_data.get("research_tools_section", "")
-
-    # Build mode section for non-interactive mode
-    mode_section = ""
-    if not interactive:
-        mode_section = raw_data.get("non_interactive_section", "")
-
-    # Render the system template
-    system_template = raw_data.get("system", "")
-    prompt = ChatPromptTemplate.from_template(system_template)
-    return prompt.format(
+    return _render_discuss_template(
+        "discuss_seed",
+        research_tools_available=research_tools_available,
+        interactive=interactive,
         brainstorm_context=brainstorm_context,
-        research_tools_section=research_section,
-        mode_section=mode_section,
     )
 
 

--- a/src/questfoundry/agents/prompts.py
+++ b/src/questfoundry/agents/prompts.py
@@ -44,6 +44,7 @@ def _get_loader() -> PromptLoader:
 
 def get_discuss_prompt(
     research_tools_available: bool = True,
+    interactive: bool = True,
 ) -> str:
     """Build the Discuss phase prompt as a system message string.
 
@@ -54,7 +55,9 @@ def get_discuss_prompt(
     separately as the initial HumanMessage to avoid duplication.
 
     Args:
-        research_tools_available: Whether research tools are available
+        research_tools_available: Whether research tools are available.
+        interactive: Whether running in interactive mode. When False,
+            includes instructions for autonomous decision-making.
 
     Returns:
         System prompt string for the Discuss agent
@@ -67,10 +70,15 @@ def get_discuss_prompt(
     if research_tools_available:
         research_section = raw_data.get("research_tools_section", "")
 
+    # Build mode section for non-interactive mode
+    mode_section = ""
+    if not interactive:
+        mode_section = raw_data.get("non_interactive_section", "")
+
     # Render the system template with ChatPromptTemplate
     system_template = raw_data.get("system", "")
     prompt = ChatPromptTemplate.from_template(system_template)
-    return prompt.format(research_tools_section=research_section)
+    return prompt.format(research_tools_section=research_section, mode_section=mode_section)
 
 
 def get_summarize_prompt() -> str:
@@ -118,6 +126,7 @@ def _load_raw_template(template_name: str) -> dict[str, Any]:
 def get_brainstorm_discuss_prompt(
     vision_context: str,
     research_tools_available: bool = True,
+    interactive: bool = True,
 ) -> str:
     """Build the BRAINSTORM discuss prompt with vision context.
 
@@ -128,6 +137,8 @@ def get_brainstorm_discuss_prompt(
     Args:
         vision_context: Formatted vision from DREAM stage.
         research_tools_available: Whether research tools are available.
+        interactive: Whether running in interactive mode. When False,
+            includes instructions for autonomous decision-making.
 
     Returns:
         System prompt string for the BRAINSTORM discuss agent.
@@ -139,12 +150,18 @@ def get_brainstorm_discuss_prompt(
     if research_tools_available:
         research_section = raw_data.get("research_tools_section", "")
 
+    # Build mode section for non-interactive mode
+    mode_section = ""
+    if not interactive:
+        mode_section = raw_data.get("non_interactive_section", "")
+
     # Render the system template
     system_template = raw_data.get("system", "")
     prompt = ChatPromptTemplate.from_template(system_template)
     return prompt.format(
         vision_context=vision_context,
         research_tools_section=research_section,
+        mode_section=mode_section,
     )
 
 
@@ -162,6 +179,7 @@ def get_brainstorm_summarize_prompt() -> str:
 def get_seed_discuss_prompt(
     brainstorm_context: str,
     research_tools_available: bool = True,
+    interactive: bool = True,
 ) -> str:
     """Build the SEED discuss prompt with brainstorm context.
 
@@ -170,6 +188,8 @@ def get_seed_discuss_prompt(
     Args:
         brainstorm_context: Formatted brainstorm output from BRAINSTORM stage.
         research_tools_available: Whether research tools are available.
+        interactive: Whether running in interactive mode. When False,
+            includes instructions for autonomous decision-making.
 
     Returns:
         System prompt string for the SEED discuss agent.
@@ -181,12 +201,18 @@ def get_seed_discuss_prompt(
     if research_tools_available:
         research_section = raw_data.get("research_tools_section", "")
 
+    # Build mode section for non-interactive mode
+    mode_section = ""
+    if not interactive:
+        mode_section = raw_data.get("non_interactive_section", "")
+
     # Render the system template
     system_template = raw_data.get("system", "")
     prompt = ChatPromptTemplate.from_template(system_template)
     return prompt.format(
         brainstorm_context=brainstorm_context,
         research_tools_section=research_section,
+        mode_section=mode_section,
     )
 
 

--- a/src/questfoundry/pipeline/stages/brainstorm.py
+++ b/src/questfoundry/pipeline/stages/brainstorm.py
@@ -210,6 +210,7 @@ class BrainstormStage:
         discuss_prompt = get_brainstorm_discuss_prompt(
             vision_context=vision_context,
             research_tools_available=bool(tools),
+            interactive=interactive,
         )
 
         # Phase 1: Discuss

--- a/src/questfoundry/pipeline/stages/seed.py
+++ b/src/questfoundry/pipeline/stages/seed.py
@@ -277,6 +277,7 @@ class SeedStage:
         discuss_prompt = get_seed_discuss_prompt(
             brainstorm_context=brainstorm_context,
             research_tools_available=bool(tools),
+            interactive=interactive,
         )
 
         # Phase 1: Discuss

--- a/src/questfoundry/providers/factory.py
+++ b/src/questfoundry/providers/factory.py
@@ -156,6 +156,7 @@ def _create_ollama_base_model(model: str, **kwargs: Any) -> BaseChatModel:
         model=model,
         base_url=host,
         temperature=kwargs.get("temperature", 0.7),
+        num_ctx=kwargs.get("num_ctx", 32768),  # Default 32k to avoid truncation
     )
     return chat_model
 

--- a/tests/unit/test_provider_factory.py
+++ b/tests/unit/test_provider_factory.py
@@ -47,6 +47,7 @@ def test_create_chat_model_ollama_success() -> None:
         model="qwen3:8b",
         base_url="http://test:11434",
         temperature=0.7,
+        num_ctx=32768,
     )
 
 
@@ -61,6 +62,7 @@ def test_create_chat_model_ollama_with_custom_host() -> None:
         model="llama3:8b",
         base_url="http://custom:8080",
         temperature=0.7,
+        num_ctx=32768,
     )
 
 
@@ -208,6 +210,20 @@ def test_create_chat_model_custom_temperature() -> None:
 
     call_kwargs = mock_class.call_args[1]
     assert call_kwargs["temperature"] == 0.5
+
+
+def test_create_chat_model_ollama_custom_num_ctx() -> None:
+    """Factory passes custom num_ctx for context window."""
+    mock_chat = MagicMock()
+
+    with (
+        patch.dict("os.environ", {"OLLAMA_HOST": "http://test:11434"}),
+        patch("langchain_ollama.ChatOllama", return_value=mock_chat) as mock_class,
+    ):
+        create_chat_model("ollama", "model", num_ctx=131072)
+
+    call_kwargs = mock_class.call_args[1]
+    assert call_kwargs["num_ctx"] == 131072
 
 
 # --- Tests for create_model_for_structured_output ---


### PR DESCRIPTION
## Problem

Two issues affecting non-interactive pipeline runs:

1. **TBD artifacts**: In non-interactive mode, LLMs would ask clarifying questions instead of making creative decisions, resulting in TBD values in artifacts. This was observed with gpt-oss:120b in `projects/run-3-ni` where the discuss phase asked questions like "What genre should this be?" instead of making decisions.

2. **Prompt truncation**: Ollama was silently truncating prompts to 4096 tokens (default `num_ctx`), losing important context in SEED stage.

## Changes

### Fix 1: Stage-aware non-interactive instructions
- Added `non_interactive_section` to all discuss prompt templates with stage-aware instructions:
  - **DREAM**: Make decisions based on initial prompt
  - **BRAINSTORM**: Make decisions consistent with "creative vision above"
  - **SEED**: Make curation decisions consistent with "creative vision and brainstormed material above"
- Added `{mode_section}` placeholder to all discuss templates
- Added `interactive` parameter to:
  - `get_discuss_prompt()`
  - `get_brainstorm_discuss_prompt()`
  - `get_seed_discuss_prompt()`
  - `create_discuss_agent()`
- Updated stage implementations (brainstorm.py, seed.py) to pass `interactive` flag

### Fix 2: Ollama context window
- Set `num_ctx=32768` as default for Ollama provider
- Allow override via kwargs for models with larger context

## Not Included / Future PRs

- Testing with the specific model (gpt-oss:120b) that originally failed
- Additional prompt engineering if other models still struggle
- Full context budget awareness (tracked in #130)

## Test Plan

```bash
# All unit tests pass
uv run pytest tests/unit/ -q
# 539 passed

# Type checking passes
uv run mypy src/questfoundry/agents/prompts.py src/questfoundry/agents/discuss.py \
  src/questfoundry/pipeline/stages/brainstorm.py src/questfoundry/pipeline/stages/seed.py \
  src/questfoundry/providers/factory.py
# Success: no issues found in 5 source files
```

## Risk / Rollback

- Low risk - only affects non-interactive mode behavior and Ollama default
- No breaking changes to API
- If instructions don't work for certain models, can adjust prompt wording

Closes #126
Addresses #130

🤖 Generated with [Claude Code](https://claude.com/claude-code)