### PR TITLE
feat(grow): implement Phase 8c entity overlay creation (#262)

### DIFF
--- a/prompts/templates/grow_phase8c_overlays.yaml
+++ b/prompts/templates/grow_phase8c_overlays.yaml
@@ -42,7 +42,7 @@ system: |
 
   ## Output Format
   Return a JSON object with an "overlays" array. Each overlay has:
-  - entity_id: the entity being modified (use prefixed form, e.g., "entity::name")
+  - entity_id: the entity being modified (e.g., "entity::name" or just "name")
   - when: list of codeword IDs that activate this overlay (all must be granted)
   - details: dict of field_name → description pairs describing the changes
 

--- a/prompts/templates/grow_phase8c_overlays.yaml
+++ b/prompts/templates/grow_phase8c_overlays.yaml
@@ -1,0 +1,54 @@
+name: grow_phase8c_overlays
+description: Create entity overlays conditioned on codewords
+
+system: |
+  You are creating entity overlays -- conditional details that change
+  based on which narrative path the player has taken. Overlays activate
+  when specific codewords are granted (i.e., when certain consequences
+  have been committed to).
+
+  ## What is an Entity Overlay?
+  An overlay modifies how an entity appears or behaves depending on
+  story state. For example:
+  - A character's attitude changes after the player betrays them
+  - A location's description changes after a disaster occurs
+  - An object gains new properties after being enchanted
+
+  ## Consequences and Codewords
+  {consequence_context}
+
+  ## Entities Available for Overlays
+  {entity_context}
+
+  ## Overlay Design Rules
+  1. Each overlay targets ONE entity and activates on one or more codewords
+  2. The "when" field lists codeword IDs that must ALL be granted for the overlay to activate
+  3. The "details" field contains key-value pairs describing what changes:
+     - Use descriptive keys like "attitude", "appearance", "description", "access"
+     - Values should be concise narrative descriptions (1 sentence each)
+  4. Only propose overlays where consequences meaningfully affect an entity
+  5. Entities already involved in consequences are the best candidates
+  6. Do NOT propose overlays for entities unaffected by any consequence
+
+  ## What NOT to Do
+  - Do NOT use IDs not listed in the Valid IDs section
+  - Do NOT propose more than 3 overlays per entity
+  - Do NOT propose overlays with empty details
+  - Do NOT add explanatory prose before or after the JSON output
+
+  ## Valid IDs
+  Valid entity_ids: {valid_entity_ids}
+  Valid codeword_ids (for "when" field): {valid_codeword_ids}
+
+  ## Output Format
+  Return a JSON object with an "overlays" array. Each overlay has:
+  - entity_id: the entity being modified (use prefixed form, e.g., "entity::name")
+  - when: list of codeword IDs that activate this overlay (all must be granted)
+  - details: dict of field_name → description pairs describing the changes
+
+  If no meaningful overlays exist, return an empty overlays array.
+
+user: |
+  Propose entity overlays based on the consequences and codewords described above.
+
+components: []

--- a/src/questfoundry/models/grow.py
+++ b/src/questfoundry/models/grow.py
@@ -153,6 +153,12 @@ class OverlayProposal(BaseModel):
     details: dict[str, str] = Field(default_factory=dict)
 
 
+class Phase8cOutput(BaseModel):
+    """Wrapper for Phase 8c structured output (entity overlay proposals)."""
+
+    overlays: list[OverlayProposal] = Field(default_factory=list)
+
+
 class ChoiceLabel(BaseModel):
     """Phase 9: Labels for player choices between passages."""
 

--- a/src/questfoundry/pipeline/stages/grow.py
+++ b/src/questfoundry/pipeline/stages/grow.py
@@ -1365,6 +1365,7 @@ class GrowStage:
             # Store overlay on entity node
             entity_data = graph.get_node(prefixed_eid)
             if entity_data is None:
+                log.error("phase8c_entity_disappeared", entity_id=prefixed_eid)
                 continue
 
             existing_overlays: list[dict[str, Any]] = entity_data.get("overlays", [])

--- a/tests/unit/test_grow_algorithms.py
+++ b/tests/unit/test_grow_algorithms.py
@@ -1308,6 +1308,7 @@ def _make_grow_mock_model(graph: Graph) -> MagicMock:
     - Phase 3: Empty knots (no candidates in typical test graphs)
     - Phase 4a: SceneTypeTag for all beats
     - Phase 4b/4c: Empty gaps (no gap proposals)
+    - Phase 8c: Empty overlays (no overlay proposals)
     """
     from unittest.mock import AsyncMock
 
@@ -1316,6 +1317,7 @@ def _make_grow_mock_model(graph: Graph) -> MagicMock:
         Phase3Output,
         Phase4aOutput,
         Phase4bOutput,
+        Phase8cOutput,
         SceneTypeTag,
         ThreadAgnosticAssessment,
     )
@@ -1371,12 +1373,16 @@ def _make_grow_mock_model(graph: Graph) -> MagicMock:
     # Phase 4b/4c: no gaps proposed (keeps test graphs simple)
     phase4b_output = Phase4bOutput(gaps=[])
 
+    # Phase 8c: no overlays proposed (keeps test graphs simple)
+    phase8c_output = Phase8cOutput(overlays=[])
+
     # Map schema -> output
     output_by_schema: dict[type, object] = {
         Phase2Output: phase2_output,
         Phase3Output: phase3_output,
         Phase4aOutput: phase4a_output,
         Phase4bOutput: phase4b_output,
+        Phase8cOutput: phase8c_output,
     }
 
     def _with_structured_output(schema: type, **_kwargs: object) -> AsyncMock:
@@ -1404,9 +1410,9 @@ class TestPhaseIntegrationEndToEnd:
         mock_model = _make_grow_mock_model(graph)
         result_dict, _llm_calls, _tokens = await stage.execute(model=mock_model, user_prompt="")
 
-        # All 12 phases should run (completed or skipped)
+        # All 13 phases should run (completed or skipped)
         phases = result_dict["phases_completed"]
-        assert len(phases) == 12
+        assert len(phases) == 13
         for phase in phases:
             assert phase["status"] in ("completed", "skipped")
 


### PR DESCRIPTION
## Problem

Phase 8c creates conditional entity overlays — modifications to entity details that activate when specific codewords are granted. This enables entity state to reflect player choices (e.g., a character's attitude changes after being betrayed).

Closes #262.

## Changes

- Add `Phase8cOutput` wrapper model to `models/grow.py`
- Implement `_phase_8c_overlays()` phase in `grow.py`:
  - Collects consequences with their codewords and entities
  - Calls LLM to propose overlays (entity + codeword conditions + detail changes)
  - Validates entity_ids and codeword IDs exist in graph
  - Skips overlays with empty details
  - Stores validated overlays on entity nodes
- Create `grow_phase8c_overlays.yaml` prompt template with defensive patterns
- Update `_phase_order()`: overlays inserted between codewords and prune (13 phases total)
- Update `execute()` to count overlays from entity nodes for `GrowResult.overlay_count`
- Add 6 unit tests covering valid creation, invalid entity/codeword rejection, empty details, no codewords, and unprefixed entity ID normalization
- Update e2e mock model to dispatch `Phase8cOutput`
- Update phase count assertions (12 → 13)

## Not Included / Future PRs

- Phase 9 Choice Derivation (#263) — separate PR
- Overlay rendering in FILL stage — later slice

## Test Plan

```
uv run pytest tests/unit/ -q        → 1123 passed
uv run mypy src/                     → Success: no issues found
uv run ruff check src/ tests/        → All checks passed
```

## Risk / Rollback

- Low risk: overlays are stored on existing entity nodes, no new node types
- Empty LLM output (no overlays proposed) is handled gracefully
- Invalid IDs are logged and skipped, not raised as errors