### PR TITLE
feat(graph): add error_type classification to SeedValidationError

### DIFF
--- a/src/questfoundry/graph/mutations.py
+++ b/src/questfoundry/graph/mutations.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 from collections import Counter
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Literal
 
 if TYPE_CHECKING:
     from questfoundry.graph.graph import Graph
@@ -86,12 +86,15 @@ class SeedValidationError:
         issue: Description of what's wrong.
         available: List of valid IDs that could be used instead.
         provided: The value that was provided.
+        error_type: Classification of error - "wrong_id" for invalid references,
+            "missing_item" for entities/tensions without decisions.
     """
 
     field_path: str
     issue: str
     available: list[str] = field(default_factory=list)
     provided: str = ""
+    error_type: Literal["wrong_id", "missing_item"] = "wrong_id"
 
 
 class SeedMutationError(MutationError):
@@ -628,10 +631,31 @@ def validate_seed_mutations(graph: Graph, output: dict[str, Any]) -> list[SeedVa
                     issue=issue_msg,
                     available=[],
                     provided="",
+                    error_type="missing_item",  # Completeness error, not wrong ID
                 )
             )
 
     return errors
+
+
+def classify_seed_errors(
+    errors: list[SeedValidationError],
+) -> tuple[list[SeedValidationError], list[SeedValidationError]]:
+    """Split SEED validation errors into wrong_id and missing_item categories.
+
+    This classification guides the outer repair loop strategy:
+    - wrong_id errors can be fixed with surgical brief repair
+    - missing_item errors require resummarization with full context
+
+    Args:
+        errors: List of SeedValidationError objects from validate_seed_mutations().
+
+    Returns:
+        Tuple of (wrong_id_errors, missing_item_errors).
+    """
+    wrong_ids = [e for e in errors if e.error_type == "wrong_id"]
+    missing = [e for e in errors if e.error_type == "missing_item"]
+    return wrong_ids, missing
 
 
 def apply_seed_mutations(graph: Graph, output: dict[str, Any]) -> None:

--- a/src/questfoundry/graph/mutations.py
+++ b/src/questfoundry/graph/mutations.py
@@ -653,8 +653,13 @@ def classify_seed_errors(
     Returns:
         Tuple of (wrong_id_errors, missing_item_errors).
     """
-    wrong_ids = [e for e in errors if e.error_type == "wrong_id"]
-    missing = [e for e in errors if e.error_type == "missing_item"]
+    wrong_ids: list[SeedValidationError] = []
+    missing: list[SeedValidationError] = []
+    for e in errors:
+        if e.error_type == "wrong_id":
+            wrong_ids.append(e)
+        else:
+            missing.append(e)
     return wrong_ids, missing
 
 


### PR DESCRIPTION
## Problem

The SEED stage two-level feedback loop (PRs 188-190) only handles "wrong ID" errors via surgical brief repair. It cannot distinguish between wrong IDs and missing items (entities/tensions from BRAINSTORM without decisions in SEED).

## Changes

- Add `error_type: Literal["wrong_id", "missing_item"]` field to `SeedValidationError`
- Update `validate_seed_mutations()` to set `error_type="missing_item"` for completeness errors
- Add `classify_seed_errors()` helper to split errors into two categories
- Add 10 unit tests for error classification

## Not Included / Future PRs

- Resummarize function (PR #2 in stack)
- Wiring into SEED stage (PR #3 in stack)

## Test Plan

```bash
uv run pytest tests/unit/test_mutations.py -v
```

All 54 tests pass including 10 new tests for error classification.

## Risk / Rollback

Low risk - additive change with default value for new field ensures backward compatibility.

---

🤖 Generated with [Claude Code](https://claude.ai/code)

**Stack:** 1/3 - Base PR