### PR TITLE
fix(mutations): make _prefix_id idempotent to prevent double-prefixing

### DIFF
--- a/src/questfoundry/graph/mutations.py
+++ b/src/questfoundry/graph/mutations.py
@@ -562,7 +562,7 @@ def _prefix_id(node_type: str, raw_id: str) -> str:
     # Strip any existing prefixes to get the raw ID
     # This handles: "the_detective", "entity::the_detective", "entity::entity::the_detective"
     if "::" in raw_id:
-        raw_id = raw_id.split("::")[-1]
+        raw_id = raw_id.rsplit("::", 1)[-1]
 
     return f"{node_type}::{raw_id}"
 

--- a/src/questfoundry/graph/mutations.py
+++ b/src/questfoundry/graph/mutations.py
@@ -548,13 +548,22 @@ def _prefix_id(node_type: str, raw_id: str) -> str:
     This allows entities and tensions to have the same raw ID without collision.
     E.g., both can use "cipher_journal" -> "entity::cipher_journal", "tension::cipher_journal"
 
+    This function is idempotent - if the ID already has the correct prefix,
+    it returns it unchanged. If it has a different prefix or multiple prefixes,
+    the raw part is extracted and re-prefixed.
+
     Args:
         node_type: Node type prefix (entity, tension, thread, etc.)
-        raw_id: Raw ID from LLM output.
+        raw_id: Raw ID from LLM output (may already be prefixed).
 
     Returns:
         Prefixed ID in format "type::raw_id".
     """
+    # Strip any existing prefixes to get the raw ID
+    # This handles: "the_detective", "entity::the_detective", "entity::entity::the_detective"
+    if "::" in raw_id:
+        raw_id = raw_id.split("::")[-1]
+
     return f"{node_type}::{raw_id}"
 
 


### PR DESCRIPTION
## Problem

The `_prefix_id` function in `mutations.py` was adding prefixes unconditionally, causing double-prefixed IDs like `tension::tension::host_motivation` when edge targets were already prefixed. This prevented the graph from being updated correctly after SEED stage.

## Changes

- Modified `_prefix_id` to strip any existing prefixes before adding the correct one
- Added 4 unit tests covering: raw IDs, already-prefixed IDs, wrong-prefixed IDs, and double-prefixed IDs

## Not Included / Future PRs

- #239: duplicate tensions in SEED serialization (separate issue)

## Test Plan

```bash
uv run pytest tests/unit/test_mutations.py::TestPrefixId -v
# All 4 tests pass
```

## Risk / Rollback

Low risk - the function is now idempotent which is safer than the previous behavior. No backwards compatibility concerns.

Fixes #238

🤖 Generated with [Claude Code](https://claude.com/claude-code)