### PR TITLE
fix(serialize): filter entity context for beats [3/10]

### DIFF
--- a/src/questfoundry/agents/serialize.py
+++ b/src/questfoundry/agents/serialize.py
@@ -15,6 +15,7 @@ from pydantic import BaseModel, ValidationError
 from questfoundry.agents.prompts import get_serialize_prompt
 from questfoundry.artifacts.validator import strip_null_values
 from questfoundry.graph.context import (
+    format_retained_entity_ids,
     format_thread_ids_context,
     format_valid_ids_context,
     normalize_scoped_id,
@@ -1097,6 +1098,15 @@ async def serialize_seed_as_function(
                 f"Expected field '{output_field}', got: {list(section_data.keys())}"
             )
         collected[output_field] = section_data[output_field]
+
+        # After entities are serialized, update entity_context to only include retained
+        # entities. This prevents beats from referencing cut entities.
+        if section_name == "entities" and graph is not None and collected.get("entities"):
+            entity_context = format_retained_entity_ids(graph, collected["entities"])
+            log.debug(
+                "retained_entity_context_updated",
+                entity_decisions=len(collected["entities"]),
+            )
 
         # After threads are serialized:
         # 1. Inject thread IDs for subsequent sections (consequences)

--- a/src/questfoundry/graph/context.py
+++ b/src/questfoundry/graph/context.py
@@ -355,7 +355,7 @@ def format_retained_entity_ids(
         entity_id = decision.get("entity_id", "")
         disposition = decision.get("disposition", "retained")
         # Handle both scoped and unscoped IDs
-        raw_id = entity_id.split("::", 1)[1] if "::" in entity_id else entity_id
+        _, raw_id = parse_scoped_id(entity_id)
         if disposition == "cut":
             cut_ids.add(raw_id)
 

--- a/src/questfoundry/graph/context.py
+++ b/src/questfoundry/graph/context.py
@@ -330,6 +330,69 @@ def get_expected_counts(graph: Graph) -> dict[str, int]:
     }
 
 
+def format_retained_entity_ids(
+    graph: Graph,
+    entity_decisions: list[dict[str, Any]],
+) -> str:
+    """Format only RETAINED entity IDs for beat generation.
+
+    After entity decisions are serialized, beats should only reference
+    entities that were marked as 'retained', not 'cut'. This function
+    filters the full entity list to just retained entities.
+
+    Args:
+        graph: Graph containing BRAINSTORM entity data.
+        entity_decisions: List of EntityDecision dicts from serialization.
+            Each must have 'entity_id' and 'disposition' fields.
+
+    Returns:
+        Formatted context string with only retained entity IDs, or empty
+        string if no retained entities.
+    """
+    # Build set of cut entity IDs for O(1) lookup
+    cut_ids: set[str] = set()
+    for decision in entity_decisions:
+        entity_id = decision.get("entity_id", "")
+        disposition = decision.get("disposition", "retained")
+        # Handle both scoped and unscoped IDs
+        raw_id = entity_id.split("::", 1)[1] if "::" in entity_id else entity_id
+        if disposition == "cut":
+            cut_ids.add(raw_id)
+
+    # Get all entities from graph, filter out cut ones
+    entities = graph.get_nodes_by_type("entity")
+    by_category: dict[str, list[str]] = {}
+    for node in entities.values():
+        cat = node.get("entity_type", "unknown")
+        raw_id = node.get("raw_id", "")
+        if raw_id and raw_id not in cut_ids:
+            by_category.setdefault(cat, []).append(raw_id)
+
+    if not by_category:
+        return ""
+
+    # Count retained entities
+    retained_count = sum(len(ids) for ids in by_category.values())
+
+    lines = [
+        "## RETAINED ENTITY IDs (use ONLY these in beats)",
+        "",
+        f"The following {retained_count} entities are RETAINED for the story.",
+        "Do NOT use cut entities - validation will fail.",
+        "",
+    ]
+
+    for category in _ENTITY_CATEGORIES:
+        if category in by_category:
+            cat_count = len(by_category[category])
+            lines.append(f"**{category.title()}s ({cat_count}):**")
+            for raw_id in sorted(by_category[category]):
+                lines.append(f"  - `{format_scoped_id(SCOPE_ENTITY, raw_id)}`")
+            lines.append("")
+
+    return "\n".join(lines)
+
+
 def format_summarize_manifest(graph: Graph) -> dict[str, str]:
     """Format entity and tension manifests for SEED summarize prompt.
 


### PR DESCRIPTION
PR 3/10 - Filter entity context to only retained entities for beat generation.