### PR TITLE
fix(seed): include entity category in validation errors (#145)

### DIFF
--- a/prompts/templates/discuss_seed.yaml
+++ b/prompts/templates/discuss_seed.yaml
@@ -13,9 +13,11 @@ system: |
   Transform the raw brainstorm material into committed story structure:
 
   1. **Entity Curation** - Decide which entities to keep
+     - You MUST make a retain/cut decision for EVERY entity (characters, locations, objects, AND factions)
      - Retained: Essential for the story
      - Cut: Interesting but not needed (can be reconsidered later)
      - Aim to retain 8-15 entities for a focused story
+     - Don't skip faction entities - they need decisions too!
 
   2. **Tension Exploration** - Decide which alternatives to explore as threads
      - Canonical alternative ALWAYS becomes a thread (this is the spine/default path)

--- a/prompts/templates/serialize_seed.yaml
+++ b/prompts/templates/serialize_seed.yaml
@@ -9,13 +9,14 @@ system: |
   SeedOutput contains six main sections that must be populated from the brief:
 
   ### 1. entities (Entity Decisions)
-  For each entity from brainstorm, create an EntityDecision:
+  For EVERY entity from brainstorm (characters, locations, objects, AND factions), create an EntityDecision:
   ```json
   {
     "entity_id": "entity_id_from_brainstorm",
     "disposition": "retained" or "cut"
   }
   ```
+  IMPORTANT: Include ALL entity types - don't skip factions!
 
   ### 2. tensions (Tension Decisions)
   For each tension from brainstorm, create a TensionDecision:

--- a/tests/unit/test_mutations.py
+++ b/tests/unit/test_mutations.py
@@ -846,7 +846,9 @@ class TestSeedCompletenessValidation:
         errors = validate_seed_mutations(graph, output)
 
         # Should find 2 missing entity decisions with category-specific messages
-        entity_errors = [e for e in errors if "Missing decision for" in e.issue]
+        entity_errors = [
+            e for e in errors if "Missing decision for" in e.issue and "tension" not in e.issue
+        ]
         assert len(entity_errors) == 2
         missing_ids = {e.issue.split("'")[1] for e in entity_errors}
         assert missing_ids == {"mentor", "archive"}

--- a/tests/unit/test_mutations.py
+++ b/tests/unit/test_mutations.py
@@ -821,10 +821,17 @@ class TestSeedCompletenessValidation:
     def test_missing_entity_decision_detected(self) -> None:
         """Detects when entity from BRAINSTORM has no decision in SEED."""
         graph = Graph.empty()
-        # Add entities from BRAINSTORM
-        graph.add_node("entity::kay", {"type": "entity", "raw_id": "kay"})
-        graph.add_node("entity::mentor", {"type": "entity", "raw_id": "mentor"})
-        graph.add_node("entity::archive", {"type": "entity", "raw_id": "archive"})
+        # Add entities from BRAINSTORM with categories
+        graph.add_node(
+            "entity::kay", {"type": "entity", "raw_id": "kay", "entity_category": "character"}
+        )
+        graph.add_node(
+            "entity::mentor", {"type": "entity", "raw_id": "mentor", "entity_category": "character"}
+        )
+        graph.add_node(
+            "entity::archive",
+            {"type": "entity", "raw_id": "archive", "entity_category": "location"},
+        )
 
         output = {
             "entities": [
@@ -838,11 +845,14 @@ class TestSeedCompletenessValidation:
 
         errors = validate_seed_mutations(graph, output)
 
-        # Should find 2 missing entity decisions
-        entity_errors = [e for e in errors if "Missing decision for entity" in e.issue]
+        # Should find 2 missing entity decisions with category-specific messages
+        entity_errors = [e for e in errors if "Missing decision for" in e.issue]
         assert len(entity_errors) == 2
         missing_ids = {e.issue.split("'")[1] for e in entity_errors}
         assert missing_ids == {"mentor", "archive"}
+        # Verify category is included in error message
+        assert any("character" in e.issue for e in entity_errors)
+        assert any("location" in e.issue for e in entity_errors)
 
     def test_missing_tension_decision_detected(self) -> None:
         """Detects when tension from BRAINSTORM has no decision in SEED."""
@@ -872,7 +882,9 @@ class TestSeedCompletenessValidation:
         """Detects missing decisions for both entities and tensions."""
         graph = Graph.empty()
         # Add entity and tension from BRAINSTORM
-        graph.add_node("entity::kay", {"type": "entity", "raw_id": "kay"})
+        graph.add_node(
+            "entity::kay", {"type": "entity", "raw_id": "kay", "entity_category": "character"}
+        )
         graph.add_node("tension::trust", {"type": "tension", "raw_id": "trust"})
 
         output = {
@@ -885,10 +897,42 @@ class TestSeedCompletenessValidation:
         errors = validate_seed_mutations(graph, output)
 
         # Should find both missing entity and missing tension
-        entity_errors = [e for e in errors if "Missing decision for entity" in e.issue]
+        # Entity errors use category-specific messages (e.g., "Missing decision for character")
+        entity_errors = [
+            e for e in errors if "Missing decision for" in e.issue and "tension" not in e.issue
+        ]
         tension_errors = [e for e in errors if "Missing decision for tension" in e.issue]
         assert len(entity_errors) == 1
         assert len(tension_errors) == 1
+
+    def test_missing_faction_entity_shows_category(self) -> None:
+        """Missing faction entity decision shows 'faction' in error message."""
+        graph = Graph.empty()
+        # Add a faction entity from BRAINSTORM
+        graph.add_node(
+            "entity::the_family",
+            {"type": "entity", "raw_id": "the_family", "entity_category": "faction"},
+        )
+        graph.add_node(
+            "entity::the_detective",
+            {"type": "entity", "raw_id": "the_detective", "entity_category": "character"},
+        )
+
+        output = {
+            "entities": [
+                {"entity_id": "the_detective", "disposition": "retained"},
+                # Missing: the_family (faction)
+            ],
+            "tensions": [],
+            "threads": [],
+            "initial_beats": [],
+        }
+
+        errors = validate_seed_mutations(graph, output)
+
+        # Should find 1 missing entity decision with "faction" in message
+        assert len(errors) == 1
+        assert "Missing decision for faction 'the_family'" in errors[0].issue
 
     def test_empty_brainstorm_valid(self) -> None:
         """Empty BRAINSTORM data (no entities/tensions) is valid."""


### PR DESCRIPTION
## Problem

LLM was skipping faction entities when making SEED retain/cut decisions. In run `projects/run-2-ni`, validation caught 3 missing faction decisions (`the_family`, `the_guests`, `the_staff`) but even with retry feedback, the LLM didn't understand what was wrong.

Closes #145

## Changes

- **mutations.py**: Include entity category (character/location/object/faction) in validation error messages
  - Before: `Missing decision for entity 'the_family'`
  - After: `Missing decision for faction 'the_family'`
- **discuss_seed.yaml**: Explicitly mention ALL entity types including factions
- **serialize_seed.yaml**: Explicitly list all entity categories in instructions
- **test_mutations.py**: Updated tests and added `test_missing_faction_entity_shows_category`

## Not Included / Future PRs

- Testing with real LLM to verify improved success rate (requires pipeline run)

## Test Plan

```bash
uv run pytest tests/unit/test_mutations.py -v -k "completeness or faction"
```

All 7 tests pass including new `test_missing_faction_entity_shows_category`.

## Risk / Rollback

Low risk - only changes error message content and prompt text. No behavioral changes to validation logic.