### PR TITLE
fix(validation): normalize seed_thread_ids for scoped ID comparison

### DIFF
--- a/src/questfoundry/graph/mutations.py
+++ b/src/questfoundry/graph/mutations.py
@@ -686,9 +686,13 @@ def validate_seed_mutations(graph: Graph, output: dict[str, Any]) -> list[SeedVa
             alt_by_tension.setdefault(raw_tension_id, set()).add(alt_node["raw_id"])
 
     # Extract thread IDs from SEED output (for internal references)
-    seed_thread_ids: set[str] = {
-        t["thread_id"] for t in output.get("threads", []) if t.get("thread_id")
-    }
+    # Normalize IDs to handle both scoped (thread::foo) and bare (foo) formats
+    seed_thread_ids: set[str] = set()
+    for t in output.get("threads", []):
+        raw_id = t.get("thread_id")
+        if raw_id:
+            normalized_id, _ = _normalize_id(raw_id, "thread")
+            seed_thread_ids.add(normalized_id)
 
     # Pre-sort available IDs once (used in error messages)
     sorted_entity_ids = sorted(valid_entity_ids)

--- a/src/questfoundry/graph/mutations.py
+++ b/src/questfoundry/graph/mutations.py
@@ -687,12 +687,11 @@ def validate_seed_mutations(graph: Graph, output: dict[str, Any]) -> list[SeedVa
 
     # Extract thread IDs from SEED output (for internal references)
     # Normalize IDs to handle both scoped (thread::foo) and bare (foo) formats
-    seed_thread_ids: set[str] = set()
-    for t in output.get("threads", []):
-        raw_id = t.get("thread_id")
-        if raw_id:
-            normalized_id, _ = _normalize_id(raw_id, "thread")
-            seed_thread_ids.add(normalized_id)
+    seed_thread_ids: set[str] = {
+        _normalize_id(t["thread_id"], "thread")[0]
+        for t in output.get("threads", [])
+        if t.get("thread_id")
+    }
 
     # Pre-sort available IDs once (used in error messages)
     sorted_entity_ids = sorted(valid_entity_ids)


### PR DESCRIPTION
## Problem

SEED validation was failing when LLM generates thread definitions with scoped IDs (e.g., `thread::you_restraint`) and consequences reference them with scoped IDs. The validation error was:

```
Thread 'you_restraint' not defined in SEED threads
Use 'thread::you_restraint' instead.
```

This occurred because:
1. `seed_thread_ids` was built directly from thread definitions without normalization
2. When thread definitions use scoped IDs, the set contains `thread::you_restraint`
3. Consequence validation normalizes `thread::you_restraint` to `you_restraint` (bare ID)
4. The check `you_restraint not in {thread::you_restraint}` fails

## Changes

- Normalize thread IDs when building `seed_thread_ids` in `validate_seed_mutations()`
- Added regression test `test_scoped_thread_definitions_and_consequences` for the exact production scenario

## Not Included / Future PRs

- This is a targeted fix for the validation bug only
- The broader prompt contamination issue (issue #230) is addressed in PR #233

## Test Plan

```bash
uv run pytest tests/unit/test_mutations.py -v
# 97 passed including new regression test

uv run pytest tests/ -v
# 892 passed
```

## Risk / Rollback

- Low risk - this is a pure bugfix with targeted change
- The fix ensures both scoped and unscoped IDs work consistently in thread ID comparison

Fixes part of #230

🤖 Generated with [Claude Code](https://claude.com/claude-code)