### PR TITLE
feat(serialize): per-thread beat serialization [1/10]

### DIFF
--- a/prompts/templates/serialize_seed_sections.yaml
+++ b/prompts/templates/serialize_seed_sections.yaml
@@ -224,8 +224,39 @@ beats_prompt: |
   - location can be null; location_alternatives can be empty array
   - Generate 2-4 beats for EACH thread in the VALID THREAD IDs list
   - tension_impacts MUST use tension IDs from the Tension IDs list — NOT entity names
-  - If a beat involves an entity that has no matching tension, use the thread's
-    parent tension or the most thematically related tension from the list
+
+  ## TENSION IMPACT CONSTRAINT (MOST IMPORTANT RULE)
+
+  Every beat belongs to a thread. Every thread has a PARENT TENSION (shown in the
+  THREAD → TENSION MAPPING in your brief). The beat's tension_impacts MUST include
+  the parent tension of the beat's thread.
+
+  RULE: Look up the beat's thread in THREAD → TENSION MAPPING. Use THAT tension_id.
+
+  EXAMPLE (format only - use YOUR story's IDs):
+  - If thread `thread::keeper_loyalty` maps to `tension::keeper_faithful_or_corrupt`
+  - Then ALL beats in `thread::keeper_loyalty` MUST have a tension_impact with
+    `tension_id: "tension::keeper_faithful_or_corrupt"`
+
+  WRONG: Picking a tension because it "feels related" to the beat's content.
+  WRONG: Using the same tension for all beats regardless of thread.
+  RIGHT: Using the THREAD → TENSION MAPPING to find the correct tension.
+
+  A beat MAY have additional tension_impacts for other tensions, but the FIRST
+  tension_impact MUST be the thread's parent tension.
+
+  ## COMMITS BEATS REQUIREMENT (CRITICAL)
+
+  Each thread MUST have at least one beat with `effect: "commits"` — and that
+  commits beat MUST reference the thread's OWN parent tension (from the mapping).
+
+  WRONG: All commits beats using the same tension_id.
+  RIGHT: Each thread's commits beat uses that thread's own parent tension.
+
+  EXAMPLE (format only):
+  - Thread `thread::keeper_loyalty` → commits beat uses `tension::keeper_faithful_or_corrupt`
+  - Thread `thread::artifact_origin` → commits beat uses `tension::artifact_natural_or_crafted`
+  - Each thread resolves ITS OWN tension, not someone else's.
 
   ## FIELD → ID TYPE MAPPING (prevents all ID confusion)
 
@@ -266,16 +297,85 @@ beats_prompt: |
   - Do NOT reference IDs not in the manifest lists
 
   ## FINAL CHECK (verify before output)
-  Before returning JSON, check each beat against the field→ID type table:
+  Before returning JSON, check each beat one by one:
   1. Every `threads` item appears in VALID THREAD IDs (short names)
   2. Every `tension_impacts.tension_id` appears in Tension IDs (long binary questions)
   3. Every `tension_impacts.tension_id` contains `_or_` — if it doesn't, you used an entity ID by mistake
-  4. Every `entities` item appears in Entity IDs (characters, objects, factions)
-  5. `location` is a location-category entity from Entity IDs
-  6. No invented IDs - copy-paste from the manifest, don't retype
+  4. For EACH beat: look up the beat's thread in THREAD → TENSION MAPPING.
+     Does the beat's tension_impacts include that mapped tension? If NO, fix it.
+  5. For EACH thread: does at least one of its beats have `effect: "commits"`
+     with that thread's parent tension? If NO, add or fix one.
+  6. Every `entities` item appears in Entity IDs (characters, objects, factions)
+  7. `location` is a location-category entity from Entity IDs
+  8. No invented IDs - copy-paste from the manifest, don't retype
 
   ## Output
   Return ONLY valid JSON with the "initial_beats" array.
+
+# Section 5b: Per-Thread Initial Beats (used by per-thread serialization)
+# This prompt generates beats for a single thread with a fixed tension_id.
+# The thread_id, tension_id, and entity context are injected at runtime.
+per_thread_beats_prompt: |
+  You are generating INITIAL BEATS for ONE SPECIFIC THREAD.
+
+  ## YOUR THREAD (CRITICAL - read first!)
+  You are generating beats ONLY for this thread:
+  - Thread ID: {thread_id}
+  - Parent tension: {tension_id}
+
+  ALL beats you generate MUST:
+  1. Have `threads: ["{thread_id}"]` (exactly this thread ID)
+  2. Have at least one tension_impact with `tension_id: "{tension_id}"`
+  3. Include at least one beat with `effect: "commits"` for `{tension_id}`
+
+  ## Schema
+  Return a JSON object with an "initial_beats" array of 2-4 beats:
+  ```json
+  {{
+    "initial_beats": [
+      {{
+        "beat_id": "unique_beat_id",
+        "summary": "What happens in this beat",
+        "threads": ["{thread_id}"],
+        "tension_impacts": [
+          {{
+            "tension_id": "{tension_id}",
+            "effect": "advances",
+            "note": "Explanation"
+          }}
+        ],
+        "entities": ["entity::character_id"],
+        "location": "entity::location_id",
+        "location_alternatives": []
+      }}
+    ]
+  }}
+  ```
+
+  ## Rules
+  - Generate exactly 2-4 beats for thread `{thread_id}`
+  - EVERY beat must include `{thread_id}` in its `threads` array
+  - EVERY beat must have at least one tension_impact for `{tension_id}`
+  - At least ONE beat must have `effect: "commits"` for `{tension_id}`
+  - effect must be "advances", "reveals", "commits", or "complicates"
+  - Use entity IDs from the Entity IDs list only
+  - Use location IDs from the Entity IDs list (location category only)
+
+  ## COMMITS BEAT REQUIREMENT
+  You MUST include exactly one beat with `effect: "commits"` for `{tension_id}`.
+  This beat represents the moment where this thread's tension is locked in.
+
+  WRONG: Generating only "advances" and "reveals" beats.
+  RIGHT: Including one beat with `effect: "commits"`.
+
+  ## What NOT to Do
+  - Do NOT generate beats for other threads
+  - Do NOT reference other tension_ids in your first tension_impact
+  - Do NOT skip the commits beat
+  - Do NOT use IDs not in the manifest
+
+  ## Output
+  Return ONLY valid JSON with the "initial_beats" array (2-4 beats).
 
 # Section 6: Convergence Sketch
 convergence_prompt: |

--- a/src/questfoundry/agents/serialize.py
+++ b/src/questfoundry/agents/serialize.py
@@ -463,6 +463,7 @@ _REQUIRED_SECTION_PROMPT_KEYS = [
     "threads_prompt",
     "consequences_prompt",
     "beats_prompt",
+    "per_thread_beats_prompt",
     "convergence_prompt",
 ]
 
@@ -510,8 +511,190 @@ def _load_seed_section_prompts() -> dict[str, str]:
         "threads": data["threads_prompt"],
         "consequences": data["consequences_prompt"],
         "beats": data["beats_prompt"],
+        "per_thread_beats": data["per_thread_beats_prompt"],
         "convergence": data["convergence_prompt"],
     }
+
+
+def _build_per_thread_beat_context(
+    thread_data: dict[str, Any],
+    entity_context: str,
+) -> str:
+    """Build a brief for generating beats for a single thread.
+
+    Creates a minimal context containing only:
+    - The thread's ID and parent tension
+    - Entity IDs for character/location references
+
+    Args:
+        thread_data: Thread dict with thread_id and tension_id.
+        entity_context: Entity IDs section from the full brief.
+
+    Returns:
+        Per-thread brief for beat generation.
+    """
+    thread_id = thread_data.get("thread_id", "")
+    tension_id = thread_data.get("tension_id", "")
+    thread_name = thread_data.get("name", "")
+    description = thread_data.get("description", "")
+
+    # Normalize IDs to include prefixes if missing
+    if not thread_id.startswith("thread::"):
+        thread_id = f"thread::{thread_id}"
+    if not tension_id.startswith("tension::"):
+        tension_id = f"tension::{tension_id}"
+
+    lines = [
+        "## Thread Context",
+        f"You are generating beats for thread: `{thread_id}`",
+        f"- Name: {thread_name}",
+        f"- Parent tension: `{tension_id}`",
+    ]
+    if description:
+        lines.append(f"- Description: {description}")
+
+    lines.append("")
+    lines.append(entity_context)
+
+    return "\n".join(lines)
+
+
+async def _serialize_thread_beats(
+    model: BaseChatModel,
+    thread_data: dict[str, Any],
+    per_thread_prompt_template: str,
+    entity_context: str,
+    provider_name: str | None,
+    max_retries: int,
+    callbacks: list[BaseCallbackHandler] | None,
+) -> tuple[list[dict[str, Any]], int]:
+    """Serialize beats for a single thread.
+
+    Uses a constrained prompt with the thread's ID and tension hard-coded.
+
+    Args:
+        model: Chat model to use.
+        thread_data: Thread dict with thread_id, tension_id, etc.
+        per_thread_prompt_template: Prompt template with {thread_id} and {tension_id} placeholders.
+        entity_context: Entity IDs context for character/location references.
+        provider_name: Provider name for strategy selection.
+        max_retries: Maximum Pydantic validation retries.
+        callbacks: LangChain callback handlers.
+
+    Returns:
+        Tuple of (list of beat dicts, tokens used).
+    """
+    from questfoundry.models.seed import ThreadBeatsSection
+
+    thread_id = thread_data.get("thread_id", "")
+    tension_id = thread_data.get("tension_id", "")
+
+    # Normalize IDs
+    if not thread_id.startswith("thread::"):
+        prefixed_thread_id = f"thread::{thread_id}"
+    else:
+        prefixed_thread_id = thread_id
+    if not tension_id.startswith("tension::"):
+        prefixed_tension_id = f"tension::{tension_id}"
+    else:
+        prefixed_tension_id = tension_id
+
+    # Format prompt with thread-specific values
+    prompt = per_thread_prompt_template.format(
+        thread_id=prefixed_thread_id,
+        tension_id=prefixed_tension_id,
+    )
+
+    # Build per-thread brief
+    brief = _build_per_thread_beat_context(thread_data, entity_context)
+
+    log.debug(
+        "serialize_thread_beats_started",
+        thread_id=thread_id,
+        tension_id=tension_id,
+    )
+
+    result, tokens = await serialize_to_artifact(
+        model=model,
+        brief=brief,
+        schema=ThreadBeatsSection,
+        provider_name=provider_name,
+        max_retries=max_retries,
+        system_prompt=prompt,
+        callbacks=callbacks,
+    )
+
+    beats = result.model_dump().get("initial_beats", [])
+
+    log.debug(
+        "serialize_thread_beats_completed",
+        thread_id=thread_id,
+        beat_count=len(beats),
+        tokens=tokens,
+    )
+
+    return beats, tokens
+
+
+async def _serialize_beats_per_thread(
+    model: BaseChatModel,
+    threads: list[dict[str, Any]],
+    per_thread_prompt: str,
+    entity_context: str,
+    provider_name: str | None,
+    max_retries: int,
+    callbacks: list[BaseCallbackHandler] | None,
+) -> tuple[list[dict[str, Any]], int]:
+    """Serialize beats for all threads in parallel.
+
+    Uses asyncio.gather() to run per-thread serialization concurrently.
+
+    Args:
+        model: Chat model to use.
+        threads: List of thread dicts from ThreadsSection serialization.
+        per_thread_prompt: Prompt template for per-thread beat generation.
+        entity_context: Entity IDs context for character/location references.
+        provider_name: Provider name for strategy selection.
+        max_retries: Maximum Pydantic validation retries per thread.
+        callbacks: LangChain callback handlers.
+
+    Returns:
+        Tuple of (all beats merged, total tokens used).
+    """
+    log.info("serialize_beats_per_thread_started", thread_count=len(threads))
+
+    # Create tasks for parallel execution
+    tasks = [
+        _serialize_thread_beats(
+            model=model,
+            thread_data=thread,
+            per_thread_prompt_template=per_thread_prompt,
+            entity_context=entity_context,
+            provider_name=provider_name,
+            max_retries=max_retries,
+            callbacks=callbacks,
+        )
+        for thread in threads
+    ]
+
+    # Run all thread serializations in parallel
+    results = await asyncio.gather(*tasks)
+
+    # Merge results
+    all_beats: list[dict[str, Any]] = []
+    total_tokens = 0
+    for beats, tokens in results:
+        all_beats.extend(beats)
+        total_tokens += tokens
+
+    log.info(
+        "serialize_beats_per_thread_completed",
+        thread_count=len(threads),
+        total_beats=len(all_beats),
+        total_tokens=total_tokens,
+    )
+
+    return all_beats, total_tokens
 
 
 @traceable(
@@ -852,7 +1035,6 @@ async def serialize_seed_as_function(
         SerializationError: If Pydantic validation fails after max_retries.
     """
     from questfoundry.models.seed import (
-        BeatsSection,
         ConsequencesSection,
         ConvergenceSection,
         EntitiesSection,
@@ -875,25 +1057,30 @@ async def serialize_seed_as_function(
             log.debug("valid_ids_context_injected", context_length=len(valid_ids_context))
 
     # Section configuration: (section_name, schema, output_field)
+    # Note: "beats" is handled specially with per-thread serialization
     sections: list[tuple[str, type[BaseModel], str]] = [
         ("entities", EntitiesSection, "entities"),
         ("tensions", TensionsSection, "tensions"),
         ("threads", ThreadsSection, "threads"),
         ("consequences", ConsequencesSection, "consequences"),
-        ("beats", BeatsSection, "initial_beats"),
+        # beats handled via per-thread serialization after threads
         ("convergence", ConvergenceSection, "convergence_sketch"),
     ]
 
     collected: dict[str, Any] = {}
     brief_with_threads = enhanced_brief
 
+    # Extract entity IDs context for per-thread beat generation
+    # This is injected into each per-thread brief for character/location refs
+    entity_context = ""
+    if graph is not None:
+        entity_context = format_valid_ids_context(graph, stage="seed")
+
     for section_name, schema, output_field in sections:
         log.debug("serialize_section_started", section=section_name)
 
-        # Use brief with thread IDs for consequences and beats
-        current_brief = (
-            brief_with_threads if section_name in ("beats", "consequences") else enhanced_brief
-        )
+        # Use brief with thread IDs for consequences
+        current_brief = brief_with_threads if section_name == "consequences" else enhanced_brief
 
         section_prompt = prompts[section_name]
         section_result, section_tokens = await serialize_to_artifact(
@@ -915,12 +1102,28 @@ async def serialize_seed_as_function(
             )
         collected[output_field] = section_data[output_field]
 
-        # After threads are serialized, inject thread IDs for subsequent sections
+        # After threads are serialized:
+        # 1. Inject thread IDs for subsequent sections (consequences)
+        # 2. Generate beats per-thread in parallel
         if section_name == "threads" and collected.get("threads"):
             thread_ids_context = format_thread_ids_context(collected["threads"])
             if thread_ids_context:
                 brief_with_threads = f"{enhanced_brief}\n\n{thread_ids_context}"
                 log.debug("thread_ids_context_injected", thread_count=len(collected["threads"]))
+
+            # Generate beats per-thread in parallel
+            # This replaces the old all-at-once beats serialization
+            beats, beats_tokens = await _serialize_beats_per_thread(
+                model=model,
+                threads=collected["threads"],
+                per_thread_prompt=prompts["per_thread_beats"],
+                entity_context=entity_context,
+                provider_name=provider_name,
+                max_retries=max_retries,
+                callbacks=callbacks,
+            )
+            collected["initial_beats"] = beats
+            total_tokens += beats_tokens
 
         log.debug(
             "serialize_section_completed",

--- a/src/questfoundry/models/seed.py
+++ b/src/questfoundry/models/seed.py
@@ -299,6 +299,22 @@ class BeatsSection(BaseModel):
     )
 
 
+class ThreadBeatsSection(BaseModel):
+    """Wrapper for serializing beats for a single thread.
+
+    Used by per-thread beat serialization to constrain the LLM to generating
+    beats for exactly one thread with a fixed tension_id. This makes the
+    thread→tension alignment trivial since the context only contains one valid
+    tension for tension_impacts.
+    """
+
+    initial_beats: list[InitialBeat] = Field(
+        min_length=2,
+        max_length=4,
+        description="2-4 initial beats for this specific thread",
+    )
+
+
 class ConvergenceSection(BaseModel):
     """Wrapper for serializing convergence sketch separately."""
 


### PR DESCRIPTION
## Summary
Serialize SEED beats per-thread instead of all at once, improving accuracy.

## Changes
- Add ThreadBeatsSection model for per-thread validation
- Add per_thread_beats_prompt for constrained serialization  
- Implement parallel per-thread beat generation

## Stack
This is PR 1/10 in the seed-overgenerate-and-select stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)