### PR TITLE
feat(artifacts): enrich SEED with BRAINSTORM entity details

### DIFF
--- a/src/questfoundry/artifacts/enrichment.py
+++ b/src/questfoundry/artifacts/enrichment.py
@@ -49,11 +49,9 @@ def enrich_seed_artifact(graph: Graph, artifact: dict[str, Any]) -> dict[str, An
     """
     # Build lookup: raw_id -> node data for entities
     entity_nodes = graph.get_nodes_by_type("entity")
-    entity_data: dict[str, dict[str, Any]] = {}
-    for _node_id, node in entity_nodes.items():
-        raw_id = node.get("raw_id")
-        if raw_id:
-            entity_data[raw_id] = node
+    entity_data: dict[str, dict[str, Any]] = {
+        node["raw_id"]: node for node in entity_nodes.values() if node.get("raw_id")
+    }
 
     # Enrich entity decisions
     enriched_entities = []
@@ -67,12 +65,9 @@ def enrich_seed_artifact(graph: Graph, artifact: dict[str, Any]) -> dict[str, An
         }
 
         # Add BRAINSTORM fields if available
-        if entity_type := node.get("entity_type"):
-            enriched["entity_type"] = entity_type
-        if concept := node.get("concept"):
-            enriched["concept"] = concept
-        if notes := node.get("notes"):
-            enriched["notes"] = notes
+        for field in ("entity_type", "concept", "notes"):
+            if value := node.get(field):
+                enriched[field] = value
 
         # Add SEED disposition
         enriched["disposition"] = decision.get("disposition")

--- a/src/questfoundry/artifacts/enrichment.py
+++ b/src/questfoundry/artifacts/enrichment.py
@@ -1,0 +1,89 @@
+"""Artifact enrichment with graph context.
+
+Enriches stage artifacts with data from previous stages stored in the graph.
+This provides full context in human-readable artifacts without requiring the
+LLM to repeat information from earlier stages.
+
+Example: SEED entities include disposition (from SEED) plus entity_type,
+concept, notes (from BRAINSTORM).
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from questfoundry.observability.logging import get_logger
+
+if TYPE_CHECKING:
+    from questfoundry.graph.graph import Graph
+
+log = get_logger(__name__)
+
+
+def enrich_seed_artifact(graph: Graph, artifact: dict[str, Any]) -> dict[str, Any]:
+    """Enrich SEED artifact with BRAINSTORM entity details.
+
+    Merges entity details (entity_type, concept, notes) from graph nodes
+    into entity decisions. This provides full context in the YAML artifact
+    without requiring the LLM to repeat information.
+
+    Args:
+        graph: Graph containing BRAINSTORM entity nodes.
+        artifact: SEED artifact dict with entity decisions.
+
+    Returns:
+        Enriched artifact dict with full entity details.
+
+    Example:
+        Input artifact:
+            {"entities": [{"entity_id": "the_detective", "disposition": "retained"}]}
+
+        Output:
+            {"entities": [{
+                "entity_id": "the_detective",
+                "entity_type": "character",
+                "concept": "Seasoned detective...",
+                "notes": "Inspector Reginald...",
+                "disposition": "retained"
+            }]}
+    """
+    # Build lookup: raw_id -> node data for entities
+    entity_nodes = graph.get_nodes_by_type("entity")
+    entity_data: dict[str, dict[str, Any]] = {}
+    for _node_id, node in entity_nodes.items():
+        raw_id = node.get("raw_id")
+        if raw_id:
+            entity_data[raw_id] = node
+
+    # Enrich entity decisions
+    enriched_entities = []
+    for decision in artifact.get("entities", []):
+        entity_id = decision.get("entity_id")
+        node = entity_data.get(entity_id, {})
+
+        # Build enriched entity in consistent field order
+        enriched: dict[str, Any] = {
+            "entity_id": entity_id,
+        }
+
+        # Add BRAINSTORM fields if available
+        if entity_type := node.get("entity_type"):
+            enriched["entity_type"] = entity_type
+        if concept := node.get("concept"):
+            enriched["concept"] = concept
+        if notes := node.get("notes"):
+            enriched["notes"] = notes
+
+        # Add SEED disposition
+        enriched["disposition"] = decision.get("disposition")
+
+        enriched_entities.append(enriched)
+
+    log.debug(
+        "artifact_enriched",
+        stage="seed",
+        entity_count=len(enriched_entities),
+        enriched_count=sum(1 for e in enriched_entities if "concept" in e),
+    )
+
+    return {**artifact, "entities": enriched_entities}

--- a/src/questfoundry/pipeline/orchestrator.py
+++ b/src/questfoundry/pipeline/orchestrator.py
@@ -9,6 +9,7 @@ from datetime import datetime
 from typing import TYPE_CHECKING, Any, Literal
 
 from questfoundry.artifacts import ArtifactReader, ArtifactValidator, ArtifactWriter
+from questfoundry.artifacts.enrichment import enrich_seed_artifact
 from questfoundry.graph import (
     Graph,
     GraphCorruptionError,
@@ -303,8 +304,6 @@ class PipelineOrchestrator:
                 # Enrich artifact with context from previous stages (SEED only for now)
                 if stage_name == "seed":
                     try:
-                        from questfoundry.artifacts.enrichment import enrich_seed_artifact
-
                         graph = Graph.load(self.project_path)
                         artifact_data = enrich_seed_artifact(graph, artifact_data)
                     except Exception as e:

--- a/tests/unit/test_enrichment.py
+++ b/tests/unit/test_enrichment.py
@@ -162,6 +162,6 @@ class TestEnrichSeedArtifact:
 
         entity = result["entities"][0]
         keys = list(entity.keys())
-        # entity_id should be first, disposition should be last
-        assert keys[0] == "entity_id"
-        assert keys[-1] == "disposition"
+        # Full expected order: entity_id, entity_type, concept, notes, disposition
+        expected_order = ["entity_id", "entity_type", "concept", "notes", "disposition"]
+        assert keys == expected_order

--- a/tests/unit/test_enrichment.py
+++ b/tests/unit/test_enrichment.py
@@ -1,0 +1,167 @@
+"""Tests for artifact enrichment."""
+
+from __future__ import annotations
+
+import pytest
+
+from questfoundry.artifacts.enrichment import enrich_seed_artifact
+from questfoundry.graph import Graph
+
+
+@pytest.fixture
+def graph_with_entities() -> Graph:
+    """Graph with BRAINSTORM entity data."""
+    graph = Graph()
+    # Add entities as BRAINSTORM would
+    graph.create_node(
+        "entity::the_detective",
+        {
+            "type": "entity",
+            "raw_id": "the_detective",
+            "entity_type": "character",
+            "concept": "Seasoned detective known for solving intricate cases",
+            "notes": "Inspector Reginald Hargrove is known for sharp wit",
+            "disposition": "proposed",
+        },
+    )
+    graph.create_node(
+        "entity::the_manor",
+        {
+            "type": "entity",
+            "raw_id": "the_manor",
+            "entity_type": "location",
+            "concept": "Grand Victorian manor with hidden passages",
+            "notes": "Whitmore Manor has been in the family for generations",
+            "disposition": "proposed",
+        },
+    )
+    graph.create_node(
+        "entity::the_victim",
+        {
+            "type": "entity",
+            "raw_id": "the_victim",
+            "entity_type": "character",
+            "concept": "Wealthy socialite whose death triggers the mystery",
+            "disposition": "proposed",
+        },
+    )
+    return graph
+
+
+class TestEnrichSeedArtifact:
+    """Tests for enrich_seed_artifact function."""
+
+    def test_enriches_entity_with_full_details(self, graph_with_entities: Graph) -> None:
+        """Enrichment adds entity_type, concept, notes from graph."""
+        artifact = {
+            "entities": [
+                {"entity_id": "the_detective", "disposition": "retained"},
+            ],
+        }
+
+        result = enrich_seed_artifact(graph_with_entities, artifact)
+
+        entity = result["entities"][0]
+        assert entity["entity_id"] == "the_detective"
+        assert entity["entity_type"] == "character"
+        assert entity["concept"] == "Seasoned detective known for solving intricate cases"
+        assert entity["notes"] == "Inspector Reginald Hargrove is known for sharp wit"
+        assert entity["disposition"] == "retained"
+
+    def test_handles_entity_without_notes(self, graph_with_entities: Graph) -> None:
+        """Enrichment handles entities missing optional fields."""
+        artifact = {
+            "entities": [
+                {"entity_id": "the_victim", "disposition": "cut"},
+            ],
+        }
+
+        result = enrich_seed_artifact(graph_with_entities, artifact)
+
+        entity = result["entities"][0]
+        assert entity["entity_id"] == "the_victim"
+        assert entity["entity_type"] == "character"
+        assert entity["concept"] == "Wealthy socialite whose death triggers the mystery"
+        assert "notes" not in entity  # Not added if not in graph
+        assert entity["disposition"] == "cut"
+
+    def test_handles_unknown_entity(self, graph_with_entities: Graph) -> None:
+        """Enrichment handles entities not in graph gracefully."""
+        artifact = {
+            "entities": [
+                {"entity_id": "unknown_entity", "disposition": "retained"},
+            ],
+        }
+
+        result = enrich_seed_artifact(graph_with_entities, artifact)
+
+        entity = result["entities"][0]
+        assert entity["entity_id"] == "unknown_entity"
+        assert "entity_type" not in entity
+        assert "concept" not in entity
+        assert entity["disposition"] == "retained"
+
+    def test_enriches_multiple_entities(self, graph_with_entities: Graph) -> None:
+        """Enrichment works for multiple entities."""
+        artifact = {
+            "entities": [
+                {"entity_id": "the_detective", "disposition": "retained"},
+                {"entity_id": "the_manor", "disposition": "retained"},
+                {"entity_id": "the_victim", "disposition": "cut"},
+            ],
+        }
+
+        result = enrich_seed_artifact(graph_with_entities, artifact)
+
+        assert len(result["entities"]) == 3
+        assert result["entities"][0]["entity_type"] == "character"
+        assert result["entities"][1]["entity_type"] == "location"
+        assert result["entities"][2]["entity_type"] == "character"
+
+    def test_preserves_other_artifact_fields(self, graph_with_entities: Graph) -> None:
+        """Enrichment preserves non-entity fields in artifact."""
+        artifact = {
+            "entities": [{"entity_id": "the_detective", "disposition": "retained"}],
+            "threads": [{"thread_id": "main_thread", "tier": "major"}],
+            "beats": [{"beat_id": "opening", "summary": "Introduction"}],
+        }
+
+        result = enrich_seed_artifact(graph_with_entities, artifact)
+
+        assert "threads" in result
+        assert result["threads"] == artifact["threads"]
+        assert "beats" in result
+        assert result["beats"] == artifact["beats"]
+
+    def test_empty_entities_list(self, graph_with_entities: Graph) -> None:
+        """Enrichment handles empty entities list."""
+        artifact = {"entities": []}
+
+        result = enrich_seed_artifact(graph_with_entities, artifact)
+
+        assert result["entities"] == []
+
+    def test_missing_entities_key(self, graph_with_entities: Graph) -> None:
+        """Enrichment handles missing entities key."""
+        artifact = {"threads": []}
+
+        result = enrich_seed_artifact(graph_with_entities, artifact)
+
+        assert result["entities"] == []
+        assert result["threads"] == []
+
+    def test_field_order_consistent(self, graph_with_entities: Graph) -> None:
+        """Enriched entities have consistent field order."""
+        artifact = {
+            "entities": [
+                {"entity_id": "the_detective", "disposition": "retained"},
+            ],
+        }
+
+        result = enrich_seed_artifact(graph_with_entities, artifact)
+
+        entity = result["entities"][0]
+        keys = list(entity.keys())
+        # entity_id should be first, disposition should be last
+        assert keys[0] == "entity_id"
+        assert keys[-1] == "disposition"


### PR DESCRIPTION
## Problem

SEED artifacts only contain differential data (entity_id + disposition), making them hard to review without cross-referencing BRAINSTORM output (#158).

**Before:**
```yaml
entities:
  - entity_id: the_detective
    disposition: retained
```

## Changes

**After:**
```yaml
entities:
  - entity_id: the_detective
    entity_type: character
    concept: Seasoned detective known for solving intricate cases
    notes: Inspector Reginald Hargrove is known for sharp wit
    disposition: retained
```

### Implementation
- Add `enrichment.py` module for artifact enrichment with graph data
- Add `enrich_seed_artifact()` function that merges BRAINSTORM entity details
- Orchestrator calls enrichment before writing artifact
- Enrichment failure is non-critical (artifact still valid without enrichment)

### Design Decisions
- Enrichment happens at write time, not in Pydantic models (keeps LLM output minimal)
- Uses existing graph data (no additional LLM calls)
- Field order is consistent: entity_id → entity_type → concept → notes → disposition

## Not Included / Future PRs

- Enrichment for other stages (GROW, FILL) - can be added as needed
- Enrichment for tension decisions - entities are highest value
- Thread enrichment with alternative details

## Test Plan

```bash
# Run enrichment tests
uv run pytest tests/unit/test_enrichment.py -v
# 8 tests pass

# Full test suite
uv run pytest tests/unit/ -v
# 623 tests pass

# Type check
uv run mypy src/questfoundry/artifacts/enrichment.py src/questfoundry/pipeline/orchestrator.py
# No errors
```

## Risk / Rollback

- Low risk - enrichment is additive and non-critical
- If enrichment fails, artifact is written without enrichment (still valid)
- Can be disabled by removing the orchestrator call

Fixes #158

🤖 Generated with [Claude Code](https://claude.com/claude-code)