### PR TITLE
feat(mutations): add considered backfill and validation check 11c

### DIFF
--- a/src/questfoundry/graph/mutations.py
+++ b/src/questfoundry/graph/mutations.py
@@ -454,6 +454,45 @@ def _clean_dict(data: dict[str, Any]) -> dict[str, Any]:
     return {k: v for k, v in data.items() if v is not None}
 
 
+def _backfill_considered_from_threads(output: dict[str, Any]) -> None:
+    """Backfill empty considered arrays from thread alternative_ids (in-place mutation).
+
+    Handles legacy data where LLM serialized threads but left considered empty.
+    The thread's alternative_id IS what was considered - if a thread exists for
+    an alternative, that alternative was necessarily considered.
+
+    This migration runs BEFORE validation to fix data integrity issues in
+    existing graphs (e.g., grow-3, grow-4) where tensions have `considered: []`
+    but threads exist with valid `alternative_id` values.
+
+    Args:
+        output: SEED stage output dictionary (mutated in place).
+    """
+    # Build mapping: tension_id -> set of alternative_ids from threads
+    thread_alts: dict[str, set[str]] = {}
+    for thread in output.get("threads", []):
+        tid = thread.get("tension_id", "")
+        # Strip scope prefix if present
+        if "::" in tid:
+            tid = tid.split("::", 1)[-1]
+        alt = thread.get("alternative_id")
+        if alt:
+            thread_alts.setdefault(tid, set()).add(alt)
+
+    # Backfill empty considered arrays
+    for tension in output.get("tensions", []):
+        # Support both new 'considered' and old 'explored' field names
+        considered = tension.get("considered", tension.get("explored", []))
+        if not considered:
+            tid = tension.get("tension_id", "")
+            # Strip scope prefix if present
+            if "::" in tid:
+                tid = tid.split("::", 1)[-1]
+            thread_alt_ids = thread_alts.get(tid, set())
+            if thread_alt_ids:
+                tension["considered"] = sorted(thread_alt_ids)
+
+
 # Registry of stages with mutation handlers
 # Note: GROW is not included because it modifies the graph directly during execution,
 # not via post-stage mutation application.
@@ -1188,6 +1227,41 @@ def validate_seed_mutations(graph: Graph, output: dict[str, Any]) -> list[SeedVa
                 )
             )
 
+    # 11c. Check each thread's alternative_id is in its tension's considered list
+    # This catches data integrity issues where threads exist but considered is empty/mismatched
+    for i, thread in enumerate(output.get("threads", [])):
+        raw_tid = thread.get("tension_id")
+        raw_alt_id = thread.get("alternative_id")
+        if not raw_tid or not raw_alt_id:
+            continue
+
+        normalized_tid, _ = _normalize_id(raw_tid, "tension")
+
+        # Find the corresponding tension decision
+        for tension_decision in output.get("tensions", []):
+            decision_tid = tension_decision.get("tension_id", "")
+            # Strip scope prefix if present
+            if "::" in decision_tid:
+                decision_tid = decision_tid.split("::", 1)[-1]
+            if decision_tid == normalized_tid:
+                considered = tension_decision.get(
+                    "considered", tension_decision.get("explored", [])
+                )
+                if raw_alt_id not in considered:
+                    errors.append(
+                        SeedValidationError(
+                            field_path=f"threads.{i}.alternative_id",
+                            issue=(
+                                f"Thread alternative '{raw_alt_id}' is not in tension "
+                                f"'{normalized_tid}' considered list: {considered}"
+                            ),
+                            available=considered,
+                            provided=raw_alt_id,
+                            category=SeedErrorCategory.SEMANTIC,
+                        )
+                    )
+                break
+
     # NOTE: Arc count validation removed - now handled by runtime pruning (over-generate-and-select)
     # See seed_pruning.py for the new approach: LLM generates freely, runtime selects best tensions
 
@@ -1283,6 +1357,10 @@ def apply_seed_mutations(graph: Graph, output: dict[str, Any]) -> None:
         SeedMutationError: If semantic validation fails (with feedback for retry).
         MutationError: If required id fields are missing.
     """
+    # Migration: backfill empty considered arrays from thread alternative_ids
+    # This fixes legacy data where LLM serialized threads but left considered empty
+    _backfill_considered_from_threads(output)
+
     # Validate cross-references first
     errors = validate_seed_mutations(graph, output)
     if errors:
@@ -1304,7 +1382,8 @@ def apply_seed_mutations(graph: Graph, output: dict[str, Any]) -> None:
         tension_id = _prefix_id("tension", raw_id)
         if graph.has_node(tension_id):
             # Support both new 'considered' and old 'explored' field names
-            considered = tension_decision.get("considered") or tension_decision.get("explored", [])
+            # Use dict.get() chaining instead of 'or' to handle empty lists correctly
+            considered = tension_decision.get("considered", tension_decision.get("explored", []))
             graph.update_node(
                 tension_id,
                 considered=considered,

--- a/tests/unit/test_mutations.py
+++ b/tests/unit/test_mutations.py
@@ -10,6 +10,7 @@ from questfoundry.graph.mutations import (
     BrainstormValidationError,
     SeedErrorCategory,
     SeedValidationError,
+    _backfill_considered_from_threads,
     _format_available_with_suggestions,
     _normalize_id,
     _prefix_id,
@@ -3098,3 +3099,468 @@ class TestCutEntityInBeats:
         assert len(cut_errors) == 1
         assert "ruins" in cut_errors[0].issue
         assert "initial_beats.0.location_alternatives" in cut_errors[0].field_path
+
+
+class TestBackfillConsideredFromThreads:
+    """Tests for _backfill_considered_from_threads migration function."""
+
+    def test_backfills_empty_considered_from_threads(self) -> None:
+        """Empty considered array is filled from thread alternative_ids."""
+        output = {
+            "tensions": [
+                {"tension_id": "choice_a_or_b", "considered": []},
+            ],
+            "threads": [
+                {
+                    "thread_id": "thread1",
+                    "tension_id": "choice_a_or_b",
+                    "alternative_id": "option_a",
+                },
+                {
+                    "thread_id": "thread2",
+                    "tension_id": "choice_a_or_b",
+                    "alternative_id": "option_b",
+                },
+            ],
+        }
+
+        _backfill_considered_from_threads(output)
+
+        assert output["tensions"][0]["considered"] == ["option_a", "option_b"]
+
+    def test_preserves_existing_considered(self) -> None:
+        """Non-empty considered array is not modified."""
+        output = {
+            "tensions": [
+                {"tension_id": "choice_a_or_b", "considered": ["existing_value"]},
+            ],
+            "threads": [
+                {
+                    "thread_id": "thread1",
+                    "tension_id": "choice_a_or_b",
+                    "alternative_id": "option_a",
+                },
+            ],
+        }
+
+        _backfill_considered_from_threads(output)
+
+        assert output["tensions"][0]["considered"] == ["existing_value"]
+
+    def test_handles_scoped_tension_ids(self) -> None:
+        """Handles tension IDs with scope prefix (tension::id)."""
+        output = {
+            "tensions": [
+                {"tension_id": "tension::choice_a_or_b", "considered": []},
+            ],
+            "threads": [
+                {
+                    "thread_id": "thread1",
+                    "tension_id": "tension::choice_a_or_b",
+                    "alternative_id": "option_a",
+                },
+            ],
+        }
+
+        _backfill_considered_from_threads(output)
+
+        assert output["tensions"][0]["considered"] == ["option_a"]
+
+    def test_handles_mixed_scoped_and_unscoped(self) -> None:
+        """Matches tension with scoped ID to thread with unscoped ID."""
+        output = {
+            "tensions": [
+                {"tension_id": "tension::choice_a_or_b", "considered": []},
+            ],
+            "threads": [
+                {
+                    "thread_id": "thread1",
+                    "tension_id": "choice_a_or_b",
+                    "alternative_id": "option_a",
+                },
+            ],
+        }
+
+        _backfill_considered_from_threads(output)
+
+        assert output["tensions"][0]["considered"] == ["option_a"]
+
+    def test_supports_old_explored_field(self) -> None:
+        """Checks both 'considered' and 'explored' for existing values."""
+        output = {
+            "tensions": [
+                {"tension_id": "choice_a_or_b", "explored": ["existing"]},
+            ],
+            "threads": [
+                {
+                    "thread_id": "thread1",
+                    "tension_id": "choice_a_or_b",
+                    "alternative_id": "option_a",
+                },
+            ],
+        }
+
+        _backfill_considered_from_threads(output)
+
+        # explored is not empty, so no backfill
+        assert "considered" not in output["tensions"][0]
+        assert output["tensions"][0]["explored"] == ["existing"]
+
+    def test_no_threads_no_backfill(self) -> None:
+        """Empty threads list does not modify tensions."""
+        output = {
+            "tensions": [
+                {"tension_id": "choice_a_or_b", "considered": []},
+            ],
+            "threads": [],
+        }
+
+        _backfill_considered_from_threads(output)
+
+        assert output["tensions"][0]["considered"] == []
+
+    def test_thread_without_alternative_id_ignored(self) -> None:
+        """Threads without alternative_id are skipped."""
+        output = {
+            "tensions": [
+                {"tension_id": "choice_a_or_b", "considered": []},
+            ],
+            "threads": [
+                {"thread_id": "thread1", "tension_id": "choice_a_or_b"},  # no alternative_id
+            ],
+        }
+
+        _backfill_considered_from_threads(output)
+
+        assert output["tensions"][0]["considered"] == []
+
+    def test_multiple_tensions_independently_backfilled(self) -> None:
+        """Each tension is backfilled from its own threads."""
+        output = {
+            "tensions": [
+                {"tension_id": "tension_one", "considered": []},
+                {"tension_id": "tension_two", "considered": []},
+            ],
+            "threads": [
+                {"thread_id": "t1", "tension_id": "tension_one", "alternative_id": "opt_a"},
+                {"thread_id": "t2", "tension_id": "tension_two", "alternative_id": "opt_x"},
+                {"thread_id": "t3", "tension_id": "tension_two", "alternative_id": "opt_y"},
+            ],
+        }
+
+        _backfill_considered_from_threads(output)
+
+        assert output["tensions"][0]["considered"] == ["opt_a"]
+        assert output["tensions"][1]["considered"] == ["opt_x", "opt_y"]
+
+
+class TestValidation11cThreadAlternativeInConsidered:
+    """Tests for validation check 11c: thread.alternative_id IN tension.considered."""
+
+    def test_thread_alternative_in_considered_passes(self) -> None:
+        """Thread with alternative_id matching considered passes validation."""
+        graph = Graph.empty()
+        graph.create_node(
+            "tension::choice_a_or_b",
+            {
+                "type": "tension",
+                "raw_id": "choice_a_or_b",
+                "alternatives": [
+                    {"alternative_id": "option_a", "is_default_path": True},
+                    {"alternative_id": "option_b", "is_default_path": False},
+                ],
+            },
+        )
+
+        output = {
+            "entities": [],
+            "tensions": [
+                {"tension_id": "choice_a_or_b", "considered": ["option_a", "option_b"]},
+            ],
+            "threads": [
+                {
+                    "thread_id": "thread1",
+                    "tension_id": "choice_a_or_b",
+                    "alternative_id": "option_a",
+                    "name": "Thread One",
+                },
+                {
+                    "thread_id": "thread2",
+                    "tension_id": "choice_a_or_b",
+                    "alternative_id": "option_b",
+                    "name": "Thread Two",
+                },
+            ],
+            "initial_beats": [
+                {
+                    "beat_id": "b1",
+                    "summary": "Test",
+                    "threads": ["thread1"],
+                    "tension_impacts": [
+                        {"tension_id": "choice_a_or_b", "effect": "commits", "note": "Commits"}
+                    ],
+                },
+                {
+                    "beat_id": "b2",
+                    "summary": "Test",
+                    "threads": ["thread2"],
+                    "tension_impacts": [
+                        {"tension_id": "choice_a_or_b", "effect": "commits", "note": "Commits"}
+                    ],
+                },
+            ],
+        }
+
+        errors = validate_seed_mutations(graph, output)
+
+        # Filter for 11c errors specifically
+        check_11c_errors = [
+            e for e in errors if "not in tension" in e.issue and "considered" in e.issue
+        ]
+        assert check_11c_errors == []
+
+    def test_thread_alternative_not_in_considered_detected(self) -> None:
+        """Thread with alternative_id NOT in considered fails validation."""
+        graph = Graph.empty()
+        graph.create_node(
+            "tension::choice_a_or_b",
+            {
+                "type": "tension",
+                "raw_id": "choice_a_or_b",
+                "alternatives": [
+                    {"alternative_id": "option_a", "is_default_path": True},
+                    {"alternative_id": "option_b", "is_default_path": False},
+                ],
+            },
+        )
+
+        output = {
+            "entities": [],
+            "tensions": [
+                {"tension_id": "choice_a_or_b", "considered": ["option_a"]},  # missing option_b!
+            ],
+            "threads": [
+                {
+                    "thread_id": "thread1",
+                    "tension_id": "choice_a_or_b",
+                    "alternative_id": "option_a",
+                    "name": "Thread One",
+                },
+                {
+                    "thread_id": "thread2",
+                    "tension_id": "choice_a_or_b",
+                    "alternative_id": "option_b",  # not in considered!
+                    "name": "Thread Two",
+                },
+            ],
+            "initial_beats": [
+                {
+                    "beat_id": "b1",
+                    "summary": "Test",
+                    "threads": ["thread1"],
+                    "tension_impacts": [
+                        {"tension_id": "choice_a_or_b", "effect": "commits", "note": "Commits"}
+                    ],
+                },
+                {
+                    "beat_id": "b2",
+                    "summary": "Test",
+                    "threads": ["thread2"],
+                    "tension_impacts": [
+                        {"tension_id": "choice_a_or_b", "effect": "commits", "note": "Commits"}
+                    ],
+                },
+            ],
+        }
+
+        errors = validate_seed_mutations(graph, output)
+
+        # Filter for 11c errors specifically
+        check_11c_errors = [
+            e for e in errors if "not in tension" in e.issue and "considered" in e.issue
+        ]
+        assert len(check_11c_errors) == 1
+        assert "option_b" in check_11c_errors[0].issue
+        assert "choice_a_or_b" in check_11c_errors[0].issue
+        assert check_11c_errors[0].field_path == "threads.1.alternative_id"
+        assert check_11c_errors[0].category == SeedErrorCategory.SEMANTIC
+
+    def test_empty_considered_detected(self) -> None:
+        """Thread with alternative_id but empty considered fails validation."""
+        graph = Graph.empty()
+        graph.create_node(
+            "tension::choice_a_or_b",
+            {
+                "type": "tension",
+                "raw_id": "choice_a_or_b",
+                "alternatives": [
+                    {"alternative_id": "option_a", "is_default_path": True},
+                ],
+            },
+        )
+
+        output = {
+            "entities": [],
+            "tensions": [
+                {"tension_id": "choice_a_or_b", "considered": []},  # empty!
+            ],
+            "threads": [
+                {
+                    "thread_id": "thread1",
+                    "tension_id": "choice_a_or_b",
+                    "alternative_id": "option_a",
+                    "name": "Thread One",
+                },
+            ],
+            "initial_beats": [
+                {
+                    "beat_id": "b1",
+                    "summary": "Test",
+                    "threads": ["thread1"],
+                    "tension_impacts": [
+                        {"tension_id": "choice_a_or_b", "effect": "commits", "note": "Commits"}
+                    ],
+                },
+            ],
+        }
+
+        errors = validate_seed_mutations(graph, output)
+
+        # Filter for 11c errors
+        check_11c_errors = [
+            e for e in errors if "not in tension" in e.issue and "considered" in e.issue
+        ]
+        assert len(check_11c_errors) == 1
+        assert "option_a" in check_11c_errors[0].issue
+
+    def test_scoped_tension_ids_matched_correctly(self) -> None:
+        """Scoped tension IDs are normalized for matching."""
+        graph = Graph.empty()
+        graph.create_node(
+            "tension::choice_a_or_b",
+            {
+                "type": "tension",
+                "raw_id": "choice_a_or_b",
+                "alternatives": [
+                    {"alternative_id": "option_a", "is_default_path": True},
+                ],
+            },
+        )
+
+        output = {
+            "entities": [],
+            "tensions": [
+                {"tension_id": "tension::choice_a_or_b", "considered": ["option_a"]},  # scoped
+            ],
+            "threads": [
+                {
+                    "thread_id": "thread1",
+                    "tension_id": "choice_a_or_b",  # unscoped
+                    "alternative_id": "option_a",
+                    "name": "Thread One",
+                },
+            ],
+            "initial_beats": [
+                {
+                    "beat_id": "b1",
+                    "summary": "Test",
+                    "threads": ["thread1"],
+                    "tension_impacts": [
+                        {"tension_id": "choice_a_or_b", "effect": "commits", "note": "Commits"}
+                    ],
+                },
+            ],
+        }
+
+        errors = validate_seed_mutations(graph, output)
+
+        # Filter for 11c errors
+        check_11c_errors = [
+            e for e in errors if "not in tension" in e.issue and "considered" in e.issue
+        ]
+        assert check_11c_errors == []
+
+
+class TestBackfillIntegrationWithApplySeedMutations:
+    """Test that backfill runs before validation in apply_seed_mutations."""
+
+    def test_backfill_runs_before_validation(self) -> None:
+        """Backfill fixes data before validation, preventing 11c errors."""
+        graph = Graph.empty()
+        # Create tension node
+        graph.create_node(
+            "tension::choice_a_or_b",
+            {
+                "type": "tension",
+                "raw_id": "choice_a_or_b",
+            },
+        )
+        # Create alternative nodes
+        graph.create_node(
+            "tension::choice_a_or_b::alt::option_a",
+            {"type": "alternative", "raw_id": "option_a", "is_default_path": True},
+        )
+        graph.create_node(
+            "tension::choice_a_or_b::alt::option_b",
+            {"type": "alternative", "raw_id": "option_b", "is_default_path": False},
+        )
+        # Create has_alternative edges (required for validation)
+        graph.add_edge(
+            "has_alternative",
+            "tension::choice_a_or_b",
+            "tension::choice_a_or_b::alt::option_a",
+        )
+        graph.add_edge(
+            "has_alternative",
+            "tension::choice_a_or_b",
+            "tension::choice_a_or_b::alt::option_b",
+        )
+
+        # Legacy data pattern: threads exist but considered is empty
+        output = {
+            "entities": [],
+            "tensions": [
+                {"tension_id": "choice_a_or_b", "considered": []},  # empty - should be backfilled
+            ],
+            "threads": [
+                {
+                    "thread_id": "thread1",
+                    "tension_id": "choice_a_or_b",
+                    "alternative_id": "option_a",
+                    "name": "Thread One",
+                },
+                {
+                    "thread_id": "thread2",
+                    "tension_id": "choice_a_or_b",
+                    "alternative_id": "option_b",
+                    "name": "Thread Two",
+                },
+            ],
+            "consequences": [],
+            "initial_beats": [
+                {
+                    "beat_id": "b1",
+                    "summary": "Test",
+                    "threads": ["thread1"],
+                    "tension_impacts": [
+                        {"tension_id": "choice_a_or_b", "effect": "commits", "note": "Commits"}
+                    ],
+                },
+                {
+                    "beat_id": "b2",
+                    "summary": "Test",
+                    "threads": ["thread2"],
+                    "tension_impacts": [
+                        {"tension_id": "choice_a_or_b", "effect": "commits", "note": "Commits"}
+                    ],
+                },
+            ],
+        }
+
+        # Should NOT raise because backfill fixes the data before validation
+        apply_seed_mutations(graph, output)
+
+        # Verify the tension node was updated with backfilled considered
+        tension_node = graph.get_node("tension::choice_a_or_b")
+        assert tension_node is not None
+        assert sorted(tension_node.get("considered", [])) == ["option_a", "option_b"]


### PR DESCRIPTION
## Problem

Existing graphs (grow-3, grow-4) have data integrity issues:
- Tension nodes have `considered: []` (empty array)
- Thread nodes exist with valid `alternative_id` values
- The thread's `alternative_id` is NOT in the tension's `considered` array

This violates the invariant: `thread.alternative_id IN tension.considered`

Root cause: LLM serialization confusion - tensions serialized before threads, with no explicit link between `considered` and thread creation in prompts.

## Changes

- Add `_backfill_considered_from_threads()` migration function that runs before validation
- Add validation check 11c: verifies each thread's `alternative_id` is in its tension's `considered` list
- Fix `or` bug with empty lists in `apply_seed_mutations()` (empty list is falsy)
- Add comprehensive tests (13 new tests for backfill, validation, and integration)

## Not Included / Future PRs

- Prompt improvements to prevent this issue in new LLM output (#325 - will be PR #2 in stack)

## Test Plan

```bash
# Run mutation tests
uv run pytest tests/unit/test_mutations.py -v
# 148 passed

# Run full test suite
uv run pytest
# 1335 passed, 6 xpassed
```

## Risk / Rollback

- **Low risk**: Migration is additive (fills empty arrays, doesn't modify existing values)
- **Backward compatible**: Supports both `explored` and `considered` field names
- **Rollback**: Revert PR, graphs still readable with empty `considered` (validation would fail though)

Fixes #324

🤖 Generated with [Claude Code](https://claude.com/claude-code)