### PR TITLE
feat(seed): 4-phase architecture schema and infra (Step 1)

### DIFF
--- a/src/questfoundry/agents/phase_runner.py
+++ b/src/questfoundry/agents/phase_runner.py
@@ -1,0 +1,128 @@
+"""Reusable runner for 4-phase SEED architecture.
+
+Implements the pattern:
+Discuss (Chat) -> Summarize (Chat) -> Serialize (Structured)
+
+Key Features:
+- Preserves proper message history between Discuss and Summarize (Issue #193)
+- Handles validation feedback loops (optional)
+- Returns structured artifact + tokens
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, TypeVar
+
+from pydantic import BaseModel
+
+from questfoundry.agents.discuss import run_discuss_phase
+from questfoundry.agents.serialize import serialize_to_artifact
+from questfoundry.agents.summarize import summarize_discussion
+from questfoundry.observability.logging import get_logger
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from langchain_core.callbacks import BaseCallbackHandler
+    from langchain_core.language_models import BaseChatModel
+    from langchain_core.messages import BaseMessage
+    from langchain_core.tools import BaseTool
+
+    from questfoundry.agents.discuss import (
+        AssistantMessageFn,
+        LLMCallbackFn,
+        UserInputFn,
+    )
+
+log = get_logger(__name__)
+
+T = TypeVar("T", bound=BaseModel)
+
+
+async def run_seed_phase(
+    phase_name: str,
+    model: BaseChatModel,
+    discuss_system_prompt: str,
+    summarize_system_prompt: str,
+    serialize_model_class: type[T],
+    user_prompt: str = "Let's proceed with this phase.",
+    tools: list[BaseTool] | None = None,
+    interactive: bool = False,
+    user_input_fn: UserInputFn | None = None,
+    on_assistant_message: AssistantMessageFn | None = None,
+    on_llm_start: LLMCallbackFn | None = None,
+    on_llm_end: LLMCallbackFn | None = None,
+    callbacks: list[BaseCallbackHandler] | None = None,
+    validator: Callable[[dict[str, Any]], list[Any]] | None = None,
+    max_retries: int = 2,
+) -> tuple[T, list[BaseMessage], int, int]:
+    """Execute a standard Discuss -> Summarize -> Serialize phase.
+
+    Args:
+        phase_name: Name of the phase (for logging/tags).
+        model: LLM to use.
+        discuss_system_prompt: System prompt for discussion.
+        summarize_system_prompt: System prompt for summarization.
+        serialize_model_class: Pydantic model for output.
+        user_prompt: Initial user message to kick off discussion.
+        tools: Optional tools for discussion.
+        interactive: Whether to allow user input.
+        user_input_fn: Function to get user input.
+        on_assistant_message: Callback for streaming.
+        on_llm_start: Callback for logging.
+        on_llm_end: Callback for logging.
+        callbacks: LangChain callbacks.
+        validator: Optional semantic validator function (returns error list).
+        max_retries: Retries for serialization validation.
+
+    Returns:
+        Tuple of (Artifact, PhaseMessages, LLMCalls, Tokens).
+    """
+    log.info("seed_phase_start", phase=phase_name)
+    total_calls = 0
+    total_tokens = 0
+
+    # 1. DISCUSS
+    discuss_messages, d_calls, d_tokens = await run_discuss_phase(
+        model=model,
+        tools=tools or [],
+        user_prompt=user_prompt,
+        system_prompt=discuss_system_prompt,
+        interactive=interactive,
+        user_input_fn=user_input_fn,
+        on_assistant_message=on_assistant_message,
+        on_llm_start=on_llm_start,
+        on_llm_end=on_llm_end,
+        stage_name=f"seed_{phase_name}",
+        callbacks=callbacks,
+    )
+    total_calls += d_calls
+    total_tokens += d_tokens
+
+    # 2. SUMMARIZE
+    # Issue #193: Pass PROPER message objects, not flattened text.
+    brief, s_tokens = await summarize_discussion(
+        model=model,
+        messages=discuss_messages,
+        system_prompt=summarize_system_prompt,
+        stage_name=f"seed_{phase_name}",
+        callbacks=callbacks,
+    )
+    total_calls += 1
+    total_tokens += s_tokens
+
+    # 3. SERIALIZE
+    artifact, ser_tokens = await serialize_to_artifact(
+        model=model,
+        brief=brief,
+        schema=serialize_model_class,
+        max_retries=max_retries,
+        callbacks=callbacks,
+        semantic_validator=validator,
+    )
+    total_calls += 1
+    total_tokens += ser_tokens
+
+    log.info("seed_phase_complete", phase=phase_name, tokens=total_tokens)
+
+    return artifact, discuss_messages, total_calls, total_tokens

--- a/src/questfoundry/agents/phase_runner.py
+++ b/src/questfoundry/agents/phase_runner.py
@@ -120,6 +120,9 @@ async def run_seed_phase(
         callbacks=callbacks,
         semantic_validator=validator,
     )
+    # serialize_to_artifact handles its own retry loop and tokens.
+    # NOTE: It currently returns only (artifact, tokens), not call count.
+    # We assume at least 1 call was made. Actual calls may be higher if retries occurred.
     total_calls += 1
     total_tokens += ser_tokens
 

--- a/src/questfoundry/models/seed.py
+++ b/src/questfoundry/models/seed.py
@@ -1,12 +1,6 @@
-"""Pydantic models for SEED stage output.
+"""Pydantic models for SEED stage 4-phase architecture.
 
-SEED is the triage stage that transforms expansive brainstorm material into
-committed story structure. It curates entities, decides which alternatives
-to explore as threads, creates consequences, and defines initial beats.
-
-CRITICAL: THREAD FREEZE - No new threads can be created after SEED.
-
-See docs/design/00-spec.md for details.
+See issue #202 for architectural details.
 """
 
 from __future__ import annotations
@@ -15,294 +9,131 @@ from typing import Literal
 
 from pydantic import BaseModel, Field
 
-# Type aliases for clarity
+# -------------------------------------------------------------------------
+# Shared / Core Models
+# -------------------------------------------------------------------------
+
 EntityDisposition = Literal["retained", "cut"]
 ThreadTier = Literal["major", "minor"]
 TensionEffect = Literal["advances", "reveals", "commits", "complicates"]
 
 
 class EntityDecision(BaseModel):
-    """Entity curation decision from SEED.
+    """Entity curation decision (Phase 1)."""
 
-    SEED receives entities from BRAINSTORM and decides which to retain
-    for the story. Entities are the building blocks; not all brainstorm
-    ideas make it into the final story.
-
-    Attributes:
-        entity_id: Entity ID from BRAINSTORM.
-        disposition: Whether to keep (retained) or discard (cut).
-    """
-
-    entity_id: str = Field(
-        min_length=1, description="Entity ID from BRAINSTORM (references entity_id)"
-    )
-    disposition: EntityDisposition = Field(
-        default="retained",
-        description="Whether to keep or discard the entity",
-    )
+    entity_id: str = Field(min_length=1, description="Entity ID from BRAINSTORM")
+    disposition: EntityDisposition = Field(default="retained")
 
 
 class TensionDecision(BaseModel):
-    """Tension exploration decision from SEED.
-
-    Each tension has two alternatives. SEED decides which alternatives to
-    explore as threads. The canonical alternative is always explored (spine).
-    Non-canonical alternatives become branches only if explicitly explored.
-
-    Attributes:
-        tension_id: Tension ID from BRAINSTORM.
-        explored: Alternative IDs that become threads.
-        implicit: Alternative IDs not explored (context for FILL shadows).
-    """
+    """Tension exploration decision (Phase 2)."""
 
     tension_id: str = Field(min_length=1, description="Tension ID from BRAINSTORM")
-    explored: list[str] = Field(
-        min_length=1,
-        description="Alternative IDs to explore as threads (always includes canonical)",
-    )
-    implicit: list[str] = Field(
-        default_factory=list,
-        description="Alternative IDs not explored (become shadows)",
-    )
+    explored: list[str] = Field(min_length=1, description="Alternative IDs to explore")
+    implicit: list[str] = Field(default_factory=list, description="Alternative IDs not explored")
+
+
+class BeatHook(BaseModel):
+    """A high-level beat concept to ensure thread coherence (Phase 2)."""
+
+    thread_id: str = Field(min_length=1, description="Thread this hook belongs to")
+    description: str = Field(min_length=1, description="Core concept for a future beat")
 
 
 class Consequence(BaseModel):
-    """Narrative consequence of a thread choice.
+    """Narrative consequence of a thread choice (Phase 2)."""
 
-    Consequences bridge the gap between "what this path represents" (alternative)
-    and "how we track it" (codeword). GROW creates codewords to track when
-    consequences become active.
-
-    Attributes:
-        consequence_id: Unique identifier for the consequence.
-        thread_id: Thread this consequence belongs to.
-        description: What happens narratively.
-        narrative_effects: Story effects this implies.
-    """
-
-    consequence_id: str = Field(min_length=1, description="Unique identifier for this consequence")
-    thread_id: str = Field(
-        min_length=1, description="Thread this belongs to (references thread_id)"
-    )
-    description: str = Field(min_length=1, description="Narrative meaning of this path")
-    narrative_effects: list[str] = Field(
-        default_factory=list,
-        description="Story effects this consequence implies (cascading impacts)",
-    )
+    consequence_id: str = Field(min_length=1, description="Unique identifier")
+    thread_id: str = Field(min_length=1, description="Thread this belongs to")
+    description: str = Field(min_length=1, description="Narrative meaning")
+    narrative_effects: list[str] = Field(default_factory=list, description="Cascading impacts")
 
 
 class Thread(BaseModel):
-    """Plot thread exploring one alternative from a tension.
+    """Plot thread exploring one alternative (Phase 2)."""
 
-    Threads are the core structural units of the branching story. Threads
-    from the same tension are automatically exclusive (choosing one means
-    not choosing the other).
-
-    Attributes:
-        thread_id: Unique identifier for the thread.
-        name: Human-readable name.
-        tension_id: The tension this thread explores.
-        alternative_id: The specific alternative this thread explores.
-        unexplored_alternative_ids: IDs of unexplored alternatives (context for FILL).
-        thread_importance: Major threads interweave; minor threads support.
-        description: What this thread is about.
-        consequence_ids: IDs of consequences for this thread.
-    """
-
-    thread_id: str = Field(min_length=1, description="Unique identifier for this thread")
+    thread_id: str = Field(min_length=1, description="Unique identifier")
     name: str = Field(min_length=1, description="Human-readable name")
-    tension_id: str = Field(
-        min_length=1, description="Tension this explores (references tension_id)"
-    )
-    alternative_id: str = Field(
-        min_length=1, description="Alternative this explores (references alternative_id)"
-    )
-    unexplored_alternative_ids: list[str] = Field(
-        default_factory=list,
-        description="IDs of unexplored alternatives from same tension (context for FILL)",
-    )
-    thread_importance: ThreadTier = Field(
-        description="Thread importance: major (interweaves) or minor (supports)"
-    )
+    tension_id: str = Field(min_length=1, description="Tension this explores")
+    alternative_id: str = Field(min_length=1, description="Alternative this explores")
+    unexplored_alternative_ids: list[str] = Field(default_factory=list)
+    thread_importance: ThreadTier = Field(description="Thread importance")
     description: str = Field(min_length=1, description="What this thread is about")
-    consequence_ids: list[str] = Field(
-        default_factory=list,
-        description="Consequence IDs for this thread (references consequence_id)",
-    )
+    consequence_ids: list[str] = Field(default_factory=list, description="Consequence IDs")
+
+
+class StoryDirectionStatement(BaseModel):
+    """North star for the story (Phase 1)."""
+
+    statement: str = Field(min_length=1, description="2-3 sentence strategic direction")
 
 
 class TensionImpact(BaseModel):
-    """How a beat affects a tension.
-
-    Each beat can impact one or more tensions, moving the story forward
-    in various ways.
-
-    Attributes:
-        tension_id: Tension being impacted.
-        effect: How the beat affects the tension.
-        note: Explanation of the impact.
-    """
+    """How a beat affects a tension (Phase 3)."""
 
     tension_id: str = Field(min_length=1, description="Tension being impacted")
     effect: TensionEffect = Field(description="How the beat affects the tension")
-    note: str = Field(min_length=1, description="Explanation of the impact")
+    note: str = Field(min_length=1, description="Explanation of impact")
 
 
 class InitialBeat(BaseModel):
-    """Initial beat created by SEED.
+    """Initial beat created by SEED (Phase 3)."""
 
-    Beats are narrative units belonging to one or more threads. SEED creates
-    the initial beats for each thread; GROW mutates and adds more.
-
-    Attributes:
-        id: Unique identifier for the beat.
-        summary: What happens in this beat.
-        threads: Thread IDs this beat serves.
-        tension_impacts: How this beat affects tensions.
-        entities: Entity IDs present in this beat.
-        location: Primary location entity ID.
-        location_alternatives: Other valid locations (enables knot flexibility).
-    """
-
-    beat_id: str = Field(min_length=1, description="Unique identifier for this beat")
+    beat_id: str = Field(min_length=1, description="Unique identifier")
     summary: str = Field(min_length=1, description="What happens in this beat")
-    threads: list[str] = Field(
-        min_length=1,
-        description="Thread IDs this beat serves",
-    )
-    tension_impacts: list[TensionImpact] = Field(
-        default_factory=list,
-        description="How this beat affects tensions",
-    )
-    entities: list[str] = Field(
-        default_factory=list,
-        description="Entity IDs present in this beat",
-    )
-    location: str | None = Field(
-        default=None,
-        description="Primary location entity ID",
-    )
-    location_alternatives: list[str] = Field(
-        default_factory=list,
-        description="Other valid locations for knot flexibility",
-    )
+    threads: list[str] = Field(min_length=1, description="Thread IDs this beat serves")
+    tension_impacts: list[TensionImpact] = Field(default_factory=list)
+    entities: list[str] = Field(default_factory=list, description="Entity IDs present")
+    location: str | None = Field(default=None, description="Primary location entity ID")
+    location_alternatives: list[str] = Field(default_factory=list)
 
 
 class ConvergenceSketch(BaseModel):
-    """Informal guidance for GROW about thread convergence.
+    """Guidance for thread convergence (Phase 4)."""
 
-    Provides hints about where threads should merge and what differences
-    should persist after convergence.
+    convergence_points: list[str] = Field(default_factory=list)
+    residue_notes: list[str] = Field(default_factory=list)
 
-    Attributes:
-        convergence_points: Where threads should merge.
-        residue_notes: What differences persist after convergence.
-    """
 
-    convergence_points: list[str] = Field(
-        default_factory=list,
-        description="Where threads should merge (e.g., 'by act 2 climax')",
-    )
-    residue_notes: list[str] = Field(
-        default_factory=list,
-        description="Differences that persist after convergence",
-    )
+# -------------------------------------------------------------------------
+# Phase Output Models
+# -------------------------------------------------------------------------
+
+
+class EntityCurationOutput(BaseModel):
+    """Output of Phase 1: Entity Curation."""
+
+    story_direction: StoryDirectionStatement
+    entities: list[EntityDecision]
+
+
+class ThreadDesignOutput(BaseModel):
+    """Output of Phase 2: Thread Design."""
+
+    tensions: list[TensionDecision]
+    threads: list[Thread]
+    consequences: list[Consequence]
+    beat_hooks: list[BeatHook]
+
+
+class BeatsOutput(BaseModel):
+    """Output of Phase 3: Beats."""
+
+    initial_beats: list[InitialBeat]
+
+
+class ConvergenceOutput(BaseModel):
+    """Output of Phase 4: Convergence."""
+
+    convergence_sketch: ConvergenceSketch
 
 
 class SeedOutput(BaseModel):
-    """Complete output of the SEED stage.
+    """Complete output of the SEED stage (Aggregated)."""
 
-    SEED transforms brainstorm material into committed story structure.
-    After SEED, no new threads can be created (THREAD FREEZE).
-
-    Attributes:
-        entities: Entity curation decisions.
-        tensions: Tension exploration decisions.
-        threads: Created plot threads.
-        consequences: Narrative consequences for threads.
-        initial_beats: Initial beats for each thread.
-        convergence_sketch: Guidance for GROW about convergence.
-    """
-
-    entities: list[EntityDecision] = Field(
-        default_factory=list,
-        description="Entity curation decisions",
-    )
-    tensions: list[TensionDecision] = Field(
-        default_factory=list,
-        description="Tension exploration decisions",
-    )
-    threads: list[Thread] = Field(
-        default_factory=list,
-        description="Created plot threads",
-    )
-    consequences: list[Consequence] = Field(
-        default_factory=list,
-        description="Narrative consequences for threads",
-    )
-    initial_beats: list[InitialBeat] = Field(
-        default_factory=list,
-        description="Initial beats for each thread",
-    )
-    convergence_sketch: ConvergenceSketch = Field(
-        default_factory=ConvergenceSketch,
-        description="Guidance for GROW about thread convergence",
-    )
-
-
-# Section wrapper models for iterative serialization
-# These allow serializing SEED output in chunks to avoid output truncation
-
-
-class EntitiesSection(BaseModel):
-    """Wrapper for serializing entity decisions separately."""
-
-    entities: list[EntityDecision] = Field(
-        default_factory=list,
-        description="Entity curation decisions",
-    )
-
-
-class TensionsSection(BaseModel):
-    """Wrapper for serializing tension decisions separately."""
-
-    tensions: list[TensionDecision] = Field(
-        default_factory=list,
-        description="Tension exploration decisions",
-    )
-
-
-class ThreadsSection(BaseModel):
-    """Wrapper for serializing threads separately."""
-
-    threads: list[Thread] = Field(
-        default_factory=list,
-        description="Created plot threads",
-    )
-
-
-class ConsequencesSection(BaseModel):
-    """Wrapper for serializing consequences separately."""
-
-    consequences: list[Consequence] = Field(
-        default_factory=list,
-        description="Narrative consequences for threads",
-    )
-
-
-class BeatsSection(BaseModel):
-    """Wrapper for serializing initial beats separately."""
-
-    initial_beats: list[InitialBeat] = Field(
-        default_factory=list,
-        description="Initial beats for each thread",
-    )
-
-
-class ConvergenceSection(BaseModel):
-    """Wrapper for serializing convergence sketch separately."""
-
-    convergence_sketch: ConvergenceSketch = Field(
-        default_factory=ConvergenceSketch,
-        description="Guidance for GROW about thread convergence",
-    )
+    entities: list[EntityDecision] = Field(default_factory=list)
+    tensions: list[TensionDecision] = Field(default_factory=list)
+    threads: list[Thread] = Field(default_factory=list)
+    consequences: list[Consequence] = Field(default_factory=list)
+    initial_beats: list[InitialBeat] = Field(default_factory=list)
+    convergence_sketch: ConvergenceSketch = Field(default_factory=ConvergenceSketch)

--- a/src/questfoundry/models/seed.py
+++ b/src/questfoundry/models/seed.py
@@ -137,3 +137,62 @@ class SeedOutput(BaseModel):
     consequences: list[Consequence] = Field(default_factory=list)
     initial_beats: list[InitialBeat] = Field(default_factory=list)
     convergence_sketch: ConvergenceSketch = Field(default_factory=ConvergenceSketch)
+
+
+# -------------------------------------------------------------------------
+# Compatibility Wrappers (for iterative serialization)
+# -------------------------------------------------------------------------
+
+
+class EntitiesSection(BaseModel):
+    """Wrapper for serializing entity decisions separately."""
+
+    entities: list[EntityDecision] = Field(
+        default_factory=list,
+        description="Entity curation decisions",
+    )
+
+
+class TensionsSection(BaseModel):
+    """Wrapper for serializing tension decisions separately."""
+
+    tensions: list[TensionDecision] = Field(
+        default_factory=list,
+        description="Tension exploration decisions",
+    )
+
+
+class ThreadsSection(BaseModel):
+    """Wrapper for serializing threads separately."""
+
+    threads: list[Thread] = Field(
+        default_factory=list,
+        description="Created plot threads",
+    )
+
+
+class ConsequencesSection(BaseModel):
+    """Wrapper for serializing consequences separately."""
+
+    consequences: list[Consequence] = Field(
+        default_factory=list,
+        description="Narrative consequences for threads",
+    )
+
+
+class BeatsSection(BaseModel):
+    """Wrapper for serializing initial beats separately."""
+
+    initial_beats: list[InitialBeat] = Field(
+        default_factory=list,
+        description="Initial beats for each thread",
+    )
+
+
+class ConvergenceSection(BaseModel):
+    """Wrapper for serializing convergence sketch separately."""
+
+    convergence_sketch: ConvergenceSketch = Field(
+        default_factory=ConvergenceSketch,
+        description="Guidance for GROW about thread convergence",
+    )


### PR DESCRIPTION
This PR implements the foundational schema and infrastructure for the new 4-phase SEED stage architecture, as proposed in #202.

## Changes
- **Models (`src/questfoundry/models/seed.py`)**: Added `StoryDirectionStatement`, `BeatHook`, and phase-specific output containers (`EntityCurationOutput`, `ThreadDesignOutput`, etc.).
- **Infrastructure (`src/questfoundry/agents/phase_runner.py`)**: Created a reusable `run_seed_phase()` function that handles the standard Discuss -> Summarize -> Serialize lifecycle.

## Architectural Improvements (Rescue from #193)
- Implemented proper message history passing in `run_seed_phase`. The `Summarize` phase now receives the actual `list[BaseMessage]` objects from the `Discuss` phase, preventing context loss from text flattening.

## Next Steps
Once reviewed and merged, we will proceed with:
- Phase 1 & 2 logic (Issue #206)
- Phase 3 & 4 logic (Issue #207)
- Pipeline orchestration (Issue #208)

Resolves part of #204 (Step 1)
