### PR TITLE
feat(grow): implement Phase 3 knot detection (#260)

### DIFF
--- a/prompts/templates/grow_phase3_knots.yaml
+++ b/prompts/templates/grow_phase3_knots.yaml
@@ -1,0 +1,46 @@
+name: grow_phase3_knots
+description: Cluster beats from different tensions into knot scenes
+
+system: |
+  You are analyzing story beats to find "knots" — scenes where multiple
+  narrative tensions intersect in the same location or moment.
+
+  ## What is a Knot?
+  A knot occurs when beats from DIFFERENT tensions naturally occur in the
+  same scene. For example:
+  - The hero meets the mentor (mentor_trust tension) at the market where
+    the artifact is displayed (artifact_quest tension) → these beats form a knot.
+
+  ## Clustering Rules
+  1. Each knot must contain beats from at least 2 DIFFERENT tensions
+  2. Beats in a knot should share a plausible location or moment
+  3. Prefer location overlap as the strongest signal for clustering
+  4. Entity overlap (same character in both beats) is a secondary signal
+  5. A beat can only appear in ONE knot proposal
+
+  ## What NOT to Do
+  - Do NOT group beats from the same tension (those are alternatives, not knots)
+  - Do NOT propose knots with only 1 beat
+  - Do NOT use beat IDs not listed in the Valid IDs section
+  - Do NOT force knots where there is no natural scene overlap
+
+  ## Candidate Beats
+  {beat_summaries}
+
+  ## Valid IDs
+  Valid beat_ids (use ONLY these): {valid_beat_ids}
+  Total candidates: {candidate_count}
+
+  ## Output Format
+  Return a JSON object with a "knots" array. Each knot has:
+  - beat_ids: list of beat IDs that form the knot (minimum 2)
+  - resolved_location: the location where this combined scene takes place (or null)
+  - rationale: brief explanation of why these beats form a natural scene
+
+  Only propose knots where the beats genuinely share a scene context.
+  If no natural knots exist, return an empty knots array.
+
+user: |
+  Analyze the candidate beats above and propose knot groupings.
+
+components: []

--- a/prompts/templates/grow_phase3_knots.yaml
+++ b/prompts/templates/grow_phase3_knots.yaml
@@ -2,27 +2,29 @@ name: grow_phase3_knots
 description: Cluster beats from different tensions into knot scenes
 
 system: |
-  You are analyzing story beats to find "knots" — scenes where multiple
+  You are analyzing story beats to find "knots" -- scenes where multiple
   narrative tensions intersect in the same location or moment.
 
   ## What is a Knot?
   A knot occurs when beats from DIFFERENT tensions naturally occur in the
   same scene. For example:
   - The hero meets the mentor (mentor_trust tension) at the market where
-    the artifact is displayed (artifact_quest tension) → these beats form a knot.
+    the artifact is displayed (artifact_quest tension). These beats form a knot.
 
   ## Clustering Rules
   1. Each knot must contain beats from at least 2 DIFFERENT tensions
   2. Beats in a knot should share a plausible location or moment
   3. Prefer location overlap as the strongest signal for clustering
   4. Entity overlap (same character in both beats) is a secondary signal
-  5. A beat can only appear in ONE knot proposal
+  5. CRITICAL: Each beat can appear in at most ONE knot. Never assign the
+     same beat to multiple knots.
 
   ## What NOT to Do
   - Do NOT group beats from the same tension (those are alternatives, not knots)
   - Do NOT propose knots with only 1 beat
   - Do NOT use beat IDs not listed in the Valid IDs section
   - Do NOT force knots where there is no natural scene overlap
+  - Do NOT reuse a beat ID across multiple knot proposals
 
   ## Candidate Beats
   {beat_summaries}
@@ -35,7 +37,8 @@ system: |
   Return a JSON object with a "knots" array. Each knot has:
   - beat_ids: list of beat IDs that form the knot (minimum 2)
   - resolved_location: the location where this combined scene takes place (or null)
-  - rationale: brief explanation of why these beats form a natural scene
+  - rationale: a concise sentence explaining why these beats form a natural scene
+    (e.g., "Both beats occur at the market and involve the hero interacting with key NPCs")
 
   Only propose knots where the beats genuinely share a scene context.
   If no natural knots exist, return an empty knots array.

--- a/src/questfoundry/models/__init__.py
+++ b/src/questfoundry/models/__init__.py
@@ -33,6 +33,7 @@ from questfoundry.models.grow import (
     OverlayProposal,
     Passage,
     Phase2Output,
+    Phase3Output,
     SceneTypeTag,
     ThreadAgnosticAssessment,
 )
@@ -74,6 +75,7 @@ __all__ = [
     "OverlayProposal",
     "Passage",
     "Phase2Output",
+    "Phase3Output",
     "SceneTypeTag",
     "Scope",
     "SeedOutput",

--- a/src/questfoundry/models/grow.py
+++ b/src/questfoundry/models/grow.py
@@ -107,6 +107,13 @@ class KnotProposal(BaseModel):
 
     beat_ids: list[str] = Field(min_length=2)
     resolved_location: str | None = None
+    rationale: str = ""
+
+
+class Phase3Output(BaseModel):
+    """Wrapper for Phase 3 structured output (knot proposals)."""
+
+    knots: list[KnotProposal] = Field(default_factory=list)
 
 
 class SceneTypeTag(BaseModel):

--- a/src/questfoundry/models/grow.py
+++ b/src/questfoundry/models/grow.py
@@ -107,7 +107,7 @@ class KnotProposal(BaseModel):
 
     beat_ids: list[str] = Field(min_length=2)
     resolved_location: str | None = None
-    rationale: str = ""
+    rationale: str = Field(min_length=1)
 
 
 class Phase3Output(BaseModel):

--- a/src/questfoundry/pipeline/stages/grow.py
+++ b/src/questfoundry/pipeline/stages/grow.py
@@ -106,6 +106,7 @@ class GrowStage:
         return [
             (self._phase_1_validate_dag, "validate_dag"),
             (self._phase_2_thread_agnostic, "thread_agnostic"),
+            (self._phase_3_knots, "knots"),
             (self._phase_5_enumerate_arcs, "enumerate_arcs"),
             (self._phase_6_divergence, "divergence"),
             (self._phase_7_convergence, "convergence"),
@@ -485,6 +486,129 @@ class GrowStage:
             phase="thread_agnostic",
             status="completed",
             detail=f"Assessed {len(candidate_beats)} beats, {agnostic_count} marked agnostic",
+            llm_calls=llm_calls,
+            tokens_used=tokens,
+        )
+
+    async def _phase_3_knots(self, graph: Graph, model: BaseChatModel) -> GrowPhaseResult:
+        """Phase 3: Knot detection.
+
+        Clusters beats from different threads (different tensions) into
+        scenes where multiple tensions intersect. Uses LLM to propose
+        knots, then validates with deterministic compatibility checks.
+
+        A knot is valid when:
+        - Beats are from different tensions
+        - No requires conflicts between the beats
+        - Location is resolvable (shared location exists)
+        """
+        from questfoundry.graph.grow_algorithms import (
+            apply_knot_mark,
+            build_knot_candidates,
+            check_knot_compatibility,
+            resolve_knot_location,
+        )
+        from questfoundry.models.grow import Phase3Output
+
+        # Build candidate pool
+        candidates = build_knot_candidates(graph)
+        if not candidates:
+            return GrowPhaseResult(
+                phase="knots",
+                status="completed",
+                detail="No knot candidates found (no beats share signals across tensions)",
+            )
+
+        # Build context for LLM
+        beat_nodes = graph.get_nodes_by_type("beat")
+        beat_summaries: list[str] = []
+        valid_beat_ids: set[str] = set()
+
+        for candidate in candidates:
+            for bid in candidate.beat_ids:
+                valid_beat_ids.add(bid)
+                data = beat_nodes.get(bid, {})
+                location = data.get("location", "unspecified")
+                alternatives = data.get("location_alternatives", [])
+                summary = data.get("summary", "")
+                entities = data.get("entities", [])
+                beat_summaries.append(
+                    f'- {bid}: summary="{summary}", '
+                    f'location="{location}", '
+                    f"location_alternatives={alternatives}, "
+                    f"entities={entities}, "
+                    f"signal={candidate.signal_type}({candidate.shared_value})"
+                )
+
+        valid_beat_ids_list = sorted(valid_beat_ids)
+
+        context = {
+            "beat_summaries": "\n".join(beat_summaries),
+            "valid_beat_ids": ", ".join(valid_beat_ids_list),
+            "candidate_count": str(len(valid_beat_ids_list)),
+        }
+
+        # Call LLM for knot proposals
+        try:
+            result, llm_calls, tokens = await self._grow_llm_call(
+                model=model,
+                template_name="grow_phase3_knots",
+                context=context,
+                output_schema=Phase3Output,
+            )
+        except GrowStageError as e:
+            return GrowPhaseResult(
+                phase="knots",
+                status="failed",
+                detail=str(e),
+            )
+
+        # Validate and apply knots
+        applied_count = 0
+        skipped_count = 0
+
+        for proposal in result.knots:
+            # Filter to valid beat IDs
+            valid_ids = [bid for bid in proposal.beat_ids if bid in beat_nodes]
+            if len(valid_ids) < 2:
+                log.warning(
+                    "phase3_insufficient_valid_beats",
+                    proposed=proposal.beat_ids,
+                    valid=valid_ids,
+                )
+                skipped_count += 1
+                continue
+
+            # Run compatibility check
+            errors = check_knot_compatibility(graph, valid_ids)
+            if errors:
+                log.warning(
+                    "phase3_incompatible_knot",
+                    beat_ids=valid_ids,
+                    errors=[e.issue for e in errors],
+                )
+                skipped_count += 1
+                continue
+
+            # Resolve location
+            location = proposal.resolved_location or resolve_knot_location(graph, valid_ids)
+
+            # Apply the knot
+            apply_knot_mark(graph, valid_ids, location)
+            applied_count += 1
+            log.debug(
+                "phase3_knot_applied",
+                beat_ids=valid_ids,
+                location=location,
+            )
+
+        return GrowPhaseResult(
+            phase="knots",
+            status="completed",
+            detail=(
+                f"Proposed {len(result.knots)} knots: "
+                f"{applied_count} applied, {skipped_count} skipped"
+            ),
             llm_calls=llm_calls,
             tokens_used=tokens,
         )

--- a/tests/fixtures/grow_fixtures.py
+++ b/tests/fixtures/grow_fixtures.py
@@ -366,3 +366,34 @@ def make_two_tension_graph() -> Graph:
         graph.add_edge("has_consequence", f"thread::{thread_id}", f"consequence::{cons_id}")
 
     return graph
+
+
+def make_knot_candidate_graph() -> Graph:
+    """Create a graph with beats from different tensions that share locations.
+
+    Structure:
+        tension: mentor_trust (2 threads)
+        tension: artifact_quest (2 threads)
+
+    Key beats for knot testing:
+        beat::mentor_meet: location="market", mentor_trust threads
+        beat::artifact_discover: location="docks", location_alternatives=["market"],
+                                 artifact_quest threads
+
+    These beats share "market" as a location signal and are from different
+    tensions, making them valid knot candidates.
+
+    Returns:
+        Graph with location-overlap knot candidates.
+    """
+    graph = make_two_tension_graph()
+
+    # Add location data to some beats for knot detection
+    graph.update_node("beat::mentor_meet", location="market")
+    graph.update_node(
+        "beat::artifact_discover",
+        location="docks",
+        location_alternatives=["market"],
+    )
+
+    return graph

--- a/tests/unit/test_grow_algorithms.py
+++ b/tests/unit/test_grow_algorithms.py
@@ -1163,7 +1163,7 @@ class TestCheckKnotCompatibility:
             graph, ["beat::mentor_commits_canonical", "beat::mentor_commits_alt"]
         )
         assert len(errors) > 0
-        assert any("same tension" in e.issue for e in errors)
+        assert any("at least 2 different tensions" in e.issue for e in errors)
 
     def test_incompatible_requires_conflict(self) -> None:
         """Beats with requires edge are incompatible."""

--- a/tests/unit/test_grow_models.py
+++ b/tests/unit/test_grow_models.py
@@ -196,9 +196,11 @@ class TestKnotProposal:
         knot = KnotProposal(
             beat_ids=["beat_1", "beat_2", "beat_3"],
             resolved_location="beat_4",
+            rationale="Shared location signal",
         )
         assert len(knot.beat_ids) == 3
         assert knot.resolved_location == "beat_4"
+        assert knot.rationale == "Shared location signal"
 
     def test_single_beat_rejected(self) -> None:
         with pytest.raises(ValidationError, match="beat_ids"):
@@ -209,7 +211,7 @@ class TestKnotProposal:
             KnotProposal(beat_ids=[])
 
     def test_no_resolved_location_allowed(self) -> None:
-        knot = KnotProposal(beat_ids=["b1", "b2"])
+        knot = KnotProposal(beat_ids=["b1", "b2"], rationale="Entity overlap")
         assert knot.resolved_location is None
 
 

--- a/tests/unit/test_grow_stage.py
+++ b/tests/unit/test_grow_stage.py
@@ -458,6 +458,7 @@ class TestPhase3Knots:
                 KnotProposal(
                     beat_ids=["beat::mentor_commits_canonical", "beat::mentor_commits_alt"],
                     resolved_location="market",
+                    rationale="Same tension beats",
                 ),
             ]
         )
@@ -487,6 +488,7 @@ class TestPhase3Knots:
                 KnotProposal(
                     beat_ids=["beat::nonexistent_a", "beat::nonexistent_b"],
                     resolved_location="market",
+                    rationale="Nonexistent beats",
                 ),
             ]
         )
@@ -520,6 +522,7 @@ class TestPhase3Knots:
                 KnotProposal(
                     beat_ids=["beat::mentor_meet", "beat::artifact_discover"],
                     resolved_location="market",
+                    rationale="Requires dependency between these beats",
                 ),
             ]
         )

--- a/tests/unit/test_grow_stage.py
+++ b/tests/unit/test_grow_stage.py
@@ -58,7 +58,7 @@ class TestGrowStageExecute:
         assert tokens == 0
         # All phases run to completion (empty graph = no work to do)
         phases = result_dict["phases_completed"]
-        assert len(phases) == 8
+        assert len(phases) == 9
         for phase in phases:
             assert phase["status"] == "completed"
 
@@ -99,10 +99,10 @@ class TestGrowStageExecute:
 
 
 class TestGrowStagePhaseOrder:
-    def test_phase_order_returns_eight_phases(self) -> None:
+    def test_phase_order_returns_nine_phases(self) -> None:
         stage = GrowStage()
         phases = stage._phase_order()
-        assert len(phases) == 8
+        assert len(phases) == 9
 
     def test_phase_order_names(self) -> None:
         stage = GrowStage()
@@ -110,6 +110,7 @@ class TestGrowStagePhaseOrder:
         assert names == [
             "validate_dag",
             "thread_agnostic",
+            "knots",
             "enumerate_arcs",
             "divergence",
             "convergence",
@@ -385,3 +386,151 @@ class TestGrowLlmCall:
                 },
                 output_schema=Phase2Output,
             )
+
+
+class TestPhase3Knots:
+    @pytest.mark.asyncio
+    async def test_phase_3_with_valid_proposals(self) -> None:
+        """Phase 3 with mocked LLM returns valid knot proposals."""
+        from questfoundry.models.grow import KnotProposal, Phase3Output
+        from tests.fixtures.grow_fixtures import make_knot_candidate_graph
+
+        graph = make_knot_candidate_graph()
+        stage = GrowStage()
+
+        # Mock model returns a knot grouping the two location-overlapping beats
+        phase3_output = Phase3Output(
+            knots=[
+                KnotProposal(
+                    beat_ids=["beat::mentor_meet", "beat::artifact_discover"],
+                    resolved_location="market",
+                    rationale="Both beats share the market location",
+                ),
+            ]
+        )
+
+        mock_structured = AsyncMock()
+        mock_structured.ainvoke = AsyncMock(return_value=phase3_output)
+        mock_model = MagicMock()
+        mock_model.with_structured_output = MagicMock(return_value=mock_structured)
+
+        result = await stage._phase_3_knots(graph, mock_model)
+
+        assert result.status == "completed"
+        assert result.llm_calls == 1
+        assert "1 applied" in result.detail
+
+        # Verify knot was applied
+        mentor_beat = graph.get_node("beat::mentor_meet")
+        assert mentor_beat["knot_group"] == ["beat::artifact_discover"]
+        assert mentor_beat["location"] == "market"
+
+        artifact_beat = graph.get_node("beat::artifact_discover")
+        assert artifact_beat["knot_group"] == ["beat::mentor_meet"]
+        assert artifact_beat["location"] == "market"
+
+    @pytest.mark.asyncio
+    async def test_phase_3_skips_no_candidates(self) -> None:
+        """Phase 3 skips when no knot candidates found."""
+        from questfoundry.graph.graph import Graph
+
+        graph = Graph.empty()
+        stage = GrowStage()
+        mock_model = MagicMock()
+        result = await stage._phase_3_knots(graph, mock_model)
+
+        assert result.status == "completed"
+        assert "No knot candidates" in result.detail
+        assert result.llm_calls == 0
+
+    @pytest.mark.asyncio
+    async def test_phase_3_skips_incompatible_knots(self) -> None:
+        """Phase 3 skips knots that fail compatibility check."""
+        from questfoundry.models.grow import KnotProposal, Phase3Output
+        from tests.fixtures.grow_fixtures import make_knot_candidate_graph
+
+        graph = make_knot_candidate_graph()
+        stage = GrowStage()
+
+        # Propose a knot with beats from the SAME tension (invalid)
+        phase3_output = Phase3Output(
+            knots=[
+                KnotProposal(
+                    beat_ids=["beat::mentor_commits_canonical", "beat::mentor_commits_alt"],
+                    resolved_location="market",
+                ),
+            ]
+        )
+
+        mock_structured = AsyncMock()
+        mock_structured.ainvoke = AsyncMock(return_value=phase3_output)
+        mock_model = MagicMock()
+        mock_model.with_structured_output = MagicMock(return_value=mock_structured)
+
+        result = await stage._phase_3_knots(graph, mock_model)
+
+        assert result.status == "completed"
+        assert "0 applied" in result.detail
+        assert "1 skipped" in result.detail
+
+    @pytest.mark.asyncio
+    async def test_phase_3_filters_invalid_beat_ids(self) -> None:
+        """Phase 3 skips proposals with nonexistent beat IDs."""
+        from questfoundry.models.grow import KnotProposal, Phase3Output
+        from tests.fixtures.grow_fixtures import make_knot_candidate_graph
+
+        graph = make_knot_candidate_graph()
+        stage = GrowStage()
+
+        phase3_output = Phase3Output(
+            knots=[
+                KnotProposal(
+                    beat_ids=["beat::nonexistent_a", "beat::nonexistent_b"],
+                    resolved_location="market",
+                ),
+            ]
+        )
+
+        mock_structured = AsyncMock()
+        mock_structured.ainvoke = AsyncMock(return_value=phase3_output)
+        mock_model = MagicMock()
+        mock_model.with_structured_output = MagicMock(return_value=mock_structured)
+
+        result = await stage._phase_3_knots(graph, mock_model)
+
+        assert result.status == "completed"
+        assert "0 applied" in result.detail
+
+    @pytest.mark.asyncio
+    async def test_phase_3_skips_requires_conflict(self) -> None:
+        """Phase 3 skips knots where beats have requires dependency."""
+        from questfoundry.models.grow import KnotProposal, Phase3Output
+        from tests.fixtures.grow_fixtures import make_knot_candidate_graph
+
+        graph = make_knot_candidate_graph()
+        stage = GrowStage()
+
+        # opening requires mentor_meet — these have a requires dependency
+        # But they're also from different tensions in this graph.
+        # Add a cross-tension requires to test: artifact_discover requires mentor_meet
+        graph.add_edge("requires", "beat::artifact_discover", "beat::mentor_meet")
+
+        phase3_output = Phase3Output(
+            knots=[
+                KnotProposal(
+                    beat_ids=["beat::mentor_meet", "beat::artifact_discover"],
+                    resolved_location="market",
+                ),
+            ]
+        )
+
+        mock_structured = AsyncMock()
+        mock_structured.ainvoke = AsyncMock(return_value=phase3_output)
+        mock_model = MagicMock()
+        mock_model.with_structured_output = MagicMock(return_value=mock_structured)
+
+        result = await stage._phase_3_knots(graph, mock_model)
+
+        assert result.status == "completed"
+        assert "0 applied" in result.detail
+        assert "1 skipped" in result.detail


### PR DESCRIPTION
## Problem
GROW Phase 3 needs to detect "knots" — scenes where beats from different narrative tensions naturally intersect at the same location or moment. This enables richer, interleaved storytelling where multiple plot lines converge.

Closes #260

## Changes
- Add `Phase3Output` model and `rationale` field to `KnotProposal` in models/grow.py
- Add knot algorithms to grow_algorithms.py:
  - `build_knot_candidates()`: finds beats sharing location/entity signals across tensions
  - `check_knot_compatibility()`: validates proposals (different tensions, no DAG conflicts)
  - `resolve_knot_location()`: finds shared location for knot beats
  - `apply_knot_mark()`: marks beats as belonging to same scene with cross-thread edges
- Implement `_phase_3_knots()` in GrowStage with LLM-based proposal generation
- Add `grow_phase3_knots.yaml` prompt template with clustering rules and defensive patterns
- Add `make_knot_candidate_graph()` test fixture with location-overlap signals
- Add 17 new unit tests covering algorithms and Phase 3 integration

## Not Included / Future PRs
- Phases 4a-4c gap detection (#261)
- Phase 8c entity overlay creation (#262)
- Phase 9 choice derivation (#263)

## Test Plan
```bash
uv run pytest tests/unit/test_grow_algorithms.py tests/unit/test_grow_stage.py -q
# 122 passed

uv run mypy src/questfoundry/graph/grow_algorithms.py src/questfoundry/pipeline/stages/grow.py src/questfoundry/models/grow.py
# Success: no issues found in 3 source files

uv run ruff check src/ tests/
# All checks passed
```

## Risk / Rollback
- No breaking changes to existing phases; Phase 3 is additive
- Knot detection is skipped when no multi-tension candidates exist
- Invalid LLM proposals are filtered by deterministic compatibility checks

## Review Guide
Suggested review order:
1. `src/questfoundry/models/grow.py` — Phase3Output model (small)
2. `src/questfoundry/graph/grow_algorithms.py` — Core algorithms
3. `prompts/templates/grow_phase3_knots.yaml` — Prompt template
4. `src/questfoundry/pipeline/stages/grow.py` — Phase 3 integration
5. Tests (fixtures, algorithms, stage)

🤖 Generated with [Claude Code](https://claude.com/claude-code)