### PR TITLE
fix: preserve thread IDs context in semantic retry

### DIFF
--- a/src/questfoundry/agents/serialize.py
+++ b/src/questfoundry/agents/serialize.py
@@ -565,8 +565,11 @@ async def serialize_seed_iteratively(
     for section_name, schema, output_field in sections:
         log.debug("serialize_section_started", section=section_name)
 
-        # Use brief with thread IDs for beats section (threads are known by then)
-        current_brief = brief_with_threads if section_name == "beats" else enhanced_brief
+        # Use brief with thread IDs for sections that reference threads
+        # (beats and consequences both have thread_id fields)
+        current_brief = (
+            brief_with_threads if section_name in ("beats", "consequences") else enhanced_brief
+        )
 
         section_prompt = prompts[section_name]
         section_result, section_tokens = await serialize_to_artifact(
@@ -639,8 +642,9 @@ async def serialize_seed_iteratively(
             )
 
             # Re-serialize problematic sections with feedback appended to brief
+            # Use brief_with_threads (not enhanced_brief) to preserve thread ID context
             brief_with_feedback = (
-                f"{enhanced_brief}\n\n## VALIDATION ERRORS - PLEASE FIX\n\n{feedback}"
+                f"{brief_with_threads}\n\n## VALIDATION ERRORS - PLEASE FIX\n\n{feedback}"
             )
 
             for section_name, schema, output_field in sections:

--- a/tests/unit/test_serialize.py
+++ b/tests/unit/test_serialize.py
@@ -666,3 +666,214 @@ class TestSerializeSeedIterativelySemanticValidation:
 
             assert len(exc_info.value.errors) == 1
             assert "threads.0.tension_id" in exc_info.value.errors[0].field_path
+
+    @pytest.mark.asyncio
+    async def test_consequences_section_gets_thread_ids_context(self) -> None:
+        """Consequences section should receive brief with thread IDs (regression test).
+
+        Bug: consequences has thread_id field but was using enhanced_brief (no thread IDs).
+        Fix: consequences section now uses brief_with_threads like beats.
+        """
+        from unittest.mock import MagicMock
+
+        from questfoundry.agents.serialize import serialize_seed_iteratively
+
+        mock_model = MagicMock()
+        mock_graph = MagicMock()
+
+        briefs_received: dict[str, str] = {}
+        call_count = [0]
+
+        # Map section names to their expected output fields
+        section_to_field = {
+            "entities": "entities",
+            "tensions": "tensions",
+            "threads": "threads",
+            "consequences": "consequences",
+            "beats": "initial_beats",
+            "convergence": "convergence_sketch",
+        }
+
+        def capture_brief_side_effect(*_args, **kwargs):
+            call_count[0] += 1
+            brief = kwargs.get("brief", "")
+            # Map call number to section
+            section_map = {
+                1: "entities",
+                2: "tensions",
+                3: "threads",
+                4: "consequences",
+                5: "beats",
+                6: "convergence",
+            }
+            section = section_map.get(call_count[0], "unknown")
+            briefs_received[section] = brief
+            output_field = section_to_field.get(section, section)
+
+            if section == "convergence":
+                return (
+                    MagicMock(
+                        model_dump=lambda: {
+                            "convergence_sketch": {"convergence_points": [], "residue_notes": []}
+                        }
+                    ),
+                    10,
+                )
+            if section == "threads":
+                # Return a valid thread with thread_id for format_thread_ids_context
+                return (
+                    MagicMock(
+                        model_dump=lambda: {
+                            "threads": [
+                                {
+                                    "thread_id": "thread_1",
+                                    "name": "Test Thread",
+                                    "tension_id": "tension_1",
+                                    "alternative_id": "alt_1",
+                                    "unexplored_alternative_ids": [],
+                                    "thread_importance": "major",
+                                    "description": "Test description",
+                                    "consequence_ids": [],
+                                }
+                            ]
+                        }
+                    ),
+                    10,
+                )
+            return (MagicMock(model_dump=lambda f=output_field: {f: []}), 10)
+
+        with (
+            patch(
+                "questfoundry.agents.serialize.serialize_to_artifact",
+                side_effect=capture_brief_side_effect,
+            ),
+            patch("questfoundry.agents.serialize.validate_seed_mutations", return_value=[]),
+        ):
+            await serialize_seed_iteratively(
+                model=mock_model,
+                brief="Test brief",
+                graph=mock_graph,
+            )
+
+        # Both beats and consequences should have thread IDs context
+        assert "## VALID THREAD IDs" in briefs_received["beats"]
+        assert "## VALID THREAD IDs" in briefs_received["consequences"]
+        # Earlier sections should NOT have thread IDs
+        assert "## VALID THREAD IDs" not in briefs_received["entities"]
+        assert "## VALID THREAD IDs" not in briefs_received["tensions"]
+
+    @pytest.mark.asyncio
+    async def test_semantic_retry_preserves_thread_ids_context(self) -> None:
+        """Semantic retry should use brief_with_threads, not enhanced_brief (regression test).
+
+        Bug: Retry used enhanced_brief as base, losing thread IDs context on retry.
+        Fix: Retry now uses brief_with_threads as base.
+        """
+        from unittest.mock import MagicMock
+
+        from questfoundry.agents.serialize import serialize_seed_iteratively
+        from questfoundry.graph.mutations import SeedValidationError
+
+        mock_model = MagicMock()
+        mock_graph = MagicMock()
+
+        briefs_received: list[tuple[str, str]] = []
+        call_count = [0]
+
+        # Map section names to their expected output fields
+        section_to_field = {
+            "entities": "entities",
+            "tensions": "tensions",
+            "threads": "threads",
+            "consequences": "consequences",
+            "beats": "initial_beats",
+            "beats_retry": "initial_beats",
+            "convergence": "convergence_sketch",
+        }
+
+        def capture_brief_side_effect(*_args, **kwargs):
+            call_count[0] += 1
+            brief = kwargs.get("brief", "")
+            section_map = {
+                1: "entities",
+                2: "tensions",
+                3: "threads",
+                4: "consequences",
+                5: "beats",
+                6: "convergence",
+                7: "beats_retry",  # Retry for beats
+            }
+            section = section_map.get(call_count[0], "unknown")
+            briefs_received.append((section, brief))
+            output_field = section_to_field.get(section, section)
+
+            if "convergence" in section:
+                return (
+                    MagicMock(
+                        model_dump=lambda: {
+                            "convergence_sketch": {"convergence_points": [], "residue_notes": []}
+                        }
+                    ),
+                    10,
+                )
+            if section == "threads":
+                # Return a valid thread with thread_id for format_thread_ids_context
+                return (
+                    MagicMock(
+                        model_dump=lambda: {
+                            "threads": [
+                                {
+                                    "thread_id": "thread_1",
+                                    "name": "Test Thread",
+                                    "tension_id": "tension_1",
+                                    "alternative_id": "alt_1",
+                                    "unexplored_alternative_ids": [],
+                                    "thread_importance": "major",
+                                    "description": "Test description",
+                                    "consequence_ids": [],
+                                }
+                            ]
+                        }
+                    ),
+                    10,
+                )
+            return (MagicMock(model_dump=lambda f=output_field: {f: []}), 10)
+
+        validation_call_count = [0]
+
+        def mock_validate_side_effect(_graph, _output):
+            validation_call_count[0] += 1
+            if validation_call_count[0] == 1:
+                # First validation: error in beats section
+                return [
+                    SeedValidationError(
+                        field_path="initial_beats.0.thread_id",
+                        issue="Thread not found",
+                        available=["thread_1"],
+                        provided="invalid_thread",
+                    )
+                ]
+            return []
+
+        with (
+            patch(
+                "questfoundry.agents.serialize.serialize_to_artifact",
+                side_effect=capture_brief_side_effect,
+            ),
+            patch(
+                "questfoundry.agents.serialize.validate_seed_mutations",
+                side_effect=mock_validate_side_effect,
+            ),
+        ):
+            await serialize_seed_iteratively(
+                model=mock_model,
+                brief="Test brief",
+                graph=mock_graph,
+            )
+
+        # Find the retry call for beats
+        retry_brief = next(brief for section, brief in briefs_received if section == "beats_retry")
+
+        # Retry should have BOTH thread IDs context AND validation errors
+        assert "## VALID THREAD IDs" in retry_brief, "Retry lost thread IDs context"
+        assert "VALIDATION ERRORS" in retry_brief, "Retry should have error feedback"


### PR DESCRIPTION
## Problem

The semantic retry loop was using `enhanced_brief` as the base for `brief_with_feedback`, but `enhanced_brief` does not include the thread IDs context that was injected after threads serialization.

This caused retries for beats and consequences sections to lose the `## VALID THREAD IDs` guidance, leading to **0% correction rate** on seq-1 and seq-3 test runs.

**Root cause identified by Codex agent:**
- First pass for `beats`: uses `brief_with_threads` (has thread ID injection) ✅
- Retry for `beats`: uses `enhanced_brief` (missing thread IDs!) ❌
- Also: `consequences` section never got thread ID context on first pass, even though it also references `thread_id`

## Changes

- Fix: `consequences` section now uses `brief_with_threads` (like `beats`)
- Fix: semantic retry uses `brief_with_threads` as base, not `enhanced_brief`
- Add 2 regression tests to prevent future regressions

## Not Included / Future PRs

- PR #2 (#186): Add `repair_seed_brief()` function for surgical ID repair
- PR #3 (#186): Implement two-level feedback loop wrapper

## Test Plan

```bash
uv run pytest tests/unit/test_serialize.py -v -k "thread_ids"
# tests/unit/test_serialize.py::...test_consequences_section_gets_thread_ids_context PASSED
# tests/unit/test_serialize.py::...test_semantic_retry_preserves_thread_ids_context PASSED

uv run pytest tests/unit/test_serialize.py -v
# 34 passed

uv run pytest tests/unit/ -v
# 706 passed
```

## Risk / Rollback

Low risk - this is a correctness fix for an existing bug. The change is minimal (~5 lines of actual logic) and well-tested.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)