### PR TITLE
test(grow): add E2E integration and context formatting (#265)

### DIFF
--- a/src/questfoundry/graph/context.py
+++ b/src/questfoundry/graph/context.py
@@ -8,6 +8,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
+from questfoundry.graph.grow_context import format_grow_valid_ids
+
 if TYPE_CHECKING:
     from questfoundry.graph.graph import Graph
 
@@ -167,8 +169,6 @@ def _format_grow_valid_ids(graph: Graph) -> str:
     Returns:
         Formatted context string with valid IDs.
     """
-    from questfoundry.graph.grow_context import format_grow_valid_ids
-
     ids = format_grow_valid_ids(graph)
     lines = ["## VALID IDs FOR GROW PHASES", ""]
 

--- a/src/questfoundry/graph/context.py
+++ b/src/questfoundry/graph/context.py
@@ -150,8 +150,43 @@ def format_valid_ids_context(graph: Graph, stage: str) -> str:
     """
     if stage == "seed":
         return _format_seed_valid_ids(graph)
-    # Future: add "grow" when GROW stage is implemented
+    if stage == "grow":
+        return _format_grow_valid_ids(graph)
     return ""
+
+
+def _format_grow_valid_ids(graph: Graph) -> str:
+    """Format GROW-stage valid IDs for LLM serialization.
+
+    Delegates to grow_context module and formats the result as a
+    human-readable context string with all ID types.
+
+    Args:
+        graph: Graph containing SEED/GROW data.
+
+    Returns:
+        Formatted context string with valid IDs.
+    """
+    from questfoundry.graph.grow_context import format_grow_valid_ids
+
+    ids = format_grow_valid_ids(graph)
+    lines = ["## VALID IDs FOR GROW PHASES", ""]
+
+    for label, key in [
+        ("Beat IDs", "valid_beat_ids"),
+        ("Thread IDs", "valid_thread_ids"),
+        ("Tension IDs", "valid_tension_ids"),
+        ("Entity IDs", "valid_entity_ids"),
+        ("Passage IDs", "valid_passage_ids"),
+        ("Choice IDs", "valid_choice_ids"),
+    ]:
+        value = ids.get(key, "")
+        if value:
+            lines.append(f"### {label}")
+            lines.append(value)
+            lines.append("")
+
+    return "\n".join(lines) if any(ids.values()) else ""
 
 
 def _format_seed_valid_ids(graph: Graph) -> str:

--- a/src/questfoundry/graph/grow_context.py
+++ b/src/questfoundry/graph/grow_context.py
@@ -1,0 +1,155 @@
+"""Context formatting for GROW stage LLM phases.
+
+Provides functions to format graph data (beats, threads, tensions) as
+context strings for GROW's LLM-powered phases. Handles token budget
+constraints via windowing when beat context exceeds limits.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from questfoundry.graph.graph import Graph
+
+
+# Rough chars-per-token estimate for budget calculations
+_CHARS_PER_TOKEN = 4
+
+
+def format_grow_beat_context(graph: Graph, max_tokens: int = 24000) -> str:
+    """Format beat summaries for LLM phases, compressed to fit token budget.
+
+    Each beat is formatted with its ID, summary, thread memberships, and
+    tension impacts. If the total output exceeds the token budget, earlier
+    beats are summarized (ID + first 40 chars) while recent beats get full
+    detail.
+
+    Args:
+        graph: Graph containing beat nodes from SEED stage.
+        max_tokens: Maximum token budget for the output. Defaults to 24000.
+
+    Returns:
+        Formatted beat context string, or empty string if no beats exist.
+    """
+    beat_nodes = graph.get_nodes_by_type("beat")
+    if not beat_nodes:
+        return ""
+
+    # Build belongs_to mapping: beat_id → [thread_ids]
+    beat_threads: dict[str, list[str]] = {}
+    for edge in graph.get_edges(edge_type="belongs_to"):
+        beat_id = edge.get("from", "")
+        thread_id = edge.get("to", "")
+        if beat_id and thread_id:
+            beat_threads.setdefault(beat_id, []).append(thread_id)
+
+    # Format each beat
+    entries: list[str] = []
+    for beat_id in sorted(beat_nodes.keys()):
+        beat_data = beat_nodes[beat_id]
+        summary = beat_data.get("summary", "")
+        threads = sorted(beat_threads.get(beat_id, []))
+        impacts = beat_data.get("tension_impacts", [])
+
+        lines = [f"- beat_id: {beat_id}", f"  summary: {summary}"]
+        if threads:
+            thread_list = ", ".join(threads)
+            lines.append(f"  threads: [{thread_list}]")
+        if impacts:
+            impact_strs = [
+                f"{imp.get('tension_id', '?')}:{imp.get('effect', '?')}" for imp in impacts
+            ]
+            lines.append(f"  impacts: [{', '.join(impact_strs)}]")
+        entries.append("\n".join(lines))
+
+    # Check budget
+    full_text = "\n".join(entries)
+    max_chars = max_tokens * _CHARS_PER_TOKEN
+    if len(full_text) <= max_chars:
+        return full_text
+
+    # Window: summarize early beats, keep recent beats in full
+    # Reserve 80% of budget for recent beats, 20% for summaries
+    recent_budget = int(max_chars * 0.8)
+    summary_budget = max_chars - recent_budget
+
+    # Work backwards to find how many recent entries fit
+    recent_entries: list[str] = []
+    recent_chars = 0
+    for entry in reversed(entries):
+        if recent_chars + len(entry) + 1 > recent_budget:
+            break
+        recent_entries.insert(0, entry)
+        recent_chars += len(entry) + 1
+
+    # Summarize remaining entries (just ID + truncated summary)
+    summarized_entries: list[str] = []
+    summarized_chars = 0
+    remaining_count = len(entries) - len(recent_entries)
+    for entry in entries[:remaining_count]:
+        # Extract beat_id from first line
+        first_line = entry.split("\n")[0]
+        beat_id = first_line.replace("- beat_id: ", "")
+        # Get truncated summary
+        beat_data = beat_nodes.get(beat_id, {})
+        summary = beat_data.get("summary", "")[:40]
+        short = f"- {beat_id}: {summary}..."
+        if summarized_chars + len(short) + 1 > summary_budget:
+            summarized_entries.append(f"  ... ({remaining_count - len(summarized_entries)} more)")
+            break
+        summarized_entries.append(short)
+        summarized_chars += len(short) + 1
+
+    parts: list[str] = []
+    if summarized_entries:
+        parts.append("## Earlier beats (summarized)")
+        parts.append("\n".join(summarized_entries))
+        parts.append("")
+        parts.append("## Recent beats (full detail)")
+    parts.append("\n".join(recent_entries))
+
+    return "\n".join(parts)
+
+
+def format_grow_valid_ids(graph: Graph) -> dict[str, str]:
+    """Collect all valid IDs for GROW LLM phases.
+
+    Returns a dict with formatted ID lists that can be injected into
+    LLM prompts to prevent phantom ID references.
+
+    Args:
+        graph: Graph containing nodes from SEED stage.
+
+    Returns:
+        Dict with keys 'valid_beat_ids', 'valid_thread_ids',
+        'valid_tension_ids', 'valid_entity_ids'. Each value is a
+        comma-separated string of scoped IDs, or empty string if none.
+    """
+    result: dict[str, str] = {}
+
+    # Beat IDs
+    beat_nodes = graph.get_nodes_by_type("beat")
+    result["valid_beat_ids"] = ", ".join(sorted(beat_nodes.keys())) if beat_nodes else ""
+
+    # Thread IDs
+    thread_nodes = graph.get_nodes_by_type("thread")
+    result["valid_thread_ids"] = ", ".join(sorted(thread_nodes.keys())) if thread_nodes else ""
+
+    # Tension IDs
+    tension_nodes = graph.get_nodes_by_type("tension")
+    result["valid_tension_ids"] = ", ".join(sorted(tension_nodes.keys())) if tension_nodes else ""
+
+    # Entity IDs
+    entity_nodes = graph.get_nodes_by_type("entity")
+    result["valid_entity_ids"] = ", ".join(sorted(entity_nodes.keys())) if entity_nodes else ""
+
+    # Passage IDs (created during GROW phases)
+    passage_nodes = graph.get_nodes_by_type("passage")
+    result["valid_passage_ids"] = ", ".join(sorted(passage_nodes.keys())) if passage_nodes else ""
+
+    # Choice IDs (created during GROW phases)
+    choice_nodes = graph.get_nodes_by_type("choice")
+    result["valid_choice_ids"] = ", ".join(sorted(choice_nodes.keys())) if choice_nodes else ""
+
+    return result


### PR DESCRIPTION
## Problem
The GROW stage has 15 phases but no end-to-end test verifying they work together.
Additionally, LLM phases lack centralized context formatting for the grow stage,
and there's no verification that context stays within 32k token budgets.

## Changes
- Add `graph/grow_context.py` with beat context formatting and token-budget windowing
- Update `context.py` to support `stage="grow"`
- Add reusable `make_e2e_fixture_graph()` (2-tension, 4-arc, 10 beats with lifecycle)
- Add E2E integration test running all 15 phases with mocked LLM (13 tests)
- Verify context budget compliance and windowing behavior

## Not Included / Future PRs
- Real LLM E2E test (requires running Ollama, deferred to manual testing)
- CLI `qf grow` command wiring (Slice 3 completion, separate issue)
- Context compression with adaptive windowing (optimize later if needed)

## Test Plan
- `uv run pytest tests/integration/test_grow_e2e.py -v` — 13 tests pass
- `uv run pytest tests/unit/ -q` — 1170 tests pass (regression)
- `uv run mypy src/` — clean
- `uv run ruff check src/ tests/` — clean

## Review Guide
Suggested review order:
1. `src/questfoundry/graph/grow_context.py` — new context formatting module
2. `src/questfoundry/graph/context.py` — integration point (small change)
3. `tests/fixtures/grow_fixtures.py` — E2E fixture
4. `tests/integration/test_grow_e2e.py` — integration tests

## Risk / Rollback
- Mock fidelity: mocked LLM may not catch integration issues with real models
- Token counting is approximate (chars/4 estimate, not exact model tokenizer)
- No backwards compatibility concerns

**Stacked PR**: depends on #274 (Phase 10 Validation). After #274 merges, retarget to main.

Closes #265