### PR TITLE
feat(graph): add post-mutation invariant checks

### DIFF
--- a/src/questfoundry/graph/__init__.py
+++ b/src/questfoundry/graph/__init__.py
@@ -10,6 +10,7 @@ See docs/architecture/graph-storage.md for architecture details.
 from questfoundry.graph.context import format_valid_ids_context
 from questfoundry.graph.errors import (
     EdgeEndpointError,
+    GraphCorruptionError,
     GraphIntegrityError,
     NodeExistsError,
     NodeNotFoundError,
@@ -41,6 +42,7 @@ __all__ = [
     "BrainstormValidationError",
     "EdgeEndpointError",
     "Graph",
+    "GraphCorruptionError",
     "GraphIntegrityError",
     "MutationError",
     "NodeExistsError",

--- a/src/questfoundry/graph/errors.py
+++ b/src/questfoundry/graph/errors.py
@@ -291,8 +291,8 @@ class GraphCorruptionError(Exception):
 
     def __str__(self) -> str:
         lines = [f"Graph corruption detected after {self.stage or 'unknown'} stage:"]
-        for v in self.violations[:10]:
+        for v in self.violations[:5]:
             lines.append(f"  - {v}")
-        if len(self.violations) > 10:
-            lines.append(f"  - ... and {len(self.violations) - 10} more")
+        if len(self.violations) > 5:
+            lines.append(f"  - ... and {len(self.violations) - 5} more")
         return "\n".join(lines)

--- a/src/questfoundry/graph/errors.py
+++ b/src/questfoundry/graph/errors.py
@@ -265,3 +265,34 @@ class EdgeEndpointError(GraphIntegrityError):
         )
 
         return "\n".join(lines)
+
+
+@dataclass
+class GraphCorruptionError(Exception):
+    """Raised when post-mutation invariant checks detect graph corruption.
+
+    Unlike GraphIntegrityError, this indicates a code bug rather than
+    invalid LLM output. The graph should be rolled back to the last
+    known good state.
+
+    Attributes:
+        violations: List of invariant violations found.
+        stage: Stage during which corruption was detected.
+    """
+
+    violations: list[str]
+    stage: str = ""
+
+    def __post_init__(self) -> None:
+        msg = f"Graph corruption detected after {self.stage or 'unknown'} stage"
+        if self.violations:
+            msg += f": {len(self.violations)} violation(s)"
+        super().__init__(msg)
+
+    def __str__(self) -> str:
+        lines = [f"Graph corruption detected after {self.stage or 'unknown'} stage:"]
+        for v in self.violations[:10]:
+            lines.append(f"  - {v}")
+        if len(self.violations) > 10:
+            lines.append(f"  - ... and {len(self.violations) - 10} more")
+        return "\n".join(lines)

--- a/src/questfoundry/graph/graph.py
+++ b/src/questfoundry/graph/graph.py
@@ -453,6 +453,47 @@ class Graph:
         return edges
 
     # -------------------------------------------------------------------------
+    # Validation
+    # -------------------------------------------------------------------------
+
+    def validate_invariants(self) -> list[str]:
+        """Check graph invariants and return any violations.
+
+        Invariants checked:
+        1. All edge endpoints exist (referential integrity)
+        2. All edges have required fields (type, from, to)
+
+        This is for detecting code bugs/data corruption, not LLM validation.
+        Call after mutations to ensure graph is in a valid state.
+
+        Returns:
+            List of violation messages (empty if valid).
+        """
+        violations: list[str] = []
+        nodes = self._data["nodes"]
+
+        for i, edge in enumerate(self._data["edges"]):
+            # Check edge has required fields
+            edge_type = edge.get("type")
+            from_id = edge.get("from")
+            to_id = edge.get("to")
+
+            if not edge_type:
+                violations.append(f"Edge {i} missing 'type' field")
+            if not from_id:
+                violations.append(f"Edge {i} missing 'from' field")
+            if not to_id:
+                violations.append(f"Edge {i} missing 'to' field")
+
+            # Check endpoints exist
+            if from_id and from_id not in nodes:
+                violations.append(f"Edge {i} ({edge_type}): source '{from_id}' does not exist")
+            if to_id and to_id not in nodes:
+                violations.append(f"Edge {i} ({edge_type}): target '{to_id}' does not exist")
+
+        return violations
+
+    # -------------------------------------------------------------------------
     # Metadata Operations
     # -------------------------------------------------------------------------
 

--- a/tests/unit/test_graph.py
+++ b/tests/unit/test_graph.py
@@ -911,20 +911,30 @@ class TestGraphValidateInvariants:
         assert "missing 'type'" in violations[0]
 
     def test_detects_edge_missing_from(self) -> None:
-        """Detects edge missing from field."""
+        """Detects edge missing from field and target not existing."""
         graph = Graph.empty()
         graph._data["edges"].append({"type": "test", "to": "b"})
 
         violations = graph.validate_invariants()
-        assert any("missing 'from'" in v for v in violations)
+        assert len(violations) == 2
+        expected_violations = {
+            "Edge 0 missing 'from' field",
+            "Edge 0 (test): target 'b' does not exist",
+        }
+        assert set(violations) == expected_violations
 
     def test_detects_edge_missing_to(self) -> None:
-        """Detects edge missing to field."""
+        """Detects edge missing to field and source not existing."""
         graph = Graph.empty()
         graph._data["edges"].append({"type": "test", "from": "a"})
 
         violations = graph.validate_invariants()
-        assert any("missing 'to'" in v for v in violations)
+        assert len(violations) == 2
+        expected_violations = {
+            "Edge 0 missing 'to' field",
+            "Edge 0 (test): source 'a' does not exist",
+        }
+        assert set(violations) == expected_violations
 
     def test_returns_multiple_violations(self) -> None:
         """Returns all violations found."""

--- a/tests/unit/test_graph.py
+++ b/tests/unit/test_graph.py
@@ -844,13 +844,15 @@ class TestGraphCorruptionError:
         """String truncates when there are many violations."""
         from questfoundry.graph.errors import GraphCorruptionError
 
-        violations = [f"Violation {i}" for i in range(15)]
+        violations = [f"Violation {i}" for i in range(10)]
         error = GraphCorruptionError(violations=violations, stage="grow")
 
         s = str(error)
-        # Should show first 10
+        # Should show first 5 (matches log limit in orchestrator)
         assert "Violation 0" in s
-        assert "Violation 9" in s
+        assert "Violation 4" in s
+        # Violation 5+ should not be shown directly
+        assert "Violation 5" not in s or "5 more" in s
         # Should indicate more
         assert "5 more" in s
 


### PR DESCRIPTION
## Problem

After mutations are applied to the graph, there's no verification that the graph is in a valid state. Data corruption from bugs or external edits could go undetected until much later.

## Changes

Implements PR 4 from the graph-referential-integrity.md plan:

- Add `GraphCorruptionError` exception type for data corruption (distinct from `GraphIntegrityError` which is for LLM validation)
- Add `Graph.validate_invariants()` method that checks:
  - All edges have required fields (`type`, `from`, `to`)
  - All edge endpoints reference existing nodes
- Orchestrator now calls `validate_invariants()` after mutations
- If violations found, rolls back to pre-mutation snapshot and raises `GraphCorruptionError`

## Not Included / Future PRs

- PR 5: Update tests using deprecated `add_node()` method (see deprecation warnings)
- No changes to the duplicate artifact validation in orchestrator (kept for defense in depth)

## Test Plan

```bash
# New tests pass
uv run pytest tests/unit/test_graph.py -v -k "Corruption or Invariants"
# 11 passed

# Full test suite passes
uv run pytest tests/unit/ -v
# 615 passed, 30 warnings (deprecation warnings for PR 5)
```

## Risk / Rollback

- Low risk: new validation is additive
- Rollback: simply merge revert if needed
- Note: The corruption check uses `validate=False` on `add_edge()` to test corruption scenarios - this is only for test fixtures, production code always validates

🤖 Generated with [Claude Code](https://claude.com/claude-code)