### PR TITLE
feat(cli): add phase-level progress for DREAM/BRAINSTORM/SEED stages

### DIFF
--- a/src/questfoundry/cli.py
+++ b/src/questfoundry/cli.py
@@ -420,14 +420,17 @@ def _run_stage_command(
     if resume_from:
         context["resume_from"] = resume_from
 
-    # Add phase progress callback for GROW stage (shows phase-by-phase progress)
-    if stage_name == "grow":
+    # Add phase progress callback for stages that support it
+    # (DREAM, BRAINSTORM, SEED, GROW all show phase-by-phase progress)
+    if stage_name in ("dream", "brainstorm", "seed", "grow"):
 
-        def _on_phase_progress(phase: str, status: str, detail: str | None) -> None:
-            """Display phase progress for GROW stage."""
+        def _on_phase_progress(
+            phase: str, status: str, detail: str | None, _stage: str = stage_name
+        ) -> None:
+            """Display phase progress for stage."""
             status_icon = "[green]✓[/green]" if status == "completed" else "[yellow]○[/yellow]"
             detail_str = f" ({detail})" if detail else ""
-            console.print(f"  {status_icon} {phase}{detail_str}")
+            console.print(f"  {_stage.upper()}: {phase}{detail_str} {status_icon}")
 
         context["on_phase_progress"] = _on_phase_progress
 
@@ -458,8 +461,8 @@ def _run_stage_command(
         )
     else:
         # Non-interactive mode
-        if stage_name == "grow":
-            # GROW shows phase-by-phase progress instead of spinner
+        if stage_name in ("dream", "brainstorm", "seed", "grow"):
+            # These stages show phase-by-phase progress instead of spinner
             console.print(f"[dim]Running {stage_name.upper()} stage...[/dim]")
             result = asyncio.run(
                 _run_stage_async(


### PR DESCRIPTION
## Problem

Only the GROW stage showed phase-level progress (discuss/summarize/serialize transitions).
Earlier stages (DREAM, BRAINSTORM, SEED) used a simple spinner, providing no feedback
about pipeline progress during longer runs.

## Changes

Add phase-level progress display to DREAM, BRAINSTORM, and SEED stages, mirroring
the existing GROW stage pattern.

### CLI (src/questfoundry/cli.py)
- Expand progress callback setup from GROW-only to all stages
- Update non-interactive mode to show progress lines instead of spinner

### Stage Implementations
- **dream.py**: Add `on_phase_progress` param, report turn count and phase completion
- **brainstorm.py**: Add `on_phase_progress` param, report entity/tension counts after serialize
- **seed.py**: Add `on_phase_progress` param, bridge to section progress for serialize

### Serialize Phase (src/questfoundry/agents/serialize.py)
- Add `on_section_progress` callback to `serialize_seed_as_function`
- Report per-section progress (entities, threads, beats, convergence)

### Example Output
```
DREAM: discuss (3 turns) ✓
DREAM: summarize ✓
DREAM: serialize ✓

BRAINSTORM: discuss (5 turns) ✓
BRAINSTORM: summarize ✓
BRAINSTORM: serialize (12 entities, 8 tensions) ✓

SEED: discuss (4 turns) ✓
SEED: summarize ✓
SEED: serialize entities... ✓
SEED: serialize threads... ✓ (8 threads)
SEED: serialize beats... ✓ (24 beats)
SEED: serialize convergence... ✓
```

## Not Included / Future PRs
- Interactive mode progress (uses different display pattern)

## Test Plan
```bash
uv run pytest tests/unit/test_dream_stage.py tests/unit/test_brainstorm_stage.py tests/unit/test_seed_stage.py tests/unit/test_cli.py -v
uv run mypy src/questfoundry/cli.py src/questfoundry/pipeline/stages/
uv run ruff check src/questfoundry/
```

## Risk / Rollback
- Low risk - additive feature, no behavior changes
- Rollback: revert commit

---
**Note:** This is a stacked PR on top of #305 (`refactor/seed-overgenerate-and-select`).
After #305 merges, this PR should be retargeted to `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)