### PR TITLE
feat(config): add ProvidersConfig for hybrid model support

### DIFF
--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -1,0 +1,230 @@
+"""Tests for pipeline configuration."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from questfoundry.pipeline.config import (
+    DEFAULT_MODEL,
+    DEFAULT_PROVIDER,
+    ProjectConfig,
+    ProvidersConfig,
+    create_default_config,
+)
+
+# --- Tests for ProvidersConfig ---
+
+
+class TestProvidersConfig:
+    """Tests for ProvidersConfig class."""
+
+    def test_from_dict_default_only(self) -> None:
+        """Parse config with only default provider."""
+        data = {"default": "ollama/qwen3:8b"}
+        config = ProvidersConfig.from_dict(data)
+
+        assert config.default == "ollama/qwen3:8b"
+        assert config.discuss is None
+        assert config.summarize is None
+        assert config.serialize is None
+
+    def test_from_dict_with_phase_overrides(self) -> None:
+        """Parse config with phase-specific overrides."""
+        data = {
+            "default": "ollama/qwen3:8b",
+            "discuss": "ollama/qwen3:8b",
+            "summarize": "openai/gpt-4o",
+            "serialize": "openai/o1-mini",
+        }
+        config = ProvidersConfig.from_dict(data)
+
+        assert config.default == "ollama/qwen3:8b"
+        assert config.discuss == "ollama/qwen3:8b"
+        assert config.summarize == "openai/gpt-4o"
+        assert config.serialize == "openai/o1-mini"
+
+    def test_from_dict_empty_uses_defaults(self) -> None:
+        """Empty dict uses system defaults."""
+        config = ProvidersConfig.from_dict({})
+
+        assert config.default == f"{DEFAULT_PROVIDER}/{DEFAULT_MODEL}"
+        assert config.discuss is None
+        assert config.summarize is None
+        assert config.serialize is None
+
+    def test_get_discuss_provider_from_config(self) -> None:
+        """get_discuss_provider returns config value when set."""
+        config = ProvidersConfig(
+            default="ollama/qwen3:8b",
+            discuss="openai/gpt-4o",
+        )
+
+        with patch.dict("os.environ", {}, clear=True):
+            assert config.get_discuss_provider() == "openai/gpt-4o"
+
+    def test_get_discuss_provider_fallback_to_default(self) -> None:
+        """get_discuss_provider falls back to default when not set."""
+        config = ProvidersConfig(default="ollama/qwen3:8b")
+
+        with patch.dict("os.environ", {}, clear=True):
+            assert config.get_discuss_provider() == "ollama/qwen3:8b"
+
+    def test_get_discuss_provider_env_override(self) -> None:
+        """Environment variable overrides config value."""
+        config = ProvidersConfig(
+            default="ollama/qwen3:8b",
+            discuss="openai/gpt-4o",
+        )
+
+        with patch.dict("os.environ", {"QF_PROVIDER_DISCUSS": "anthropic/claude-3"}):
+            assert config.get_discuss_provider() == "anthropic/claude-3"
+
+    def test_get_summarize_provider_from_config(self) -> None:
+        """get_summarize_provider returns config value when set."""
+        config = ProvidersConfig(
+            default="ollama/qwen3:8b",
+            summarize="openai/gpt-4o",
+        )
+
+        with patch.dict("os.environ", {}, clear=True):
+            assert config.get_summarize_provider() == "openai/gpt-4o"
+
+    def test_get_summarize_provider_fallback_to_default(self) -> None:
+        """get_summarize_provider falls back to default when not set."""
+        config = ProvidersConfig(default="ollama/qwen3:8b")
+
+        with patch.dict("os.environ", {}, clear=True):
+            assert config.get_summarize_provider() == "ollama/qwen3:8b"
+
+    def test_get_summarize_provider_env_override(self) -> None:
+        """Environment variable overrides config value."""
+        config = ProvidersConfig(
+            default="ollama/qwen3:8b",
+            summarize="openai/gpt-4o",
+        )
+
+        with patch.dict("os.environ", {"QF_PROVIDER_SUMMARIZE": "anthropic/claude-3"}):
+            assert config.get_summarize_provider() == "anthropic/claude-3"
+
+    def test_get_serialize_provider_from_config(self) -> None:
+        """get_serialize_provider returns config value when set."""
+        config = ProvidersConfig(
+            default="ollama/qwen3:8b",
+            serialize="openai/o1-mini",
+        )
+
+        with patch.dict("os.environ", {}, clear=True):
+            assert config.get_serialize_provider() == "openai/o1-mini"
+
+    def test_get_serialize_provider_fallback_to_default(self) -> None:
+        """get_serialize_provider falls back to default when not set."""
+        config = ProvidersConfig(default="ollama/qwen3:8b")
+
+        with patch.dict("os.environ", {}, clear=True):
+            assert config.get_serialize_provider() == "ollama/qwen3:8b"
+
+    def test_get_serialize_provider_env_override(self) -> None:
+        """Environment variable overrides config value."""
+        config = ProvidersConfig(
+            default="ollama/qwen3:8b",
+            serialize="openai/o1-mini",
+        )
+
+        with patch.dict("os.environ", {"QF_PROVIDER_SERIALIZE": "openai/o3-mini"}):
+            assert config.get_serialize_provider() == "openai/o3-mini"
+
+
+# --- Tests for ProjectConfig with hybrid providers ---
+
+
+class TestProjectConfigHybridProviders:
+    """Tests for ProjectConfig with hybrid provider support."""
+
+    def test_from_dict_backward_compatible(self) -> None:
+        """Parsing old format with only default provider still works."""
+        data = {
+            "name": "test-project",
+            "providers": {
+                "default": "ollama/qwen3:8b",
+            },
+        }
+        config = ProjectConfig.from_dict(data)
+
+        # Legacy field populated
+        assert config.provider.name == "ollama"
+        assert config.provider.model == "qwen3:8b"
+
+        # New field also populated
+        assert config.providers.default == "ollama/qwen3:8b"
+        assert config.providers.discuss is None
+        assert config.providers.serialize is None
+
+    def test_from_dict_with_hybrid_providers(self) -> None:
+        """Parsing new format with phase-specific providers."""
+        data = {
+            "name": "hybrid-project",
+            "providers": {
+                "default": "ollama/qwen3:8b",
+                "discuss": "ollama/qwen3:8b",
+                "summarize": "openai/gpt-4o",
+                "serialize": "openai/o1-mini",
+            },
+        }
+        config = ProjectConfig.from_dict(data)
+
+        # Legacy field uses default
+        assert config.provider.name == "ollama"
+        assert config.provider.model == "qwen3:8b"
+
+        # New field has all values
+        assert config.providers.default == "ollama/qwen3:8b"
+        assert config.providers.discuss == "ollama/qwen3:8b"
+        assert config.providers.summarize == "openai/gpt-4o"
+        assert config.providers.serialize == "openai/o1-mini"
+
+    def test_from_dict_provider_without_model(self) -> None:
+        """Provider string without model uses default model."""
+        data = {
+            "name": "test",
+            "providers": {
+                "default": "openai",  # No model specified
+            },
+        }
+        config = ProjectConfig.from_dict(data)
+
+        # Should use DEFAULT_MODEL
+        assert config.provider.name == "openai"
+        assert config.provider.model == DEFAULT_MODEL
+
+
+# --- Tests for create_default_config ---
+
+
+class TestCreateDefaultConfig:
+    """Tests for create_default_config function."""
+
+    def test_create_default_config_no_provider(self) -> None:
+        """Create config with system defaults."""
+        config = create_default_config("test-project")
+
+        assert config.name == "test-project"
+        assert config.provider.name == DEFAULT_PROVIDER
+        assert config.provider.model == DEFAULT_MODEL
+        assert config.providers.default == f"{DEFAULT_PROVIDER}/{DEFAULT_MODEL}"
+
+    def test_create_default_config_with_provider(self) -> None:
+        """Create config with explicit provider."""
+        config = create_default_config("test-project", provider="openai/gpt-4o")
+
+        assert config.name == "test-project"
+        assert config.provider.name == "openai"
+        assert config.provider.model == "gpt-4o"
+        assert config.providers.default == "openai/gpt-4o"
+
+    def test_create_default_config_provider_without_model(self) -> None:
+        """Create config with provider but no model uses default model."""
+        config = create_default_config("test-project", provider="anthropic")
+
+        assert config.provider.name == "anthropic"
+        assert config.provider.model == DEFAULT_MODEL
+        assert config.providers.default == "anthropic"


### PR DESCRIPTION
## Problem

The current configuration only supports a single LLM provider for all pipeline phases. Model comparison analysis (#168) shows that different models excel at different tasks - GPT-4o is strong at discussion but weak at serialization, while reasoning models may excel at structured output. Supporting hybrid configurations would allow leveraging each model's strengths.

## Changes

- Add `ProvidersConfig` dataclass with phase-specific provider overrides
- Support new config structure with `discuss`, `summarize`, `serialize` fields
- Add environment variable support for phase overrides:
  - `QF_PROVIDER_DISCUSS`
  - `QF_PROVIDER_SUMMARIZE`
  - `QF_PROVIDER_SERIALIZE`
- Update `ProjectConfig` to include both legacy `provider` and new `providers` fields
- Update `create_default_config()` to accept optional provider parameter
- Add comprehensive tests for the new configuration parsing

## Not Included / Future PRs

- Orchestrator changes to use phase-specific providers (PR #3)
- CLI flags for `--provider-discuss`, `--provider-summarize`, `--provider-serialize` (PR #4)

## Test Plan

```bash
uv run pytest tests/unit/test_config.py -v
# All 18 tests pass

uv run pytest tests/unit/test_orchestrator.py -v
# All 26 tests pass (backward compatibility verified)
```

## Risk / Rollback

- Low risk: Additive changes only
- Backward compatible: existing configs continue to work
- Can be rolled back by reverting this single commit

Refs: #166

🤖 Generated with [Claude Code](https://claude.com/claude-code)