### PR TITLE
feat: add repair_seed_brief function for surgical ID repair

### DIFF
--- a/prompts/templates/repair_seed_brief.yaml
+++ b/prompts/templates/repair_seed_brief.yaml
@@ -1,0 +1,74 @@
+name: repair_seed_brief
+description: Repair invalid ID references in SEED brief while preserving structure
+
+system: |
+  You are a precision text editor. Your ONLY job is to replace invalid IDs with valid ones.
+
+  ## Your Task
+
+  The brief below contains ID references that don't exist. You must:
+  1. Find each invalid ID mentioned in the errors
+  2. Replace it with the suggested replacement (or closest match from valid options)
+  3. Return the ENTIRE brief with ONLY those IDs changed
+
+  ## CRITICAL RULES
+
+  - DO NOT change any text except the specific invalid IDs listed in the errors
+  - DO NOT add new sections, entities, or concepts
+  - DO NOT remove any content
+  - DO NOT rephrase descriptions or rationales
+  - DO NOT change valid IDs that aren't in the error list
+  - PRESERVE exact formatting, whitespace, and structure
+
+  ## Valid IDs Reference
+
+  {valid_ids_context}
+
+  ## Errors to Fix
+
+  {error_list}
+
+  ## Self-Check Before Responding
+
+  For each error listed above, verify you:
+  1. Found the exact invalid ID string in the brief text
+  2. Selected the suggested replacement (or closest semantic match from "Available")
+  3. Made the replacement at ALL occurrences of that invalid ID
+  4. Changed NOTHING else in that sentence/section
+
+  ## WRONG Examples (do NOT do these)
+
+  WRONG - Adding explanation:
+    Before: "tension_id: archive_access"
+    After:  "tension_id: archive_nature (corrected from archive_access)"
+
+  WRONG - Restructuring:
+    Before: "- entity_id: old_id"
+    After:  "- entity_id:\n      value: new_id"
+
+  WRONG - Over-correcting valid IDs:
+    Before: "tension_id: mentor_trust" (if this is VALID - not in errors)
+    After:  "tension_id: mentor_protector" (WRONG - changed valid ID)
+
+  WRONG - Partial replacement:
+    Before: "threads: host_motive, butler_fidelity, archive_access"
+    After:  "threads: host_motive, butler_fidelity, archive_access"
+    (archive_access should have been replaced!)
+
+  CORRECT - Minimal surgical fix:
+    Before: "tension_id: archive_access"
+    After:  "tension_id: diary_truth"
+
+user: |
+  Here is the brief that needs repair:
+
+  ---
+
+  {brief}
+
+  ---
+
+  Return the complete brief with ONLY the invalid IDs fixed.
+  Do NOT wrap in markdown code blocks. Return the brief text directly.
+
+components: []

--- a/src/questfoundry/agents/prompts.py
+++ b/src/questfoundry/agents/prompts.py
@@ -254,3 +254,35 @@ def get_seed_serialize_prompt() -> str:
     loader = _get_loader()
     template = loader.load("serialize_seed")
     return template.system
+
+
+def get_repair_seed_brief_prompt(
+    valid_ids_context: str,
+    error_list: str,
+    brief: str,
+) -> tuple[str, str]:
+    """Build the repair SEED brief prompt.
+
+    This prompt instructs the model to surgically fix invalid ID references
+    in a brief without changing any other content.
+
+    Args:
+        valid_ids_context: Formatted list of valid IDs from BRAINSTORM.
+        error_list: Formatted list of semantic validation errors with suggestions.
+        brief: The original brief with invalid IDs to repair.
+
+    Returns:
+        Tuple of (system_prompt, user_prompt) for the repair call.
+    """
+    raw_data = _load_raw_template("repair_seed_brief")
+
+    system_template = raw_data.get("system", "")
+    user_template = raw_data.get("user", "")
+
+    system_prompt = ChatPromptTemplate.from_template(system_template)
+    user_prompt = ChatPromptTemplate.from_template(user_template)
+
+    return (
+        system_prompt.format(valid_ids_context=valid_ids_context, error_list=error_list),
+        user_prompt.format(brief=brief),
+    )

--- a/src/questfoundry/agents/summarize.py
+++ b/src/questfoundry/agents/summarize.py
@@ -136,14 +136,14 @@ def _extract_token_usage(response: AIMessage) -> int:
     if hasattr(response, "usage_metadata") and response.usage_metadata:
         tokens = response.usage_metadata.get("total_tokens")
         if tokens is not None:
-            return tokens
+            return int(tokens)
     # Then check response_metadata (OpenAI)
     if hasattr(response, "response_metadata") and response.response_metadata:
         metadata = response.response_metadata
         if "token_usage" in metadata:
             tokens = metadata["token_usage"].get("total_tokens")
             if tokens is not None:
-                return tokens
+                return int(tokens)
     return 0
 
 

--- a/tests/unit/test_summarize.py
+++ b/tests/unit/test_summarize.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -15,6 +14,7 @@ from questfoundry.agents.summarize import (
     repair_seed_brief,
     summarize_discussion,
 )
+from questfoundry.graph.mutations import SeedValidationError
 
 
 class TestGetSummarizePrompt:
@@ -266,18 +266,9 @@ class TestGetFuzzyIdSuggestions:
 class TestFormatRepairErrors:
     """Test error formatting for repair prompt."""
 
-    @dataclass
-    class MockError:
-        """Mock error object for testing."""
-
-        field_path: str
-        issue: str
-        available: list[str]
-        provided: str
-
     def test_formats_single_error(self) -> None:
         """Should format a single error with all fields."""
-        error = self.MockError(
+        error = SeedValidationError(
             field_path="threads.0.tension_id",
             issue="Tension not found",
             available=["mentor_trust", "diary_truth"],
@@ -295,7 +286,7 @@ class TestFormatRepairErrors:
 
     def test_includes_fuzzy_suggestion(self) -> None:
         """Should include fuzzy match suggestion when available."""
-        error = self.MockError(
+        error = SeedValidationError(
             field_path="initial_beats.0.thread_id",
             issue="Thread not found",
             available=["archive_nature", "diary_truth"],
@@ -311,13 +302,13 @@ class TestFormatRepairErrors:
     def test_formats_multiple_errors(self) -> None:
         """Should format multiple errors with numbering."""
         errors = [
-            self.MockError(
+            SeedValidationError(
                 field_path="threads.0.tension_id",
                 issue="Tension not found",
                 available=["t1"],
                 provided="bad_id",
             ),
-            self.MockError(
+            SeedValidationError(
                 field_path="initial_beats.1.entities",
                 issue="Entity not found",
                 available=["e1", "e2"],
@@ -332,7 +323,7 @@ class TestFormatRepairErrors:
 
     def test_truncates_long_available_list(self) -> None:
         """Should truncate available list if longer than 8."""
-        error = self.MockError(
+        error = SeedValidationError(
             field_path="field",
             issue="Not found",
             available=[f"id_{i}" for i in range(15)],
@@ -346,7 +337,7 @@ class TestFormatRepairErrors:
 
     def test_handles_empty_available(self) -> None:
         """Should handle error with no available options."""
-        error = self.MockError(
+        error = SeedValidationError(
             field_path="field",
             issue="Not found",
             available=[],
@@ -408,15 +399,6 @@ class TestGetRepairSeedBriefPrompt:
 class TestRepairSeedBrief:
     """Test repair_seed_brief function."""
 
-    @dataclass
-    class MockError:
-        """Mock error for testing."""
-
-        field_path: str
-        issue: str
-        available: list[str]
-        provided: str
-
     @pytest.mark.asyncio
     async def test_repair_returns_repaired_brief_and_tokens(self) -> None:
         """repair_seed_brief should return repaired brief and token count."""
@@ -426,7 +408,7 @@ class TestRepairSeedBrief:
         mock_model.ainvoke = AsyncMock(return_value=mock_response)
 
         errors = [
-            self.MockError(
+            SeedValidationError(
                 field_path="threads.0.tension_id",
                 issue="Tension not found",
                 available=["mentor_trust"],
@@ -452,7 +434,7 @@ class TestRepairSeedBrief:
         mock_model.ainvoke = AsyncMock(return_value=mock_response)
 
         errors = [
-            self.MockError(
+            SeedValidationError(
                 field_path="field",
                 issue="Issue",
                 available=["valid"],
@@ -482,7 +464,7 @@ class TestRepairSeedBrief:
         mock_model.ainvoke = AsyncMock(return_value=mock_response)
 
         errors = [
-            self.MockError(
+            SeedValidationError(
                 field_path="f",
                 issue="i",
                 available=["a"],
@@ -507,7 +489,7 @@ class TestRepairSeedBrief:
         mock_model.ainvoke = AsyncMock(return_value=mock_response)
 
         errors = [
-            self.MockError(
+            SeedValidationError(
                 field_path="threads.0.tension_id",
                 issue="Tension not found in BRAINSTORM",
                 available=["mentor_trust", "diary_truth"],

--- a/tests/unit/test_summarize.py
+++ b/tests/unit/test_summarize.py
@@ -2,13 +2,19 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from langchain_core.messages import AIMessage, HumanMessage, SystemMessage
 
-from questfoundry.agents.prompts import get_summarize_prompt
-from questfoundry.agents.summarize import summarize_discussion
+from questfoundry.agents.prompts import get_repair_seed_brief_prompt, get_summarize_prompt
+from questfoundry.agents.summarize import (
+    format_repair_errors,
+    get_fuzzy_id_suggestions,
+    repair_seed_brief,
+    summarize_discussion,
+)
 
 
 class TestGetSummarizePrompt:
@@ -222,3 +228,303 @@ class TestSummarizeDiscussion:
         assert "System: System context" in conversation_text
         assert "User: User input" in conversation_text
         assert "Assistant: AI response" in conversation_text
+
+
+class TestGetFuzzyIdSuggestions:
+    """Test fuzzy ID matching."""
+
+    def test_exact_match_returns_first(self) -> None:
+        """Exact match should be returned first."""
+        suggestions = get_fuzzy_id_suggestions("diary_truth", ["diary_truth", "diary_access"])
+        assert suggestions[0] == "diary_truth"
+
+    def test_close_match_found(self) -> None:
+        """Close matches should be found."""
+        suggestions = get_fuzzy_id_suggestions(
+            "archive_access", ["archive_nature", "diary_truth", "mentor_trust"]
+        )
+        assert "archive_nature" in suggestions
+
+    def test_no_match_returns_empty(self) -> None:
+        """When no close match exists, return empty list."""
+        suggestions = get_fuzzy_id_suggestions("completely_different", ["a", "b", "c"])
+        assert suggestions == []
+
+    def test_returns_multiple_suggestions(self) -> None:
+        """Should return multiple suggestions when available."""
+        suggestions = get_fuzzy_id_suggestions(
+            "test_id", ["test_id_1", "test_id_2", "test_id_3"], n=3
+        )
+        assert len(suggestions) <= 3
+
+    def test_empty_available_returns_empty(self) -> None:
+        """Empty available list should return empty."""
+        suggestions = get_fuzzy_id_suggestions("test", [])
+        assert suggestions == []
+
+
+class TestFormatRepairErrors:
+    """Test error formatting for repair prompt."""
+
+    @dataclass
+    class MockError:
+        """Mock error object for testing."""
+
+        field_path: str
+        issue: str
+        available: list[str]
+        provided: str
+
+    def test_formats_single_error(self) -> None:
+        """Should format a single error with all fields."""
+        error = self.MockError(
+            field_path="threads.0.tension_id",
+            issue="Tension not found",
+            available=["mentor_trust", "diary_truth"],
+            provided="archive_access",
+        )
+
+        result = format_repair_errors([error])
+
+        assert "### Error 1" in result
+        assert "`threads.0.tension_id`" in result
+        assert "`archive_access`" in result
+        assert "Tension not found" in result
+        assert "`mentor_trust`" in result
+        assert "`diary_truth`" in result
+
+    def test_includes_fuzzy_suggestion(self) -> None:
+        """Should include fuzzy match suggestion when available."""
+        error = self.MockError(
+            field_path="initial_beats.0.thread_id",
+            issue="Thread not found",
+            available=["archive_nature", "diary_truth"],
+            provided="archive_access",
+        )
+
+        result = format_repair_errors([error])
+
+        # Should suggest archive_nature as closest match to archive_access
+        assert "**Suggested replacement**" in result
+        assert "archive_nature" in result
+
+    def test_formats_multiple_errors(self) -> None:
+        """Should format multiple errors with numbering."""
+        errors = [
+            self.MockError(
+                field_path="threads.0.tension_id",
+                issue="Tension not found",
+                available=["t1"],
+                provided="bad_id",
+            ),
+            self.MockError(
+                field_path="initial_beats.1.entities",
+                issue="Entity not found",
+                available=["e1", "e2"],
+                provided="wrong_entity",
+            ),
+        ]
+
+        result = format_repair_errors(errors)
+
+        assert "### Error 1" in result
+        assert "### Error 2" in result
+
+    def test_truncates_long_available_list(self) -> None:
+        """Should truncate available list if longer than 8."""
+        error = self.MockError(
+            field_path="field",
+            issue="Not found",
+            available=[f"id_{i}" for i in range(15)],
+            provided="bad_id",
+        )
+
+        result = format_repair_errors([error])
+
+        # Should show truncation message
+        assert "... and 7 more" in result
+
+    def test_handles_empty_available(self) -> None:
+        """Should handle error with no available options."""
+        error = self.MockError(
+            field_path="field",
+            issue="Not found",
+            available=[],
+            provided="bad_id",
+        )
+
+        result = format_repair_errors([error])
+
+        assert "### Error 1" in result
+        assert "**Available options**" not in result
+
+
+class TestGetRepairSeedBriefPrompt:
+    """Test repair brief prompt loading."""
+
+    def test_prompt_loads_successfully(self) -> None:
+        """Prompt should load from template file."""
+        system_prompt, user_prompt = get_repair_seed_brief_prompt(
+            valid_ids_context="Valid IDs: a, b, c",
+            error_list="### Error 1\n- Invalid: x",
+            brief="Test brief with x",
+        )
+
+        assert isinstance(system_prompt, str)
+        assert isinstance(user_prompt, str)
+
+    def test_prompt_includes_valid_ids(self) -> None:
+        """System prompt should include valid IDs context."""
+        system_prompt, _ = get_repair_seed_brief_prompt(
+            valid_ids_context="VALID IDS: entity_1, entity_2",
+            error_list="errors",
+            brief="brief",
+        )
+
+        assert "VALID IDS: entity_1, entity_2" in system_prompt
+
+    def test_prompt_includes_errors(self) -> None:
+        """System prompt should include error list."""
+        system_prompt, _ = get_repair_seed_brief_prompt(
+            valid_ids_context="ids",
+            error_list="### Error 1\n- **Invalid ID**: `bad_id`",
+            brief="brief",
+        )
+
+        assert "### Error 1" in system_prompt
+        assert "`bad_id`" in system_prompt
+
+    def test_user_prompt_includes_brief(self) -> None:
+        """User prompt should include the brief to repair."""
+        _, user_prompt = get_repair_seed_brief_prompt(
+            valid_ids_context="ids",
+            error_list="errors",
+            brief="This is the brief with invalid IDs",
+        )
+
+        assert "This is the brief with invalid IDs" in user_prompt
+
+
+class TestRepairSeedBrief:
+    """Test repair_seed_brief function."""
+
+    @dataclass
+    class MockError:
+        """Mock error for testing."""
+
+        field_path: str
+        issue: str
+        available: list[str]
+        provided: str
+
+    @pytest.mark.asyncio
+    async def test_repair_returns_repaired_brief_and_tokens(self) -> None:
+        """repair_seed_brief should return repaired brief and token count."""
+        mock_model = MagicMock()
+        mock_response = AIMessage(content="Repaired brief content")
+        mock_response.usage_metadata = {"total_tokens": 150}
+        mock_model.ainvoke = AsyncMock(return_value=mock_response)
+
+        errors = [
+            self.MockError(
+                field_path="threads.0.tension_id",
+                issue="Tension not found",
+                available=["mentor_trust"],
+                provided="bad_tension",
+            )
+        ]
+
+        repaired, tokens = await repair_seed_brief(
+            model=mock_model,
+            brief="Original brief with bad_tension",
+            errors=errors,
+            valid_ids_context="Valid IDs: mentor_trust",
+        )
+
+        assert repaired == "Repaired brief content"
+        assert tokens == 150
+
+    @pytest.mark.asyncio
+    async def test_repair_calls_model_with_repair_prompt(self) -> None:
+        """repair_seed_brief should use repair prompt structure."""
+        mock_model = MagicMock()
+        mock_response = AIMessage(content="Repaired")
+        mock_model.ainvoke = AsyncMock(return_value=mock_response)
+
+        errors = [
+            self.MockError(
+                field_path="field",
+                issue="Issue",
+                available=["valid"],
+                provided="invalid",
+            )
+        ]
+
+        await repair_seed_brief(
+            model=mock_model,
+            brief="Brief",
+            errors=errors,
+            valid_ids_context="IDs",
+        )
+
+        # Should call ainvoke with 2 messages (system + user)
+        call_args = mock_model.ainvoke.call_args
+        messages = call_args[0][0]
+        assert len(messages) == 2
+        assert isinstance(messages[0], SystemMessage)
+        assert isinstance(messages[1], HumanMessage)
+
+    @pytest.mark.asyncio
+    async def test_repair_handles_missing_token_metadata(self) -> None:
+        """repair_seed_brief should handle responses without token metadata."""
+        mock_model = MagicMock()
+        mock_response = AIMessage(content="Repaired")
+        mock_model.ainvoke = AsyncMock(return_value=mock_response)
+
+        errors = [
+            self.MockError(
+                field_path="f",
+                issue="i",
+                available=["a"],
+                provided="p",
+            )
+        ]
+
+        _, tokens = await repair_seed_brief(
+            model=mock_model,
+            brief="Brief",
+            errors=errors,
+            valid_ids_context="IDs",
+        )
+
+        assert tokens == 0
+
+    @pytest.mark.asyncio
+    async def test_repair_includes_error_in_system_prompt(self) -> None:
+        """repair_seed_brief should include formatted errors in prompt."""
+        mock_model = MagicMock()
+        mock_response = AIMessage(content="Repaired")
+        mock_model.ainvoke = AsyncMock(return_value=mock_response)
+
+        errors = [
+            self.MockError(
+                field_path="threads.0.tension_id",
+                issue="Tension not found in BRAINSTORM",
+                available=["mentor_trust", "diary_truth"],
+                provided="invented_tension",
+            )
+        ]
+
+        await repair_seed_brief(
+            model=mock_model,
+            brief="Brief with invented_tension",
+            errors=errors,
+            valid_ids_context="Valid tension IDs: mentor_trust, diary_truth",
+        )
+
+        call_args = mock_model.ainvoke.call_args
+        system_message = call_args[0][0][0]
+
+        # System prompt should contain the error details
+        assert "`invented_tension`" in system_message.content
+        assert "Tension not found" in system_message.content


### PR DESCRIPTION
## Problem

When semantic validation fails (e.g., invented IDs like `archive_access`), the current retry loop gives the serialize phase the same broken brief every time, resulting in 0% correction rate.

This PR adds the foundation for a two-level feedback loop that can **repair the brief** instead of just retrying serialization.

## Changes

### New Components

1. **Repair Prompt Template** (`prompts/templates/repair_seed_brief.yaml`)
   - Instructs model to surgically fix invalid IDs
   - Includes self-check patterns and negative examples to prevent creative drift
   - Uses "find and replace" framing, not creative rewriting

2. **Fuzzy ID Matching** (`get_fuzzy_id_suggestions`)
   - Uses `difflib.get_close_matches` to suggest replacements
   - 0.4 cutoff for reasonable matches
   - Returns up to 3 suggestions per invalid ID

3. **Error Formatting** (`format_repair_errors`)
   - Action-oriented error messages
   - Includes: location, invalid ID, problem, suggested replacement, available options
   - Truncates long option lists (>8 items)

4. **Repair Function** (`repair_seed_brief`)
   - Takes: original brief, errors, valid IDs context
   - Returns: repaired brief, token count
   - Traceable for LangSmith observability

### Example Error Format

```markdown
### Error 1
- **Location**: `threads.0.tension_id`
- **Invalid ID**: `archive_access`
- **Problem**: Tension not found in BRAINSTORM
- **Suggested replacement**: `archive_nature`
- **Available options**: `mentor_trust`, `diary_truth`, `archive_nature`
```

## Not Included / Future PRs

- PR #3 (#186): Two-level loop wrapper that calls `repair_seed_brief` on semantic failure
- Integration into `serialize_seed_iteratively`

## Test Plan

```bash
uv run pytest tests/unit/test_summarize.py -v
# 32 passed (18 new tests for repair functionality)

uv run pytest tests/unit/ -v
# 722 passed
```

### Tests Added

- `TestGetFuzzyIdSuggestions`: 5 tests for fuzzy matching
- `TestFormatRepairErrors`: 5 tests for error formatting
- `TestGetRepairSeedBriefPrompt`: 4 tests for prompt loading
- `TestRepairSeedBrief`: 4 tests for repair function

## Risk / Rollback

Low risk - this is additive code that's not yet integrated into the main pipeline. The repair function won't be called until PR #3 adds the two-level loop wrapper.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)