### PR TITLE
feat(agents): add SEED 4-phase pipeline infrastructure

### DIFF
--- a/docs/architecture/seed-4-phase-implementation-plan.md
+++ b/docs/architecture/seed-4-phase-implementation-plan.md
@@ -1,0 +1,545 @@
+# SEED 4-Phase Architecture Implementation Plan
+
+**Status**: Ready for review
+**Related Issues**: #202, #204
+**Author**: Implementation analysis based on codebase research
+
+## Executive Summary
+
+The current SEED stage has a single monolithic discuss phase handling 5 complex tasks simultaneously, leading to "phantom ID" hallucinations where models invent locations and IDs that don't exist in BRAINSTORM. The root cause is **cognitive overload** - the model can't hold all constraints while making creative decisions.
+
+**Solution**: Split into 4 focused phases, each with the standard Discuss → Summarize → Serialize pattern. Each phase outputs a validated artifact that feeds into the next, creating a chain of constraints that prevents ID invention.
+
+## Current Architecture Analysis
+
+### What Exists Today
+
+```
+src/questfoundry/
+├── pipeline/stages/seed.py          # 3-phase: discuss → summarize → serialize
+├── agents/
+│   ├── discuss.py                   # Agent-based discussion with tools
+│   ├── summarize.py                 # Single LLM call to condense
+│   └── serialize.py                 # Structured output with validation
+│       └── serialize_seed_iteratively()  # 6-section serialization
+├── models/seed.py                   # SeedOutput + section wrappers
+├── graph/
+│   ├── context.py                   # format_valid_ids_context(), format_thread_ids_context()
+│   └── mutations.py                 # validate_seed_mutations(), apply_seed_mutations()
+└── prompts/templates/
+    ├── discuss_seed.yaml            # Monolithic 5-task prompt
+    ├── summarize_seed.yaml
+    ├── serialize_seed.yaml
+    └── serialize_seed_sections.yaml # 6 section-specific prompts
+```
+
+### Key Strengths to Preserve
+
+1. **Iterative Serialization** - 6-section approach avoids truncation
+2. **Semantic Validation** - Cross-references checked against BRAINSTORM graph
+3. **ID Context Injection** - Valid IDs provided upfront to prevent phantoms
+4. **Thread IDs Injection** - Thread IDs injected after threads serialized (for beats)
+5. **Repair Loops** - Targeted re-serialization of problematic sections only
+6. **Hybrid Provider Support** - Different models for discuss/summarize/serialize
+
+### Problems Being Solved
+
+| Problem | Root Cause | Solution |
+|---------|------------|----------|
+| Phantom locations | Cognitive overload in monolithic discuss | Entity decisions finalized in Phase 1 |
+| Thread ID confusion | Thread/tension ID naming collision | Explicit naming guidance + Phase 2 isolation |
+| Beat ID errors | Invalid thread refs in beats | Thread IDs known before Phase 3 starts |
+| Convergence vagueness | Low priority in crowded discuss | Dedicated Phase 4 with focused attention |
+
+## Proposed 4-Phase Architecture
+
+```
+┌─────────────────────────────────────────────────────────────────────────┐
+│                          BRAINSTORM Graph                               │
+│  (entities, tensions, alternatives - all IDs are authoritative)         │
+└─────────────────────────────────────────────────────────────────────────┘
+                                    │
+                                    ▼
+┌─────────────────────────────────────────────────────────────────────────┐
+│ PHASE 1: Entity Curation (~2000 tokens output)                          │
+│ ─────────────────────────────────────────────────────────────────────── │
+│ Input:  BRAINSTORM context (entities, tensions)                         │
+│ Tasks:  • Retain/cut decisions for ALL entities                         │
+│         • Story Direction Statement (2-3 sentence "north star")         │
+│ Output: EntityCurationOutput { story_direction, entities[] }            │
+│ Gate:   Validate all entities have decisions                            │
+└─────────────────────────────────────────────────────────────────────────┘
+                                    │
+                    story_direction + retained_entity_ids
+                                    ▼
+┌─────────────────────────────────────────────────────────────────────────┐
+│ PHASE 2: Thread Design (~2500 tokens output)                            │
+│ ─────────────────────────────────────────────────────────────────────── │
+│ Input:  Story direction + retained entities + all tensions              │
+│ Tasks:  • Tension exploration decisions (explored vs implicit alts)     │
+│         • Thread creation (thread_id DIFFERENT from tension_id)         │
+│         • Consequences for each thread                                  │
+│         • Beat Hooks (2-3 beat concepts per thread for coherence)       │
+│ Output: ThreadDesignOutput { tensions[], threads[], consequences[],     │
+│                              beat_hooks[] }                             │
+│ Gate:   Validate thread IDs are unique and not tension IDs              │
+└─────────────────────────────────────────────────────────────────────────┘
+                                    │
+                    thread_ids + beat_hooks + consequences
+                                    ▼
+┌─────────────────────────────────────────────────────────────────────────┐
+│ PHASE 3: Initial Beats (STRICT VALIDATION)                              │
+│ ─────────────────────────────────────────────────────────────────────── │
+│ Input:  Story direction + retained entities + threads + beat hooks      │
+│ Tasks:  • Create 2-4 beats per thread                                   │
+│         • Map beats to threads (MUST use valid thread IDs)              │
+│         • Map beats to entities (MUST use retained entity IDs)          │
+│         • Location diversity (2+ locations per thread)                  │
+│ Output: BeatsOutput { initial_beats[] }                                 │
+│ Gate:   ZERO TOLERANCE for invented IDs - fail immediately              │
+└─────────────────────────────────────────────────────────────────────────┘
+                                    │
+                                    ▼
+┌─────────────────────────────────────────────────────────────────────────┐
+│ PHASE 4: Convergence Sketch                                             │
+│ ─────────────────────────────────────────────────────────────────────── │
+│ Input:  Full context (story direction, threads, beats)                  │
+│ Tasks:  • Where threads should merge                                    │
+│         • What differences persist after convergence                    │
+│ Output: ConvergenceOutput { convergence_sketch }                        │
+│ Gate:   Structural validation only                                      │
+└─────────────────────────────────────────────────────────────────────────┘
+                                    │
+                                    ▼
+┌─────────────────────────────────────────────────────────────────────────┐
+│ MERGE: Combine all phase outputs into SeedOutput                        │
+│ ─────────────────────────────────────────────────────────────────────── │
+│ Final semantic validation against BRAINSTORM graph                      │
+│ Apply mutations to graph                                                │
+└─────────────────────────────────────────────────────────────────────────┘
+```
+
+## Implementation Plan
+
+### PR #1: Schema & Phase Runner Infrastructure (~300 lines)
+
+**Goal**: Define data models and create reusable phase execution infrastructure.
+
+#### New Models (`src/questfoundry/models/seed.py`)
+
+```python
+# Story direction as explicit artifact (not just prose in discussion)
+class StoryDirectionStatement(BaseModel):
+    """2-3 sentence north star for the story."""
+    statement: str = Field(min_length=10, description="Core story direction")
+
+# Beat hooks provide continuity between Phase 2 and Phase 3
+class BeatHook(BaseModel):
+    """Beat concept from Thread Design to guide Beat creation."""
+    thread_id: str = Field(min_length=1)
+    hook: str = Field(min_length=1, description="Beat concept, e.g., 'discovery in library'")
+
+# Phase 1 output
+class EntityCurationOutput(BaseModel):
+    """Phase 1 output: Entity decisions + story direction."""
+    story_direction: StoryDirectionStatement
+    entities: list[EntityDecision]
+
+# Phase 2 output
+class ThreadDesignOutput(BaseModel):
+    """Phase 2 output: Threads, tensions, consequences, beat hooks."""
+    tensions: list[TensionDecision]
+    threads: list[Thread]
+    consequences: list[Consequence]
+    beat_hooks: list[BeatHook]
+
+# Phase 3 output
+class BeatsOutput(BaseModel):
+    """Phase 3 output: Initial beats with strict ID validation."""
+    initial_beats: list[InitialBeat]
+
+# Phase 4 output
+class ConvergenceOutput(BaseModel):
+    """Phase 4 output: Convergence guidance for GROW."""
+    convergence_sketch: ConvergenceSketch
+```
+
+#### Phase Runner (`src/questfoundry/agents/phase_runner.py`)
+
+```python
+@dataclass
+class PhaseResult:
+    """Result from running a single phase."""
+    artifact: BaseModel
+    messages: list[BaseMessage]  # For context passing to next phase
+    tokens: int
+    llm_calls: int
+
+async def run_seed_phase(
+    model: BaseChatModel,
+    phase_name: str,
+    schema: type[T],
+    discuss_prompt: str,
+    summarize_prompt: str,
+    serialize_prompt: str,
+    context: str,                    # Injected context (story direction, IDs, etc.)
+    *,
+    user_prompt: str = "",
+    tools: list | None = None,
+    interactive: bool = False,
+    callbacks: list[BaseCallbackHandler] | None = None,
+    summarize_model: BaseChatModel | None = None,
+    serialize_model: BaseChatModel | None = None,
+    semantic_validator: SemanticValidator | None = None,
+) -> PhaseResult:
+    """Run a single SEED phase with Discuss → Summarize → Serialize pattern."""
+```
+
+**Key architectural improvement**: Pass actual `list[BaseMessage]` from Discuss to Summarize (rescued from #193) to preserve context, not flattened text.
+
+#### Files Changed
+
+- `src/questfoundry/models/seed.py` - Add new models (~80 lines)
+- `src/questfoundry/agents/phase_runner.py` - New file (~150 lines)
+- `src/questfoundry/agents/__init__.py` - Export new function
+- `tests/unit/test_phase_runner.py` - Unit tests (~70 lines)
+
+---
+
+### PR #2: Phase 1 & 2 Prompts + Validation (~350 lines)
+
+**Goal**: Implement Entity Curation and Thread Design phases with validation.
+
+#### New Prompts
+
+```
+prompts/templates/
+├── phase1_discuss.yaml      # Entity curation focus
+├── phase1_summarize.yaml    # Extract story direction + decisions
+├── phase1_serialize.yaml    # EntityCurationOutput schema
+├── phase2_discuss.yaml      # Thread design focus
+├── phase2_summarize.yaml    # Extract threads + consequences + hooks
+└── phase2_serialize.yaml    # ThreadDesignOutput schema
+```
+
+#### Phase 1 Validation
+
+```python
+def validate_phase1_output(
+    output: EntityCurationOutput,
+    graph: Graph,
+) -> list[Phase1ValidationError]:
+    """Validate Phase 1 output against BRAINSTORM graph."""
+    errors = []
+
+    # Check all BRAINSTORM entities have decisions
+    brainstorm_entities = set(graph.get_nodes_by_type("entity").keys())
+    decided_entities = {e.entity_id for e in output.entities}
+
+    for missing in brainstorm_entities - decided_entities:
+        entity_type = graph.get_node(missing).get("entity_type", "entity")
+        errors.append(Phase1ValidationError(
+            field_path=f"entities",
+            error_type="missing_decision",
+            message=f"Missing decision for {entity_type} '{missing}'",
+            available_ids=list(brainstorm_entities),
+        ))
+
+    return errors
+```
+
+#### Phase 2 Validation (Thread Naming)
+
+```python
+def validate_phase2_output(
+    output: ThreadDesignOutput,
+    graph: Graph,
+) -> list[Phase2ValidationError]:
+    """Validate Phase 2 with strict thread ID rules."""
+    errors = []
+
+    # Thread IDs must not match tension IDs
+    tension_ids = set(graph.get_nodes_by_type("tension").keys())
+    for thread in output.threads:
+        if thread.thread_id in tension_ids:
+            errors.append(Phase2ValidationError(
+                field_path=f"threads.{thread.thread_id}",
+                error_type="thread_id_collision",
+                message=f"Thread ID '{thread.thread_id}' matches a tension ID. "
+                        f"Thread IDs must be SHORT and DIFFERENT from tension IDs.",
+                suggestion=f"Try '{thread.thread_id[:10]}_path' or similar",
+            ))
+
+    return errors
+```
+
+#### Files Changed
+
+- `prompts/templates/phase1_*.yaml` - 3 new prompt files (~200 lines total)
+- `prompts/templates/phase2_*.yaml` - 3 new prompt files (~250 lines total)
+- `src/questfoundry/graph/validation.py` - New validation functions (~100 lines)
+- `tests/unit/test_phase_validation.py` - Unit tests (~100 lines)
+
+---
+
+### PR #3: Phase 3 & 4 Prompts + STRICT Validation (~300 lines)
+
+**Goal**: Implement Beats and Convergence phases with zero-tolerance ID validation.
+
+#### Phase 3: STRICT ID Validation
+
+The key innovation here is **zero tolerance** - if ANY beat references an invalid ID, fail immediately without repair attempts. This forces the model to pay attention to the ID constraints.
+
+```python
+def validate_phase3_output_strict(
+    output: BeatsOutput,
+    valid_thread_ids: set[str],
+    valid_entity_ids: set[str],
+    valid_location_ids: set[str],
+) -> list[Phase3ValidationError]:
+    """STRICT validation - zero tolerance for invented IDs."""
+    errors = []
+
+    for beat in output.initial_beats:
+        # Check thread references
+        for thread_id in beat.threads:
+            if thread_id not in valid_thread_ids:
+                errors.append(Phase3ValidationError(
+                    field_path=f"initial_beats.{beat.beat_id}.threads",
+                    error_type="invalid_thread_id",
+                    message=f"Thread '{thread_id}' does not exist",
+                    valid_ids=list(valid_thread_ids),
+                    severity="FATAL",  # No retry, fail immediately
+                ))
+
+        # Check entity references
+        for entity_id in beat.entities:
+            if entity_id not in valid_entity_ids:
+                errors.append(Phase3ValidationError(
+                    field_path=f"initial_beats.{beat.beat_id}.entities",
+                    error_type="invalid_entity_id",
+                    message=f"Entity '{entity_id}' was cut or doesn't exist",
+                    valid_ids=list(valid_entity_ids),
+                    severity="FATAL",
+                ))
+
+    return errors
+```
+
+#### Phase 3 Prompt Structure
+
+```yaml
+# phase3_serialize.yaml
+system: |
+  ## CRITICAL: Valid IDs (copy EXACTLY, do not invent)
+
+  ### VALID THREAD IDs
+  {thread_ids}
+
+  ### RETAINED ENTITY IDs
+  {entity_ids}
+
+  ### LOCATION IDs (subset of entities)
+  {location_ids}
+
+  ## Beat Hooks (use as inspiration)
+  {beat_hooks}
+
+  ## Your Task
+  Create 2-4 initial beats per thread using ONLY the IDs above.
+
+  ## FINAL CHECK (verify before output)
+  1. Every `threads` item appears in VALID THREAD IDs
+  2. Every `entities` item appears in RETAINED ENTITY IDs
+  3. Every `location` appears in LOCATION IDs
+  4. 2-4 beats per thread (check count!)
+```
+
+#### Files Changed
+
+- `prompts/templates/phase3_*.yaml` - 3 new prompt files (~200 lines total)
+- `prompts/templates/phase4_*.yaml` - 3 new prompt files (~100 lines total)
+- `src/questfoundry/graph/validation.py` - Add strict validation (~80 lines)
+- `tests/unit/test_strict_validation.py` - Unit tests (~100 lines)
+
+---
+
+### PR #4: Orchestration Integration (~400 lines)
+
+**Goal**: Wire up 4-phase execution in SeedStage, merge outputs into SeedOutput.
+
+#### Updated SeedStage
+
+```python
+class SeedStage:
+    """SEED stage - 4-phase architecture."""
+
+    async def execute(self, ...) -> tuple[dict[str, Any], int, int]:
+        """Execute SEED using 4-phase pattern."""
+
+        # Load BRAINSTORM context
+        graph = Graph.load(project_path)
+        brainstorm_context = format_brainstorm_context(graph)
+
+        # Phase 1: Entity Curation
+        phase1_result = await run_seed_phase(
+            model=model,
+            phase_name="entity_curation",
+            schema=EntityCurationOutput,
+            discuss_prompt=get_phase1_discuss_prompt(brainstorm_context),
+            summarize_prompt=get_phase1_summarize_prompt(brainstorm_context),
+            serialize_prompt=get_phase1_serialize_prompt(),
+            context=brainstorm_context,
+            semantic_validator=lambda d: validate_phase1_output(
+                EntityCurationOutput.model_validate(d), graph
+            ),
+        )
+
+        # Extract outputs for next phase
+        story_direction = phase1_result.artifact.story_direction
+        retained_ids = {e.entity_id for e in phase1_result.artifact.entities
+                        if e.disposition == "retained"}
+
+        # Phase 2: Thread Design
+        phase2_context = format_phase2_context(
+            story_direction=story_direction,
+            retained_entities=retained_ids,
+            brainstorm_context=brainstorm_context,
+        )
+        phase2_result = await run_seed_phase(...)
+
+        # Extract thread IDs for Phase 3
+        thread_ids = {t.thread_id for t in phase2_result.artifact.threads}
+        beat_hooks = phase2_result.artifact.beat_hooks
+
+        # Phase 3: Initial Beats (STRICT validation)
+        phase3_context = format_phase3_context(
+            story_direction=story_direction,
+            thread_ids=thread_ids,
+            retained_entities=retained_ids,
+            beat_hooks=beat_hooks,
+        )
+        phase3_result = await run_seed_phase(
+            ...,
+            semantic_validator=lambda d: validate_phase3_output_strict(
+                BeatsOutput.model_validate(d),
+                valid_thread_ids=thread_ids,
+                valid_entity_ids=retained_ids,
+                valid_location_ids=location_ids,
+            ),
+        )
+
+        # Phase 4: Convergence Sketch
+        phase4_result = await run_seed_phase(...)
+
+        # Merge all phases into SeedOutput
+        seed_output = SeedOutput(
+            entities=phase1_result.artifact.entities,
+            tensions=phase2_result.artifact.tensions,
+            threads=phase2_result.artifact.threads,
+            consequences=phase2_result.artifact.consequences,
+            initial_beats=phase3_result.artifact.initial_beats,
+            convergence_sketch=phase4_result.artifact.convergence_sketch,
+        )
+
+        # Final semantic validation
+        errors = validate_seed_mutations(graph, seed_output.model_dump())
+        if errors:
+            raise SeedMutationError(errors)
+
+        return seed_output.model_dump(), total_llm_calls, total_tokens
+```
+
+#### Context Formatting Functions
+
+```python
+def format_phase2_context(
+    story_direction: StoryDirectionStatement,
+    retained_entities: set[str],
+    brainstorm_context: str,
+) -> str:
+    """Format context for Phase 2 with story direction."""
+    return f"""## Story Direction (from Phase 1)
+{story_direction.statement}
+
+## Retained Entities
+{', '.join(sorted(retained_entities))}
+
+{brainstorm_context}
+"""
+
+def format_phase3_context(
+    story_direction: StoryDirectionStatement,
+    thread_ids: set[str],
+    retained_entities: set[str],
+    beat_hooks: list[BeatHook],
+) -> str:
+    """Format context for Phase 3 with strict ID lists."""
+    hooks_text = "\n".join(f"- {h.thread_id}: {h.hook}" for h in beat_hooks)
+    return f"""## Story Direction
+{story_direction.statement}
+
+## VALID THREAD IDs (use EXACTLY)
+{' | '.join(sorted(thread_ids))}
+
+## RETAINED ENTITY IDs (use EXACTLY)
+{' | '.join(sorted(retained_entities))}
+
+## Beat Hooks (inspiration, not requirements)
+{hooks_text}
+"""
+```
+
+#### Files Changed
+
+- `src/questfoundry/pipeline/stages/seed.py` - Replace execute() (~200 lines)
+- `src/questfoundry/agents/context.py` - New context formatting (~100 lines)
+- `src/questfoundry/agents/prompts.py` - Add phase prompt loaders (~50 lines)
+- `tests/unit/test_seed_stage.py` - Update tests (~150 lines)
+- `tests/integration/test_seed_4phase.py` - New integration tests (~100 lines)
+
+---
+
+## Backward Compatibility
+
+| Concern | Mitigation |
+|---------|------------|
+| `SeedOutput` structure | **Unchanged** - final artifact identical to current |
+| Graph mutations | **Unchanged** - `apply_seed_mutations()` receives same data |
+| CLI interface | **Unchanged** - `qf seed` works identically |
+| Token counting | Aggregate across all 4 phases |
+| Hybrid providers | Each phase respects discuss/summarize/serialize model selection |
+
+## Risk Assessment
+
+| Risk | Likelihood | Impact | Mitigation |
+|------|------------|--------|------------|
+| More LLM calls (4x3=12 vs 1x3=3) | Certain | Medium | Accept tradeoff for quality |
+| Context loss between phases | Medium | High | Pass `list[BaseMessage]` not text |
+| Phase 3 strict validation too strict | Low | Medium | Can add retry loop if needed |
+| Prompt bloat | Medium | Low | Keep prompts focused per phase |
+
+## Success Criteria
+
+1. **Zero phantom IDs** - No invented locations, entities, or threads
+2. **100% entity coverage** - Every BRAINSTORM entity has a decision
+3. **Thread ID uniqueness** - No collision between thread_id and tension_id
+4. **Beat count compliance** - 2-4 beats per thread consistently
+5. **Location diversity** - 2+ locations per thread
+
+## Open Questions
+
+1. **Beat hooks granularity**: Should beat hooks be required output from Phase 2, or optional guidance?
+2. **Strict validation scope**: Should Phase 3 use zero-tolerance, or allow 1 retry with feedback?
+3. **Context window pressure**: With 4 phases, each has less context budget. Monitor token usage.
+
+## Timeline
+
+| PR | Depends On | Estimated Lines |
+|----|------------|-----------------|
+| PR #1: Schema & Infrastructure | None | ~300 |
+| PR #2: Phase 1 & 2 | PR #1 | ~350 |
+| PR #3: Phase 3 & 4 | PR #1 | ~300 |
+| PR #4: Orchestration | PR #2, PR #3 | ~400 |
+
+PRs #2 and #3 can be developed in parallel after PR #1 merges.

--- a/src/questfoundry/agents/__init__.py
+++ b/src/questfoundry/agents/__init__.py
@@ -1,6 +1,12 @@
 """LangChain agents for QuestFoundry stages."""
 
 from questfoundry.agents.discuss import create_discuss_agent, run_discuss_phase
+from questfoundry.agents.phase_runner import (
+    PhaseResult,
+    extract_ids_from_phase1,
+    extract_ids_from_phase2,
+    run_seed_phase,
+)
 from questfoundry.agents.prompts import (
     get_brainstorm_discuss_prompt,
     get_brainstorm_serialize_prompt,
@@ -20,8 +26,11 @@ from questfoundry.agents.serialize import (
 from questfoundry.agents.summarize import summarize_discussion
 
 __all__ = [
+    "PhaseResult",
     "SerializationError",
     "create_discuss_agent",
+    "extract_ids_from_phase1",
+    "extract_ids_from_phase2",
     "get_brainstorm_discuss_prompt",
     "get_brainstorm_serialize_prompt",
     "get_brainstorm_summarize_prompt",
@@ -32,6 +41,7 @@ __all__ = [
     "get_serialize_prompt",
     "get_summarize_prompt",
     "run_discuss_phase",
+    "run_seed_phase",
     "serialize_seed_iteratively",
     "serialize_to_artifact",
     "summarize_discussion",

--- a/src/questfoundry/agents/phase_runner.py
+++ b/src/questfoundry/agents/phase_runner.py
@@ -1,0 +1,284 @@
+"""Phase runner for executing SEED 4-phase pipeline stages.
+
+Each phase follows the Discuss -> Summarize -> Serialize pattern.
+This module provides a reusable function for running any phase with
+proper message history passing between sub-phases.
+
+Key improvement over monolithic SEED: actual list[BaseMessage] is passed
+from Discuss to Summarize, preserving full context instead of flattening.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any, TypeVar
+
+from pydantic import BaseModel
+
+from questfoundry.agents.discuss import run_discuss_phase
+from questfoundry.agents.serialize import (
+    SemanticValidator,
+    serialize_to_artifact,
+)
+from questfoundry.agents.summarize import summarize_discussion
+from questfoundry.observability.logging import get_logger
+from questfoundry.observability.tracing import traceable
+
+if TYPE_CHECKING:
+    from langchain_core.callbacks import BaseCallbackHandler
+    from langchain_core.language_models import BaseChatModel
+    from langchain_core.messages import BaseMessage
+    from langchain_core.tools import BaseTool
+
+    from questfoundry.agents.discuss import (
+        AssistantMessageFn,
+        LLMCallbackFn,
+        UserInputFn,
+    )
+    from questfoundry.agents.serialize import SemanticErrorFormatter
+
+log = get_logger(__name__)
+
+T = TypeVar("T", bound=BaseModel)
+
+
+@dataclass
+class PhaseResult:
+    """Result from running a single SEED phase.
+
+    Contains the validated artifact, conversation history for context
+    passing to subsequent phases, and metrics.
+
+    Attributes:
+        artifact: The validated Pydantic model output from this phase.
+        messages: Full conversation history from Discuss phase. Pass this
+            to the next phase for context continuity.
+        tokens: Total tokens used across all sub-phases.
+        llm_calls: Total LLM calls across all sub-phases.
+        brief: The summarized brief text (useful for debugging).
+    """
+
+    artifact: BaseModel
+    messages: list[BaseMessage] = field(default_factory=list)
+    tokens: int = 0
+    llm_calls: int = 0
+    brief: str = ""
+
+
+@traceable(name="SEED Phase", run_type="chain", tags=["phase:seed_phase"])
+async def run_seed_phase(
+    model: BaseChatModel,
+    phase_name: str,
+    schema: type[T],
+    discuss_prompt: str,
+    summarize_prompt: str,
+    serialize_prompt: str,
+    context: str,
+    *,
+    user_prompt: str = "",
+    tools: list[BaseTool] | None = None,
+    interactive: bool = False,
+    user_input_fn: UserInputFn | None = None,
+    on_assistant_message: AssistantMessageFn | None = None,
+    on_llm_start: LLMCallbackFn | None = None,
+    on_llm_end: LLMCallbackFn | None = None,
+    callbacks: list[BaseCallbackHandler] | None = None,
+    summarize_model: BaseChatModel | None = None,
+    serialize_model: BaseChatModel | None = None,
+    provider_name: str | None = None,
+    semantic_validator: SemanticValidator | None = None,
+    semantic_error_class: type[SemanticErrorFormatter] | None = None,
+    max_serialize_retries: int = 3,
+) -> PhaseResult:
+    """Run a single SEED phase with Discuss -> Summarize -> Serialize pattern.
+
+    This function orchestrates the three sub-phases that make up each
+    phase of the 4-phase SEED pipeline:
+
+    1. **Discuss**: Agent-based exploration with optional research tools.
+       Returns conversation history as list[BaseMessage].
+
+    2. **Summarize**: Single LLM call to condense discussion into brief.
+       Receives actual message objects (not flattened text) for full context.
+
+    3. **Serialize**: Structured output generation with validation/repair loop.
+       Converts brief into validated Pydantic model.
+
+    Args:
+        model: Chat model for discuss phase (and default for others).
+        phase_name: Name for logging/tracing (e.g., "entity_curation").
+        schema: Pydantic model class for the phase output.
+        discuss_prompt: System prompt for the discuss phase.
+        summarize_prompt: System prompt for the summarize phase.
+        serialize_prompt: System prompt for the serialize phase.
+        context: Injected context (story direction, valid IDs, etc.).
+        user_prompt: Initial user message for discuss phase.
+        tools: Research tools available to discuss agent.
+        interactive: Enable interactive multi-turn discussion.
+        user_input_fn: Async function to get user input (for interactive).
+        on_assistant_message: Callback when assistant responds.
+        on_llm_start: Callback when LLM call starts.
+        on_llm_end: Callback when LLM call ends.
+        callbacks: LangChain callback handlers for logging.
+        summarize_model: Optional model for summarize phase.
+        serialize_model: Optional model for serialize phase.
+        provider_name: Provider name for serialize strategy selection.
+        semantic_validator: Optional function to validate semantic correctness.
+        semantic_error_class: Error class for formatting semantic errors.
+        max_serialize_retries: Maximum retries for serialization (default 3).
+
+    Returns:
+        PhaseResult containing the validated artifact, messages, and metrics.
+
+    Raises:
+        SerializationError: If serialization fails after all retries.
+        ValueError: If interactive=True but user_input_fn is None.
+    """
+    log.info(
+        "phase_started",
+        phase=phase_name,
+        schema=schema.__name__,
+        interactive=interactive,
+    )
+
+    total_tokens = 0
+    total_llm_calls = 0
+
+    # Build the full user prompt with context
+    full_user_prompt = user_prompt or f"Let's work through the {phase_name} phase."
+    if context:
+        full_user_prompt = f"{context}\n\n---\n\n{full_user_prompt}"
+
+    # Phase 1: Discuss
+    log.debug("phase_discuss_started", phase=phase_name)
+    messages, discuss_calls, discuss_tokens = await run_discuss_phase(
+        model=model,
+        tools=tools or [],
+        user_prompt=full_user_prompt,
+        interactive=interactive,
+        user_input_fn=user_input_fn,
+        on_assistant_message=on_assistant_message,
+        on_llm_start=on_llm_start,
+        on_llm_end=on_llm_end,
+        system_prompt=discuss_prompt,
+        stage_name=f"seed_{phase_name}",
+        callbacks=callbacks,
+    )
+    total_llm_calls += discuss_calls
+    total_tokens += discuss_tokens
+    log.debug(
+        "phase_discuss_completed",
+        phase=phase_name,
+        message_count=len(messages),
+        llm_calls=discuss_calls,
+        tokens=discuss_tokens,
+    )
+
+    # Phase 2: Summarize
+    # KEY: Pass actual list[BaseMessage] to summarize, not flattened text.
+    # This preserves full context including tool calls and responses.
+    log.debug("phase_summarize_started", phase=phase_name)
+    brief, summarize_tokens = await summarize_discussion(
+        model=summarize_model or model,
+        messages=messages,
+        system_prompt=summarize_prompt,
+        stage_name=f"seed_{phase_name}",
+        callbacks=callbacks,
+    )
+    total_llm_calls += 1
+    total_tokens += summarize_tokens
+    log.debug(
+        "phase_summarize_completed",
+        phase=phase_name,
+        brief_length=len(brief),
+        tokens=summarize_tokens,
+    )
+
+    # Phase 3: Serialize
+    log.debug("phase_serialize_started", phase=phase_name)
+    artifact, serialize_tokens = await serialize_to_artifact(
+        model=serialize_model or model,
+        brief=brief,
+        schema=schema,
+        provider_name=provider_name,
+        max_retries=max_serialize_retries,
+        system_prompt=serialize_prompt,
+        callbacks=callbacks,
+        semantic_validator=semantic_validator,
+        semantic_error_class=semantic_error_class,
+    )
+    total_llm_calls += 1  # Base call, retries add more
+    total_tokens += serialize_tokens
+    log.debug(
+        "phase_serialize_completed",
+        phase=phase_name,
+        tokens=serialize_tokens,
+    )
+
+    log.info(
+        "phase_completed",
+        phase=phase_name,
+        schema=schema.__name__,
+        llm_calls=total_llm_calls,
+        tokens=total_tokens,
+    )
+
+    return PhaseResult(
+        artifact=artifact,
+        messages=messages,
+        tokens=total_tokens,
+        llm_calls=total_llm_calls,
+        brief=brief,
+    )
+
+
+def extract_ids_from_phase1(result: PhaseResult) -> tuple[str, set[str]]:
+    """Extract story direction and retained entity IDs from Phase 1 result.
+
+    Helper function to extract data needed for Phase 2 context.
+
+    Args:
+        result: PhaseResult from Phase 1 (EntityCurationOutput).
+
+    Returns:
+        Tuple of (story_direction_statement, retained_entity_ids).
+
+    Raises:
+        ValueError: If result artifact is not EntityCurationOutput.
+    """
+    from questfoundry.models.seed import EntityCurationOutput
+
+    if not isinstance(result.artifact, EntityCurationOutput):
+        raise ValueError(f"Expected EntityCurationOutput, got {type(result.artifact).__name__}")
+
+    artifact: EntityCurationOutput = result.artifact
+    story_direction = artifact.story_direction.statement
+    retained_ids = {e.entity_id for e in artifact.entities if e.disposition == "retained"}
+
+    return story_direction, retained_ids
+
+
+def extract_ids_from_phase2(result: PhaseResult) -> tuple[set[str], list[Any]]:
+    """Extract thread IDs and beat hooks from Phase 2 result.
+
+    Helper function to extract data needed for Phase 3 context.
+
+    Args:
+        result: PhaseResult from Phase 2 (ThreadDesignOutput).
+
+    Returns:
+        Tuple of (thread_ids, beat_hooks).
+
+    Raises:
+        ValueError: If result artifact is not ThreadDesignOutput.
+    """
+    from questfoundry.models.seed import ThreadDesignOutput
+
+    if not isinstance(result.artifact, ThreadDesignOutput):
+        raise ValueError(f"Expected ThreadDesignOutput, got {type(result.artifact).__name__}")
+
+    artifact: ThreadDesignOutput = result.artifact
+    thread_ids = {t.thread_id for t in artifact.threads}
+    beat_hooks = artifact.beat_hooks
+
+    return thread_ids, beat_hooks

--- a/src/questfoundry/models/seed.py
+++ b/src/questfoundry/models/seed.py
@@ -306,3 +306,130 @@ class ConvergenceSection(BaseModel):
         default_factory=ConvergenceSketch,
         description="Guidance for GROW about thread convergence",
     )
+
+
+# =============================================================================
+# 4-Phase Architecture Output Models
+# =============================================================================
+# These models represent the output of each phase in the 4-phase SEED pipeline.
+# Each phase has its own output type that feeds into the next phase.
+
+
+class StoryDirectionStatement(BaseModel):
+    """Story direction "north star" from Phase 1.
+
+    A 2-3 sentence statement that captures the protagonist's main goal,
+    the central conflict, and the intended tone. This guides all subsequent
+    phases to maintain narrative coherence.
+
+    Attributes:
+        statement: The story direction statement.
+    """
+
+    statement: str = Field(
+        min_length=10,
+        description="2-3 sentence story direction capturing goal, conflict, and tone",
+    )
+
+
+class BeatHook(BaseModel):
+    """Beat concept from Phase 2 to guide Phase 3 beat creation.
+
+    Beat hooks provide continuity between Thread Design (Phase 2) and
+    Beat Creation (Phase 3). They are inspirational concepts, not strict
+    requirements.
+
+    Attributes:
+        thread_id: Thread this hook belongs to.
+        hook: Beat concept description (e.g., "discovery in library").
+    """
+
+    thread_id: str = Field(min_length=1, description="Thread this hook belongs to")
+    hook: str = Field(
+        min_length=1,
+        description="Beat concept, e.g., 'discovery in library', 'confrontation at dinner'",
+    )
+
+
+class EntityCurationOutput(BaseModel):
+    """Phase 1 output: Entity curation decisions + story direction.
+
+    Phase 1 establishes the foundation by curating which entities to keep
+    and defining a clear narrative direction for the story.
+
+    Attributes:
+        story_direction: The story's "north star" statement.
+        entities: Retain/cut decisions for all BRAINSTORM entities.
+    """
+
+    story_direction: StoryDirectionStatement = Field(
+        description="Story direction north star from Phase 1",
+    )
+    entities: list[EntityDecision] = Field(
+        default_factory=list,
+        description="Entity curation decisions (retain/cut)",
+    )
+
+
+class ThreadDesignOutput(BaseModel):
+    """Phase 2 output: Thread design with tensions, threads, and beat hooks.
+
+    Phase 2 creates the branching structure by deciding which alternatives
+    to explore as threads and defining consequences for each path.
+
+    Attributes:
+        tensions: Tension exploration decisions.
+        threads: Created plot threads.
+        consequences: Narrative consequences for threads.
+        beat_hooks: Beat concepts to guide Phase 3.
+    """
+
+    tensions: list[TensionDecision] = Field(
+        default_factory=list,
+        description="Tension exploration decisions",
+    )
+    threads: list[Thread] = Field(
+        default_factory=list,
+        description="Created plot threads",
+    )
+    consequences: list[Consequence] = Field(
+        default_factory=list,
+        description="Narrative consequences for threads",
+    )
+    beat_hooks: list[BeatHook] = Field(
+        default_factory=list,
+        description="Beat concepts to guide Phase 3 beat creation",
+    )
+
+
+class BeatsOutput(BaseModel):
+    """Phase 3 output: Initial beats with strict ID validation.
+
+    Phase 3 creates the initial beats for each thread. This phase has
+    STRICT validation - any reference to an invalid thread ID or entity ID
+    causes immediate failure without retry.
+
+    Attributes:
+        initial_beats: Initial beats for each thread (2-4 per thread).
+    """
+
+    initial_beats: list[InitialBeat] = Field(
+        default_factory=list,
+        description="Initial beats for each thread (2-4 per thread required)",
+    )
+
+
+class ConvergenceOutput(BaseModel):
+    """Phase 4 output: Convergence guidance for GROW.
+
+    Phase 4 provides guidance about where threads should merge and what
+    differences persist after convergence.
+
+    Attributes:
+        convergence_sketch: Convergence guidance for GROW.
+    """
+
+    convergence_sketch: ConvergenceSketch = Field(
+        default_factory=ConvergenceSketch,
+        description="Guidance for GROW about thread convergence",
+    )

--- a/tests/unit/test_phase_runner.py
+++ b/tests/unit/test_phase_runner.py
@@ -1,0 +1,551 @@
+"""Tests for phase runner - SEED 4-phase pipeline infrastructure."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from langchain_core.messages import AIMessage, HumanMessage
+from pydantic import BaseModel, Field
+
+from questfoundry.agents.phase_runner import (
+    PhaseResult,
+    extract_ids_from_phase1,
+    extract_ids_from_phase2,
+    run_seed_phase,
+)
+from questfoundry.models.seed import (
+    BeatHook,
+    EntityCurationOutput,
+    EntityDecision,
+    StoryDirectionStatement,
+    Thread,
+    ThreadDesignOutput,
+)
+
+
+class SimplePhaseSchema(BaseModel):
+    """Simple schema for testing phase runner."""
+
+    title: str = Field(min_length=1)
+    items: list[str] = Field(default_factory=list)
+
+
+class TestPhaseResult:
+    """Test PhaseResult dataclass."""
+
+    def test_phase_result_defaults(self) -> None:
+        """PhaseResult should have sensible defaults."""
+        artifact = SimplePhaseSchema(title="Test")
+        result = PhaseResult(artifact=artifact)
+
+        assert result.artifact == artifact
+        assert result.messages == []
+        assert result.tokens == 0
+        assert result.llm_calls == 0
+        assert result.brief == ""
+
+    def test_phase_result_with_all_fields(self) -> None:
+        """PhaseResult should store all provided fields."""
+        artifact = SimplePhaseSchema(title="Test", items=["a", "b"])
+        messages = [HumanMessage(content="Test"), AIMessage(content="Response")]
+
+        result = PhaseResult(
+            artifact=artifact,
+            messages=messages,
+            tokens=500,
+            llm_calls=3,
+            brief="Test brief content",
+        )
+
+        assert result.artifact == artifact
+        assert len(result.messages) == 2
+        assert result.tokens == 500
+        assert result.llm_calls == 3
+        assert result.brief == "Test brief content"
+
+
+class TestRunSeedPhase:
+    """Test run_seed_phase function."""
+
+    @pytest.mark.asyncio
+    @patch("questfoundry.agents.phase_runner.serialize_to_artifact")
+    @patch("questfoundry.agents.phase_runner.summarize_discussion")
+    @patch("questfoundry.agents.phase_runner.run_discuss_phase")
+    async def test_run_seed_phase_orchestrates_three_phases(
+        self,
+        mock_discuss: MagicMock,
+        mock_summarize: MagicMock,
+        mock_serialize: MagicMock,
+    ) -> None:
+        """run_seed_phase should call discuss, summarize, and serialize in order."""
+        # Setup mocks
+        discuss_messages = [HumanMessage(content="User"), AIMessage(content="Response")]
+        mock_discuss.return_value = (discuss_messages, 2, 100)
+        mock_summarize.return_value = ("Brief summary", 50)
+        mock_serialize.return_value = (SimplePhaseSchema(title="Result"), 75)
+
+        mock_model = MagicMock()
+
+        result = await run_seed_phase(
+            model=mock_model,
+            phase_name="test_phase",
+            schema=SimplePhaseSchema,
+            discuss_prompt="Discuss prompt",
+            summarize_prompt="Summarize prompt",
+            serialize_prompt="Serialize prompt",
+            context="Test context",
+        )
+
+        # Verify all three phases were called
+        mock_discuss.assert_called_once()
+        mock_summarize.assert_called_once()
+        mock_serialize.assert_called_once()
+
+        # Verify result
+        assert isinstance(result, PhaseResult)
+        assert result.artifact.title == "Result"
+        assert result.messages == discuss_messages
+        assert result.brief == "Brief summary"
+
+    @pytest.mark.asyncio
+    @patch("questfoundry.agents.phase_runner.serialize_to_artifact")
+    @patch("questfoundry.agents.phase_runner.summarize_discussion")
+    @patch("questfoundry.agents.phase_runner.run_discuss_phase")
+    async def test_run_seed_phase_passes_messages_to_summarize(
+        self,
+        mock_discuss: MagicMock,
+        mock_summarize: MagicMock,
+        mock_serialize: MagicMock,
+    ) -> None:
+        """run_seed_phase should pass actual list[BaseMessage] to summarize."""
+        discuss_messages = [
+            HumanMessage(content="User"),
+            AIMessage(content="Response with tool calls"),
+        ]
+        mock_discuss.return_value = (discuss_messages, 1, 50)
+        mock_summarize.return_value = ("Brief", 25)
+        mock_serialize.return_value = (SimplePhaseSchema(title="X"), 30)
+
+        await run_seed_phase(
+            model=MagicMock(),
+            phase_name="test",
+            schema=SimplePhaseSchema,
+            discuss_prompt="",
+            summarize_prompt="",
+            serialize_prompt="",
+            context="",
+        )
+
+        # KEY: Verify summarize received the actual message list
+        summarize_call_kwargs = mock_summarize.call_args.kwargs
+        assert summarize_call_kwargs["messages"] == discuss_messages
+
+    @pytest.mark.asyncio
+    @patch("questfoundry.agents.phase_runner.serialize_to_artifact")
+    @patch("questfoundry.agents.phase_runner.summarize_discussion")
+    @patch("questfoundry.agents.phase_runner.run_discuss_phase")
+    async def test_run_seed_phase_aggregates_metrics(
+        self,
+        mock_discuss: MagicMock,
+        mock_summarize: MagicMock,
+        mock_serialize: MagicMock,
+    ) -> None:
+        """run_seed_phase should aggregate tokens and llm_calls from all phases."""
+        mock_discuss.return_value = ([], 3, 100)  # 3 calls, 100 tokens
+        mock_summarize.return_value = ("Brief", 50)  # 1 call, 50 tokens
+        mock_serialize.return_value = (SimplePhaseSchema(title="X"), 75)  # 1 call, 75 tokens
+
+        result = await run_seed_phase(
+            model=MagicMock(),
+            phase_name="test",
+            schema=SimplePhaseSchema,
+            discuss_prompt="",
+            summarize_prompt="",
+            serialize_prompt="",
+            context="",
+        )
+
+        # 3 (discuss) + 1 (summarize) + 1 (serialize) = 5 calls
+        assert result.llm_calls == 5
+        # 100 (discuss) + 50 (summarize) + 75 (serialize) = 225 tokens
+        assert result.tokens == 225
+
+    @pytest.mark.asyncio
+    @patch("questfoundry.agents.phase_runner.serialize_to_artifact")
+    @patch("questfoundry.agents.phase_runner.summarize_discussion")
+    @patch("questfoundry.agents.phase_runner.run_discuss_phase")
+    async def test_run_seed_phase_uses_custom_models(
+        self,
+        mock_discuss: MagicMock,
+        mock_summarize: MagicMock,
+        mock_serialize: MagicMock,
+    ) -> None:
+        """run_seed_phase should use separate models for each phase if provided."""
+        mock_discuss.return_value = ([], 1, 50)
+        mock_summarize.return_value = ("Brief", 25)
+        mock_serialize.return_value = (SimplePhaseSchema(title="X"), 30)
+
+        discuss_model = MagicMock(name="discuss_model")
+        summarize_model = MagicMock(name="summarize_model")
+        serialize_model = MagicMock(name="serialize_model")
+
+        await run_seed_phase(
+            model=discuss_model,
+            phase_name="test",
+            schema=SimplePhaseSchema,
+            discuss_prompt="",
+            summarize_prompt="",
+            serialize_prompt="",
+            context="",
+            summarize_model=summarize_model,
+            serialize_model=serialize_model,
+        )
+
+        # Verify each phase used the correct model
+        discuss_call_kwargs = mock_discuss.call_args.kwargs
+        assert discuss_call_kwargs["model"] == discuss_model
+
+        summarize_call_kwargs = mock_summarize.call_args.kwargs
+        assert summarize_call_kwargs["model"] == summarize_model
+
+        serialize_call_kwargs = mock_serialize.call_args.kwargs
+        assert serialize_call_kwargs["model"] == serialize_model
+
+    @pytest.mark.asyncio
+    @patch("questfoundry.agents.phase_runner.serialize_to_artifact")
+    @patch("questfoundry.agents.phase_runner.summarize_discussion")
+    @patch("questfoundry.agents.phase_runner.run_discuss_phase")
+    async def test_run_seed_phase_falls_back_to_main_model(
+        self,
+        mock_discuss: MagicMock,
+        mock_summarize: MagicMock,
+        mock_serialize: MagicMock,
+    ) -> None:
+        """run_seed_phase should use main model if phase-specific not provided."""
+        mock_discuss.return_value = ([], 1, 50)
+        mock_summarize.return_value = ("Brief", 25)
+        mock_serialize.return_value = (SimplePhaseSchema(title="X"), 30)
+
+        main_model = MagicMock(name="main_model")
+
+        await run_seed_phase(
+            model=main_model,
+            phase_name="test",
+            schema=SimplePhaseSchema,
+            discuss_prompt="",
+            summarize_prompt="",
+            serialize_prompt="",
+            context="",
+            # No summarize_model or serialize_model
+        )
+
+        # All phases should use main_model
+        assert mock_discuss.call_args.kwargs["model"] == main_model
+        assert mock_summarize.call_args.kwargs["model"] == main_model
+        assert mock_serialize.call_args.kwargs["model"] == main_model
+
+    @pytest.mark.asyncio
+    @patch("questfoundry.agents.phase_runner.serialize_to_artifact")
+    @patch("questfoundry.agents.phase_runner.summarize_discussion")
+    @patch("questfoundry.agents.phase_runner.run_discuss_phase")
+    async def test_run_seed_phase_injects_context_into_user_prompt(
+        self,
+        mock_discuss: MagicMock,
+        mock_summarize: MagicMock,
+        mock_serialize: MagicMock,
+    ) -> None:
+        """run_seed_phase should prepend context to user prompt."""
+        mock_discuss.return_value = ([], 1, 50)
+        mock_summarize.return_value = ("Brief", 25)
+        mock_serialize.return_value = (SimplePhaseSchema(title="X"), 30)
+
+        await run_seed_phase(
+            model=MagicMock(),
+            phase_name="test",
+            schema=SimplePhaseSchema,
+            discuss_prompt="",
+            summarize_prompt="",
+            serialize_prompt="",
+            context="## Valid IDs\nentity1, entity2",
+            user_prompt="Let's discuss",
+        )
+
+        discuss_call_kwargs = mock_discuss.call_args.kwargs
+        user_prompt = discuss_call_kwargs["user_prompt"]
+
+        # Context should be prepended
+        assert "## Valid IDs" in user_prompt
+        assert "Let's discuss" in user_prompt
+        assert user_prompt.index("Valid IDs") < user_prompt.index("Let's discuss")
+
+    @pytest.mark.asyncio
+    @patch("questfoundry.agents.phase_runner.serialize_to_artifact")
+    @patch("questfoundry.agents.phase_runner.summarize_discussion")
+    @patch("questfoundry.agents.phase_runner.run_discuss_phase")
+    async def test_run_seed_phase_passes_semantic_validator(
+        self,
+        mock_discuss: MagicMock,
+        mock_summarize: MagicMock,
+        mock_serialize: MagicMock,
+    ) -> None:
+        """run_seed_phase should pass semantic validator to serialize."""
+        mock_discuss.return_value = ([], 1, 50)
+        mock_summarize.return_value = ("Brief", 25)
+        mock_serialize.return_value = (SimplePhaseSchema(title="X"), 30)
+
+        def my_validator(_data: dict) -> list:
+            return []
+
+        await run_seed_phase(
+            model=MagicMock(),
+            phase_name="test",
+            schema=SimplePhaseSchema,
+            discuss_prompt="",
+            summarize_prompt="",
+            serialize_prompt="",
+            context="",
+            semantic_validator=my_validator,
+        )
+
+        serialize_call_kwargs = mock_serialize.call_args.kwargs
+        assert serialize_call_kwargs["semantic_validator"] == my_validator
+
+    @pytest.mark.asyncio
+    @patch("questfoundry.agents.phase_runner.serialize_to_artifact")
+    @patch("questfoundry.agents.phase_runner.summarize_discussion")
+    @patch("questfoundry.agents.phase_runner.run_discuss_phase")
+    async def test_run_seed_phase_passes_tools_to_discuss(
+        self,
+        mock_discuss: MagicMock,
+        mock_summarize: MagicMock,
+        mock_serialize: MagicMock,
+    ) -> None:
+        """run_seed_phase should pass tools to discuss phase."""
+        mock_discuss.return_value = ([], 1, 50)
+        mock_summarize.return_value = ("Brief", 25)
+        mock_serialize.return_value = (SimplePhaseSchema(title="X"), 30)
+
+        mock_tools = [MagicMock(), MagicMock()]
+
+        await run_seed_phase(
+            model=MagicMock(),
+            phase_name="test",
+            schema=SimplePhaseSchema,
+            discuss_prompt="",
+            summarize_prompt="",
+            serialize_prompt="",
+            context="",
+            tools=mock_tools,
+        )
+
+        discuss_call_kwargs = mock_discuss.call_args.kwargs
+        assert discuss_call_kwargs["tools"] == mock_tools
+
+    @pytest.mark.asyncio
+    @patch("questfoundry.agents.phase_runner.serialize_to_artifact")
+    @patch("questfoundry.agents.phase_runner.summarize_discussion")
+    @patch("questfoundry.agents.phase_runner.run_discuss_phase")
+    async def test_run_seed_phase_uses_phase_name_for_stage_name(
+        self,
+        mock_discuss: MagicMock,
+        mock_summarize: MagicMock,
+        mock_serialize: MagicMock,
+    ) -> None:
+        """run_seed_phase should use phase_name for logging/tracing."""
+        mock_discuss.return_value = ([], 1, 50)
+        mock_summarize.return_value = ("Brief", 25)
+        mock_serialize.return_value = (SimplePhaseSchema(title="X"), 30)
+
+        await run_seed_phase(
+            model=MagicMock(),
+            phase_name="entity_curation",
+            schema=SimplePhaseSchema,
+            discuss_prompt="",
+            summarize_prompt="",
+            serialize_prompt="",
+            context="",
+        )
+
+        # Stage names should include phase name
+        discuss_call_kwargs = mock_discuss.call_args.kwargs
+        assert discuss_call_kwargs["stage_name"] == "seed_entity_curation"
+
+        summarize_call_kwargs = mock_summarize.call_args.kwargs
+        assert summarize_call_kwargs["stage_name"] == "seed_entity_curation"
+
+
+class TestExtractIdsFromPhase1:
+    """Test extract_ids_from_phase1 helper."""
+
+    def test_extracts_story_direction_and_retained_ids(self) -> None:
+        """extract_ids_from_phase1 should return story direction and retained IDs."""
+        artifact = EntityCurationOutput(
+            story_direction=StoryDirectionStatement(statement="A mystery about a haunted mansion."),
+            entities=[
+                EntityDecision(entity_id="butler", disposition="retained"),
+                EntityDecision(entity_id="garden", disposition="retained"),
+                EntityDecision(entity_id="unused_room", disposition="cut"),
+            ],
+        )
+        result = PhaseResult(artifact=artifact)
+
+        story_direction, retained_ids = extract_ids_from_phase1(result)
+
+        assert story_direction == "A mystery about a haunted mansion."
+        assert retained_ids == {"butler", "garden"}
+        assert "unused_room" not in retained_ids
+
+    def test_handles_all_retained(self) -> None:
+        """extract_ids_from_phase1 should handle all entities retained."""
+        artifact = EntityCurationOutput(
+            story_direction=StoryDirectionStatement(statement="Test story."),
+            entities=[
+                EntityDecision(entity_id="a", disposition="retained"),
+                EntityDecision(entity_id="b", disposition="retained"),
+            ],
+        )
+        result = PhaseResult(artifact=artifact)
+
+        _, retained_ids = extract_ids_from_phase1(result)
+
+        assert retained_ids == {"a", "b"}
+
+    def test_handles_all_cut(self) -> None:
+        """extract_ids_from_phase1 should handle all entities cut."""
+        artifact = EntityCurationOutput(
+            story_direction=StoryDirectionStatement(statement="Test story."),
+            entities=[
+                EntityDecision(entity_id="a", disposition="cut"),
+                EntityDecision(entity_id="b", disposition="cut"),
+            ],
+        )
+        result = PhaseResult(artifact=artifact)
+
+        _, retained_ids = extract_ids_from_phase1(result)
+
+        assert retained_ids == set()
+
+    def test_raises_for_wrong_artifact_type(self) -> None:
+        """extract_ids_from_phase1 should raise ValueError for wrong type."""
+        result = PhaseResult(artifact=SimplePhaseSchema(title="Wrong type"))
+
+        with pytest.raises(ValueError, match="Expected EntityCurationOutput"):
+            extract_ids_from_phase1(result)
+
+
+class TestExtractIdsFromPhase2:
+    """Test extract_ids_from_phase2 helper."""
+
+    def test_extracts_thread_ids_and_beat_hooks(self) -> None:
+        """extract_ids_from_phase2 should return thread IDs and beat hooks."""
+        artifact = ThreadDesignOutput(
+            tensions=[],
+            threads=[
+                Thread(
+                    thread_id="host_motive",
+                    name="Host's Motivation",
+                    tension_id="host_benevolent",
+                    alternative_id="benevolent",
+                    thread_importance="major",
+                    description="Test",
+                ),
+                Thread(
+                    thread_id="butler_loyalty",
+                    name="Butler's Loyalty",
+                    tension_id="butler_loyal",
+                    alternative_id="loyal",
+                    thread_importance="minor",
+                    description="Test",
+                ),
+            ],
+            consequences=[],
+            beat_hooks=[
+                BeatHook(thread_id="host_motive", hook="Discovery in library"),
+                BeatHook(thread_id="butler_loyalty", hook="Confrontation at dinner"),
+            ],
+        )
+        result = PhaseResult(artifact=artifact)
+
+        thread_ids, beat_hooks = extract_ids_from_phase2(result)
+
+        assert thread_ids == {"host_motive", "butler_loyalty"}
+        assert len(beat_hooks) == 2
+        assert beat_hooks[0].hook == "Discovery in library"
+
+    def test_handles_empty_threads(self) -> None:
+        """extract_ids_from_phase2 should handle empty thread list."""
+        artifact = ThreadDesignOutput(
+            tensions=[],
+            threads=[],
+            consequences=[],
+            beat_hooks=[],
+        )
+        result = PhaseResult(artifact=artifact)
+
+        thread_ids, beat_hooks = extract_ids_from_phase2(result)
+
+        assert thread_ids == set()
+        assert beat_hooks == []
+
+    def test_raises_for_wrong_artifact_type(self) -> None:
+        """extract_ids_from_phase2 should raise ValueError for wrong type."""
+        result = PhaseResult(artifact=SimplePhaseSchema(title="Wrong type"))
+
+        with pytest.raises(ValueError, match="Expected ThreadDesignOutput"):
+            extract_ids_from_phase2(result)
+
+
+class TestNewSeedModels:
+    """Test the new 4-phase models in seed.py."""
+
+    def test_story_direction_statement_min_length(self) -> None:
+        """StoryDirectionStatement should enforce minimum length."""
+        # Valid
+        stmt = StoryDirectionStatement(statement="A mystery about solving a crime.")
+        assert len(stmt.statement) >= 10
+
+        # Invalid - too short
+        with pytest.raises(ValueError):
+            StoryDirectionStatement(statement="Short")
+
+    def test_beat_hook_requires_fields(self) -> None:
+        """BeatHook should require thread_id and hook."""
+        hook = BeatHook(thread_id="host_motive", hook="Discovery scene")
+        assert hook.thread_id == "host_motive"
+        assert hook.hook == "Discovery scene"
+
+    def test_entity_curation_output_structure(self) -> None:
+        """EntityCurationOutput should combine story direction and entities."""
+        output = EntityCurationOutput(
+            story_direction=StoryDirectionStatement(
+                statement="A detective investigates a haunted mansion."
+            ),
+            entities=[
+                EntityDecision(entity_id="detective", disposition="retained"),
+            ],
+        )
+
+        assert output.story_direction.statement.startswith("A detective")
+        assert len(output.entities) == 1
+
+    def test_thread_design_output_structure(self) -> None:
+        """ThreadDesignOutput should combine all Phase 2 outputs."""
+        output = ThreadDesignOutput(
+            tensions=[],
+            threads=[
+                Thread(
+                    thread_id="test",
+                    name="Test Thread",
+                    tension_id="t1",
+                    alternative_id="a1",
+                    thread_importance="major",
+                    description="Test",
+                ),
+            ],
+            consequences=[],
+            beat_hooks=[BeatHook(thread_id="test", hook="Test hook")],
+        )
+
+        assert len(output.threads) == 1
+        assert len(output.beat_hooks) == 1


### PR DESCRIPTION
## Problem

The monolithic SEED stage causes cognitive overload for LLMs, leading to "phantom ID" errors where the model invents IDs that don't exist in the BRAINSTORM graph (issue #202). This PR implements the infrastructure for the 4-phase SEED architecture that addresses this by giving each phase a focused scope.

## Changes

### New Phase Output Models (`models/seed.py`)
- `StoryDirectionStatement` - Story direction "north star" from Phase 1
- `BeatHook` - Beat concept from Phase 2 to guide Phase 3
- `EntityCurationOutput` - Phase 1 output: entity curation + story direction
- `ThreadDesignOutput` - Phase 2 output: tensions, threads, consequences, beat hooks
- `BeatsOutput` - Phase 3 output: initial beats with strict ID validation
- `ConvergenceOutput` - Phase 4 output: convergence guidance for GROW

### Phase Runner (`agents/phase_runner.py`)
- `PhaseResult` dataclass to track phase outputs including artifact, messages, metrics, and brief
- `run_seed_phase()` function orchestrating the Discuss → Summarize → Serialize pattern
- `extract_ids_from_phase1()` and `extract_ids_from_phase2()` helpers for context passing between phases

### Exports (`agents/__init__.py`)
- Added `PhaseResult`, `run_seed_phase`, `extract_ids_from_phase1`, `extract_ids_from_phase2`

### Documentation
- `docs/architecture/seed-4-phase-implementation-plan.md` - Comprehensive implementation plan for all 4 PRs

### Tests
- 22 comprehensive unit tests covering PhaseResult, run_seed_phase, extract helpers, and new models

## Key Design Decisions

1. **Pass actual `list[BaseMessage]` to summarize** - Preserves full context including tool calls and responses (key improvement from #193)
2. **Hybrid provider support** - Accepts `summarize_model` and `serialize_model` parameters for using different models per sub-phase
3. **Semantic validation callbacks** - Supports `semantic_validator` and `semantic_error_class` for cross-reference checking

## Not Included / Future PRs

- Phase 1 & 2 prompt templates (PR #2)
- Phase 3 & 4 prompt templates (PR #3)
- Orchestrator integration and CLI flags (PR #4)
- Prompt template files in `prompts/templates/` (created but not committed - for PR #2)

## Test Plan

- [x] All 22 new unit tests pass
- [x] Full test suite passes (726 tests)
- [x] mypy type checking passes
- [x] ruff linting passes

```bash
uv run pytest tests/unit/test_phase_runner.py -v  # 22 passed
uv run pytest tests/unit/ -q  # 726 passed in 4.31s
uv run mypy src/questfoundry/agents/phase_runner.py  # Success
uv run ruff check src/questfoundry/agents/phase_runner.py  # All checks passed
```

## Risk / Rollback

- **Low risk** - This PR only adds new code, does not modify existing SEED stage behavior
- **No feature flags needed** - Infrastructure is unused until orchestrator integration (PR #4)
- **Rollback** - Simply revert the commit if issues arise

## Review Guide

Suggested review order:
1. `models/seed.py` (127 lines) - New phase output models
2. `agents/phase_runner.py` (290 lines) - Core infrastructure
3. `agents/__init__.py` (10 lines) - Exports
4. `tests/unit/test_phase_runner.py` (553 lines) - Test coverage
5. `docs/architecture/seed-4-phase-implementation-plan.md` - Overall plan context

Related: #202, #204

🤖 Generated with [Claude Code](https://claude.com/claude-code)