### PR TITLE
feat(orchestrator): add phase-aware model selection for hybrid providers

### DIFF
--- a/src/questfoundry/pipeline/stages/base.py
+++ b/src/questfoundry/pipeline/stages/base.py
@@ -21,6 +21,8 @@ class Stage(Protocol):
     - Discuss: Explore with research tools
     - Summarize: Condense discussion into brief
     - Serialize: Convert brief to structured artifact
+
+    Each phase can optionally use a different LLM provider (hybrid model support).
     """
 
     name: str
@@ -36,18 +38,26 @@ class Stage(Protocol):
         on_assistant_message: AssistantMessageFn | None = None,
         on_llm_start: LLMCallbackFn | None = None,
         on_llm_end: LLMCallbackFn | None = None,
+        summarize_model: BaseChatModel | None = None,
+        serialize_model: BaseChatModel | None = None,
+        summarize_provider_name: str | None = None,
+        serialize_provider_name: str | None = None,
     ) -> tuple[dict[str, Any], int, int]:
         """Execute the stage.
 
         Args:
-            model: LangChain chat model for all phases.
+            model: LangChain chat model for discuss phase (and default for others).
             user_prompt: The user's creative input.
-            provider_name: Provider name for structured output strategy.
+            provider_name: Provider name for discuss phase (and default for others).
             interactive: Enable interactive multi-turn discussion mode.
             user_input_fn: Async function to get user input (for interactive mode).
             on_assistant_message: Callback when assistant responds.
             on_llm_start: Callback when LLM call starts.
             on_llm_end: Callback when LLM call ends.
+            summarize_model: Optional LLM model for summarize phase (defaults to model).
+            serialize_model: Optional LLM model for serialize phase (defaults to model).
+            summarize_provider_name: Provider name for summarize phase.
+            serialize_provider_name: Provider name for serialize phase.
 
         Returns:
             Tuple of (artifact_data, llm_calls, tokens_used).

--- a/src/questfoundry/pipeline/stages/dream.py
+++ b/src/questfoundry/pipeline/stages/dream.py
@@ -67,13 +67,17 @@ class DreamStage:
         on_llm_end: LLMCallbackFn | None = None,
         project_path: Path | None = None,  # noqa: ARG002 - API consistency
         callbacks: list[BaseCallbackHandler] | None = None,
+        summarize_model: BaseChatModel | None = None,
+        serialize_model: BaseChatModel | None = None,
+        summarize_provider_name: str | None = None,  # noqa: ARG002 - for future use
+        serialize_provider_name: str | None = None,
     ) -> tuple[dict[str, Any], int, int]:
         """Execute the DREAM stage using the 3-phase pattern.
 
         Args:
-            model: LangChain chat model for all phases.
+            model: LangChain chat model for discuss phase (and default for others).
             user_prompt: The user's story idea.
-            provider_name: Provider name for structured output strategy selection.
+            provider_name: Provider name for discuss phase.
             interactive: Enable interactive multi-turn discussion mode.
             user_input_fn: Async function to get user input (for interactive mode).
             on_assistant_message: Callback when assistant responds.
@@ -81,6 +85,10 @@ class DreamStage:
             on_llm_end: Callback when LLM call ends.
             project_path: Path to project directory (unused by DREAM, for API consistency).
             callbacks: LangChain callback handlers for logging LLM calls.
+            summarize_model: Optional model for summarize phase (defaults to model).
+            serialize_model: Optional model for serialize phase (defaults to model).
+            summarize_provider_name: Provider name for summarize phase (for future use).
+            serialize_provider_name: Provider name for serialize phase.
 
         Returns:
             Tuple of (artifact_data, llm_calls, tokens_used).
@@ -122,23 +130,23 @@ class DreamStage:
         total_llm_calls += discuss_calls
         total_tokens += discuss_tokens
 
-        # Phase 2: Summarize
+        # Phase 2: Summarize (use summarize_model if provided)
         log.debug("dream_phase", phase="summarize")
         brief, summarize_tokens = await summarize_discussion(
-            model=model,
+            model=summarize_model or model,
             messages=messages,
             callbacks=callbacks,
         )
         total_llm_calls += 1  # Summarize is a single call
         total_tokens += summarize_tokens
 
-        # Phase 3: Serialize
+        # Phase 3: Serialize (use serialize_model if provided)
         log.debug("dream_phase", phase="serialize")
         artifact, serialize_tokens = await serialize_to_artifact(
-            model=model,
+            model=serialize_model or model,
             brief=brief,
             schema=DreamArtifact,
-            provider_name=provider_name,
+            provider_name=serialize_provider_name or provider_name,
             callbacks=callbacks,
         )
         total_llm_calls += 1  # Count as 1 even with retries (simplification)


### PR DESCRIPTION
## Summary
- Add infrastructure for using different LLM models for each pipeline phase (discuss, summarize, serialize)
- Add helper methods for provider string parsing and model creation
- Update Stage protocol with optional `summarize_model`, `serialize_model`, and provider name params
- Update dream, brainstorm, seed stages to accept and use phase-specific models

## Changes
This PR implements the orchestrator side of hybrid model support (#166):

- **orchestrator.py**: Add `_get_summarize_model()` and `_get_serialize_model()` methods that respect phase-specific provider config from PR #171. Models are lazily created and cached; when the same provider is used for multiple phases, the same model instance is reused.
- **base.py**: Update Stage protocol with optional phase-specific model parameters
- **dream.py, brainstorm.py, seed.py**: Accept optional `summarize_model` and `serialize_model` parameters and use them in the appropriate phases

## Not Included / Future PRs
- CLI flags for `--provider-discuss`, `--provider-summarize`, `--provider-serialize` (PR #4)
- Documentation (PR #5)

## Test Plan
- [x] All unit tests pass (orchestrator, config, provider tests)
- [x] Import tests pass for all modified modules
- [x] Type checking passes with mypy
- [x] Linting passes with ruff

## Risk / Rollback
- Backward compatible: optional parameters default to existing behavior
- Stacked on PR #171 (`feat/hybrid-provider-config`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)