### PR TITLE
fix(enrichment): strip entity/tension prefixes for graph lookup

### DIFF
--- a/src/questfoundry/artifacts/enrichment.py
+++ b/src/questfoundry/artifacts/enrichment.py
@@ -70,7 +70,9 @@ def _enrich_entities(graph: Graph, entity_decisions: list[dict[str, Any]]) -> li
     enriched_entities = []
     for decision in entity_decisions:
         entity_id = decision.get("entity_id", "")
-        node = entity_data.get(entity_id, {}) if entity_id else {}
+        # Strip prefix if present (e.g., "entity::the_detective" -> "the_detective")
+        lookup_id = entity_id.split("::")[-1]
+        node = entity_data.get(lookup_id, {}) if lookup_id else {}
 
         # Build enriched entity in consistent field order
         enriched: dict[str, Any] = {
@@ -114,7 +116,9 @@ def _enrich_tensions(graph: Graph, tension_decisions: list[dict[str, Any]]) -> l
     enriched_tensions = []
     for decision in tension_decisions:
         tension_id = decision.get("tension_id", "")
-        node = tension_data.get(tension_id, {}) if tension_id else {}
+        # Strip prefix if present (e.g., "tension::host_motivation" -> "host_motivation")
+        lookup_id = tension_id.split("::")[-1]
+        node = tension_data.get(lookup_id, {}) if lookup_id else {}
 
         # Build enriched tension in consistent field order
         enriched: dict[str, Any] = {
@@ -128,9 +132,7 @@ def _enrich_tensions(graph: Graph, tension_decisions: list[dict[str, Any]]) -> l
 
         # Handle central_entity_ids with prefix stripping for readability
         if value := node.get("central_entity_ids"):
-            enriched["central_entity_ids"] = [
-                eid.split("::")[-1] if "::" in eid else eid for eid in value
-            ]
+            enriched["central_entity_ids"] = [eid.split("::")[-1] for eid in value]
 
         # Add SEED decision fields
         enriched["explored"] = decision.get("explored", [])

--- a/tests/unit/test_enrichment.py
+++ b/tests/unit/test_enrichment.py
@@ -129,6 +129,24 @@ class TestEnrichSeedArtifact:
         assert "concept" not in entity
         assert entity["disposition"] == "retained"
 
+    def test_handles_prefixed_entity_ids(self, graph_with_entities: Graph) -> None:
+        """Enrichment strips prefix from entity_id for graph lookup."""
+        artifact = {
+            "entities": [
+                {"entity_id": "entity::the_detective", "disposition": "retained"},
+            ],
+        }
+
+        result = enrich_seed_artifact(graph_with_entities, artifact)
+
+        entity = result["entities"][0]
+        # Original prefixed ID preserved in output
+        assert entity["entity_id"] == "entity::the_detective"
+        # But graph lookup succeeds with prefix stripped
+        assert entity["entity_category"] == "character"
+        assert entity["concept"] == "Seasoned detective known for solving intricate cases"
+        assert entity["disposition"] == "retained"
+
     def test_enriches_multiple_entities(self, graph_with_entities: Graph) -> None:
         """Enrichment works for multiple entities."""
         artifact = {
@@ -237,6 +255,28 @@ class TestEnrichTensions:
         assert "question" not in tension
         assert "why_it_matters" not in tension
         assert tension["explored"] == ["option_a"]
+
+    def test_handles_prefixed_tension_ids(self, graph_with_tensions: Graph) -> None:
+        """Enrichment strips prefix from tension_id for graph lookup."""
+        artifact = {
+            "tensions": [
+                {
+                    "tension_id": "tension::host_motivation",
+                    "explored": ["benevolent"],
+                    "implicit": [],
+                },
+            ],
+        }
+
+        result = enrich_seed_artifact(graph_with_tensions, artifact)
+
+        tension = result["tensions"][0]
+        # Original prefixed ID preserved in output
+        assert tension["tension_id"] == "tension::host_motivation"
+        # But graph lookup succeeds with prefix stripped
+        assert tension["question"] == "Is the host benevolent or self-serving?"
+        assert tension["why_it_matters"] == "Determines whether protagonist can trust their guide"
+        assert tension["explored"] == ["benevolent"]
 
     def test_enriches_multiple_tensions(self, graph_with_tensions: Graph) -> None:
         """Enrichment works for multiple tensions."""


### PR DESCRIPTION
## Problem

Artifact enrichment fails to find entities and tensions in the graph because:
- Artifact uses prefixed IDs: `entity::archivist_zero`
- Graph lookup uses raw IDs: `archivist_zero`

This was discovered validating `projects/run-1-int` where logs showed:
```json
{"message": "artifact_enriched", "entity_count": 50, "enriched_count": 0}
```

## Changes

- Strip `entity::` and `tension::` prefixes before graph lookup
- Preserve original prefixed ID in output artifact
- Add tests for prefixed entity and tension IDs

## Not Included / Future PRs

Two additional bugs discovered during validation have separate issues:
- #238: Double-prefixed tension edge targets in mutations
- #239: Duplicate entities in SEED serialization output

## Test Plan

```bash
uv run pytest tests/unit/test_enrichment.py -v
# 14 passed
```

## Risk / Rollback

Low risk - fixes a lookup bug without changing output format.

🤖 Generated with [Claude Code](https://claude.com/claude-code)