### PR TITLE
fix(prompts): replace contaminated butler/host examples with placeholders

### DIFF
--- a/prompts/templates/discuss_brainstorm.yaml
+++ b/prompts/templates/discuss_brainstorm.yaml
@@ -21,7 +21,7 @@ system: |
      - Each tension has exactly TWO alternatives (not more, not less)
      - One alternative should be marked as the "default path" (the canonical story outcome)
      - For nuanced concepts, use MULTIPLE binary tensions rather than one multi-way choice
-     - Each tension must list its **central entities by ID** (e.g., "Central entities: the_host, the_butler")
+     - Each tension must list its **central entities by ID** (e.g., "Central entities: [entity_id_1], [entity_id_2]")
 
   ## Guidelines
   - Be expansive! Generate MORE material than needed (15-25 entities, 4-8 tensions is good)
@@ -37,10 +37,17 @@ system: |
   Bad: "What is the mentor's alignment?" (open-ended, not binary)
 
   ## Tension ID Naming
-  Use descriptive binary format: `subject_optionA_or_optionB`
+  Use descriptive binary format: `[subject]_[optionA]_or_[optionB]`
 
-  GOOD: `host_benevolent_or_self_serving`, `butler_loyal_or_treacherous`
-  BAD: `t1`, `host_motivation`, `butler_trust` (too short or ambiguous)
+  FORMAT: `[subject]_[optionA]_or_[optionB]`
+  Examples for different genres:
+  - Mystery: `detective_corrupt_or_honorable`, `witness_truthful_or_lying`
+  - Fantasy: `mentor_benevolent_or_manipulative`, `artifact_blessed_or_cursed`
+  - Sci-fi: `ai_helpful_or_hostile`, `colony_thriving_or_doomed`
+
+  BAD: `t1`, `character_motivation`, `trust_issue` (too short or ambiguous)
+
+  **DO NOT copy example IDs** - generate IDs specific to YOUR story's characters and tensions.
 
   ## What NOT to Do
   - Do NOT write prose paragraphs with backstories - use concise notes

--- a/prompts/templates/discuss_seed.yaml
+++ b/prompts/templates/discuss_seed.yaml
@@ -78,15 +78,25 @@ system: |
      - Characters, locations, objects, AND factions
      - No entity should be left undecided
 
-  ## Thread Naming
+  ## Thread Naming (CRITICAL)
 
   When creating threads from tensions:
   - Thread IDs should be SHORT and distinct from tension IDs
-  - Example: tension `library_knowledge_salvation_or_corruption` → thread `library_secret`
-  - Example: tension `host_benevolent_or_self_serving` → thread `host_motive`
+  - Thread ID = short storyline name, Tension ID = the binary question
 
-  BAD: Using the same ID for thread and tension
+  FORMAT:
+  - Tension: `[subject]_[optionA]_or_[optionB]` (the question)
+  - Thread: `[subject]_[aspect]` (the storyline exploring it)
+
+  Example patterns:
+  - Tension about a mentor's nature → Thread: `mentor_loyalty`
+  - Tension about an artifact's origin → Thread: `artifact_truth`
+  - Tension about a faction's goals → Thread: `faction_agenda`
+
+  BAD: Using the same ID for thread and tension (will fail validation)
   GOOD: Thread ID summarizes the storyline, tension ID shows the binary choice
+
+  **Generate IDs based on YOUR story's characters** - do not copy example IDs.
 
   ## What NOT to Do
 

--- a/prompts/templates/serialize_brainstorm.yaml
+++ b/prompts/templates/serialize_brainstorm.yaml
@@ -37,17 +37,20 @@ system: |
 
   Use descriptive binary format that shows both options: `subject_optionA_or_optionB`
 
-  GOOD examples:
-  - `host_benevolent_or_self_serving`
-  - `butler_loyal_or_treacherous`
-  - `artifact_authentic_or_forgery`
-  - `library_knowledge_salvation_or_corruption`
+  FORMAT: `[subject]_[optionA]_or_[optionB]`
+
+  Good patterns (generate YOUR OWN based on your story):
+  - `[character]_[trait1]_or_[trait2]` for character dilemmas
+  - `[object]_[state1]_or_[state2]` for artifact mysteries
+  - `[faction]_[stance1]_or_[stance2]` for group conflicts
 
   BAD examples (will cause downstream failures):
   - `t1`, `t2`, `tension_a` (too short, not descriptive)
-  - `host_motivation` (ambiguous, could be confused with thread name)
-  - `butler_trust` (too vague)
-  - `murder_intent` (could be mistaken for a thread ID)
+  - `character_motivation` (ambiguous, could be confused with thread name)
+  - `trust_issue` (too vague)
+  - `single_word` (could be mistaken for a thread ID)
+
+  **DO NOT copy IDs from other stories** - generate IDs specific to YOUR story.
 
   The tension_id should clearly show the binary choice being made.
 

--- a/prompts/templates/serialize_seed_sections.yaml
+++ b/prompts/templates/serialize_seed_sections.yaml
@@ -104,16 +104,22 @@ threads_prompt: |
 
   Thread IDs must be DIFFERENT from tension IDs. Use short descriptive names.
 
-  GOOD examples:
-  - tension `host_benevolent_or_self_serving` → thread `host_motive`
-  - tension `butler_loyal_or_treacherous` → thread `butler_loyalty`
-  - tension `library_knowledge_salvation_or_corruption` → thread `library_secret`
+  FORMAT:
+  - Tension: `[subject]_[optionA]_or_[optionB]` (the binary question)
+  - Thread: `[subject]_[aspect]` (short storyline name)
 
-  BAD examples (will cause validation failures):
-  - tension `murder_intent` → thread `murder_intent` (same ID - WRONG!)
+  Pattern examples (generate YOUR OWN based on your story):
+  - Tension about character loyalty → Thread: `[character]_loyalty`
+  - Tension about artifact's nature → Thread: `[artifact]_secret`
+  - Tension about faction's agenda → Thread: `[faction]_agenda`
+
+  BAD patterns (will cause validation failures):
+  - Using the SAME ID for both tension and thread
   - Using the tension_id as the thread_id
 
   Thread IDs should be short names for the storyline, NOT the binary question.
+
+  **DO NOT copy example IDs** - generate IDs specific to YOUR story.
 
   ## Rules
   - thread_importance must be exactly "major" or "minor" (lowercase)
@@ -193,21 +199,23 @@ beats_prompt: |
       {
         "beat_id": "unique_beat_id",
         "summary": "What happens in this beat",
-        "threads": ["host_motive", "butler_fidelity"],
+        "threads": ["thread::[your_thread_id]", "thread::[another_thread]"],
         "tension_impacts": [
           {
-            "tension_id": "host_benevolent_or_self_serving",
+            "tension_id": "tension::[your_tension_id]",
             "effect": "advances",
             "note": "Explanation of the impact"
           }
         ],
-        "entities": ["butler", "garden"],
-        "location": "garden",
-        "location_alternatives": ["library"]
+        "entities": ["entity::[character_id]", "entity::[location_id]"],
+        "location": "entity::[location_id]",
+        "location_alternatives": ["entity::[other_location]"]
       }
     ]
   }
   ```
+
+  **Use IDs from YOUR story's manifest** - the examples above show the FORMAT only.
 
   ## Rules
   - effect must be exactly "advances", "reveals", "commits", or "complicates"

--- a/prompts/templates/summarize_brainstorm.yaml
+++ b/prompts/templates/summarize_brainstorm.yaml
@@ -34,7 +34,7 @@ system: |
   For each tension, describe in prose:
   - The central question or conflict
   - The two possible answers/outcomes (one being the "default path")
-  - **Central entity IDs**: List the exact entity IDs involved (e.g., "the_host, the_butler, vane_manor")
+  - **Central entity IDs**: List the exact entity IDs involved (e.g., "[character_id], [location_id]")
   - Why this tension matters thematically
 
   ## Guidelines


### PR DESCRIPTION
## Problem

Fixes #218 - LLM copies example IDs (`butler`, `host`, `host_benevolent_or_self_serving`, `vane_manor`) verbatim across all genres. Found in 6/6 test projects.

When prompts contain concrete example IDs, the LLM treats them as canonical and copies them regardless of the story's actual genre (space opera, fantasy, etc.).

## Changes

Replaced contaminated examples in 5 prompt template files:

| File | What Changed |
|------|--------------|
| `discuss_brainstorm.yaml` | Replaced `the_host`, `butler_loyal_or_treacherous` with format placeholders |
| `summarize_brainstorm.yaml` | Replaced `the_host, the_butler, vane_manor` with `[character_id], [location_id]` |
| `serialize_brainstorm.yaml` | Replaced concrete examples with format patterns |
| `serialize_seed_sections.yaml` | Replaced JSON examples with scoped placeholders (`thread::[your_thread_id]`) |
| `discuss_seed.yaml` | Replaced `host_motive`, `butler_loyalty` with format patterns |

**Key patterns used:**
- Format templates: `[subject]_[optionA]_or_[optionB]`
- Genre-diverse examples: mystery, fantasy, sci-fi patterns (no single-genre bias)
- Scoped placeholders in JSON: `thread::[your_thread_id]`
- Inline warnings: "DO NOT copy example IDs - generate IDs specific to YOUR story"

## Not Included / Future PRs

- No changes to validation code (handled in PR#220, #221)
- No changes to context formatting (handled in PR#220)

## Test Plan

- [x] All prompt-related tests pass (`pytest tests/unit/test_prompt_compiler.py tests/unit/test_seed_prompts.py`)
- [x] All modified YAML files parse correctly
- [x] Pre-commit hooks pass (YAML validation)

**Manual verification (recommended after merge):**
```bash
# Run different genre projects and verify no shared example IDs
uv run qf dream --project test-scifi "space opera"
uv run qf dream --project test-fantasy "high fantasy"
# Check artifacts for absence of: butler, host, vane_manor
```

## Risk / Rollback

- Low risk: Only changes example text in prompts
- Easy rollback: Revert single commit
- Works in combination with PR#220 (scoped IDs) and PR#221 (scoped validation) for full fix

## Related PRs

- PR#220: Scoped IDs in LLM context - **merged**
- PR#221: Scoped ID validation - **merged**
- This PR completes the 3-PR solution for Issues #218 and #219

🤖 Generated with [Claude Code](https://claude.com/claude-code)