### PR TITLE
feat(graph): error classification and structural completeness (#211)

### DIFF
--- a/src/questfoundry/graph/__init__.py
+++ b/src/questfoundry/graph/__init__.py
@@ -7,7 +7,11 @@ mutations through the runtime.
 See docs/architecture/graph-storage.md for architecture details.
 """
 
-from questfoundry.graph.context import format_summarize_manifest, format_valid_ids_context
+from questfoundry.graph.context import (
+    check_structural_completeness,
+    format_summarize_manifest,
+    format_valid_ids_context,
+)
 from questfoundry.graph.errors import (
     EdgeEndpointError,
     GraphCorruptionError,
@@ -21,12 +25,15 @@ from questfoundry.graph.mutations import (
     BrainstormMutationError,
     BrainstormValidationError,
     MutationError,
+    SeedErrorCategory,
     SeedMutationError,
     SeedValidationError,
     apply_brainstorm_mutations,
     apply_dream_mutations,
     apply_mutations,
     apply_seed_mutations,
+    categorize_error,
+    categorize_errors,
     has_mutation_handler,
     validate_brainstorm_mutations,
     validate_seed_mutations,
@@ -48,12 +55,16 @@ __all__ = [
     "NodeExistsError",
     "NodeNotFoundError",
     "NodeReferencedError",
+    "SeedErrorCategory",
     "SeedMutationError",
     "SeedValidationError",
     "apply_brainstorm_mutations",
     "apply_dream_mutations",
     "apply_mutations",
     "apply_seed_mutations",
+    "categorize_error",
+    "categorize_errors",
+    "check_structural_completeness",
     "format_summarize_manifest",
     "format_valid_ids_context",
     "has_mutation_handler",

--- a/src/questfoundry/graph/context.py
+++ b/src/questfoundry/graph/context.py
@@ -266,33 +266,29 @@ def check_structural_completeness(
     Args:
         output: SEED output dict with 'entities' and 'tensions' arrays.
         expected: Dict from get_expected_counts() with expected counts.
+            Values must be non-negative integers.
 
     Returns:
         List of (field_path, issue) tuples for any completeness errors.
         Empty list if counts match.
+
+    Raises:
+        ValueError: If expected counts contain negative values.
     """
     errors: list[tuple[str, str]] = []
 
-    # Check entity decisions count
-    actual_entities = len(output.get("entities", []))
-    expected_entities = expected.get("entities", 0)
-    if actual_entities != expected_entities:
-        errors.append(
-            (
-                "entities",
-                f"Expected {expected_entities} entity decisions, got {actual_entities}",
-            )
-        )
+    # Validate expected counts are non-negative (defensive check)
+    for field, count in expected.items():
+        if count < 0:
+            raise ValueError(f"Expected count for '{field}' cannot be negative: {count}")
 
-    # Check tension decisions count
-    actual_tensions = len(output.get("tensions", []))
-    expected_tensions = expected.get("tensions", 0)
-    if actual_tensions != expected_tensions:
-        errors.append(
-            (
-                "tensions",
-                f"Expected {expected_tensions} tension decisions, got {actual_tensions}",
+    # Check counts for each tracked field
+    for field in ("entities", "tensions"):
+        actual = len(output.get(field, []))
+        expected_count = expected.get(field, 0)
+        if actual != expected_count:
+            errors.append(
+                (field, f"Expected {expected_count} {field[:-1]} decisions, got {actual}")
             )
-        )
 
     return errors

--- a/src/questfoundry/graph/context.py
+++ b/src/questfoundry/graph/context.py
@@ -252,3 +252,47 @@ def format_summarize_manifest(graph: Graph) -> dict[str, str]:
         "entity_manifest": "\n".join(entity_lines) if entity_lines else "(No entities)",
         "tension_manifest": "\n".join(tension_lines) if tension_lines else "(No tensions)",
     }
+
+
+def check_structural_completeness(
+    output: dict[str, Any],
+    expected: dict[str, int],
+) -> list[tuple[str, str]]:
+    """Check SEED output structural completeness using count-based validation.
+
+    This is a fast pre-check before expensive semantic validation. It catches
+    obvious completeness issues (wrong count of decisions) without parsing IDs.
+
+    Args:
+        output: SEED output dict with 'entities' and 'tensions' arrays.
+        expected: Dict from get_expected_counts() with expected counts.
+
+    Returns:
+        List of (field_path, issue) tuples for any completeness errors.
+        Empty list if counts match.
+    """
+    errors: list[tuple[str, str]] = []
+
+    # Check entity decisions count
+    actual_entities = len(output.get("entities", []))
+    expected_entities = expected.get("entities", 0)
+    if actual_entities != expected_entities:
+        errors.append(
+            (
+                "entities",
+                f"Expected {expected_entities} entity decisions, got {actual_entities}",
+            )
+        )
+
+    # Check tension decisions count
+    actual_tensions = len(output.get("tensions", []))
+    expected_tensions = expected.get("tensions", 0)
+    if actual_tensions != expected_tensions:
+        errors.append(
+            (
+                "tensions",
+                f"Expected {expected_tensions} tension decisions, got {actual_tensions}",
+            )
+        )
+
+    return errors

--- a/tests/unit/test_graph_context.py
+++ b/tests/unit/test_graph_context.py
@@ -802,3 +802,13 @@ class TestCheckStructuralCompleteness:
         errors = check_structural_completeness(output, expected)
 
         assert errors == []
+
+    def test_raises_on_negative_expected_count(self) -> None:
+        """Raises ValueError when expected count is negative."""
+        import pytest
+
+        output = {"entities": [], "tensions": []}
+        expected = {"entities": -1, "tensions": 0}
+
+        with pytest.raises(ValueError, match="cannot be negative"):
+            check_structural_completeness(output, expected)

--- a/tests/unit/test_graph_context.py
+++ b/tests/unit/test_graph_context.py
@@ -3,7 +3,11 @@
 from __future__ import annotations
 
 from questfoundry.graph import Graph, format_summarize_manifest, format_valid_ids_context
-from questfoundry.graph.context import format_thread_ids_context, get_expected_counts
+from questfoundry.graph.context import (
+    check_structural_completeness,
+    format_thread_ids_context,
+    get_expected_counts,
+)
 
 
 class TestFormatValidIdsContext:
@@ -705,3 +709,96 @@ class TestFormatSummarizeManifest:
 
         # Should have blank line after Characters section, before Locations
         assert "**Characters:**\n  - `hero`\n\n**Locations:**" in result["entity_manifest"]
+
+
+class TestCheckStructuralCompleteness:
+    """Tests for check_structural_completeness function."""
+
+    def test_returns_empty_when_counts_match(self) -> None:
+        """No errors when actual counts match expected."""
+        output = {
+            "entities": [{"entity_id": "a"}, {"entity_id": "b"}],
+            "tensions": [{"tension_id": "x"}],
+        }
+        expected = {"entities": 2, "tensions": 1}
+
+        errors = check_structural_completeness(output, expected)
+
+        assert errors == []
+
+    def test_detects_missing_entities(self) -> None:
+        """Reports error when entity count is less than expected."""
+        output = {
+            "entities": [{"entity_id": "a"}],
+            "tensions": [],
+        }
+        expected = {"entities": 3, "tensions": 0}
+
+        errors = check_structural_completeness(output, expected)
+
+        assert len(errors) == 1
+        assert errors[0][0] == "entities"
+        assert "Expected 3" in errors[0][1]
+        assert "got 1" in errors[0][1]
+
+    def test_detects_missing_tensions(self) -> None:
+        """Reports error when tension count is less than expected."""
+        output = {
+            "entities": [],
+            "tensions": [{"tension_id": "x"}],
+        }
+        expected = {"entities": 0, "tensions": 2}
+
+        errors = check_structural_completeness(output, expected)
+
+        assert len(errors) == 1
+        assert errors[0][0] == "tensions"
+        assert "Expected 2" in errors[0][1]
+        assert "got 1" in errors[0][1]
+
+    def test_detects_extra_entities(self) -> None:
+        """Reports error when entity count exceeds expected."""
+        output = {
+            "entities": [{"entity_id": "a"}, {"entity_id": "b"}, {"entity_id": "c"}],
+            "tensions": [],
+        }
+        expected = {"entities": 2, "tensions": 0}
+
+        errors = check_structural_completeness(output, expected)
+
+        assert len(errors) == 1
+        assert errors[0][0] == "entities"
+        assert "Expected 2" in errors[0][1]
+        assert "got 3" in errors[0][1]
+
+    def test_detects_multiple_errors(self) -> None:
+        """Reports errors for both entities and tensions."""
+        output = {
+            "entities": [],
+            "tensions": [],
+        }
+        expected = {"entities": 2, "tensions": 1}
+
+        errors = check_structural_completeness(output, expected)
+
+        assert len(errors) == 2
+        field_paths = {e[0] for e in errors}
+        assert field_paths == {"entities", "tensions"}
+
+    def test_handles_missing_output_keys(self) -> None:
+        """Handles output missing entities or tensions keys."""
+        output: dict[str, list[dict[str, str]]] = {}
+        expected = {"entities": 1, "tensions": 1}
+
+        errors = check_structural_completeness(output, expected)
+
+        assert len(errors) == 2
+
+    def test_handles_zero_expected(self) -> None:
+        """No error when both expected and actual are zero."""
+        output = {"entities": [], "tensions": []}
+        expected = {"entities": 0, "tensions": 0}
+
+        errors = check_structural_completeness(output, expected)
+
+        assert errors == []


### PR DESCRIPTION
## Problem
All SEED validation errors were treated the same, requiring the same retry strategy. This made recovery inefficient and obscured the root cause of failures. Part 4 of the manifest-first freeze architecture (Issue #211).

## Changes
- Add `SeedErrorCategory` enum with four categories:
  - `INNER`: Schema/type errors - retry with Pydantic feedback
  - `SEMANTIC`: Invalid ID references - retry with valid ID list
  - `COMPLETENESS`: Missing decisions - retry with manifest counts
  - `FATAL`: Unrecoverable errors - fail immediately

- Add `categorize_error(error)` function to classify a single error
- Add `categorize_errors(errors)` function to group errors by category
- Add `check_structural_completeness(output, expected)` for fast count-based validation before expensive semantic validation

- Export all new functions from `graph/__init__.py`

## Not Included / Future PRs
- Integration with serialize.py retry logic (can be done separately)
- PR#5: Documentation Updates

## Test Plan
```bash
# All new tests pass
uv run pytest tests/unit/test_mutations.py -v -k "Category or Categorize"  # 11 tests
uv run pytest tests/unit/test_graph_context.py -v -k "Completeness"        # 7 tests
uv run pytest tests/unit/ -v                                                # 758 tests pass
```

## Risk / Rollback
- Low risk - adds new functions without modifying existing behavior
- Backward compatible - existing code doesn't use these functions yet
- Pre-commit hooks pass (ruff, mypy, formatting)

🤖 Generated with [Claude Code](https://claude.ai/code)