### PR TITLE
fix(seed): add semantic validation to serialize phase (#138)

### DIFF
--- a/src/questfoundry/agents/serialize.py
+++ b/src/questfoundry/agents/serialize.py
@@ -519,6 +519,11 @@ async def serialize_seed_iteratively(
                 total_tokens += section_tokens
 
                 section_data = section_result.model_dump()
+                if output_field not in section_data:
+                    raise ValueError(
+                        f"Section {section_name} returned unexpected structure on retry. "
+                        f"Expected field '{output_field}', got: {list(section_data.keys())}"
+                    )
                 collected[output_field] = section_data[output_field]
 
             # Re-merge with updated sections

--- a/src/questfoundry/pipeline/stages/seed.py
+++ b/src/questfoundry/pipeline/stages/seed.py
@@ -313,14 +313,17 @@ class SeedStage:
         total_tokens += summarize_tokens
 
         # Phase 3: Serialize (iteratively to avoid output truncation)
+        # Load graph for semantic validation against BRAINSTORM data
         log.debug("seed_phase", phase="serialize")
+        graph = Graph.load(resolved_path)
         artifact, serialize_tokens = await serialize_seed_iteratively(
             model=model,
             brief=brief,
             provider_name=provider_name,
             callbacks=callbacks,
+            graph=graph,  # Enables semantic validation
         )
-        # Iterative serialization makes 6 calls (one per section)
+        # Iterative serialization makes 6 calls (one per section) + potential retries
         total_llm_calls += 6
         total_tokens += serialize_tokens
 


### PR DESCRIPTION
## Problem

Issue #138: The orchestrator swallows `SeedMutationError` - when semantic validation fails during `apply_mutations()`, the error is caught by a broad exception handler and logged as a warning, but the invalid artifact has already been written. This means validation errors are never surfaced to the LLM for retry.

## Changes

- Add `graph` parameter to `serialize_seed_iteratively()` for semantic validation
- Run `validate_seed_mutations()` after merging all sections in serialize phase
- If errors, re-serialize problematic sections with error feedback appended to brief
- Add `_get_sections_to_retry()` helper to map error field paths to section names
- Update orchestrator to re-raise `SeedMutationError` (indicates a bug if it reaches there since validation should happen during serialize)
- Update SEED stage to load graph and pass to serialization

## Not Included / Future PRs

- BRAINSTORM semantic validation (#133) - next PR
- SEED completeness validation (#134) - future PR

## Test Plan

- Added 8 new tests:
  - `test_maps_entities_field_to_entities_section` - field path mapping
  - `test_maps_threads_field_to_threads_section` - field path mapping
  - `test_maps_initial_beats_to_beats_section` - field path mapping
  - `test_multiple_errors_from_different_sections` - multiple section retry
  - `test_skips_semantic_validation_when_graph_is_none` - backward compatibility
  - `test_semantic_validation_passes_on_first_try` - happy path
  - `test_semantic_validation_retries_on_error` - retry logic
  - `test_semantic_validation_raises_after_max_retries` - failure case

```bash
uv run pytest tests/unit/test_serialize.py -v
# 32 passed in 0.26s

uv run pytest tests/unit/ -v
# 553 passed in 3.75s
```

## Risk / Rollback

- Low risk - adds validation to existing serialization flow
- Backward compatible - `graph=None` skips semantic validation
- If issues arise, can disable by not passing graph to `serialize_seed_iteratively()`

🤖 Generated with [Claude Code](https://claude.com/claude-code)