### PR TITLE
feat: add entity validation feedback loop to summarize phase

### DIFF
--- a/src/questfoundry/agents/__init__.py
+++ b/src/questfoundry/agents/__init__.py
@@ -6,11 +6,13 @@ from questfoundry.agents.prompts import (
     get_brainstorm_serialize_prompt,
     get_brainstorm_summarize_prompt,
     get_discuss_prompt,
+    get_expected_entity_count,
     get_seed_discuss_prompt,
     get_seed_serialize_prompt,
     get_seed_summarize_prompt,
     get_serialize_prompt,
     get_summarize_prompt,
+    validate_entity_coverage,
 )
 from questfoundry.agents.serialize import (
     SerializationError,
@@ -27,6 +29,7 @@ __all__ = [
     "get_brainstorm_serialize_prompt",
     "get_brainstorm_summarize_prompt",
     "get_discuss_prompt",
+    "get_expected_entity_count",
     "get_seed_discuss_prompt",
     "get_seed_serialize_prompt",
     "get_seed_summarize_prompt",
@@ -37,4 +40,5 @@ __all__ = [
     "serialize_to_artifact",
     "serialize_with_brief_repair",
     "summarize_discussion",
+    "validate_entity_coverage",
 ]

--- a/src/questfoundry/agents/prompts.py
+++ b/src/questfoundry/agents/prompts.py
@@ -286,3 +286,117 @@ def get_repair_seed_brief_prompt(
         system_prompt.format(valid_ids_context=valid_ids_context, error_list=error_list),
         user_prompt.format(brief=brief),
     )
+
+
+# --- Entity Coverage Validation ---
+
+
+def _extract_entity_checklist(brainstorm_context: str) -> tuple[str, int]:
+    """Extract entity IDs from brainstorm context for explicit checklist.
+
+    Parses the "## Entities from BRAINSTORM" section and creates a
+    numbered list for the LLM to process sequentially. Uses simple
+    formatting that's harder to creatively reformat.
+
+    Args:
+        brainstorm_context: Formatted brainstorm context string containing
+            entities in the format "- **entity_id** (type): concept".
+
+    Returns:
+        Tuple of (checklist_text, entity_count).
+    """
+    import re
+
+    # Parse entity IDs from formatted context (lines like "- **entity_id** (type): concept")
+    pattern = r"\- \*\*([a-z_]+)\*\* \((\w+)\):"
+    matches = re.findall(pattern, brainstorm_context)
+
+    if not matches:
+        return "No entities found in brainstorm context.", 0
+
+    # Group by type for clearer presentation
+    by_type: dict[str, list[str]] = {}
+    for entity_id, entity_type in matches:
+        by_type.setdefault(entity_type, []).append(entity_id)
+
+    # Use numbered list format - research shows this prevents skipping
+    lines = []
+    counter = 1
+    for entity_type in sorted(by_type.keys()):
+        ids = by_type[entity_type]
+        lines.append(f"**{entity_type.title()}s** ({len(ids)}):")
+        for eid in sorted(ids):
+            lines.append(f"  {counter}. {eid}")
+            counter += 1
+        lines.append("")
+
+    lines.append(f"Total: {len(matches)} entities. Process each one sequentially.")
+
+    return "\n".join(lines), len(matches)
+
+
+def _count_tensions(brainstorm_context: str) -> int:
+    """Count tensions in brainstorm context.
+
+    Args:
+        brainstorm_context: Formatted brainstorm context string.
+
+    Returns:
+        Number of tensions found.
+    """
+    import re
+
+    # Tensions are formatted as "- **tension_id**: question"
+    pattern = r"\- \*\*([a-z_]+)\*\*:"
+    # Look in the tensions section only
+    tensions_section = ""
+    if "## Tensions from BRAINSTORM" in brainstorm_context:
+        start = brainstorm_context.find("## Tensions from BRAINSTORM")
+        tensions_section = brainstorm_context[start:]
+
+    matches = re.findall(pattern, tensions_section)
+    return len(matches)
+
+
+def validate_entity_coverage(brief: str, expected_count: int) -> tuple[bool, int, list[str]]:
+    """Validate that brief contains decisions for all expected entities.
+
+    External validation after summarize - LLMs cannot self-verify mid-generation.
+    This catches incomplete coverage before serialize phase.
+
+    Args:
+        brief: The summarized brief from the LLM.
+        expected_count: Number of entities expected from brainstorm context.
+
+    Returns:
+        Tuple of (is_complete, actual_count, missing_ids).
+        - is_complete: True if actual >= expected
+        - actual_count: Number of entity decisions found
+        - missing_ids: List of entity IDs that should be present but weren't found
+          (currently returns empty list as we don't have expected IDs here)
+    """
+    import re
+
+    # Count entity decisions in brief
+    # Format: "- id: entity_id" or "id: entity_id" at start of line
+    # The summarize prompt asks for "id: entity_id_here" format
+    pattern = r"^\s*-?\s*id:\s*([a-z_]+)"
+    matches = re.findall(pattern, brief, re.MULTILINE)
+
+    actual_count = len(matches)
+    is_complete = actual_count >= expected_count
+
+    return is_complete, actual_count, []
+
+
+def get_expected_entity_count(brainstorm_context: str) -> int:
+    """Get expected entity count from brainstorm context.
+
+    Args:
+        brainstorm_context: Formatted brainstorm context string.
+
+    Returns:
+        Number of entities expected.
+    """
+    _, count = _extract_entity_checklist(brainstorm_context)
+    return count

--- a/tests/unit/test_prompts.py
+++ b/tests/unit/test_prompts.py
@@ -116,7 +116,7 @@ class TestValidateEntityCoverage:
 - id: archive
   disposition: cut
 """
-        is_complete, actual, _missing = validate_entity_coverage(brief, expected_count=3)
+        is_complete, actual = validate_entity_coverage(brief, expected_count=3)
 
         assert is_complete is True
         assert actual == 3
@@ -127,7 +127,7 @@ class TestValidateEntityCoverage:
 - id: kay
   disposition: retained
 """
-        is_complete, actual, _missing = validate_entity_coverage(brief, expected_count=3)
+        is_complete, actual = validate_entity_coverage(brief, expected_count=3)
 
         assert is_complete is False
         assert actual == 1
@@ -139,14 +139,14 @@ id: kay
 id: morgan
   - id: archive
 """
-        is_complete, actual, _missing = validate_entity_coverage(brief, expected_count=3)
+        is_complete, actual = validate_entity_coverage(brief, expected_count=3)
 
         assert is_complete is True
         assert actual == 3
 
     def test_empty_brief_returns_zero(self) -> None:
         """Should return 0 for empty brief."""
-        is_complete, actual, _missing = validate_entity_coverage("", expected_count=3)
+        is_complete, actual = validate_entity_coverage("", expected_count=3)
 
         assert is_complete is False
         assert actual == 0
@@ -158,7 +158,7 @@ id: morgan
 - id: c
 - id: d
 """
-        is_complete, actual, _missing = validate_entity_coverage(brief, expected_count=3)
+        is_complete, actual = validate_entity_coverage(brief, expected_count=3)
 
         assert is_complete is True
         assert actual == 4

--- a/tests/unit/test_prompts.py
+++ b/tests/unit/test_prompts.py
@@ -1,0 +1,182 @@
+"""Tests for prompt utilities and validation functions."""
+
+from __future__ import annotations
+
+from questfoundry.agents.prompts import (
+    _count_tensions,
+    _extract_entity_checklist,
+    get_expected_entity_count,
+    validate_entity_coverage,
+)
+
+
+class TestExtractEntityChecklist:
+    """Tests for _extract_entity_checklist function."""
+
+    def test_extracts_entities_from_context(self) -> None:
+        """Should extract entity IDs and create numbered checklist."""
+        context = """## Entities from BRAINSTORM
+- **kay** (character): Protagonist
+- **morgan** (character): Mentor
+- **archive** (location): Ancient library
+"""
+        checklist, count = _extract_entity_checklist(context)
+
+        assert count == 3
+        assert "kay" in checklist
+        assert "morgan" in checklist
+        assert "archive" in checklist
+
+    def test_groups_by_type(self) -> None:
+        """Should group entities by type."""
+        context = """## Entities from BRAINSTORM
+- **kay** (character): Hero
+- **archive** (location): Library
+- **morgan** (character): Mentor
+"""
+        checklist, count = _extract_entity_checklist(context)
+
+        assert count == 3
+        assert "Characters" in checklist
+        assert "Locations" in checklist
+
+    def test_uses_numbered_list(self) -> None:
+        """Should use numbered list format."""
+        context = """## Entities from BRAINSTORM
+- **kay** (character): Hero
+- **morgan** (character): Mentor
+"""
+        checklist, _count = _extract_entity_checklist(context)
+
+        assert "1." in checklist
+        assert "2." in checklist
+
+    def test_empty_context_returns_zero(self) -> None:
+        """Should handle empty context."""
+        checklist, count = _extract_entity_checklist("")
+
+        assert count == 0
+        assert "No entities found" in checklist
+
+    def test_no_matching_format_returns_zero(self) -> None:
+        """Should handle context with no matching entity format."""
+        context = "Just some text without entities"
+        checklist, count = _extract_entity_checklist(context)
+
+        assert count == 0
+        assert "No entities found" in checklist
+
+
+class TestCountTensions:
+    """Tests for _count_tensions function."""
+
+    def test_counts_tensions_in_section(self) -> None:
+        """Should count tensions in the tensions section."""
+        context = """## Entities from BRAINSTORM
+- **kay** (character): Hero
+
+## Tensions from BRAINSTORM
+- **mentor_trust**: Can the mentor be trusted?
+- **diary_truth**: What secrets does the diary hold?
+"""
+        count = _count_tensions(context)
+        assert count == 2
+
+    def test_ignores_entities(self) -> None:
+        """Should only count in tensions section, not entities."""
+        context = """## Entities from BRAINSTORM
+- **kay** (character): Hero
+- **morgan** (character): Mentor
+
+## Tensions from BRAINSTORM
+- **trust**: Trust question
+"""
+        count = _count_tensions(context)
+        assert count == 1
+
+    def test_no_tensions_section_returns_zero(self) -> None:
+        """Should return 0 if no tensions section."""
+        context = """## Entities from BRAINSTORM
+- **kay** (character): Hero
+"""
+        count = _count_tensions(context)
+        assert count == 0
+
+
+class TestValidateEntityCoverage:
+    """Tests for validate_entity_coverage function."""
+
+    def test_complete_coverage_passes(self) -> None:
+        """Should pass when all entities are covered."""
+        brief = """## Entity Decisions
+- id: kay
+  disposition: retained
+- id: morgan
+  disposition: retained
+- id: archive
+  disposition: cut
+"""
+        is_complete, actual, _missing = validate_entity_coverage(brief, expected_count=3)
+
+        assert is_complete is True
+        assert actual == 3
+
+    def test_incomplete_coverage_fails(self) -> None:
+        """Should fail when not enough entities covered."""
+        brief = """## Entity Decisions
+- id: kay
+  disposition: retained
+"""
+        is_complete, actual, _missing = validate_entity_coverage(brief, expected_count=3)
+
+        assert is_complete is False
+        assert actual == 1
+
+    def test_handles_different_formats(self) -> None:
+        """Should handle different ID formats in brief."""
+        brief = """## Entity Decisions
+id: kay
+id: morgan
+  - id: archive
+"""
+        is_complete, actual, _missing = validate_entity_coverage(brief, expected_count=3)
+
+        assert is_complete is True
+        assert actual == 3
+
+    def test_empty_brief_returns_zero(self) -> None:
+        """Should return 0 for empty brief."""
+        is_complete, actual, _missing = validate_entity_coverage("", expected_count=3)
+
+        assert is_complete is False
+        assert actual == 0
+
+    def test_exceeding_expected_passes(self) -> None:
+        """Should pass when actual exceeds expected."""
+        brief = """- id: a
+- id: b
+- id: c
+- id: d
+"""
+        is_complete, actual, _missing = validate_entity_coverage(brief, expected_count=3)
+
+        assert is_complete is True
+        assert actual == 4
+
+
+class TestGetExpectedEntityCount:
+    """Tests for get_expected_entity_count function."""
+
+    def test_returns_entity_count(self) -> None:
+        """Should return count of entities in context."""
+        context = """## Entities from BRAINSTORM
+- **kay** (character): Hero
+- **morgan** (character): Mentor
+"""
+        count = get_expected_entity_count(context)
+        assert count == 2
+
+    def test_empty_context_returns_zero(self) -> None:
+        """Should return 0 for empty context."""
+        count = get_expected_entity_count("")
+        assert count == 0

--- a/tests/unit/test_summarize.py
+++ b/tests/unit/test_summarize.py
@@ -552,8 +552,8 @@ class TestSummarizeFeedbackLoop:
 
         messages = [HumanMessage(content="Test")]
 
-        def validator(_brief: str, _expected: int) -> tuple[bool, int, list[str]]:
-            return (True, 2, [])
+        def validator(_brief: str, _expected: int) -> tuple[bool, int]:
+            return (True, 2)
 
         summary, _result_messages, _tokens = await summarize_discussion(
             mock_model,
@@ -579,9 +579,9 @@ class TestSummarizeFeedbackLoop:
 
         messages = [HumanMessage(content="Test")]
 
-        def validator(brief: str, expected: int) -> tuple[bool, int, list[str]]:
+        def validator(brief: str, expected: int) -> tuple[bool, int]:
             count = brief.count("id:")
-            return (count >= expected, count, [])
+            return (count >= expected, count)
 
         summary, _result_messages, tokens = await summarize_discussion(
             mock_model,
@@ -607,9 +607,9 @@ class TestSummarizeFeedbackLoop:
 
         messages = [HumanMessage(content="Test")]
 
-        def validator(brief: str, expected: int) -> tuple[bool, int, list[str]]:
+        def validator(brief: str, expected: int) -> tuple[bool, int]:
             count = brief.count("id:")
-            return (count >= expected, count, [])
+            return (count >= expected, count)
 
         _summary, result_messages, _tokens = await summarize_discussion(
             mock_model,
@@ -634,8 +634,8 @@ class TestSummarizeFeedbackLoop:
 
         messages = [HumanMessage(content="Test")]
 
-        def validator(_brief: str, _expected: int) -> tuple[bool, int, list[str]]:
-            return (False, 1, [])  # Always fail
+        def validator(_brief: str, _expected: int) -> tuple[bool, int]:
+            return (False, 1)  # Always fail
 
         summary, _result_messages, _tokens = await summarize_discussion(
             mock_model,
@@ -661,9 +661,9 @@ class TestSummarizeFeedbackLoop:
 
         validator_called = []
 
-        def validator(_brief: str, _expected: int) -> tuple[bool, int, list[str]]:
+        def validator(_brief: str, _expected: int) -> tuple[bool, int]:
             validator_called.append(True)
-            return (False, 0, [])
+            return (False, 0)
 
         await summarize_discussion(
             mock_model,


### PR DESCRIPTION
## Problem

The summarize phase currently runs once without validation. When the LLM produces an incomplete summary (missing entity decisions), this isn't detected until the serialize phase, where it's harder to fix. We need a feedback loop that validates entity coverage and requests regeneration while the full conversation context is still available.

## Changes

- Add optional validation feedback loop to `summarize_discussion()`:
  - New parameters: `max_retries`, `entity_validator`, `expected_entity_count`
  - When validator fails, adds feedback message and retries with proper message history (multi-turn conversation)
  - Accumulates tokens across retries for accurate cost tracking

- Add validation functions in `prompts.py`:
  - `validate_entity_coverage()`: check entity coverage in brief
  - `get_expected_entity_count()`: extract count from brainstorm context
  - `_extract_entity_checklist()`: parse entities for numbered list
  - `_count_tensions()`: count tensions in context

- Export new functions from `agents/__init__.py`

## Not Included / Future PRs

- Integration with SEED stage (will be done when this is merged)
- PR 3: Optional context passing to serialize phase

## Test Plan

- Added 15 tests for validation functions in `test_prompts.py`
- Added 6 tests for feedback loop in `test_summarize.py`
- All 749 unit tests pass

```bash
uv run pytest tests/unit/ -q
# 749 passed in 3.62s
```

## Risk / Rollback

- Backward compatible: existing code using `summarize_discussion()` without new parameters continues to work unchanged
- New parameters are optional with sensible defaults (no retries, no validation)

Part of issue #193 (PR 2/3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)