### PR TITLE
fix(grow): pass provider_name to with_structured_output

### DIFF
--- a/tests/unit/test_grow_stage.py
+++ b/tests/unit/test_grow_stage.py
@@ -465,14 +465,23 @@ class TestGrowLlmCall:
         assert llm_calls == 1
 
     @pytest.mark.asyncio
-    async def test_provider_name_passed_to_structured_output(self) -> None:
-        """_grow_llm_call passes provider_name to with_structured_output."""
+    @pytest.mark.parametrize(
+        ("provider_name", "expected_provider"),
+        [
+            pytest.param("ollama", "ollama", id="with_provider"),
+            pytest.param(None, None, id="without_provider"),
+        ],
+    )
+    async def test_provider_name_forwarding(
+        self, provider_name: str | None, expected_provider: str | None
+    ) -> None:
+        """_grow_llm_call forwards provider_name to with_structured_output."""
         from unittest.mock import patch
 
         from questfoundry.models.grow import Phase2Output, ThreadAgnosticAssessment
 
         stage = GrowStage()
-        stage._provider_name = "ollama"
+        stage._provider_name = provider_name
 
         valid_output = Phase2Output(
             assessments=[ThreadAgnosticAssessment(beat_id="beat::a", agnostic_for=["t1"])]
@@ -497,42 +506,9 @@ class TestGrowLlmCall:
                 output_schema=Phase2Output,
             )
 
-            mock_wso.assert_called_once_with(mock_model, Phase2Output, provider_name="ollama")
-
-    @pytest.mark.asyncio
-    async def test_provider_name_none_when_not_set(self) -> None:
-        """_grow_llm_call passes None provider_name when not configured."""
-        from unittest.mock import patch
-
-        from questfoundry.models.grow import Phase2Output, ThreadAgnosticAssessment
-
-        stage = GrowStage()
-        # _provider_name defaults to None
-
-        valid_output = Phase2Output(
-            assessments=[ThreadAgnosticAssessment(beat_id="beat::a", agnostic_for=["t1"])]
-        )
-        mock_structured = AsyncMock()
-        mock_structured.ainvoke = AsyncMock(return_value=valid_output)
-
-        mock_model = MagicMock()
-
-        with patch(
-            "questfoundry.pipeline.stages.grow.with_structured_output",
-            return_value=mock_structured,
-        ) as mock_wso:
-            await stage._grow_llm_call(
-                model=mock_model,
-                template_name="grow_phase2_agnostic",
-                context={
-                    "beat_summaries": "test",
-                    "valid_beat_ids": "beat::a",
-                    "valid_tension_ids": "t1",
-                },
-                output_schema=Phase2Output,
+            mock_wso.assert_called_once_with(
+                mock_model, Phase2Output, provider_name=expected_provider
             )
-
-            mock_wso.assert_called_once_with(mock_model, Phase2Output, provider_name=None)
 
 
 class TestPhase3Knots:


### PR DESCRIPTION
## Problem

`_grow_llm_call()` calls `with_structured_output(model, output_schema)` without passing `provider_name`. This causes the strategy selection to default to `StructuredOutputStrategy.TOOL` (function_calling method), which returns `None` for complex nested schemas on Ollama — the project's primary provider.

DREAM/BRAINSTORM/SEED correctly pass `provider_name` to get `JSON_MODE` strategy.

The `projects/seq-1` example run shows GROW failing validation (3 of 6 checks in Phase 10), likely a downstream consequence of degraded output from the wrong strategy.

## Changes

- Store `provider_name` on `self._provider_name` in `execute()` (same pattern as `self._callbacks`)
- Initialize `self._provider_name = None` in `__init__()` 
- Pass `provider_name=self._provider_name` to `with_structured_output()` in `_grow_llm_call()`
- Remove `# noqa: ARG002` from `provider_name` parameter
- Update docstring to reflect the parameter is now used
- Add 2 unit tests verifying provider_name is forwarded correctly

## Not Included / Future PRs

- Hybrid provider support for per-phase model selection (#285)
- Semantic validation feedback loop (#280)
- Token tracking (#282)

## Test Plan

- `uv run pytest tests/unit/test_grow_stage.py::TestGrowLlmCall -xvs` — 6/6 pass (2 new tests)
- `uv run pytest tests/unit/test_grow_stage.py tests/integration/test_grow_e2e.py` — 67/67 pass
- `uv run pytest tests/unit/` — 1183/1183 pass
- `uv run ruff check src/questfoundry/pipeline/stages/grow.py` — all checks passed
- Pre-commit hooks (ruff, mypy, formatting) — all pass

## Risk / Rollback

- Low risk: purely additive parameter forwarding
- No behavior change when `provider_name=None` (preserves existing TOOL default)
- With `provider_name` set, GROW phases now correctly use JSON_MODE on Ollama

Closes #279

🤖 Generated with [Claude Code](https://claude.com/claude-code)