### PR TITLE
feat(serialize): add SerializeResult and serialize_seed_as_function for two-loop architecture

### DIFF
--- a/src/questfoundry/agents/__init__.py
+++ b/src/questfoundry/agents/__init__.py
@@ -14,6 +14,8 @@ from questfoundry.agents.prompts import (
 )
 from questfoundry.agents.serialize import (
     SerializationError,
+    SerializeResult,
+    serialize_seed_as_function,
     serialize_seed_iteratively,
     serialize_to_artifact,
 )
@@ -21,6 +23,7 @@ from questfoundry.agents.summarize import summarize_discussion
 
 __all__ = [
     "SerializationError",
+    "SerializeResult",
     "create_discuss_agent",
     "get_brainstorm_discuss_prompt",
     "get_brainstorm_serialize_prompt",
@@ -32,6 +35,7 @@ __all__ = [
     "get_serialize_prompt",
     "get_summarize_prompt",
     "run_discuss_phase",
+    "serialize_seed_as_function",
     "serialize_seed_iteratively",
     "serialize_to_artifact",
     "summarize_discussion",

--- a/src/questfoundry/agents/serialize.py
+++ b/src/questfoundry/agents/serialize.py
@@ -740,3 +740,152 @@ def _get_sections_to_retry(errors: list[SeedValidationError]) -> set[str]:
             sections.add(field_to_section[top_level])
 
     return sections
+
+
+@traceable(
+    name="Serialize SEED (Function)", run_type="chain", tags=["phase:serialize", "stage:seed"]
+)
+async def serialize_seed_as_function(
+    model: BaseChatModel,
+    brief: str,
+    provider_name: str | None = None,
+    max_retries: int = 3,
+    callbacks: list[BaseCallbackHandler] | None = None,
+    graph: Graph | None = None,
+) -> SerializeResult:
+    """Serialize SEED brief to structured output, returning result for outer loop.
+
+    This function performs ONE pass of section-by-section serialization and ONE
+    semantic validation. Unlike serialize_seed_iteratively(), it does not retry
+    on semantic errors internally. Instead, it returns a SerializeResult that
+    the caller (SeedStage.execute()) can use to implement conversation-level retry.
+
+    The inner Pydantic validation loop is still handled internally - only semantic
+    errors (phantom IDs, missing decisions) are surfaced to the caller.
+
+    Args:
+        model: Chat model to use for generation.
+        brief: The summary brief from the Summarize phase.
+        provider_name: Provider name for strategy auto-detection.
+        max_retries: Maximum retries per section (Pydantic validation).
+        callbacks: LangChain callback handlers for logging LLM calls.
+        graph: Graph containing BRAINSTORM data for semantic validation.
+            If None, semantic validation is skipped.
+
+    Returns:
+        SerializeResult with artifact and any semantic errors.
+
+    Raises:
+        SerializationError: If Pydantic validation fails after max_retries.
+    """
+    from questfoundry.models.seed import (
+        BeatsSection,
+        ConsequencesSection,
+        ConvergenceSection,
+        EntitiesSection,
+        SeedOutput,
+        TensionsSection,
+        ThreadsSection,
+    )
+
+    log.info("serialize_seed_as_function_started")
+
+    prompts = _load_seed_section_prompts()
+    total_tokens = 0
+
+    # Inject valid IDs context if graph is provided
+    enhanced_brief = brief
+    if graph is not None:
+        valid_ids_context = format_valid_ids_context(graph, stage="seed")
+        if valid_ids_context:
+            enhanced_brief = f"{valid_ids_context}\n\n---\n\n{brief}"
+            log.debug("valid_ids_context_injected", context_length=len(valid_ids_context))
+
+    # Section configuration: (section_name, schema, output_field)
+    sections: list[tuple[str, type[BaseModel], str]] = [
+        ("entities", EntitiesSection, "entities"),
+        ("tensions", TensionsSection, "tensions"),
+        ("threads", ThreadsSection, "threads"),
+        ("consequences", ConsequencesSection, "consequences"),
+        ("beats", BeatsSection, "initial_beats"),
+        ("convergence", ConvergenceSection, "convergence_sketch"),
+    ]
+
+    collected: dict[str, Any] = {}
+    brief_with_threads = enhanced_brief
+
+    for section_name, schema, output_field in sections:
+        log.debug("serialize_section_started", section=section_name)
+
+        # Use brief with thread IDs for consequences and beats
+        current_brief = (
+            brief_with_threads if section_name in ("beats", "consequences") else enhanced_brief
+        )
+
+        section_prompt = prompts[section_name]
+        section_result, section_tokens = await serialize_to_artifact(
+            model=model,
+            brief=current_brief,
+            schema=schema,
+            provider_name=provider_name,
+            max_retries=max_retries,
+            system_prompt=section_prompt,
+            callbacks=callbacks,
+        )
+        total_tokens += section_tokens
+
+        section_data = section_result.model_dump()
+        if output_field not in section_data:
+            raise ValueError(
+                f"Section {section_name} returned unexpected structure. "
+                f"Expected field '{output_field}', got: {list(section_data.keys())}"
+            )
+        collected[output_field] = section_data[output_field]
+
+        # After threads are serialized, inject thread IDs for subsequent sections
+        if section_name == "threads" and collected.get("threads"):
+            thread_ids_context = format_thread_ids_context(collected["threads"])
+            if thread_ids_context:
+                brief_with_threads = f"{enhanced_brief}\n\n{thread_ids_context}"
+                log.debug("thread_ids_context_injected", thread_count=len(collected["threads"]))
+
+        log.debug(
+            "serialize_section_completed",
+            section=section_name,
+            items=len(collected[output_field]) if isinstance(collected[output_field], list) else 1,
+            tokens=section_tokens,
+        )
+
+    # Merge all sections into SeedOutput
+    seed_output = SeedOutput.model_validate(collected)
+
+    # Semantic validation (if graph provided) - single pass, no retry
+    semantic_errors: list[SeedValidationError] = []
+    if graph is not None:
+        semantic_errors = validate_seed_mutations(graph, seed_output.model_dump())
+        if semantic_errors:
+            log.warning(
+                "serialize_seed_semantic_errors",
+                error_count=len(semantic_errors),
+            )
+            return SerializeResult(
+                artifact=seed_output,
+                tokens_used=total_tokens,
+                semantic_errors=semantic_errors,
+            )
+
+    log.info(
+        "serialize_seed_as_function_completed",
+        entities=len(seed_output.entities),
+        tensions=len(seed_output.tensions),
+        threads=len(seed_output.threads),
+        consequences=len(seed_output.consequences),
+        beats=len(seed_output.initial_beats),
+        tokens=total_tokens,
+    )
+
+    return SerializeResult(
+        artifact=seed_output,
+        tokens_used=total_tokens,
+        semantic_errors=[],
+    )

--- a/tests/unit/test_serialize.py
+++ b/tests/unit/test_serialize.py
@@ -666,3 +666,238 @@ class TestSerializeSeedIterativelySemanticValidation:
 
             assert len(exc_info.value.errors) == 1
             assert "threads.0.tension_id" in exc_info.value.errors[0].field_path
+
+
+class TestSerializeResult:
+    """Tests for SerializeResult dataclass."""
+
+    def test_success_property_true_when_artifact_and_no_errors(self) -> None:
+        """success should be True when artifact exists and no semantic errors."""
+        from questfoundry.agents.serialize import SerializeResult
+        from questfoundry.models.seed import SeedOutput
+
+        artifact = SeedOutput(entities=[], tensions=[], threads=[], initial_beats=[])
+        result = SerializeResult(artifact=artifact, tokens_used=100, semantic_errors=[])
+
+        assert result.success is True
+
+    def test_success_property_false_when_artifact_none(self) -> None:
+        """success should be False when artifact is None."""
+        from questfoundry.agents.serialize import SerializeResult
+
+        result = SerializeResult(artifact=None, tokens_used=100, semantic_errors=[])
+
+        assert result.success is False
+
+    def test_success_property_false_when_semantic_errors_present(self) -> None:
+        """success should be False when semantic errors exist."""
+        from questfoundry.agents.serialize import SerializeResult
+        from questfoundry.graph.mutations import SeedValidationError
+        from questfoundry.models.seed import SeedOutput
+
+        artifact = SeedOutput(entities=[], tensions=[], threads=[], initial_beats=[])
+        errors = [
+            SeedValidationError(
+                field_path="entities.0.entity_id",
+                issue="Entity not found",
+                available=["a", "b"],
+                provided="x",
+            )
+        ]
+        result = SerializeResult(artifact=artifact, tokens_used=100, semantic_errors=errors)
+
+        assert result.success is False
+
+    def test_result_is_immutable(self) -> None:
+        """SerializeResult should be frozen (immutable)."""
+        from questfoundry.agents.serialize import SerializeResult
+
+        result = SerializeResult(artifact=None, tokens_used=100, semantic_errors=[])
+
+        with pytest.raises(AttributeError):
+            result.tokens_used = 200  # type: ignore[misc]
+
+
+class TestSerializeSeedAsFunction:
+    """Tests for serialize_seed_as_function."""
+
+    @pytest.mark.asyncio
+    async def test_returns_success_result_when_validation_passes(self) -> None:
+        """Should return successful SerializeResult when no semantic errors."""
+        from questfoundry.agents.serialize import SerializeResult, serialize_seed_as_function
+
+        mock_model = MagicMock()
+        mock_graph = MagicMock()
+
+        with patch("questfoundry.agents.serialize.serialize_to_artifact") as mock_serialize:
+            mock_serialize.side_effect = [
+                (MagicMock(model_dump=lambda: {"entities": []}), 10),
+                (MagicMock(model_dump=lambda: {"tensions": []}), 10),
+                (MagicMock(model_dump=lambda: {"threads": []}), 10),
+                (MagicMock(model_dump=lambda: {"consequences": []}), 10),
+                (MagicMock(model_dump=lambda: {"initial_beats": []}), 10),
+                (
+                    MagicMock(
+                        model_dump=lambda: {
+                            "convergence_sketch": {"convergence_points": [], "residue_notes": []}
+                        }
+                    ),
+                    10,
+                ),
+            ]
+
+            with patch("questfoundry.agents.serialize.validate_seed_mutations", return_value=[]):
+                result = await serialize_seed_as_function(
+                    model=mock_model,
+                    brief="Test brief",
+                    graph=mock_graph,
+                )
+
+                assert isinstance(result, SerializeResult)
+                assert result.success is True
+                assert result.artifact is not None
+                assert result.semantic_errors == []
+                assert result.tokens_used == 60  # 6 sections * 10 tokens
+
+    @pytest.mark.asyncio
+    async def test_returns_result_with_errors_when_semantic_validation_fails(self) -> None:
+        """Should return SerializeResult with semantic_errors on validation failure."""
+        from questfoundry.agents.serialize import serialize_seed_as_function
+        from questfoundry.graph.mutations import SeedValidationError
+
+        mock_model = MagicMock()
+        mock_graph = MagicMock()
+
+        errors = [
+            SeedValidationError(
+                field_path="threads.0.tension_id",
+                issue="Tension not found",
+                available=["valid_tension"],
+                provided="invalid_tension",
+            )
+        ]
+
+        with patch("questfoundry.agents.serialize.serialize_to_artifact") as mock_serialize:
+            mock_serialize.side_effect = [
+                (MagicMock(model_dump=lambda: {"entities": []}), 10),
+                (MagicMock(model_dump=lambda: {"tensions": []}), 10),
+                (MagicMock(model_dump=lambda: {"threads": []}), 10),
+                (MagicMock(model_dump=lambda: {"consequences": []}), 10),
+                (MagicMock(model_dump=lambda: {"initial_beats": []}), 10),
+                (
+                    MagicMock(
+                        model_dump=lambda: {
+                            "convergence_sketch": {"convergence_points": [], "residue_notes": []}
+                        }
+                    ),
+                    10,
+                ),
+            ]
+
+            with patch(
+                "questfoundry.agents.serialize.validate_seed_mutations", return_value=errors
+            ):
+                result = await serialize_seed_as_function(
+                    model=mock_model,
+                    brief="Test brief",
+                    graph=mock_graph,
+                )
+
+                assert result.success is False
+                assert result.artifact is not None  # Artifact is still returned
+                assert len(result.semantic_errors) == 1
+                assert result.semantic_errors[0].field_path == "threads.0.tension_id"
+
+    @pytest.mark.asyncio
+    async def test_skips_semantic_validation_when_graph_is_none(self) -> None:
+        """Should skip semantic validation when graph is not provided."""
+        from questfoundry.agents.serialize import serialize_seed_as_function
+
+        mock_model = MagicMock()
+
+        with patch("questfoundry.agents.serialize.serialize_to_artifact") as mock_serialize:
+            mock_serialize.side_effect = [
+                (MagicMock(model_dump=lambda: {"entities": []}), 10),
+                (MagicMock(model_dump=lambda: {"tensions": []}), 10),
+                (MagicMock(model_dump=lambda: {"threads": []}), 10),
+                (MagicMock(model_dump=lambda: {"consequences": []}), 10),
+                (MagicMock(model_dump=lambda: {"initial_beats": []}), 10),
+                (
+                    MagicMock(
+                        model_dump=lambda: {
+                            "convergence_sketch": {"convergence_points": [], "residue_notes": []}
+                        }
+                    ),
+                    10,
+                ),
+            ]
+
+            with patch("questfoundry.agents.serialize.validate_seed_mutations") as mock_validate:
+                result = await serialize_seed_as_function(
+                    model=mock_model,
+                    brief="Test brief",
+                    graph=None,  # No graph
+                )
+
+                mock_validate.assert_not_called()
+                assert result.success is True
+
+    @pytest.mark.asyncio
+    async def test_does_not_retry_on_semantic_errors(self) -> None:
+        """Should NOT retry internally on semantic errors (that's for outer loop)."""
+        from questfoundry.agents.serialize import serialize_seed_as_function
+        from questfoundry.graph.mutations import SeedValidationError
+
+        mock_model = MagicMock()
+        mock_graph = MagicMock()
+
+        errors = [
+            SeedValidationError(
+                field_path="entities.0.entity_id",
+                issue="Entity not found",
+                available=["valid"],
+                provided="invalid",
+            )
+        ]
+
+        call_count = [0]
+
+        def mock_serialize_side_effect(*_args, **_kwargs):
+            call_count[0] += 1
+            section_map = {
+                1: "entities",
+                2: "tensions",
+                3: "threads",
+                4: "consequences",
+                5: "initial_beats",
+                6: "convergence_sketch",
+            }
+            section = section_map.get(call_count[0], "unknown")
+            if section == "convergence_sketch":
+                return (
+                    MagicMock(
+                        model_dump=lambda: {
+                            "convergence_sketch": {"convergence_points": [], "residue_notes": []}
+                        }
+                    ),
+                    10,
+                )
+            return (MagicMock(model_dump=lambda s=section: {s: []}), 10)
+
+        with (
+            patch(
+                "questfoundry.agents.serialize.serialize_to_artifact",
+                side_effect=mock_serialize_side_effect,
+            ),
+            patch("questfoundry.agents.serialize.validate_seed_mutations", return_value=errors),
+        ):
+            result = await serialize_seed_as_function(
+                model=mock_model,
+                brief="Test brief",
+                graph=mock_graph,
+            )
+
+            # Should only call serialize 6 times (once per section), no retries
+            assert call_count[0] == 6
+            assert result.success is False
+            assert len(result.semantic_errors) == 1


### PR DESCRIPTION
## Problem

SEED stage currently uses `serialize_seed_iteratively()` which raises exceptions on semantic errors, making it difficult to implement an outer conversation-level retry loop. The calling code has no clean way to capture semantic validation failures and append corrective feedback to the conversation history.

## Changes

- Add `SerializeResult` dataclass with `artifact`, `tokens_used`, and `semantic_errors` fields
- Add `serialize_seed_as_function()` that returns `SerializeResult` instead of raising
- Export new types from `questfoundry.agents` module
- Add comprehensive tests for new functionality

## Not Included / Future PRs

- Outer loop implementation in `SeedStage.execute()` (PR #2)
- `format_semantic_errors_as_content()` function (PR #2)
- Cleanup/deprecation of `serialize_seed_iteratively()` (PR #3)

Related issues: #244, #245, #246

## Test Plan

```bash
# Run serialize tests
uv run pytest tests/unit/test_serialize.py -v
# 40 passed

# Run full unit test suite
uv run pytest tests/unit/ -q
# 927 passed

# Type checking
uv run mypy src/
# Success: no issues found

# Linting
uv run ruff check src/ tests/
# All checks passed
```

## Risk / Rollback

- Low risk: adds new code without modifying existing behavior
- `serialize_seed_iteratively()` remains unchanged and continues to work
- No feature flags needed; new function is opt-in

## Review Guide

Suggested review order:
1. `src/questfoundry/agents/serialize.py` - New `SerializeResult` dataclass and `serialize_seed_as_function()` 
2. `src/questfoundry/agents/__init__.py` - Export additions
3. `tests/unit/test_serialize.py` - New test classes at the end

🤖 Generated with [Claude Code](https://claude.com/claude-code)