### PR TITLE
feat(grow): implement Phase 2 thread-agnostic assessment with LLM infrastructure (#259)

### DIFF
--- a/prompts/templates/grow_phase2_agnostic.yaml
+++ b/prompts/templates/grow_phase2_agnostic.yaml
@@ -39,6 +39,12 @@ system: |
   Valid beat_ids: {valid_beat_ids}
   Valid tension IDs for agnostic_for: {valid_tension_ids}
 
+  ## What NOT to Do
+  - Do NOT use partial beat IDs like "opening" (must include "beat::" prefix)
+  - Do NOT invent tension IDs not listed in the Valid IDs section
+  - Do NOT include beats with empty agnostic_for arrays
+  - Do NOT include beats that are NOT thread-agnostic for any tension
+
   ## Output Format
   Return a JSON object with an "assessments" array. Each assessment has:
   - beat_id: the full beat ID (e.g., "beat::opening")

--- a/prompts/templates/grow_phase2_agnostic.yaml
+++ b/prompts/templates/grow_phase2_agnostic.yaml
@@ -1,0 +1,53 @@
+name: grow_phase2_agnostic
+description: Assess which beats are thread-agnostic for their tensions
+
+system: |
+  You are analyzing story beats to determine which ones are "thread-agnostic".
+
+  ## What is Thread-Agnostic?
+  A beat is thread-agnostic for a tension when its prose would read the same
+  regardless of which thread (path) the reader is on for that tension.
+
+  This is about PROSE COMPATIBILITY, not logical compatibility:
+  - A beat describing "the hero enters the tavern" is thread-agnostic if it
+    doesn't reference any thread-specific choices or consequences.
+  - A beat describing "the hero, grateful for the mentor's guidance" is NOT
+    thread-agnostic for the mentor_trust tension, because it assumes the
+    trust path was chosen.
+
+  ## Examples
+
+  THREAD-AGNOSTIC:
+  - "The hero arrives at the crossroads" (no thread-specific references)
+  - "Night falls over the village" (purely environmental)
+  - "The artifact glows faintly" (describes object without path-dependent context)
+
+  NOT THREAD-AGNOSTIC:
+  - "The mentor smiles, pleased with the hero's trust" (references trust path)
+  - "Having rejected the artifact, the hero feels lighter" (references specific choice)
+  - "The ally they saved earlier returns" (references specific path outcome)
+
+  ## Your Task
+  For each beat listed below, assess whether its prose would be compatible
+  across all threads of each tension it belongs to. If yes, mark it as
+  agnostic for that tension.
+
+  ## Candidate Beats
+  {beat_summaries}
+
+  ## Valid IDs
+  Valid beat_ids: {valid_beat_ids}
+  Valid tension IDs for agnostic_for: {valid_tension_ids}
+
+  ## Output Format
+  Return a JSON object with an "assessments" array. Each assessment has:
+  - beat_id: the full beat ID (e.g., "beat::opening")
+  - agnostic_for: list of tension raw_ids this beat is agnostic for
+
+  Only include beats that ARE thread-agnostic for at least one tension.
+  Omit beats that are NOT thread-agnostic for any tension.
+
+user: |
+  Analyze the candidate beats above and return your thread-agnostic assessments.
+
+components: []

--- a/src/questfoundry/models/__init__.py
+++ b/src/questfoundry/models/__init__.py
@@ -32,6 +32,7 @@ from questfoundry.models.grow import (
     KnotProposal,
     OverlayProposal,
     Passage,
+    Phase2Output,
     SceneTypeTag,
     ThreadAgnosticAssessment,
 )
@@ -72,6 +73,7 @@ __all__ = [
     "KnotProposal",
     "OverlayProposal",
     "Passage",
+    "Phase2Output",
     "SceneTypeTag",
     "Scope",
     "SeedOutput",

--- a/src/questfoundry/models/grow.py
+++ b/src/questfoundry/models/grow.py
@@ -85,7 +85,7 @@ class EntityOverlay(BaseModel):
 
 
 # ---------------------------------------------------------------------------
-# LLM sub-phase output models (for future LLM phases)
+# LLM sub-phase output models
 # ---------------------------------------------------------------------------
 
 
@@ -94,6 +94,12 @@ class ThreadAgnosticAssessment(BaseModel):
 
     beat_id: str = Field(min_length=1)
     agnostic_for: list[str] = Field(default_factory=list)
+
+
+class Phase2Output(BaseModel):
+    """Wrapper for Phase 2 structured output (thread-agnostic assessment)."""
+
+    assessments: list[ThreadAgnosticAssessment] = Field(default_factory=list)
 
 
 class KnotProposal(BaseModel):
@@ -147,6 +153,8 @@ class GrowPhaseResult(BaseModel):
     phase: str = Field(min_length=1)
     status: Literal["completed", "skipped", "failed"]
     detail: str = ""
+    llm_calls: int = 0
+    tokens_used: int = 0
 
 
 class GrowResult(BaseModel):
@@ -155,5 +163,7 @@ class GrowResult(BaseModel):
     arc_count: int = 0
     passage_count: int = 0
     codeword_count: int = 0
+    choice_count: int = 0
+    overlay_count: int = 0
     phases_completed: list[GrowPhaseResult] = Field(default_factory=list)
     spine_arc_id: str | None = None

--- a/src/questfoundry/pipeline/stages/grow.py
+++ b/src/questfoundry/pipeline/stages/grow.py
@@ -1,7 +1,8 @@
 """GROW stage implementation.
 
 The GROW stage builds the complete branching structure from the SEED
-graph. It runs deterministic phases that enumerate arcs, compute
+graph. It runs a mix of deterministic and LLM-powered phases that
+enumerate arcs, assess thread-agnostic beats, compute
 divergence/convergence points, create passages and codewords, and
 prune unreachable nodes.
 
@@ -9,24 +10,30 @@ GROW manages its own graph: it loads, mutates, and saves the graph
 within execute(). The orchestrator should skip post-execute
 apply_mutations() for GROW.
 
-Phase dispatch is sequential method calls - no PhaseRunner abstraction.
+Phase dispatch is sequential async method calls - no PhaseRunner abstraction.
 Pure graph algorithms live in graph/grow_algorithms.py.
+
+LLM phases use direct structured output (not discuss→summarize→serialize):
+context from graph state → single LLM call → validate → retry (max 3).
 """
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+from collections.abc import Awaitable, Callable
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, TypeVar
+
+from langchain_core.messages import HumanMessage, SystemMessage
+from pydantic import BaseModel, ValidationError
 
 from questfoundry.graph.graph import Graph
 from questfoundry.graph.mutations import GrowMutationError, GrowValidationError
 from questfoundry.models.grow import GrowPhaseResult, GrowResult
 from questfoundry.observability.logging import get_logger
 from questfoundry.pipeline.gates import AutoApprovePhaseGate
+from questfoundry.providers.structured_output import with_structured_output
 
 if TYPE_CHECKING:
-    from collections.abc import Callable
-    from pathlib import Path
-
     from langchain_core.language_models import BaseChatModel
 
     from questfoundry.pipeline.gates import PhaseGateHook
@@ -35,6 +42,20 @@ if TYPE_CHECKING:
         LLMCallbackFn,
         UserInputFn,
     )
+
+T = TypeVar("T", bound=BaseModel)
+
+
+def _get_prompts_path() -> Path:
+    """Get the prompts directory path.
+
+    Returns prompts from package first, then falls back to project root.
+    """
+    pkg_path = Path(__file__).parents[4] / "prompts"
+    if pkg_path.exists():
+        return pkg_path
+    return Path.cwd() / "prompts"
+
 
 log = get_logger(__name__)
 
@@ -71,14 +92,20 @@ class GrowStage:
         self.project_path = project_path
         self.gate = gate or AutoApprovePhaseGate()
 
-    def _phase_order(self) -> list[tuple[Callable[[Graph], GrowPhaseResult], str]]:
+    # Type for async phase functions: (Graph, BaseChatModel) -> GrowPhaseResult
+    PhaseFunc = Callable[["Graph", "BaseChatModel"], Awaitable[GrowPhaseResult]]
+
+    def _phase_order(self) -> list[tuple[PhaseFunc, str]]:
         """Return ordered list of (phase_function, phase_name) tuples.
 
         Returns:
             List of phase functions with their names, in execution order.
+            All phases are async and accept (graph, model) parameters.
+            Deterministic phases ignore the model parameter.
         """
         return [
             (self._phase_1_validate_dag, "validate_dag"),
+            (self._phase_2_thread_agnostic, "thread_agnostic"),
             (self._phase_5_enumerate_arcs, "enumerate_arcs"),
             (self._phase_6_divergence, "divergence"),
             (self._phase_7_convergence, "convergence"),
@@ -89,7 +116,7 @@ class GrowStage:
 
     async def execute(
         self,
-        model: BaseChatModel,  # noqa: ARG002 - unused in deterministic phases
+        model: BaseChatModel,
         user_prompt: str,  # noqa: ARG002
         provider_name: str | None = None,  # noqa: ARG002
         *,
@@ -143,13 +170,17 @@ class GrowStage:
         log.info("stage_start", stage="grow")
         graph = Graph.load(resolved_path)
         phase_results: list[GrowPhaseResult] = []
+        total_llm_calls = 0
+        total_tokens = 0
 
         for phase_fn, phase_name in self._phase_order():
             log.debug("phase_start", phase=phase_name)
             snapshot = graph.to_dict()
 
-            result = phase_fn(graph)
+            result = await phase_fn(graph, model)
             phase_results.append(result)
+            total_llm_calls += result.llm_calls
+            total_tokens += result.tokens_used
 
             if result.status == "failed":
                 log.error("phase_failed", phase=phase_name, detail=result.detail)
@@ -199,13 +230,266 @@ class GrowStage:
             codewords=grow_result.codeword_count,
         )
 
-        return grow_result.model_dump(), 0, 0
+        return grow_result.model_dump(), total_llm_calls, total_tokens
+
+    # -------------------------------------------------------------------------
+    # LLM helper
+    # -------------------------------------------------------------------------
+
+    async def _grow_llm_call(
+        self,
+        model: BaseChatModel,
+        template_name: str,
+        context: dict[str, Any],
+        output_schema: type[T],
+        max_retries: int = 3,
+    ) -> tuple[T, int, int]:
+        """Call LLM with structured output and retry on validation failure.
+
+        Loads prompt template, injects context, calls model.with_structured_output(),
+        validates with Pydantic, retries with error feedback on failure.
+
+        Args:
+            model: LangChain chat model.
+            template_name: Name of the prompt template (without .yaml).
+            context: Variables to inject into the prompt template.
+            output_schema: Pydantic model class for structured output.
+            max_retries: Maximum retry attempts on validation failure.
+
+        Returns:
+            Tuple of (validated_result, llm_calls, tokens_used).
+
+        Raises:
+            GrowStageError: After max_retries exhausted.
+        """
+        from questfoundry.prompts.loader import PromptLoader
+
+        loader = PromptLoader(_get_prompts_path())
+        template = loader.load(template_name)
+
+        # Build system message from template with context injection
+        system_text = template.system.format(**context) if context else template.system
+        user_text = template.user.format(**context) if template.user and context else template.user
+
+        structured_model = with_structured_output(model, output_schema)
+
+        messages: list[SystemMessage | HumanMessage] = [SystemMessage(content=system_text)]
+        if user_text:
+            messages.append(HumanMessage(content=user_text))
+
+        total_tokens = 0
+        llm_calls = 0
+
+        for attempt in range(max_retries):
+            log.debug(
+                "grow_llm_call",
+                template=template_name,
+                attempt=attempt + 1,
+                max_retries=max_retries,
+            )
+
+            try:
+                result = await structured_model.ainvoke(messages)
+                llm_calls += 1
+
+                # Extract token usage from response metadata if available
+                if hasattr(result, "response_metadata"):
+                    usage = getattr(result, "response_metadata", {}).get("token_usage", {})
+                    total_tokens += usage.get("total_tokens", 0)
+
+                # Validate with Pydantic
+                if isinstance(result, output_schema):
+                    log.debug("grow_llm_validation_pass", template=template_name)
+                    return result, llm_calls, total_tokens
+
+                # If result is a dict, try to validate it
+                if isinstance(result, dict):
+                    validated = output_schema.model_validate(result)
+                    return validated, llm_calls, total_tokens
+
+                # Unexpected result type - try model_validate
+                validated = output_schema.model_validate(result)
+                return validated, llm_calls, total_tokens
+
+            except (ValidationError, TypeError, AttributeError) as e:
+                log.warning(
+                    "grow_llm_validation_fail",
+                    template=template_name,
+                    attempt=attempt + 1,
+                    error=str(e),
+                )
+
+                if attempt < max_retries - 1:
+                    # Add error feedback for retry
+                    error_msg = (
+                        f"Your previous response had validation errors:\n{e}\n\n"
+                        f"Please fix these issues and try again. "
+                        f"Ensure all IDs are valid and all required fields are present."
+                    )
+                    messages.append(HumanMessage(content=error_msg))
+
+        raise GrowStageError(
+            f"LLM call for {template_name} failed after {max_retries} attempts. "
+            f"Could not produce valid {output_schema.__name__} output."
+        )
+
+    # -------------------------------------------------------------------------
+    # LLM phases
+    # -------------------------------------------------------------------------
+
+    async def _phase_2_thread_agnostic(self, graph: Graph, model: BaseChatModel) -> GrowPhaseResult:
+        """Phase 2: Thread-agnostic assessment.
+
+        Identifies beats whose prose is compatible across multiple threads
+        of the same tension. Thread-agnostic beats don't need separate
+        renderings per thread — they read the same regardless of path.
+
+        This is about prose compatibility, not logical compatibility.
+        A beat is thread-agnostic if its narrative content doesn't reference
+        thread-specific choices or consequences.
+        """
+        from questfoundry.models.grow import Phase2Output, ThreadAgnosticAssessment
+
+        # Collect tensions with multiple threads
+        tension_nodes = graph.get_nodes_by_type("tension")
+        thread_nodes = graph.get_nodes_by_type("thread")
+        beat_nodes = graph.get_nodes_by_type("beat")
+
+        if not tension_nodes or not thread_nodes or not beat_nodes:
+            return GrowPhaseResult(
+                phase="thread_agnostic",
+                status="completed",
+                detail="No tensions/threads/beats to assess",
+            )
+
+        # Build tension → threads mapping
+        tension_threads: dict[str, list[str]] = {}
+        explores_edges = graph.get_edges(from_id=None, to_id=None, edge_type="explores")
+        for edge in explores_edges:
+            thread_id = edge["from"]
+            tension_id = edge["to"]
+            if thread_id in thread_nodes and tension_id in tension_nodes:
+                tension_threads.setdefault(tension_id, []).append(thread_id)
+
+        # Only assess tensions with multiple threads
+        multi_thread_tensions = {
+            tid: threads for tid, threads in tension_threads.items() if len(threads) > 1
+        }
+
+        if not multi_thread_tensions:
+            return GrowPhaseResult(
+                phase="thread_agnostic",
+                status="completed",
+                detail="No multi-thread tensions to assess",
+            )
+
+        # Build beat → threads mapping via belongs_to edges
+        beat_thread_map: dict[str, list[str]] = {}
+        belongs_to_edges = graph.get_edges(from_id=None, to_id=None, edge_type="belongs_to")
+        for edge in belongs_to_edges:
+            beat_id = edge["from"]
+            thread_id = edge["to"]
+            beat_thread_map.setdefault(beat_id, []).append(thread_id)
+
+        # Find beats that belong to multiple threads of the same tension
+        # These are candidates for thread-agnostic assessment
+        candidate_beats: dict[str, list[str]] = {}  # beat_id → list of tension_ids
+        for beat_id, beat_threads in beat_thread_map.items():
+            if beat_id not in beat_nodes:
+                continue
+            for tension_id, tension_thread_list in multi_thread_tensions.items():
+                # Count how many of this tension's threads the beat belongs to
+                shared = [t for t in beat_threads if t in tension_thread_list]
+                if len(shared) > 1:
+                    candidate_beats.setdefault(beat_id, []).append(tension_id)
+
+        if not candidate_beats:
+            return GrowPhaseResult(
+                phase="thread_agnostic",
+                status="completed",
+                detail="No candidate beats for thread-agnostic assessment",
+            )
+
+        # Build context for LLM
+        beat_summaries: list[str] = []
+        valid_beat_ids: list[str] = []
+        valid_tension_ids: list[str] = []
+
+        for beat_id, tension_ids in sorted(candidate_beats.items()):
+            beat_data = beat_nodes[beat_id]
+            summary = beat_data.get("summary", "No summary")
+            tensions_str = ", ".join(tension_nodes[tid].get("raw_id", tid) for tid in tension_ids)
+            beat_summaries.append(
+                f"- beat_id: {beat_id}\n  summary: {summary}\n  tensions: [{tensions_str}]"
+            )
+            valid_beat_ids.append(beat_id)
+            for tid in tension_ids:
+                raw_tid = tension_nodes[tid].get("raw_id", tid)
+                if raw_tid not in valid_tension_ids:
+                    valid_tension_ids.append(raw_tid)
+
+        context = {
+            "beat_summaries": "\n".join(beat_summaries),
+            "valid_beat_ids": ", ".join(valid_beat_ids),
+            "valid_tension_ids": ", ".join(valid_tension_ids),
+        }
+
+        # Call LLM
+        try:
+            result, llm_calls, tokens = await self._grow_llm_call(
+                model=model,
+                template_name="grow_phase2_agnostic",
+                context=context,
+                output_schema=Phase2Output,
+            )
+        except GrowStageError as e:
+            return GrowPhaseResult(
+                phase="thread_agnostic",
+                status="failed",
+                detail=str(e),
+            )
+
+        # Semantic validation: check all IDs exist
+        valid_assessments: list[ThreadAgnosticAssessment] = []
+        for assessment in result.assessments:
+            if assessment.beat_id not in beat_nodes:
+                log.warning(
+                    "phase2_invalid_beat_id",
+                    beat_id=assessment.beat_id,
+                )
+                continue
+            # Filter agnostic_for to valid tension raw_ids
+            valid_tensions = [t for t in assessment.agnostic_for if t in valid_tension_ids]
+            if valid_tensions:
+                valid_assessments.append(
+                    ThreadAgnosticAssessment(
+                        beat_id=assessment.beat_id,
+                        agnostic_for=valid_tensions,
+                    )
+                )
+
+        # Apply results to graph
+        agnostic_count = 0
+        for assessment in valid_assessments:
+            graph.update_node(
+                assessment.beat_id,
+                thread_agnostic_for=assessment.agnostic_for,
+            )
+            agnostic_count += 1
+
+        return GrowPhaseResult(
+            phase="thread_agnostic",
+            status="completed",
+            detail=f"Assessed {len(candidate_beats)} beats, {agnostic_count} marked agnostic",
+            llm_calls=llm_calls,
+            tokens_used=tokens,
+        )
 
     # -------------------------------------------------------------------------
     # Deterministic phases
     # -------------------------------------------------------------------------
 
-    def _phase_1_validate_dag(self, graph: Graph) -> GrowPhaseResult:
+    async def _phase_1_validate_dag(self, graph: Graph, model: BaseChatModel) -> GrowPhaseResult:  # noqa: ARG002
         """Phase 1: Validate beat DAG and commits beats.
 
         Checks:
@@ -229,7 +513,7 @@ class GrowStage:
 
         return GrowPhaseResult(phase="validate_dag", status="completed")
 
-    def _phase_5_enumerate_arcs(self, graph: Graph) -> GrowPhaseResult:
+    async def _phase_5_enumerate_arcs(self, graph: Graph, model: BaseChatModel) -> GrowPhaseResult:  # noqa: ARG002
         """Phase 5: Enumerate arcs from thread combinations.
 
         Creates arc nodes and arc_contains edges for each beat in the arc.
@@ -276,7 +560,7 @@ class GrowStage:
             detail=f"Created {len(arcs)} arcs",
         )
 
-    def _phase_6_divergence(self, graph: Graph) -> GrowPhaseResult:
+    async def _phase_6_divergence(self, graph: Graph, model: BaseChatModel) -> GrowPhaseResult:  # noqa: ARG002
         """Phase 6: Compute divergence points between arcs.
 
         Updates arc nodes with divergence metadata and creates diverges_at edges.
@@ -334,7 +618,7 @@ class GrowStage:
             detail=f"Computed {len(divergence_map)} divergence points",
         )
 
-    def _phase_7_convergence(self, graph: Graph) -> GrowPhaseResult:
+    async def _phase_7_convergence(self, graph: Graph, model: BaseChatModel) -> GrowPhaseResult:  # noqa: ARG002
         """Phase 7: Find convergence points for diverged arcs.
 
         Updates arc nodes with convergence metadata and creates converges_at edges.
@@ -399,7 +683,7 @@ class GrowStage:
             detail=f"Found {convergence_count} convergence points",
         )
 
-    def _phase_8a_passages(self, graph: Graph) -> GrowPhaseResult:
+    async def _phase_8a_passages(self, graph: Graph, model: BaseChatModel) -> GrowPhaseResult:  # noqa: ARG002
         """Phase 8a: Create passage nodes from beats.
 
         Each beat gets exactly one passage node and a passage_from edge.
@@ -438,7 +722,7 @@ class GrowStage:
             detail=f"Created {passage_count} passages",
         )
 
-    def _phase_8b_codewords(self, graph: Graph) -> GrowPhaseResult:
+    async def _phase_8b_codewords(self, graph: Graph, model: BaseChatModel) -> GrowPhaseResult:  # noqa: ARG002
         """Phase 8b: Create codeword nodes from consequences.
 
         For each consequence, creates a codeword node with a tracks edge.
@@ -530,7 +814,7 @@ class GrowStage:
             detail=f"Created {codeword_count} codewords",
         )
 
-    def _phase_11_prune(self, graph: Graph) -> GrowPhaseResult:
+    async def _phase_11_prune(self, graph: Graph, model: BaseChatModel) -> GrowPhaseResult:  # noqa: ARG002
         """Phase 11: Prune unreachable passages.
 
         Uses arc membership to identify reachable passages.

--- a/tests/unit/test_grow_stage.py
+++ b/tests/unit/test_grow_stage.py
@@ -58,7 +58,7 @@ class TestGrowStageExecute:
         assert tokens == 0
         # All phases run to completion (empty graph = no work to do)
         phases = result_dict["phases_completed"]
-        assert len(phases) == 7
+        assert len(phases) == 8
         for phase in phases:
             assert phase["status"] == "completed"
 
@@ -99,16 +99,17 @@ class TestGrowStageExecute:
 
 
 class TestGrowStagePhaseOrder:
-    def test_phase_order_returns_seven_phases(self) -> None:
+    def test_phase_order_returns_eight_phases(self) -> None:
         stage = GrowStage()
         phases = stage._phase_order()
-        assert len(phases) == 7
+        assert len(phases) == 8
 
     def test_phase_order_names(self) -> None:
         stage = GrowStage()
         names = [name for _, name in stage._phase_order()]
         assert names == [
             "validate_dag",
+            "thread_agnostic",
             "enumerate_arcs",
             "divergence",
             "convergence",
@@ -182,7 +183,7 @@ class TestGrowStagePhaseFailed:
         stage = GrowStage(project_path=tmp_project)
 
         # Override a phase to return failed
-        def failing_phase(_graph: MagicMock) -> GrowPhaseResult:
+        async def failing_phase(_graph: MagicMock, _model: MagicMock) -> GrowPhaseResult:
             return GrowPhaseResult(phase="validate_dag", status="failed", detail="cycle detected")
 
         stage._phase_1_validate_dag = failing_phase  # type: ignore[assignment]
@@ -205,3 +206,182 @@ class TestCreateGrowStage:
         gate = AsyncMock()
         stage = create_grow_stage(gate=gate)
         assert stage.gate is gate
+
+
+class TestPhase2ThreadAgnostic:
+    @pytest.mark.asyncio
+    async def test_phase_2_with_valid_assessments(self) -> None:
+        """Phase 2 with mocked LLM returns valid assessments and updates beats."""
+        from questfoundry.models.grow import Phase2Output, ThreadAgnosticAssessment
+        from tests.fixtures.grow_fixtures import make_single_tension_graph
+
+        graph = make_single_tension_graph()
+        stage = GrowStage()
+
+        # Mock model returns assessments for shared beats
+        phase2_output = Phase2Output(
+            assessments=[
+                ThreadAgnosticAssessment(
+                    beat_id="beat::opening",
+                    agnostic_for=["mentor_trust"],
+                ),
+                ThreadAgnosticAssessment(
+                    beat_id="beat::mentor_meet",
+                    agnostic_for=["mentor_trust"],
+                ),
+            ]
+        )
+
+        mock_structured = AsyncMock()
+        mock_structured.ainvoke = AsyncMock(return_value=phase2_output)
+        mock_model = MagicMock()
+        mock_model.with_structured_output = MagicMock(return_value=mock_structured)
+
+        result = await stage._phase_2_thread_agnostic(graph, mock_model)
+
+        assert result.status == "completed"
+        assert result.llm_calls == 1
+        assert "2 marked agnostic" in result.detail
+
+        # Verify beat nodes updated
+        beat_opening = graph.get_node("beat::opening")
+        assert beat_opening["thread_agnostic_for"] == ["mentor_trust"]
+        beat_meet = graph.get_node("beat::mentor_meet")
+        assert beat_meet["thread_agnostic_for"] == ["mentor_trust"]
+
+    @pytest.mark.asyncio
+    async def test_phase_2_skips_no_multi_thread_tensions(self) -> None:
+        """Phase 2 skips when no tensions have multiple threads."""
+        from questfoundry.graph.graph import Graph
+
+        graph = Graph.empty()
+        # Single tension with single thread
+        graph.create_node("tension::t1", {"type": "tension", "raw_id": "t1"})
+        graph.create_node(
+            "thread::th1",
+            {"type": "thread", "raw_id": "th1", "is_canonical": True},
+        )
+        graph.add_edge("explores", "thread::th1", "tension::t1")
+        graph.create_node("beat::b1", {"type": "beat", "raw_id": "b1", "summary": "test"})
+        graph.add_edge("belongs_to", "beat::b1", "thread::th1")
+
+        stage = GrowStage()
+        mock_model = MagicMock()
+        result = await stage._phase_2_thread_agnostic(graph, mock_model)
+
+        assert result.status == "completed"
+        assert "No multi-thread tensions" in result.detail
+        assert result.llm_calls == 0
+
+    @pytest.mark.asyncio
+    async def test_phase_2_filters_invalid_beat_ids(self) -> None:
+        """Phase 2 filters out assessments with invalid beat IDs."""
+        from questfoundry.models.grow import Phase2Output, ThreadAgnosticAssessment
+        from tests.fixtures.grow_fixtures import make_single_tension_graph
+
+        graph = make_single_tension_graph()
+        stage = GrowStage()
+
+        # Mock returns one valid and one invalid assessment
+        phase2_output = Phase2Output(
+            assessments=[
+                ThreadAgnosticAssessment(
+                    beat_id="beat::opening",
+                    agnostic_for=["mentor_trust"],
+                ),
+                ThreadAgnosticAssessment(
+                    beat_id="beat::nonexistent",
+                    agnostic_for=["mentor_trust"],
+                ),
+            ]
+        )
+
+        mock_structured = AsyncMock()
+        mock_structured.ainvoke = AsyncMock(return_value=phase2_output)
+        mock_model = MagicMock()
+        mock_model.with_structured_output = MagicMock(return_value=mock_structured)
+
+        result = await stage._phase_2_thread_agnostic(graph, mock_model)
+
+        assert result.status == "completed"
+        # Only 1 valid assessment applied
+        assert "1 marked agnostic" in result.detail
+
+    @pytest.mark.asyncio
+    async def test_phase_2_empty_graph_skips(self) -> None:
+        """Phase 2 skips with empty graph."""
+        from questfoundry.graph.graph import Graph
+
+        graph = Graph.empty()
+        stage = GrowStage()
+        mock_model = MagicMock()
+        result = await stage._phase_2_thread_agnostic(graph, mock_model)
+
+        assert result.status == "completed"
+        assert result.llm_calls == 0
+
+
+class TestGrowLlmCall:
+    @pytest.mark.asyncio
+    async def test_retry_on_validation_failure(self) -> None:
+        """_grow_llm_call retries on validation failure."""
+
+        from questfoundry.models.grow import Phase2Output, ThreadAgnosticAssessment
+
+        stage = GrowStage()
+
+        # First call returns invalid data (assessments must be a list, not a string)
+        valid_output = Phase2Output(
+            assessments=[ThreadAgnosticAssessment(beat_id="beat::a", agnostic_for=["t1"])]
+        )
+        mock_structured = AsyncMock()
+        mock_structured.ainvoke = AsyncMock(
+            side_effect=[
+                {"assessments": "not_a_list"},  # First call: invalid type
+                valid_output,  # Second call: valid
+            ]
+        )
+
+        mock_model = MagicMock()
+        mock_model.with_structured_output = MagicMock(return_value=mock_structured)
+
+        result, llm_calls, _tokens = await stage._grow_llm_call(
+            model=mock_model,
+            template_name="grow_phase2_agnostic",
+            context={
+                "beat_summaries": "test",
+                "valid_beat_ids": "beat::a",
+                "valid_tension_ids": "t1",
+            },
+            output_schema=Phase2Output,
+        )
+
+        assert isinstance(result, Phase2Output)
+        assert llm_calls == 2  # Retried once
+
+    @pytest.mark.asyncio
+    async def test_raises_after_max_retries(self) -> None:
+        """_grow_llm_call raises GrowStageError after max retries."""
+        from questfoundry.models.grow import Phase2Output
+        from questfoundry.pipeline.stages.grow import GrowStageError
+
+        stage = GrowStage()
+
+        # All calls return data with invalid type for assessments field
+        mock_structured = AsyncMock()
+        mock_structured.ainvoke = AsyncMock(return_value={"assessments": "not_a_list"})
+
+        mock_model = MagicMock()
+        mock_model.with_structured_output = MagicMock(return_value=mock_structured)
+
+        with pytest.raises(GrowStageError, match="failed after 3 attempts"):
+            await stage._grow_llm_call(
+                model=mock_model,
+                template_name="grow_phase2_agnostic",
+                context={
+                    "beat_summaries": "test",
+                    "valid_beat_ids": "beat::a",
+                    "valid_tension_ids": "t1",
+                },
+                output_schema=Phase2Output,
+            )


### PR DESCRIPTION
## Problem

GROW phases 2-9 require LLM calls for tasks like thread-agnostic assessment, knot detection, and gap analysis. The existing GROW stage only supports deterministic phases with synchronous `(Graph) -> GrowPhaseResult` signatures and has no LLM calling infrastructure.

Closes #259

## Changes

- **Phase signature refactor**: All phase functions now use `async (Graph, BaseChatModel) -> GrowPhaseResult`; execute loop awaits phases and tracks LLM calls/tokens
- **`_grow_llm_call()` helper**: Shared method handling prompt template loading, structured output via `with_structured_output()`, Pydantic validation, and retry with error feedback (max 3 attempts)
- **Phase 2 implementation**: Thread-agnostic assessment — identifies beats whose prose reads the same regardless of which thread path the reader is on. Collects multi-thread tensions, calls LLM for prose-compatibility evaluation, validates IDs against graph, updates beat nodes with `thread_agnostic_for` field
- **`Phase2Output` model**: Wrapper for structured LLM output; extends `GrowPhaseResult` with `llm_calls`/`tokens_used` fields; extends `GrowResult` with `choice_count`/`overlay_count` for future phases
- **Prompt template**: `grow_phase2_agnostic.yaml` with thread-agnostic concept explanation, good/bad examples, and valid ID injection
- **Test updates**: Converted existing phase tests to async, added Phase 2 tests (valid assessments, skip conditions, ID filtering), added `_grow_llm_call` retry tests

## Not Included / Future PRs

- Phase 3 Knot Detection (#260) — next in stack
- Phases 4a-4c Gap Detection (#261)
- Phase 8c Entity Overlay Creation (#262)
- Phase 9 Choice Derivation (#263)

## Test Plan

```bash
uv run pytest tests/unit/test_grow_stage.py tests/unit/test_grow_algorithms.py -q
# 101 passed in 0.44s

uv run ruff check src/ tests/
# All passed

uv run pytest tests/unit/ -q
# 1071 passed
```

## Risk / Rollback

- Phase signature change is breaking for any external code calling phase methods directly (internal only, no public API)
- LLM retry logic uses max 3 attempts — configurable per-call via `max_retries` parameter
- No backwards-compatibility concerns: deterministic phases still work unchanged (ignore model param)

## Review Guide

Suggested review order:
1. `src/questfoundry/models/grow.py` — small schema additions
2. `prompts/templates/grow_phase2_agnostic.yaml` — prompt template
3. `src/questfoundry/pipeline/stages/grow.py` — core implementation (signature change → helper → Phase 2)
4. `tests/unit/test_grow_stage.py` — Phase 2 and helper tests
5. `tests/unit/test_grow_algorithms.py` — async conversion of existing tests