### PR TITLE
fix(graph): use entity_type instead of entity_category in mutations.py

### DIFF
--- a/src/questfoundry/graph/mutations.py
+++ b/src/questfoundry/graph/mutations.py
@@ -430,9 +430,9 @@ def validate_seed_mutations(graph: Graph, output: dict[str, Any]) -> list[SeedVa
     valid_entity_ids: set[str] = {n["raw_id"] for n in entity_nodes.values() if n.get("raw_id")}
     valid_tension_ids: set[str] = {n["raw_id"] for n in tension_nodes.values() if n.get("raw_id")}
 
-    # Entity category lookup for informative error messages
-    entity_categories: dict[str, str] = {
-        n["raw_id"]: n.get("entity_category", "entity")
+    # Entity type lookup for informative error messages
+    entity_types: dict[str, str] = {
+        n["raw_id"]: n.get("entity_type", "entity")
         for n in entity_nodes.values()
         if n.get("raw_id")
     }
@@ -604,9 +604,9 @@ def validate_seed_mutations(graph: Graph, output: dict[str, Any]) -> list[SeedVa
         }
         missing_ids = valid_ids - decided_ids
         for item_id in sorted(missing_ids):
-            # For entities, include category (character/location/object/faction) for clarity
+            # For entities, include type (character/location/object/faction) for clarity
             if item_type == "entity":
-                category = entity_categories.get(item_id, "entity")
+                category = entity_types.get(item_id, "entity")
                 issue_msg = f"Missing decision for {category} '{item_id}'"
             else:
                 issue_msg = f"Missing decision for {item_type} '{item_id}'"

--- a/src/questfoundry/graph/mutations.py
+++ b/src/questfoundry/graph/mutations.py
@@ -606,8 +606,8 @@ def validate_seed_mutations(graph: Graph, output: dict[str, Any]) -> list[SeedVa
         for item_id in sorted(missing_ids):
             # For entities, include type (character/location/object/faction) for clarity
             if item_type == "entity":
-                category = entity_types.get(item_id, "entity")
-                issue_msg = f"Missing decision for {category} '{item_id}'"
+                entity_type_name = entity_types.get(item_id, "entity")
+                issue_msg = f"Missing decision for {entity_type_name} '{item_id}'"
             else:
                 issue_msg = f"Missing decision for {item_type} '{item_id}'"
             errors.append(

--- a/tests/unit/test_mutations.py
+++ b/tests/unit/test_mutations.py
@@ -823,14 +823,14 @@ class TestSeedCompletenessValidation:
         graph = Graph.empty()
         # Add entities from BRAINSTORM with categories
         graph.create_node(
-            "entity::kay", {"type": "entity", "raw_id": "kay", "entity_category": "character"}
+            "entity::kay", {"type": "entity", "raw_id": "kay", "entity_type": "character"}
         )
         graph.create_node(
-            "entity::mentor", {"type": "entity", "raw_id": "mentor", "entity_category": "character"}
+            "entity::mentor", {"type": "entity", "raw_id": "mentor", "entity_type": "character"}
         )
         graph.create_node(
             "entity::archive",
-            {"type": "entity", "raw_id": "archive", "entity_category": "location"},
+            {"type": "entity", "raw_id": "archive", "entity_type": "location"},
         )
 
         output = {
@@ -885,7 +885,7 @@ class TestSeedCompletenessValidation:
         graph = Graph.empty()
         # Add entity and tension from BRAINSTORM
         graph.create_node(
-            "entity::kay", {"type": "entity", "raw_id": "kay", "entity_category": "character"}
+            "entity::kay", {"type": "entity", "raw_id": "kay", "entity_type": "character"}
         )
         graph.create_node("tension::trust", {"type": "tension", "raw_id": "trust"})
 
@@ -913,11 +913,11 @@ class TestSeedCompletenessValidation:
         # Add a faction entity from BRAINSTORM
         graph.create_node(
             "entity::the_family",
-            {"type": "entity", "raw_id": "the_family", "entity_category": "faction"},
+            {"type": "entity", "raw_id": "the_family", "entity_type": "faction"},
         )
         graph.create_node(
             "entity::the_detective",
-            {"type": "entity", "raw_id": "the_detective", "entity_category": "character"},
+            {"type": "entity", "raw_id": "the_detective", "entity_type": "character"},
         )
 
         output = {


### PR DESCRIPTION
## Problem

`mutations.py` line 435 used `entity_category` to look up entity types for error messages, but graph nodes store entities with the `entity_type` field. This caused entity type lookups to fail silently, defaulting to generic "entity" instead of showing proper category (character/location/object/faction) in SEED completeness validation error messages.

This is a companion fix to PR #155, which fixed the same issue in `context.py`.

Closes #156

## Changes

- Rename `entity_categories` dict to `entity_types` for clarity
- Change field lookup from `entity_category` to `entity_type` to match graph node schema
- Update test data to use `entity_type` for graph node creation

## Not Included / Future PRs

- Nothing deferred; this is a small targeted fix

## Test Plan

```bash
uv run pytest tests/unit/test_mutations.py -v
# 44 passed

uv run pytest tests/unit/test_graph_context.py -v
# 9 passed
```

Tests specifically verify that entity category is included in error messages:
- `test_missing_entity_decision_detected` - verifies "character" and "location" appear
- `test_missing_faction_entity_shows_category` - verifies "faction" appears

## Risk / Rollback

- Low risk - changes only affect error message formatting
- No API changes, no schema changes
- Safe to rollback if needed

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)