### PR TITLE
fix(prompts): defensive prompt engineering for ID constraints

### DIFF
--- a/prompts/templates/discuss_brainstorm.yaml
+++ b/prompts/templates/discuss_brainstorm.yaml
@@ -35,6 +35,30 @@ system: |
   Good: "Is the mentor benevolent or self-serving?" (yes/no)
   Good: "Is the archive's knowledge salvation or corruption?" (binary choice)
   Bad: "What is the mentor's alignment?" (open-ended, not binary)
+
+  ## Tension ID Naming
+  Use descriptive binary format: `subject_optionA_or_optionB`
+
+  GOOD: `host_benevolent_or_self_serving`, `butler_loyal_or_treacherous`
+  BAD: `t1`, `host_motivation`, `butler_trust` (too short or ambiguous)
+
+  ## What NOT to Do
+  - Do NOT write prose paragraphs with backstories - use concise notes
+  - Do NOT include atmospheric descriptions - save prose for FILL stage
+  - Do NOT end with "let me know if you need..." - this is not a chat
+  - Do NOT ask clarifying questions in non-interactive mode
+  - Do NOT use short codes like `t1`, `t2` for tension IDs - use descriptive names
+
+  ## Output Format Examples
+
+  BAD entity description:
+  "Detective Eleanor Chase is a seasoned private investigator known for her
+  sharp wit and keen observational skills. She has a penchant for classical
+  music and is always impeccably dressed."
+
+  GOOD entity description:
+  "Concept: Seasoned detective with sharp wit. Notes: Classical music lover,
+  impeccable dresser - surface polish hiding relentless curiosity."
   {mode_section}
 
 non_interactive_section: |

--- a/prompts/templates/discuss_seed.yaml
+++ b/prompts/templates/discuss_seed.yaml
@@ -77,6 +77,25 @@ system: |
   3. **Entity Coverage**: Every entity needs a retain/cut decision.
      - Characters, locations, objects, AND factions
      - No entity should be left undecided
+
+  ## Thread Naming
+
+  When creating threads from tensions:
+  - Thread IDs should be SHORT and distinct from tension IDs
+  - Example: tension `library_knowledge_salvation_or_corruption` → thread `library_secret`
+  - Example: tension `host_benevolent_or_self_serving` → thread `host_motive`
+
+  BAD: Using the same ID for thread and tension
+  GOOD: Thread ID summarizes the storyline, tension ID shows the binary choice
+
+  ## What NOT to Do
+
+  - Do NOT skip beat creation - beats are REQUIRED, not optional
+  - Do NOT end with "Good luck!" or similar pleasantries
+  - Do NOT write prose descriptions - use structured beat entries
+  - Do NOT stop at 2 beats per thread - aim for 3-4
+  - Do NOT reuse tension IDs as thread IDs - they must be different
+  - Do NOT ask clarifying questions in non-interactive mode
   {mode_section}
 
 non_interactive_section: |

--- a/prompts/templates/serialize_brainstorm.yaml
+++ b/prompts/templates/serialize_brainstorm.yaml
@@ -24,7 +24,7 @@ system: |
   ## Tension Structure
 
   Tensions represent binary dramatic questions with exactly TWO alternatives:
-  - `tension_id`: Short snake_case identifier
+  - `tension_id`: Descriptive snake_case identifier showing the binary choice
   - `question`: The dramatic question (should end with "?")
   - `alternatives`: Exactly 2 items, each with:
     - `alternative_id`: Unique short identifier for THIS alternative (e.g., "guilty", "framed", "dagger", "poison")
@@ -32,6 +32,24 @@ system: |
     - `is_default_path`: true for ONE alternative (the default path), false for the other
   - `central_entity_ids`: List of entity_id values related to this tension
   - `why_it_matters`: Thematic stakes
+
+  ## Tension ID Naming (CRITICAL)
+
+  Use descriptive binary format that shows both options: `subject_optionA_or_optionB`
+
+  GOOD examples:
+  - `host_benevolent_or_self_serving`
+  - `butler_loyal_or_treacherous`
+  - `artifact_authentic_or_forgery`
+  - `library_knowledge_salvation_or_corruption`
+
+  BAD examples (will cause downstream failures):
+  - `t1`, `t2`, `tension_a` (too short, not descriptive)
+  - `host_motivation` (ambiguous, could be confused with thread name)
+  - `butler_trust` (too vague)
+  - `murder_intent` (could be mistaken for a thread ID)
+
+  The tension_id should clearly show the binary choice being made.
 
   ## Guidelines
 

--- a/prompts/templates/serialize_seed_sections.yaml
+++ b/prompts/templates/serialize_seed_sections.yaml
@@ -77,6 +77,21 @@ threads_prompt: |
   }
   ```
 
+  ## Thread ID Naming (CRITICAL)
+
+  Thread IDs must be DIFFERENT from tension IDs. Use short descriptive names.
+
+  GOOD examples:
+  - tension `host_benevolent_or_self_serving` → thread `host_motive`
+  - tension `butler_loyal_or_treacherous` → thread `butler_loyalty`
+  - tension `library_knowledge_salvation_or_corruption` → thread `library_secret`
+
+  BAD examples (will cause validation failures):
+  - tension `murder_intent` → thread `murder_intent` (same ID - WRONG!)
+  - Using the tension_id as the thread_id
+
+  Thread IDs should be short names for the storyline, NOT the binary question.
+
   ## Rules
   - thread_importance must be exactly "major" or "minor" (lowercase)
   - unexplored_alternative_ids: IDs of alternatives NOT explored (implicit ones)
@@ -118,25 +133,36 @@ consequences_prompt: |
 beats_prompt: |
   You are extracting INITIAL BEATS from a SEED stage brief.
 
+  ## CRITICAL: ID CONSTRAINTS (read first!)
+
+  The brief contains valid ID lists. You MUST copy IDs exactly from these lists:
+  - `## VALID THREAD IDs` - use ONLY these in `threads` arrays
+  - `### Entity IDs` - use ONLY these in `entities` and `location` fields
+
+  WRONG examples that WILL FAIL:
+  - `"clock_distortion"` - NOT a valid thread (derived from concept)
+  - `"the_garden"` - WRONG, use `"garden"` (no prefix)
+  - `"murder_intent"` - This is a tension ID, not a thread ID
+
   ## Schema
-  Return a JSON object with an "initial_beats" array. Each item is an InitialBeat:
+  Return a JSON object with an "initial_beats" array:
   ```json
   {
     "initial_beats": [
       {
         "beat_id": "unique_beat_id",
         "summary": "What happens in this beat",
-        "threads": ["thread_id_1", "thread_id_2"],
+        "threads": ["host_motive", "butler_fidelity"],
         "tension_impacts": [
           {
-            "tension_id": "which_tension",
+            "tension_id": "host_benevolent_or_self_serving",
             "effect": "advances",
             "note": "Explanation of the impact"
           }
         ],
-        "entities": ["entity_id_1", "entity_id_2"],
-        "location": "location_entity_id",
-        "location_alternatives": ["other_location_id"]
+        "entities": ["butler", "garden"],
+        "location": "garden",
+        "location_alternatives": ["library"]
       }
     ]
   }
@@ -144,10 +170,18 @@ beats_prompt: |
 
   ## Rules
   - effect must be exactly "advances", "reveals", "commits", or "complicates"
-  - threads: Array of thread IDs this beat serves
-  - location: Primary location entity ID (can be null)
-  - location_alternatives: Other valid locations (can be empty array)
+  - threads: Array of thread IDs from the VALID THREAD IDs list ONLY
+  - entities: Array of entity IDs from the Entity IDs list ONLY
+  - location: Entity ID from locations list (can be null)
+  - location_alternatives: Other valid location IDs (can be empty array)
   - Include ALL initial beats mentioned in the Initial Beats section
+
+  ## FINAL CHECK (verify before output)
+  Before returning JSON, check each beat:
+  1. Every `threads` item appears in the ## VALID THREAD IDs list
+  2. Every `entities` item appears in the ### Entity IDs list
+  3. `location` appears in the Locations section
+  4. No invented IDs, no prefixes added
 
   ## Output
   Return ONLY valid JSON with the "initial_beats" array.

--- a/src/questfoundry/graph/context.py
+++ b/src/questfoundry/graph/context.py
@@ -28,7 +28,8 @@ def format_thread_ids_context(threads: list[dict[str, Any]]) -> str:
     if not threads:
         return ""
 
-    thread_ids = [t.get("thread_id", "") for t in threads if t.get("thread_id")]
+    # Sort for deterministic output across runs
+    thread_ids = sorted(tid for t in threads if (tid := t.get("thread_id")))
 
     if not thread_ids:
         return ""


### PR DESCRIPTION
## Problem

SEED stage failures due to LLMs inventing or modifying IDs instead of using exact IDs from earlier stages:
- Thread ID invention: `clock_distortion` created when only `host_motive`, `butler_fidelity` exist
- Entity ID modification: `the_garden` used when brainstorm has `garden` (prefix added)
- Tension/Thread confusion: Using tension IDs in thread arrays

Root cause: Small models (8B) don't "look back" at ID lists referenced earlier in the prompt. Constraints must be visible at the point where the model generates the constrained output.

## Changes

### Code Changes
- `src/questfoundry/graph/context.py`: Add `format_thread_ids_context()` with pipe-delimited format and explicit WRONG examples
- `src/questfoundry/agents/serialize.py`: Inject thread IDs before beats serialization

### Prompt Engineering Patterns Applied
- **Pipe-delimited format**: `host_motive | butler_fidelity` for easy scanning
- **Sandwich pattern**: ID constraints at START and END of beats_prompt
- **Explicit WRONG examples**: Show `clock_distortion` will fail validation
- **Inline schema examples**: Use concrete IDs not placeholders
- **FINAL CHECK section**: Tell model to verify before output
- **Binary tension naming**: `subject_optionA_or_optionB` format

### Prompt Files Updated
- `prompts/templates/discuss_brainstorm.yaml`: Added tension ID naming guidance and "What NOT to Do"
- `prompts/templates/discuss_seed.yaml`: Added thread naming guidance and "What NOT to Do"  
- `prompts/templates/serialize_brainstorm.yaml`: Added tension ID naming examples
- `prompts/templates/serialize_seed_sections.yaml`: Complete rewrite of beats_prompt with sandwich pattern

### Documentation
- `CLAUDE.md`: Added sections 6-7 on Valid ID Injection and Defensive Prompt Patterns

## Not Included / Future PRs

- Entity ID prefix normalization (e.g., `the_garden` → `garden`) - different class of fix
- Additional validation retry logic

## Test Plan

- [x] `uv run pytest tests/` - passes (1 fail due to Ollama unavailable, unrelated)
- [x] Verified `format_thread_ids_context()` produces correct output
- [ ] Manual test with SEED stage on problematic brainstorms

## Risk / Rollback

Low risk - prompt-only changes with one small code change for thread ID injection. Can be reverted cleanly.

Fixes #183, #181, #169

🤖 Generated with [Claude Code](https://claude.com/claude-code)