### PR TITLE
refactor: tech debt sweep (#38, #176, #216, #222)

### DIFF
--- a/src/questfoundry/pipeline/config.py
+++ b/src/questfoundry/pipeline/config.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import os
 from dataclasses import dataclass, field
 from pathlib import Path  # noqa: TC003 - used at runtime
 from typing import TYPE_CHECKING, Any
@@ -34,13 +33,8 @@ class ProvidersConfig:
     LLM providers. Each phase (discuss, summarize, serialize) can optionally
     override the default provider.
 
-    Resolution order for each phase (within this class):
-    1. Environment variable (e.g., QF_PROVIDER_SERIALIZE)
-    2. Project config (e.g., providers.serialize)
-    3. Default provider (from providers.default)
-
-    Note: CLI flags and QF_PROVIDER are handled by the orchestrator for
-    backward compatibility, not by this class.
+    This class resolves only from project config. Environment variables and
+    CLI flags are handled by the orchestrator's full precedence chain.
 
     Attributes:
         default: Default provider string (e.g., "ollama/qwen3:4b-instruct-32k"). Required.
@@ -73,28 +67,28 @@ class ProvidersConfig:
         return self.settings.get(phase) or get_default_phase_settings(phase)
 
     def get_discuss_provider(self) -> str:
-        """Get the effective provider for the discuss phase.
+        """Get the config-level provider for the discuss phase.
 
-        Checks environment variable QF_PROVIDER_DISCUSS, then config,
-        then falls back to default.
+        Returns phase-specific config if set, otherwise default.
+        Environment variables are resolved by the orchestrator.
         """
-        return os.getenv("QF_PROVIDER_DISCUSS") or self.discuss or self.default
+        return self.discuss or self.default
 
     def get_summarize_provider(self) -> str:
-        """Get the effective provider for the summarize phase.
+        """Get the config-level provider for the summarize phase.
 
-        Checks environment variable QF_PROVIDER_SUMMARIZE, then config,
-        then falls back to default.
+        Returns phase-specific config if set, otherwise default.
+        Environment variables are resolved by the orchestrator.
         """
-        return os.getenv("QF_PROVIDER_SUMMARIZE") or self.summarize or self.default
+        return self.summarize or self.default
 
     def get_serialize_provider(self) -> str:
-        """Get the effective provider for the serialize phase.
+        """Get the config-level provider for the serialize phase.
 
-        Checks environment variable QF_PROVIDER_SERIALIZE, then config,
-        then falls back to default.
+        Returns phase-specific config if set, otherwise default.
+        Environment variables are resolved by the orchestrator.
         """
-        return os.getenv("QF_PROVIDER_SERIALIZE") or self.serialize or self.default
+        return self.serialize or self.default
 
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> ProvidersConfig:

--- a/src/questfoundry/tools/base.py
+++ b/src/questfoundry/tools/base.py
@@ -80,7 +80,7 @@ class Tool(Protocol):
         ...             parameters={...},
         ...         )
         ...
-        ...     def execute(self, arguments: dict[str, Any]) -> str:
+        ...     async def execute(self, arguments: dict[str, Any]) -> str:
         ...         query = arguments["query"]
         ...         return search_results
     """
@@ -90,7 +90,7 @@ class Tool(Protocol):
         """Return the tool definition for LLM binding."""
         ...
 
-    def execute(self, arguments: dict[str, Any]) -> str:
+    async def execute(self, arguments: dict[str, Any]) -> str:
         """Execute the tool with given arguments.
 
         Args:
@@ -98,9 +98,5 @@ class Tool(Protocol):
 
         Returns:
             String result to send back to LLM.
-
-        Note:
-            Execute is synchronous. For async operations, use
-            asyncio.get_event_loop().run_until_complete() internally.
         """
         ...

--- a/src/questfoundry/tools/langchain_tools.py
+++ b/src/questfoundry/tools/langchain_tools.py
@@ -39,7 +39,7 @@ _present_options_tool = PresentOptionsTool()
 
 
 @tool
-def search_corpus(query: str, cluster: str | None = None, limit: int = 5) -> str:
+async def search_corpus(query: str, cluster: str | None = None, limit: int = 5) -> str:
     """Search the IF Craft Corpus knowledge base for relevant craft guidance.
 
     The corpus contains curated writing guidance on interactive fiction craft,
@@ -60,11 +60,11 @@ def search_corpus(query: str, cluster: str | None = None, limit: int = 5) -> str
         - {"result": "error", "error": "...", "action": "..."}
     """
     arguments = {"query": query, "limit": limit, "cluster": cluster}
-    return _search_corpus_tool.execute(arguments)
+    return await _search_corpus_tool.execute(arguments)
 
 
 @tool
-def get_document(name: str) -> str:
+async def get_document(name: str) -> str:
     """Retrieve a full document from the IF Craft Corpus by name.
 
     Use this after search_corpus identifies a relevant document that needs
@@ -80,11 +80,11 @@ def get_document(name: str) -> str:
         - {"result": "no_results", "document": "...", "action": "..."}
         - {"result": "error", "error": "...", "action": "..."}
     """
-    return _get_document_tool.execute({"name": name})
+    return await _get_document_tool.execute({"name": name})
 
 
 @tool
-def list_clusters() -> str:
+async def list_clusters() -> str:
     """List available topic clusters in the IF Craft Corpus.
 
     Discovers what categories of craft knowledge are available for targeted
@@ -95,11 +95,11 @@ def list_clusters() -> str:
         - {"result": "success", "clusters": [...], "content": "...", "action": "..."}
         - {"result": "error", "error": "...", "action": "..."}
     """
-    return _list_clusters_tool.execute({})
+    return await _list_clusters_tool.execute({})
 
 
 @tool
-def web_search(query: str, max_results: int = 5, recency: str = "all_time") -> str:
+async def web_search(query: str, max_results: int = 5, recency: str = "all_time") -> str:
     """Search the web using SearXNG for current information and trends.
 
     Useful for researching contemporary topics, current events, or information
@@ -118,13 +118,13 @@ def web_search(query: str, max_results: int = 5, recency: str = "all_time") -> s
         - {"result": "no_results", "query": "...", "action": "..."}
         - {"result": "error", "error": "...", "action": "..."}
     """
-    return _web_search_tool.execute(
+    return await _web_search_tool.execute(
         {"query": query, "max_results": max_results, "recency": recency}
     )
 
 
 @tool
-def web_fetch(url: str, extract_mode: str = "markdown") -> str:
+async def web_fetch(url: str, extract_mode: str = "markdown") -> str:
     """Fetch and extract content from a URL as markdown.
 
     Retrieves web page content with intelligent extraction that strips
@@ -139,11 +139,11 @@ def web_fetch(url: str, extract_mode: str = "markdown") -> str:
         - {"result": "success", "content": "...", "url": "...", "action": "..."}
         - {"result": "error", "url": "...", "error": "...", "action": "..."}
     """
-    return _web_fetch_tool.execute({"url": url, "extract_mode": extract_mode})
+    return await _web_fetch_tool.execute({"url": url, "extract_mode": extract_mode})
 
 
 @tool
-def present_options(question: str, options: list[dict[str, str | bool]]) -> str:
+async def present_options(question: str, options: list[dict[str, str | bool]]) -> str:
     """Present structured choices to the user during conversation.
 
     Use when offering clear alternatives for decisions like genre, tone,
@@ -174,7 +174,7 @@ def present_options(question: str, options: list[dict[str, str | bool]]) -> str:
             ]
         )
     """
-    return _present_options_tool.execute({"question": question, "options": options})
+    return await _present_options_tool.execute({"question": question, "options": options})
 
 
 def get_all_research_tools() -> list[BaseTool]:

--- a/src/questfoundry/tools/research/corpus_tools.py
+++ b/src/questfoundry/tools/research/corpus_tools.py
@@ -158,7 +158,7 @@ class SearchCorpusTool:
             },
         )
 
-    def execute(self, arguments: dict[str, Any]) -> str:
+    async def execute(self, arguments: dict[str, Any]) -> str:
         """Execute corpus search.
 
         Args:
@@ -272,7 +272,7 @@ class GetDocumentTool:
             },
         )
 
-    def execute(self, arguments: dict[str, Any]) -> str:
+    async def execute(self, arguments: dict[str, Any]) -> str:
         """Execute document retrieval.
 
         Args:
@@ -355,7 +355,7 @@ class ListClustersTool:
             },
         )
 
-    def execute(self, arguments: dict[str, Any]) -> str:  # noqa: ARG002
+    async def execute(self, arguments: dict[str, Any]) -> str:  # noqa: ARG002
         """Execute cluster listing.
 
         Args:

--- a/src/questfoundry/tools/research/web_tools.py
+++ b/src/questfoundry/tools/research/web_tools.py
@@ -16,7 +16,6 @@ All tools return structured JSON following ADR-008:
 
 from __future__ import annotations
 
-import asyncio
 import json
 import logging
 import os
@@ -94,7 +93,7 @@ class WebSearchTool:
             },
         )
 
-    def execute(self, arguments: dict[str, Any]) -> str:
+    async def execute(self, arguments: dict[str, Any]) -> str:
         """Execute web search.
 
         Args:
@@ -128,23 +127,7 @@ class WebSearchTool:
         try:
             from pvlwebtools import web_search
 
-            # Run async function in sync context
-            # Try to get running loop first (if called from async context),
-            # otherwise create a new one
-            try:
-                asyncio.get_running_loop()
-                # We're in an async context - run in thread to avoid blocking
-                import concurrent.futures
-
-                with concurrent.futures.ThreadPoolExecutor() as executor:
-                    future = executor.submit(
-                        asyncio.run,
-                        web_search(query, max_results=max_results, recency=recency),
-                    )
-                    results = future.result()
-            except RuntimeError:
-                # No running loop - safe to use asyncio.run()
-                results = asyncio.run(web_search(query, max_results=max_results, recency=recency))
+            results = await web_search(query, max_results=max_results, recency=recency)
         except Exception as e:
             logger.warning("Web search failed: %s", e)
             return json.dumps(
@@ -225,7 +208,7 @@ class WebFetchTool:
             },
         )
 
-    def execute(self, arguments: dict[str, Any]) -> str:
+    async def execute(self, arguments: dict[str, Any]) -> str:
         """Execute web fetch.
 
         Args:
@@ -249,23 +232,7 @@ class WebFetchTool:
         try:
             from pvlwebtools import web_fetch
 
-            # Run async function in sync context
-            # Try to get running loop first (if called from async context),
-            # otherwise create a new one
-            try:
-                asyncio.get_running_loop()
-                # We're in an async context - run in thread to avoid blocking
-                import concurrent.futures
-
-                with concurrent.futures.ThreadPoolExecutor() as executor:
-                    future = executor.submit(
-                        asyncio.run,
-                        web_fetch(url, extract_mode=extract_mode),
-                    )
-                    result = future.result()
-            except RuntimeError:
-                # No running loop - safe to use asyncio.run()
-                result = asyncio.run(web_fetch(url, extract_mode=extract_mode))
+            result = await web_fetch(url, extract_mode=extract_mode)
         except Exception as e:
             logger.warning("Web fetch failed for %s: %s", url, e)
             return json.dumps(

--- a/tests/integration/test_present_options_integration.py
+++ b/tests/integration/test_present_options_integration.py
@@ -202,15 +202,14 @@ class TestPresentOptionsToolIntegration:
 
         # Execute tool
         tool = PresentOptionsTool()
-        result = await tool._execute_async(
+        result = await tool.execute(
             {
                 "question": "What genre?",
                 "options": [
                     {"label": "Mystery", "recommended": True},
                     {"label": "Horror"},
                 ],
-            },
-            get_interactive_callbacks(),
+            }
         )
 
         parsed = json.loads(result)
@@ -228,7 +227,8 @@ class TestPresentOptionsToolIntegration:
         # Verify user input was awaited
         user_input_fn.assert_awaited_once()
 
-    def test_langchain_wrapper_available(self) -> None:
+    @pytest.mark.asyncio
+    async def test_langchain_wrapper_available(self) -> None:
         """present_options is available as a LangChain tool."""
         from questfoundry.tools import get_interactive_tools, present_options
 
@@ -237,7 +237,7 @@ class TestPresentOptionsToolIntegration:
         assert tools[0].name == "present_options"
 
         # Verify tool can be invoked (returns skipped in non-interactive)
-        result = present_options.invoke(
+        result = await present_options.ainvoke(
             {
                 "question": "Test?",
                 "options": [{"label": "A"}, {"label": "B"}],

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -69,15 +69,15 @@ class TestProvidersConfig:
         with patch.dict("os.environ", {}, clear=True):
             assert config.get_discuss_provider() == "ollama/qwen3:4b-instruct-32k"
 
-    def test_get_discuss_provider_env_override(self) -> None:
-        """Environment variable overrides config value."""
+    def test_get_discuss_provider_ignores_env(self) -> None:
+        """ProvidersConfig returns config value, not env var (SRP: orchestrator handles env)."""
         config = ProvidersConfig(
             default="ollama/qwen3:4b-instruct-32k",
             discuss="openai/gpt-5-mini",
         )
 
         with patch.dict("os.environ", {"QF_PROVIDER_DISCUSS": "anthropic/claude-3"}):
-            assert config.get_discuss_provider() == "anthropic/claude-3"
+            assert config.get_discuss_provider() == "openai/gpt-5-mini"
 
     def test_get_summarize_provider_from_config(self) -> None:
         """get_summarize_provider returns config value when set."""
@@ -96,15 +96,15 @@ class TestProvidersConfig:
         with patch.dict("os.environ", {}, clear=True):
             assert config.get_summarize_provider() == "ollama/qwen3:4b-instruct-32k"
 
-    def test_get_summarize_provider_env_override(self) -> None:
-        """Environment variable overrides config value."""
+    def test_get_summarize_provider_ignores_env(self) -> None:
+        """ProvidersConfig returns config value, not env var (SRP: orchestrator handles env)."""
         config = ProvidersConfig(
             default="ollama/qwen3:4b-instruct-32k",
             summarize="openai/gpt-5-mini",
         )
 
         with patch.dict("os.environ", {"QF_PROVIDER_SUMMARIZE": "anthropic/claude-3"}):
-            assert config.get_summarize_provider() == "anthropic/claude-3"
+            assert config.get_summarize_provider() == "openai/gpt-5-mini"
 
     def test_get_serialize_provider_from_config(self) -> None:
         """get_serialize_provider returns config value when set."""
@@ -123,15 +123,15 @@ class TestProvidersConfig:
         with patch.dict("os.environ", {}, clear=True):
             assert config.get_serialize_provider() == "ollama/qwen3:4b-instruct-32k"
 
-    def test_get_serialize_provider_env_override(self) -> None:
-        """Environment variable overrides config value."""
+    def test_get_serialize_provider_ignores_env(self) -> None:
+        """ProvidersConfig returns config value, not env var (SRP: orchestrator handles env)."""
         config = ProvidersConfig(
             default="ollama/qwen3:4b-instruct-32k",
             serialize="openai/o1-mini",
         )
 
         with patch.dict("os.environ", {"QF_PROVIDER_SERIALIZE": "openai/o3-mini"}):
-            assert config.get_serialize_provider() == "openai/o3-mini"
+            assert config.get_serialize_provider() == "openai/o1-mini"
 
 
 # --- Tests for ProjectConfig with hybrid providers ---

--- a/tests/unit/test_langchain_tools.py
+++ b/tests/unit/test_langchain_tools.py
@@ -3,7 +3,9 @@
 from __future__ import annotations
 
 import json
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, patch
+
+import pytest
 
 from questfoundry.tools.langchain_tools import (
     get_all_research_tools,
@@ -83,227 +85,266 @@ class TestToolCollections:
 class TestSearchCorpusExecution:
     """Test search_corpus tool execution."""
 
-    @patch("questfoundry.tools.langchain_tools._search_corpus_tool")
-    def test_search_corpus_delegates(self, mock_tool: MagicMock) -> None:
+    @pytest.mark.asyncio
+    async def test_search_corpus_delegates(self) -> None:
         """search_corpus should delegate to SearchCorpusTool."""
-        mock_tool.execute.return_value = json.dumps(
-            {"result": "success", "content": "test content", "action": "use this"}
-        )
+        with patch("questfoundry.tools.langchain_tools._search_corpus_tool") as mock_tool:
+            mock_tool.execute = AsyncMock(
+                return_value=json.dumps(
+                    {"result": "success", "content": "test content", "action": "use this"}
+                )
+            )
 
-        result = search_corpus.invoke({"query": "test", "limit": 3})
+            result = await search_corpus.ainvoke({"query": "test", "limit": 3})
 
-        mock_tool.execute.assert_called_once_with({"query": "test", "limit": 3, "cluster": None})
-        assert "success" in result
-        assert "test content" in result
+            mock_tool.execute.assert_called_once_with(
+                {"query": "test", "limit": 3, "cluster": None}
+            )
+            assert "success" in result
+            assert "test content" in result
 
-    @patch("questfoundry.tools.langchain_tools._search_corpus_tool")
-    def test_search_corpus_with_cluster(self, mock_tool: MagicMock) -> None:
+    @pytest.mark.asyncio
+    async def test_search_corpus_with_cluster(self) -> None:
         """search_corpus should pass cluster parameter."""
-        mock_tool.execute.return_value = json.dumps({"result": "success"})
+        with patch("questfoundry.tools.langchain_tools._search_corpus_tool") as mock_tool:
+            mock_tool.execute = AsyncMock(return_value=json.dumps({"result": "success"}))
 
-        search_corpus.invoke({"query": "mystery", "cluster": "genre-conventions", "limit": 5})
+            await search_corpus.ainvoke(
+                {"query": "mystery", "cluster": "genre-conventions", "limit": 5}
+            )
 
-        call_args = mock_tool.execute.call_args[0][0]
-        assert call_args["query"] == "mystery"
-        assert call_args["cluster"] == "genre-conventions"
-        assert call_args["limit"] == 5
+            call_args = mock_tool.execute.call_args[0][0]
+            assert call_args["query"] == "mystery"
+            assert call_args["cluster"] == "genre-conventions"
+            assert call_args["limit"] == 5
 
-    @patch("questfoundry.tools.langchain_tools._search_corpus_tool")
-    def test_search_corpus_default_limit(self, mock_tool: MagicMock) -> None:
+    @pytest.mark.asyncio
+    async def test_search_corpus_default_limit(self) -> None:
         """search_corpus should use default limit of 5."""
-        mock_tool.execute.return_value = json.dumps({"result": "success"})
+        with patch("questfoundry.tools.langchain_tools._search_corpus_tool") as mock_tool:
+            mock_tool.execute = AsyncMock(return_value=json.dumps({"result": "success"}))
 
-        search_corpus.invoke({"query": "test"})
+            await search_corpus.ainvoke({"query": "test"})
 
-        call_args = mock_tool.execute.call_args[0][0]
-        assert call_args["limit"] == 5
+            call_args = mock_tool.execute.call_args[0][0]
+            assert call_args["limit"] == 5
 
 
 class TestGetDocumentExecution:
     """Test get_document tool execution."""
 
-    @patch("questfoundry.tools.langchain_tools._get_document_tool")
-    def test_get_document_delegates(self, mock_tool: MagicMock) -> None:
+    @pytest.mark.asyncio
+    async def test_get_document_delegates(self) -> None:
         """get_document should delegate to GetDocumentTool."""
-        mock_tool.execute.return_value = json.dumps(
-            {
-                "result": "success",
-                "title": "Test Doc",
-                "content": "document content",
-                "action": "use this",
-            }
-        )
+        with patch("questfoundry.tools.langchain_tools._get_document_tool") as mock_tool:
+            mock_tool.execute = AsyncMock(
+                return_value=json.dumps(
+                    {
+                        "result": "success",
+                        "title": "Test Doc",
+                        "content": "document content",
+                        "action": "use this",
+                    }
+                )
+            )
 
-        result = get_document.invoke({"name": "test_doc"})
+            result = await get_document.ainvoke({"name": "test_doc"})
 
-        mock_tool.execute.assert_called_once_with({"name": "test_doc"})
-        assert "success" in result
-        assert "Test Doc" in result
+            mock_tool.execute.assert_called_once_with({"name": "test_doc"})
+            assert "success" in result
+            assert "Test Doc" in result
 
 
 class TestListClustersExecution:
     """Test list_clusters tool execution."""
 
-    @patch("questfoundry.tools.langchain_tools._list_clusters_tool")
-    def test_list_clusters_delegates(self, mock_tool: MagicMock) -> None:
+    @pytest.mark.asyncio
+    async def test_list_clusters_delegates(self) -> None:
         """list_clusters should delegate to ListClustersTool."""
-        mock_tool.execute.return_value = json.dumps(
-            {
-                "result": "success",
-                "clusters": ["genre-conventions", "narrative-structure"],
-                "content": "cluster list",
-                "action": "use search_corpus",
-            }
-        )
+        with patch("questfoundry.tools.langchain_tools._list_clusters_tool") as mock_tool:
+            mock_tool.execute = AsyncMock(
+                return_value=json.dumps(
+                    {
+                        "result": "success",
+                        "clusters": ["genre-conventions", "narrative-structure"],
+                        "content": "cluster list",
+                        "action": "use search_corpus",
+                    }
+                )
+            )
 
-        result = list_clusters.invoke({})
+            result = await list_clusters.ainvoke({})
 
-        mock_tool.execute.assert_called_once_with({})
-        assert "success" in result
-        assert "genre-conventions" in result
+            mock_tool.execute.assert_called_once_with({})
+            assert "success" in result
+            assert "genre-conventions" in result
 
 
 class TestWebSearchExecution:
     """Test web_search tool execution."""
 
-    @patch("questfoundry.tools.langchain_tools._web_search_tool")
-    def test_web_search_delegates(self, mock_tool: MagicMock) -> None:
+    @pytest.mark.asyncio
+    async def test_web_search_delegates(self) -> None:
         """web_search should delegate to WebSearchTool."""
-        mock_tool.execute.return_value = json.dumps(
-            {"result": "success", "content": "search results", "action": "use this"}
-        )
+        with patch("questfoundry.tools.langchain_tools._web_search_tool") as mock_tool:
+            mock_tool.execute = AsyncMock(
+                return_value=json.dumps(
+                    {"result": "success", "content": "search results", "action": "use this"}
+                )
+            )
 
-        result = web_search.invoke({"query": "test search", "max_results": 3})
+            result = await web_search.ainvoke({"query": "test search", "max_results": 3})
 
-        mock_tool.execute.assert_called_once_with(
-            {"query": "test search", "max_results": 3, "recency": "all_time"}
-        )
-        assert "success" in result
+            mock_tool.execute.assert_called_once_with(
+                {"query": "test search", "max_results": 3, "recency": "all_time"}
+            )
+            assert "success" in result
 
-    @patch("questfoundry.tools.langchain_tools._web_search_tool")
-    def test_web_search_with_recency(self, mock_tool: MagicMock) -> None:
+    @pytest.mark.asyncio
+    async def test_web_search_with_recency(self) -> None:
         """web_search should pass recency parameter."""
-        mock_tool.execute.return_value = json.dumps({"result": "success"})
+        with patch("questfoundry.tools.langchain_tools._web_search_tool") as mock_tool:
+            mock_tool.execute = AsyncMock(return_value=json.dumps({"result": "success"}))
 
-        web_search.invoke({"query": "recent news", "max_results": 5, "recency": "week"})
+            await web_search.ainvoke({"query": "recent news", "max_results": 5, "recency": "week"})
 
-        call_args = mock_tool.execute.call_args[0][0]
-        assert call_args["recency"] == "week"
+            call_args = mock_tool.execute.call_args[0][0]
+            assert call_args["recency"] == "week"
 
-    @patch("questfoundry.tools.langchain_tools._web_search_tool")
-    def test_web_search_defaults(self, mock_tool: MagicMock) -> None:
+    @pytest.mark.asyncio
+    async def test_web_search_defaults(self) -> None:
         """web_search should use default values."""
-        mock_tool.execute.return_value = json.dumps({"result": "success"})
+        with patch("questfoundry.tools.langchain_tools._web_search_tool") as mock_tool:
+            mock_tool.execute = AsyncMock(return_value=json.dumps({"result": "success"}))
 
-        web_search.invoke({"query": "test"})
+            await web_search.ainvoke({"query": "test"})
 
-        call_args = mock_tool.execute.call_args[0][0]
-        assert call_args["max_results"] == 5
-        assert call_args["recency"] == "all_time"
+            call_args = mock_tool.execute.call_args[0][0]
+            assert call_args["max_results"] == 5
+            assert call_args["recency"] == "all_time"
 
 
 class TestWebFetchExecution:
     """Test web_fetch tool execution."""
 
-    @patch("questfoundry.tools.langchain_tools._web_fetch_tool")
-    def test_web_fetch_delegates(self, mock_tool: MagicMock) -> None:
+    @pytest.mark.asyncio
+    async def test_web_fetch_delegates(self) -> None:
         """web_fetch should delegate to WebFetchTool."""
-        mock_tool.execute.return_value = json.dumps(
-            {
-                "result": "success",
-                "url": "https://example.com",
-                "content": "page content",
-                "action": "use this",
-            }
-        )
+        with patch("questfoundry.tools.langchain_tools._web_fetch_tool") as mock_tool:
+            mock_tool.execute = AsyncMock(
+                return_value=json.dumps(
+                    {
+                        "result": "success",
+                        "url": "https://example.com",
+                        "content": "page content",
+                        "action": "use this",
+                    }
+                )
+            )
 
-        result = web_fetch.invoke({"url": "https://example.com"})
+            result = await web_fetch.ainvoke({"url": "https://example.com"})
 
-        mock_tool.execute.assert_called_once_with(
-            {"url": "https://example.com", "extract_mode": "markdown"}
-        )
-        assert "success" in result
-        assert "page content" in result
+            mock_tool.execute.assert_called_once_with(
+                {"url": "https://example.com", "extract_mode": "markdown"}
+            )
+            assert "success" in result
+            assert "page content" in result
 
-    @patch("questfoundry.tools.langchain_tools._web_fetch_tool")
-    def test_web_fetch_with_extract_mode(self, mock_tool: MagicMock) -> None:
+    @pytest.mark.asyncio
+    async def test_web_fetch_with_extract_mode(self) -> None:
         """web_fetch should pass extract_mode parameter."""
-        mock_tool.execute.return_value = json.dumps({"result": "success"})
+        with patch("questfoundry.tools.langchain_tools._web_fetch_tool") as mock_tool:
+            mock_tool.execute = AsyncMock(return_value=json.dumps({"result": "success"}))
 
-        web_fetch.invoke({"url": "https://example.com", "extract_mode": "article"})
+            await web_fetch.ainvoke({"url": "https://example.com", "extract_mode": "article"})
 
-        call_args = mock_tool.execute.call_args[0][0]
-        assert call_args["extract_mode"] == "article"
+            call_args = mock_tool.execute.call_args[0][0]
+            assert call_args["extract_mode"] == "article"
 
 
 class TestToolReturnTypes:
     """Test that all tools return strings (required for LangChain)."""
 
-    @patch("questfoundry.tools.langchain_tools._search_corpus_tool")
-    def test_search_corpus_returns_string(self, mock_tool: MagicMock) -> None:
+    @pytest.mark.asyncio
+    async def test_search_corpus_returns_string(self) -> None:
         """search_corpus must return a string."""
-        mock_tool.execute.return_value = '{"result": "success"}'
+        with patch("questfoundry.tools.langchain_tools._search_corpus_tool") as mock_tool:
+            mock_tool.execute = AsyncMock(return_value='{"result": "success"}')
 
-        result = search_corpus.invoke({"query": "test"})
-        assert isinstance(result, str)
+            result = await search_corpus.ainvoke({"query": "test"})
+            assert isinstance(result, str)
 
-    @patch("questfoundry.tools.langchain_tools._get_document_tool")
-    def test_get_document_returns_string(self, mock_tool: MagicMock) -> None:
+    @pytest.mark.asyncio
+    async def test_get_document_returns_string(self) -> None:
         """get_document must return a string."""
-        mock_tool.execute.return_value = '{"result": "success"}'
+        with patch("questfoundry.tools.langchain_tools._get_document_tool") as mock_tool:
+            mock_tool.execute = AsyncMock(return_value='{"result": "success"}')
 
-        result = get_document.invoke({"name": "test"})
-        assert isinstance(result, str)
+            result = await get_document.ainvoke({"name": "test"})
+            assert isinstance(result, str)
 
-    @patch("questfoundry.tools.langchain_tools._list_clusters_tool")
-    def test_list_clusters_returns_string(self, mock_tool: MagicMock) -> None:
+    @pytest.mark.asyncio
+    async def test_list_clusters_returns_string(self) -> None:
         """list_clusters must return a string."""
-        mock_tool.execute.return_value = '{"result": "success"}'
+        with patch("questfoundry.tools.langchain_tools._list_clusters_tool") as mock_tool:
+            mock_tool.execute = AsyncMock(return_value='{"result": "success"}')
 
-        result = list_clusters.invoke({})
-        assert isinstance(result, str)
+            result = await list_clusters.ainvoke({})
+            assert isinstance(result, str)
 
-    @patch("questfoundry.tools.langchain_tools._web_search_tool")
-    def test_web_search_returns_string(self, mock_tool: MagicMock) -> None:
+    @pytest.mark.asyncio
+    async def test_web_search_returns_string(self) -> None:
         """web_search must return a string."""
-        mock_tool.execute.return_value = '{"result": "success"}'
+        with patch("questfoundry.tools.langchain_tools._web_search_tool") as mock_tool:
+            mock_tool.execute = AsyncMock(return_value='{"result": "success"}')
 
-        result = web_search.invoke({"query": "test"})
-        assert isinstance(result, str)
+            result = await web_search.ainvoke({"query": "test"})
+            assert isinstance(result, str)
 
-    @patch("questfoundry.tools.langchain_tools._web_fetch_tool")
-    def test_web_fetch_returns_string(self, mock_tool: MagicMock) -> None:
+    @pytest.mark.asyncio
+    async def test_web_fetch_returns_string(self) -> None:
         """web_fetch must return a string."""
-        mock_tool.execute.return_value = '{"result": "success"}'
+        with patch("questfoundry.tools.langchain_tools._web_fetch_tool") as mock_tool:
+            mock_tool.execute = AsyncMock(return_value='{"result": "success"}')
 
-        result = web_fetch.invoke({"url": "https://example.com"})
-        assert isinstance(result, str)
+            result = await web_fetch.ainvoke({"url": "https://example.com"})
+            assert isinstance(result, str)
 
 
 class TestErrorHandling:
     """Test that tools handle errors gracefully."""
 
-    @patch("questfoundry.tools.langchain_tools._search_corpus_tool")
-    def test_search_corpus_error_propagates(self, mock_tool: MagicMock) -> None:
+    @pytest.mark.asyncio
+    async def test_search_corpus_error_propagates(self) -> None:
         """search_corpus should return error JSON from underlying tool."""
-        mock_tool.execute.return_value = json.dumps(
-            {"result": "error", "error": "Corpus not available", "action": "proceed"}
-        )
+        with patch("questfoundry.tools.langchain_tools._search_corpus_tool") as mock_tool:
+            mock_tool.execute = AsyncMock(
+                return_value=json.dumps(
+                    {"result": "error", "error": "Corpus not available", "action": "proceed"}
+                )
+            )
 
-        result = search_corpus.invoke({"query": "test"})
+            result = await search_corpus.ainvoke({"query": "test"})
 
-        data = json.loads(result)
-        assert data["result"] == "error"
-        assert "error" in data
+            data = json.loads(result)
+            assert data["result"] == "error"
+            assert "error" in data
 
-    @patch("questfoundry.tools.langchain_tools._web_search_tool")
-    def test_web_search_error_propagates(self, mock_tool: MagicMock) -> None:
+    @pytest.mark.asyncio
+    async def test_web_search_error_propagates(self) -> None:
         """web_search should return error JSON from underlying tool."""
-        mock_tool.execute.return_value = json.dumps(
-            {"result": "error", "error": "SEARXNG_URL not configured", "action": "proceed"}
-        )
+        with patch("questfoundry.tools.langchain_tools._web_search_tool") as mock_tool:
+            mock_tool.execute = AsyncMock(
+                return_value=json.dumps(
+                    {
+                        "result": "error",
+                        "error": "SEARXNG_URL not configured",
+                        "action": "proceed",
+                    }
+                )
+            )
 
-        result = web_search.invoke({"query": "test"})
+            result = await web_search.ainvoke({"query": "test"})
 
-        data = json.loads(result)
-        assert data["result"] == "error"
+            data = json.loads(result)
+            assert data["result"] == "error"

--- a/tests/unit/test_tools.py
+++ b/tests/unit/test_tools.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import pytest
+
 from questfoundry.tools import (
     ToolCall,
     ToolDefinition,
@@ -67,11 +69,12 @@ class MockTool:
             parameters={"type": "object", "properties": {"input": {"type": "string"}}},
         )
 
-    def execute(self, arguments: dict) -> str:
+    async def execute(self, arguments: dict) -> str:
         return f"Executed with: {arguments.get('input', 'none')}"
 
 
-def test_tool_protocol_implementation() -> None:
+@pytest.mark.asyncio
+async def test_tool_protocol_implementation() -> None:
     """Custom tool implements Tool protocol correctly."""
     tool = MockTool()
 
@@ -82,7 +85,7 @@ def test_tool_protocol_implementation() -> None:
     definition = tool.definition
     assert isinstance(definition, ToolDefinition)
 
-    result = tool.execute({"input": "test"})
+    result = await tool.execute({"input": "test"})
     assert "test" in result
 
 


### PR DESCRIPTION
## Problem

Tracker issue #252 identified several tech debt items that needed cleanup. This PR addresses four of them in a single coherent commit.

## Changes

### #38: Make `Tool.execute()` async
- Changed `Tool` protocol from sync `execute()` to `async execute()`
- Removed `ThreadPoolExecutor`/`asyncio.run_coroutine_threadsafe` bridging in LangChain wrappers
- `PresentOptionsTool` no longer has separate `_execute_async`; interactive callbacks use context-variable pattern
- All tool implementations now `async def execute()`

### #176: Remove env var checks from ProvidersConfig
- `ProvidersConfig.get_*_provider()` methods no longer check `QF_PROVIDER_*` env vars
- SRP: orchestrator handles the 6-level precedence chain (CLI → env → config)
- Config class is a pure data container that resolves from config file only

### #216: Add category field to SeedValidationError
- `SeedErrorCategory` enum: `SEMANTIC`, `INNER`, `COMPLETENESS`
- All error creation sites annotated with appropriate category
- Enables the outer retry loop to distinguish retryable semantic errors from hard failures

### #222: Extract `_validate_id` helper + merge beat loops
- Extracted `_validate_id()` and `_normalize_id()` helpers from duplicated validation logic
- Merged two sequential beat-iteration loops into one
- Reduced `validate_seed_mutations()` from ~500 to ~350 lines
- Added `_cross_type_hint()` for type-aware feedback (entity used as tension, etc.)
- Added cut-entity-in-beats detection

## Not Included / Future PRs
- Closing tracker issue #252 (will close when PR merges)
- Issues #182, #229, #224 were already fixed and closed in a previous session

## Test Plan

```bash
# All 943 unit tests pass
uv run pytest tests/unit/ -x --tb=short  # ✓

# Integration tests for affected code pass
uv run pytest tests/integration/test_present_options_integration.py -v  # 6 passed

# Pre-commit hooks pass (ruff, mypy, formatting)
git commit  # ✓ all hooks passed
```

## Risk / Rollback
- The async `execute()` change is a breaking change for any external `Tool` implementations (none exist outside this repo)
- ProvidersConfig env var removal: orchestrator already handles precedence, so no behavior change at the CLI level
- All existing tests updated and passing

Closes #38
Closes #176
Closes #216
Closes #222

🤖 Generated with [Claude Code](https://claude.com/claude-code)