### PR TITLE
fix(prompts): add scope boundaries to DREAM templates

### DIFF
--- a/prompts/templates/discuss.yaml
+++ b/prompts/templates/discuss.yaml
@@ -31,7 +31,7 @@ system: |
   - Scope constraints (word count, branching complexity)
   - Style guidance (prose style, POV, pacing notes)
 
-  **What NOT to include in DREAM (save for BRAINSTORM/SEED):**
+  **What NOT to include in DREAM (these details belong in BRAINSTORM/SEED):**
   1. Character names or arcs ("Julia the baker lost her sister")
   2. Scene names or plot beats ("The Lighthouse Night")
   3. Mechanics or variables ("memory bank decreases with edits")

--- a/prompts/templates/discuss.yaml
+++ b/prompts/templates/discuss.yaml
@@ -2,10 +2,11 @@ name: discuss
 description: Creative exploration phase for interactive fiction development
 
 system: |
-  You are a creative collaborator helping to develop an interactive fiction concept.
+  You are a creative collaborator establishing HIGH-LEVEL VISION for interactive fiction.
+  Your goal is genre, tone, and themes - NOT characters, plot, or mechanics.
 
   ## Your Goal
-  Help the user explore and refine their story idea for interactive fiction. Discuss:
+  Help the user explore and refine their story's creative direction:
   - Genre and tone
   - Themes and motifs
   - Target audience
@@ -31,11 +32,11 @@ system: |
   - Style guidance (prose style, POV, pacing notes)
 
   **What NOT to include in DREAM (save for BRAINSTORM/SEED):**
-  - Specific character names or detailed character arcs
-  - Specific scene names or plot beats
-  - Detailed mechanics or variable systems
-  - Specific endings or outcome lists
-  - Full story treatments or synopses
+  1. Character names or arcs ("Julia the baker lost her sister")
+  2. Scene names or plot beats ("The Lighthouse Night")
+  3. Mechanics or variables ("memory bank decreases with edits")
+  4. Specific endings ("four endings: Accepting, Withdrawing...")
+  5. Full story treatments or synopses
 
   If you find yourself naming characters, describing specific scenes, or designing
   mechanics, STOP. You're going too deep. DREAM is about the *kind* of story,
@@ -48,6 +49,10 @@ system: |
   **Example of going too far (belongs in BRAINSTORM):**
   "Julia the baker lost her sister. Elias the lighthouse keeper has a secret.
   The player can Deliver, Delay, or Edit letters using a memory resource system."
+
+  Remember: DREAM = vision only. A sparse, evocative vision (50-100 words) is better
+  than a comprehensive treatment. If you're naming characters or designing mechanics,
+  you've gone too far.
   {mode_section}
 
 non_interactive_section: |

--- a/prompts/templates/discuss.yaml
+++ b/prompts/templates/discuss.yaml
@@ -18,6 +18,36 @@ system: |
   - Be conversational and supportive
   - Focus on creative exploration, not implementation details
   {research_tools_section}
+
+  ## DREAM Stage Scope (CRITICAL)
+  DREAM establishes HIGH-LEVEL VISION only. You are NOT writing the story yet.
+
+  **What DREAM captures:**
+  - Genre/subgenre (e.g., "dark fantasy mystery")
+  - Tone descriptors (e.g., "melancholic, intimate, fogbound")
+  - Themes to explore (e.g., "memory vs consent", "grief and letting go")
+  - Target audience (e.g., "fans of literary IF")
+  - Scope constraints (word count, branching complexity)
+  - Style guidance (prose style, POV, pacing notes)
+
+  **What NOT to include in DREAM (save for BRAINSTORM/SEED):**
+  - Specific character names or detailed character arcs
+  - Specific scene names or plot beats
+  - Detailed mechanics or variable systems
+  - Specific endings or outcome lists
+  - Full story treatments or synopses
+
+  If you find yourself naming characters, describing specific scenes, or designing
+  mechanics, STOP. You're going too deep. DREAM is about the *kind* of story,
+  not the story itself.
+
+  **Example of appropriate DREAM output:**
+  "A melancholic small-town mystery where letters can travel through time.
+  Themes: memory, consent, the ethics of intervention. Tone: fogbound, intimate."
+
+  **Example of going too far (belongs in BRAINSTORM):**
+  "Julia the baker lost her sister. Elias the lighthouse keeper has a secret.
+  The player can Deliver, Delay, or Edit letters using a memory resource system."
   {mode_section}
 
 non_interactive_section: |

--- a/prompts/templates/serialize.yaml
+++ b/prompts/templates/serialize.yaml
@@ -20,4 +20,15 @@ system: |
   - Output ONLY the structured JSON
   - Follow the schema exactly
 
+  ## Scope Boundary (for DREAM artifacts)
+  DREAM artifacts capture HIGH-LEVEL VISION only. Even if the brief contains
+  detailed content, include ONLY:
+  - genre, subgenre, tone, audience, themes (high-level descriptors)
+  - style_notes (prose guidance, 50-200 chars, NOT plot summaries)
+  - scope (word count, passages, branching complexity)
+  - content_notes (warnings/guidance, NOT specific scenes or character arcs)
+
+  Do NOT serialize specific characters, scenes, endings, or mechanics into
+  DREAM fields. Those belong in BRAINSTORM/SEED stages.
+
 components: []

--- a/prompts/templates/summarize.yaml
+++ b/prompts/templates/summarize.yaml
@@ -22,6 +22,25 @@ system: |
   - Use bullet points or structured format for clarity
   - If something wasn't discussed, note it as "not specified" rather than inventing
 
+  ## Scope Boundary (CRITICAL)
+  DREAM captures HIGH-LEVEL VISION only. If the discussion went into detail that
+  belongs in later stages, DO NOT include it in the summary.
+
+  **Exclude from DREAM summary (save for BRAINSTORM):**
+  - Specific character names and arcs (e.g., "Julia the baker lost her sister")
+  - Specific scene names or plot beats (e.g., "The Lighthouse Night scene")
+  - Detailed mechanics or variable systems (e.g., "memory bank decreases with edits")
+  - Specific endings (e.g., "four endings: Accepting, Withdrawing, Architect, Erasure")
+
+  **Keep only:**
+  - Genre, tone, themes (high-level)
+  - Audience and scope constraints
+  - Style guidance
+  - Content warnings/notes (general, not specific scenes)
+
+  If the discussion produced a full story treatment, distill it back to vision-level
+  concepts. The detailed content will be rediscovered in BRAINSTORM.
+
   ## Output Format
   Provide a structured summary covering all the categories above.
   Be specific and actionable - the next stage will serialize this into a formal artifact.

--- a/prompts/templates/summarize.yaml
+++ b/prompts/templates/summarize.yaml
@@ -26,7 +26,7 @@ system: |
   DREAM captures HIGH-LEVEL VISION only. If the discussion went into detail that
   belongs in later stages, DO NOT include it in the summary.
 
-  **Exclude from DREAM summary (save for BRAINSTORM):**
+  **Exclude from DREAM summary (these details belong in BRAINSTORM):**
   - Specific character names and arcs (e.g., "Julia the baker lost her sister")
   - Specific scene names or plot beats (e.g., "The Lighthouse Night scene")
   - Detailed mechanics or variable systems (e.g., "memory bank decreases with edits")


### PR DESCRIPTION
## Problem

Chat-optimized models (GPT-4o-mini) generate full story treatments during DREAM discuss phase, including specific characters, scenes, mechanics, and endings. This content belongs in BRAINSTORM/SEED, not DREAM.

**Example from `projects/seq-1-openai`:**
- Model generated 9512 chars during DREAM discuss
- Included full character arcs: "Julia the baker lost her sister", "Elias the lighthouse keeper has a secret"
- Detailed mechanics: "memory bank decreases with edits", "Deliver/Delay/Edit letters"
- Specific endings: "Accepting, Withdrawing, Architect, Erasure"
- All crammed into `content_notes.includes` as prose strings

This is BRAINSTORM/SEED-level content appearing in DREAM.

## Changes

**prompts/templates/discuss.yaml (+30 lines):**
- Add "DREAM Stage Scope (CRITICAL)" section
- List what DREAM should capture (genre, tone, themes, audience, scope)
- List what NOT to include (character names, scene names, mechanics, endings)
- Add good/bad examples showing the boundary
- Explicit guidance: "If you find yourself naming characters... STOP"

**prompts/templates/summarize.yaml (+19 lines):**
- Add "Scope Boundary (CRITICAL)" section
- List what to exclude from DREAM summary
- Guidance to distill full story treatments back to vision-level concepts

## Not Included / Future PRs

- Similar boundaries for BRAINSTORM/SEED (may need their own guardrails)
- Validation to reject DREAM artifacts with too much detail

## Test Plan

- [x] All prompt tests pass
- [x] YAML files parse correctly (pre-commit hooks)
- [ ] Manual test: Run GPT-4o-mini with "Surprise me" and verify output stays high-level

## Risk / Rollback

- Low risk: Prompt guidance only
- Easy rollback: Revert single commit

## Related

- Issue #169: Add "what NOT to do" guidance for chat-optimized models
- `projects/seq-1-openai`: Example of the problem

🤖 Generated with [Claude Code](https://claude.com/claude-code)