### PR TITLE
fix(prompts): replace genre-specific examples with meta placeholders

### DIFF
--- a/prompts/templates/discuss_brainstorm.yaml
+++ b/prompts/templates/discuss_brainstorm.yaml
@@ -17,7 +17,7 @@ system: |
      - Factions: Groups, organizations, collectives
 
   2. **Tensions** - Binary dramatic questions that drive the story
-     - Each tension is a yes/no question (e.g., "Can the mentor be trusted?")
+     - Each tension is a yes/no question (e.g., "Can <CHARACTER> be trusted?")
      - Each tension has exactly TWO alternatives (not more, not less)
      - One alternative should be marked as the "default path" (the canonical story outcome)
      - For nuanced concepts, use MULTIPLE binary tensions rather than one multi-way choice
@@ -32,22 +32,22 @@ system: |
   {research_tools_section}
 
   ## Binary Tension Examples
-  Good: "Is the mentor benevolent or self-serving?" (yes/no)
-  Good: "Is the archive's knowledge salvation or corruption?" (binary choice)
-  Bad: "What is the mentor's alignment?" (open-ended, not binary)
+  Good: "Is <CHARACTER> trustworthy or deceptive?" (yes/no)
+  Good: "Is the <LOCATION>'s secret helpful or dangerous?" (binary choice)
+  Bad: "What is the character's alignment?" (open-ended, not binary)
 
   ## Tension ID Naming
   Use descriptive binary format: `[subject]_[optionA]_or_[optionB]`
 
   FORMAT: `[subject]_[optionA]_or_[optionB]`
-  Examples for different genres:
-  - Mystery: `detective_corrupt_or_honorable`, `witness_truthful_or_lying`
-  - Fantasy: `mentor_benevolent_or_manipulative`, `artifact_blessed_or_cursed`
-  - Sci-fi: `ai_helpful_or_hostile`, `colony_thriving_or_doomed`
+  Pattern (use YOUR story's characters and concepts):
+  - `<character_name>_<trait_a>_or_<trait_b>` for character dilemmas
+  - `<object_name>_<state_a>_or_<state_b>` for object mysteries
+  - `<faction_name>_<stance_a>_or_<stance_b>` for group conflicts
 
   BAD: `t1`, `character_motivation`, `trust_issue` (too short or ambiguous)
 
-  **DO NOT copy example IDs** - generate IDs specific to YOUR story's characters and tensions.
+  **DO NOT copy example patterns** - generate IDs specific to YOUR story's characters and tensions.
 
   ## What NOT to Do
   - Do NOT write prose paragraphs with backstories - use concise notes
@@ -58,14 +58,14 @@ system: |
 
   ## Output Format Examples
 
-  BAD entity description:
-  "Detective Eleanor Chase is a seasoned private investigator known for her
-  sharp wit and keen observational skills. She has a penchant for classical
-  music and is always impeccably dressed."
+  BAD entity description (too verbose, includes backstory):
+  "<CHARACTER_NAME> is a <ROLE> known for their <TRAIT>. They have a penchant
+  for <HOBBY> and are always <DESCRIPTIVE_QUALITY>. They grew up in <PLACE>
+  and have been through many hardships..."
 
-  GOOD entity description:
-  "Concept: Seasoned detective with sharp wit. Notes: Classical music lover,
-  impeccable dresser - surface polish hiding relentless curiosity."
+  GOOD entity description (concise, evocative):
+  "Concept: <ROLE> with <KEY_TRAIT>. Notes: <HOBBY> enthusiast,
+  <QUALITY> - surface detail hiding deeper complexity."
   {mode_section}
 
 non_interactive_section: |

--- a/prompts/templates/discuss_seed.yaml
+++ b/prompts/templates/discuss_seed.yaml
@@ -85,18 +85,18 @@ system: |
   - Thread ID = short storyline name, Tension ID = the binary question
 
   FORMAT:
-  - Tension: `[subject]_[optionA]_or_[optionB]` (the question)
-  - Thread: `[subject]_[aspect]` (the storyline exploring it)
+  - Tension: `[subject]_[optionA]_or_[optionB]` (the binary question)
+  - Thread: `[subject]_[aspect]` (short storyline name)
 
-  Example patterns:
-  - Tension about a mentor's nature → Thread: `mentor_loyalty`
-  - Tension about an artifact's origin → Thread: `artifact_truth`
-  - Tension about a faction's goals → Thread: `faction_agenda`
+  Pattern (derive from YOUR story's elements):
+  - Tension about a character's nature -> Thread: `<character>_<aspect>`
+  - Tension about an object's origin -> Thread: `<object>_<aspect>`
+  - Tension about a faction's goals -> Thread: `<faction>_<aspect>`
 
   BAD: Using the same ID for thread and tension (will fail validation)
   GOOD: Thread ID summarizes the storyline, tension ID shows the binary choice
 
-  **Generate IDs based on YOUR story's characters** - do not copy example IDs.
+  **Generate IDs based on YOUR story's characters** - do not copy example patterns.
 
   ## What NOT to Do
 

--- a/prompts/templates/serialize_brainstorm.yaml
+++ b/prompts/templates/serialize_brainstorm.yaml
@@ -16,7 +16,7 @@ system: |
   | Factions       | "faction"        |
 
   Each entity needs:
-  - `entity_id`: Short snake_case identifier (e.g., "lady_beatrice", "vane_manor")
+  - `entity_id`: Short snake_case identifier derived from the entity name
   - `entity_category`: One of "character", "location", "object", "faction"
   - `concept`: One-line essence from the brief
   - `notes`: Optional additional context from the brief
@@ -39,10 +39,10 @@ system: |
 
   FORMAT: `[subject]_[optionA]_or_[optionB]`
 
-  Good patterns (generate YOUR OWN based on your story):
-  - `[character]_[trait1]_or_[trait2]` for character dilemmas
-  - `[object]_[state1]_or_[state2]` for artifact mysteries
-  - `[faction]_[stance1]_or_[stance2]` for group conflicts
+  Format pattern (generate YOUR OWN based on your story):
+  - `<character_name>_<trait_a>_or_<trait_b>` for character dilemmas
+  - `<object_name>_<state_a>_or_<state_b>` for object mysteries
+  - `<faction_name>_<stance_a>_or_<stance_b>` for group conflicts
 
   BAD examples (will cause downstream failures):
   - `t1`, `t2`, `tension_a` (too short, not descriptive)

--- a/prompts/templates/serialize_seed_sections.yaml
+++ b/prompts/templates/serialize_seed_sections.yaml
@@ -108,10 +108,10 @@ threads_prompt: |
   - Tension: `[subject]_[optionA]_or_[optionB]` (the binary question)
   - Thread: `[subject]_[aspect]` (short storyline name)
 
-  Pattern examples (generate YOUR OWN based on your story):
-  - Tension about character loyalty → Thread: `[character]_loyalty`
-  - Tension about artifact's nature → Thread: `[artifact]_secret`
-  - Tension about faction's agenda → Thread: `[faction]_agenda`
+  Pattern (generate YOUR OWN based on your story):
+  - Tension about a character -> Thread: `<character_name>_<aspect>`
+  - Tension about an object -> Thread: `<object_name>_<aspect>`
+  - Tension about a faction -> Thread: `<faction_name>_<aspect>`
 
   BAD patterns (will cause validation failures):
   - Using the SAME ID for both tension and thread


### PR DESCRIPTION
## Summary
- Follow-up to PR #223 which replaced butler/host examples with multi-genre examples
- Replaces genre-specific examples (detective, mentor, artifact) with pure meta placeholders
- Addresses issue #230 for BRAINSTORM/SEED stages

## Test plan
- [x] All prompt YAML files parse correctly (pre-commit hooks)
- [ ] Manual verification: run different genre projects and verify no shared patterns

## DREAM Stage Findings

Investigation revealed that DREAM stage templates are already clean - the model generates mystery/memory themes independently in response to "Surprise me" prompts. This is model preference, not template contamination. See issue #230 comment for details.

🤖 Generated with [Claude Code](https://claude.com/claude-code)