### PR TITLE
feat(prompts): add entity checklist to SEED summarize prompt

### DIFF
--- a/prompts/templates/summarize_seed.yaml
+++ b/prompts/templates/summarize_seed.yaml
@@ -8,15 +8,27 @@ system: |
   ## Brainstorm Reference
   {brainstorm_context}
 
+  ## CRITICAL: Complete Coverage Required
+
+  This output MUST include a decision for EVERY entity and tension from brainstorm.
+  Missing items will cause validation failure. Use the checklists below.
+
+  ## Entity Checklist (ALL {entity_count} MUST BE COVERED)
+
+  {entity_checklist}
+
   ## Your Task
   Condense the discussion into a complete story structure:
 
-  ### Entity Decisions
-  For each entity from brainstorm:
-  - id: the entity ID from brainstorm
+  ### Entity Decisions (EXACTLY {entity_count} required)
+  For each entity listed in the checklist above:
+  - id: the EXACT entity ID from the checklist (copy it precisely)
   - disposition: "retained" or "cut"
 
-  ### Tension Decisions
+  WARNING: Do NOT skip any entity. The serializer will FAIL if any entity is missing.
+  Copy each ID exactly as shown in the checklist.
+
+  ### Tension Decisions (ALL {tension_count} required)
   For each tension from brainstorm:
   - tension_id: the tension ID from brainstorm
   - explored: list of alternative IDs that become threads (MUST include canonical)
@@ -54,7 +66,7 @@ system: |
     - tension_id: which tension
     - effect: "advances", "reveals", "commits", or "complicates"
     - note: explanation of the impact
-  - entities: entity IDs present in this beat
+  - entities: entity IDs present in this beat (must be retained entities)
   - location: primary location entity ID (must be a retained location)
   - location_alternatives: other valid location IDs for knot flexibility
 
@@ -67,16 +79,25 @@ system: |
 
   ## Guidelines
   - Be complete - capture ALL decisions discussed
-  - Entity IDs must match those from brainstorm
+  - Entity IDs must match those from brainstorm EXACTLY
   - Every tension must have a decision (explored vs implicit)
   - Canonical alternative MUST be in the explored list
   - Every thread needs at least one consequence
   - Use clear, consistent IDs (snake_case recommended)
 
-  ## FINAL CHECK (verify before submitting)
-  ✓ Beat count: Did you create 2-4 beats PER thread? (3 threads = 6-12 beats)
-  ✓ Location diversity: Does each thread use at least 2 different locations?
-  ✓ Entity coverage: Does every entity have a retain/cut decision?
+  ## SELF-VERIFICATION CHECKLIST (MANDATORY)
+
+  Before outputting, count and verify each of these:
+
+  | Check | Expected | Your Count |
+  |-------|----------|------------|
+  | Entity decisions | {entity_count} | ___ |
+  | Tension decisions | {tension_count} | ___ |
+  | Beats per thread | 2-4 each | ___ |
+  | Locations per thread | 2+ different | ___ |
+
+  If your entity count does NOT equal {entity_count}, STOP and add the missing entities.
+  Go back to the Entity Checklist and ensure every single ID appears in your output.
 
   ## Output Format
   Provide a structured summary with all six sections clearly labeled.

--- a/tests/unit/test_prompts.py
+++ b/tests/unit/test_prompts.py
@@ -1,0 +1,140 @@
+"""Tests for prompt template functions."""
+
+from questfoundry.agents.prompts import (
+    _count_tensions,
+    _extract_entity_checklist,
+    get_seed_summarize_prompt,
+)
+
+
+class TestExtractEntityChecklist:
+    """Test entity checklist extraction from brainstorm context."""
+
+    def test_extracts_entities_by_type(self) -> None:
+        """Should parse entities and group by type."""
+        context = """## Entities from BRAINSTORM
+- **host** (character): A reclusive aristocrat
+- **butler** (character): A decades-old servant
+- **vane_manor** (location): A 1940s English country estate
+- **garden** (location): A manicured garden
+- **golden_cup** (object): A golden cup used during dinner
+"""
+        checklist, count = _extract_entity_checklist(context)
+
+        assert count == 5
+        assert "Characters" in checklist
+        assert "Locations" in checklist
+        assert "Objects" in checklist
+        assert "`host`" in checklist
+        assert "`butler`" in checklist
+        assert "`vane_manor`" in checklist
+        assert "`garden`" in checklist
+        assert "`golden_cup`" in checklist
+        assert "Total: 5 entities" in checklist
+
+    def test_handles_empty_context(self) -> None:
+        """Should return fallback when no entities found."""
+        checklist, count = _extract_entity_checklist("")
+
+        assert count == 0
+        assert "No entities found" in checklist
+
+    def test_handles_factions(self) -> None:
+        """Should include faction type entities."""
+        context = """## Entities from BRAINSTORM
+- **old_family_line** (faction): An established family line
+- **gardener_council** (faction): A group of local gardeners
+"""
+        checklist, count = _extract_entity_checklist(context)
+
+        assert count == 2
+        assert "Factions" in checklist
+        assert "`old_family_line`" in checklist
+        assert "`gardener_council`" in checklist
+
+
+class TestCountTensions:
+    """Test tension counting from brainstorm context."""
+
+    def test_counts_tensions_in_section(self) -> None:
+        """Should count tensions in the tensions section."""
+        context = """## Entities from BRAINSTORM
+- **host** (character): A character
+
+## Tensions from BRAINSTORM
+- **host_benevolent_or_self_serving**: Is the host genuine?
+  Central entities: host
+  Stakes: Determines trust dynamics
+  Alternatives:
+  - benevolent_host: Host is genuinely caring
+  - self_serving_host: Host has ulterior motives
+
+- **butler_loyal_or_treacherous**: Is the butler faithful?
+  Central entities: butler
+  Stakes: Defines service loyalty
+  Alternatives:
+  - loyal_butler: Butler serves faithfully
+  - treacherous_butler: Butler has hidden agenda
+"""
+        count = _count_tensions(context)
+
+        assert count == 2
+
+    def test_ignores_entities_section(self) -> None:
+        """Should not count entities as tensions."""
+        context = """## Entities from BRAINSTORM
+- **host** (character): A character
+- **butler** (character): Another character
+
+## Tensions from BRAINSTORM
+- **single_tension**: One tension only
+"""
+        count = _count_tensions(context)
+
+        assert count == 1
+
+    def test_handles_no_tensions_section(self) -> None:
+        """Should return 0 when no tensions section exists."""
+        context = """## Entities from BRAINSTORM
+- **host** (character): A character
+"""
+        count = _count_tensions(context)
+
+        assert count == 0
+
+
+class TestGetSeedSummarizePrompt:
+    """Test SEED summarize prompt generation."""
+
+    def test_includes_entity_checklist(self) -> None:
+        """Should include entity checklist in prompt."""
+        context = """## Entities from BRAINSTORM
+- **host** (character): A reclusive aristocrat
+- **manor** (location): An English estate
+"""
+        prompt = get_seed_summarize_prompt(context)
+
+        assert "`host`" in prompt
+        assert "`manor`" in prompt
+        assert "Total: 2 entities" in prompt
+
+    def test_includes_counts(self) -> None:
+        """Should include entity and tension counts."""
+        context = """## Entities from BRAINSTORM
+- **host** (character): A reclusive aristocrat
+
+## Tensions from BRAINSTORM
+- **host_motive**: What drives the host?
+"""
+        prompt = get_seed_summarize_prompt(context)
+
+        # Check that counts are injected
+        assert "EXACTLY 1 required" in prompt or "ALL 1 MUST BE COVERED" in prompt
+
+    def test_includes_self_verification(self) -> None:
+        """Should include self-verification checklist."""
+        prompt = get_seed_summarize_prompt("")
+
+        assert "SELF-VERIFICATION" in prompt
+        assert "Entity decisions" in prompt
+        assert "Tension decisions" in prompt


### PR DESCRIPTION
## Problem

The SEED summarize phase produces incomplete briefs that miss some entities from BRAINSTORM. When 18 entities exist in BRAINSTORM but only 15 are accounted for in the brief, validation fails with "Missing decision for entity" errors. The repair mechanism can't help because it only fixes wrong IDs - it cannot add missing content.

Root cause: The summarize prompt doesn't explicitly enumerate entities, allowing the LLM to skip some during summarization.

## Changes

- Add `_extract_entity_checklist()` function to parse entities from brainstorm context and create a checkbox-style list
- Add `_count_tensions()` function to count tensions for self-verification
- Update `get_seed_summarize_prompt()` to inject entity checklist and counts into the template
- Update `summarize_seed.yaml` template with:
  - Explicit entity checklist section with `{entity_checklist}` variable
  - Entity/tension count variables (`{entity_count}`, `{tension_count}`)
  - Self-verification checklist table for the LLM to complete before outputting

## Not Included / Future PRs

- Beat count and location diversity validation (lower priority, partially addressed in prompt guidance)
- Pre-serialize validation layer (would catch issues earlier but requires more infrastructure)

## Test Plan

```bash
# Unit tests for new functions pass
uv run pytest tests/unit/test_prompts.py -v
# 9 tests passed

# Related serialize tests still pass
uv run pytest tests/unit/test_serialize.py -v  
# 47 tests passed
```

## Risk / Rollback

- **Low risk**: Changes are additive to the prompt template
- **Rollback**: Revert the YAML template variables and remove the helper functions
- **No breaking changes**: Existing code continues to work; the checklist is generated dynamically

Fixes #191

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)