### PR TITLE
fix(context): use entity_type instead of entity_category

### DIFF
--- a/src/questfoundry/graph/context.py
+++ b/src/questfoundry/graph/context.py
@@ -50,11 +50,11 @@ def _format_seed_valid_ids(graph: Graph) -> str:
         "",
     ]
 
-    # Group entities by category
+    # Group entities by type (character, location, object, faction)
     entities = graph.get_nodes_by_type("entity")
     by_category: dict[str, list[str]] = {}
     for node in entities.values():
-        cat = node.get("entity_category", "unknown")
+        cat = node.get("entity_type", "unknown")
         raw_id = node.get("raw_id", "")
         if raw_id:  # Only include entities with valid raw_id
             by_category.setdefault(cat, []).append(raw_id)

--- a/tests/unit/test_graph_context.py
+++ b/tests/unit/test_graph_context.py
@@ -30,7 +30,7 @@ class TestFormatValidIdsContext:
             {
                 "type": "entity",
                 "raw_id": "hero",
-                "entity_category": "character",
+                "entity_type": "character",
             },
         )
         graph.create_node(
@@ -38,7 +38,7 @@ class TestFormatValidIdsContext:
             {
                 "type": "entity",
                 "raw_id": "tavern",
-                "entity_category": "location",
+                "entity_type": "location",
             },
         )
         graph.create_node(
@@ -46,7 +46,7 @@ class TestFormatValidIdsContext:
             {
                 "type": "entity",
                 "raw_id": "sword",
-                "entity_category": "object",
+                "entity_type": "object",
             },
         )
 
@@ -114,7 +114,7 @@ class TestFormatValidIdsContext:
             {
                 "type": "entity",
                 "raw_id": "zara",
-                "entity_category": "character",
+                "entity_type": "character",
             },
         )
         graph.create_node(
@@ -122,7 +122,7 @@ class TestFormatValidIdsContext:
             {
                 "type": "entity",
                 "raw_id": "bob",
-                "entity_category": "character",
+                "entity_type": "character",
             },
         )
         graph.create_node(
@@ -130,7 +130,7 @@ class TestFormatValidIdsContext:
             {
                 "type": "entity",
                 "raw_id": "alice",
-                "entity_category": "character",
+                "entity_type": "character",
             },
         )
 
@@ -151,7 +151,7 @@ class TestFormatValidIdsContext:
             {
                 "type": "entity",
                 "raw_id": "valid",
-                "entity_category": "character",
+                "entity_type": "character",
             },
         )
         graph.create_node(
@@ -159,7 +159,7 @@ class TestFormatValidIdsContext:
             {
                 "type": "entity",
                 # Missing raw_id
-                "entity_category": "character",
+                "entity_type": "character",
             },
         )
 
@@ -176,7 +176,7 @@ class TestFormatValidIdsContext:
             {
                 "type": "entity",
                 "raw_id": "something",
-                "entity_category": "custom_type",  # Not a standard category
+                "entity_type": "custom_type",  # Not a standard category
             },
         )
 
@@ -194,7 +194,7 @@ class TestFormatValidIdsContext:
             {
                 "type": "entity",
                 "raw_id": "hero",
-                "entity_category": "character",
+                "entity_type": "character",
             },
         )
         graph.create_node(
@@ -202,7 +202,7 @@ class TestFormatValidIdsContext:
             {
                 "type": "entity",
                 "raw_id": "castle",
-                "entity_category": "location",
+                "entity_type": "location",
             },
         )
 


### PR DESCRIPTION
## Problem

The valid IDs context formatter was looking for `entity_category` field on entity nodes, but the actual schema uses `entity_type`. This caused the entity IDs section to be empty in SEED feedback, leading to validation failures where the LLM couldn't see which entity IDs were valid.

**Bug found**: OpenAI run in `run-2-ni` failed on SEED validation because `montrose_family` entity wasn't included in LLM output. The feedback showed "### Entity IDs" but no actual IDs were listed.

**Root cause**: `context.py` line 57 used `node.get("entity_category")` but graph nodes use `entity_type` field.

## Changes

- Changed `entity_category` to `entity_type` in `context.py`
- Updated tests to use `entity_type` field (tests were also using wrong field name)

## Not Included / Future PRs

- No additional changes needed

## Test Plan

```bash
# Unit tests
uv run pytest tests/unit/test_graph_context.py -v
# 9 passed

uv run pytest tests/unit/ -v
# 615 passed

# E2E verification with OpenAI
uv run qf run --to seed --project projects/run-3-openai --provider openai/gpt-4o
# SEED completed successfully with 19/19 entity decisions

# Re-ran failed project
uv run qf run --to seed --project projects/run-2-ni --provider openai/gpt-4o  
# SEED completed successfully with 22/22 entity decisions
```

## Risk / Rollback

Low risk - simple field name fix. The fix is necessary for SEED validation to work correctly with entity completeness checks.