### PR TITLE
feat(grow): add graph checkpoints and --resume-from support (#281)

### DIFF
--- a/src/questfoundry/cli.py
+++ b/src/questfoundry/cli.py
@@ -373,6 +373,7 @@ def _run_stage_command(
     provider_discuss: str | None = None,
     provider_summarize: str | None = None,
     provider_serialize: str | None = None,
+    resume_from: str | None = None,
 ) -> None:
     """Common logic for running a stage command.
 
@@ -416,6 +417,8 @@ def _run_stage_command(
 
     # Build context
     context: dict[str, Any] = {"user_prompt": prompt, "interactive": use_interactive}
+    if resume_from:
+        context["resume_from"] = resume_from
 
     if use_interactive:
         log.debug("interactive_mode", mode="enabled")
@@ -932,6 +935,10 @@ def grow(
         str | None,
         typer.Option("--provider-serialize", help="LLM provider for serialize phase"),
     ] = None,
+    resume_from: Annotated[
+        str | None,
+        typer.Option("--resume-from", help="Resume from named phase (skips earlier phases)"),
+    ] = None,
 ) -> None:
     """Run GROW stage - build complete branching structure.
 
@@ -961,6 +968,7 @@ def grow(
         provider_discuss=provider_discuss,
         provider_summarize=provider_summarize,
         provider_serialize=provider_serialize,
+        resume_from=resume_from,
     )
 
 

--- a/src/questfoundry/pipeline/orchestrator.py
+++ b/src/questfoundry/pipeline/orchestrator.py
@@ -494,6 +494,7 @@ class PipelineOrchestrator:
             on_assistant_message = context.get("on_assistant_message")
             on_llm_start = context.get("on_llm_start")
             on_llm_end = context.get("on_llm_end")
+            resume_from = context.get("resume_from")
 
             artifact_data, llm_calls, tokens_used = await stage.execute(
                 model=model,
@@ -511,6 +512,8 @@ class PipelineOrchestrator:
                 serialize_model=serialize_model,
                 summarize_provider_name=self._summarize_provider_name,
                 serialize_provider_name=self._serialize_provider_name,
+                # Checkpoint resume support
+                resume_from=resume_from,
             )
 
             # Validate artifact

--- a/src/questfoundry/pipeline/stages/grow.py
+++ b/src/questfoundry/pipeline/stages/grow.py
@@ -103,8 +103,36 @@ class GrowStage:
         self._serialize_model: BaseChatModel | None = None
         self._serialize_provider_name: str | None = None
 
+    CHECKPOINT_DIR = "snapshots"
+
     # Type for async phase functions: (Graph, BaseChatModel) -> GrowPhaseResult
     PhaseFunc = Callable[["Graph", "BaseChatModel"], Awaitable[GrowPhaseResult]]
+
+    def _save_checkpoint(self, graph: Graph, project_path: Path, phase_name: str) -> None:
+        """Save graph state before a phase runs.
+
+        Creates a snapshot file that can be used to resume from this phase
+        if execution is interrupted or needs to be re-run.
+        """
+        checkpoint_dir = project_path / self.CHECKPOINT_DIR
+        checkpoint_dir.mkdir(parents=True, exist_ok=True)
+        path = checkpoint_dir / f"grow-pre-{phase_name}.json"
+        graph.save(path)
+        log.debug("checkpoint_saved", phase=phase_name, path=str(path))
+
+    def _load_checkpoint(self, project_path: Path, phase_name: str) -> Graph:
+        """Load graph state from a checkpoint.
+
+        Raises:
+            GrowStageError: If checkpoint file doesn't exist.
+        """
+        path = project_path / self.CHECKPOINT_DIR / f"grow-pre-{phase_name}.json"
+        if not path.exists():
+            raise GrowStageError(
+                f"No checkpoint found for phase '{phase_name}'. Expected at: {path}"
+            )
+        log.info("checkpoint_loaded", phase=phase_name, path=str(path))
+        return Graph.load_from_file(path)
 
     def _phase_order(self) -> list[tuple[PhaseFunc, str]]:
         """Return ordered list of (phase_function, phase_name) tuples.
@@ -150,6 +178,7 @@ class GrowStage:
         serialize_model: BaseChatModel | None = None,
         summarize_provider_name: str | None = None,  # noqa: ARG002
         serialize_provider_name: str | None = None,
+        resume_from: str | None = None,
         **kwargs: Any,  # noqa: ARG002
     ) -> tuple[dict[str, Any], int, int]:
         """Execute the GROW stage.
@@ -172,6 +201,7 @@ class GrowStage:
             serialize_model: Model for structured output (falls back to model).
             summarize_provider_name: Summarize provider name (unused).
             serialize_provider_name: Provider name for structured output strategy.
+            resume_from: Phase name to resume from (skips earlier phases).
             **kwargs: Additional keyword arguments (ignored).
 
         Returns:
@@ -193,12 +223,35 @@ class GrowStage:
         self._serialize_model = serialize_model
         self._serialize_provider_name = serialize_provider_name
         log.info("stage_start", stage="grow")
-        graph = Graph.load(resolved_path)
+
+        phases = self._phase_order()
+        phase_names = [name for _, name in phases]
+        start_idx = 0
+
+        if resume_from:
+            if resume_from not in phase_names:
+                raise GrowStageError(
+                    f"Unknown phase: '{resume_from}'. Valid phases: {', '.join(phase_names)}"
+                )
+            start_idx = phase_names.index(resume_from)
+            graph = self._load_checkpoint(resolved_path, resume_from)
+            log.info(
+                "resume_from_checkpoint",
+                phase=resume_from,
+                skipped=start_idx,
+            )
+        else:
+            graph = Graph.load(resolved_path)
+
         phase_results: list[GrowPhaseResult] = []
         total_llm_calls = 0
         total_tokens = 0
 
-        for phase_fn, phase_name in self._phase_order():
+        for idx, (phase_fn, phase_name) in enumerate(phases):
+            if idx < start_idx:
+                continue
+
+            self._save_checkpoint(graph, resolved_path, phase_name)
             log.debug("phase_start", phase=phase_name)
             snapshot = graph.to_dict()
 


### PR DESCRIPTION
## Problem

When GROW stage execution is interrupted (error, timeout, or user stop), all progress is lost. Users must re-run all 15 phases from scratch, which wastes LLM calls and time.

## Changes

- **`src/questfoundry/pipeline/stages/grow.py`**:
  - `_save_checkpoint()`: Saves graph state to `snapshots/grow-pre-{phase}.json` before each phase
  - `_load_checkpoint()`: Restores graph from checkpoint (raises if missing)
  - `execute()`: Accepts `resume_from` parameter; validates phase name, loads checkpoint, skips earlier phases
- **`src/questfoundry/cli.py`**: Added `--resume-from` option to `qf grow` command
- **`src/questfoundry/pipeline/orchestrator.py`**: Forwards `resume_from` from context to `stage.execute()`

## Not Included / Future PRs

- Automatic resume detection (always requires explicit `--resume-from`)
- Checkpoint cleanup/rotation
- Phase completion markers (only pre-phase snapshots)

## Test Plan

- 6 unit tests covering:
  - Checkpoint file creation
  - Checkpoint round-trip (save + load)
  - Missing checkpoint raises GrowStageError
  - Invalid phase name raises GrowStageError
  - Phases before resume point are skipped
  - Checkpoints are saved before each phase runs
- All 1239 unit tests pass

```bash
uv run pytest tests/unit/test_grow_stage.py::TestGrowCheckpoints -xvs
uv run ruff check src/questfoundry/pipeline/stages/grow.py src/questfoundry/cli.py src/questfoundry/pipeline/orchestrator.py
```

## Risk / Rollback

- Low risk: checkpoint saves are additive (new files in `snapshots/` directory)
- `--resume-from` is opt-in; default behavior unchanged
- No breaking changes to existing interfaces

Closes #281

🤖 Generated with [Claude Code](https://claude.com/claude-code)