### PR TITLE
feat(agents): add resummarize_with_feedback for missing items

### DIFF
--- a/src/questfoundry/agents/__init__.py
+++ b/src/questfoundry/agents/__init__.py
@@ -20,11 +20,16 @@ from questfoundry.agents.serialize import (
     serialize_to_artifact,
     serialize_with_brief_repair,
 )
-from questfoundry.agents.summarize import summarize_discussion
+from questfoundry.agents.summarize import (
+    format_missing_items_feedback,
+    resummarize_with_feedback,
+    summarize_discussion,
+)
 
 __all__ = [
     "SerializationError",
     "create_discuss_agent",
+    "format_missing_items_feedback",
     "get_brainstorm_discuss_prompt",
     "get_brainstorm_serialize_prompt",
     "get_brainstorm_summarize_prompt",
@@ -35,6 +40,7 @@ __all__ = [
     "get_seed_summarize_prompt",
     "get_serialize_prompt",
     "get_summarize_prompt",
+    "resummarize_with_feedback",
     "run_discuss_phase",
     "serialize_seed_iteratively",
     "serialize_to_artifact",

--- a/src/questfoundry/agents/summarize.py
+++ b/src/questfoundry/agents/summarize.py
@@ -255,7 +255,6 @@ def format_repair_errors(errors: list[SeedValidationError]) -> str:
 
 def format_missing_items_feedback(
     errors: list[SeedValidationError],
-    brainstorm_context: str = "",  # noqa: ARG001
 ) -> str:
     """Format feedback for missing entity/tension decisions.
 
@@ -266,23 +265,13 @@ def format_missing_items_feedback(
 
     Args:
         errors: List of SeedValidationError objects with error_type="missing_item".
-        brainstorm_context: The formatted BRAINSTORM context string that contains
-            the full entity/tension information.
 
     Returns:
         Formatted feedback string to append to summarize messages.
     """
-    # Separate entity and tension errors
-    entity_errors = [
-        e for e in errors if e.error_type == "missing_item" and "entity" not in e.issue.lower()[:20]
-    ]
-    tension_errors = [
-        e for e in errors if e.error_type == "missing_item" and "tension" in e.issue.lower()
-    ]
-
-    # Actually, let's parse based on issue content more robustly
-    entity_errors = []
-    tension_errors = []
+    # Separate entity and tension errors based on issue content
+    entity_errors: list[SeedValidationError] = []
+    tension_errors: list[SeedValidationError] = []
     for e in errors:
         if e.error_type != "missing_item":
             continue

--- a/tests/unit/test_summarize.py
+++ b/tests/unit/test_summarize.py
@@ -701,7 +701,7 @@ class TestFormatMissingItemsFeedback:
             ),
         ]
 
-        result = format_missing_items_feedback(errors, "## Entities from BRAINSTORM\n...")
+        result = format_missing_items_feedback(errors)
 
         assert "SUMMARY INCOMPLETE" in result
         assert "Missing Entity Decisions" in result
@@ -720,7 +720,7 @@ class TestFormatMissingItemsFeedback:
             ),
         ]
 
-        result = format_missing_items_feedback(errors, "## Tensions from BRAINSTORM\n...")
+        result = format_missing_items_feedback(errors)
 
         assert "SUMMARY INCOMPLETE" in result
         assert "Missing Tension Decisions" in result
@@ -745,7 +745,7 @@ class TestFormatMissingItemsFeedback:
             ),
         ]
 
-        result = format_missing_items_feedback(errors, "brainstorm context")
+        result = format_missing_items_feedback(errors)
 
         assert "Missing Entity Decisions" in result
         assert "Missing Tension Decisions" in result
@@ -764,7 +764,7 @@ class TestFormatMissingItemsFeedback:
             ),
         ]
 
-        result = format_missing_items_feedback(errors, "brainstorm context")
+        result = format_missing_items_feedback(errors)
 
         assert "SUMMARY INCOMPLETE" in result
         # wrong_id error should not appear in entity or tension sections
@@ -783,14 +783,14 @@ class TestFormatMissingItemsFeedback:
             ),
         ]
 
-        result = format_missing_items_feedback(errors, "brainstorm")
+        result = format_missing_items_feedback(errors)
 
         assert "regenerate" in result.lower()
         assert "ALL items from BRAINSTORM" in result
 
     def test_handles_empty_errors(self) -> None:
         """Should handle empty error list gracefully."""
-        result = format_missing_items_feedback([], "brainstorm")
+        result = format_missing_items_feedback([])
 
         assert "SUMMARY INCOMPLETE" in result
         # No specific error sections


### PR DESCRIPTION
## Problem

When SEED serialization fails due to missing entity/tension decisions, surgical brief repair cannot add content that was never in the brief. The model needs access to the full discussion context to add missing decisions.

## Changes

- Add `format_missing_items_feedback()` helper to create actionable feedback listing missing items
- Add `resummarize_with_feedback()` async function that continues the summarize conversation with feedback
- Export new functions from `agents/__init__.py`
- Add 13 unit tests for resummarize functionality

## Not Included / Future PRs

- Wiring into SEED stage (PR #3 in stack)

## Test Plan

```bash
uv run pytest tests/unit/test_summarize.py -v
```

All 50 tests pass including 13 new tests for resummarize.

## Risk / Rollback

Low risk - new functions with no callers yet. Will be wired in PR #3.

---

🤖 Generated with [Claude Code](https://claude.ai/code)

**Stack:** 2/3 - Depends on #199