### PR TITLE
feat(agents): preserve tool calls in summarize phase

### DIFF
--- a/src/questfoundry/agents/summarize.py
+++ b/src/questfoundry/agents/summarize.py
@@ -2,9 +2,10 @@
 
 from __future__ import annotations
 
+import json
 from typing import TYPE_CHECKING
 
-from langchain_core.messages import AIMessage, BaseMessage, HumanMessage, SystemMessage
+from langchain_core.messages import AIMessage, BaseMessage, HumanMessage, SystemMessage, ToolMessage
 
 from questfoundry.agents.prompts import get_summarize_prompt
 from questfoundry.observability.logging import get_logger
@@ -101,6 +102,10 @@ async def summarize_discussion(
 def _format_messages_for_summary(messages: list[BaseMessage]) -> str:
     """Format conversation messages for the summary prompt.
 
+    Preserves tool call context by including tool invocations and their results.
+    This ensures research insights from tools (like corpus searches) are available
+    in the summarized output.
+
     Args:
         messages: List of conversation messages
 
@@ -110,15 +115,30 @@ def _format_messages_for_summary(messages: list[BaseMessage]) -> str:
     formatted_parts = []
     for msg in messages:
         if isinstance(msg, HumanMessage):
-            prefix = "User"
+            content = msg.content if isinstance(msg.content, str) else str(msg.content)
+            formatted_parts.append(f"User: {content}")
         elif isinstance(msg, AIMessage):
-            prefix = "Assistant"
+            # Include text content if present
+            if msg.content:
+                content = msg.content if isinstance(msg.content, str) else str(msg.content)
+                formatted_parts.append(f"Assistant: {content}")
+            # Include tool calls if present (research decisions made by the model)
+            if hasattr(msg, "tool_calls") and msg.tool_calls:
+                for tc in msg.tool_calls:
+                    tool_name = tc.get("name", "unknown_tool")
+                    tool_args = tc.get("args", {})
+                    args_str = json.dumps(tool_args, indent=2)
+                    formatted_parts.append(f"[Tool Call: {tool_name}]\n{args_str}")
+        elif isinstance(msg, ToolMessage):
+            # Include tool results (research findings)
+            tool_name = msg.name if msg.name else "unknown_tool"
+            content = msg.content if isinstance(msg.content, str) else str(msg.content)
+            formatted_parts.append(f"[Tool Result: {tool_name}]\n{content}")
         elif isinstance(msg, SystemMessage):
-            prefix = "System"
+            content = msg.content if isinstance(msg.content, str) else str(msg.content)
+            formatted_parts.append(f"System: {content}")
         else:
-            prefix = "Message"
-
-        content = msg.content if isinstance(msg.content, str) else str(msg.content)
-        formatted_parts.append(f"{prefix}: {content}")
+            content = msg.content if isinstance(msg.content, str) else str(msg.content)
+            formatted_parts.append(f"Message: {content}")
 
     return "\n\n".join(formatted_parts)


### PR DESCRIPTION
## Problem
The `_format_messages_for_summary` function ignores `AIMessage.tool_calls` and `ToolMessage`, causing research context from tools (like corpus searches) to be lost when formatting messages for the summarize phase. This is the information bottleneck identified in #211.

## Changes
- Enhanced `_format_messages_for_summary` to include tool call invocations (name + args)
- Added handling for `ToolMessage` to include tool results
- Added 7 new tests covering tool call preservation scenarios

## Not Included / Future PRs
- Manifest-driven serialize prompts (PR#2)
- Manifest-aware summarize prompt (PR#3)
- Error classification (PR#4)
- Documentation updates (PR#5)

## Test Plan
```bash
uv run pytest tests/unit/test_summarize.py -v
# 21 passed

uv run pytest tests/unit/ -q
# 711 passed

uv run mypy src/questfoundry/agents/summarize.py --strict
# Success: no issues found

uv run ruff check src/questfoundry/agents/summarize.py tests/unit/test_summarize.py
# All checks passed
```

## Risk / Rollback
- Low risk: additive change to message formatting
- No breaking changes to existing behavior
- Summaries will now include more context (tool research)

Part of #211 (SEED Stage Feedback Loop Architecture)

🤖 Generated with [Claude Code](https://claude.com/claude-code)