### PR TITLE
fix: misc pipeline fixes (orchestrator error handling, mutations registry)

### DIFF
--- a/src/questfoundry/graph/mutations.py
+++ b/src/questfoundry/graph/mutations.py
@@ -455,7 +455,9 @@ def _clean_dict(data: dict[str, Any]) -> dict[str, Any]:
 
 
 # Registry of stages with mutation handlers
-_MUTATION_STAGES = frozenset({"dream", "brainstorm", "seed", "grow"})
+# Note: GROW is not included because it modifies the graph directly during execution,
+# not via post-stage mutation application.
+_MUTATION_STAGES = frozenset({"dream", "brainstorm", "seed"})
 
 
 def has_mutation_handler(stage: str) -> bool:

--- a/src/questfoundry/pipeline/orchestrator.py
+++ b/src/questfoundry/pipeline/orchestrator.py
@@ -580,9 +580,7 @@ class PipelineOrchestrator:
                     except GraphCorruptionError:
                         # Re-raise corruption errors - already logged and rolled back above
                         raise
-                    except Exception as e:
-                        # Other graph operations are non-critical - artifact was written successfully
-                        log.warning("graph_update_failed", stage=stage_name, error=str(e))
+                    # All other exceptions propagate - never swallow errors
 
             # Calculate duration
             duration = time.perf_counter() - start_time

--- a/tests/unit/test_mutations.py
+++ b/tests/unit/test_mutations.py
@@ -41,9 +41,9 @@ class TestHasMutationHandler:
         """Seed stage has a mutation handler."""
         assert has_mutation_handler("seed") is True
 
-    def test_returns_true_for_grow(self) -> None:
-        """Grow stage has a mutation handler."""
-        assert has_mutation_handler("grow") is True
+    def test_returns_false_for_grow(self) -> None:
+        """Grow stage handles its own mutations directly, not via apply_mutations."""
+        assert has_mutation_handler("grow") is False
 
     def test_returns_false_for_unknown_stage(self) -> None:
         """Unknown stages don't have mutation handlers."""


### PR DESCRIPTION
## Problem

Two small issues in the pipeline:
1. Orchestrator was silently swallowing graph mutation errors, making debugging difficult
2. GROW was incorrectly registered in the mutation stages registry (GROW doesn't produce mutations)

## Changes

- **orchestrator.py**: Remove error suppression - let mutation errors propagate
- **mutations.py**: Remove "grow" from MUTATION_STAGES since GROW doesn't produce mutations

## Not Included / Future PRs

Part of larger refactor branch being split per PR guidelines.

## Test Plan

```bash
uv run pytest tests/unit/test_mutations.py tests/unit/test_orchestrator.py -v
# 158 passed
```

## Risk / Rollback

- Low risk - removes error suppression (better observability)
- No behavior change for normal operation

🤖 Generated with [Claude Code](https://claude.com/claude-code)