### PR TITLE
feat: rename explored to considered with derived state

### DIFF
--- a/docs/design/00-spec.md
+++ b/docs/design/00-spec.md
@@ -336,10 +336,17 @@ tension:
   involves: entity_id[]
   why_it_matters: string        # thematic stakes
   # Added by SEED:
-  explored: alternative_id[]    # which alternatives become threads
+  considered: alternative_id[]  # which alternatives LLM intended to explore
 ```
 
 **Lifecycle:** Created in BRAINSTORM, exploration decisions added in SEED. Not exported.
+
+**Derived development states** (computed from thread existence, not stored):
+- **committed**: Alternative has a thread in the graph (will become a story path)
+- **deferred**: Alternative in `considered` but no thread (LLM intended to explore but was pruned)
+- **latent**: Alternative not in `considered` (never intended for exploration, becomes shadow)
+
+The `considered` field records what the LLM *intended* to explore. Actual thread existence determines what was *committed*. This separation allows pruning to drop threads without modifying the tension's stored intent, keeping the field immutable after SEED.
 
 **Binary constraint:** Exactly two alternatives per tension. This keeps contrasts crisp.
 

--- a/docs/design/00-spec.md
+++ b/docs/design/00-spec.md
@@ -337,9 +337,12 @@ tension:
   why_it_matters: string        # thematic stakes
   # Added by SEED:
   considered: alternative_id[]  # which alternatives LLM intended to explore
+  implicit: alternative_id[]    # alternatives not explored (for FILL shadows)
 ```
 
 **Lifecycle:** Created in BRAINSTORM, exploration decisions added in SEED. Not exported.
+
+**The `implicit` field** holds alternatives that are intentionally NOT explored as threads. These provide narrative context for the FILL stage—the "road not taken" that gives meaning to the chosen path. For example, if we explore "mentor is deceptive", the implicit "mentor is trustworthy" informs how the deception contrasts with what could have been.
 
 **Derived development states** (computed from thread existence, not stored):
 - **committed**: Alternative has a thread in the graph (will become a story path)

--- a/docs/design/procedures/seed.md
+++ b/docs/design/procedures/seed.md
@@ -100,7 +100,12 @@ LLMs are poor at counting and self-constraint. Instead of teaching the LLM to st
    - Thread tier: Major threads score higher than minor
    - Content distinctiveness: How different the paths are (Jaccard distance)
 3. **Runtime selects top N** - The highest-scoring tensions are kept fully explored (up to 4 tensions = 16 arcs)
-4. **Runtime prunes excess** - Demoted tensions have their non-canonical alternatives moved to `implicit`, and associated threads, consequences, and beats are removed
+4. **Runtime prunes excess** - Demoted tensions have their threads, consequences, and beats removed
+
+**Key invariant: The `considered` field is immutable after SEED.** Pruning only drops threads; it never modifies the tension's `considered` field. This separation between "LLM intent" (stored as `considered`) and "runtime state" (derived from thread existence) ensures:
+- The pruning operation is idempotent
+- Arc count is derived from actual threads, not potentially stale metadata
+- Debugging is simpler—you can see what the LLM originally intended vs what survived pruning
 
 This pattern:
 - Simplifies prompts (no arc math, verification checklists, or hard limits)
@@ -148,8 +153,8 @@ LLM proposes exploration map per tension:
 ```yaml
 tension_exploration:
   - tension_id: mentor_trust
-    explore:
-      - alternative_id: mentor_protector    # canonical, always explored
+    considered:
+      - alternative_id: mentor_protector    # canonical, always considered
         rationale: "Spine path - mentor as ally"
       - alternative_id: mentor_manipulator  # non-canonical
         rationale: "Dark branch - doubles content but adds replayability"

--- a/prompts/templates/serialize_seed_sections.yaml
+++ b/prompts/templates/serialize_seed_sections.yaml
@@ -52,7 +52,7 @@ tensions_prompt: |
     "tensions": [
       {
         "tension_id": "tension_id_from_brainstorm",
-        "explored": ["alt_id_1", "alt_id_2"],
+        "considered": ["alt_id_1", "alt_id_2"],
         "implicit": ["alt_id_3"]
       }
     ]
@@ -61,7 +61,7 @@ tensions_prompt: |
 
   ## Rules
   - tension_id must match EXACTLY an ID from the Tension IDs manifest
-  - explored: Alternative IDs that become threads (MUST include the default path)
+  - considered: Alternative IDs to explore as threads (MUST include the default path)
   - implicit: Alternative IDs NOT explored (become shadows)
   - Generate a decision for EVERY tension in the manifest
 
@@ -78,7 +78,7 @@ threads_prompt: |
   You are generating THREADS for a SEED stage based on tension decisions.
 
   ## Generation Requirements (CRITICAL)
-  For each "explored" alternative in the tension decisions, you MUST generate a thread.
+  For each "considered" alternative in the tension decisions, you MUST generate a thread.
   Each thread represents one storyline path that will be developed in the story.
 
   ## Schema
@@ -125,11 +125,11 @@ threads_prompt: |
   - thread_importance must be exactly "major" or "minor" (lowercase)
   - unexplored_alternative_ids: IDs of alternatives NOT explored (implicit ones)
   - consequence_ids: References to consequences for this thread
-  - Generate a thread for EACH explored alternative from tension decisions
+  - Generate a thread for EACH considered alternative from tension decisions
 
   ## What NOT to Do
   - Do NOT reuse tension IDs as thread IDs
-  - Do NOT skip alternatives marked as "explored"
+  - Do NOT skip alternatives marked as "considered"
   - Do NOT create threads for "implicit" alternatives (they become shadows, not threads)
 
   ## Output

--- a/src/questfoundry/graph/mutations.py
+++ b/src/questfoundry/graph/mutations.py
@@ -1168,7 +1168,8 @@ def validate_seed_mutations(graph: Graph, output: dict[str, Any]) -> list[SeedVa
             continue
 
         # Support both new 'considered' and old 'explored' field names
-        considered = tension_decision.get("considered") or tension_decision.get("explored", [])
+        # Use dict.get() chaining instead of 'or' to handle empty lists correctly
+        considered = tension_decision.get("considered", tension_decision.get("explored", []))
         thread_count = tension_thread_counts.get(normalized_tid, 0)
 
         if len(considered) > thread_count:

--- a/src/questfoundry/graph/mutations.py
+++ b/src/questfoundry/graph/mutations.py
@@ -1157,8 +1157,8 @@ def validate_seed_mutations(graph: Graph, output: dict[str, Any]) -> list[SeedVa
             )
         )
 
-    # 11b. Check each explored alternative has a thread
-    # For each tension decision, verify thread count matches explored count
+    # 11b. Check each considered alternative has a thread
+    # For each tension decision, verify thread count matches considered count
     for tension_decision in output.get("tensions", []):
         raw_tid = tension_decision.get("tension_id")
         if not raw_tid:
@@ -1167,20 +1167,21 @@ def validate_seed_mutations(graph: Graph, output: dict[str, Any]) -> list[SeedVa
         if scope_error:
             continue
 
-        explored = tension_decision.get("explored", [])
+        # Support both new 'considered' and old 'explored' field names
+        considered = tension_decision.get("considered") or tension_decision.get("explored", [])
         thread_count = tension_thread_counts.get(normalized_tid, 0)
 
-        if len(explored) > thread_count:
-            missing_count = len(explored) - thread_count
+        if len(considered) > thread_count:
+            missing_count = len(considered) - thread_count
             errors.append(
                 SeedValidationError(
                     field_path="threads",
                     issue=(
-                        f"Tension '{normalized_tid}' has {len(explored)} explored alternatives "
+                        f"Tension '{normalized_tid}' has {len(considered)} considered alternatives "
                         f"but only {thread_count} thread(s). "
-                        f"Create {missing_count} more thread(s) - one for EACH explored alternative."
+                        f"Create {missing_count} more thread(s) - one for EACH considered alternative."
                     ),
-                    available=explored,
+                    available=considered,
                     provided=str(thread_count),
                     category=SeedErrorCategory.COMPLETENESS,
                 )
@@ -1263,7 +1264,7 @@ def apply_seed_mutations(graph: Graph, output: dict[str, Any]) -> None:
 
     First validates all cross-references, then applies mutations.
 
-    Updates entity dispositions, creates threads from explored tensions,
+    Updates entity dispositions, creates threads from considered tensions,
     creates consequences, and creates initial beats.
 
     Node IDs are prefixed by type to match BRAINSTORM's namespacing:
@@ -1301,13 +1302,15 @@ def apply_seed_mutations(graph: Graph, output: dict[str, Any]) -> None:
         raw_id = _require_field(tension_decision, "tension_id", f"Tension decision at index {i}")
         tension_id = _prefix_id("tension", raw_id)
         if graph.has_node(tension_id):
+            # Support both new 'considered' and old 'explored' field names
+            considered = tension_decision.get("considered") or tension_decision.get("explored", [])
             graph.update_node(
                 tension_id,
-                explored=tension_decision.get("explored", []),
+                considered=considered,
                 implicit=tension_decision.get("implicit", []),
             )
 
-    # Create threads from explored tensions (must be created before consequences)
+    # Create threads from considered tensions (must be created before consequences)
     for i, thread in enumerate(output.get("threads", [])):
         raw_id = _require_field(thread, "thread_id", f"Thread at index {i}")
         thread_id = _prefix_id("thread", raw_id)

--- a/src/questfoundry/graph/tension_scoring.py
+++ b/src/questfoundry/graph/tension_scoring.py
@@ -63,8 +63,8 @@ def _get_threads_for_tension(
     if not threads:
         return None, None
 
-    # Assume first explored alternative is canonical (typical pattern)
-    canonical_alt = tension_decision.explored[0] if tension_decision.explored else None
+    # Assume first considered alternative is canonical (typical pattern)
+    canonical_alt = tension_decision.considered[0] if tension_decision.considered else None
 
     canonical_thread = None
     noncanonical_thread = None
@@ -121,9 +121,11 @@ def score_tension(seed_output: SeedOutput, tension_id: str) -> ScoredTension:
             noncanonical_thread_id=None,
         )
 
-    is_fully_explored = len(tension_decision.explored) >= 2
-
     canonical_thread, noncanonical_thread = _get_threads_for_tension(seed_output, tension_id)
+
+    # is_fully_explored is derived from actual thread existence, not from considered field
+    # A tension is fully explored when BOTH canonical and non-canonical threads exist
+    is_fully_explored = canonical_thread is not None and noncanonical_thread is not None
 
     if not noncanonical_thread:
         # No non-canonical thread - nothing to score

--- a/tests/unit/test_mutations.py
+++ b/tests/unit/test_mutations.py
@@ -147,8 +147,8 @@ class TestApplyMutations:
         output = {
             "entities": [{"entity_id": "char_001", "disposition": "retained"}],
             "tensions": [
-                {"tension_id": "t0", "explored": ["a", "b"], "implicit": []},
-                {"tension_id": "t1", "explored": ["a", "b"], "implicit": []},
+                {"tension_id": "t0", "considered": ["a", "b"], "implicit": []},
+                {"tension_id": "t1", "considered": ["a", "b"], "implicit": []},
             ],
             "threads": [
                 {"thread_id": "thread_0", "tension_id": "t0", "alternative_id": "a"},
@@ -763,7 +763,7 @@ class TestSeedMutations:
         output = {
             "entities": [],
             "tensions": [
-                {"tension_id": "mentor_trust", "explored": ["protector"], "implicit": []},
+                {"tension_id": "mentor_trust", "considered": ["protector"], "implicit": []},
             ],
             "threads": [
                 {
@@ -839,7 +839,7 @@ class TestSeedMutations:
             "tensions": [
                 {
                     "tension_id": "mentor_trust",
-                    "explored": ["protector", "manipulator"],
+                    "considered": ["protector", "manipulator"],
                     "implicit": [],
                 },
             ],
@@ -930,7 +930,7 @@ class TestSeedMutations:
             ],
             # Completeness: decisions for all tensions
             "tensions": [
-                {"tension_id": "mentor_trust", "explored": ["protector"], "implicit": []},
+                {"tension_id": "mentor_trust", "considered": ["protector"], "implicit": []},
             ],
             # Thread must be in SEED output for beat thread references to validate
             "threads": [
@@ -1040,7 +1040,7 @@ class TestSeedCompletenessValidation:
                 {"entity_id": "mentor", "disposition": "cut"},
             ],
             "tensions": [
-                {"tension_id": "trust", "explored": ["yes"], "implicit": []},
+                {"tension_id": "trust", "considered": ["yes"], "implicit": []},
             ],
             "threads": [
                 {
@@ -1114,7 +1114,7 @@ class TestSeedCompletenessValidation:
         output = {
             "entities": [],
             "tensions": [
-                {"tension_id": "trust", "explored": [], "implicit": []},
+                {"tension_id": "trust", "considered": [], "implicit": []},
                 # Missing: loyalty
             ],
             "threads": [],
@@ -1195,8 +1195,8 @@ class TestSeedCompletenessValidation:
         output = {
             "entities": [],
             "tensions": [
-                {"tension_id": "trust", "explored": ["yes"], "implicit": []},
-                {"tension_id": "loyalty", "explored": [], "implicit": []},
+                {"tension_id": "trust", "considered": ["yes"], "implicit": []},
+                {"tension_id": "loyalty", "considered": [], "implicit": []},
             ],
             "threads": [
                 {
@@ -1232,8 +1232,8 @@ class TestSeedCompletenessValidation:
         output = {
             "entities": [],
             "tensions": [
-                {"tension_id": "trust", "explored": ["yes"], "implicit": []},
-                {"tension_id": "loyalty", "explored": ["stand"], "implicit": []},
+                {"tension_id": "trust", "considered": ["yes"], "implicit": []},
+                {"tension_id": "loyalty", "considered": ["stand"], "implicit": []},
             ],
             "threads": [
                 {
@@ -1266,7 +1266,7 @@ class TestSeedCompletenessValidation:
 
         output = {
             "entities": [],
-            "tensions": [{"tension_id": "trust", "explored": ["yes"], "implicit": []}],
+            "tensions": [{"tension_id": "trust", "considered": ["yes"], "implicit": []}],
             "threads": [
                 {
                     "thread_id": "trust_arc",
@@ -1283,8 +1283,8 @@ class TestSeedCompletenessValidation:
         thread_errors = [e for e in errors if "has no thread" in e.issue]
         assert thread_errors == []
 
-    def test_missing_threads_for_explored_alternatives(self) -> None:
-        """Each explored alternative needs its own thread - missing threads caught."""
+    def test_missing_threads_for_considered_alternatives(self) -> None:
+        """Each considered alternative needs its own thread - missing threads caught."""
         graph = Graph.empty()
         graph.create_node("tension::trust", {"type": "tension", "raw_id": "trust"})
         graph.create_node("tension::trust::alt::yes", {"type": "alternative", "raw_id": "yes"})
@@ -1295,8 +1295,8 @@ class TestSeedCompletenessValidation:
         output = {
             "entities": [],
             "tensions": [
-                # Both alternatives explored, but only 1 thread created
-                {"tension_id": "trust", "explored": ["yes", "no"], "implicit": []},
+                # Both alternatives considered, but only 1 thread created
+                {"tension_id": "trust", "considered": ["yes", "no"], "implicit": []},
             ],
             "threads": [
                 {
@@ -1312,14 +1312,14 @@ class TestSeedCompletenessValidation:
 
         errors = validate_seed_mutations(graph, output)
 
-        missing_thread_errors = [e for e in errors if "explored alternatives" in e.issue]
+        missing_thread_errors = [e for e in errors if "considered alternatives" in e.issue]
         assert len(missing_thread_errors) == 1
-        assert "2 explored alternatives" in missing_thread_errors[0].issue
+        assert "2 considered alternatives" in missing_thread_errors[0].issue
         assert "1 thread" in missing_thread_errors[0].issue
         assert missing_thread_errors[0].category == SeedErrorCategory.COMPLETENESS
 
-    def test_all_explored_alternatives_have_threads(self) -> None:
-        """When each explored alternative has a thread, validation passes."""
+    def test_all_considered_alternatives_have_threads(self) -> None:
+        """When each considered alternative has a thread, validation passes."""
         graph = Graph.empty()
         graph.create_node("tension::trust", {"type": "tension", "raw_id": "trust"})
         graph.create_node("tension::trust::alt::yes", {"type": "alternative", "raw_id": "yes"})
@@ -1330,7 +1330,7 @@ class TestSeedCompletenessValidation:
         output = {
             "entities": [],
             "tensions": [
-                {"tension_id": "trust", "explored": ["yes", "no"], "implicit": []},
+                {"tension_id": "trust", "considered": ["yes", "no"], "implicit": []},
             ],
             "threads": [
                 {
@@ -1351,7 +1351,7 @@ class TestSeedCompletenessValidation:
 
         errors = validate_seed_mutations(graph, output)
 
-        missing_thread_errors = [e for e in errors if "explored alternatives" in e.issue]
+        missing_thread_errors = [e for e in errors if "considered alternatives" in e.issue]
         assert missing_thread_errors == []
 
     # NOTE: Arc count validation tests removed - now handled by runtime pruning
@@ -1420,8 +1420,8 @@ class TestBeatTensionAlignment:
         return {
             "entities": [{"entity_id": "hero", "disposition": "retained"}],
             "tensions": [
-                {"tension_id": "trust", "explored": ["yes"], "implicit": []},
-                {"tension_id": "loyalty", "explored": ["faithful"], "implicit": []},
+                {"tension_id": "trust", "considered": ["yes"], "implicit": []},
+                {"tension_id": "loyalty", "considered": ["faithful"], "implicit": []},
             ],
             "threads": [
                 {
@@ -1644,9 +1644,9 @@ class TestSeedDuplicateValidation:
         output = {
             "entities": [],
             "tensions": [
-                {"tension_id": "trust", "explored": ["yes"], "implicit": []},
-                {"tension_id": "trust", "explored": ["yes"], "implicit": []},  # Duplicate!
-                {"tension_id": "trust", "explored": ["yes"], "implicit": []},  # Triple!
+                {"tension_id": "trust", "considered": ["yes"], "implicit": []},
+                {"tension_id": "trust", "considered": ["yes"], "implicit": []},  # Duplicate!
+                {"tension_id": "trust", "considered": ["yes"], "implicit": []},  # Triple!
             ],
             "threads": [],
             "initial_beats": [],
@@ -1764,7 +1764,7 @@ class TestMutationIntegration:
             ],
             # Completeness: decisions for all tensions
             "tensions": [
-                {"tension_id": "mentor_trust", "explored": ["protector"], "implicit": []},
+                {"tension_id": "mentor_trust", "considered": ["protector"], "implicit": []},
             ],
             "threads": [
                 {
@@ -2084,7 +2084,7 @@ class TestScopedIdValidation:
 
         output = {
             "entities": [],
-            "tensions": [{"tension_id": "tension::trust", "explored": ["yes"], "implicit": []}],
+            "tensions": [{"tension_id": "tension::trust", "considered": ["yes"], "implicit": []}],
             "threads": [
                 {
                     "thread_id": "trust_arc",
@@ -2120,7 +2120,7 @@ class TestScopedIdValidation:
 
         output = {
             "entities": [{"entity_id": "entity::hero", "disposition": "retained"}],
-            "tensions": [{"tension_id": "tension::trust", "explored": ["yes"], "implicit": []}],
+            "tensions": [{"tension_id": "tension::trust", "considered": ["yes"], "implicit": []}],
             "threads": [
                 {
                     "thread_id": "mentor",
@@ -2173,7 +2173,7 @@ class TestScopedIdValidation:
 
         output = {
             "entities": [],
-            "tensions": [{"tension_id": "entity::trust", "explored": [], "implicit": []}],
+            "tensions": [{"tension_id": "entity::trust", "considered": [], "implicit": []}],
             "threads": [],
             "initial_beats": [],
         }
@@ -2196,7 +2196,7 @@ class TestScopedIdValidation:
 
         output = {
             "entities": [{"entity_id": "entity::hero", "disposition": "retained"}],
-            "tensions": [{"tension_id": "tension::trust", "explored": ["yes"], "implicit": []}],
+            "tensions": [{"tension_id": "tension::trust", "considered": ["yes"], "implicit": []}],
             "threads": [
                 {
                     "thread_id": "mentor",
@@ -2301,7 +2301,7 @@ class TestScopedIdValidation:
                 {"entity_id": "entity::hero", "disposition": "retained"},
                 {"entity_id": "entity::mentor", "disposition": "retained"},
             ],
-            "tensions": [{"tension_id": "tension::trust", "explored": ["yes"], "implicit": []}],
+            "tensions": [{"tension_id": "tension::trust", "considered": ["yes"], "implicit": []}],
             "threads": [
                 {
                     "thread_id": "mentor_arc",
@@ -2339,7 +2339,7 @@ class TestScopedIdValidation:
 
         output = {
             "entities": [{"entity_id": "entity::hero", "disposition": "retained"}],
-            "tensions": [{"tension_id": "tension::trust", "explored": ["yes"], "implicit": []}],
+            "tensions": [{"tension_id": "tension::trust", "considered": ["yes"], "implicit": []}],
             "threads": [
                 {
                     "thread_id": "mentor_arc",
@@ -2380,7 +2380,7 @@ class TestScopedIdValidation:
 
         output = {
             "entities": [{"entity_id": "entity::hero", "disposition": "retained"}],
-            "tensions": [{"tension_id": "tension::trust", "explored": ["yes"], "implicit": []}],
+            "tensions": [{"tension_id": "tension::trust", "considered": ["yes"], "implicit": []}],
             "threads": [
                 {
                     "thread_id": "mentor_arc",
@@ -2427,7 +2427,7 @@ class TestScopedIdValidation:
 
         output = {
             "entities": [{"entity_id": "entity::hero", "disposition": "retained"}],
-            "tensions": [{"tension_id": "tension::trust", "explored": ["yes"], "implicit": []}],
+            "tensions": [{"tension_id": "tension::trust", "considered": ["yes"], "implicit": []}],
             "threads": [
                 {
                     "thread_id": "thread::mentor_arc",  # Scoped ID in definition
@@ -2834,7 +2834,7 @@ class TestTypeAwareFeedback:
                 {"entity_id": "isolation_protocol", "disposition": "retained"},
             ],
             "tensions": [
-                {"tension_id": "trust_or_betray", "explored": [], "implicit": []},
+                {"tension_id": "trust_or_betray", "considered": [], "implicit": []},
             ],
             "threads": [],
             "initial_beats": [
@@ -2881,7 +2881,7 @@ class TestTypeAwareFeedback:
         output = {
             "entities": [{"entity_id": "hero", "disposition": "retained"}],
             "tensions": [
-                {"tension_id": "trust_or_betray", "explored": ["trust"], "implicit": []},
+                {"tension_id": "trust_or_betray", "considered": ["trust"], "implicit": []},
             ],
             "threads": [
                 {
@@ -2924,7 +2924,7 @@ class TestTypeAwareFeedback:
         output = {
             "entities": [{"entity_id": "hero", "disposition": "retained"}],
             "tensions": [
-                {"tension_id": "trust_or_betray", "explored": [], "implicit": []},
+                {"tension_id": "trust_or_betray", "considered": [], "implicit": []},
             ],
             "threads": [],
             "initial_beats": [

--- a/tests/unit/test_ontology_considered.py
+++ b/tests/unit/test_ontology_considered.py
@@ -1,0 +1,437 @@
+"""Tests for the 'explored' to 'considered' ontology change.
+
+This module tests:
+1. Backward compatibility: old 'explored' field migrates to 'considered'
+2. Development state derivation from thread existence
+3. Arc count derivation from threads (not from considered field)
+4. Tension immutability during pruning
+"""
+
+from __future__ import annotations
+
+from questfoundry.graph.context import (
+    STATE_COMMITTED,
+    STATE_DEFERRED,
+    STATE_LATENT,
+    count_threads_per_tension,
+    get_tension_development_states,
+)
+from questfoundry.graph.seed_pruning import compute_arc_count, prune_to_arc_limit
+from questfoundry.models.seed import (
+    InitialBeat,
+    SeedOutput,
+    TensionDecision,
+    Thread,
+)
+
+
+class TestTensionDecisionBackwardCompat:
+    """Test backward compatibility for old 'explored' field."""
+
+    def test_new_considered_field_works(self) -> None:
+        """New 'considered' field is accepted."""
+        decision = TensionDecision(
+            tension_id="test_tension",
+            considered=["alt_a", "alt_b"],
+            implicit=["alt_c"],
+        )
+        assert decision.considered == ["alt_a", "alt_b"]
+        assert decision.implicit == ["alt_c"]
+
+    def test_old_explored_field_migrates(self) -> None:
+        """Old 'explored' field is migrated to 'considered'."""
+        # Simulate old graph data with 'explored' field
+        old_data = {
+            "tension_id": "test_tension",
+            "explored": ["alt_a", "alt_b"],
+            "implicit": ["alt_c"],
+        }
+        decision = TensionDecision.model_validate(old_data)
+        assert decision.considered == ["alt_a", "alt_b"]
+        assert decision.implicit == ["alt_c"]
+
+    def test_considered_takes_precedence_over_explored(self) -> None:
+        """If both 'considered' and 'explored' present, 'considered' is used."""
+        # This shouldn't happen in practice, but test the behavior
+        data = {
+            "tension_id": "test_tension",
+            "considered": ["new_alt"],
+            "explored": ["old_alt"],
+            "implicit": [],
+        }
+        decision = TensionDecision.model_validate(data)
+        assert decision.considered == ["new_alt"]
+
+
+class TestCountThreadsPerTension:
+    """Test counting threads per tension."""
+
+    def test_counts_threads_correctly(self) -> None:
+        """Counts threads grouped by tension_id."""
+        seed = SeedOutput(
+            tensions=[
+                TensionDecision(tension_id="t1", considered=["a", "b"], implicit=[]),
+                TensionDecision(tension_id="t2", considered=["c"], implicit=[]),
+            ],
+            threads=[
+                Thread(
+                    thread_id="th1",
+                    name="Thread 1",
+                    tension_id="t1",
+                    alternative_id="a",
+                    thread_importance="major",
+                    description="desc",
+                ),
+                Thread(
+                    thread_id="th2",
+                    name="Thread 2",
+                    tension_id="t1",
+                    alternative_id="b",
+                    thread_importance="major",
+                    description="desc",
+                ),
+                Thread(
+                    thread_id="th3",
+                    name="Thread 3",
+                    tension_id="t2",
+                    alternative_id="c",
+                    thread_importance="minor",
+                    description="desc",
+                ),
+            ],
+        )
+
+        counts = count_threads_per_tension(seed)
+
+        assert counts == {"t1": 2, "t2": 1}
+
+    def test_handles_scoped_tension_ids(self) -> None:
+        """Handles tension_id with scope prefix."""
+        seed = SeedOutput(
+            tensions=[TensionDecision(tension_id="t1", considered=["a"], implicit=[])],
+            threads=[
+                Thread(
+                    thread_id="th1",
+                    name="Thread 1",
+                    tension_id="tension::t1",  # Scoped
+                    alternative_id="a",
+                    thread_importance="major",
+                    description="desc",
+                ),
+            ],
+        )
+
+        counts = count_threads_per_tension(seed)
+
+        assert counts == {"t1": 1}
+
+    def test_empty_threads_returns_empty_dict(self) -> None:
+        """Returns empty dict when no threads."""
+        seed = SeedOutput(
+            tensions=[TensionDecision(tension_id="t1", considered=["a"], implicit=[])],
+            threads=[],
+        )
+
+        counts = count_threads_per_tension(seed)
+
+        assert counts == {}
+
+
+class TestGetTensionDevelopmentStates:
+    """Test derivation of development states from thread existence."""
+
+    def test_committed_state_when_thread_exists(self) -> None:
+        """Alternative in 'considered' with thread is 'committed'."""
+        seed = SeedOutput(
+            tensions=[
+                TensionDecision(tension_id="t1", considered=["a", "b"], implicit=[]),
+            ],
+            threads=[
+                Thread(
+                    thread_id="th1",
+                    name="Thread 1",
+                    tension_id="t1",
+                    alternative_id="a",
+                    thread_importance="major",
+                    description="desc",
+                ),
+                Thread(
+                    thread_id="th2",
+                    name="Thread 2",
+                    tension_id="t1",
+                    alternative_id="b",
+                    thread_importance="major",
+                    description="desc",
+                ),
+            ],
+        )
+
+        states = get_tension_development_states(seed)
+
+        assert states["t1"]["a"] == STATE_COMMITTED
+        assert states["t1"]["b"] == STATE_COMMITTED
+
+    def test_deferred_state_when_considered_but_no_thread(self) -> None:
+        """Alternative in 'considered' without thread is 'deferred'."""
+        seed = SeedOutput(
+            tensions=[
+                TensionDecision(tension_id="t1", considered=["a", "b"], implicit=[]),
+            ],
+            threads=[
+                Thread(
+                    thread_id="th1",
+                    name="Thread 1",
+                    tension_id="t1",
+                    alternative_id="a",  # Only 'a' has thread
+                    thread_importance="major",
+                    description="desc",
+                ),
+            ],
+        )
+
+        states = get_tension_development_states(seed)
+
+        assert states["t1"]["a"] == STATE_COMMITTED
+        assert states["t1"]["b"] == STATE_DEFERRED  # Considered but no thread
+
+    def test_latent_state_for_implicit_alternatives(self) -> None:
+        """Alternative in 'implicit' is 'latent'."""
+        seed = SeedOutput(
+            tensions=[
+                TensionDecision(tension_id="t1", considered=["a"], implicit=["b"]),
+            ],
+            threads=[
+                Thread(
+                    thread_id="th1",
+                    name="Thread 1",
+                    tension_id="t1",
+                    alternative_id="a",
+                    thread_importance="major",
+                    description="desc",
+                ),
+            ],
+        )
+
+        states = get_tension_development_states(seed)
+
+        assert states["t1"]["a"] == STATE_COMMITTED
+        assert states["t1"]["b"] == STATE_LATENT  # In implicit, never considered
+
+
+class TestComputeArcCountFromThreads:
+    """Test that arc count is derived from thread existence, not considered field."""
+
+    def test_arc_count_from_threads_not_considered(self) -> None:
+        """Arc count is 2^n where n = tensions with 2+ threads."""
+        seed = SeedOutput(
+            tensions=[
+                # Both alts considered, but only one has thread
+                TensionDecision(tension_id="t1", considered=["a", "b"], implicit=[]),
+                # Both alts considered and have threads
+                TensionDecision(tension_id="t2", considered=["c", "d"], implicit=[]),
+            ],
+            threads=[
+                # t1: only one thread (despite 2 considered)
+                Thread(
+                    thread_id="th1",
+                    name="Thread 1",
+                    tension_id="t1",
+                    alternative_id="a",
+                    thread_importance="major",
+                    description="desc",
+                ),
+                # t2: two threads
+                Thread(
+                    thread_id="th2",
+                    name="Thread 2",
+                    tension_id="t2",
+                    alternative_id="c",
+                    thread_importance="major",
+                    description="desc",
+                ),
+                Thread(
+                    thread_id="th3",
+                    name="Thread 3",
+                    tension_id="t2",
+                    alternative_id="d",
+                    thread_importance="major",
+                    description="desc",
+                ),
+            ],
+        )
+
+        arc_count = compute_arc_count(seed)
+
+        # Only t2 has 2+ threads, so 2^1 = 2 arcs
+        assert arc_count == 2
+
+    def test_arc_count_one_when_no_fully_developed(self) -> None:
+        """Arc count is 1 when no tensions have 2+ threads."""
+        seed = SeedOutput(
+            tensions=[
+                TensionDecision(tension_id="t1", considered=["a", "b"], implicit=[]),
+            ],
+            threads=[
+                Thread(
+                    thread_id="th1",
+                    name="Thread 1",
+                    tension_id="t1",
+                    alternative_id="a",
+                    thread_importance="major",
+                    description="desc",
+                ),
+            ],
+        )
+
+        arc_count = compute_arc_count(seed)
+
+        assert arc_count == 1
+
+    def test_arc_count_multiple_tensions(self) -> None:
+        """Arc count is 2^n for multiple fully developed tensions."""
+        seed = SeedOutput(
+            tensions=[
+                TensionDecision(tension_id="t1", considered=["a", "b"], implicit=[]),
+                TensionDecision(tension_id="t2", considered=["c", "d"], implicit=[]),
+            ],
+            threads=[
+                Thread(
+                    thread_id="th1",
+                    tension_id="t1",
+                    alternative_id="a",
+                    name="T1",
+                    thread_importance="major",
+                    description="d",
+                ),
+                Thread(
+                    thread_id="th2",
+                    tension_id="t1",
+                    alternative_id="b",
+                    name="T2",
+                    thread_importance="major",
+                    description="d",
+                ),
+                Thread(
+                    thread_id="th3",
+                    tension_id="t2",
+                    alternative_id="c",
+                    name="T3",
+                    thread_importance="major",
+                    description="d",
+                ),
+                Thread(
+                    thread_id="th4",
+                    tension_id="t2",
+                    alternative_id="d",
+                    name="T4",
+                    thread_importance="major",
+                    description="d",
+                ),
+            ],
+        )
+
+        arc_count = compute_arc_count(seed)
+
+        # Both tensions have 2 threads: 2^2 = 4 arcs
+        assert arc_count == 4
+
+
+class TestPruningImmutability:
+    """Test that pruning doesn't mutate tension decisions."""
+
+    def _make_seed_output_with_threads(
+        self,
+        tensions_count: int = 5,
+        threads_per_tension: int = 2,
+    ) -> SeedOutput:
+        """Helper to create a SeedOutput with multiple fully developed tensions."""
+        tensions = []
+        threads = []
+        beats = []
+
+        for i in range(tensions_count):
+            tid = f"t{i}"
+            tensions.append(
+                TensionDecision(
+                    tension_id=tid,
+                    considered=["a", "b"],
+                    implicit=[],
+                )
+            )
+
+            for j in range(threads_per_tension):
+                alt_id = "a" if j == 0 else "b"
+                thread_id = f"th_{tid}_{alt_id}"
+                threads.append(
+                    Thread(
+                        thread_id=thread_id,
+                        name=f"Thread {tid} {alt_id}",
+                        tension_id=tid,
+                        alternative_id=alt_id,
+                        thread_importance="major",
+                        description="desc",
+                    )
+                )
+
+                # Add a commits beat for each thread
+                beats.append(
+                    InitialBeat(
+                        beat_id=f"beat_{thread_id}",
+                        summary="Summary",
+                        threads=[thread_id],
+                        tension_impacts=[
+                            {"tension_id": tid, "effect": "commits", "note": "Commits the tension"}
+                        ],
+                    )
+                )
+
+        return SeedOutput(
+            tensions=tensions,
+            threads=threads,
+            initial_beats=beats,
+        )
+
+    def test_pruning_does_not_mutate_considered_field(self) -> None:
+        """Pruning drops threads but doesn't change tension.considered."""
+        seed = self._make_seed_output_with_threads(tensions_count=6, threads_per_tension=2)
+
+        # All tensions have considered=["a", "b"]
+        original_considered = {t.tension_id: list(t.considered) for t in seed.tensions}
+
+        # Prune to max 4 arcs (2 fully developed tensions)
+        pruned = prune_to_arc_limit(seed, max_arcs=4)
+
+        # Verify tensions were not mutated
+        for tension in pruned.tensions:
+            assert tension.considered == original_considered[tension.tension_id], (
+                f"Tension {tension.tension_id} was mutated: "
+                f"expected {original_considered[tension.tension_id]}, got {tension.considered}"
+            )
+
+    def test_pruning_reduces_thread_count(self) -> None:
+        """Pruning removes threads to stay within arc limit."""
+        seed = self._make_seed_output_with_threads(tensions_count=6, threads_per_tension=2)
+
+        # 6 tensions * 2 threads = 2^6 = 64 arcs before pruning
+        assert compute_arc_count(seed) == 64
+
+        # Prune to max 4 arcs (2 fully developed tensions)
+        pruned = prune_to_arc_limit(seed, max_arcs=4)
+
+        # After pruning: 2 tensions with 2 threads = 2^2 = 4 arcs
+        assert compute_arc_count(pruned) <= 4
+
+        # Threads were reduced
+        assert len(pruned.threads) < len(seed.threads)
+
+    def test_pruning_keeps_all_tensions(self) -> None:
+        """Pruning keeps all tension decisions (just drops threads)."""
+        seed = self._make_seed_output_with_threads(tensions_count=6, threads_per_tension=2)
+
+        pruned = prune_to_arc_limit(seed, max_arcs=4)
+
+        # All tension decisions are preserved
+        assert len(pruned.tensions) == len(seed.tensions)
+        original_ids = {t.tension_id for t in seed.tensions}
+        pruned_ids = {t.tension_id for t in pruned.tensions}
+        assert pruned_ids == original_ids


### PR DESCRIPTION
## Problem

The over-generate-and-select pattern has a bug where tensions with `explored >= 2` but only one actual thread slip through pruning. This happens because:
1. Arc count was computed from the `explored` field, not thread existence
2. Tension scoring used different criteria than arc counting
3. Pruning mutated tensions, making the field unreliable

## Changes

- **Rename `explored` → `considered`**: Better reflects semantic meaning (LLM's intent)
- **Add backward compat validator**: Old graphs with `explored` field auto-migrate
- **Derive development state from threads**: `committed`/`deferred`/`latent` computed at runtime
- **Remove tension mutation in pruning**: `considered` is now immutable after SEED
- **Fix arc count derivation**: Now counts threads per tension, not `considered` field
- **Fix scoring consistency**: `is_fully_explored` checks thread existence

### Key Invariants

1. `canonical ∈ committed` (spine path always has thread)
2. `committed ⊆ considered` (can only develop what was considered)
3. `arc_count = 2^n` where `n = tensions with 2+ threads`
4. Pruning only drops threads, never modifies tension fields

## Not Included / Future PRs

- Migration script for existing project graphs (backward compat handles reading)
- UI updates if any reference the old field name

## Test Plan

- [x] All 1322 existing tests pass
- [x] 15 new tests for ontology change:
  - Backward compatibility (old `explored` migrates to `considered`)
  - Development state derivation
  - Arc count from thread existence
  - Pruning immutability

```bash
uv run pytest  # 1322 passed, 6 xpassed
```

## Risk / Rollback

- Low risk: backward compatibility validator handles old graphs
- Rollback: revert PR, old graphs still readable

🤖 Generated with [Claude Code](https://claude.com/claude-code)