### PR TITLE
feat(grow): add semantic validation feedback loop for LLM phases (#280)

### DIFF
--- a/src/questfoundry/graph/grow_validators.py
+++ b/src/questfoundry/graph/grow_validators.py
@@ -53,7 +53,7 @@ def validate_phase2_output(
                         field_path=f"assessments.{i}.agnostic_for",
                         issue=f"Tension ID not found: {tension_id}",
                         provided=tension_id,
-                        available=sorted(valid_tension_ids),
+                        available=sorted(valid_tension_ids)[:10],
                     )
                 )
     return errors
@@ -204,7 +204,12 @@ def format_semantic_errors(errors: list[GrowValidationError]) -> str:
 
 
 def count_entries(result: object) -> int:
-    """Count the number of entries in a phase output for threshold calculation."""
+    """Count the number of entries in a phase output for threshold calculation.
+
+    Note: Relies on known attribute names (assessments, knots, tags, gaps,
+    overlays, labels). If adding a new phase output type, ensure its entries
+    attribute is listed here, otherwise the fallback of 1 is used.
+    """
     for attr in ("assessments", "knots", "tags", "gaps", "overlays", "labels"):
         entries = getattr(result, attr, None)
         if entries is not None:

--- a/src/questfoundry/graph/grow_validators.py
+++ b/src/questfoundry/graph/grow_validators.py
@@ -1,0 +1,212 @@
+"""Semantic validators for GROW LLM phase outputs.
+
+Each validator checks that IDs referenced in LLM output actually exist
+in the graph. Returns a list of GrowValidationError for invalid entries.
+
+These validators run AFTER Pydantic validation succeeds. They catch
+"phantom ID" hallucinations where the LLM invents IDs not present in
+the graph.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from questfoundry.graph.mutations import GrowValidationError
+
+if TYPE_CHECKING:
+    from questfoundry.models.grow import (
+        Phase2Output,
+        Phase3Output,
+        Phase4aOutput,
+        Phase8cOutput,
+        Phase9Output,
+    )
+
+
+def validate_phase2_output(
+    result: Phase2Output,
+    valid_beat_ids: set[str],
+    valid_tension_ids: set[str],
+) -> list[GrowValidationError]:
+    """Validate Phase 2 thread-agnostic assessments.
+
+    Checks:
+    - beat_id exists in graph
+    - agnostic_for tension IDs exist
+    """
+    errors: list[GrowValidationError] = []
+    for i, assessment in enumerate(result.assessments):
+        if assessment.beat_id not in valid_beat_ids:
+            errors.append(
+                GrowValidationError(
+                    field_path=f"assessments.{i}.beat_id",
+                    issue=f"Beat ID not found in graph: {assessment.beat_id}",
+                    provided=assessment.beat_id,
+                    available=sorted(valid_beat_ids)[:10],
+                )
+            )
+        for tension_id in assessment.agnostic_for:
+            if tension_id not in valid_tension_ids:
+                errors.append(
+                    GrowValidationError(
+                        field_path=f"assessments.{i}.agnostic_for",
+                        issue=f"Tension ID not found: {tension_id}",
+                        provided=tension_id,
+                        available=sorted(valid_tension_ids),
+                    )
+                )
+    return errors
+
+
+def validate_phase3_output(
+    result: Phase3Output,
+    valid_beat_ids: set[str],
+) -> list[GrowValidationError]:
+    """Validate Phase 3 knot proposals.
+
+    Checks:
+    - beat_ids exist in graph
+    - No beat reused across multiple knots
+    """
+    errors: list[GrowValidationError] = []
+    seen_beats: set[str] = set()
+    for i, knot in enumerate(result.knots):
+        for beat_id in knot.beat_ids:
+            if beat_id not in valid_beat_ids:
+                errors.append(
+                    GrowValidationError(
+                        field_path=f"knots.{i}.beat_ids",
+                        issue=f"Beat ID not found: {beat_id}",
+                        provided=beat_id,
+                        available=sorted(valid_beat_ids)[:10],
+                    )
+                )
+            if beat_id in seen_beats:
+                errors.append(
+                    GrowValidationError(
+                        field_path=f"knots.{i}.beat_ids",
+                        issue=f"Beat reused across knots: {beat_id}",
+                        provided=beat_id,
+                    )
+                )
+            seen_beats.add(beat_id)
+    return errors
+
+
+def validate_phase4a_output(
+    result: Phase4aOutput,
+    valid_beat_ids: set[str],
+) -> list[GrowValidationError]:
+    """Validate Phase 4a scene type tags.
+
+    Checks:
+    - beat_id exists in graph
+    """
+    errors: list[GrowValidationError] = []
+    for i, tag in enumerate(result.tags):
+        if tag.beat_id not in valid_beat_ids:
+            errors.append(
+                GrowValidationError(
+                    field_path=f"tags.{i}.beat_id",
+                    issue=f"Beat ID not found: {tag.beat_id}",
+                    provided=tag.beat_id,
+                    available=sorted(valid_beat_ids)[:10],
+                )
+            )
+    return errors
+
+
+def validate_phase8c_output(
+    result: Phase8cOutput,
+    valid_entity_ids: set[str],
+    valid_codeword_ids: set[str],
+) -> list[GrowValidationError]:
+    """Validate Phase 8c entity overlay proposals.
+
+    Checks:
+    - entity_id exists in graph
+    - codeword IDs in 'when' exist
+    """
+    errors: list[GrowValidationError] = []
+    for i, overlay in enumerate(result.overlays):
+        if overlay.entity_id not in valid_entity_ids:
+            errors.append(
+                GrowValidationError(
+                    field_path=f"overlays.{i}.entity_id",
+                    issue=f"Entity ID not found: {overlay.entity_id}",
+                    provided=overlay.entity_id,
+                    available=sorted(valid_entity_ids)[:10],
+                )
+            )
+        for cw_id in overlay.when:
+            if cw_id not in valid_codeword_ids:
+                errors.append(
+                    GrowValidationError(
+                        field_path=f"overlays.{i}.when",
+                        issue=f"Codeword ID not found: {cw_id}",
+                        provided=cw_id,
+                        available=sorted(valid_codeword_ids)[:10],
+                    )
+                )
+    return errors
+
+
+def validate_phase9_output(
+    result: Phase9Output,
+    valid_passage_ids: set[str],
+) -> list[GrowValidationError]:
+    """Validate Phase 9 choice labels.
+
+    Checks:
+    - from_passage exists in graph
+    - to_passage exists in graph
+    """
+    errors: list[GrowValidationError] = []
+    for i, label in enumerate(result.labels):
+        if label.from_passage not in valid_passage_ids:
+            errors.append(
+                GrowValidationError(
+                    field_path=f"labels.{i}.from_passage",
+                    issue=f"Passage ID not found: {label.from_passage}",
+                    provided=label.from_passage,
+                    available=sorted(valid_passage_ids)[:10],
+                )
+            )
+        if label.to_passage not in valid_passage_ids:
+            errors.append(
+                GrowValidationError(
+                    field_path=f"labels.{i}.to_passage",
+                    issue=f"Passage ID not found: {label.to_passage}",
+                    provided=label.to_passage,
+                    available=sorted(valid_passage_ids)[:10],
+                )
+            )
+    return errors
+
+
+def format_semantic_errors(errors: list[GrowValidationError]) -> str:
+    """Format semantic validation errors as LLM feedback.
+
+    Produces a structured message listing each invalid reference
+    with the valid alternatives.
+    """
+    lines = ["Semantic validation errors in your response:"]
+    for err in errors:
+        line = f"  - {err.field_path}: {err.issue}"
+        if err.available:
+            line += f"\n    Valid options: {', '.join(err.available[:5])}"
+            if len(err.available) > 5:
+                line += f" (and {len(err.available) - 5} more)"
+        lines.append(line)
+    lines.append("\nPlease fix the invalid IDs and return the corrected output.")
+    return "\n".join(lines)
+
+
+def count_entries(result: object) -> int:
+    """Count the number of entries in a phase output for threshold calculation."""
+    for attr in ("assessments", "knots", "tags", "gaps", "overlays", "labels"):
+        entries = getattr(result, attr, None)
+        if entries is not None:
+            return len(entries)
+    return 1

--- a/src/questfoundry/pipeline/stages/grow.py
+++ b/src/questfoundry/pipeline/stages/grow.py
@@ -20,6 +20,7 @@ context from graph state → single LLM call → validate → retry (max 3).
 from __future__ import annotations
 
 from collections.abc import Awaitable, Callable
+from functools import partial
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, TypeVar
 
@@ -371,6 +372,8 @@ class GrowStage:
                             entries=entry_count,
                             ratio=f"{error_ratio:.0%}",
                         )
+                        # Retry when >50% of entries have errors (majority invalid).
+                        # Below threshold, return and let caller filter minor hallucinations.
                         if error_ratio > 0.5 and attempt < max_retries - 1:
                             feedback = format_semantic_errors(sem_errors)
                             messages = list(base_messages)
@@ -529,8 +532,6 @@ class GrowStage:
         }
 
         # Call LLM with semantic validation
-        from functools import partial
-
         from questfoundry.graph.grow_validators import validate_phase2_output
 
         validator = partial(
@@ -658,8 +659,6 @@ class GrowStage:
         }
 
         # Call LLM for knot proposals
-        from functools import partial
-
         from questfoundry.graph.grow_validators import validate_phase3_output
 
         validator = partial(validate_phase3_output, valid_beat_ids=valid_beat_ids)
@@ -769,8 +768,6 @@ class GrowStage:
             "valid_beat_ids": ", ".join(sorted(beat_nodes.keys())),
             "beat_count": str(len(beat_nodes)),
         }
-
-        from functools import partial
 
         from questfoundry.graph.grow_validators import validate_phase4a_output
 
@@ -1426,8 +1423,6 @@ class GrowStage:
             "valid_codeword_ids": ", ".join(valid_codeword_ids),
         }
 
-        from functools import partial
-
         from questfoundry.graph.grow_validators import validate_phase8c_output
 
         validator = partial(
@@ -1587,8 +1582,6 @@ class GrowStage:
                 "valid_from_ids": ", ".join(valid_from_ids),
                 "valid_to_ids": ", ".join(valid_to_ids),
             }
-
-            from functools import partial
 
             from questfoundry.graph.grow_validators import validate_phase9_output
 

--- a/tests/unit/test_grow_validators.py
+++ b/tests/unit/test_grow_validators.py
@@ -1,0 +1,384 @@
+"""Tests for GROW semantic validators (grow_validators.py)."""
+
+from __future__ import annotations
+
+from questfoundry.graph.grow_validators import (
+    count_entries,
+    format_semantic_errors,
+    validate_phase2_output,
+    validate_phase3_output,
+    validate_phase4a_output,
+    validate_phase8c_output,
+    validate_phase9_output,
+)
+from questfoundry.graph.mutations import GrowValidationError
+from questfoundry.models.grow import (
+    ChoiceLabel,
+    KnotProposal,
+    OverlayProposal,
+    Phase2Output,
+    Phase3Output,
+    Phase4aOutput,
+    Phase8cOutput,
+    Phase9Output,
+    SceneTypeTag,
+    ThreadAgnosticAssessment,
+)
+
+
+class TestValidatePhase2Output:
+    def test_valid_output_no_errors(self) -> None:
+        result = Phase2Output(
+            assessments=[
+                ThreadAgnosticAssessment(beat_id="beat::b1", agnostic_for=["t1"]),
+                ThreadAgnosticAssessment(beat_id="beat::b2", agnostic_for=["t1", "t2"]),
+            ]
+        )
+        errors = validate_phase2_output(
+            result,
+            valid_beat_ids={"beat::b1", "beat::b2"},
+            valid_tension_ids={"t1", "t2"},
+        )
+        assert errors == []
+
+    def test_invalid_beat_id(self) -> None:
+        result = Phase2Output(
+            assessments=[
+                ThreadAgnosticAssessment(beat_id="beat::phantom", agnostic_for=[]),
+            ]
+        )
+        errors = validate_phase2_output(
+            result,
+            valid_beat_ids={"beat::b1", "beat::b2"},
+            valid_tension_ids=set(),
+        )
+        assert len(errors) == 1
+        assert errors[0].field_path == "assessments.0.beat_id"
+        assert "phantom" in errors[0].issue
+        assert errors[0].provided == "beat::phantom"
+
+    def test_invalid_tension_id(self) -> None:
+        result = Phase2Output(
+            assessments=[
+                ThreadAgnosticAssessment(beat_id="beat::b1", agnostic_for=["t_bad"]),
+            ]
+        )
+        errors = validate_phase2_output(
+            result,
+            valid_beat_ids={"beat::b1"},
+            valid_tension_ids={"t1", "t2"},
+        )
+        assert len(errors) == 1
+        assert errors[0].field_path == "assessments.0.agnostic_for"
+        assert "t_bad" in errors[0].issue
+
+    def test_multiple_errors(self) -> None:
+        result = Phase2Output(
+            assessments=[
+                ThreadAgnosticAssessment(beat_id="beat::bad", agnostic_for=["t_bad1", "t_bad2"]),
+            ]
+        )
+        errors = validate_phase2_output(
+            result,
+            valid_beat_ids={"beat::b1"},
+            valid_tension_ids={"t1"},
+        )
+        # 1 bad beat_id + 2 bad tension_ids = 3 errors
+        assert len(errors) == 3
+
+    def test_empty_assessments(self) -> None:
+        result = Phase2Output(assessments=[])
+        errors = validate_phase2_output(
+            result,
+            valid_beat_ids={"beat::b1"},
+            valid_tension_ids={"t1"},
+        )
+        assert errors == []
+
+
+class TestValidatePhase3Output:
+    def test_valid_output_no_errors(self) -> None:
+        result = Phase3Output(
+            knots=[
+                KnotProposal(beat_ids=["beat::b1", "beat::b2"], rationale="test"),
+            ]
+        )
+        errors = validate_phase3_output(
+            result,
+            valid_beat_ids={"beat::b1", "beat::b2", "beat::b3"},
+        )
+        assert errors == []
+
+    def test_invalid_beat_id(self) -> None:
+        result = Phase3Output(
+            knots=[
+                KnotProposal(beat_ids=["beat::b1", "beat::phantom"], rationale="test"),
+            ]
+        )
+        errors = validate_phase3_output(
+            result,
+            valid_beat_ids={"beat::b1", "beat::b2"},
+        )
+        assert len(errors) == 1
+        assert "phantom" in errors[0].issue
+
+    def test_beat_reused_across_knots(self) -> None:
+        result = Phase3Output(
+            knots=[
+                KnotProposal(beat_ids=["beat::b1", "beat::b2"], rationale="knot1"),
+                KnotProposal(beat_ids=["beat::b2", "beat::b3"], rationale="knot2"),
+            ]
+        )
+        errors = validate_phase3_output(
+            result,
+            valid_beat_ids={"beat::b1", "beat::b2", "beat::b3"},
+        )
+        # beat::b2 reused → 1 error
+        assert len(errors) == 1
+        assert "reused" in errors[0].issue
+        assert errors[0].provided == "beat::b2"
+
+    def test_both_invalid_and_reused(self) -> None:
+        result = Phase3Output(
+            knots=[
+                KnotProposal(beat_ids=["beat::b1", "beat::bad"], rationale="knot1"),
+                KnotProposal(beat_ids=["beat::b1", "beat::b2"], rationale="knot2"),
+            ]
+        )
+        errors = validate_phase3_output(
+            result,
+            valid_beat_ids={"beat::b1", "beat::b2"},
+        )
+        # beat::bad invalid + beat::b1 reused = 2 errors
+        assert len(errors) == 2
+
+
+class TestValidatePhase4aOutput:
+    def test_valid_output_no_errors(self) -> None:
+        result = Phase4aOutput(
+            tags=[
+                SceneTypeTag(beat_id="beat::b1", scene_type="scene"),
+                SceneTypeTag(beat_id="beat::b2", scene_type="sequel"),
+            ]
+        )
+        errors = validate_phase4a_output(
+            result,
+            valid_beat_ids={"beat::b1", "beat::b2"},
+        )
+        assert errors == []
+
+    def test_invalid_beat_id(self) -> None:
+        result = Phase4aOutput(
+            tags=[
+                SceneTypeTag(beat_id="beat::phantom", scene_type="scene"),
+            ]
+        )
+        errors = validate_phase4a_output(
+            result,
+            valid_beat_ids={"beat::b1"},
+        )
+        assert len(errors) == 1
+        assert errors[0].field_path == "tags.0.beat_id"
+        assert "phantom" in errors[0].issue
+
+
+class TestValidatePhase8cOutput:
+    def test_valid_output_no_errors(self) -> None:
+        result = Phase8cOutput(
+            overlays=[
+                OverlayProposal(entity_id="entity::e1", when=["cw::c1"], details={}),
+            ]
+        )
+        errors = validate_phase8c_output(
+            result,
+            valid_entity_ids={"entity::e1"},
+            valid_codeword_ids={"cw::c1"},
+        )
+        assert errors == []
+
+    def test_invalid_entity_id(self) -> None:
+        result = Phase8cOutput(
+            overlays=[
+                OverlayProposal(entity_id="entity::bad", when=["cw::c1"], details={}),
+            ]
+        )
+        errors = validate_phase8c_output(
+            result,
+            valid_entity_ids={"entity::e1"},
+            valid_codeword_ids={"cw::c1"},
+        )
+        assert len(errors) == 1
+        assert "entity::bad" in errors[0].issue
+
+    def test_invalid_codeword_id(self) -> None:
+        result = Phase8cOutput(
+            overlays=[
+                OverlayProposal(entity_id="entity::e1", when=["cw::bad"], details={}),
+            ]
+        )
+        errors = validate_phase8c_output(
+            result,
+            valid_entity_ids={"entity::e1"},
+            valid_codeword_ids={"cw::c1"},
+        )
+        assert len(errors) == 1
+        assert "cw::bad" in errors[0].issue
+
+    def test_multiple_invalid_codewords(self) -> None:
+        result = Phase8cOutput(
+            overlays=[
+                OverlayProposal(entity_id="entity::e1", when=["cw::bad1", "cw::bad2"], details={}),
+            ]
+        )
+        errors = validate_phase8c_output(
+            result,
+            valid_entity_ids={"entity::e1"},
+            valid_codeword_ids={"cw::c1"},
+        )
+        assert len(errors) == 2
+
+
+class TestValidatePhase9Output:
+    def test_valid_output_no_errors(self) -> None:
+        result = Phase9Output(
+            labels=[
+                ChoiceLabel(from_passage="p::a", to_passage="p::b", label="go left"),
+            ]
+        )
+        errors = validate_phase9_output(
+            result,
+            valid_passage_ids={"p::a", "p::b"},
+        )
+        assert errors == []
+
+    def test_invalid_from_passage(self) -> None:
+        result = Phase9Output(
+            labels=[
+                ChoiceLabel(from_passage="p::bad", to_passage="p::b", label="go"),
+            ]
+        )
+        errors = validate_phase9_output(
+            result,
+            valid_passage_ids={"p::a", "p::b"},
+        )
+        assert len(errors) == 1
+        assert errors[0].field_path == "labels.0.from_passage"
+        assert "p::bad" in errors[0].issue
+
+    def test_invalid_to_passage(self) -> None:
+        result = Phase9Output(
+            labels=[
+                ChoiceLabel(from_passage="p::a", to_passage="p::bad", label="go"),
+            ]
+        )
+        errors = validate_phase9_output(
+            result,
+            valid_passage_ids={"p::a", "p::b"},
+        )
+        assert len(errors) == 1
+        assert errors[0].field_path == "labels.0.to_passage"
+
+    def test_both_invalid(self) -> None:
+        result = Phase9Output(
+            labels=[
+                ChoiceLabel(from_passage="p::bad1", to_passage="p::bad2", label="go"),
+            ]
+        )
+        errors = validate_phase9_output(
+            result,
+            valid_passage_ids={"p::a", "p::b"},
+        )
+        assert len(errors) == 2
+
+    def test_available_ids_in_error(self) -> None:
+        result = Phase9Output(
+            labels=[
+                ChoiceLabel(from_passage="p::bad", to_passage="p::a", label="go"),
+            ]
+        )
+        errors = validate_phase9_output(
+            result,
+            valid_passage_ids={"p::a", "p::b", "p::c"},
+        )
+        assert len(errors) == 1
+        assert "p::a" in errors[0].available
+        assert "p::b" in errors[0].available
+        assert "p::c" in errors[0].available
+
+
+class TestFormatSemanticErrors:
+    def test_basic_formatting(self) -> None:
+        errors = [
+            GrowValidationError(
+                field_path="assessments.0.beat_id",
+                issue="Beat ID not found: beat::bad",
+                provided="beat::bad",
+                available=["beat::b1", "beat::b2"],
+            ),
+        ]
+        text = format_semantic_errors(errors)
+        assert "Semantic validation errors" in text
+        assert "assessments.0.beat_id" in text
+        assert "beat::bad" in text
+        assert "beat::b1" in text
+        assert "Please fix" in text
+
+    def test_truncates_available_to_five(self) -> None:
+        errors = [
+            GrowValidationError(
+                field_path="tags.0.beat_id",
+                issue="Beat ID not found: x",
+                provided="x",
+                available=["a", "b", "c", "d", "e", "f", "g"],
+            ),
+        ]
+        text = format_semantic_errors(errors)
+        assert "and 2 more" in text
+
+    def test_no_available_ids(self) -> None:
+        errors = [
+            GrowValidationError(
+                field_path="knots.0.beat_ids",
+                issue="Beat reused across knots: beat::b1",
+                provided="beat::b1",
+            ),
+        ]
+        text = format_semantic_errors(errors)
+        assert "Valid options" not in text
+        assert "reused" in text
+
+
+class TestCountEntries:
+    def test_counts_assessments(self) -> None:
+        result = Phase2Output(
+            assessments=[
+                ThreadAgnosticAssessment(beat_id="b1", agnostic_for=[]),
+                ThreadAgnosticAssessment(beat_id="b2", agnostic_for=[]),
+            ]
+        )
+        assert count_entries(result) == 2
+
+    def test_counts_knots(self) -> None:
+        result = Phase3Output(knots=[KnotProposal(beat_ids=["b1", "b2"], rationale="test")])
+        assert count_entries(result) == 1
+
+    def test_counts_tags(self) -> None:
+        result = Phase4aOutput(
+            tags=[
+                SceneTypeTag(beat_id="b1", scene_type="scene"),
+                SceneTypeTag(beat_id="b2", scene_type="sequel"),
+                SceneTypeTag(beat_id="b3", scene_type="micro_beat"),
+            ]
+        )
+        assert count_entries(result) == 3
+
+    def test_counts_overlays(self) -> None:
+        result = Phase8cOutput(overlays=[])
+        assert count_entries(result) == 0
+
+    def test_counts_labels(self) -> None:
+        result = Phase9Output(labels=[ChoiceLabel(from_passage="a", to_passage="b", label="go")])
+        assert count_entries(result) == 1
+
+    def test_fallback_for_unknown_object(self) -> None:
+        assert count_entries(object()) == 1


### PR DESCRIPTION
## Problem

GROW LLM phases can hallucinate IDs that don't exist in the graph (phantom IDs). Currently these are silently filtered by each phase's post-processing logic, but a retry with targeted feedback would improve output quality by giving the LLM a chance to self-correct.

## Changes

- **New `src/questfoundry/graph/grow_validators.py`**: Semantic validators for phases 2, 3, 4a, 8c, and 9 that check all referenced IDs exist in the graph
  - `validate_phase2_output`: Checks beat_id and agnostic_for tension IDs
  - `validate_phase3_output`: Checks beat_ids + detects reuse across knots
  - `validate_phase4a_output`: Checks beat_id in scene type tags
  - `validate_phase8c_output`: Checks entity_id and codeword IDs in `when`
  - `validate_phase9_output`: Checks from_passage and to_passage IDs
  - `format_semantic_errors`: Formats errors as LLM feedback with valid alternatives
  - `count_entries`: Counts entries for threshold calculation
- **Extended `_grow_llm_call()`**: New `semantic_validator` parameter; when >50% of entries have errors, retries with structured feedback. Below threshold, returns for caller to filter.
- **Wired validators into phases**: 2, 3, 4a, 8c, 9 via `functools.partial` binding the phase-specific valid ID sets

## Not Included / Future PRs

- Phase 4b/4c gap validation (these phases already have inline validation)
- Adjustable threshold (hardcoded at 50%)
- Configurable max retries per phase

## Test Plan

- 29 unit tests for all validator functions, `format_semantic_errors`, and `count_entries`
- 4 integration tests for retry logic in `_grow_llm_call`:
  - Retry when >50% errors (majority invalid)
  - No retry when <=50% errors (minority invalid)
  - Returns on last attempt even with high errors
  - Passes through when validator returns no errors
- All 1267 existing tests pass

```bash
uv run pytest tests/unit/test_grow_validators.py tests/unit/test_grow_stage.py -x
uv run ruff check src/questfoundry/graph/grow_validators.py src/questfoundry/pipeline/stages/grow.py
```

## Risk / Rollback

- Low risk: semantic validators are additive. Removing the `semantic_validator=` kwarg from each phase call reverts to previous behavior.
- No breaking changes to public interfaces.

Closes #280

🤖 Generated with [Claude Code](https://claude.com/claude-code)