### PR TITLE
feat(grow): implement Phases 4a-4c gap detection (#261)

### DIFF
--- a/prompts/templates/grow_phase4a_scene_types.yaml
+++ b/prompts/templates/grow_phase4a_scene_types.yaml
@@ -1,0 +1,39 @@
+name: grow_phase4a_scene_types
+description: Classify beats as scene, sequel, or micro_beat
+
+system: |
+  You are classifying story beats by their narrative function.
+
+  ## Scene Types
+  - **scene**: Active conflict, action, confrontation, or decision moment.
+    The protagonist faces opposition or makes a critical choice.
+  - **sequel**: Reaction, reflection, or processing. The protagonist
+    absorbs what happened and considers next steps.
+  - **micro_beat**: Brief transitional moment (travel, time skip, minor
+    observation) that connects larger beats without standalone drama.
+
+  ## Classification Guidelines
+  1. Beats with tension_impacts (commits/escalates) are almost always scenes
+  2. Opening/setup beats are typically scenes (they introduce conflict)
+  3. Beats after major decisions are often sequels (processing the choice)
+  4. Short connecting beats with no named characters acting are micro_beats
+  5. When in doubt between scene and sequel, prefer scene
+
+  ## Beats to Classify
+  {beat_summaries}
+
+  ## Valid IDs
+  Valid beat_ids (use ONLY these): {valid_beat_ids}
+  Total beats: {beat_count}
+
+  ## Output Format
+  Return a JSON object with a "tags" array. Each tag has:
+  - beat_id: the beat ID being classified
+  - scene_type: one of "scene", "sequel", or "micro_beat"
+
+  Classify ALL beats listed above. Every beat must get exactly one tag.
+
+user: |
+  Classify each beat above by its narrative function.
+
+components: []

--- a/prompts/templates/grow_phase4a_scene_types.yaml
+++ b/prompts/templates/grow_phase4a_scene_types.yaml
@@ -22,6 +22,11 @@ system: |
   ## Beats to Classify
   {beat_summaries}
 
+  ## What NOT to Do
+  - Do NOT use IDs not listed in the Valid IDs section
+  - Do NOT leave any beat unclassified
+  - Do NOT add explanatory prose before or after the JSON output
+
   ## Valid IDs
   Valid beat_ids (use ONLY these): {valid_beat_ids}
   Total beats: {beat_count}

--- a/prompts/templates/grow_phase4a_scene_types.yaml
+++ b/prompts/templates/grow_phase4a_scene_types.yaml
@@ -13,9 +13,9 @@ system: |
     observation) that connects larger beats without standalone drama.
 
   ## Classification Guidelines
-  1. Beats with tension_impacts (commits/escalates) are almost always scenes
-  2. Opening/setup beats are typically scenes (they introduce conflict)
-  3. Beats after major decisions are often sequels (processing the choice)
+  1. Beats with tension_impacts (commits/escalates) are scenes — they drive conflict forward
+  2. Opening/setup beats are scenes (they introduce conflict or establish stakes)
+  3. Beats after major decisions are sequels (processing the choice, emotional reaction)
   4. Short connecting beats with no named characters acting are micro_beats
   5. When in doubt between scene and sequel, prefer scene
 

--- a/prompts/templates/grow_phase4b_narrative_gaps.yaml
+++ b/prompts/templates/grow_phase4b_narrative_gaps.yaml
@@ -29,6 +29,7 @@ system: |
   - Do NOT propose gaps between beats that already flow naturally
   - Do NOT use IDs not listed in the Valid IDs section
   - Do NOT propose more than 2 gap beats per thread
+  - Do NOT add explanatory prose before or after the JSON output
 
   ## Valid IDs
   Valid thread_ids: {valid_thread_ids}

--- a/prompts/templates/grow_phase4b_narrative_gaps.yaml
+++ b/prompts/templates/grow_phase4b_narrative_gaps.yaml
@@ -18,7 +18,9 @@ system: |
   ## Gap Detection Rules
   1. Look for jumps in narrative intensity (setup to climax with nothing between)
   2. Look for missing emotional transitions (big decision to next action without reflection)
-  3. Propose gap beats that are sequel type unless the gap needs action
+  3. Default to sequel type for gap beats. Use scene type only when the gap
+     requires a concrete action to bridge (e.g., a character must physically
+     travel or make a visible choice to connect the surrounding beats)
   4. Each gap beat must specify where it goes (after_beat and/or before_beat)
   5. Gap beats should be concise transitions, not major story events
 

--- a/prompts/templates/grow_phase4b_narrative_gaps.yaml
+++ b/prompts/templates/grow_phase4b_narrative_gaps.yaml
@@ -1,0 +1,48 @@
+name: grow_phase4b_narrative_gaps
+description: Identify missing beats in thread sequences
+
+system: |
+  You are analyzing thread beat sequences to find narrative gaps --
+  places where the story jumps too abruptly between beats.
+
+  ## What is a Narrative Gap?
+  A gap occurs when a thread's beat sequence lacks a natural transition.
+  For example:
+  - Setup directly to climax (missing development/escalation)
+  - Decision directly to consequence (missing reaction/processing)
+  - Introduction directly to commitment (missing exploration)
+
+  ## Thread Sequences (in execution order)
+  {thread_sequences}
+
+  ## Gap Detection Rules
+  1. Look for jumps in narrative intensity (setup to climax with nothing between)
+  2. Look for missing emotional transitions (big decision to next action without reflection)
+  3. Propose gap beats that are sequel type unless the gap needs action
+  4. Each gap beat must specify where it goes (after_beat and/or before_beat)
+  5. Gap beats should be concise transitions, not major story events
+
+  ## What NOT to Do
+  - Do NOT propose gaps for threads with only 1-2 beats (those are minimal by design)
+  - Do NOT propose gaps between beats that already flow naturally
+  - Do NOT use IDs not listed in the Valid IDs section
+  - Do NOT propose more than 2 gap beats per thread
+
+  ## Valid IDs
+  Valid thread_ids: {valid_thread_ids}
+  Valid beat_ids (for after_beat/before_beat): {valid_beat_ids}
+
+  ## Output Format
+  Return a JSON object with a "gaps" array. Each gap has:
+  - thread_id: the thread this gap belongs to (use prefixed form, e.g., "thread::name")
+  - after_beat: the beat this gap comes after (or null for start of thread)
+  - before_beat: the beat this gap comes before (or null for end of thread)
+  - summary: a concise description of the gap beat (1 sentence)
+  - scene_type: "scene", "sequel", or "micro_beat" (default: "sequel")
+
+  If no gaps are needed, return an empty gaps array.
+
+user: |
+  Analyze the thread sequences above and propose gap beats where needed.
+
+components: []

--- a/prompts/templates/grow_phase4c_pacing_gaps.yaml
+++ b/prompts/templates/grow_phase4c_pacing_gaps.yaml
@@ -26,6 +26,7 @@ system: |
   - Do NOT propose correction beats of the SAME type as the issue
   - Do NOT use IDs not listed in the Valid IDs section
   - Do NOT insert more than 2 correction beats per issue
+  - Do NOT add explanatory prose before or after the JSON output
 
   ## Valid IDs
   Valid thread_ids: {valid_thread_ids}

--- a/prompts/templates/grow_phase4c_pacing_gaps.yaml
+++ b/prompts/templates/grow_phase4c_pacing_gaps.yaml
@@ -1,0 +1,48 @@
+name: grow_phase4c_pacing_gaps
+description: Fix pacing issues with correction beats
+
+system: |
+  You are fixing pacing issues in story threads. Pacing problems occur
+  when 3 or more consecutive beats have the same scene type (all scenes,
+  all sequels, or all micro_beats).
+
+  ## Why This Matters
+  - 3+ scenes in a row feels exhausting (no breathing room)
+  - 3+ sequels in a row feels stagnant (no forward momentum)
+  - 3+ micro_beats in a row feels disconnected (no substance)
+
+  ## Detected Pacing Issues
+  {pacing_issues}
+
+  ## Correction Strategy
+  1. Insert a beat of a DIFFERENT type to break the monotony
+  2. For a run of scenes: insert a sequel (reflection moment) between two scenes
+  3. For a run of sequels: insert a scene (action/decision) to re-engage
+  4. For a run of micro_beats: insert a scene or sequel with substance
+  5. Place the correction beat where it makes the most narrative sense
+  6. One correction beat per issue is usually sufficient
+
+  ## What NOT to Do
+  - Do NOT propose correction beats of the SAME type as the issue
+  - Do NOT use IDs not listed in the Valid IDs section
+  - Do NOT insert more than 2 correction beats per issue
+
+  ## Valid IDs
+  Valid thread_ids: {valid_thread_ids}
+  Valid beat_ids: {valid_beat_ids}
+  Issues to fix: {issue_count}
+
+  ## Output Format
+  Return a JSON object with a "gaps" array. Each gap has:
+  - thread_id: the thread this correction belongs to (use prefixed form)
+  - after_beat: the beat this correction comes after
+  - before_beat: the beat this correction comes before
+  - summary: a concise description of the correction beat (1 sentence)
+  - scene_type: "scene", "sequel", or "micro_beat" (must differ from the issue type)
+
+  If the issues are acceptable, return an empty gaps array.
+
+user: |
+  Propose correction beats to fix the pacing issues described above.
+
+components: []

--- a/src/questfoundry/models/__init__.py
+++ b/src/questfoundry/models/__init__.py
@@ -34,6 +34,8 @@ from questfoundry.models.grow import (
     Passage,
     Phase2Output,
     Phase3Output,
+    Phase4aOutput,
+    Phase4bOutput,
     SceneTypeTag,
     ThreadAgnosticAssessment,
 )
@@ -76,6 +78,8 @@ __all__ = [
     "Passage",
     "Phase2Output",
     "Phase3Output",
+    "Phase4aOutput",
+    "Phase4bOutput",
     "SceneTypeTag",
     "Scope",
     "SeedOutput",

--- a/src/questfoundry/models/grow.py
+++ b/src/questfoundry/models/grow.py
@@ -123,14 +123,26 @@ class SceneTypeTag(BaseModel):
     scene_type: Literal["scene", "sequel", "micro_beat"]
 
 
+class Phase4aOutput(BaseModel):
+    """Wrapper for Phase 4a structured output (scene-type tags)."""
+
+    tags: list[SceneTypeTag] = Field(default_factory=list)
+
+
 class GapProposal(BaseModel):
-    """Phase 4b: Proposes new beats to fill structural gaps."""
+    """Phase 4b/4c: Proposes new beats to fill structural gaps."""
 
     thread_id: str = Field(min_length=1)
     after_beat: str | None = None
     before_beat: str | None = None
     summary: str = Field(min_length=1)
     scene_type: Literal["scene", "sequel", "micro_beat"] = "sequel"
+
+
+class Phase4bOutput(BaseModel):
+    """Wrapper for Phase 4b/4c structured output (gap proposals)."""
+
+    gaps: list[GapProposal] = Field(default_factory=list)
 
 
 class OverlayProposal(BaseModel):

--- a/src/questfoundry/pipeline/stages/grow.py
+++ b/src/questfoundry/pipeline/stages/grow.py
@@ -775,6 +775,22 @@ class GrowStage:
             if gap.before_beat and gap.before_beat not in valid_beat_ids:
                 log.warning("phase4b_invalid_before_beat", beat_id=gap.before_beat)
                 continue
+            # Validate ordering: after_beat must come before before_beat
+            if gap.after_beat and gap.before_beat:
+                sequence = get_thread_beat_sequence(graph, prefixed_tid)
+                try:
+                    after_idx = sequence.index(gap.after_beat)
+                    before_idx = sequence.index(gap.before_beat)
+                    if after_idx >= before_idx:
+                        log.warning(
+                            "phase4b_invalid_beat_order",
+                            after_beat=gap.after_beat,
+                            before_beat=gap.before_beat,
+                        )
+                        continue
+                except ValueError:
+                    log.warning("phase4b_beat_not_in_sequence", thread_id=gap.thread_id)
+                    continue
 
             insert_gap_beat(
                 graph,
@@ -803,6 +819,7 @@ class GrowStage:
         """
         from questfoundry.graph.grow_algorithms import (
             detect_pacing_issues,
+            get_thread_beat_sequence,
             insert_gap_beat,
         )
         from questfoundry.models.grow import Phase4bOutput
@@ -885,6 +902,22 @@ class GrowStage:
             if gap.before_beat and gap.before_beat not in beat_nodes:
                 log.warning("phase4c_invalid_before_beat", beat_id=gap.before_beat)
                 continue
+            # Validate ordering: after_beat must come before before_beat
+            if gap.after_beat and gap.before_beat:
+                sequence = get_thread_beat_sequence(graph, prefixed_tid)
+                try:
+                    after_idx = sequence.index(gap.after_beat)
+                    before_idx = sequence.index(gap.before_beat)
+                    if after_idx >= before_idx:
+                        log.warning(
+                            "phase4c_invalid_beat_order",
+                            after_beat=gap.after_beat,
+                            before_beat=gap.before_beat,
+                        )
+                        continue
+                except ValueError:
+                    log.warning("phase4c_beat_not_in_sequence", thread_id=gap.thread_id)
+                    continue
 
             insert_gap_beat(
                 graph,

--- a/src/questfoundry/pipeline/stages/grow.py
+++ b/src/questfoundry/pipeline/stages/grow.py
@@ -107,6 +107,9 @@ class GrowStage:
             (self._phase_1_validate_dag, "validate_dag"),
             (self._phase_2_thread_agnostic, "thread_agnostic"),
             (self._phase_3_knots, "knots"),
+            (self._phase_4a_scene_types, "scene_types"),
+            (self._phase_4b_narrative_gaps, "narrative_gaps"),
+            (self._phase_4c_pacing_gaps, "pacing_gaps"),
             (self._phase_5_enumerate_arcs, "enumerate_arcs"),
             (self._phase_6_divergence, "divergence"),
             (self._phase_7_convergence, "convergence"),
@@ -620,6 +623,283 @@ class GrowStage:
                 f"Proposed {len(result.knots)} knots: "
                 f"{applied_count} applied, {skipped_count} skipped"
             ),
+            llm_calls=llm_calls,
+            tokens_used=tokens,
+        )
+
+    async def _phase_4a_scene_types(self, graph: Graph, model: BaseChatModel) -> GrowPhaseResult:
+        """Phase 4a: Tag beats with scene type classification.
+
+        Asks the LLM to classify each beat as scene (active conflict/action),
+        sequel (reaction/reflection), or micro_beat (brief transition).
+        Updates beat nodes with scene_type field.
+        """
+        from questfoundry.models.grow import Phase4aOutput
+
+        beat_nodes = graph.get_nodes_by_type("beat")
+        if not beat_nodes:
+            return GrowPhaseResult(
+                phase="scene_types",
+                status="completed",
+                detail="No beats to classify",
+            )
+
+        # Build beat summaries with position context
+        beat_summaries: list[str] = []
+        for bid in sorted(beat_nodes.keys()):
+            data = beat_nodes[bid]
+            summary = data.get("summary", "")
+            threads = data.get("threads", [])
+            impacts = data.get("tension_impacts", [])
+            beat_summaries.append(
+                f'- {bid}: summary="{summary}", threads={threads}, tension_impacts={impacts}'
+            )
+
+        context = {
+            "beat_summaries": "\n".join(beat_summaries),
+            "valid_beat_ids": ", ".join(sorted(beat_nodes.keys())),
+            "beat_count": str(len(beat_nodes)),
+        }
+
+        try:
+            result, llm_calls, tokens = await self._grow_llm_call(
+                model=model,
+                template_name="grow_phase4a_scene_types",
+                context=context,
+                output_schema=Phase4aOutput,
+            )
+        except GrowStageError as e:
+            return GrowPhaseResult(
+                phase="scene_types",
+                status="failed",
+                detail=str(e),
+            )
+
+        # Validate and apply tags
+        applied = 0
+        for tag in result.tags:
+            if tag.beat_id not in beat_nodes:
+                log.warning("phase4a_invalid_beat_id", beat_id=tag.beat_id)
+                continue
+            graph.update_node(tag.beat_id, scene_type=tag.scene_type)
+            applied += 1
+
+        return GrowPhaseResult(
+            phase="scene_types",
+            status="completed",
+            detail=f"Tagged {applied}/{len(beat_nodes)} beats with scene types",
+            llm_calls=llm_calls,
+            tokens_used=tokens,
+        )
+
+    async def _phase_4b_narrative_gaps(self, graph: Graph, model: BaseChatModel) -> GrowPhaseResult:
+        """Phase 4b: Detect narrative gaps in thread beat sequences.
+
+        For each thread, traces the beat sequence and asks the LLM
+        to identify missing beats (e.g., a thread jumps from setup
+        to climax without a development beat). Inserts proposed gap
+        beats into the graph.
+        """
+        from questfoundry.graph.grow_algorithms import (
+            get_thread_beat_sequence,
+            insert_gap_beat,
+        )
+        from questfoundry.models.grow import Phase4bOutput
+
+        thread_nodes = graph.get_nodes_by_type("thread")
+        if not thread_nodes:
+            return GrowPhaseResult(
+                phase="narrative_gaps",
+                status="completed",
+                detail="No threads to check for gaps",
+            )
+
+        # Build thread sequences with summaries
+        thread_sequences: list[str] = []
+        valid_beat_ids: set[str] = set()
+        for tid in sorted(thread_nodes.keys()):
+            sequence = get_thread_beat_sequence(graph, tid)
+            if len(sequence) < 2:
+                continue
+            beat_list: list[str] = []
+            for bid in sequence:
+                node = graph.get_node(bid)
+                summary = node.get("summary", "") if node else ""
+                scene_type = node.get("scene_type", "untagged") if node else "untagged"
+                beat_list.append(f"    {bid} [{scene_type}]: {summary}")
+                valid_beat_ids.add(bid)
+            raw_tid = thread_nodes[tid].get("raw_id", tid)
+            thread_sequences.append(f"  Thread: {raw_tid} ({tid})\n" + "\n".join(beat_list))
+
+        if not thread_sequences:
+            return GrowPhaseResult(
+                phase="narrative_gaps",
+                status="completed",
+                detail="No threads with 2+ beats to check",
+            )
+
+        context = {
+            "thread_sequences": "\n\n".join(thread_sequences),
+            "valid_thread_ids": ", ".join(sorted(thread_nodes.keys())),
+            "valid_beat_ids": ", ".join(sorted(valid_beat_ids)),
+        }
+
+        try:
+            result, llm_calls, tokens = await self._grow_llm_call(
+                model=model,
+                template_name="grow_phase4b_narrative_gaps",
+                context=context,
+                output_schema=Phase4bOutput,
+            )
+        except GrowStageError as e:
+            return GrowPhaseResult(
+                phase="narrative_gaps",
+                status="failed",
+                detail=str(e),
+            )
+
+        # Validate and insert gap beats
+        inserted = 0
+        for gap in result.gaps:
+            prefixed_tid = (
+                gap.thread_id
+                if gap.thread_id.startswith("thread::")
+                else f"thread::{gap.thread_id}"
+            )
+            if prefixed_tid not in thread_nodes:
+                log.warning("phase4b_invalid_thread_id", thread_id=gap.thread_id)
+                continue
+            if gap.after_beat and gap.after_beat not in valid_beat_ids:
+                log.warning("phase4b_invalid_after_beat", beat_id=gap.after_beat)
+                continue
+            if gap.before_beat and gap.before_beat not in valid_beat_ids:
+                log.warning("phase4b_invalid_before_beat", beat_id=gap.before_beat)
+                continue
+
+            insert_gap_beat(
+                graph,
+                thread_id=prefixed_tid,
+                after_beat=gap.after_beat,
+                before_beat=gap.before_beat,
+                summary=gap.summary,
+                scene_type=gap.scene_type,
+            )
+            inserted += 1
+
+        return GrowPhaseResult(
+            phase="narrative_gaps",
+            status="completed",
+            detail=f"Inserted {inserted} gap beats from {len(result.gaps)} proposals",
+            llm_calls=llm_calls,
+            tokens_used=tokens,
+        )
+
+    async def _phase_4c_pacing_gaps(self, graph: Graph, model: BaseChatModel) -> GrowPhaseResult:
+        """Phase 4c: Detect and fix pacing issues (3+ same scene_type in a row).
+
+        Runs deterministic pacing detection first. If issues are found,
+        asks the LLM to propose correction beats. Only proceeds if
+        Phase 4a has tagged beats with scene types.
+        """
+        from questfoundry.graph.grow_algorithms import (
+            detect_pacing_issues,
+            insert_gap_beat,
+        )
+        from questfoundry.models.grow import Phase4bOutput
+
+        beat_nodes = graph.get_nodes_by_type("beat")
+        if not beat_nodes:
+            return GrowPhaseResult(
+                phase="pacing_gaps",
+                status="completed",
+                detail="No beats to check for pacing",
+            )
+
+        # Check if scene types have been assigned
+        has_scene_types = any(b.get("scene_type") for b in beat_nodes.values())
+        if not has_scene_types:
+            return GrowPhaseResult(
+                phase="pacing_gaps",
+                status="skipped",
+                detail="No scene_type tags found (Phase 4a may not have run)",
+            )
+
+        issues = detect_pacing_issues(graph)
+        if not issues:
+            return GrowPhaseResult(
+                phase="pacing_gaps",
+                status="completed",
+                detail="No pacing issues detected",
+            )
+
+        # Build context for LLM
+        issue_descriptions: list[str] = []
+        for issue in issues:
+            beat_summaries: list[str] = []
+            for bid in issue.beat_ids:
+                node = graph.get_node(bid)
+                summary = node.get("summary", "") if node else ""
+                beat_summaries.append(f"    {bid}: {summary}")
+            raw_tid = issue.thread_id.removeprefix("thread::")
+            issue_descriptions.append(
+                f"  Thread {raw_tid}: {len(issue.beat_ids)} consecutive "
+                f"'{issue.scene_type}' beats:\n" + "\n".join(beat_summaries)
+            )
+
+        thread_nodes = graph.get_nodes_by_type("thread")
+        context = {
+            "pacing_issues": "\n\n".join(issue_descriptions),
+            "valid_thread_ids": ", ".join(sorted(thread_nodes.keys())),
+            "valid_beat_ids": ", ".join(sorted(beat_nodes.keys())),
+            "issue_count": str(len(issues)),
+        }
+
+        try:
+            result, llm_calls, tokens = await self._grow_llm_call(
+                model=model,
+                template_name="grow_phase4c_pacing_gaps",
+                context=context,
+                output_schema=Phase4bOutput,
+            )
+        except GrowStageError as e:
+            return GrowPhaseResult(
+                phase="pacing_gaps",
+                status="failed",
+                detail=str(e),
+            )
+
+        # Insert correction beats
+        inserted = 0
+        for gap in result.gaps:
+            prefixed_tid = (
+                gap.thread_id
+                if gap.thread_id.startswith("thread::")
+                else f"thread::{gap.thread_id}"
+            )
+            if prefixed_tid not in thread_nodes:
+                log.warning("phase4c_invalid_thread_id", thread_id=gap.thread_id)
+                continue
+            if gap.after_beat and gap.after_beat not in beat_nodes:
+                log.warning("phase4c_invalid_after_beat", beat_id=gap.after_beat)
+                continue
+            if gap.before_beat and gap.before_beat not in beat_nodes:
+                log.warning("phase4c_invalid_before_beat", beat_id=gap.before_beat)
+                continue
+
+            insert_gap_beat(
+                graph,
+                thread_id=prefixed_tid,
+                after_beat=gap.after_beat,
+                before_beat=gap.before_beat,
+                summary=gap.summary,
+                scene_type=gap.scene_type,
+            )
+            inserted += 1
+
+        return GrowPhaseResult(
+            phase="pacing_gaps",
+            status="completed",
+            detail=(f"Found {len(issues)} pacing issues, inserted {inserted} correction beats"),
             llm_calls=llm_calls,
             tokens_used=tokens,
         )

--- a/tests/unit/test_grow_algorithms.py
+++ b/tests/unit/test_grow_algorithms.py
@@ -1713,8 +1713,8 @@ class TestInsertGapBeat:
         graph.create_node("thread::t1", {"type": "thread", "raw_id": "t1"})
         graph.create_node("beat::a", {"type": "beat", "summary": "A"})
         # Simulate existing gap beats (gap_1 exists, gap_2 was deleted)
-        graph.create_node("beat::gap_1", {"type": "beat", "summary": "Gap 1"})
-        graph.create_node("beat::gap_3", {"type": "beat", "summary": "Gap 3"})
+        graph.create_node("beat::gap_1", {"type": "beat", "summary": "Gap 1", "is_gap_beat": True})
+        graph.create_node("beat::gap_3", {"type": "beat", "summary": "Gap 3", "is_gap_beat": True})
         graph.add_edge("belongs_to", "beat::a", "thread::t1")
 
         beat_id = insert_gap_beat(

--- a/tests/unit/test_grow_algorithms.py
+++ b/tests/unit/test_grow_algorithms.py
@@ -1300,21 +1300,32 @@ class TestApplyKnotMark:
 
 
 def _make_grow_mock_model(graph: Graph) -> MagicMock:
-    """Create a mock model that returns valid Phase2Output for thread-agnostic assessment.
+    """Create a mock model that returns valid structured output for all LLM phases.
 
-    Examines the graph to find candidate beats and marks shared beats
-    (those belonging to multiple threads of the same tension) as agnostic.
+    Inspects the output schema passed to with_structured_output() and returns
+    the appropriate mock response for each phase:
+    - Phase 2: ThreadAgnosticAssessment for shared beats
+    - Phase 3: Empty knots (no candidates in typical test graphs)
+    - Phase 4a: SceneTypeTag for all beats
+    - Phase 4b/4c: Empty gaps (no gap proposals)
     """
     from unittest.mock import AsyncMock
 
-    from questfoundry.models.grow import Phase2Output, ThreadAgnosticAssessment
+    from questfoundry.models.grow import (
+        Phase2Output,
+        Phase3Output,
+        Phase4aOutput,
+        Phase4bOutput,
+        SceneTypeTag,
+        ThreadAgnosticAssessment,
+    )
 
-    # Build the response based on graph structure
+    # Build Phase 2 response based on graph structure
     tension_nodes = graph.get_nodes_by_type("tension")
     thread_nodes = graph.get_nodes_by_type("thread")
     beat_nodes = graph.get_nodes_by_type("beat")
 
-    # Build tension → threads mapping
+    # Build tension -> threads mapping
     tension_threads: dict[str, list[str]] = {}
     explores_edges = graph.get_edges(from_id=None, to_id=None, edge_type="explores")
     for edge in explores_edges:
@@ -1323,7 +1334,7 @@ def _make_grow_mock_model(graph: Graph) -> MagicMock:
         if thread_id in thread_nodes and tension_id in tension_nodes:
             tension_threads.setdefault(tension_id, []).append(thread_id)
 
-    # Build beat → threads via belongs_to
+    # Build beat -> threads via belongs_to
     beat_threads: dict[str, list[str]] = {}
     belongs_to_edges = graph.get_edges(from_id=None, to_id=None, edge_type="belongs_to")
     for edge in belongs_to_edges:
@@ -1345,14 +1356,38 @@ def _make_grow_mock_model(graph: Graph) -> MagicMock:
                 ThreadAgnosticAssessment(beat_id=beat_id, agnostic_for=agnostic_tensions)
             )
 
+    # Pre-build outputs for each phase
     phase2_output = Phase2Output(assessments=assessments)
+    phase3_output = Phase3Output(knots=[])
 
-    # Create mock model with structured output support
-    mock_structured = AsyncMock()
-    mock_structured.ainvoke = AsyncMock(return_value=phase2_output)
+    # Phase 4a: tag all beats with alternating scene types
+    scene_types = ["scene", "sequel", "micro_beat"]
+    tags = [
+        SceneTypeTag(beat_id=bid, scene_type=scene_types[i % 3])
+        for i, bid in enumerate(sorted(beat_nodes.keys()))
+    ]
+    phase4a_output = Phase4aOutput(tags=tags)
+
+    # Phase 4b/4c: no gaps proposed (keeps test graphs simple)
+    phase4b_output = Phase4bOutput(gaps=[])
+
+    # Map schema -> output
+    output_by_schema: dict[type, object] = {
+        Phase2Output: phase2_output,
+        Phase3Output: phase3_output,
+        Phase4aOutput: phase4a_output,
+        Phase4bOutput: phase4b_output,
+    }
+
+    def _with_structured_output(schema: type, **_kwargs: object) -> AsyncMock:
+        """Return a mock that produces the correct output for the given schema."""
+        output = output_by_schema.get(schema, phase2_output)
+        mock_structured = AsyncMock()
+        mock_structured.ainvoke = AsyncMock(return_value=output)
+        return mock_structured
 
     mock_model = MagicMock()
-    mock_model.with_structured_output = MagicMock(return_value=mock_structured)
+    mock_model.with_structured_output = MagicMock(side_effect=_with_structured_output)
 
     return mock_model
 
@@ -1369,11 +1404,11 @@ class TestPhaseIntegrationEndToEnd:
         mock_model = _make_grow_mock_model(graph)
         result_dict, _llm_calls, _tokens = await stage.execute(model=mock_model, user_prompt="")
 
-        # All 9 phases should be completed
+        # All 12 phases should run (completed or skipped)
         phases = result_dict["phases_completed"]
-        assert len(phases) == 9
+        assert len(phases) == 12
         for phase in phases:
-            assert phase["status"] == "completed"
+            assert phase["status"] in ("completed", "skipped")
 
         # Should have created arcs
         assert result_dict["arc_count"] == 4  # 2x2 = 4 arcs
@@ -1396,9 +1431,9 @@ class TestPhaseIntegrationEndToEnd:
         mock_model = _make_grow_mock_model(graph)
         result_dict, _llm_calls, _tokens = await stage.execute(model=mock_model, user_prompt="")
 
-        # All phases completed
+        # All phases run (completed or skipped)
         phases = result_dict["phases_completed"]
-        assert all(p["status"] == "completed" for p in phases)
+        assert all(p["status"] in ("completed", "skipped") for p in phases)
 
         assert result_dict["arc_count"] == 2  # 1 tension x 2 threads = 2 arcs
         assert result_dict["passage_count"] == 4  # 4 beats
@@ -1451,3 +1486,204 @@ class TestPhaseIntegrationEndToEnd:
 
         grants = saved_graph.get_edges(from_id=None, to_id=None, edge_type="grants")
         assert len(grants) == 4
+
+
+# ---------------------------------------------------------------------------
+# Phase 4: Gap detection algorithm tests
+# ---------------------------------------------------------------------------
+
+
+class TestGetThreadBeatSequence:
+    def test_returns_ordered_sequence(self) -> None:
+        """Beats are returned in dependency order."""
+        from questfoundry.graph.grow_algorithms import get_thread_beat_sequence
+
+        graph = make_single_tension_graph()
+        sequence = get_thread_beat_sequence(graph, "thread::mentor_trust_canonical")
+        # opening → mentor_meet → mentor_commits_canonical
+        assert sequence == [
+            "beat::opening",
+            "beat::mentor_meet",
+            "beat::mentor_commits_canonical",
+        ]
+
+    def test_empty_thread(self) -> None:
+        """Empty result for nonexistent thread."""
+        from questfoundry.graph.grow_algorithms import get_thread_beat_sequence
+
+        graph = make_single_tension_graph()
+        sequence = get_thread_beat_sequence(graph, "thread::nonexistent")
+        assert sequence == []
+
+    def test_multiple_roots(self) -> None:
+        """Handles beats with no dependencies (multiple roots)."""
+        from questfoundry.graph.grow_algorithms import get_thread_beat_sequence
+
+        graph = Graph.empty()
+        graph.create_node("thread::t1", {"type": "thread", "raw_id": "t1"})
+        graph.create_node("beat::a", {"type": "beat", "raw_id": "a", "summary": "A"})
+        graph.create_node("beat::b", {"type": "beat", "raw_id": "b", "summary": "B"})
+        graph.add_edge("belongs_to", "beat::a", "thread::t1")
+        graph.add_edge("belongs_to", "beat::b", "thread::t1")
+        # No requires edges — both are roots
+        sequence = get_thread_beat_sequence(graph, "thread::t1")
+        assert set(sequence) == {"beat::a", "beat::b"}
+        assert len(sequence) == 2
+
+    def test_alt_thread_sequence(self) -> None:
+        """Alternative thread has its own sequence."""
+        from questfoundry.graph.grow_algorithms import get_thread_beat_sequence
+
+        graph = make_single_tension_graph()
+        sequence = get_thread_beat_sequence(graph, "thread::mentor_trust_alt")
+        assert sequence == [
+            "beat::opening",
+            "beat::mentor_meet",
+            "beat::mentor_commits_alt",
+        ]
+
+
+class TestDetectPacingIssues:
+    def test_no_issues_without_scene_types(self) -> None:
+        """No issues when beats lack scene_type."""
+        from questfoundry.graph.grow_algorithms import detect_pacing_issues
+
+        graph = make_single_tension_graph()
+        issues = detect_pacing_issues(graph)
+        assert issues == []
+
+    def test_detects_three_consecutive_scenes(self) -> None:
+        """Flags 3+ consecutive beats with same scene_type."""
+        from questfoundry.graph.grow_algorithms import detect_pacing_issues
+
+        graph = make_single_tension_graph()
+        # Tag all canonical thread beats as "scene"
+        graph.update_node("beat::opening", scene_type="scene")
+        graph.update_node("beat::mentor_meet", scene_type="scene")
+        graph.update_node("beat::mentor_commits_canonical", scene_type="scene")
+
+        issues = detect_pacing_issues(graph)
+        assert len(issues) >= 1
+        issue = next(i for i in issues if i.thread_id == "thread::mentor_trust_canonical")
+        assert issue.scene_type == "scene"
+        assert len(issue.beat_ids) == 3
+
+    def test_no_issue_with_varied_types(self) -> None:
+        """No issues when scene types alternate."""
+        from questfoundry.graph.grow_algorithms import detect_pacing_issues
+
+        graph = make_single_tension_graph()
+        graph.update_node("beat::opening", scene_type="scene")
+        graph.update_node("beat::mentor_meet", scene_type="sequel")
+        graph.update_node("beat::mentor_commits_canonical", scene_type="scene")
+
+        issues = detect_pacing_issues(graph)
+        # No run of 3+, so no issues
+        assert issues == []
+
+    def test_short_thread_skipped(self) -> None:
+        """Threads with fewer than 3 beats are skipped."""
+        from questfoundry.graph.grow_algorithms import detect_pacing_issues
+
+        graph = Graph.empty()
+        graph.create_node("thread::short", {"type": "thread", "raw_id": "short"})
+        graph.create_node("beat::x", {"type": "beat", "raw_id": "x", "scene_type": "scene"})
+        graph.create_node("beat::y", {"type": "beat", "raw_id": "y", "scene_type": "scene"})
+        graph.add_edge("belongs_to", "beat::x", "thread::short")
+        graph.add_edge("belongs_to", "beat::y", "thread::short")
+
+        issues = detect_pacing_issues(graph)
+        assert issues == []
+
+
+class TestInsertGapBeat:
+    def test_creates_beat_node(self) -> None:
+        """Creates a new beat node with correct data."""
+        from questfoundry.graph.grow_algorithms import insert_gap_beat
+
+        graph = make_single_tension_graph()
+        beat_id = insert_gap_beat(
+            graph,
+            thread_id="thread::mentor_trust_canonical",
+            after_beat="beat::opening",
+            before_beat="beat::mentor_meet",
+            summary="Hero reflects on the journey so far.",
+            scene_type="sequel",
+        )
+
+        assert beat_id.startswith("beat::gap_")
+        node = graph.get_node(beat_id)
+        assert node is not None
+        assert node["type"] == "beat"
+        assert node["scene_type"] == "sequel"
+        assert node["is_gap_beat"] is True
+        assert node["summary"] == "Hero reflects on the journey so far."
+
+    def test_adds_requires_edges(self) -> None:
+        """New beat gets requires edges for ordering."""
+        from questfoundry.graph.grow_algorithms import insert_gap_beat
+
+        graph = make_single_tension_graph()
+        beat_id = insert_gap_beat(
+            graph,
+            thread_id="thread::mentor_trust_canonical",
+            after_beat="beat::opening",
+            before_beat="beat::mentor_meet",
+            summary="Transition beat",
+            scene_type="sequel",
+        )
+
+        # New beat requires after_beat
+        requires_from_new = graph.get_edges(
+            from_id=beat_id, to_id="beat::opening", edge_type="requires"
+        )
+        assert len(requires_from_new) == 1
+
+        # before_beat requires new beat
+        requires_to_new = graph.get_edges(
+            from_id="beat::mentor_meet", to_id=beat_id, edge_type="requires"
+        )
+        assert len(requires_to_new) == 1
+
+    def test_adds_belongs_to_edge(self) -> None:
+        """New beat gets belongs_to edge for thread."""
+        from questfoundry.graph.grow_algorithms import insert_gap_beat
+
+        graph = make_single_tension_graph()
+        beat_id = insert_gap_beat(
+            graph,
+            thread_id="thread::mentor_trust_canonical",
+            after_beat="beat::opening",
+            before_beat=None,
+            summary="End of thread transition",
+            scene_type="micro_beat",
+        )
+
+        belongs_to = graph.get_edges(
+            from_id=beat_id, to_id="thread::mentor_trust_canonical", edge_type="belongs_to"
+        )
+        assert len(belongs_to) == 1
+
+    def test_no_after_beat(self) -> None:
+        """Handles insertion at start of thread."""
+        from questfoundry.graph.grow_algorithms import insert_gap_beat
+
+        graph = make_single_tension_graph()
+        beat_id = insert_gap_beat(
+            graph,
+            thread_id="thread::mentor_trust_canonical",
+            after_beat=None,
+            before_beat="beat::opening",
+            summary="Prologue beat",
+            scene_type="scene",
+        )
+
+        # No requires from new beat (no after_beat)
+        requires_from_new = graph.get_edges(from_id=beat_id, to_id=None, edge_type="requires")
+        assert len(requires_from_new) == 0
+
+        # before_beat requires new beat
+        requires_to_new = graph.get_edges(
+            from_id="beat::opening", to_id=beat_id, edge_type="requires"
+        )
+        assert len(requires_to_new) == 1


### PR DESCRIPTION
## Problem

GROW needs scene-type classification and gap detection phases (4a, 4b, 4c) to identify missing narrative beats and fix pacing issues before arc enumeration. This implements issue #261.

## Changes

- **Models**: Added `Phase4aOutput` (scene-type tags) and `Phase4bOutput` (gap proposals) wrapper models for structured LLM output
- **Algorithms** (`grow_algorithms.py`):
  - `get_thread_beat_sequence()`: topological sort of beats within a thread via requires edges
  - `detect_pacing_issues()`: finds runs of 3+ consecutive same scene_type
  - `insert_gap_beat()`: creates new beat nodes with proper thread/requires edges
  - `PacingIssue` dataclass for issue tracking
- **Phase 4a** (`scene_types`): LLM classifies each beat as scene/sequel/micro_beat
- **Phase 4b** (`narrative_gaps`): LLM proposes missing beats where thread sequences jump too abruptly
- **Phase 4c** (`pacing_gaps`): Deterministic detection + LLM correction for monotonous pacing
- **Prompt templates**: 3 new YAML templates for each sub-phase
- **Phase order**: Updated from 9 to 12 phases (4a, 4b, 4c inserted between knots and enumerate_arcs)
- **Tests**: 11 new phase tests + 12 algorithm tests + updated e2e mock to handle all LLM phases

## Not Included / Future PRs

- Phase 8c entity overlays (#262)
- Phase 9 choice derivation (#263)

## Test Plan

```bash
uv run pytest tests/unit/ -q           # 1115 passed
uv run mypy src/                       # Success: no issues found
uv run ruff check src/ tests/          # All checks passed
```

## Risk / Rollback

- No breaking changes to existing deterministic phases
- LLM phases gracefully degrade: Phase 4c skips if 4a hasn't tagged beats
- Gap beats are additive (never remove existing beats)