### PR TITLE
feat: add phase-specific model settings (#225)

### DIFF
--- a/src/questfoundry/pipeline/config.py
+++ b/src/questfoundry/pipeline/config.py
@@ -63,26 +63,14 @@ class ProvidersConfig:
             phase: Pipeline phase (discuss, summarize, serialize).
 
         Returns:
-            PhaseSettings for the phase (may be default if not configured).
+            PhaseSettings for the phase. Returns configured settings if present,
+            otherwise returns default (empty) PhaseSettings. Note that actual
+            temperature values are computed dynamically in to_model_kwargs()
+            based on the phase and provider when not explicitly configured.
         """
-        from questfoundry.providers.settings import PhaseSettings as PS
         from questfoundry.providers.settings import get_default_phase_settings
 
-        config_settings = self.settings.get(phase)
-        if config_settings is None:
-            return get_default_phase_settings(phase)
-
-        # Merge config with defaults (config overrides defaults)
-        defaults = get_default_phase_settings(phase)
-        return PS(
-            temperature=(
-                config_settings.temperature
-                if config_settings.temperature is not None
-                else defaults.temperature
-            ),
-            top_p=(config_settings.top_p if config_settings.top_p is not None else defaults.top_p),
-            seed=config_settings.seed if config_settings.seed is not None else defaults.seed,
-        )
+        return self.settings.get(phase) or get_default_phase_settings(phase)
 
     def get_discuss_provider(self) -> str:
         """Get the effective provider for the discuss phase.

--- a/src/questfoundry/pipeline/orchestrator.py
+++ b/src/questfoundry/pipeline/orchestrator.py
@@ -218,7 +218,7 @@ class PipelineOrchestrator:
         Args:
             provider_string: Provider string like "ollama/qwen3:4b-instruct-32k".
             phase: Pipeline phase (discuss, summarize, serialize) for settings.
-                If None, uses balanced defaults.
+                If None, uses discuss phase defaults (CREATIVE temperature).
 
         Returns:
             Tuple of (chat_model, provider_name, model_name).

--- a/src/questfoundry/providers/factory.py
+++ b/src/questfoundry/providers/factory.py
@@ -171,7 +171,7 @@ def _create_ollama_base_model(model: str, **kwargs: Any) -> BaseChatModel:
         model: Model name.
         **kwargs: Model options including:
             - host: Ollama server URL (or use OLLAMA_HOST env var)
-            - temperature: Sampling temperature (required, no default)
+            - temperature: Sampling temperature (optional, uses model default if not provided)
             - top_p: Nucleus sampling parameter
             - seed: Random seed for reproducibility
             - num_ctx: Context window size (default 32768)
@@ -206,7 +206,7 @@ def _create_ollama_base_model(model: str, **kwargs: Any) -> BaseChatModel:
         "num_ctx": kwargs.get("num_ctx", 32768),  # Default 32k to avoid truncation
     }
 
-    # Temperature is required - caller must provide via phase settings
+    # Temperature is provided by phase settings; if absent, model uses its default
     if "temperature" in kwargs:
         model_kwargs["temperature"] = kwargs["temperature"]
 
@@ -245,7 +245,7 @@ def _create_openai_base_model(model: str, **kwargs: Any) -> BaseChatModel:
         model: Model name.
         **kwargs: Model options including:
             - api_key: OpenAI API key (or use OPENAI_API_KEY env var)
-            - temperature: Sampling temperature (required for non-reasoning models)
+            - temperature: Sampling temperature (optional, ignored for reasoning models)
             - top_p: Nucleus sampling parameter
             - seed: Random seed for reproducibility
 
@@ -301,7 +301,7 @@ def _create_anthropic_base_model(model: str, **kwargs: Any) -> BaseChatModel:
         model: Model name.
         **kwargs: Model options including:
             - api_key: Anthropic API key (or use ANTHROPIC_API_KEY env var)
-            - temperature: Sampling temperature (required, no default)
+            - temperature: Sampling temperature (optional, uses model default if not provided)
             - top_p: Nucleus sampling parameter
 
     Note:

--- a/src/questfoundry/providers/factory.py
+++ b/src/questfoundry/providers/factory.py
@@ -165,7 +165,23 @@ def create_model_for_structured_output(
 
 
 def _create_ollama_base_model(model: str, **kwargs: Any) -> BaseChatModel:
-    """Create base Ollama chat model (unstructured)."""
+    """Create base Ollama chat model (unstructured).
+
+    Args:
+        model: Model name.
+        **kwargs: Model options including:
+            - host: Ollama server URL (or use OLLAMA_HOST env var)
+            - temperature: Sampling temperature (required, no default)
+            - top_p: Nucleus sampling parameter
+            - seed: Random seed for reproducibility
+            - num_ctx: Context window size (default 32768)
+
+    Returns:
+        Configured ChatOllama model.
+
+    Raises:
+        ProviderError: If OLLAMA_HOST not configured.
+    """
     try:
         from langchain_ollama import ChatOllama
     except ImportError as e:
@@ -183,13 +199,24 @@ def _create_ollama_base_model(model: str, **kwargs: Any) -> BaseChatModel:
             "OLLAMA_HOST not configured. Set OLLAMA_HOST environment variable.",
         )
 
-    # Cast needed: ChatOllama runtime type is BaseChatModel, but mypy can't verify
-    chat_model: BaseChatModel = ChatOllama(
-        model=model,
-        base_url=host,
-        temperature=kwargs.get("temperature", 0.7),
-        num_ctx=kwargs.get("num_ctx", 32768),  # Default 32k to avoid truncation
-    )
+    # Build model kwargs - only include parameters that are provided
+    model_kwargs: dict[str, Any] = {
+        "model": model,
+        "base_url": host,
+        "num_ctx": kwargs.get("num_ctx", 32768),  # Default 32k to avoid truncation
+    }
+
+    # Temperature is required - caller must provide via phase settings
+    if "temperature" in kwargs:
+        model_kwargs["temperature"] = kwargs["temperature"]
+
+    if "top_p" in kwargs:
+        model_kwargs["top_p"] = kwargs["top_p"]
+
+    if "seed" in kwargs:
+        model_kwargs["seed"] = kwargs["seed"]
+
+    chat_model: BaseChatModel = ChatOllama(**model_kwargs)
     return chat_model
 
 
@@ -212,7 +239,22 @@ def _is_reasoning_model(model: str) -> bool:
 
 
 def _create_openai_base_model(model: str, **kwargs: Any) -> BaseChatModel:
-    """Create base OpenAI chat model (unstructured)."""
+    """Create base OpenAI chat model (unstructured).
+
+    Args:
+        model: Model name.
+        **kwargs: Model options including:
+            - api_key: OpenAI API key (or use OPENAI_API_KEY env var)
+            - temperature: Sampling temperature (required for non-reasoning models)
+            - top_p: Nucleus sampling parameter
+            - seed: Random seed for reproducibility
+
+    Returns:
+        Configured ChatOpenAI model.
+
+    Raises:
+        ProviderError: If API key not configured.
+    """
     try:
         from langchain_openai import ChatOpenAI
     except ImportError as e:
@@ -238,15 +280,40 @@ def _create_openai_base_model(model: str, **kwargs: Any) -> BaseChatModel:
 
     # Reasoning models (o1, o1-mini, o3, etc.) don't support temperature
     if not _is_reasoning_model(model):
-        model_kwargs["temperature"] = kwargs.get("temperature", 0.7)
+        if "temperature" in kwargs:
+            model_kwargs["temperature"] = kwargs["temperature"]
+        if "top_p" in kwargs:
+            model_kwargs["top_p"] = kwargs["top_p"]
     else:
         log.debug("reasoning_model_detected", model=model, note="skipping temperature parameter")
+
+    # Seed is supported for all OpenAI models
+    if "seed" in kwargs:
+        model_kwargs["seed"] = kwargs["seed"]
 
     return ChatOpenAI(**model_kwargs)
 
 
 def _create_anthropic_base_model(model: str, **kwargs: Any) -> BaseChatModel:
-    """Create base Anthropic chat model (unstructured)."""
+    """Create base Anthropic chat model (unstructured).
+
+    Args:
+        model: Model name.
+        **kwargs: Model options including:
+            - api_key: Anthropic API key (or use ANTHROPIC_API_KEY env var)
+            - temperature: Sampling temperature (required, no default)
+            - top_p: Nucleus sampling parameter
+
+    Note:
+        Anthropic does not support the seed parameter. It is filtered out
+        by PhaseSettings.to_model_kwargs() before reaching this function.
+
+    Returns:
+        Configured ChatAnthropic model.
+
+    Raises:
+        ProviderError: If API key not configured.
+    """
     try:
         from langchain_anthropic import ChatAnthropic
     except ImportError as e:
@@ -264,8 +331,18 @@ def _create_anthropic_base_model(model: str, **kwargs: Any) -> BaseChatModel:
             "API key required. Set ANTHROPIC_API_KEY environment variable.",
         )
 
-    return ChatAnthropic(
-        model=model,  # type: ignore[call-arg]
-        api_key=api_key,  # type: ignore[arg-type]
-        temperature=kwargs.get("temperature", 0.7),
-    )
+    # Build model kwargs
+    model_kwargs: dict[str, Any] = {
+        "model": model,
+        "api_key": api_key,
+    }
+
+    if "temperature" in kwargs:
+        model_kwargs["temperature"] = kwargs["temperature"]
+
+    if "top_p" in kwargs:
+        model_kwargs["top_p"] = kwargs["top_p"]
+
+    # Note: seed is not supported by Anthropic - filtered upstream
+
+    return ChatAnthropic(**model_kwargs)

--- a/src/questfoundry/providers/settings.py
+++ b/src/questfoundry/providers/settings.py
@@ -170,13 +170,36 @@ class PhaseSettings:
 
         Returns:
             PhaseSettings instance.
+
+        Raises:
+            ValueError: If values are out of valid range.
         """
         if not data:
             return cls()
+
+        temperature = data.get("temperature")
+        top_p = data.get("top_p")
+        seed = data.get("seed")
+
+        # Validate temperature (non-negative)
+        if temperature is not None and temperature < 0:
+            msg = f"temperature must be non-negative, got {temperature}"
+            raise ValueError(msg)
+
+        # Validate top_p (0 to 1 inclusive)
+        if top_p is not None and not (0 <= top_p <= 1):
+            msg = f"top_p must be between 0 and 1, got {top_p}"
+            raise ValueError(msg)
+
+        # Validate seed (must be an integer)
+        if seed is not None and not isinstance(seed, int):
+            msg = f"seed must be an integer, got {type(seed).__name__}"
+            raise ValueError(msg)
+
         return cls(
-            temperature=data.get("temperature"),
-            top_p=data.get("top_p"),
-            seed=data.get("seed"),
+            temperature=temperature,
+            top_p=top_p,
+            seed=seed,
         )
 
 

--- a/src/questfoundry/providers/settings.py
+++ b/src/questfoundry/providers/settings.py
@@ -1,0 +1,197 @@
+"""Phase-specific model settings with provider-aware temperature mapping.
+
+Temperature scales differ across providers - Anthropic's 1.0 is more conservative
+than OpenAI's 1.0. This module provides semantic creativity levels that map to
+provider-appropriate temperature values.
+
+See: https://gist.github.com/pvliesdonk/35b36897a42c41b371c8898bfec55882
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any
+
+from questfoundry.observability.logging import get_logger
+
+log = get_logger(__name__)
+
+
+class CreativityLevel(Enum):
+    """Semantic creativity levels that map to provider-specific temperatures.
+
+    These levels abstract away provider-specific temperature scales:
+    - Anthropic's 1.0 is more conservative than OpenAI's 1.0
+    - Ollama models vary, but typically use 0.0-1.0 scale
+    """
+
+    DETERMINISTIC = "deterministic"  # Structured output, minimal variance
+    FOCUSED = "focused"  # Consistent but some variation
+    BALANCED = "balanced"  # Default, good for most tasks
+    CREATIVE = "creative"  # Exploratory, high variance
+
+
+# Provider-specific temperature mappings
+# Based on empirical testing and provider documentation
+TEMPERATURE_MAP: dict[str, dict[CreativityLevel, float]] = {
+    "openai": {
+        CreativityLevel.DETERMINISTIC: 0.0,
+        CreativityLevel.FOCUSED: 0.3,
+        CreativityLevel.BALANCED: 0.7,
+        CreativityLevel.CREATIVE: 0.9,
+    },
+    "anthropic": {
+        CreativityLevel.DETERMINISTIC: 0.0,
+        CreativityLevel.FOCUSED: 0.3,
+        CreativityLevel.BALANCED: 0.5,
+        CreativityLevel.CREATIVE: 0.8,
+    },
+    "ollama": {
+        CreativityLevel.DETERMINISTIC: 0.0,
+        CreativityLevel.FOCUSED: 0.2,
+        CreativityLevel.BALANCED: 0.5,
+        CreativityLevel.CREATIVE: 0.8,
+    },
+}
+
+# Phase defaults (semantic level, not raw temperature)
+# Based on agent prompt engineering best practices:
+# - discuss: high creativity for exploration
+# - summarize: balanced for coherent narratives
+# - serialize: deterministic for structured output
+PHASE_CREATIVITY: dict[str, CreativityLevel] = {
+    "discuss": CreativityLevel.CREATIVE,
+    "summarize": CreativityLevel.BALANCED,
+    "serialize": CreativityLevel.DETERMINISTIC,
+}
+
+
+def get_temperature_for_phase(phase: str, provider: str) -> float:
+    """Get provider-appropriate temperature for a phase.
+
+    Args:
+        phase: Pipeline phase (discuss, summarize, serialize).
+        provider: Provider name (ollama, openai, anthropic).
+
+    Returns:
+        Temperature value appropriate for the provider's scale.
+    """
+    level = PHASE_CREATIVITY.get(phase, CreativityLevel.BALANCED)
+    provider_key = provider.lower()
+    temps = TEMPERATURE_MAP.get(provider_key, TEMPERATURE_MAP["ollama"])
+    return temps[level]
+
+
+def get_max_temperature(provider: str) -> float:
+    """Get the maximum valid temperature for a provider.
+
+    Args:
+        provider: Provider name (ollama, openai, anthropic).
+
+    Returns:
+        Maximum temperature value for the provider.
+    """
+    provider_limits: dict[str, float] = {
+        "openai": 2.0,
+        "anthropic": 1.0,
+        "ollama": 2.0,  # Ollama allows > 1.0 though rarely useful
+    }
+    return provider_limits.get(provider.lower(), 1.0)
+
+
+@dataclass
+class PhaseSettings:
+    """Model settings for a specific pipeline phase.
+
+    Attributes:
+        temperature: Override temperature, or None to use phase/provider default.
+        top_p: Nucleus sampling parameter, or None to use provider default.
+        seed: Random seed for reproducibility, or None.
+    """
+
+    temperature: float | None = None
+    top_p: float | None = None
+    seed: int | None = None
+
+    def to_model_kwargs(self, phase: str, provider: str) -> dict[str, Any]:
+        """Convert to kwargs for model creation.
+
+        Applies provider-specific temperature clamping when user provides
+        explicit values that exceed provider limits.
+
+        Args:
+            phase: Pipeline phase (discuss, summarize, serialize).
+            provider: Provider name for temperature mapping.
+
+        Returns:
+            Dictionary of model kwargs (temperature, top_p, seed).
+        """
+        kwargs: dict[str, Any] = {}
+
+        # Use explicit temperature if set, otherwise use phase/provider default
+        if self.temperature is not None:
+            max_temp = get_max_temperature(provider)
+            if self.temperature > max_temp:
+                log.warning(
+                    "temperature_clamped",
+                    provider=provider,
+                    requested=self.temperature,
+                    max=max_temp,
+                )
+                kwargs["temperature"] = max_temp
+            else:
+                kwargs["temperature"] = self.temperature
+        else:
+            kwargs["temperature"] = get_temperature_for_phase(phase, provider)
+
+        if self.top_p is not None:
+            kwargs["top_p"] = self.top_p
+
+        if self.seed is not None:
+            # Anthropic doesn't support seed - log warning and skip
+            if provider.lower() == "anthropic":
+                log.warning(
+                    "seed_not_supported",
+                    provider=provider,
+                    note="Anthropic does not support seed parameter, ignoring",
+                )
+            else:
+                kwargs["seed"] = self.seed
+
+        return kwargs
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any] | None) -> PhaseSettings:
+        """Create from config dict.
+
+        Args:
+            data: Dictionary with optional temperature, top_p, seed keys.
+
+        Returns:
+            PhaseSettings instance.
+        """
+        if not data:
+            return cls()
+        return cls(
+            temperature=data.get("temperature"),
+            top_p=data.get("top_p"),
+            seed=data.get("seed"),
+        )
+
+
+def get_default_phase_settings(_phase: str) -> PhaseSettings:
+    """Get default settings for a phase.
+
+    This returns an empty PhaseSettings - the actual temperature will be
+    computed based on the phase and provider when to_model_kwargs is called.
+
+    Args:
+        _phase: Pipeline phase name (unused - defaults are computed dynamically).
+
+    Returns:
+        PhaseSettings with no overrides (uses phase/provider defaults).
+    """
+    # Return empty settings - defaults are computed dynamically
+    # based on phase and provider in to_model_kwargs
+    return PhaseSettings()

--- a/tests/unit/test_settings.py
+++ b/tests/unit/test_settings.py
@@ -1,0 +1,257 @@
+"""Tests for phase-specific model settings."""
+
+from __future__ import annotations
+
+import pytest
+
+from questfoundry.providers.settings import (
+    PHASE_CREATIVITY,
+    TEMPERATURE_MAP,
+    CreativityLevel,
+    PhaseSettings,
+    get_default_phase_settings,
+    get_max_temperature,
+    get_temperature_for_phase,
+)
+
+
+class TestCreativityLevel:
+    """Tests for CreativityLevel enum."""
+
+    def test_all_levels_defined(self) -> None:
+        """All creativity levels are defined."""
+        assert CreativityLevel.DETERMINISTIC.value == "deterministic"
+        assert CreativityLevel.FOCUSED.value == "focused"
+        assert CreativityLevel.BALANCED.value == "balanced"
+        assert CreativityLevel.CREATIVE.value == "creative"
+
+
+class TestTemperatureMap:
+    """Tests for temperature mapping configuration."""
+
+    def test_all_providers_have_mappings(self) -> None:
+        """All supported providers have temperature mappings."""
+        assert "openai" in TEMPERATURE_MAP
+        assert "anthropic" in TEMPERATURE_MAP
+        assert "ollama" in TEMPERATURE_MAP
+
+    def test_all_levels_mapped_for_each_provider(self) -> None:
+        """Each provider has mappings for all creativity levels."""
+        for provider, temps in TEMPERATURE_MAP.items():
+            for level in CreativityLevel:
+                assert level in temps, f"{provider} missing {level}"
+
+    def test_deterministic_is_zero(self) -> None:
+        """Deterministic level is 0.0 for all providers."""
+        for provider, temps in TEMPERATURE_MAP.items():
+            assert temps[CreativityLevel.DETERMINISTIC] == 0.0, f"{provider}"
+
+    def test_creative_is_highest(self) -> None:
+        """Creative level has highest temperature for each provider."""
+        for provider, temps in TEMPERATURE_MAP.items():
+            creative_temp = temps[CreativityLevel.CREATIVE]
+            for level, temp in temps.items():
+                assert temp <= creative_temp, f"{provider} {level}"
+
+
+class TestPhaseCreativity:
+    """Tests for phase creativity defaults."""
+
+    def test_discuss_is_creative(self) -> None:
+        """Discuss phase uses creative temperature."""
+        assert PHASE_CREATIVITY["discuss"] == CreativityLevel.CREATIVE
+
+    def test_summarize_is_balanced(self) -> None:
+        """Summarize phase uses balanced temperature."""
+        assert PHASE_CREATIVITY["summarize"] == CreativityLevel.BALANCED
+
+    def test_serialize_is_deterministic(self) -> None:
+        """Serialize phase uses deterministic temperature."""
+        assert PHASE_CREATIVITY["serialize"] == CreativityLevel.DETERMINISTIC
+
+
+class TestGetTemperatureForPhase:
+    """Tests for get_temperature_for_phase function."""
+
+    @pytest.mark.parametrize(
+        ("phase", "provider", "expected"),
+        [
+            # Discuss phase (CREATIVE)
+            ("discuss", "openai", 0.9),
+            ("discuss", "anthropic", 0.8),
+            ("discuss", "ollama", 0.8),
+            # Summarize phase (BALANCED)
+            ("summarize", "openai", 0.7),
+            ("summarize", "anthropic", 0.5),
+            ("summarize", "ollama", 0.5),
+            # Serialize phase (DETERMINISTIC)
+            ("serialize", "openai", 0.0),
+            ("serialize", "anthropic", 0.0),
+            ("serialize", "ollama", 0.0),
+        ],
+    )
+    def test_phase_provider_temperatures(self, phase: str, provider: str, expected: float) -> None:
+        """Correct temperature for each phase/provider combination."""
+        assert get_temperature_for_phase(phase, provider) == expected
+
+    def test_unknown_phase_uses_balanced(self) -> None:
+        """Unknown phase falls back to BALANCED."""
+        temp = get_temperature_for_phase("unknown_phase", "openai")
+        assert temp == TEMPERATURE_MAP["openai"][CreativityLevel.BALANCED]
+
+    def test_unknown_provider_uses_ollama_defaults(self) -> None:
+        """Unknown provider falls back to Ollama defaults."""
+        temp = get_temperature_for_phase("discuss", "unknown_provider")
+        assert temp == TEMPERATURE_MAP["ollama"][CreativityLevel.CREATIVE]
+
+    def test_case_insensitive_provider(self) -> None:
+        """Provider lookup is case insensitive."""
+        assert get_temperature_for_phase("discuss", "OPENAI") == 0.9
+        assert get_temperature_for_phase("discuss", "OpenAI") == 0.9
+
+
+class TestGetMaxTemperature:
+    """Tests for get_max_temperature function."""
+
+    def test_openai_max(self) -> None:
+        """OpenAI has max temperature of 2.0."""
+        assert get_max_temperature("openai") == 2.0
+
+    def test_anthropic_max(self) -> None:
+        """Anthropic has max temperature of 1.0."""
+        assert get_max_temperature("anthropic") == 1.0
+
+    def test_ollama_max(self) -> None:
+        """Ollama has max temperature of 2.0."""
+        assert get_max_temperature("ollama") == 2.0
+
+    def test_unknown_provider_defaults_to_1(self) -> None:
+        """Unknown provider defaults to 1.0 max."""
+        assert get_max_temperature("unknown") == 1.0
+
+    def test_case_insensitive(self) -> None:
+        """Provider lookup is case insensitive."""
+        assert get_max_temperature("ANTHROPIC") == 1.0
+
+
+class TestPhaseSettings:
+    """Tests for PhaseSettings dataclass."""
+
+    def test_default_values(self) -> None:
+        """Default PhaseSettings has all None values."""
+        settings = PhaseSettings()
+        assert settings.temperature is None
+        assert settings.top_p is None
+        assert settings.seed is None
+
+    def test_from_dict_empty(self) -> None:
+        """from_dict with empty dict returns defaults."""
+        settings = PhaseSettings.from_dict({})
+        assert settings.temperature is None
+        assert settings.top_p is None
+        assert settings.seed is None
+
+    def test_from_dict_none(self) -> None:
+        """from_dict with None returns defaults."""
+        settings = PhaseSettings.from_dict(None)
+        assert settings.temperature is None
+
+    def test_from_dict_with_values(self) -> None:
+        """from_dict parses all values."""
+        settings = PhaseSettings.from_dict(
+            {
+                "temperature": 0.5,
+                "top_p": 0.9,
+                "seed": 42,
+            }
+        )
+        assert settings.temperature == 0.5
+        assert settings.top_p == 0.9
+        assert settings.seed == 42
+
+    def test_from_dict_partial(self) -> None:
+        """from_dict handles partial values."""
+        settings = PhaseSettings.from_dict({"temperature": 0.3})
+        assert settings.temperature == 0.3
+        assert settings.top_p is None
+        assert settings.seed is None
+
+
+class TestPhaseSettingsToModelKwargs:
+    """Tests for PhaseSettings.to_model_kwargs method."""
+
+    def test_uses_phase_default_when_no_override(self) -> None:
+        """Uses phase/provider default temperature when not overridden."""
+        settings = PhaseSettings()
+        kwargs = settings.to_model_kwargs("discuss", "openai")
+        assert kwargs["temperature"] == 0.9  # CREATIVE for OpenAI
+
+    def test_uses_explicit_temperature(self) -> None:
+        """Uses explicit temperature when provided."""
+        settings = PhaseSettings(temperature=0.5)
+        kwargs = settings.to_model_kwargs("discuss", "openai")
+        assert kwargs["temperature"] == 0.5
+
+    def test_includes_top_p_when_set(self) -> None:
+        """Includes top_p in kwargs when set."""
+        settings = PhaseSettings(top_p=0.95)
+        kwargs = settings.to_model_kwargs("discuss", "openai")
+        assert kwargs["top_p"] == 0.95
+
+    def test_excludes_top_p_when_none(self) -> None:
+        """Excludes top_p from kwargs when None."""
+        settings = PhaseSettings()
+        kwargs = settings.to_model_kwargs("discuss", "openai")
+        assert "top_p" not in kwargs
+
+    def test_includes_seed_for_openai(self) -> None:
+        """Includes seed in kwargs for OpenAI."""
+        settings = PhaseSettings(seed=42)
+        kwargs = settings.to_model_kwargs("discuss", "openai")
+        assert kwargs["seed"] == 42
+
+    def test_includes_seed_for_ollama(self) -> None:
+        """Includes seed in kwargs for Ollama."""
+        settings = PhaseSettings(seed=42)
+        kwargs = settings.to_model_kwargs("discuss", "ollama")
+        assert kwargs["seed"] == 42
+
+    def test_excludes_seed_for_anthropic(self) -> None:
+        """Excludes seed from kwargs for Anthropic (not supported)."""
+        settings = PhaseSettings(seed=42)
+        kwargs = settings.to_model_kwargs("discuss", "anthropic")
+        assert "seed" not in kwargs
+
+    def test_clamps_temperature_for_anthropic(self) -> None:
+        """Clamps temperature to provider max."""
+        settings = PhaseSettings(temperature=1.5)
+        kwargs = settings.to_model_kwargs("discuss", "anthropic")
+        assert kwargs["temperature"] == 1.0  # Clamped to Anthropic max
+
+    def test_does_not_clamp_within_range(self) -> None:
+        """Does not clamp temperature within provider range."""
+        settings = PhaseSettings(temperature=1.5)
+        kwargs = settings.to_model_kwargs("discuss", "openai")
+        assert kwargs["temperature"] == 1.5  # OpenAI allows up to 2.0
+
+
+class TestGetDefaultPhaseSettings:
+    """Tests for get_default_phase_settings function."""
+
+    def test_returns_empty_settings(self) -> None:
+        """Returns PhaseSettings with no overrides."""
+        settings = get_default_phase_settings("discuss")
+        assert settings.temperature is None
+        assert settings.top_p is None
+        assert settings.seed is None
+
+    def test_works_for_all_phases(self) -> None:
+        """Works for all standard phases."""
+        for phase in ["discuss", "summarize", "serialize"]:
+            settings = get_default_phase_settings(phase)
+            assert isinstance(settings, PhaseSettings)
+
+    def test_works_for_unknown_phase(self) -> None:
+        """Works for unknown phases (returns defaults)."""
+        settings = get_default_phase_settings("unknown")
+        assert isinstance(settings, PhaseSettings)

--- a/tests/unit/test_settings.py
+++ b/tests/unit/test_settings.py
@@ -176,6 +176,43 @@ class TestPhaseSettings:
         assert settings.top_p is None
         assert settings.seed is None
 
+    def test_from_dict_rejects_negative_temperature(self) -> None:
+        """from_dict rejects negative temperature."""
+        with pytest.raises(ValueError, match="temperature must be non-negative"):
+            PhaseSettings.from_dict({"temperature": -0.5})
+
+    def test_from_dict_accepts_zero_temperature(self) -> None:
+        """from_dict accepts zero temperature."""
+        settings = PhaseSettings.from_dict({"temperature": 0.0})
+        assert settings.temperature == 0.0
+
+    def test_from_dict_rejects_top_p_below_zero(self) -> None:
+        """from_dict rejects top_p below 0."""
+        with pytest.raises(ValueError, match="top_p must be between 0 and 1"):
+            PhaseSettings.from_dict({"top_p": -0.1})
+
+    def test_from_dict_rejects_top_p_above_one(self) -> None:
+        """from_dict rejects top_p above 1."""
+        with pytest.raises(ValueError, match="top_p must be between 0 and 1"):
+            PhaseSettings.from_dict({"top_p": 1.5})
+
+    def test_from_dict_accepts_boundary_top_p(self) -> None:
+        """from_dict accepts top_p at boundaries (0 and 1)."""
+        settings = PhaseSettings.from_dict({"top_p": 0.0})
+        assert settings.top_p == 0.0
+        settings = PhaseSettings.from_dict({"top_p": 1.0})
+        assert settings.top_p == 1.0
+
+    def test_from_dict_rejects_non_integer_seed(self) -> None:
+        """from_dict rejects non-integer seed."""
+        with pytest.raises(ValueError, match="seed must be an integer"):
+            PhaseSettings.from_dict({"seed": 42.5})
+
+    def test_from_dict_accepts_integer_seed(self) -> None:
+        """from_dict accepts integer seed."""
+        settings = PhaseSettings.from_dict({"seed": 42})
+        assert settings.seed == 42
+
 
 class TestPhaseSettingsToModelKwargs:
     """Tests for PhaseSettings.to_model_kwargs method."""


### PR DESCRIPTION
## Problem

Issue #225 identified that small models generate repetitive content for "surprise me" prompts. The root cause is model bias, exacerbated by using the same temperature (0.7) across all phases. Different phases need different temperature settings:
- **Discuss**: High creativity for exploration
- **Summarize**: Balanced for coherent narratives
- **Serialize**: Deterministic for structured output

Additionally, temperature scales are **not equivalent across providers** - Anthropic's 1.0 is more conservative than OpenAI's 1.0.

## Changes

- Add `settings.py` module with:
  - `CreativityLevel` enum (DETERMINISTIC, FOCUSED, BALANCED, CREATIVE)
  - Provider-specific temperature mappings
  - `PhaseSettings` dataclass with temperature, top_p, seed support
  - Temperature clamping for provider limits (Anthropic max=1.0)
  - Seed exclusion for Anthropic (not supported)

- Update `ProvidersConfig` with settings field and `get_phase_settings()` method

- Update `factory.py` to remove hardcoded temperature defaults and pass through kwargs

- Update `orchestrator.py` to use phase-specific settings when creating models

### Temperature Defaults by Phase/Provider

| Phase | OpenAI | Anthropic | Ollama |
|-------|--------|-----------|--------|
| discuss | 0.9 | 0.8 | 0.8 |
| summarize | 0.7 | 0.5 | 0.5 |
| serialize | 0.0 | 0.0 | 0.0 |

## Not Included / Future PRs

- CLI flags for phase-specific settings (just sane defaults + project config)
- Environment variable overrides for settings
- Validation phase settings (shares serialize settings)

## Test Plan

- [x] All 866 unit tests pass
- [x] mypy passes with no errors
- [x] ruff passes with no errors
- [x] New tests for settings module (43 tests)
- [x] Updated factory tests for kwargs passthrough

```bash
uv run pytest tests/unit/ -q
# 866 passed

uv run mypy src/questfoundry/providers/settings.py src/questfoundry/pipeline/config.py
# Success: no issues found
```

## Risk / Rollback

- **Low risk**: Temperature changes are additive defaults
- **Backward compatible**: Existing configs without settings work unchanged
- **Rollback**: Revert and hardcode temperatures back to 0.7

## Related

- Closes #225
- Created https://github.com/pvliesdonk/if-craft-corpus/issues/21 to document provider-specific temperature scales

🤖 Generated with [Claude Code](https://claude.com/claude-code)