### PR TITLE
fix(brainstorm): add semantic validation for internal consistency (#133)

### DIFF
--- a/src/questfoundry/agents/serialize.py
+++ b/src/questfoundry/agents/serialize.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+from collections.abc import Callable
 from functools import lru_cache
 from typing import TYPE_CHECKING, Any, TypeVar
 
@@ -52,6 +53,10 @@ class SerializationError(Exception):
         super().__init__(message)
 
 
+# Type alias for semantic validator functions
+SemanticValidator = Callable[[dict[str, Any]], list[Any]]
+
+
 @traceable(name="Serialize Phase", run_type="chain", tags=["phase:serialize"])
 async def serialize_to_artifact(
     model: BaseChatModel,
@@ -62,6 +67,8 @@ async def serialize_to_artifact(
     max_retries: int = 3,
     system_prompt: str | None = None,
     callbacks: list[BaseCallbackHandler] | None = None,
+    semantic_validator: SemanticValidator | None = None,
+    semantic_error_class: type[Exception] | None = None,
 ) -> tuple[T, int]:
     """Serialize a brief into a structured artifact.
 
@@ -78,6 +85,11 @@ async def serialize_to_artifact(
         max_retries: Maximum total attempts (default 3).
         system_prompt: Stage-specific serialize prompt. If None, uses generic prompt.
         callbacks: LangChain callback handlers for logging LLM calls.
+        semantic_validator: Optional function that validates semantic correctness.
+            Takes a dict and returns a list of validation errors (empty if valid).
+        semantic_error_class: Exception class with to_feedback() method for
+            formatting semantic validation errors. Required if semantic_validator
+            is provided.
 
     Returns:
         Tuple of (validated_artifact, tokens_used).
@@ -147,6 +159,27 @@ async def serialize_to_artifact(
 
                 # If result is already a Pydantic model, validate succeeded
                 if isinstance(result, schema):
+                    # Run semantic validation if provided
+                    if semantic_validator is not None:
+                        artifact_dict = result.model_dump()
+                        semantic_errors = semantic_validator(artifact_dict)
+                        if semantic_errors:
+                            # Create feedback and retry
+                            if semantic_error_class is not None:
+                                error_obj = semantic_error_class(semantic_errors)
+                                feedback = error_obj.to_feedback()  # type: ignore[attr-defined]
+                            else:
+                                feedback = f"Semantic validation errors: {semantic_errors}"
+                            last_errors = [feedback]
+                            log.debug(
+                                "semantic_validation_failed",
+                                attempt=attempt,
+                                error_count=len(semantic_errors),
+                            )
+                            if attempt < max_retries:
+                                messages.append(HumanMessage(content=feedback))
+                            continue
+
                     log.info(
                         "serialize_completed",
                         attempt=attempt,
@@ -159,6 +192,27 @@ async def serialize_to_artifact(
                     # Strip null values (LLMs often send null for optional fields)
                     cleaned = strip_null_values(result)
                     artifact = schema.model_validate(cleaned)
+
+                    # Run semantic validation if provided
+                    if semantic_validator is not None:
+                        semantic_errors = semantic_validator(cleaned)
+                        if semantic_errors:
+                            # Create feedback and retry
+                            if semantic_error_class is not None:
+                                error_obj = semantic_error_class(semantic_errors)
+                                feedback = error_obj.to_feedback()  # type: ignore[attr-defined]
+                            else:
+                                feedback = f"Semantic validation errors: {semantic_errors}"
+                            last_errors = [feedback]
+                            log.debug(
+                                "semantic_validation_failed",
+                                attempt=attempt,
+                                error_count=len(semantic_errors),
+                            )
+                            if attempt < max_retries:
+                                messages.append(HumanMessage(content=feedback))
+                            continue
+
                     log.info(
                         "serialize_completed",
                         attempt=attempt,

--- a/src/questfoundry/graph/__init__.py
+++ b/src/questfoundry/graph/__init__.py
@@ -9,6 +9,8 @@ See docs/architecture/graph-storage.md for architecture details.
 
 from questfoundry.graph.graph import Graph
 from questfoundry.graph.mutations import (
+    BrainstormMutationError,
+    BrainstormValidationError,
     MutationError,
     SeedMutationError,
     SeedValidationError,
@@ -17,6 +19,7 @@ from questfoundry.graph.mutations import (
     apply_mutations,
     apply_seed_mutations,
     has_mutation_handler,
+    validate_brainstorm_mutations,
     validate_seed_mutations,
 )
 from questfoundry.graph.snapshots import (
@@ -26,6 +29,8 @@ from questfoundry.graph.snapshots import (
 )
 
 __all__ = [
+    "BrainstormMutationError",
+    "BrainstormValidationError",
     "Graph",
     "MutationError",
     "SeedMutationError",
@@ -38,5 +43,6 @@ __all__ = [
     "list_snapshots",
     "rollback_to_snapshot",
     "save_snapshot",
+    "validate_brainstorm_mutations",
     "validate_seed_mutations",
 ]

--- a/src/questfoundry/graph/mutations.py
+++ b/src/questfoundry/graph/mutations.py
@@ -22,6 +22,57 @@ class MutationError(ValueError):
 
 
 @dataclass
+class BrainstormValidationError:
+    """Semantic error for BRAINSTORM internal consistency.
+
+    Attributes:
+        field_path: Path to the invalid field (e.g., "tensions.0.central_entity_ids").
+        issue: Description of what's wrong.
+        available: List of valid IDs that could be used instead.
+        provided: The value that was provided.
+    """
+
+    field_path: str
+    issue: str
+    available: list[str] = field(default_factory=list)
+    provided: str = ""
+
+
+class BrainstormMutationError(MutationError):
+    """BRAINSTORM output failed internal consistency validation.
+
+    This error contains structured validation errors that can be formatted
+    as feedback for the LLM to retry with correct values.
+    """
+
+    def __init__(self, errors: list[BrainstormValidationError]) -> None:
+        self.errors = errors
+        super().__init__(self._format_message())
+
+    def _format_message(self) -> str:
+        """Format errors for exception message."""
+        lines = ["BRAINSTORM has invalid internal references:"]
+        for e in self.errors[:8]:  # Limit to 8 errors for readability
+            lines.append(f"  - {e.field_path}: {e.issue}")
+            if e.available:
+                avail = e.available[:5]
+                suffix = "..." if len(e.available) > 5 else ""
+                lines.append(f"    Available: {avail}{suffix}")
+        if len(self.errors) > 8:
+            lines.append(f"  ... and {len(self.errors) - 8} more errors")
+        lines.append("Use entity_id values from the entities list.")
+        return "\n".join(lines)
+
+    def to_feedback(self) -> str:
+        """Format for LLM retry feedback.
+
+        Returns:
+            Human-readable error message for LLM to fix.
+        """
+        return self._format_message()
+
+
+@dataclass
 class SeedValidationError:
     """Semantic error with context for LLM feedback.
 
@@ -175,6 +226,84 @@ def apply_dream_mutations(graph: Graph, output: dict[str, Any]) -> None:
     vision_data = _clean_dict(vision_data)
 
     graph.set_node("vision", vision_data)
+
+
+def validate_brainstorm_mutations(output: dict[str, Any]) -> list[BrainstormValidationError]:
+    """Validate BRAINSTORM output internal consistency.
+
+    Checks that the output is self-consistent (no graph needed):
+    1. All central_entity_ids in tensions exist in entities list
+    2. All alternative IDs within a tension are unique
+    3. Each tension has exactly one is_default_path=true alternative
+
+    Args:
+        output: BRAINSTORM stage output (entities, tensions).
+
+    Returns:
+        List of validation errors (empty if valid).
+    """
+    errors: list[BrainstormValidationError] = []
+
+    # Build entity ID set from entities list
+    entity_ids: set[str] = {
+        e.get("entity_id") for e in output.get("entities", []) if e.get("entity_id")
+    }
+    sorted_entity_ids = sorted(entity_ids)
+
+    # Validate each tension
+    for i, tension in enumerate(output.get("tensions", [])):
+        tension_id = tension.get("tension_id", f"<index {i}>")
+
+        # 1. Check central_entity_ids reference valid entities
+        for eid in tension.get("central_entity_ids", []):
+            if eid not in entity_ids:
+                errors.append(
+                    BrainstormValidationError(
+                        field_path=f"tensions.{i}.central_entity_ids",
+                        issue=f"Entity '{eid}' not in entities list",
+                        available=sorted_entity_ids,
+                        provided=eid,
+                    )
+                )
+
+        # 2. Check alternative IDs are unique within this tension
+        alts = tension.get("alternatives", [])
+        alt_ids = [a.get("alternative_id") for a in alts if a.get("alternative_id")]
+        seen_alt_ids: set[str] = set()
+        for alt_id in alt_ids:
+            if alt_id in seen_alt_ids:
+                errors.append(
+                    BrainstormValidationError(
+                        field_path=f"tensions.{i}.alternatives",
+                        issue=f"Duplicate alternative_id '{alt_id}' in tension '{tension_id}'",
+                        available=[],
+                        provided=alt_id,
+                    )
+                )
+            seen_alt_ids.add(alt_id)
+
+        # 3. Check exactly one alternative has is_default_path=True
+        default_count = sum(1 for a in alts if a.get("is_default_path"))
+        if default_count == 0:
+            errors.append(
+                BrainstormValidationError(
+                    field_path=f"tensions.{i}.alternatives",
+                    issue=f"No alternative has is_default_path=true in tension '{tension_id}'",
+                    available=[],
+                    provided=f"found {default_count} defaults",
+                )
+            )
+        elif default_count > 1:
+            errors.append(
+                BrainstormValidationError(
+                    field_path=f"tensions.{i}.alternatives",
+                    issue=f"Multiple alternatives have is_default_path=true in tension '{tension_id}'",
+                    available=[],
+                    provided=f"found {default_count} defaults",
+                )
+            )
+
+    return errors
 
 
 def _prefix_id(node_type: str, raw_id: str) -> str:

--- a/tests/unit/test_mutations.py
+++ b/tests/unit/test_mutations.py
@@ -7,6 +7,7 @@ import pytest
 from questfoundry.graph import Graph, MutationError, SeedMutationError
 from questfoundry.graph.mutations import (
     BrainstormMutationError,
+    BrainstormValidationError,
     apply_brainstorm_mutations,
     apply_dream_mutations,
     apply_mutations,
@@ -395,7 +396,7 @@ class TestValidateBrainstormMutations:
 
         errors = validate_brainstorm_mutations(output)
 
-        # Should find: duplicate ID + more than one default
+        # Should find: duplicate ID (not default path issue since one is True, one is False)
         duplicate_errors = [e for e in errors if "Duplicate" in e.issue]
         assert len(duplicate_errors) == 1
 
@@ -505,8 +506,6 @@ class TestBrainstormMutationError:
 
     def test_to_feedback_includes_all_error_info(self) -> None:
         """to_feedback() includes error details for LLM retry."""
-        from questfoundry.graph.mutations import BrainstormValidationError
-
         errors = [
             BrainstormValidationError(
                 field_path="tensions.0.central_entity_ids",
@@ -527,8 +526,6 @@ class TestBrainstormMutationError:
 
     def test_error_limit_applied(self) -> None:
         """Only shows first 8 errors plus count of remaining."""
-        from questfoundry.graph.mutations import BrainstormValidationError
-
         errors = [
             BrainstormValidationError(
                 field_path=f"tensions.{i}.central_entity_ids",


### PR DESCRIPTION
## Problem

Issue #133: BRAINSTORM stage generates tensions with phantom entity references - `central_entity_ids` references entities that don't exist in the entities list.

Example from observed pipeline run:
```yaml
tensions:
  - tension_id: storm_power_outage_cause
    central_entity_ids: [storm, power_outage]  # These IDs don't exist in entities!
```

This creates invalid graph data that causes downstream issues in SEED.

## Changes

- Add `BrainstormValidationError` and `BrainstormMutationError` classes in `mutations.py`
- Add `validate_brainstorm_mutations()` function that checks:
  - All `central_entity_ids` reference valid entity IDs from the same output
  - No duplicate `alternative_id` values within a tension
  - Exactly one alternative has `is_default_path=true` per tension
- Add `semantic_validator` parameter to `serialize_to_artifact()` for reusable validation hooks
- Update BRAINSTORM stage to pass the semantic validator during serialization
- Add 11 new tests for BRAINSTORM validation

## Not Included / Future PRs

- SEED completeness validation (issue #134) - will be next PR
- Prompt quality improvements (#135, #137) - lower priority

## Test Plan

```bash
# Run targeted tests
uv run pytest tests/unit/test_mutations.py -v

# Output: 37 passed (including 11 new tests)
```

All tests pass including:
- `TestValidateBrainstormMutations` - 8 tests covering validation logic
- `TestBrainstormMutationError` - 2 tests for error formatting

## Risk / Rollback

- Low risk: Validation only adds checks, doesn't change existing behavior
- Backward compatible: Existing BRAINSTORM outputs that pass validation continue to work
- If issues arise, remove the `semantic_validator` parameter from BRAINSTORM stage call

🤖 Generated with [Claude Code](https://claude.com/claude-code)