### PR TITLE
fix(serialize): enable beat retry and context refresh in semantic loop

### DIFF
--- a/src/questfoundry/agents/serialize.py
+++ b/src/questfoundry/agents/serialize.py
@@ -1281,7 +1281,8 @@ async def serialize_seed_as_function(
                     error_count=len(section_errors["beats"]),
                 )
                 try:
-                    # Re-generate all beats with current (possibly corrected) threads
+                    # Re-generate all beats with current (possibly corrected) threads.
+                    # If threads is empty, _serialize_beats_per_thread returns ([], 0) gracefully.
                     beats, beats_tokens = await _serialize_beats_per_thread(
                         model=model,
                         threads=collected["threads"],

--- a/src/questfoundry/agents/serialize.py
+++ b/src/questfoundry/agents/serialize.py
@@ -1258,10 +1258,45 @@ async def serialize_seed_as_function(
                     if output_field in section_data:
                         collected[output_field] = section_data[output_field]
                         retried_any = True
+
+                        # Refresh thread context for dependent sections when threads change
+                        if section_name == "threads":
+                            thread_ids_context = format_thread_ids_context(collected["threads"])
+                            if thread_ids_context:
+                                brief_with_threads = f"{enhanced_brief}\n\n{thread_ids_context}"
+                                log.debug("thread_context_refreshed_on_retry")
+
                 except SerializationError as e:
                     log.warning(
                         "serialize_section_retry_failed",
                         section=section_name,
+                        error=str(e),
+                    )
+
+            # Handle beats separately - not in sections list but generated per-thread
+            if "beats" in section_errors:
+                log.debug(
+                    "serialize_beats_retry",
+                    attempt=semantic_attempt,
+                    error_count=len(section_errors["beats"]),
+                )
+                try:
+                    # Re-generate all beats with current (possibly corrected) threads
+                    beats, beats_tokens = await _serialize_beats_per_thread(
+                        model=model,
+                        threads=collected["threads"],
+                        per_thread_prompt=prompts["per_thread_beats"],
+                        entity_context=entity_context,
+                        provider_name=provider_name,
+                        max_retries=max_retries,
+                        callbacks=callbacks,
+                    )
+                    collected["initial_beats"] = beats
+                    total_tokens += beats_tokens
+                    retried_any = True
+                except SerializationError as e:
+                    log.warning(
+                        "serialize_beats_retry_failed",
                         error=str(e),
                     )
 


### PR DESCRIPTION
## Problem

Issue #329 identified root causes for recurring SEED validation failures. Four independent analyses (LLM architect, architect-reviewer, code-reviewer, Gemini agent) confirmed two critical bugs in the retry loop:

1. **Beat retry was broken** - Beats are generated via `_serialize_beats_per_thread()` but not in the `sections` list. When semantic validation found beat errors, the retry loop looked for "beats" in `sections`, got `None`, and skipped it.

2. **Stale context on thread retry** - When threads were re-serialized, `brief_with_threads` was not updated, causing subsequent sections (consequences, beats) to use stale thread IDs.

## Changes

- Added special handling for beats after the regular section retry loop
- When "beats" is in `section_errors`, re-generate all beats using `_serialize_beats_per_thread()`
- After successful thread retry, refresh `brief_with_threads` with updated thread IDs
- Added 2 new tests for beat retry and context refresh

## Not Included / Future PRs

- PR #3: Cleanup dead code and fix field names (`explored` → `considered`)
- PR #4: Consolidate ID normalization (optional)

These are tracked in issue #329.

## Test Plan

```bash
uv run pytest tests/unit/test_serialize.py -v
# 47 passed

uv run pytest tests/unit/test_serialize.py::TestBeatRetryAndContextRefresh -v
# 2 passed (new tests)
```

## Risk / Rollback

- Beat retry adds one additional call to `_serialize_beats_per_thread()` when beat errors occur
- This is acceptable token cost for correctness
- No backwards compatibility concerns

🤖 Generated with [Claude Code](https://claude.com/claude-code)