### PR TITLE
feat(seed): implement outer retry loop for semantic errors

### DIFF
--- a/src/questfoundry/agents/__init__.py
+++ b/src/questfoundry/agents/__init__.py
@@ -14,6 +14,8 @@ from questfoundry.agents.prompts import (
 )
 from questfoundry.agents.serialize import (
     SerializationError,
+    SerializeResult,
+    serialize_seed_as_function,
     serialize_seed_iteratively,
     serialize_to_artifact,
 )
@@ -21,6 +23,7 @@ from questfoundry.agents.summarize import summarize_discussion
 
 __all__ = [
     "SerializationError",
+    "SerializeResult",
     "create_discuss_agent",
     "get_brainstorm_discuss_prompt",
     "get_brainstorm_serialize_prompt",
@@ -32,6 +35,7 @@ __all__ = [
     "get_serialize_prompt",
     "get_summarize_prompt",
     "run_discuss_phase",
+    "serialize_seed_as_function",
     "serialize_seed_iteratively",
     "serialize_to_artifact",
     "summarize_discussion",

--- a/src/questfoundry/graph/mutations.py
+++ b/src/questfoundry/graph/mutations.py
@@ -1182,3 +1182,89 @@ def apply_seed_mutations(graph: Graph, output: dict[str, Any]) -> None:
                 "residue_notes": sketch.get("residue_notes", []),
             },
         )
+
+
+def format_semantic_errors_as_content(errors: list[SeedValidationError]) -> str:
+    """Format semantic errors as content-focused feedback for outer loop retry.
+
+    This function formats errors in a way that helps the LLM understand what
+    went wrong conceptually, not just structurally. It groups errors by type
+    and provides actionable guidance.
+
+    Args:
+        errors: List of SeedValidationError objects from validate_seed_mutations.
+
+    Returns:
+        Content-focused feedback string suitable for appending to conversation.
+
+    Example output:
+        I found some issues with the summary that need correction:
+
+        **Missing items** - these need decisions:
+          - hollow_key
+          - ancient_scroll
+
+        **Invalid references** - these don't exist in BRAINSTORM:
+          - 'ghost' was referenced but isn't defined
+
+        Please reconsider the summary, ensuring you only reference
+        entities and tensions from the BRAINSTORM phase.
+    """
+    if not errors:
+        return ""
+
+    by_category = categorize_errors(errors)
+    lines: list[str] = ["I found some issues with the summary that need correction:"]
+
+    # Completeness errors (missing decisions)
+    completeness_errors = by_category.get(SeedErrorCategory.COMPLETENESS, [])
+    if completeness_errors:
+        lines.append("")
+        lines.append("**Missing items** - these need decisions:")
+        for e in completeness_errors[:_MAX_ERRORS_DISPLAY]:
+            # Extract item ID from issue message (e.g., "Missing decision for entity 'X'")
+            # The provided field is empty for completeness errors, so we parse the issue
+            issue = e.issue
+            # Try to extract the quoted ID
+            if "'" in issue:
+                item_id = issue.split("'")[1]
+                lines.append(f"  - {item_id}")
+            else:
+                lines.append(f"  - {e.field_path}: {issue}")
+        if len(completeness_errors) > _MAX_ERRORS_DISPLAY:
+            lines.append(f"  ... and {len(completeness_errors) - _MAX_ERRORS_DISPLAY} more")
+
+    # Semantic errors (invalid references)
+    semantic_errors = by_category.get(SeedErrorCategory.SEMANTIC, [])
+    if semantic_errors:
+        lines.append("")
+        lines.append("**Invalid references** - these don't exist in BRAINSTORM:")
+        for e in semantic_errors[:_MAX_ERRORS_DISPLAY]:
+            if e.provided:
+                lines.append(f"  - '{e.provided}' was referenced but isn't defined")
+                # Add suggestion if available
+                suggestion = _format_error_available(e.provided, e.available)
+                if suggestion and not suggestion.startswith("Available"):
+                    lines.append(f"    {suggestion}")
+            else:
+                lines.append(f"  - {e.field_path}: {e.issue}")
+        if len(semantic_errors) > _MAX_ERRORS_DISPLAY:
+            lines.append(f"  ... and {len(semantic_errors) - _MAX_ERRORS_DISPLAY} more")
+
+    # Inner/structural errors (rarely should make it to outer loop, but handle gracefully)
+    inner_errors = by_category.get(SeedErrorCategory.INNER, [])
+    if inner_errors:
+        lines.append("")
+        lines.append("**Structural issues**:")
+        for e in inner_errors[:_MAX_ERRORS_DISPLAY]:
+            lines.append(f"  - {e.field_path}: {e.issue}")
+        if len(inner_errors) > _MAX_ERRORS_DISPLAY:
+            lines.append(f"  ... and {len(inner_errors) - _MAX_ERRORS_DISPLAY} more")
+
+    lines.append("")
+    lines.append(
+        "Please reconsider the summary, ensuring you only reference "
+        "entities and tensions from the BRAINSTORM phase."
+    )
+
+    return "\n".join(lines)

--- a/src/questfoundry/graph/mutations.py
+++ b/src/questfoundry/graph/mutations.py
@@ -8,6 +8,7 @@ See docs/architecture/graph-storage.md for design details.
 
 from __future__ import annotations
 
+import re
 from collections import Counter
 from dataclasses import dataclass, field
 from difflib import SequenceMatcher
@@ -1224,13 +1225,13 @@ def format_semantic_errors_as_content(errors: list[SeedValidationError]) -> str:
         for e in completeness_errors[:_MAX_ERRORS_DISPLAY]:
             # Extract item ID from issue message (e.g., "Missing decision for entity 'X'")
             # The provided field is empty for completeness errors, so we parse the issue
-            issue = e.issue
-            # Try to extract the quoted ID
-            if "'" in issue:
-                item_id = issue.split("'")[1]
+            # Use regex for robust extraction in case of multiple quotes
+            match = re.search(r"'([^']+)'", e.issue)
+            if match:
+                item_id = match.group(1)
                 lines.append(f"  - {item_id}")
             else:
-                lines.append(f"  - {e.field_path}: {issue}")
+                lines.append(f"  - {e.field_path}: {e.issue}")
         if len(completeness_errors) > _MAX_ERRORS_DISPLAY:
             lines.append(f"  ... and {len(completeness_errors) - _MAX_ERRORS_DISPLAY} more")
 

--- a/src/questfoundry/pipeline/stages/seed.py
+++ b/src/questfoundry/pipeline/stages/seed.py
@@ -364,7 +364,8 @@ class SeedStage:
                 callbacks=callbacks,
                 graph=graph,  # Enables semantic validation
             )
-            # Iterative serialization makes 6 calls (one per section) + potential retries
+            # Iterative serialization makes one call per section plus potential retries
+            # (actual count depends on serialize_seed_as_function implementation)
             total_llm_calls += 6
             total_tokens += result.tokens_used
 


### PR DESCRIPTION
## Problem

SEED stage currently cannot recover from semantic validation errors (phantom IDs, missing decisions) because there's no mechanism to append corrective feedback to the conversation history and re-run summarize+serialize. The LLM needs to see what went wrong to produce better output.

## Changes

- Add `format_semantic_errors_as_content()` in mutations.py for content-focused error formatting
- Refactor `SeedStage.execute()` with outer retry loop:
  - Run summarize → serialize in a loop
  - Track brief as `AIMessage` in conversation history
  - On semantic errors, format feedback with `format_semantic_errors_as_content()` 
  - Append feedback as `HumanMessage` and retry
  - Add `max_outer_retries` parameter (default 2)
- Add comprehensive tests for new functionality

## Not Included / Future PRs

- Cleanup/deprecation of `serialize_seed_iteratively()` (PR #3)
- Positive reinforcement for partial successes (future enhancement)

Related issues: #244, #245, #246

**Note**: This is a stacked PR based on #247

## Test Plan

```bash
# Run seed stage tests
uv run pytest tests/unit/test_seed_stage.py -v
# 25 passed (including 4 new outer loop tests)

# Run mutations tests  
uv run pytest tests/unit/test_mutations.py -v
# 109 passed (including 5 new format_semantic_errors_as_content tests)

# Run full unit test suite
uv run pytest tests/unit/ -q
# 936 passed

# Type checking
uv run mypy src/
# Success: no issues found

# Linting
uv run ruff check src/ tests/
# All checks passed
```

## Risk / Rollback

- Medium risk: changes the core summarize+serialize flow in SeedStage
- Outer loop adds LLM calls on retry (max 2 additional summarize+serialize cycles)
- Easy rollback: revert to calling `serialize_seed_iteratively()` directly
- No feature flags needed; behavior is backward-compatible (succeeds on first try = no change)

## Review Guide

Suggested review order:
1. `src/questfoundry/graph/mutations.py` - `format_semantic_errors_as_content()` function at end of file
2. `src/questfoundry/pipeline/stages/seed.py` - Outer loop in `execute()` method
3. `tests/unit/test_mutations.py` - `TestFormatSemanticErrorsAsContent` class at end
4. `tests/unit/test_seed_stage.py` - Outer loop tests at end

🤖 Generated with [Claude Code](https://claude.com/claude-code)