### PR TITLE
feat(providers): add ModelInfo for context budget awareness (#130)

### DIFF
--- a/src/questfoundry/providers/__init__.py
+++ b/src/questfoundry/providers/__init__.py
@@ -10,6 +10,10 @@ from questfoundry.providers.factory import (
     create_chat_model,
     create_model_for_structured_output,
 )
+from questfoundry.providers.model_info import (
+    ModelInfo,
+    get_model_info,
+)
 from questfoundry.providers.structured_output import (
     StructuredOutputStrategy,
     get_default_strategy,
@@ -17,6 +21,7 @@ from questfoundry.providers.structured_output import (
 )
 
 __all__ = [
+    "ModelInfo",
     "ProviderConnectionError",
     "ProviderError",
     "ProviderModelError",
@@ -25,5 +30,6 @@ __all__ = [
     "create_chat_model",
     "create_model_for_structured_output",
     "get_default_strategy",
+    "get_model_info",
     "with_structured_output",
 ]

--- a/src/questfoundry/providers/model_info.py
+++ b/src/questfoundry/providers/model_info.py
@@ -1,0 +1,91 @@
+"""Model information and capabilities."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class ModelInfo:
+    """Model capabilities and limits.
+
+    Attributes:
+        context_window: Maximum input tokens the model can process.
+        supports_tools: Whether the model supports tool/function calling.
+        supports_vision: Whether the model can process images.
+        max_output_tokens: Maximum tokens in model response (None if unknown).
+    """
+
+    context_window: int
+    supports_tools: bool = True
+    supports_vision: bool = False
+    max_output_tokens: int | None = None
+
+
+# Known context windows by provider and model.
+# Used as fallback when API doesn't provide this information.
+KNOWN_CONTEXT_WINDOWS: dict[str, dict[str, int]] = {
+    "ollama": {
+        "qwen3:8b": 32_768,
+        "qwen2.5:7b": 32_768,
+        "llama3:8b": 8_192,
+        "llama3.1:8b": 128_000,
+        "mistral:7b": 32_768,
+        "deepseek-coder:6.7b": 16_384,
+    },
+    "openai": {
+        "gpt-4o": 128_000,
+        "gpt-4o-mini": 128_000,
+        "gpt-4-turbo": 128_000,
+        "gpt-4": 8_192,
+        "gpt-3.5-turbo": 16_385,
+        "o1": 200_000,
+        "o1-mini": 128_000,
+    },
+    "anthropic": {
+        "claude-sonnet-4-20250514": 200_000,
+        "claude-opus-4-20250514": 200_000,
+        "claude-3-5-sonnet-latest": 200_000,
+        "claude-3-5-sonnet-20241022": 200_000,
+        "claude-3-opus-20240229": 200_000,
+        "claude-3-haiku-20240307": 200_000,
+    },
+}
+
+# Default context window when model is not in known list.
+# Conservative value to avoid context overflow.
+DEFAULT_CONTEXT_WINDOW = 32_768
+
+
+def get_model_info(provider: str, model: str) -> ModelInfo:
+    """Get model information from known values or defaults.
+
+    Args:
+        provider: Provider name (e.g., "ollama", "openai", "anthropic").
+        model: Model name (e.g., "gpt-4o", "qwen3:8b").
+
+    Returns:
+        ModelInfo with context window and capabilities.
+    """
+    provider_lower = provider.lower()
+    provider_models = KNOWN_CONTEXT_WINDOWS.get(provider_lower, {})
+    context_window = provider_models.get(model, DEFAULT_CONTEXT_WINDOW)
+
+    # Vision support for known multimodal models
+    supports_vision = model in {
+        "gpt-4o",
+        "gpt-4o-mini",
+        "gpt-4-turbo",
+        "claude-sonnet-4-20250514",
+        "claude-opus-4-20250514",
+        "claude-3-5-sonnet-latest",
+        "claude-3-5-sonnet-20241022",
+        "claude-3-opus-20240229",
+        "claude-3-haiku-20240307",
+    }
+
+    return ModelInfo(
+        context_window=context_window,
+        supports_tools=True,  # All supported providers have tool support
+        supports_vision=supports_vision,
+    )

--- a/tests/unit/test_orchestrator.py
+++ b/tests/unit/test_orchestrator.py
@@ -204,6 +204,32 @@ providers:
     assert orchestrator.config.name == "test_project"
 
 
+def test_orchestrator_model_info_before_run(tmp_path: Path) -> None:
+    """Orchestrator model_info is None before first stage run."""
+    orchestrator = PipelineOrchestrator(tmp_path)
+
+    assert orchestrator.model_info is None
+
+
+def test_orchestrator_model_info_after_model_creation(tmp_path: Path) -> None:
+    """Orchestrator model_info is populated after model creation."""
+    orchestrator = PipelineOrchestrator(tmp_path)
+    # Inject mock chat model and model info directly
+    mock_model = MagicMock()
+    orchestrator._chat_model = mock_model
+    orchestrator._provider_name = "openai"
+    orchestrator._model_name = "gpt-4o"
+
+    # Manually populate model_info as _get_chat_model would
+    from questfoundry.providers.model_info import get_model_info
+
+    orchestrator._model_info = get_model_info("openai", "gpt-4o")
+
+    assert orchestrator.model_info is not None
+    assert orchestrator.model_info.context_window == 128_000
+    assert orchestrator.model_info.supports_vision is True
+
+
 @pytest.mark.asyncio
 async def test_orchestrator_run_stage_not_found(tmp_path: Path) -> None:
     """Orchestrator raises error for unknown stage."""


### PR DESCRIPTION
## Problem
Issue #130 requested programmatic access to model context window size so stages can make informed decisions about context injection. Currently there's no way to know how much context a model can handle.

## Changes
- Add `model_info.py` with `ModelInfo` frozen dataclass containing:
  - `context_window`: Maximum input tokens
  - `supports_tools`: Whether model supports function calling
  - `supports_vision`: Whether model can process images
  - `max_output_tokens`: Maximum response tokens (optional)
- Add `KNOWN_CONTEXT_WINDOWS` dict with known context windows for Ollama, OpenAI, and Anthropic models
- Add `get_model_info()` function to query model capabilities
- Update `PipelineOrchestrator` to store and expose `model_info` property after model creation
- Export `ModelInfo` and `get_model_info` from providers module
- Add tests for `get_model_info` and `orchestrator.model_info` property

## Not Included / Future PRs
- Query Ollama `/api/show` endpoint for actual model metadata (noted as future enhancement)
- Automatic context truncation based on model limits (separate concern)

## Test Plan
```bash
uv run pytest tests/unit/test_provider_factory.py tests/unit/test_orchestrator.py -v
# 52 tests pass

uv run pytest tests/unit/ -q
# 623 tests pass

uv run mypy src/questfoundry/providers/model_info.py src/questfoundry/pipeline/orchestrator.py
# No errors
```

## Risk / Rollback
- Low risk - additive changes only
- No breaking changes to existing APIs
- `create_chat_model` return type unchanged

Closes #130

🤖 Generated with [Claude Code](https://claude.com/claude-code)