### PR TITLE
chore: cleanup dead code and fix field names (#329)

### DIFF
--- a/src/questfoundry/agents/serialize.py
+++ b/src/questfoundry/agents/serialize.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import re
+import warnings
 from collections.abc import Callable
 from dataclasses import dataclass, field
 from functools import lru_cache
@@ -713,6 +714,11 @@ async def serialize_seed_iteratively(
 ) -> tuple[Any, int]:
     """Serialize SEED brief in sections to avoid output truncation.
 
+    .. deprecated:: 5.2
+        Use serialize_seed_as_function() instead. This function raises
+        SeedMutationError on validation failures; the new function returns
+        a SerializeResult with errors for conversation-level retry.
+
     Instead of serializing the entire SeedOutput at once (which can cause
     truncation with complex schemas on smaller models), this function
     serializes each section independently and merges the results.
@@ -746,6 +752,11 @@ async def serialize_seed_iteratively(
         SerializationError: If any section fails validation after retries.
         SeedMutationError: If semantic validation fails after all retries.
     """
+    warnings.warn(
+        "serialize_seed_iteratively() is deprecated. Use serialize_seed_as_function() instead.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
     from questfoundry.models.seed import (
         BeatsSection,
         ConsequencesSection,

--- a/src/questfoundry/pipeline/stages/seed.py
+++ b/src/questfoundry/pipeline/stages/seed.py
@@ -429,7 +429,7 @@ class SeedStage:
         # This indicates the LLM didn't generate enough branching content
         if final_arc_count < 4:
             tensions_fully_explored = sum(
-                1 for t in artifact_data.get("tensions", []) if len(t.get("explored", [])) >= 2
+                1 for t in artifact_data.get("tensions", []) if len(t.get("considered", [])) >= 2
             )
             log.warning(
                 "seed_low_arc_count",


### PR DESCRIPTION
## Problem

Part of #329 architectural cleanup. Two issues identified by code review:

1. **Wrong field name in seed.py** - Line 432 referenced `explored` but the model uses `considered`
2. **Unused function** - `serialize_seed_iteratively()` is no longer used by the stage (uses `serialize_seed_as_function()` instead)

## Changes

- Fix `explored` → `considered` in seed.py:432
- Mark `serialize_seed_iteratively()` as deprecated with:
  - Runtime `DeprecationWarning`
  - Docstring `.. deprecated:: 5.2` notice
  - Guidance to use `serialize_seed_as_function()` instead

## Not Included / Future PRs

- PR #4 (optional): Consolidate ID normalization
- Removing `serialize_seed_iteratively()` entirely (keeping for backward compatibility)

## Test Plan

```bash
# All serialize tests pass
uv run pytest tests/unit/test_serialize.py -v
# 45 passed

# Deprecation warning shows in test output
# DeprecationWarning: serialize_seed_iteratively() is deprecated...
```

## Risk / Rollback

- Low risk - field name fix is purely cosmetic (logging)
- Deprecation warning doesn't break existing code
- Tests continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)