### PR TITLE
fix(seed): set is_canonical on threads from alternative's is_default_path

### DIFF
--- a/src/questfoundry/graph/mutations.py
+++ b/src/questfoundry/graph/mutations.py
@@ -1211,6 +1211,15 @@ def apply_seed_mutations(graph: Graph, output: dict[str, Any]) -> None:
                 full_unexplored_id = f"{prefixed_tension_id}::alt::{unexplored_alt_id}"
                 prefixed_unexplored.append(full_unexplored_id)
 
+        # Look up alternative's is_default_path to determine if thread is canonical (spine)
+        is_canonical = False
+        if prefixed_tension_id and "alternative_id" in thread:
+            alt_local_id = thread["alternative_id"]
+            full_alt_id = f"{prefixed_tension_id}::alt::{alt_local_id}"
+            alt_node = graph.get_node(full_alt_id)
+            if alt_node is not None:
+                is_canonical = alt_node.get("is_default_path", False)
+
         thread_data = {
             "type": "thread",
             "raw_id": raw_id,
@@ -1221,6 +1230,7 @@ def apply_seed_mutations(graph: Graph, output: dict[str, Any]) -> None:
             "thread_importance": thread.get("thread_importance"),
             "description": thread.get("description"),
             "consequence_ids": thread.get("consequence_ids", []),
+            "is_canonical": is_canonical,  # True if exploring default path (for spine arc)
         }
         thread_data = _clean_dict(thread_data)
         graph.create_node(thread_id, thread_data)

--- a/tests/unit/test_mutations.py
+++ b/tests/unit/test_mutations.py
@@ -753,6 +753,98 @@ class TestSeedMutations:
         assert len(edges) == 1
         assert edges[0]["to"] == "tension::mentor_trust::alt::protector"
 
+    def test_thread_is_canonical_from_alternative(self) -> None:
+        """Thread's is_canonical is set from alternative's is_default_path."""
+        graph = Graph.empty()
+        # Create tension with two alternatives - one canonical, one not
+        graph.create_node(
+            "tension::mentor_trust",
+            {"type": "tension", "raw_id": "mentor_trust", "question": "Can the mentor be trusted?"},
+        )
+        graph.create_node(
+            "tension::mentor_trust::alt::protector",
+            {
+                "type": "alternative",
+                "raw_id": "protector",
+                "description": "Mentor protects",
+                "is_default_path": True,  # This is the canonical path
+            },
+        )
+        graph.create_node(
+            "tension::mentor_trust::alt::manipulator",
+            {
+                "type": "alternative",
+                "raw_id": "manipulator",
+                "description": "Mentor manipulates",
+                "is_default_path": False,  # Branch path
+            },
+        )
+        graph.add_edge(
+            "has_alternative", "tension::mentor_trust", "tension::mentor_trust::alt::protector"
+        )
+        graph.add_edge(
+            "has_alternative", "tension::mentor_trust", "tension::mentor_trust::alt::manipulator"
+        )
+
+        output = {
+            "entities": [],
+            "tensions": [
+                {
+                    "tension_id": "mentor_trust",
+                    "explored": ["protector", "manipulator"],
+                    "implicit": [],
+                },
+            ],
+            "threads": [
+                {
+                    "thread_id": "mentor_protects",
+                    "name": "Mentor Protects Arc",
+                    "tension_id": "mentor_trust",
+                    "alternative_id": "protector",  # Canonical
+                    "description": "The mentor genuinely protects",
+                    "consequence_ids": [],
+                },
+                {
+                    "thread_id": "mentor_manipulates",
+                    "name": "Mentor Manipulates Arc",
+                    "tension_id": "mentor_trust",
+                    "alternative_id": "manipulator",  # Non-canonical
+                    "description": "The mentor is manipulating",
+                    "consequence_ids": [],
+                },
+            ],
+            "initial_beats": [
+                {
+                    "beat_id": "protects_beat_01",
+                    "summary": "Mentor reveals protection",
+                    "threads": ["mentor_protects"],
+                    "tension_impacts": [
+                        {"tension_id": "mentor_trust", "effect": "commits", "note": "Locked"}
+                    ],
+                },
+                {
+                    "beat_id": "manipulates_beat_01",
+                    "summary": "Mentor reveals manipulation",
+                    "threads": ["mentor_manipulates"],
+                    "tension_impacts": [
+                        {"tension_id": "mentor_trust", "effect": "commits", "note": "Locked"}
+                    ],
+                },
+            ],
+        }
+
+        apply_seed_mutations(graph, output)
+
+        # Thread from canonical alternative should have is_canonical=True
+        protects_thread = graph.get_node("thread::mentor_protects")
+        assert protects_thread is not None
+        assert protects_thread.get("is_canonical") is True
+
+        # Thread from non-canonical alternative should have is_canonical=False
+        manipulates_thread = graph.get_node("thread::mentor_manipulates")
+        assert manipulates_thread is not None
+        assert manipulates_thread.get("is_canonical") is False
+
     def test_creates_beats(self) -> None:
         """Creates beat nodes from seed output."""
         graph = Graph.empty()


### PR DESCRIPTION
## Problem

When creating threads from tension alternatives, the `is_canonical` flag wasn't being
set based on the alternative's `is_default_path` property. This meant all threads
had `is_canonical=False` even when they represented the default path.

## Changes

- **mutations.py**: Copy `is_default_path` from alternative to thread's `is_canonical` during mutation processing
- Add test to verify this behavior

## Not Included / Future PRs

Part of larger refactor branch being split per PR guidelines.

## Test Plan

```bash
uv run pytest tests/unit/test_mutations.py -v -k "canonical"
# 1 passed
```

## Risk / Rollback

- Low risk - additive fix
- Affects downstream GROW phase which uses is_canonical for arc enumeration

🤖 Generated with [Claude Code](https://claude.com/claude-code)