### PR TITLE
feat(cli): add phase-by-phase progress output for GROW stage

### DIFF
--- a/src/questfoundry/pipeline/orchestrator.py
+++ b/src/questfoundry/pipeline/orchestrator.py
@@ -495,11 +495,14 @@ class PipelineOrchestrator:
             on_llm_start = context.get("on_llm_start")
             on_llm_end = context.get("on_llm_end")
             resume_from = context.get("resume_from")
+            on_phase_progress = context.get("on_phase_progress")
 
-            # Build stage kwargs, only including resume_from if set (GROW-specific)
+            # Build stage kwargs, only including optional params if set
             stage_kwargs: dict[str, Any] = {}
             if resume_from:
                 stage_kwargs["resume_from"] = resume_from
+            if on_phase_progress:
+                stage_kwargs["on_phase_progress"] = on_phase_progress
 
             artifact_data, llm_calls, tokens_used = await stage.execute(
                 model=model,

--- a/src/questfoundry/pipeline/stages/base.py
+++ b/src/questfoundry/pipeline/stages/base.py
@@ -12,6 +12,8 @@ if TYPE_CHECKING:
 UserInputFn = Callable[[], Awaitable[str | None]]
 AssistantMessageFn = Callable[[str], None]
 LLMCallbackFn = Callable[[str], None]
+# Phase progress callback: (phase_name, status, detail) -> None
+PhaseProgressFn = Callable[[str, str, str | None], None]
 
 
 class Stage(Protocol):

--- a/src/questfoundry/pipeline/stages/grow.py
+++ b/src/questfoundry/pipeline/stages/grow.py
@@ -48,6 +48,7 @@ if TYPE_CHECKING:
     from questfoundry.pipeline.stages.base import (
         AssistantMessageFn,
         LLMCallbackFn,
+        PhaseProgressFn,
         UserInputFn,
     )
 
@@ -183,6 +184,7 @@ class GrowStage:
         summarize_provider_name: str | None = None,  # noqa: ARG002
         serialize_provider_name: str | None = None,
         resume_from: str | None = None,
+        on_phase_progress: PhaseProgressFn | None = None,
         **kwargs: Any,  # noqa: ARG002
     ) -> tuple[dict[str, Any], int, int]:
         """Execute the GROW stage.
@@ -206,6 +208,7 @@ class GrowStage:
             summarize_provider_name: Summarize provider name (unused).
             serialize_provider_name: Provider name for structured output strategy.
             resume_from: Phase name to resume from (skips earlier phases).
+            on_phase_progress: Callback for phase progress (phase, status, detail).
             **kwargs: Additional keyword arguments (ignored).
 
         Returns:
@@ -290,6 +293,10 @@ class GrowStage:
                 break
 
             log.debug("phase_complete", phase=phase_name, status=result.status)
+
+            # Notify progress callback if provided
+            if on_phase_progress is not None:
+                on_phase_progress(phase_name, result.status, result.detail)
 
         graph.save(resolved_path / "graph.json")
 


### PR DESCRIPTION
## Problem

The GROW stage runs multiple phases (enumerate-arcs, weave-spine, etc.) but shows only
a spinner during execution. Users can't tell which phase is running or how many have completed.

## Changes

- **cli.py**: Add progress callback setup for GROW stage that prints phase progress
- **orchestrator.py**: Extract and pass `on_phase_progress` from context to stage kwargs
- **stages/base.py**: Add `PhaseProgressFn` type alias for progress callbacks
- **stages/grow.py**: Accept `on_phase_progress` parameter and report phase transitions

Example output:
```
Running GROW stage...
  ✓ enumerate-arcs (8 arcs)
  ✓ weave-spine
  ✓ identify-knots (2 knots)
  ...
```

## Not Included / Future PRs

- Phase progress for DREAM/BRAINSTORM/SEED (separate PR #306)

## Test Plan

```bash
uv run pytest tests/unit/test_cli.py -v -k "grow"
# 9 passed
```

## Risk / Rollback

- Low risk - additive feature, no behavior changes
- Progress callback is optional (None check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)