### PR TITLE
feat(seed): manifest-aware summarize prompt (#211)

### DIFF
--- a/prompts/templates/summarize_seed.yaml
+++ b/prompts/templates/summarize_seed.yaml
@@ -5,6 +5,20 @@ system: |
   You are summarizing a story architecture discussion into structured output.
   This is the SEED stage output - the committed foundation for the story.
 
+  ## CRITICAL: Manifest Completeness (read first!)
+  Your summary MUST include explicit decisions for:
+  - ALL {entity_count} entities listed below
+  - ALL {tension_count} tensions listed below
+
+  This is GENERATION, not extraction. Even if an entity/tension wasn't discussed,
+  you must still include a decision for it (use your judgment to retain or cut).
+
+  ## Required Entity IDs ({entity_count} total - MUST all appear in output)
+  {entity_manifest}
+
+  ## Required Tension IDs ({tension_count} total - MUST all appear in output)
+  {tension_manifest}
+
   ## Brainstorm Reference
   {brainstorm_context}
 
@@ -74,12 +88,33 @@ system: |
   - Use clear, consistent IDs (snake_case recommended)
 
   ## FINAL CHECK (verify before submitting)
-  ✓ Beat count: Did you create 2-4 beats PER thread? (3 threads = 6-12 beats)
-  ✓ Location diversity: Does each thread use at least 2 different locations?
-  ✓ Entity coverage: Does every entity have a retain/cut decision?
+  COUNT your output before submitting:
+  - Entity decisions: Do you have exactly {entity_count} decisions?
+  - Tension decisions: Do you have exactly {tension_count} decisions?
+  - Beat count: Did you create 2-4 beats PER thread? (3 threads = 6-12 beats)
+  - Location diversity: Does each thread use at least 2 different locations?
+
+  If your counts don't match, you have missed items. Add them before submitting.
 
   ## Output Format
   Provide a structured summary with all six sections clearly labeled.
   Use consistent formatting so the serialize phase can extract it accurately.
+
+  ### Entity Decisions Manifest
+  List EVERY entity ID with its decision:
+  ```
+  - hero: retained - protagonist
+  - castle: retained - main setting
+  - unused_npc: cut - not relevant to core story
+  ```
+  VERIFY: Your list should have exactly {entity_count} items.
+
+  ### Tension Decisions Manifest
+  List EVERY tension ID with its decision:
+  ```
+  - trust_or_betray: explored=[trust], implicit=[betray]
+  - save_or_abandon: explored=[save, abandon], implicit=[]
+  ```
+  VERIFY: Your list should have exactly {tension_count} items.
 
 components: []

--- a/src/questfoundry/agents/prompts.py
+++ b/src/questfoundry/agents/prompts.py
@@ -208,22 +208,41 @@ def get_seed_discuss_prompt(
     )
 
 
-def get_seed_summarize_prompt(brainstorm_context: str = "") -> str:
-    """Build the SEED summarize prompt.
+def get_seed_summarize_prompt(
+    brainstorm_context: str = "",
+    entity_count: int = 0,
+    tension_count: int = 0,
+    entity_manifest: str = "",
+    tension_manifest: str = "",
+) -> str:
+    """Build the SEED summarize prompt with manifest awareness.
+
+    The manifest parameters enable the summarizer to know exactly which IDs
+    it must include decisions for, enforcing completeness by construction.
 
     Args:
         brainstorm_context: YAML representation of brainstorm entities/tensions.
             Required for the summarizer to know what IDs to reference.
+        entity_count: Total number of entities requiring decisions.
+        tension_count: Total number of tensions requiring decisions.
+        entity_manifest: Formatted list of entity IDs for manifest.
+        tension_manifest: Formatted list of tension IDs for manifest.
 
     Returns:
         System prompt string for the SEED summarize call.
     """
     raw_data = _load_raw_template("summarize_seed")
 
-    # Render the system template with brainstorm context
+    # Render the system template with brainstorm context and manifest info
     system_template = raw_data.get("system", "")
     prompt = ChatPromptTemplate.from_template(system_template)
-    return prompt.format(brainstorm_context=brainstorm_context)
+    return prompt.format(
+        brainstorm_context=brainstorm_context,
+        entity_count=entity_count,
+        tension_count=tension_count,
+        entity_manifest=entity_manifest or "(No entities)",
+        tension_manifest=tension_manifest or "(No tensions)",
+    )
 
 
 def get_brainstorm_serialize_prompt() -> str:

--- a/src/questfoundry/graph/__init__.py
+++ b/src/questfoundry/graph/__init__.py
@@ -7,7 +7,7 @@ mutations through the runtime.
 See docs/architecture/graph-storage.md for architecture details.
 """
 
-from questfoundry.graph.context import format_valid_ids_context
+from questfoundry.graph.context import format_summarize_manifest, format_valid_ids_context
 from questfoundry.graph.errors import (
     EdgeEndpointError,
     GraphCorruptionError,
@@ -54,6 +54,7 @@ __all__ = [
     "apply_dream_mutations",
     "apply_mutations",
     "apply_seed_mutations",
+    "format_summarize_manifest",
     "format_valid_ids_context",
     "has_mutation_handler",
     "list_snapshots",

--- a/tests/unit/test_graph_context.py
+++ b/tests/unit/test_graph_context.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from questfoundry.graph import Graph, format_valid_ids_context
+from questfoundry.graph import Graph, format_summarize_manifest, format_valid_ids_context
 from questfoundry.graph.context import format_thread_ids_context, get_expected_counts
 
 
@@ -482,3 +482,174 @@ class TestManifestCounts:
         assert "Verification" in result
         assert "entities array should have 1 item" in result
         assert "tensions array should have 1 item" in result
+
+
+class TestFormatSummarizeManifest:
+    """Tests for format_summarize_manifest function."""
+
+    def test_returns_no_entities_for_empty_graph(self) -> None:
+        """Empty graph returns '(No entities)' and '(No tensions)'."""
+        graph = Graph.empty()
+        result = format_summarize_manifest(graph)
+
+        assert result["entity_manifest"] == "(No entities)"
+        assert result["tension_manifest"] == "(No tensions)"
+
+    def test_formats_entities_by_category(self) -> None:
+        """Entities are grouped by category with markdown formatting."""
+        graph = Graph.empty()
+        graph.create_node(
+            "entity::hero",
+            {
+                "type": "entity",
+                "raw_id": "hero",
+                "entity_type": "character",
+            },
+        )
+        graph.create_node(
+            "entity::castle",
+            {
+                "type": "entity",
+                "raw_id": "castle",
+                "entity_type": "location",
+            },
+        )
+
+        result = format_summarize_manifest(graph)
+
+        assert "**Characters:**" in result["entity_manifest"]
+        assert "`hero`" in result["entity_manifest"]
+        assert "**Locations:**" in result["entity_manifest"]
+        assert "`castle`" in result["entity_manifest"]
+
+    def test_formats_tensions_as_list(self) -> None:
+        """Tensions are formatted as simple bullet list."""
+        graph = Graph.empty()
+        graph.create_node(
+            "tension::trust",
+            {
+                "type": "tension",
+                "raw_id": "trust",
+            },
+        )
+        graph.create_node(
+            "tension::loyalty",
+            {
+                "type": "tension",
+                "raw_id": "loyalty",
+            },
+        )
+
+        result = format_summarize_manifest(graph)
+
+        assert "- `loyalty`" in result["tension_manifest"]
+        assert "- `trust`" in result["tension_manifest"]
+
+    def test_skips_entities_without_raw_id(self) -> None:
+        """Entities without raw_id are excluded."""
+        graph = Graph.empty()
+        graph.create_node(
+            "entity::valid",
+            {
+                "type": "entity",
+                "raw_id": "valid",
+                "entity_type": "character",
+            },
+        )
+        graph.create_node(
+            "entity::invalid",
+            {
+                "type": "entity",
+                "entity_type": "character",
+                # Missing raw_id
+            },
+        )
+
+        result = format_summarize_manifest(graph)
+
+        assert "`valid`" in result["entity_manifest"]
+        assert "invalid" not in result["entity_manifest"]
+
+    def test_skips_tensions_without_raw_id(self) -> None:
+        """Tensions without raw_id are excluded."""
+        graph = Graph.empty()
+        graph.create_node(
+            "tension::valid",
+            {
+                "type": "tension",
+                "raw_id": "valid",
+            },
+        )
+        graph.create_node(
+            "tension::invalid",
+            {
+                "type": "tension",
+                # Missing raw_id
+            },
+        )
+
+        result = format_summarize_manifest(graph)
+
+        assert "`valid`" in result["tension_manifest"]
+        assert "invalid" not in result["tension_manifest"]
+
+    def test_sorts_entities_alphabetically(self) -> None:
+        """Entity IDs are sorted alphabetically within categories."""
+        graph = Graph.empty()
+        graph.create_node(
+            "entity::zara",
+            {"type": "entity", "raw_id": "zara", "entity_type": "character"},
+        )
+        graph.create_node(
+            "entity::alice",
+            {"type": "entity", "raw_id": "alice", "entity_type": "character"},
+        )
+
+        result = format_summarize_manifest(graph)
+
+        alice_pos = result["entity_manifest"].find("`alice`")
+        zara_pos = result["entity_manifest"].find("`zara`")
+        assert alice_pos < zara_pos
+
+    def test_sorts_tensions_by_node_id(self) -> None:
+        """Tensions are sorted by node ID for deterministic output."""
+        graph = Graph.empty()
+        graph.create_node(
+            "tension::zebra",
+            {"type": "tension", "raw_id": "zebra"},
+        )
+        graph.create_node(
+            "tension::alpha",
+            {"type": "tension", "raw_id": "alpha"},
+        )
+
+        result = format_summarize_manifest(graph)
+
+        alpha_pos = result["tension_manifest"].find("`alpha`")
+        zebra_pos = result["tension_manifest"].find("`zebra`")
+        assert alpha_pos < zebra_pos
+
+    def test_handles_all_entity_categories(self) -> None:
+        """All standard entity categories are included in output."""
+        graph = Graph.empty()
+        for cat in ["character", "location", "object", "faction"]:
+            graph.create_node(
+                f"entity::{cat}_example",
+                {"type": "entity", "raw_id": f"{cat}_example", "entity_type": cat},
+            )
+
+        result = format_summarize_manifest(graph)
+
+        assert "**Characters:**" in result["entity_manifest"]
+        assert "**Locations:**" in result["entity_manifest"]
+        assert "**Objects:**" in result["entity_manifest"]
+        assert "**Factions:**" in result["entity_manifest"]
+
+    def test_returns_dict_with_both_keys(self) -> None:
+        """Result always contains both entity_manifest and tension_manifest keys."""
+        graph = Graph.empty()
+        result = format_summarize_manifest(graph)
+
+        assert "entity_manifest" in result
+        assert "tension_manifest" in result
+        assert len(result) == 2

--- a/tests/unit/test_seed_prompts.py
+++ b/tests/unit/test_seed_prompts.py
@@ -1,0 +1,118 @@
+"""Tests for SEED stage prompts with manifest injection."""
+
+from __future__ import annotations
+
+from questfoundry.agents.prompts import get_seed_summarize_prompt
+
+
+class TestGetSeedSummarizePrompt:
+    """Tests for get_seed_summarize_prompt function."""
+
+    def test_includes_entity_count_placeholder(self) -> None:
+        """Prompt includes the entity count value."""
+        result = get_seed_summarize_prompt(
+            entity_count=5,
+            tension_count=3,
+        )
+
+        assert "5 entities" in result or "ALL 5 entities" in result
+
+    def test_includes_tension_count_placeholder(self) -> None:
+        """Prompt includes the tension count value."""
+        result = get_seed_summarize_prompt(
+            entity_count=5,
+            tension_count=3,
+        )
+
+        assert "3 tensions" in result or "ALL 3 tensions" in result
+
+    def test_includes_entity_manifest(self) -> None:
+        """Prompt includes the entity manifest content."""
+        entity_manifest = """**Characters:**
+  - `hero`
+  - `villain`
+**Locations:**
+  - `castle`"""
+
+        result = get_seed_summarize_prompt(
+            entity_count=3,
+            tension_count=1,
+            entity_manifest=entity_manifest,
+        )
+
+        assert "**Characters:**" in result
+        assert "`hero`" in result
+        assert "`villain`" in result
+        assert "`castle`" in result
+
+    def test_includes_tension_manifest(self) -> None:
+        """Prompt includes the tension manifest content."""
+        tension_manifest = """- `trust_or_betray`
+- `save_or_abandon`"""
+
+        result = get_seed_summarize_prompt(
+            entity_count=2,
+            tension_count=2,
+            tension_manifest=tension_manifest,
+        )
+
+        assert "`trust_or_betray`" in result
+        assert "`save_or_abandon`" in result
+
+    def test_includes_critical_manifest_completeness_header(self) -> None:
+        """Prompt includes critical header about manifest completeness."""
+        result = get_seed_summarize_prompt(
+            entity_count=3,
+            tension_count=2,
+        )
+
+        assert "CRITICAL" in result
+        assert "Manifest" in result or "manifest" in result
+
+    def test_includes_verification_section(self) -> None:
+        """Prompt includes final verification check section."""
+        result = get_seed_summarize_prompt(
+            entity_count=3,
+            tension_count=2,
+        )
+
+        assert "FINAL CHECK" in result or "COUNT" in result
+
+    def test_defaults_to_no_entities_when_empty(self) -> None:
+        """Empty manifests show placeholder text."""
+        result = get_seed_summarize_prompt(
+            entity_count=0,
+            tension_count=0,
+            entity_manifest="",
+            tension_manifest="",
+        )
+
+        assert "(No entities)" in result
+        assert "(No tensions)" in result
+
+    def test_includes_brainstorm_context_when_provided(self) -> None:
+        """Brainstorm context is included in the prompt."""
+        brainstorm = "## Entities\n- hero: A brave warrior"
+
+        result = get_seed_summarize_prompt(
+            brainstorm_context=brainstorm,
+            entity_count=1,
+            tension_count=0,
+        )
+
+        assert "hero: A brave warrior" in result
+
+    def test_all_required_sections_present(self) -> None:
+        """Prompt contains all required output format sections."""
+        result = get_seed_summarize_prompt(
+            entity_count=2,
+            tension_count=1,
+        )
+
+        # These sections should be described in the prompt
+        assert "Entity Decisions" in result
+        assert "Tension Decisions" in result
+        assert "Threads" in result
+        assert "Consequences" in result
+        assert "Initial Beats" in result
+        assert "Convergence" in result


### PR DESCRIPTION
## Problem
The SEED stage's summarize phase produces freeform briefs that may omit entities or tensions discussed via research tools. This is part 3 of the manifest-first freeze architecture (Issue #211).

## Changes
- Add `format_summarize_manifest()` in `graph/context.py` - formats entity/tension IDs as bullet lists for summarize prompt
- Update `get_seed_summarize_prompt()` to accept manifest parameters: `entity_count`, `tension_count`, `entity_manifest`, `tension_manifest`
- Update `summarize_seed.yaml` with:
  - Critical manifest completeness header at top
  - Required Entity/Tension ID sections with counts
  - Final verification check section
  - Entity/Tension Decisions Manifest output format
- Update SEED stage to load graph before summarize phase and pass manifest info
- Export `format_summarize_manifest` from `graph/__init__.py`

## Not Included / Future PRs
- Error classification and structural completeness checks (PR#4)
- Documentation updates (PR#5)

## Test Plan
```bash
# All tests pass
uv run pytest tests/unit/test_graph_context.py -v  # 34 tests pass
uv run pytest tests/unit/test_seed_prompts.py -v   # 9 tests pass
uv run pytest tests/unit/test_seed_stage.py -v     # 25 tests pass
uv run pytest tests/unit/ -v                       # 737 tests pass
```

## Risk / Rollback
- Low risk - adds new parameters with defaults to existing function
- Backward compatible - existing callers without manifest params will get default values
- Pre-commit hooks pass (ruff, mypy, formatting)

🤖 Generated with [Claude Code](https://claude.ai/code)