### PR TITLE
feat(agents): preserve message structure in summarize phase

### DIFF
--- a/docs/architecture/plans/193-proper-message-history.md
+++ b/docs/architecture/plans/193-proper-message-history.md
@@ -1,0 +1,259 @@
+# Plan: Proper Message History Across Pipeline Phases
+
+**Issue**: #193
+**Date**: 2026-01-17
+
+---
+
+## Current State
+
+```
+Discuss Phase                    Summarize Phase                 Serialize Phase
+┌─────────────────┐             ┌─────────────────┐             ┌─────────────────┐
+│ LangChain Agent │             │ Single LLM Call │             │ Feedback Loop   │
+│                 │             │                 │             │                 │
+│ Returns:        │───────────▶│ Receives:       │───────────▶│ Receives:       │
+│ messages[]      │             │ messages[]      │             │ brief (string)  │
+│ (proper list)   │             │ BUT flattens to │             │ (no messages)   │
+│                 │             │ text in prompt  │             │                 │
+└─────────────────┘             └─────────────────┘             └─────────────────┘
+```
+
+### Problem Areas
+
+1. **summarize_discussion()** flattens messages:
+   ```python
+   # Current: Loses structure
+   HumanMessage(content="Here is the discussion:\n\n" +
+       _format_messages_for_summary(messages))  # "User: ... Assistant: ..."
+   ```
+
+2. **serialize_with_brief_repair()** has no history:
+   ```python
+   # Current: Only receives brief text
+   async def serialize_with_brief_repair(model, brief, graph, ...)
+   # Cannot regenerate from discussion context
+   ```
+
+3. **repair_seed_brief()** can only do text replacement:
+   ```python
+   # Current: Surgical fix, no context
+   async def repair_seed_brief(model, brief, errors, valid_ids_context, ...)
+   ```
+
+---
+
+## Proposed Design
+
+### Option A: Pass messages as proper list (minimal change)
+
+Keep current architecture but fix message handling:
+
+```python
+async def summarize_discussion(
+    model: BaseChatModel,
+    messages: list[BaseMessage],  # From discuss phase
+    system_prompt: str,
+    ...
+) -> tuple[str, list[BaseMessage], int]:  # Return messages for chaining
+    """
+    Instead of flattening, use messages directly with a new system message.
+    """
+    summarize_messages: list[BaseMessage] = [
+        SystemMessage(content=system_prompt),
+        # Include discuss history as proper messages
+        *messages,
+        # Add summarize instruction
+        HumanMessage(content="Now summarize the above discussion into the required format."),
+    ]
+
+    response = await model.ainvoke(summarize_messages)
+
+    # Return full history for next phase
+    return brief, summarize_messages + [response], tokens
+```
+
+**Pros**: Minimal changes, preserves tool call structure
+**Cons**: Context window may grow large; system prompt changes mid-conversation
+
+### Option B: Structured context injection
+
+Pass messages but format them as structured context (not flattened text):
+
+```python
+async def summarize_discussion(
+    model: BaseChatModel,
+    messages: list[BaseMessage],
+    system_prompt: str,
+    ...
+) -> tuple[str, int]:
+    """
+    Format messages as structured context, not flattened text.
+    """
+    # Format with role structure preserved
+    context = format_messages_as_context(messages)  # Keeps role/tool structure
+
+    summarize_messages: list[BaseMessage] = [
+        SystemMessage(content=system_prompt),
+        HumanMessage(content=f"## Discussion Transcript\n\n{context}\n\n## Your Task\nSummarize..."),
+    ]
+```
+
+**Pros**: Cleaner context window, explicit task separation
+**Cons**: Still "flattens" but with better structure
+
+### Option C: LangGraph state with checkpointer
+
+Use LangGraph's state management for proper memory:
+
+```python
+from langgraph.graph import StateGraph
+from langgraph.checkpoint.memory import InMemorySaver
+
+class PipelineState(TypedDict):
+    messages: list[BaseMessage]
+    discuss_complete: bool
+    brief: str | None
+    artifact: dict | None
+
+def build_pipeline_graph():
+    graph = StateGraph(PipelineState)
+    graph.add_node("discuss", discuss_node)
+    graph.add_node("summarize", summarize_node)
+    graph.add_node("serialize", serialize_node)
+    # ...
+    return graph.compile(checkpointer=InMemorySaver())
+```
+
+**Pros**: Proper memory management, persistence, debugging
+**Cons**: Significant refactor, may be overkill for our use case
+
+---
+
+## Recommended Approach: Option A with feedback loop
+
+1. **Phase 1**: Fix `summarize_discussion()` to pass messages properly
+2. **Phase 2**: Add feedback loop to summarize (using the message list)
+3. **Phase 3**: Optionally pass messages to serialize for richer context
+
+### Implementation Steps
+
+#### Step 1: Update `summarize_discussion()` signature
+
+```python
+async def summarize_discussion(
+    model: BaseChatModel,
+    messages: list[BaseMessage],
+    system_prompt: str,
+    max_retries: int = 2,  # NEW: for feedback loop
+    entity_validator: Callable[[str], tuple[bool, int, list[str]]] | None = None,  # NEW
+    expected_entity_count: int | None = None,  # NEW
+    ...
+) -> tuple[str, list[BaseMessage], int]:  # CHANGED: return messages
+```
+
+#### Step 2: Implement proper message handling
+
+```python
+# Build initial messages with proper structure
+summarize_messages: list[BaseMessage] = [
+    SystemMessage(content=system_prompt),
+]
+
+# Add discuss messages (Human/AI/Tool properly typed)
+for msg in messages:
+    # Filter or transform as needed
+    summarize_messages.append(msg)
+
+# Add the summarize instruction
+summarize_messages.append(
+    HumanMessage(content="Based on the above discussion, create a summary...")
+)
+```
+
+#### Step 3: Add feedback loop
+
+```python
+for attempt in range(max_retries):
+    response = await model.ainvoke(summarize_messages)
+    brief = str(response.content)
+
+    # Add AI response to history
+    summarize_messages.append(AIMessage(content=brief))
+
+    # Validate if validator provided
+    if entity_validator and expected_entity_count:
+        is_complete, actual, missing = entity_validator(brief, expected_entity_count)
+        if is_complete:
+            break
+        # Add feedback
+        summarize_messages.append(HumanMessage(
+            content=f"Your summary is incomplete. Missing: {missing}. Please regenerate."
+        ))
+    else:
+        break
+
+return brief, summarize_messages, tokens
+```
+
+#### Step 4: Update stage callers
+
+```python
+# In seed.py
+brief, summarize_messages, summarize_tokens = await summarize_discussion(
+    model=summarize_model or model,
+    messages=messages,
+    system_prompt=summarize_prompt,
+    entity_validator=validate_entity_coverage,
+    expected_entity_count=get_expected_entity_count(brainstorm_context),
+)
+
+# Optionally pass to serialize for context
+artifact, serialize_tokens = await serialize_with_brief_repair(
+    model=serialize_model or model,
+    brief=brief,
+    context_messages=summarize_messages,  # NEW: optional context
+    graph=graph,
+)
+```
+
+---
+
+## Files to Modify
+
+| File | Changes |
+|------|---------|
+| `src/questfoundry/agents/summarize.py` | New message handling, feedback loop |
+| `src/questfoundry/agents/prompts.py` | Move validation functions here (already done) |
+| `src/questfoundry/pipeline/stages/seed.py` | Update to use new signature |
+| `src/questfoundry/pipeline/stages/brainstorm.py` | Update similarly |
+| `src/questfoundry/pipeline/stages/dream.py` | Update similarly |
+| `tests/unit/test_summarize.py` | Test new behavior |
+
+---
+
+## PR Plan
+
+### PR 1: Proper message passing in summarize (~200 lines)
+- Update `summarize_discussion()` to not flatten messages
+- Return message history from summarize
+- Update all stage callers
+- Tests for message structure preservation
+
+### PR 2: Summarize feedback loop (~150 lines)
+- Add validation and retry logic to summarize
+- Integrate `validate_entity_coverage()` from parked branch
+- Tests for feedback loop
+
+### PR 3: (Optional) Context for serialize (~100 lines)
+- Pass messages to serialize for richer error context
+- Update repair to use context when available
+
+---
+
+## Verification
+
+1. Run seq-1, seq-2, seq-3 with new implementation
+2. Check that entity coverage issues trigger re-summarize
+3. Verify messages in logs show proper structure
+4. Confirm tool calls are visible in summarize context

--- a/src/questfoundry/agents/summarize.py
+++ b/src/questfoundry/agents/summarize.py
@@ -31,25 +31,30 @@ async def summarize_discussion(
     system_prompt: str | None = None,
     stage_name: str = "dream",
     callbacks: list[BaseCallbackHandler] | None = None,
-) -> tuple[str, int]:
+) -> tuple[str, list[BaseMessage], int]:
     """Summarize a discussion into a compact brief.
 
     This is a single LLM call (not an agent) that takes the conversation
     history from the Discuss phase and produces a compact summary for
     the Serialize phase.
 
-    Uses lower temperature (0.3) for more focused, consistent output.
+    The discuss phase messages are passed as proper LangChain messages,
+    preserving role structure and tool call associations. This enables
+    future feedback loops where the model can reference the original
+    discussion context.
 
     Args:
-        model: Chat model to use (will be invoked with low temperature)
-        messages: Conversation history from Discuss phase
+        model: Chat model to use
+        messages: Conversation history from Discuss phase (proper message list)
         system_prompt: Optional custom system prompt. If not provided,
             uses the default summarize prompt.
         stage_name: Stage name for logging/tagging (default "dream")
         callbacks: LangChain callback handlers for logging LLM calls
 
     Returns:
-        Tuple of (summary_text, tokens_used)
+        Tuple of (summary_text, full_message_history, tokens_used).
+        The message history includes the discuss messages, summarize instruction,
+        and the model's response - useful for feedback loops.
     """
     log.info("summarize_started", message_count=len(messages), stage=stage_name)
 
@@ -58,15 +63,25 @@ async def summarize_discussion(
         system_prompt = get_summarize_prompt()
 
     # Build the messages for the summarize call
-    # We include the system prompt, then the conversation as context,
-    # then ask for the summary
+    # We include the system prompt, then the ACTUAL conversation messages
+    # (not flattened text), then the summarize instruction.
+    # This preserves message roles and tool call structure.
     summarize_messages: list[BaseMessage] = [
         SystemMessage(content=system_prompt),
-        HumanMessage(
-            content="Here is the discussion to summarize:\n\n"
-            + _format_messages_for_summary(messages)
-        ),
     ]
+
+    # Add discuss messages with proper structure
+    # Filter out any system messages from discuss (we have our own)
+    for msg in messages:
+        if not isinstance(msg, SystemMessage):
+            summarize_messages.append(msg)
+
+    # Add the summarize instruction
+    summarize_messages.append(
+        HumanMessage(
+            content="Based on the discussion above, create the summary in the format specified."
+        )
+    )
 
     # Build tracing config for the LLM call
     config = build_runnable_config(
@@ -76,10 +91,6 @@ async def summarize_discussion(
         callbacks=callbacks,
     )
 
-    # Note: We use the model as configured rather than trying to override temperature
-    # at runtime. The bind(temperature=X) approach is not compatible with all providers
-    # (e.g., langchain-ollama doesn't support runtime temperature in chat()).
-    # The model's default temperature (0.7) works fine for summarization.
     response = await model.ainvoke(summarize_messages, config=config)
 
     # Extract the summary text
@@ -88,9 +99,12 @@ async def summarize_discussion(
     # Extract token usage
     tokens = _extract_token_usage(response) if isinstance(response, AIMessage) else 0
 
+    # Add response to message history for potential feedback loops
+    summarize_messages.append(AIMessage(content=summary))
+
     log.info("summarize_completed", summary_length=len(summary), tokens=tokens)
 
-    return summary, tokens
+    return summary, summarize_messages, tokens
 
 
 def _format_messages_for_summary(messages: list[BaseMessage]) -> str:

--- a/src/questfoundry/pipeline/stages/brainstorm.py
+++ b/src/questfoundry/pipeline/stages/brainstorm.py
@@ -247,7 +247,7 @@ class BrainstormStage:
         # Phase 2: Summarize (use summarize_model if provided)
         log.debug("brainstorm_phase", phase="summarize")
         summarize_prompt = get_brainstorm_summarize_prompt()
-        brief, summarize_tokens = await summarize_discussion(
+        brief, _summarize_messages, summarize_tokens = await summarize_discussion(
             model=summarize_model or model,
             messages=messages,
             system_prompt=summarize_prompt,

--- a/src/questfoundry/pipeline/stages/dream.py
+++ b/src/questfoundry/pipeline/stages/dream.py
@@ -132,7 +132,7 @@ class DreamStage:
 
         # Phase 2: Summarize (use summarize_model if provided)
         log.debug("dream_phase", phase="summarize")
-        brief, summarize_tokens = await summarize_discussion(
+        brief, _summarize_messages, summarize_tokens = await summarize_discussion(
             model=summarize_model or model,
             messages=messages,
             callbacks=callbacks,

--- a/src/questfoundry/pipeline/stages/seed.py
+++ b/src/questfoundry/pipeline/stages/seed.py
@@ -310,7 +310,7 @@ class SeedStage:
         # Phase 2: Summarize (use summarize_model if provided)
         log.debug("seed_phase", phase="summarize")
         summarize_prompt = get_seed_summarize_prompt(brainstorm_context=brainstorm_context)
-        brief, summarize_tokens = await summarize_discussion(
+        brief, _summarize_messages, summarize_tokens = await summarize_discussion(
             model=summarize_model or model,
             messages=messages,
             system_prompt=summarize_prompt,

--- a/tests/unit/test_brainstorm_stage.py
+++ b/tests/unit/test_brainstorm_stage.py
@@ -90,7 +90,7 @@ async def test_execute_calls_all_three_phases() -> None:
             2,  # llm_calls
             500,  # tokens
         )
-        mock_summarize.return_value = ("Brief summary", 100)
+        mock_summarize.return_value = ("Brief summary", [], 100)  # summary, messages, tokens
         mock_artifact = BrainstormOutput(
             entities=[
                 {"entity_id": "hero", "entity_category": "character", "concept": "A brave warrior"}
@@ -164,7 +164,7 @@ async def test_execute_passes_vision_context_to_discuss() -> None:
         mock_tools.return_value = []
         mock_prompt.return_value = "System prompt with vision"
         mock_discuss.return_value = ([], 1, 100)
-        mock_summarize.return_value = ("Brief", 50)
+        mock_summarize.return_value = ("Brief", [], 50)  # summary, messages, tokens
         mock_artifact = BrainstormOutput(entities=[], tensions=[])
         mock_serialize.return_value = (mock_artifact, 100)
 
@@ -201,7 +201,7 @@ async def test_execute_passes_brainstorm_output_schema() -> None:
         MockGraph.load.return_value = mock_graph
         mock_tools.return_value = []
         mock_discuss.return_value = ([], 1, 100)
-        mock_summarize.return_value = ("Brief", 50)
+        mock_summarize.return_value = ("Brief", [], 50)  # summary, messages, tokens
         mock_artifact = BrainstormOutput(entities=[], tensions=[])
         mock_serialize.return_value = (mock_artifact, 100)
 
@@ -237,7 +237,7 @@ async def test_execute_uses_brainstorm_summarize_prompt() -> None:
         mock_tools.return_value = []
         mock_prompt.return_value = "Brainstorm summarize prompt"
         mock_discuss.return_value = ([], 1, 100)
-        mock_summarize.return_value = ("Brief", 50)
+        mock_summarize.return_value = ("Brief", [], 50)  # summary, messages, tokens
         mock_artifact = BrainstormOutput(entities=[], tensions=[])
         mock_serialize.return_value = (mock_artifact, 100)
 
@@ -271,7 +271,7 @@ async def test_execute_returns_artifact_as_dict() -> None:
         MockGraph.load.return_value = mock_graph
         mock_tools.return_value = []
         mock_discuss.return_value = ([], 1, 100)
-        mock_summarize.return_value = ("Brief", 50)
+        mock_summarize.return_value = ("Brief", [], 50)  # summary, messages, tokens
         mock_artifact = BrainstormOutput(
             entities=[
                 {"entity_id": "kay", "entity_category": "character", "concept": "Protagonist"}

--- a/tests/unit/test_dream_stage.py
+++ b/tests/unit/test_dream_stage.py
@@ -50,7 +50,7 @@ async def test_execute_calls_all_three_phases() -> None:
             2,  # llm_calls
             500,  # tokens
         )
-        mock_summarize.return_value = ("Brief summary", 100)
+        mock_summarize.return_value = ("Brief summary", [], 100)  # summary, messages, tokens
         mock_artifact = DreamArtifact(
             genre="fantasy",
             tone=["epic"],
@@ -92,7 +92,7 @@ async def test_execute_passes_model_to_all_phases() -> None:
     ):
         mock_tools.return_value = []
         mock_discuss.return_value = ([], 1, 100)
-        mock_summarize.return_value = ("Brief", 50)
+        mock_summarize.return_value = ("Brief", [], 50)  # summary, messages, tokens
         mock_artifact = DreamArtifact(
             genre="mystery",
             tone=["dark"],
@@ -122,7 +122,7 @@ async def test_execute_passes_user_prompt_to_discuss() -> None:
     ):
         mock_tools.return_value = []
         mock_discuss.return_value = ([], 1, 100)
-        mock_summarize.return_value = ("Brief", 50)
+        mock_summarize.return_value = ("Brief", [], 50)  # summary, messages, tokens
         mock_artifact = DreamArtifact(
             genre="sci-fi",
             tone=["epic"],
@@ -154,7 +154,7 @@ async def test_execute_passes_messages_to_summarize() -> None:
     ):
         mock_tools.return_value = []
         mock_discuss.return_value = (discuss_messages, 2, 200)
-        mock_summarize.return_value = ("Brief", 50)
+        mock_summarize.return_value = ("Brief", [], 50)  # summary, messages, tokens
         mock_artifact = DreamArtifact(
             genre="fantasy",
             tone=["epic"],
@@ -181,7 +181,11 @@ async def test_execute_passes_brief_to_serialize() -> None:
     ):
         mock_tools.return_value = []
         mock_discuss.return_value = ([], 1, 100)
-        mock_summarize.return_value = ("Detailed brief about fantasy story", 75)
+        mock_summarize.return_value = (
+            "Detailed brief about fantasy story",
+            [],
+            75,
+        )  # summary, messages, tokens
         mock_artifact = DreamArtifact(
             genre="fantasy",
             tone=["epic"],
@@ -208,7 +212,7 @@ async def test_execute_passes_provider_name_to_serialize() -> None:
     ):
         mock_tools.return_value = []
         mock_discuss.return_value = ([], 1, 100)
-        mock_summarize.return_value = ("Brief", 50)
+        mock_summarize.return_value = ("Brief", [], 50)  # summary, messages, tokens
         mock_artifact = DreamArtifact(
             genre="horror",
             tone=["dark"],
@@ -239,7 +243,7 @@ async def test_execute_passes_dream_artifact_schema() -> None:
     ):
         mock_tools.return_value = []
         mock_discuss.return_value = ([], 1, 100)
-        mock_summarize.return_value = ("Brief", 50)
+        mock_summarize.return_value = ("Brief", [], 50)  # summary, messages, tokens
         mock_artifact = DreamArtifact(
             genre="romance",
             tone=["sweet"],
@@ -266,7 +270,7 @@ async def test_execute_returns_artifact_as_dict() -> None:
     ):
         mock_tools.return_value = []
         mock_discuss.return_value = ([], 1, 100)
-        mock_summarize.return_value = ("Brief", 50)
+        mock_summarize.return_value = ("Brief", [], 50)  # summary, messages, tokens
         mock_artifact = DreamArtifact(
             genre="thriller",
             subgenre="psychological",
@@ -299,7 +303,7 @@ async def test_execute_uses_research_tools() -> None:
     ):
         mock_get_tools.return_value = mock_tools
         mock_discuss.return_value = ([], 1, 100)
-        mock_summarize.return_value = ("Brief", 50)
+        mock_summarize.return_value = ("Brief", [], 50)  # summary, messages, tokens
         mock_artifact = DreamArtifact(
             genre="mystery",
             tone=["suspenseful"],

--- a/tests/unit/test_seed_stage.py
+++ b/tests/unit/test_seed_stage.py
@@ -93,7 +93,7 @@ async def test_execute_calls_all_three_phases() -> None:
             2,  # llm_calls
             500,  # tokens
         )
-        mock_summarize.return_value = ("Brief summary", 100)
+        mock_summarize.return_value = ("Brief summary", [], 100)  # summary, messages, tokens
         mock_artifact = SeedOutput(
             entities=[{"entity_id": "kay", "disposition": "retained"}],
             tensions=[{"tension_id": "trust", "explored": ["yes"], "implicit": ["no"]}],
@@ -164,7 +164,7 @@ async def test_execute_passes_brainstorm_context_to_discuss() -> None:
         mock_tools.return_value = []
         mock_prompt.return_value = "System prompt with brainstorm"
         mock_discuss.return_value = ([], 1, 100)
-        mock_summarize.return_value = ("Brief", 50)
+        mock_summarize.return_value = ("Brief", [], 50)  # summary, messages, tokens
         mock_artifact = SeedOutput(entities=[], tensions=[], threads=[], initial_beats=[])
         mock_serialize.return_value = (mock_artifact, 100)
 
@@ -204,7 +204,7 @@ async def test_execute_uses_brief_repair_serialization() -> None:
         MockGraph.load.return_value = mock_graph
         mock_tools.return_value = []
         mock_discuss.return_value = ([], 1, 100)
-        mock_summarize.return_value = ("Brief", 50)
+        mock_summarize.return_value = ("Brief", [], 50)  # summary, messages, tokens
         mock_artifact = SeedOutput(entities=[], tensions=[], threads=[], initial_beats=[])
         mock_serialize.return_value = (mock_artifact, 100)
 
@@ -243,7 +243,7 @@ async def test_execute_uses_seed_summarize_prompt() -> None:
         mock_tools.return_value = []
         mock_prompt.return_value = "Seed summarize prompt"
         mock_discuss.return_value = ([], 1, 100)
-        mock_summarize.return_value = ("Brief", 50)
+        mock_summarize.return_value = ("Brief", [], 50)  # summary, messages, tokens
         mock_artifact = SeedOutput(entities=[], tensions=[], threads=[], initial_beats=[])
         mock_serialize.return_value = (mock_artifact, 100)
 
@@ -280,7 +280,7 @@ async def test_execute_returns_artifact_as_dict() -> None:
         MockGraph.load.return_value = mock_graph
         mock_tools.return_value = []
         mock_discuss.return_value = ([], 1, 100)
-        mock_summarize.return_value = ("Brief", 50)
+        mock_summarize.return_value = ("Brief", [], 50)  # summary, messages, tokens
         mock_artifact = SeedOutput(
             entities=[{"entity_id": "kay", "disposition": "retained"}],
             tensions=[],

--- a/tests/unit/test_summarize.py
+++ b/tests/unit/test_summarize.py
@@ -96,23 +96,19 @@ class TestSummarizeDiscussion:
             AIMessage(content="Assistant response"),
         ]
 
-        await summarize_discussion(mock_model, messages)
+        _summary, result_messages, _tokens = await summarize_discussion(mock_model, messages)
 
-        # Check the call to ainvoke included proper message structure
-        # Note: mock captures list by reference, so response is appended after call
-        call_args = mock_model.ainvoke.call_args
-        invoke_messages = call_args[0][0]
-
-        # Should have: system, human, ai, summarize instruction, response (appended after)
-        assert len(invoke_messages) == 5
-        assert isinstance(invoke_messages[0], SystemMessage)  # System prompt
-        assert isinstance(invoke_messages[1], HumanMessage)  # User message
-        assert invoke_messages[1].content == "User message"
-        assert isinstance(invoke_messages[2], AIMessage)  # Assistant response
-        assert invoke_messages[2].content == "Assistant response"
-        assert isinstance(invoke_messages[3], HumanMessage)  # Summarize instruction
-        assert isinstance(invoke_messages[4], AIMessage)  # Response appended after call
-        assert invoke_messages[4].content == "Summary"
+        # Verify returned message history has proper structure
+        # Should have: system, human, ai, summarize instruction, response
+        assert len(result_messages) == 5
+        assert isinstance(result_messages[0], SystemMessage)  # System prompt
+        assert isinstance(result_messages[1], HumanMessage)  # User message
+        assert result_messages[1].content == "User message"
+        assert isinstance(result_messages[2], AIMessage)  # Assistant response
+        assert result_messages[2].content == "Assistant response"
+        assert isinstance(result_messages[3], HumanMessage)  # Summarize instruction
+        assert isinstance(result_messages[4], AIMessage)  # Response
+        assert result_messages[4].content == "Summary"
 
     @pytest.mark.asyncio
     async def test_summarize_handles_missing_metadata(self) -> None:
@@ -228,22 +224,20 @@ class TestSummarizeDiscussion:
             AIMessage(content="AI response"),
         ]
 
-        await summarize_discussion(mock_model, messages)
+        _summary, result_messages, _tokens = await summarize_discussion(mock_model, messages)
 
-        call_args = mock_model.ainvoke.call_args
-        invoke_messages = call_args[0][0]
-
+        # Verify returned message history has proper structure
         # Should have: our system prompt, human, ai, summarize instruction, response
-        # (original system message is filtered out; response appended after call)
-        assert len(invoke_messages) == 5
-        assert isinstance(invoke_messages[0], SystemMessage)  # Our system prompt
-        assert "System context" not in invoke_messages[0].content  # Not the input one
-        assert isinstance(invoke_messages[1], HumanMessage)
-        assert invoke_messages[1].content == "User input"
-        assert isinstance(invoke_messages[2], AIMessage)
-        assert invoke_messages[2].content == "AI response"
-        assert isinstance(invoke_messages[3], HumanMessage)  # Summarize instruction
-        assert isinstance(invoke_messages[4], AIMessage)  # Response appended after call
+        # (original system message is filtered out)
+        assert len(result_messages) == 5
+        assert isinstance(result_messages[0], SystemMessage)  # Our system prompt
+        assert "System context" not in result_messages[0].content  # Not the input one
+        assert isinstance(result_messages[1], HumanMessage)
+        assert result_messages[1].content == "User input"
+        assert isinstance(result_messages[2], AIMessage)
+        assert result_messages[2].content == "AI response"
+        assert isinstance(result_messages[3], HumanMessage)  # Summarize instruction
+        assert isinstance(result_messages[4], AIMessage)  # Response
 
 
 class TestGetFuzzyIdSuggestions:

--- a/tests/unit/test_summarize.py
+++ b/tests/unit/test_summarize.py
@@ -48,8 +48,8 @@ class TestSummarizeDiscussion:
     """Test summarize_discussion function."""
 
     @pytest.mark.asyncio
-    async def test_summarize_returns_summary_and_tokens(self) -> None:
-        """summarize_discussion should return summary text and token count."""
+    async def test_summarize_returns_summary_messages_and_tokens(self) -> None:
+        """summarize_discussion should return summary, message history, and tokens."""
         mock_model = MagicMock()
         mock_response = AIMessage(content="Summary of discussion")
         # Token usage via usage_metadata attribute (Ollama-style)
@@ -61,10 +61,14 @@ class TestSummarizeDiscussion:
             AIMessage(content="Great! Tell me more about the setting."),
         ]
 
-        summary, tokens = await summarize_discussion(mock_model, messages)
+        summary, result_messages, tokens = await summarize_discussion(mock_model, messages)
 
         assert summary == "Summary of discussion"
         assert tokens == 100
+        # Message history should include: system, discuss messages, instruction, response
+        assert len(result_messages) >= 4
+        assert isinstance(result_messages[0], SystemMessage)
+        assert isinstance(result_messages[-1], AIMessage)  # Response added
 
     @pytest.mark.asyncio
     async def test_summarize_uses_model_directly(self) -> None:
@@ -81,8 +85,8 @@ class TestSummarizeDiscussion:
         mock_model.ainvoke.assert_called_once()
 
     @pytest.mark.asyncio
-    async def test_summarize_includes_conversation_in_prompt(self) -> None:
-        """summarize_discussion should include formatted conversation."""
+    async def test_summarize_includes_conversation_as_proper_messages(self) -> None:
+        """summarize_discussion should include conversation as proper message objects."""
         mock_model = MagicMock()
         mock_response = AIMessage(content="Summary")
         mock_model.ainvoke = AsyncMock(return_value=mock_response)
@@ -94,16 +98,21 @@ class TestSummarizeDiscussion:
 
         await summarize_discussion(mock_model, messages)
 
-        # Check the call to ainvoke included the conversation
+        # Check the call to ainvoke included proper message structure
+        # Note: mock captures list by reference, so response is appended after call
         call_args = mock_model.ainvoke.call_args
         invoke_messages = call_args[0][0]
 
-        # Should have system message and human message with conversation
-        assert len(invoke_messages) == 2
-        assert isinstance(invoke_messages[0], SystemMessage)
-        assert isinstance(invoke_messages[1], HumanMessage)
-        assert "User message" in invoke_messages[1].content
-        assert "Assistant response" in invoke_messages[1].content
+        # Should have: system, human, ai, summarize instruction, response (appended after)
+        assert len(invoke_messages) == 5
+        assert isinstance(invoke_messages[0], SystemMessage)  # System prompt
+        assert isinstance(invoke_messages[1], HumanMessage)  # User message
+        assert invoke_messages[1].content == "User message"
+        assert isinstance(invoke_messages[2], AIMessage)  # Assistant response
+        assert invoke_messages[2].content == "Assistant response"
+        assert isinstance(invoke_messages[3], HumanMessage)  # Summarize instruction
+        assert isinstance(invoke_messages[4], AIMessage)  # Response appended after call
+        assert invoke_messages[4].content == "Summary"
 
     @pytest.mark.asyncio
     async def test_summarize_handles_missing_metadata(self) -> None:
@@ -115,7 +124,7 @@ class TestSummarizeDiscussion:
 
         messages = [HumanMessage(content="Test")]
 
-        summary, tokens = await summarize_discussion(mock_model, messages)
+        summary, _messages, tokens = await summarize_discussion(mock_model, messages)
 
         assert summary == "Summary"
         assert tokens == 0
@@ -130,7 +139,7 @@ class TestSummarizeDiscussion:
 
         messages = [HumanMessage(content="Test")]
 
-        summary, tokens = await summarize_discussion(mock_model, messages)
+        summary, _messages, tokens = await summarize_discussion(mock_model, messages)
 
         assert summary == "Summary"
         assert tokens == 0
@@ -146,7 +155,7 @@ class TestSummarizeDiscussion:
 
         messages = [HumanMessage(content="Test")]
 
-        _summary, tokens = await summarize_discussion(mock_model, messages)
+        _summary, _messages, tokens = await summarize_discussion(mock_model, messages)
 
         assert tokens == 200
 
@@ -161,7 +170,7 @@ class TestSummarizeDiscussion:
 
         messages = [HumanMessage(content="Test")]
 
-        _summary, tokens = await summarize_discussion(mock_model, messages)
+        _summary, _messages, tokens = await summarize_discussion(mock_model, messages)
 
         assert tokens == 150
 
@@ -177,7 +186,7 @@ class TestSummarizeDiscussion:
 
         messages = [HumanMessage(content="Test")]
 
-        _summary, tokens = await summarize_discussion(mock_model, messages)
+        _summary, _messages, tokens = await summarize_discussion(mock_model, messages)
 
         assert tokens == 100  # From usage_metadata, not response_metadata
 
@@ -188,7 +197,7 @@ class TestSummarizeDiscussion:
         mock_response = AIMessage(content="Nothing to summarize")
         mock_model.ainvoke = AsyncMock(return_value=mock_response)
 
-        summary, _tokens = await summarize_discussion(mock_model, [])
+        summary, _messages, _tokens = await summarize_discussion(mock_model, [])
 
         assert summary == "Nothing to summarize"
 
@@ -201,20 +210,20 @@ class TestSummarizeDiscussion:
 
         messages = [HumanMessage(content="Test")]
 
-        summary, _tokens = await summarize_discussion(mock_model, messages)
+        summary, _messages, _tokens = await summarize_discussion(mock_model, messages)
 
         # Should convert to string
         assert isinstance(summary, str)
 
     @pytest.mark.asyncio
-    async def test_summarize_formats_all_message_types(self) -> None:
-        """summarize_discussion should format different message types."""
+    async def test_summarize_passes_message_types_correctly(self) -> None:
+        """summarize_discussion should pass messages with proper types (filter system)."""
         mock_model = MagicMock()
         mock_response = AIMessage(content="Summary")
         mock_model.ainvoke = AsyncMock(return_value=mock_response)
 
         messages = [
-            SystemMessage(content="System context"),
+            SystemMessage(content="System context"),  # Should be filtered out
             HumanMessage(content="User input"),
             AIMessage(content="AI response"),
         ]
@@ -223,11 +232,18 @@ class TestSummarizeDiscussion:
 
         call_args = mock_model.ainvoke.call_args
         invoke_messages = call_args[0][0]
-        conversation_text = invoke_messages[1].content
 
-        assert "System: System context" in conversation_text
-        assert "User: User input" in conversation_text
-        assert "Assistant: AI response" in conversation_text
+        # Should have: our system prompt, human, ai, summarize instruction, response
+        # (original system message is filtered out; response appended after call)
+        assert len(invoke_messages) == 5
+        assert isinstance(invoke_messages[0], SystemMessage)  # Our system prompt
+        assert "System context" not in invoke_messages[0].content  # Not the input one
+        assert isinstance(invoke_messages[1], HumanMessage)
+        assert invoke_messages[1].content == "User input"
+        assert isinstance(invoke_messages[2], AIMessage)
+        assert invoke_messages[2].content == "AI response"
+        assert isinstance(invoke_messages[3], HumanMessage)  # Summarize instruction
+        assert isinstance(invoke_messages[4], AIMessage)  # Response appended after call
 
 
 class TestGetFuzzyIdSuggestions:


### PR DESCRIPTION
## Problem

The `summarize_discussion()` function was flattening discuss phase messages into a single text string like `"User: ... Assistant: ..."`. This lost message role structure, tool call associations, and proper LangChain message formatting - making it impossible for feedback loops to reference the original discussion context.

## Changes

- **summarize.py**: Pass messages as proper `list[BaseMessage]` instead of flattening to text. Return message history for chaining.
- **dream.py, brainstorm.py, seed.py**: Handle new 3-value return signature `(brief, messages, tokens)`
- **Tests**: Updated for new behavior and return signature

## Not Included / Future PRs

- Summarize feedback loop (PR 2 per issue #193)
- Context injection for serialize phase (PR 3, optional)
- Integration with `repair_seed_brief()` for full context

## Test Plan

```bash
uv run pytest tests/unit/test_summarize.py -v  # 32 passed
uv run pytest tests/unit/ -v  # 728 passed
```

## Risk / Rollback

- Low risk: Interface change is additive (returns more data)
- Callers updated to unpack 3 values instead of 2
- No behavior change in pipeline output, only internal message handling

---

Closes part of #193

🤖 Generated with [Claude Code](https://claude.com/claude-code)