### PR TITLE
fix(observability): extract stage from metadata, handle ToolMessage

### DIFF
--- a/src/questfoundry/observability/langchain_callbacks.py
+++ b/src/questfoundry/observability/langchain_callbacks.py
@@ -12,6 +12,7 @@ from time import perf_counter
 from typing import TYPE_CHECKING, Any
 
 from langchain_core.callbacks import BaseCallbackHandler
+from langchain_core.messages import ToolMessage
 
 from questfoundry.observability.logging import get_logger
 
@@ -276,8 +277,6 @@ class LLMLoggingCallback(BaseCallbackHandler):
             **kwargs: Additional arguments.
         """
         # Handle different output types - output may be ToolMessage, str, or other
-        from langchain_core.messages import ToolMessage
-
         if isinstance(output, ToolMessage):
             content = output.content
             output_len = len(content) if isinstance(content, str) else None

--- a/src/questfoundry/observability/langchain_callbacks.py
+++ b/src/questfoundry/observability/langchain_callbacks.py
@@ -43,6 +43,7 @@ class LLMLoggingCallback(BaseCallbackHandler):
         super().__init__()
         self._llm_logger = llm_logger
         self._pending_calls: dict[UUID, dict[str, Any]] = {}
+        self._run_metadata: dict[UUID, dict[str, Any]] = {}
 
     def on_chat_model_start(
         self,
@@ -89,6 +90,9 @@ class LLMLoggingCallback(BaseCallbackHandler):
             "start_time": perf_counter(),
         }
 
+        # Store metadata for stage extraction in on_llm_end
+        self._run_metadata[run_id] = metadata or {}
+
         log.debug(
             "llm_call_start",
             run_id=str(run_id),
@@ -114,8 +118,10 @@ class LLMLoggingCallback(BaseCallbackHandler):
             tags: Optional tags.
             **kwargs: Additional arguments.
         """
-        # Get pending call info
+        # Get pending call info and metadata
         call_info = self._pending_calls.pop(run_id, {})
+        run_metadata = self._run_metadata.pop(run_id, {})
+        stage = run_metadata.get("stage", "")
 
         # Calculate duration if start_time was recorded
         duration_seconds = 0.0
@@ -177,7 +183,7 @@ class LLMLoggingCallback(BaseCallbackHandler):
 
         # Write to logger
         entry = self._llm_logger.create_entry(
-            stage="",  # Stage not available in callback context (would require tags)
+            stage=stage,  # Extracted from metadata passed via RunnableConfig
             model=call_info.get("model", "unknown"),
             messages=call_info.get("messages", []),
             content=content,
@@ -213,8 +219,9 @@ class LLMLoggingCallback(BaseCallbackHandler):
             tags: Optional tags.
             **kwargs: Additional arguments.
         """
-        # Clean up pending call
+        # Clean up pending call and metadata
         call_info = self._pending_calls.pop(run_id, {})
+        self._run_metadata.pop(run_id, None)
 
         log.warning(
             "llm_call_error",
@@ -252,7 +259,7 @@ class LLMLoggingCallback(BaseCallbackHandler):
 
     def on_tool_end(
         self,
-        output: str,
+        output: Any,
         *,
         run_id: UUID,
         parent_run_id: UUID | None = None,
@@ -262,13 +269,25 @@ class LLMLoggingCallback(BaseCallbackHandler):
         """Called when a tool completes.
 
         Args:
-            output: Tool output.
+            output: Tool output (can be str, ToolMessage, or other types).
             run_id: Unique run identifier.
             parent_run_id: Parent run ID.
             tags: Optional tags.
             **kwargs: Additional arguments.
         """
-        log.debug("tool_end", run_id=str(run_id), output_length=len(output))
+        # Handle different output types - output may be ToolMessage, str, or other
+        from langchain_core.messages import ToolMessage
+
+        if isinstance(output, ToolMessage):
+            content = output.content
+            output_len = len(content) if isinstance(content, str) else None
+        elif isinstance(output, str):
+            output_len = len(output)
+        else:
+            # Fallback for other types
+            output_len = None
+
+        log.debug("tool_end", run_id=str(run_id), output_length=output_len)
 
     def on_agent_action(
         self,


### PR DESCRIPTION
## Problem

Two observability bugs were causing issues with LLM call logging:

1. **#136**: Stage field was always empty in `llm_calls.jsonl` - made it impossible to filter/analyze calls by stage
2. **#139**: `on_tool_end` threw `TypeError("object of type 'ToolMessage' has no len()")` when output was a ToolMessage

## Changes

- Store run metadata in `_run_metadata` dict keyed by run_id in `on_chat_model_start`
- Extract stage from stored metadata in `on_llm_end`
- Clean up `_run_metadata` in `on_llm_error` to prevent memory leaks
- Handle `ToolMessage`, `str`, and other types gracefully in `on_tool_end`
- Add 6 new unit tests for the functionality

## Not Included / Future PRs

- Validation flow fixes (#138) - separate PR
- BRAINSTORM validation (#133) - separate PR
- SEED completeness validation (#134) - separate PR

## Test Plan

```bash
# Run unit tests
uv run pytest tests/unit/test_langchain_callbacks.py -v

# All 23 tests pass including new ones:
# - test_on_chat_model_start_stores_metadata
# - test_on_chat_model_start_handles_no_metadata
# - test_on_llm_end_extracts_stage_from_metadata
# - test_on_llm_error_cleans_run_metadata
# - test_on_tool_end_handles_tool_message
# - test_on_tool_end_handles_non_string_types
```

## Risk / Rollback

Low risk - changes are additive and backward compatible:
- If metadata isn't passed, stage defaults to empty string (same as before)
- ToolMessage handling is a fallback, won't affect string outputs

Fixes #136
Fixes #139