### PR TITLE
docs(prompts): add considered/thread invariant to SEED prompts

### DIFF
--- a/prompts/templates/serialize_seed_sections.yaml
+++ b/prompts/templates/serialize_seed_sections.yaml
@@ -65,10 +65,20 @@ tensions_prompt: |
   - implicit: Alternative IDs NOT explored (become shadows)
   - Generate a decision for EVERY tension in the manifest
 
+  ## CRITICAL INVARIANT: considered ↔ threads linkage
+  The `considered` array defines which alternatives will have threads created.
+  For EACH alternative_id in `considered`, you MUST create a thread later.
+  The thread's `alternative_id` field MUST match an entry in `considered`.
+
+  WRONG: `considered: []` with threads that have `alternative_id` values
+  WRONG: `considered: ["opt_a"]` but thread uses `alternative_id: "opt_b"`
+  RIGHT: `considered: ["opt_a", "opt_b"]` and threads use those exact IDs
+
   ## What NOT to Do
   - Do NOT skip tensions because they aren't mentioned in the brief
   - Do NOT invent tensions not in the manifest
   - Do NOT partially complete the list
+  - Do NOT leave `considered` empty if you plan to create threads for that tension
 
   ## Output
   Return ONLY valid JSON with the "tensions" array.
@@ -80,6 +90,13 @@ threads_prompt: |
   ## Generation Requirements (CRITICAL)
   For each "considered" alternative in the tension decisions, you MUST generate a thread.
   Each thread represents one storyline path that will be developed in the story.
+
+  ## CRITICAL INVARIANT: alternative_id MUST match considered
+  Each thread's `alternative_id` MUST be one of the IDs listed in the tension's
+  `considered` array. This is a hard constraint enforced by validation.
+
+  WRONG: Thread with `alternative_id: "option_b"` when tension has `considered: ["option_a"]`
+  RIGHT: Thread with `alternative_id: "option_a"` when tension has `considered: ["option_a", "option_b"]`
 
   ## Schema
   Return a JSON object with a "threads" array. Each item is a Thread:
@@ -126,11 +143,13 @@ threads_prompt: |
   - unexplored_alternative_ids: IDs of alternatives NOT explored (implicit ones)
   - consequence_ids: References to consequences for this thread
   - Generate a thread for EACH considered alternative from tension decisions
+  - alternative_id MUST be one of the IDs from the tension's `considered` array
 
   ## What NOT to Do
   - Do NOT reuse tension IDs as thread IDs
   - Do NOT skip alternatives marked as "considered"
   - Do NOT create threads for "implicit" alternatives (they become shadows, not threads)
+  - Do NOT use an alternative_id that isn't in the tension's `considered` list
 
   ## Output
   Return ONLY valid JSON with the "threads" array.


### PR DESCRIPTION
## Problem

LLMs serializing SEED output sometimes produce data integrity issues where:
- Tension decisions have empty `considered` arrays
- Threads exist with `alternative_id` values that aren't in `considered`

This violates the invariant: `thread.alternative_id IN tension.considered`

While PR #326 adds migration code to fix existing data, we should also prevent this issue in new LLM output by making the constraint explicit in prompts.

## Changes

- **tensions_prompt**: Add "CRITICAL INVARIANT: considered ↔ threads linkage" section
  - Explains that `considered` defines which alternatives will have threads
  - Provides WRONG/RIGHT examples
  - Adds rule: "Do NOT leave `considered` empty if you plan to create threads"

- **threads_prompt**: Add "CRITICAL INVARIANT: alternative_id MUST match considered" section
  - Explains that `alternative_id` must be in tension's `considered` array
  - Provides WRONG/RIGHT examples  
  - Adds rule: "alternative_id MUST be one of the IDs from the tension's `considered` array"

## Not Included / Future PRs

None - this completes the fix for the data integrity issue.

## Test Plan

```bash
# Run SEED-related tests
uv run pytest tests/ -k "seed" --tb=short
# 105 passed
```

## Risk / Rollback

- **Low risk**: Prompt changes only add clarifying documentation
- **No behavior change**: Validation logic unchanged
- **Rollback**: Revert PR, prompts still work but less explicit

**Stacked PR**: This PR targets `fix/324-considered-backfill` (PR #326). Merge order:
1. Merge PR #326 (migration + validation)
2. Retarget this PR to main
3. Merge this PR

Fixes #325

🤖 Generated with [Claude Code](https://claude.com/claude-code)