### PR TITLE
feat(grow): add observability with @traceable and token extraction (#282)

### DIFF
--- a/src/questfoundry/agents/serialize.py
+++ b/src/questfoundry/agents/serialize.py
@@ -266,7 +266,7 @@ async def serialize_to_artifact(
                 result = await structured_model.ainvoke(messages, config=config)
 
                 # Extract token usage from response if available
-                tokens = _extract_tokens(result)
+                tokens = extract_tokens(result)
                 total_tokens += tokens
 
                 # If result is already a Pydantic model, validate succeeded
@@ -384,7 +384,7 @@ async def serialize_to_artifact(
     )
 
 
-def _extract_tokens(result: object) -> int:
+def extract_tokens(result: object) -> int:
     """Extract token usage from response metadata.
 
     LangChain tracks token usage in different places:

--- a/tests/unit/test_grow_stage.py
+++ b/tests/unit/test_grow_stage.py
@@ -1770,7 +1770,7 @@ class TestGrowErrorFeedback:
 class TestGrowLLMCallTokens:
     @pytest.mark.asyncio
     async def test_tokens_extracted_from_result(self) -> None:
-        """_grow_llm_call passes result through _extract_tokens and returns total."""
+        """_grow_llm_call passes result through extract_tokens and returns total."""
         from unittest.mock import patch
 
         from pydantic import BaseModel
@@ -1791,7 +1791,7 @@ class TestGrowLLMCallTokens:
                 return_value=mock_structured,
             ),
             patch(
-                "questfoundry.pipeline.stages.grow._extract_tokens",
+                "questfoundry.pipeline.stages.grow.extract_tokens",
                 return_value=150,
             ),
             patch("questfoundry.pipeline.stages.grow._get_prompts_path") as mock_path,
@@ -1810,7 +1810,7 @@ class TestGrowLLMCallTokens:
 
     @pytest.mark.asyncio
     async def test_tokens_zero_when_no_metadata(self) -> None:
-        """_grow_llm_call returns 0 tokens when _extract_tokens finds nothing."""
+        """_grow_llm_call returns 0 tokens when extract_tokens finds nothing."""
         from unittest.mock import patch
 
         from pydantic import BaseModel
@@ -1831,7 +1831,7 @@ class TestGrowLLMCallTokens:
                 return_value=mock_structured,
             ),
             patch(
-                "questfoundry.pipeline.stages.grow._extract_tokens",
+                "questfoundry.pipeline.stages.grow.extract_tokens",
                 return_value=0,
             ),
             patch("questfoundry.pipeline.stages.grow._get_prompts_path") as mock_path,
@@ -1877,7 +1877,7 @@ class TestGrowLLMCallTokens:
                 return_value=mock_structured,
             ),
             patch(
-                "questfoundry.pipeline.stages.grow._extract_tokens",
+                "questfoundry.pipeline.stages.grow.extract_tokens",
                 side_effect=extract_tokens_calls,
             ),
             patch("questfoundry.pipeline.stages.grow._get_prompts_path") as mock_path,

--- a/tests/unit/test_serialize.py
+++ b/tests/unit/test_serialize.py
@@ -11,8 +11,8 @@ from questfoundry.agents.prompts import get_serialize_prompt
 from questfoundry.agents.serialize import (
     SerializationError,
     _build_error_feedback,
-    _extract_tokens,
     _format_validation_errors,
+    extract_tokens,
     serialize_to_artifact,
 )
 from questfoundry.providers.structured_output import StructuredOutputStrategy
@@ -139,15 +139,15 @@ class TestSerializeToArtifact:
 
     @pytest.mark.asyncio
     async def test_serialize_extracts_tokens_from_response(self) -> None:
-        """serialize_to_artifact should call _extract_tokens on response."""
+        """serialize_to_artifact should call extract_tokens on response."""
         mock_model = MagicMock()
         mock_model.with_structured_output.return_value.ainvoke = AsyncMock(
             return_value={"title": "Test", "count": 5}
         )
 
-        # Patch _extract_tokens to return a known value
+        # Patch extract_tokens to return a known value
         with patch(
-            "questfoundry.agents.serialize._extract_tokens", return_value=150
+            "questfoundry.agents.serialize.extract_tokens", return_value=150
         ) as mock_extract:
             _artifact, tokens = await serialize_to_artifact(
                 mock_model,
@@ -171,7 +171,7 @@ class TestSerializeToArtifact:
         mock_model.with_structured_output.return_value.ainvoke = mock_invoke
 
         # Return 100 tokens per call
-        with patch("questfoundry.agents.serialize._extract_tokens", return_value=100):
+        with patch("questfoundry.agents.serialize.extract_tokens", return_value=100):
             _artifact, tokens = await serialize_to_artifact(
                 mock_model,
                 "A test brief",
@@ -280,47 +280,47 @@ class TestSerializeToArtifact:
 class TestHelperFunctions:
     """Test helper functions."""
 
-    def test_extract_tokens_from_usage_metadata_attribute(self) -> None:
-        """_extract_tokens should extract from usage_metadata attribute (Ollama)."""
+    def testextract_tokens_from_usage_metadata_attribute(self) -> None:
+        """extract_tokens should extract from usage_metadata attribute (Ollama)."""
         mock_result = MagicMock()
         mock_result.usage_metadata = {"total_tokens": 200}
 
-        assert _extract_tokens(mock_result) == 200
+        assert extract_tokens(mock_result) == 200
 
-    def test_extract_tokens_from_response_metadata_token_usage(self) -> None:
-        """_extract_tokens should extract from response_metadata (OpenAI)."""
+    def testextract_tokens_from_response_metadata_token_usage(self) -> None:
+        """extract_tokens should extract from response_metadata (OpenAI)."""
         mock_result = MagicMock(spec=["response_metadata"])
         mock_result.response_metadata = {"token_usage": {"total_tokens": 100}}
 
-        assert _extract_tokens(mock_result) == 100
+        assert extract_tokens(mock_result) == 100
 
-    def test_extract_tokens_prefers_usage_metadata_over_response_metadata(self) -> None:
-        """_extract_tokens should prefer usage_metadata attribute."""
+    def testextract_tokens_prefers_usage_metadata_over_response_metadata(self) -> None:
+        """extract_tokens should prefer usage_metadata attribute."""
         mock_result = MagicMock()
         mock_result.usage_metadata = {"total_tokens": 150}
         mock_result.response_metadata = {"token_usage": {"total_tokens": 200}}
 
-        assert _extract_tokens(mock_result) == 150  # From usage_metadata
+        assert extract_tokens(mock_result) == 150  # From usage_metadata
 
-    def test_extract_tokens_returns_zero_when_no_metadata(self) -> None:
-        """_extract_tokens should return 0 when no metadata."""
+    def testextract_tokens_returns_zero_when_no_metadata(self) -> None:
+        """extract_tokens should return 0 when no metadata."""
         mock_result = MagicMock(spec=[])  # No attributes
 
-        assert _extract_tokens(mock_result) == 0
+        assert extract_tokens(mock_result) == 0
 
-    def test_extract_tokens_handles_none_total_tokens_in_usage_metadata(self) -> None:
-        """_extract_tokens should handle None total_tokens in usage_metadata."""
+    def testextract_tokens_handles_none_total_tokens_in_usage_metadata(self) -> None:
+        """extract_tokens should handle None total_tokens in usage_metadata."""
         mock_result = MagicMock(spec=["usage_metadata"])
         mock_result.usage_metadata = {"total_tokens": None}
 
-        assert _extract_tokens(mock_result) == 0
+        assert extract_tokens(mock_result) == 0
 
-    def test_extract_tokens_handles_none_total_tokens_in_response_metadata(self) -> None:
-        """_extract_tokens should handle None total_tokens in response_metadata."""
+    def testextract_tokens_handles_none_total_tokens_in_response_metadata(self) -> None:
+        """extract_tokens should handle None total_tokens in response_metadata."""
         mock_result = MagicMock(spec=["response_metadata"])
         mock_result.response_metadata = {"token_usage": {"total_tokens": None}}
 
-        assert _extract_tokens(mock_result) == 0
+        assert extract_tokens(mock_result) == 0
 
     def test_format_validation_errors_with_location(self) -> None:
         """_format_validation_errors should include field location."""


### PR DESCRIPTION
## Problem
GROW stage LLM calls always return `tokens_used=0`, making it impossible to track token consumption. Additionally, the stage lacks tracing support for LangSmith observability.

## Changes
- Add `@traceable` decorator to `execute()` and `_grow_llm_call()` for LangSmith tracing
- Import and use `_extract_tokens()` from serialize module after each `ainvoke()` call
- Track `total_tokens` across retry attempts within `_grow_llm_call()`
- Return actual accumulated token counts instead of hardcoded `0`
- Update `execute()` docstring to reflect correct return semantics

## Not Included / Future PRs
- Per-phase token breakdowns in log output (can be added as follow-up)
- Custom metadata injection per phase template (GROW phases share the same traceable config)

## Test Plan
- `test_tokens_extracted_from_result`: Mocks `_extract_tokens` to return 150, verifies propagation
- `test_tokens_zero_when_no_metadata`: Verifies 0 returned when no usage metadata available
- `test_tokens_accumulate_across_retries`: Verifies tokens sum across retry attempts (100+120=220)
- All 79 existing GROW tests pass (unit + integration)

```bash
uv run pytest tests/unit/test_grow_stage.py tests/integration/test_grow_e2e.py -xvs
uv run ruff check src/questfoundry/pipeline/stages/grow.py
```

## Risk / Rollback
- `@traceable` is a no-op without `LANGSMITH_TRACING=true` — zero runtime impact when tracing disabled
- `_extract_tokens` returns 0 for structured output results (Pydantic instances lack metadata), so behavior matches previous `0` for most providers until LangChain passes metadata through

Closes #282