### PR TITLE
feat(graph): add valid IDs context for serialize phase

### DIFF
--- a/src/questfoundry/graph/__init__.py
+++ b/src/questfoundry/graph/__init__.py
@@ -7,6 +7,7 @@ mutations through the runtime.
 See docs/architecture/graph-storage.md for architecture details.
 """
 
+from questfoundry.graph.context import format_valid_ids_context
 from questfoundry.graph.errors import (
     EdgeEndpointError,
     GraphIntegrityError,
@@ -51,6 +52,7 @@ __all__ = [
     "apply_dream_mutations",
     "apply_mutations",
     "apply_seed_mutations",
+    "format_valid_ids_context",
     "has_mutation_handler",
     "list_snapshots",
     "rollback_to_snapshot",

--- a/src/questfoundry/graph/context.py
+++ b/src/questfoundry/graph/context.py
@@ -1,0 +1,111 @@
+"""Graph context formatting for LLM prompts.
+
+Provides functions to format graph data as context for LLM serialization,
+giving the model authoritative lists of valid IDs to reference.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from questfoundry.graph.graph import Graph
+
+
+def format_valid_ids_context(graph: Graph, stage: str) -> str:
+    """Format valid IDs as context for LLM serialization.
+
+    Provides the authoritative list of IDs the LLM must use.
+    This prevents phantom ID references by showing valid options upfront.
+
+    Args:
+        graph: Graph containing nodes from previous stages.
+        stage: Current stage name ("seed", "grow", etc.).
+
+    Returns:
+        Formatted context string, or empty string if not applicable.
+    """
+    if stage == "seed":
+        return _format_seed_valid_ids(graph)
+    # Future: add "grow" when GROW stage is implemented
+    return ""
+
+
+def _format_seed_valid_ids(graph: Graph) -> str:
+    """Format BRAINSTORM IDs for SEED serialization.
+
+    Groups entities by category and lists tensions with their alternatives,
+    making it clear which IDs are valid for the SEED stage to reference.
+
+    Args:
+        graph: Graph containing BRAINSTORM data.
+
+    Returns:
+        Formatted context string with valid IDs.
+    """
+    lines = [
+        "## VALID IDS - USE EXACTLY THESE",
+        "",
+        "You MUST use these exact IDs. Any other ID will be rejected.",
+        "",
+    ]
+
+    # Group entities by category
+    entities = graph.get_nodes_by_type("entity")
+    by_category: dict[str, list[str]] = {}
+    for node in entities.values():
+        cat = node.get("entity_category", "unknown")
+        raw_id = node.get("raw_id", "")
+        if raw_id:  # Only include entities with valid raw_id
+            by_category.setdefault(cat, []).append(raw_id)
+
+    if by_category:
+        lines.append("### Entity IDs")
+        lines.append("Use these for `entity_id`, `entities`, and `location` fields:")
+        lines.append("")
+
+        for category in ["character", "location", "object", "faction"]:
+            if category in by_category:
+                lines.append(f"**{category.title()}s:**")
+                for raw_id in sorted(by_category[category]):
+                    lines.append(f"  - `{raw_id}`")
+                lines.append("")
+
+    # Tensions with alternatives
+    tensions = graph.get_nodes_by_type("tension")
+    if tensions:
+        lines.append("### Tension IDs with their Alternative IDs")
+        lines.append("Format: tension_id → [alternative_ids]")
+        lines.append("")
+
+        for tid, tdata in sorted(tensions.items()):
+            raw_id = tdata.get("raw_id")
+            if not raw_id:
+                continue
+
+            alts = []
+            for edge in graph.get_edges(from_id=tid, edge_type="has_alternative"):
+                alt_node = graph.get_node(edge.get("to", ""))
+                if alt_node:
+                    alt_id = alt_node.get("raw_id")
+                    if alt_id:
+                        default = " (default)" if alt_node.get("is_default_path") else ""
+                        alts.append(f"`{alt_id}`{default}")
+
+            if alts:
+                lines.append(f"- `{raw_id}` → [{', '.join(alts)}]")
+
+        lines.append("")
+
+    # Rules
+    lines.extend(
+        [
+            "### Rules",
+            "- Every entity above needs a decision (retained/cut)",
+            "- Every tension above needs a decision (which alternative to explore)",
+            "- Thread `alternative_id` must be from that tension's alternatives list",
+            "- Beat `entities` and `location` must use entity IDs from above",
+        ]
+    )
+
+    return "\n".join(lines)

--- a/tests/unit/test_graph_context.py
+++ b/tests/unit/test_graph_context.py
@@ -1,0 +1,239 @@
+"""Tests for graph context formatting."""
+
+from __future__ import annotations
+
+from questfoundry.graph import Graph, format_valid_ids_context
+
+
+class TestFormatValidIdsContext:
+    """Tests for format_valid_ids_context function."""
+
+    def test_returns_empty_for_unknown_stage(self) -> None:
+        """Unknown stages return empty string."""
+        graph = Graph.empty()
+        result = format_valid_ids_context(graph, "unknown")
+        assert result == ""
+
+    def test_returns_empty_for_empty_graph(self) -> None:
+        """Empty graph returns minimal context for seed stage."""
+        graph = Graph.empty()
+        result = format_valid_ids_context(graph, "seed")
+        # Should still have header and rules even with no entities
+        assert "VALID IDS" in result
+        assert "Rules" in result
+
+    def test_seed_includes_entities_by_category(self) -> None:
+        """SEED context groups entities by category."""
+        graph = Graph.empty()
+        graph.create_node(
+            "entity::hero",
+            {
+                "type": "entity",
+                "raw_id": "hero",
+                "entity_category": "character",
+            },
+        )
+        graph.create_node(
+            "entity::tavern",
+            {
+                "type": "entity",
+                "raw_id": "tavern",
+                "entity_category": "location",
+            },
+        )
+        graph.create_node(
+            "entity::sword",
+            {
+                "type": "entity",
+                "raw_id": "sword",
+                "entity_category": "object",
+            },
+        )
+
+        result = format_valid_ids_context(graph, "seed")
+
+        assert "**Characters:**" in result
+        assert "`hero`" in result
+        assert "**Locations:**" in result
+        assert "`tavern`" in result
+        assert "**Objects:**" in result
+        assert "`sword`" in result
+
+    def test_seed_includes_tensions_with_alternatives(self) -> None:
+        """SEED context lists tensions with their alternatives."""
+        graph = Graph.empty()
+        graph.create_node(
+            "tension::trust",
+            {
+                "type": "tension",
+                "raw_id": "trust",
+            },
+        )
+        graph.create_node(
+            "tension::trust::alt::yes",
+            {
+                "type": "alternative",
+                "raw_id": "yes",
+                "is_default_path": True,
+            },
+        )
+        graph.create_node(
+            "tension::trust::alt::no",
+            {
+                "type": "alternative",
+                "raw_id": "no",
+                "is_default_path": False,
+            },
+        )
+        graph.add_edge("has_alternative", "tension::trust", "tension::trust::alt::yes")
+        graph.add_edge("has_alternative", "tension::trust", "tension::trust::alt::no")
+
+        result = format_valid_ids_context(graph, "seed")
+
+        assert "Tension IDs" in result
+        assert "`trust`" in result
+        assert "`yes`" in result
+        assert "(default)" in result
+        assert "`no`" in result
+
+    def test_seed_includes_rules(self) -> None:
+        """SEED context includes rules for ID usage."""
+        graph = Graph.empty()
+        result = format_valid_ids_context(graph, "seed")
+
+        assert "Rules" in result
+        assert "entity" in result.lower()
+        assert "tension" in result.lower()
+        assert "alternative" in result.lower()
+
+    def test_seed_sorts_entity_ids_alphabetically(self) -> None:
+        """Entity IDs are sorted alphabetically within categories."""
+        graph = Graph.empty()
+        graph.create_node(
+            "entity::zara",
+            {
+                "type": "entity",
+                "raw_id": "zara",
+                "entity_category": "character",
+            },
+        )
+        graph.create_node(
+            "entity::bob",
+            {
+                "type": "entity",
+                "raw_id": "bob",
+                "entity_category": "character",
+            },
+        )
+        graph.create_node(
+            "entity::alice",
+            {
+                "type": "entity",
+                "raw_id": "alice",
+                "entity_category": "character",
+            },
+        )
+
+        result = format_valid_ids_context(graph, "seed")
+
+        # Check order: alice should come before bob, bob before zara
+        alice_pos = result.find("`alice`")
+        bob_pos = result.find("`bob`")
+        zara_pos = result.find("`zara`")
+
+        assert alice_pos < bob_pos < zara_pos
+
+    def test_seed_skips_entities_without_raw_id(self) -> None:
+        """Entities without raw_id are skipped."""
+        graph = Graph.empty()
+        graph.create_node(
+            "entity::valid",
+            {
+                "type": "entity",
+                "raw_id": "valid",
+                "entity_category": "character",
+            },
+        )
+        graph.create_node(
+            "entity::invalid",
+            {
+                "type": "entity",
+                # Missing raw_id
+                "entity_category": "character",
+            },
+        )
+
+        result = format_valid_ids_context(graph, "seed")
+
+        assert "`valid`" in result
+        assert "invalid" not in result
+
+    def test_seed_handles_unknown_category(self) -> None:
+        """Unknown entity categories are handled gracefully."""
+        graph = Graph.empty()
+        graph.create_node(
+            "entity::something",
+            {
+                "type": "entity",
+                "raw_id": "something",
+                "entity_category": "custom_type",  # Not a standard category
+            },
+        )
+
+        # Should not raise, just won't appear in standard categories
+        result = format_valid_ids_context(graph, "seed")
+        assert "VALID IDS" in result
+
+    def test_full_context_format(self) -> None:
+        """Test complete context format with entities and tensions."""
+        graph = Graph.empty()
+
+        # Add entities
+        graph.create_node(
+            "entity::hero",
+            {
+                "type": "entity",
+                "raw_id": "hero",
+                "entity_category": "character",
+            },
+        )
+        graph.create_node(
+            "entity::castle",
+            {
+                "type": "entity",
+                "raw_id": "castle",
+                "entity_category": "location",
+            },
+        )
+
+        # Add tension with alternatives
+        graph.create_node(
+            "tension::quest",
+            {
+                "type": "tension",
+                "raw_id": "quest",
+            },
+        )
+        graph.create_node(
+            "tension::quest::alt::accept",
+            {
+                "type": "alternative",
+                "raw_id": "accept",
+                "is_default_path": True,
+            },
+        )
+        graph.add_edge("has_alternative", "tension::quest", "tension::quest::alt::accept")
+
+        result = format_valid_ids_context(graph, "seed")
+
+        # Verify structure
+        assert result.startswith("## VALID IDS")
+        assert "### Entity IDs" in result
+        assert "### Tension IDs" in result
+        assert "### Rules" in result
+
+        # Verify content
+        assert "`hero`" in result
+        assert "`castle`" in result
+        assert "`quest`" in result
+        assert "`accept` (default)" in result


### PR DESCRIPTION
## Problem
LLMs generating SEED output don't know what entity/tension IDs are valid until semantic validation fails. This leads to:
- Phantom ID references (referencing entities that don't exist)
- Wasted retries fixing validation errors
- Poor LLM experience - they're flying blind

## Changes
- Add `src/questfoundry/graph/context.py` with `format_valid_ids_context()` function
- Inject valid IDs context into brief at start of `serialize_seed_iteratively()`
- Export `format_valid_ids_context` from graph package
- Add 9 comprehensive tests for context formatting

The context includes:
- Entity IDs grouped by category (character, location, object, faction)
- Tension IDs with their alternative IDs (marking default path)
- Rules for ID usage in SEED stage

## Not Included / Future PRs
- GROW stage valid IDs (deferred until GROW is implemented)
- PR 4: Orchestrator cleanup + post-mutation checks
- PR 5: Update tests using deprecated methods

## Test Plan
```bash
uv run pytest tests/unit/test_graph_context.py -v  # 9 passed
uv run pytest tests/unit/ -q  # 604 passed
```

## Risk / Rollback
- Low risk - additive change that doesn't modify existing behavior
- If context is too verbose, can adjust formatting
- Rollback: remove context injection from serialize.py

🤖 Generated with [Claude Code](https://claude.com/claude-code)