### PR TITLE
feat(tools): add present_options tool infrastructure

### DIFF
--- a/src/questfoundry/tools/interactive_context.py
+++ b/src/questfoundry/tools/interactive_context.py
@@ -1,0 +1,89 @@
+"""Context variables for interactive tool callbacks.
+
+This module provides async-safe storage for interactive callbacks that tools
+can access during execution. Uses contextvars for proper async isolation.
+
+The callbacks are set before agent invocation and cleared after, allowing
+interactive tools (like present_options) to display UI and collect user input
+without requiring changes to the Tool protocol.
+
+Usage in discuss.py:
+    from questfoundry.tools.interactive_context import set_interactive_callbacks
+
+    async def run_discuss_phase(...):
+        if interactive:
+            set_interactive_callbacks(user_input_fn, on_assistant_message)
+        try:
+            # ... agent invocation ...
+        finally:
+            clear_interactive_callbacks()
+
+Usage in tools:
+    from questfoundry.tools.interactive_context import get_interactive_callbacks
+
+    class PresentOptionsTool:
+        def execute(self, arguments):
+            callbacks = get_interactive_callbacks()
+            if callbacks is None:
+                return '{"result": "skipped", ...}'
+            # Use callbacks to display UI and get input
+"""
+
+from __future__ import annotations
+
+import contextvars
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+
+# Type aliases matching discuss.py
+UserInputFn = Callable[[], Awaitable[str | None]]
+DisplayFn = Callable[[str], None]
+
+
+@dataclass
+class InteractiveCallbacks:
+    """Container for interactive mode callbacks.
+
+    Attributes:
+        user_input_fn: Async function to get user input.
+        display_fn: Function to display formatted content to user.
+    """
+
+    user_input_fn: UserInputFn
+    display_fn: DisplayFn
+
+
+# Context variable for async-safe callback storage
+_interactive_callbacks: contextvars.ContextVar[InteractiveCallbacks | None] = (
+    contextvars.ContextVar("interactive_callbacks", default=None)
+)
+
+
+def set_interactive_callbacks(
+    user_input_fn: UserInputFn,
+    display_fn: DisplayFn,
+) -> None:
+    """Set callbacks for current async context.
+
+    Call this before agent invocation when in interactive mode.
+    The callbacks will be available to any tools that need them.
+
+    Args:
+        user_input_fn: Async function that prompts user and returns input.
+        display_fn: Function to display formatted content (e.g., rich panel).
+    """
+    _interactive_callbacks.set(InteractiveCallbacks(user_input_fn, display_fn))
+
+
+def get_interactive_callbacks() -> InteractiveCallbacks | None:
+    """Get callbacks for current async context.
+
+    Returns:
+        InteractiveCallbacks if in interactive mode, None otherwise.
+    """
+    return _interactive_callbacks.get()
+
+
+def clear_interactive_callbacks() -> None:
+    """Clear callbacks after agent invocation completes."""
+    _interactive_callbacks.set(None)

--- a/src/questfoundry/tools/present_options.py
+++ b/src/questfoundry/tools/present_options.py
@@ -1,0 +1,287 @@
+"""Present structured options to user during interactive conversation.
+
+This tool allows the LLM to present structured choices during the discuss
+phase, providing a better UX than freeform questions for decisions like
+genre, tone, or scope selection.
+
+The tool:
+1. Displays formatted options to the user
+2. Collects their selection (number or freeform text)
+3. Returns the selection to the LLM as structured JSON
+
+Requires interactive mode with callbacks set via interactive_context.
+In non-interactive mode, returns "skipped" to let LLM proceed autonomously.
+
+Example tool call:
+    {
+        "question": "What genre fits your haunted mansion idea?",
+        "options": [
+            {"label": "Mystery", "description": "Focus on clues and deduction", "recommended": true},
+            {"label": "Horror", "description": "Focus on fear and dread"},
+            {"label": "Gothic Romance", "description": "Atmosphere and emotion"}
+        ]
+    }
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from typing import Any, TypedDict
+
+from questfoundry.observability.logging import get_logger
+from questfoundry.tools.base import Tool, ToolDefinition
+from questfoundry.tools.interactive_context import get_interactive_callbacks
+
+log = get_logger(__name__)
+
+
+class Option(TypedDict, total=False):
+    """A single option in the choices list."""
+
+    label: str  # Required: display text (1-5 words)
+    description: str  # Optional: explains implications
+    recommended: bool  # Optional: mark as recommended choice
+
+
+class PresentOptionsInput(TypedDict):
+    """Input schema for present_options tool."""
+
+    question: str  # The question to ask
+    options: list[Option]  # 2-4 options to present
+
+
+# JSON Schema for LLM tool binding
+PRESENT_OPTIONS_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "required": ["question", "options"],
+    "properties": {
+        "question": {
+            "type": "string",
+            "description": "The question to ask the user. Should be clear and specific.",
+        },
+        "options": {
+            "type": "array",
+            "minItems": 2,
+            "maxItems": 4,
+            "description": "2-4 options for the user to choose from.",
+            "items": {
+                "type": "object",
+                "required": ["label"],
+                "properties": {
+                    "label": {
+                        "type": "string",
+                        "description": "Short option name (1-5 words).",
+                    },
+                    "description": {
+                        "type": "string",
+                        "description": "Brief explanation of this choice.",
+                    },
+                    "recommended": {
+                        "type": "boolean",
+                        "description": "True if this is your recommended option.",
+                    },
+                },
+            },
+        },
+    },
+}
+
+
+class PresentOptionsTool:
+    """Tool for presenting structured choices to users.
+
+    This tool bridges the LLM's desire to present options with the
+    interactive CLI's ability to collect user input. It uses the
+    callback bridge in interactive_context to access display and
+    input functions.
+    """
+
+    @property
+    def definition(self) -> ToolDefinition:
+        """Return the tool definition for LLM binding."""
+        return ToolDefinition(
+            name="present_options",
+            description=(
+                "Present structured choices to the user. Use when offering "
+                "clear alternatives for genre, tone, scope, or similar decisions. "
+                "User can select by number or type a custom response."
+            ),
+            parameters=PRESENT_OPTIONS_SCHEMA,
+        )
+
+    def execute(self, arguments: dict[str, Any]) -> str:
+        """Execute the tool synchronously.
+
+        In non-interactive mode, returns immediately with guidance.
+        In interactive mode, runs the async logic via the event loop.
+
+        Args:
+            arguments: Tool arguments with question and options.
+
+        Returns:
+            JSON string following ADR-008 format.
+        """
+        callbacks = get_interactive_callbacks()
+
+        if callbacks is None:
+            log.debug("present_options_skipped", reason="not_interactive")
+            return json.dumps(
+                {
+                    "result": "skipped",
+                    "reason": "Not in interactive mode",
+                    "action": "Proceed with your best judgment on this decision.",
+                }
+            )
+
+        # Run async logic - we need to get into the running event loop
+        try:
+            loop = asyncio.get_running_loop()
+            # We're inside an async context - use run_coroutine_threadsafe
+            # to run our coroutine from within sync code
+            future = asyncio.run_coroutine_threadsafe(
+                self._execute_async(arguments, callbacks),
+                loop,
+            )
+            return future.result(timeout=300)  # 5 minute timeout for user input
+        except RuntimeError:
+            # No running loop - shouldn't happen in normal use
+            log.warning("present_options_no_loop")
+            return json.dumps(
+                {
+                    "result": "error",
+                    "error": "No event loop available",
+                    "action": "Proceed with your best judgment on this decision.",
+                }
+            )
+
+    async def _execute_async(
+        self,
+        arguments: dict[str, Any],
+        callbacks: Any,  # InteractiveCallbacks but avoid circular import
+    ) -> str:
+        """Async implementation that uses interactive callbacks.
+
+        Args:
+            arguments: Tool arguments with question and options.
+            callbacks: InteractiveCallbacks with user_input_fn and display_fn.
+
+        Returns:
+            JSON string with user's selection.
+        """
+        question = arguments.get("question", "Please choose an option:")
+        options: list[dict[str, Any]] = arguments.get("options", [])
+
+        if not options or len(options) < 2:
+            return json.dumps(
+                {
+                    "result": "error",
+                    "error": "At least 2 options required",
+                    "action": "Ask the question directly without structured options.",
+                }
+            )
+
+        # Format and display the options
+        display_text = self._format_options(question, options)
+        callbacks.display_fn(display_text)
+
+        # Collect user input
+        user_response = await callbacks.user_input_fn()
+
+        # Parse the selection
+        selection = self._parse_selection(user_response, options)
+
+        log.debug(
+            "present_options_complete",
+            question=question[:50],
+            selection=selection[:50] if isinstance(selection, str) else str(selection),
+        )
+
+        return json.dumps(
+            {
+                "result": "success",
+                "question": question,
+                "selected": selection,
+                "action": "User has made their selection. Continue based on their choice.",
+            }
+        )
+
+    def _format_options(self, question: str, options: list[dict[str, Any]]) -> str:
+        """Format question and options for display.
+
+        Args:
+            question: The question to display.
+            options: List of option dicts with label, description, recommended.
+
+        Returns:
+            Formatted markdown string for display.
+        """
+        lines = [f"**{question}**\n"]
+
+        for i, opt in enumerate(options, 1):
+            label = opt.get("label", f"Option {i}")
+            description = opt.get("description", "")
+            recommended = opt.get("recommended", False)
+
+            # Build option line
+            rec_marker = " *(Recommended)*" if recommended else ""
+            lines.append(f"  **[{i}]** {label}{rec_marker}")
+
+            if description:
+                lines.append(f"      {description}")
+
+        lines.append("")
+        lines.append("  **[0]** Something else...")
+        lines.append("")
+        lines.append("*Enter number or type your own response:*")
+
+        return "\n".join(lines)
+
+    def _parse_selection(
+        self,
+        response: str | None,
+        options: list[dict[str, Any]],
+    ) -> str:
+        """Parse user response into a selection.
+
+        Args:
+            response: User's raw input (number, label, or freeform text).
+            options: Original options list for lookup.
+
+        Returns:
+            The selected option label or the user's freeform response.
+        """
+        if not response or not response.strip():
+            # Default to recommended option, or first option
+            for opt in options:
+                if opt.get("recommended"):
+                    label: str = opt.get("label", "")
+                    return label
+            first_label: str = options[0].get("label", "") if options else ""
+            return first_label
+
+        response = response.strip()
+
+        # Handle numeric selection
+        if response.isdigit():
+            idx = int(response)
+            if idx == 0:
+                # User wants to type something else - return marker
+                return "[custom]"
+            if 1 <= idx <= len(options):
+                selected_label: str = options[idx - 1].get("label", f"Option {idx}")
+                return selected_label
+
+        # Check if response matches an option label (case-insensitive)
+        response_lower = response.lower()
+        for opt in options:
+            opt_label: str = opt.get("label", "")
+            if opt_label.lower() == response_lower:
+                return opt_label
+
+        # Treat as freeform custom response
+        return response
+
+
+# Implement Tool protocol
+assert isinstance(PresentOptionsTool(), Tool)

--- a/tests/unit/test_present_options.py
+++ b/tests/unit/test_present_options.py
@@ -1,0 +1,367 @@
+"""Tests for present_options tool and interactive context."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from questfoundry.tools.interactive_context import (
+    InteractiveCallbacks,
+    clear_interactive_callbacks,
+    get_interactive_callbacks,
+    set_interactive_callbacks,
+)
+from questfoundry.tools.present_options import (
+    PRESENT_OPTIONS_SCHEMA,
+    PresentOptionsTool,
+)
+
+# --- Interactive Context Tests ---
+
+
+class TestInteractiveContext:
+    """Tests for interactive callback context management."""
+
+    def setup_method(self) -> None:
+        """Clear context before each test."""
+        clear_interactive_callbacks()
+
+    def teardown_method(self) -> None:
+        """Clear context after each test."""
+        clear_interactive_callbacks()
+
+    def test_get_returns_none_when_not_set(self) -> None:
+        """get_interactive_callbacks returns None when not set."""
+        assert get_interactive_callbacks() is None
+
+    def test_set_and_get_callbacks(self) -> None:
+        """Callbacks can be set and retrieved."""
+        mock_input = AsyncMock(return_value="test")
+        mock_display = MagicMock()
+
+        set_interactive_callbacks(mock_input, mock_display)
+
+        callbacks = get_interactive_callbacks()
+        assert callbacks is not None
+        assert callbacks.user_input_fn is mock_input
+        assert callbacks.display_fn is mock_display
+
+    def test_clear_removes_callbacks(self) -> None:
+        """clear_interactive_callbacks removes stored callbacks."""
+        mock_input = AsyncMock(return_value="test")
+        mock_display = MagicMock()
+
+        set_interactive_callbacks(mock_input, mock_display)
+        assert get_interactive_callbacks() is not None
+
+        clear_interactive_callbacks()
+        assert get_interactive_callbacks() is None
+
+    def test_callbacks_dataclass(self) -> None:
+        """InteractiveCallbacks is a proper dataclass."""
+        mock_input = AsyncMock()
+        mock_display = MagicMock()
+
+        callbacks = InteractiveCallbacks(
+            user_input_fn=mock_input,
+            display_fn=mock_display,
+        )
+
+        assert callbacks.user_input_fn is mock_input
+        assert callbacks.display_fn is mock_display
+
+
+# --- PresentOptionsTool Tests ---
+
+
+class TestPresentOptionsToolDefinition:
+    """Tests for tool definition and schema."""
+
+    def test_definition_has_required_fields(self) -> None:
+        """Tool definition has name, description, parameters."""
+        tool = PresentOptionsTool()
+        definition = tool.definition
+
+        assert definition.name == "present_options"
+        assert "structured choices" in definition.description.lower()
+        assert definition.parameters is not None
+
+    def test_schema_structure(self) -> None:
+        """Schema has correct structure."""
+        assert PRESENT_OPTIONS_SCHEMA["type"] == "object"
+        assert "question" in PRESENT_OPTIONS_SCHEMA["required"]
+        assert "options" in PRESENT_OPTIONS_SCHEMA["required"]
+
+        props = PRESENT_OPTIONS_SCHEMA["properties"]
+        assert "question" in props
+        assert "options" in props
+
+        options_schema = props["options"]
+        assert options_schema["type"] == "array"
+        assert options_schema["minItems"] == 2
+        assert options_schema["maxItems"] == 4
+
+    def test_option_schema(self) -> None:
+        """Option items have correct schema."""
+        option_schema = PRESENT_OPTIONS_SCHEMA["properties"]["options"]["items"]
+
+        assert option_schema["type"] == "object"
+        assert "label" in option_schema["required"]
+
+        opt_props = option_schema["properties"]
+        assert "label" in opt_props
+        assert "description" in opt_props
+        assert "recommended" in opt_props
+
+
+class TestPresentOptionsToolNonInteractive:
+    """Tests for non-interactive mode behavior."""
+
+    def setup_method(self) -> None:
+        """Clear context before each test."""
+        clear_interactive_callbacks()
+
+    def test_returns_skipped_when_not_interactive(self) -> None:
+        """Tool returns skipped result when callbacks not available."""
+        tool = PresentOptionsTool()
+        result = tool.execute(
+            {
+                "question": "What genre?",
+                "options": [
+                    {"label": "Mystery"},
+                    {"label": "Horror"},
+                ],
+            }
+        )
+
+        parsed = json.loads(result)
+        assert parsed["result"] == "skipped"
+        assert "not in interactive" in parsed["reason"].lower()
+        assert "action" in parsed
+
+
+class TestPresentOptionsToolFormatting:
+    """Tests for option formatting logic."""
+
+    def test_format_options_basic(self) -> None:
+        """Basic option formatting works."""
+        tool = PresentOptionsTool()
+        options = [
+            {"label": "Mystery", "description": "Focus on clues"},
+            {"label": "Horror", "description": "Focus on fear"},
+        ]
+
+        formatted = tool._format_options("What genre?", options)
+
+        assert "What genre?" in formatted
+        assert "[1]" in formatted
+        assert "Mystery" in formatted
+        assert "[2]" in formatted
+        assert "Horror" in formatted
+        assert "[0]" in formatted  # Something else option
+        assert "Focus on clues" in formatted
+
+    def test_format_options_with_recommended(self) -> None:
+        """Recommended option is marked."""
+        tool = PresentOptionsTool()
+        options = [
+            {"label": "Mystery", "recommended": True},
+            {"label": "Horror"},
+        ]
+
+        formatted = tool._format_options("What genre?", options)
+
+        assert "Recommended" in formatted
+
+    def test_format_options_without_descriptions(self) -> None:
+        """Options without descriptions still format correctly."""
+        tool = PresentOptionsTool()
+        options = [
+            {"label": "Mystery"},
+            {"label": "Horror"},
+        ]
+
+        formatted = tool._format_options("What genre?", options)
+
+        assert "Mystery" in formatted
+        assert "Horror" in formatted
+
+
+class TestPresentOptionsToolParsing:
+    """Tests for user response parsing."""
+
+    def test_parse_numeric_selection(self) -> None:
+        """Numeric input selects corresponding option."""
+        tool = PresentOptionsTool()
+        options = [
+            {"label": "Mystery"},
+            {"label": "Horror"},
+            {"label": "Romance"},
+        ]
+
+        assert tool._parse_selection("1", options) == "Mystery"
+        assert tool._parse_selection("2", options) == "Horror"
+        assert tool._parse_selection("3", options) == "Romance"
+
+    def test_parse_zero_returns_custom_marker(self) -> None:
+        """Zero input returns custom marker."""
+        tool = PresentOptionsTool()
+        options = [{"label": "Mystery"}, {"label": "Horror"}]
+
+        assert tool._parse_selection("0", options) == "[custom]"
+
+    def test_parse_out_of_range_treated_as_freeform(self) -> None:
+        """Out-of-range numbers treated as freeform text."""
+        tool = PresentOptionsTool()
+        options = [{"label": "Mystery"}, {"label": "Horror"}]
+
+        # "5" is out of range, treated as freeform
+        assert tool._parse_selection("5", options) == "5"
+
+    def test_parse_label_match_case_insensitive(self) -> None:
+        """Label matching is case-insensitive."""
+        tool = PresentOptionsTool()
+        options = [{"label": "Mystery"}, {"label": "Horror"}]
+
+        assert tool._parse_selection("mystery", options) == "Mystery"
+        assert tool._parse_selection("HORROR", options) == "Horror"
+        assert tool._parse_selection("Mystery", options) == "Mystery"
+
+    def test_parse_freeform_text(self) -> None:
+        """Non-matching text returned as-is."""
+        tool = PresentOptionsTool()
+        options = [{"label": "Mystery"}, {"label": "Horror"}]
+
+        result = tool._parse_selection("Something dark but accessible", options)
+        assert result == "Something dark but accessible"
+
+    def test_parse_empty_defaults_to_recommended(self) -> None:
+        """Empty input defaults to recommended option."""
+        tool = PresentOptionsTool()
+        options = [
+            {"label": "Mystery"},
+            {"label": "Horror", "recommended": True},
+        ]
+
+        assert tool._parse_selection("", options) == "Horror"
+        assert tool._parse_selection(None, options) == "Horror"
+
+    def test_parse_empty_defaults_to_first_when_no_recommended(self) -> None:
+        """Empty input defaults to first option when none recommended."""
+        tool = PresentOptionsTool()
+        options = [{"label": "Mystery"}, {"label": "Horror"}]
+
+        assert tool._parse_selection("", options) == "Mystery"
+
+    def test_parse_whitespace_only_treated_as_empty(self) -> None:
+        """Whitespace-only input treated as empty."""
+        tool = PresentOptionsTool()
+        options = [{"label": "Mystery", "recommended": True}, {"label": "Horror"}]
+
+        assert tool._parse_selection("   ", options) == "Mystery"
+
+
+class TestPresentOptionsToolAsync:
+    """Tests for async execution with mocked callbacks."""
+
+    @pytest.fixture
+    def mock_callbacks(self) -> InteractiveCallbacks:
+        """Create mock callbacks for testing."""
+        return InteractiveCallbacks(
+            user_input_fn=AsyncMock(return_value="1"),
+            display_fn=MagicMock(),
+        )
+
+    @pytest.mark.asyncio
+    async def test_execute_async_success(self, mock_callbacks: InteractiveCallbacks) -> None:
+        """Async execution returns success with selection."""
+        tool = PresentOptionsTool()
+        arguments: dict[str, Any] = {
+            "question": "What genre?",
+            "options": [
+                {"label": "Mystery", "description": "Focus on clues"},
+                {"label": "Horror", "description": "Focus on fear"},
+            ],
+        }
+
+        result = await tool._execute_async(arguments, mock_callbacks)
+        parsed = json.loads(result)
+
+        assert parsed["result"] == "success"
+        assert parsed["question"] == "What genre?"
+        assert parsed["selected"] == "Mystery"
+        assert "action" in parsed
+
+        # Verify display was called
+        mock_callbacks.display_fn.assert_called_once()
+        display_call = mock_callbacks.display_fn.call_args[0][0]
+        assert "What genre?" in display_call
+
+    @pytest.mark.asyncio
+    async def test_execute_async_with_freeform_response(
+        self, mock_callbacks: InteractiveCallbacks
+    ) -> None:
+        """Async execution handles freeform user response."""
+        mock_callbacks.user_input_fn = AsyncMock(return_value="Something dark and moody")
+
+        tool = PresentOptionsTool()
+        arguments: dict[str, Any] = {
+            "question": "What tone?",
+            "options": [
+                {"label": "Light"},
+                {"label": "Dark"},
+            ],
+        }
+
+        result = await tool._execute_async(arguments, mock_callbacks)
+        parsed = json.loads(result)
+
+        assert parsed["result"] == "success"
+        assert parsed["selected"] == "Something dark and moody"
+
+    @pytest.mark.asyncio
+    async def test_execute_async_insufficient_options(
+        self, mock_callbacks: InteractiveCallbacks
+    ) -> None:
+        """Async execution returns error with insufficient options."""
+        tool = PresentOptionsTool()
+        arguments: dict[str, Any] = {
+            "question": "What genre?",
+            "options": [{"label": "Only one"}],  # Need at least 2
+        }
+
+        result = await tool._execute_async(arguments, mock_callbacks)
+        parsed = json.loads(result)
+
+        assert parsed["result"] == "error"
+        assert "2 options" in parsed["error"].lower()
+
+
+class TestPresentOptionsToolProtocol:
+    """Tests for Tool protocol compliance."""
+
+    def test_implements_tool_protocol(self) -> None:
+        """PresentOptionsTool implements Tool protocol."""
+        from questfoundry.tools.base import Tool
+
+        tool = PresentOptionsTool()
+        assert isinstance(tool, Tool)
+
+    def test_execute_returns_string(self) -> None:
+        """execute() returns a string."""
+        clear_interactive_callbacks()
+        tool = PresentOptionsTool()
+
+        result = tool.execute(
+            {
+                "question": "Test?",
+                "options": [{"label": "A"}, {"label": "B"}],
+            }
+        )
+
+        assert isinstance(result, str)
+        # Should be valid JSON
+        json.loads(result)


### PR DESCRIPTION
## Problem

In interactive DREAM mode, the LLM produces "walls of text" asking multiple questions at once (genre, tone, audience, themes, scope). This overwhelms users and makes it hard to focus on one decision at a time.

## Solution

Add a `present_options` tool that allows the LLM to present structured choices during the discuss phase. This PR provides the infrastructure:

1. **interactive_context.py** - Context variables for async-safe callback storage
2. **present_options.py** - Tool implementation with:
   - Simple schema: question + 2-4 options (label, description, recommended)
   - Formatted display via callbacks
   - Numeric selection, label matching, or freeform response
   - "skipped" result in non-interactive mode
3. **Unit tests** - 24 tests covering all functionality

## Schema

```json
{
  "question": "What genre fits your haunted mansion idea?",
  "options": [
    {"label": "Mystery", "description": "Focus on clues", "recommended": true},
    {"label": "Horror", "description": "Focus on fear"},
    {"label": "Gothic Romance", "description": "Atmosphere and emotion"}
  ]
}
```

## Not Included / Future PRs

- Tool registration in langchain_tools.py
- Wiring callbacks in discuss.py  
- Prompt template updates
- Integration tests

These will be in PR #2 (integration).

## Test Plan

- [x] 24 unit tests pass
- [x] All 898 existing tests pass
- [x] mypy passes
- [x] ruff passes

## Risk / Rollback

Low risk - this PR adds new files without modifying existing functionality. The tool is not yet wired up, so it has no runtime effect until PR #2.

Closes #52 (with PR #2)

---

🤖 Generated with [Claude Code](https://claude.ai/code)