### PR TITLE
feat(validation): add SEED completeness validation (#134)

### DIFF
--- a/src/questfoundry/graph/mutations.py
+++ b/src/questfoundry/graph/mutations.py
@@ -584,35 +584,26 @@ def validate_seed_mutations(graph: Graph, output: dict[str, Any]) -> list[SeedVa
                     )
                 )
 
-    # 9. Check completeness: all BRAINSTORM entities should have decisions
-    decided_entity_ids: set[str] = {
-        d.get("entity_id") for d in output.get("entities", []) if d.get("entity_id")
-    }
-    missing_entities = valid_entity_ids - decided_entity_ids
-    for entity_id in sorted(missing_entities):
-        errors.append(
-            SeedValidationError(
-                field_path="entities",
-                issue=f"Missing decision for entity '{entity_id}'",
-                available=[],
-                provided="",
+    # 9 & 10. Check completeness: all BRAINSTORM entities and tensions should have decisions
+    completeness_checks = [
+        ("entities", "entity", valid_entity_ids),
+        ("tensions", "tension", valid_tension_ids),
+    ]
+    for field_path, item_type, valid_ids in completeness_checks:
+        id_field = f"{item_type}_id"
+        decided_ids: set[str] = {
+            item_id for item_id in (d.get(id_field) for d in output.get(field_path, [])) if item_id
+        }
+        missing_ids = valid_ids - decided_ids
+        for item_id in sorted(missing_ids):
+            errors.append(
+                SeedValidationError(
+                    field_path=field_path,
+                    issue=f"Missing decision for {item_type} '{item_id}'",
+                    available=[],
+                    provided="",
+                )
             )
-        )
-
-    # 10. Check completeness: all BRAINSTORM tensions should have decisions
-    decided_tension_ids: set[str] = {
-        d.get("tension_id") for d in output.get("tensions", []) if d.get("tension_id")
-    }
-    missing_tensions = valid_tension_ids - decided_tension_ids
-    for tension_id in sorted(missing_tensions):
-        errors.append(
-            SeedValidationError(
-                field_path="tensions",
-                issue=f"Missing decision for tension '{tension_id}'",
-                available=[],
-                provided="",
-            )
-        )
 
     return errors
 

--- a/src/questfoundry/graph/mutations.py
+++ b/src/questfoundry/graph/mutations.py
@@ -408,6 +408,8 @@ def validate_seed_mutations(graph: Graph, output: dict[str, Any]) -> list[SeedVa
     6. Beat thread references exist (within SEED output)
     7. Consequence thread references exist (within SEED output)
     8. Tension impacts reference valid tensions
+    9. All BRAINSTORM entities have decisions (completeness)
+    10. All BRAINSTORM tensions have decisions (completeness)
 
     Args:
         graph: Graph containing BRAINSTORM data (entities, tensions, alternatives).
@@ -581,6 +583,36 @@ def validate_seed_mutations(graph: Graph, output: dict[str, Any]) -> list[SeedVa
                         provided=tension_id,
                     )
                 )
+
+    # 9. Check completeness: all BRAINSTORM entities should have decisions
+    decided_entity_ids: set[str] = {
+        d.get("entity_id") for d in output.get("entities", []) if d.get("entity_id")
+    }
+    missing_entities = valid_entity_ids - decided_entity_ids
+    for entity_id in sorted(missing_entities):
+        errors.append(
+            SeedValidationError(
+                field_path="entities",
+                issue=f"Missing decision for entity '{entity_id}'",
+                available=[],
+                provided="",
+            )
+        )
+
+    # 10. Check completeness: all BRAINSTORM tensions should have decisions
+    decided_tension_ids: set[str] = {
+        d.get("tension_id") for d in output.get("tensions", []) if d.get("tension_id")
+    }
+    missing_tensions = valid_tension_ids - decided_tension_ids
+    for tension_id in sorted(missing_tensions):
+        errors.append(
+            SeedValidationError(
+                field_path="tensions",
+                issue=f"Missing decision for tension '{tension_id}'",
+                available=[],
+                provided="",
+            )
+        )
 
     return errors
 


### PR DESCRIPTION
## Problem

Issue #134: SEED output may not include decisions for all BRAINSTORM entities and tensions. The LLM might skip some items, leading to incomplete state.

## Changes

- Add completeness validation (checks 9 and 10) to `validate_seed_mutations()`:
  - Check 9: All BRAINSTORM entities have decisions in SEED output
  - Check 10: All BRAINSTORM tensions have decisions in SEED output
- Update docstring to document new validation checks
- Update existing tests to include required completeness decisions
- Add new test class `TestSeedCompletenessValidation` with 6 test cases

## Not Included / Future PRs

- Soft warnings for optional completeness issues (e.g., beat count per thread)
- Prompt improvements from #135, #137 (separate issue)

## Test Plan

```bash
# Run mutation tests
uv run pytest tests/unit/test_mutations.py -v
# 43 tests pass

# Type check
uv run mypy src/questfoundry/graph/mutations.py
# Success

# Lint
uv run ruff check src/questfoundry/graph/mutations.py tests/unit/test_mutations.py
# All checks passed
```

## Risk / Rollback

Low risk - additive validation change. Existing valid SEED outputs will still pass. Invalid outputs that were previously accepted will now be caught and retry will be triggered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)