### PR TITLE
feat(graph): standardize scoped ID handling across pruning

### DIFF
--- a/prompts/templates/serialize_seed.yaml
+++ b/prompts/templates/serialize_seed.yaml
@@ -4,6 +4,15 @@ description: Convert seed brief into SeedOutput artifact
 system: |
   You are converting a SEED stage brief into a structured SeedOutput artifact.
 
+  ## Scoped ID Format (CRITICAL)
+
+  All IDs use type prefixes for disambiguation. Copy IDs EXACTLY as shown in the brief:
+  - Entity IDs: `entity::butler`, `entity::manor`
+  - Tension IDs: `tension::host_benevolent_or_selfish`
+  - Thread IDs: `thread::host_motive`
+
+  The manifest shows which IDs are valid - copy them with their prefixes.
+
   ## Schema Overview
 
   SeedOutput contains six main sections that must be populated from the brief:
@@ -12,8 +21,8 @@ system: |
   For EVERY entity from brainstorm (characters, locations, objects, AND factions), create an EntityDecision:
   ```json
   {
-    "entity_id": "entity_id_from_brainstorm",
-    "disposition": "retained" or "cut"
+    "entity_id": "entity::butler",
+    "disposition": "retained"
   }
   ```
   IMPORTANT: Include ALL entity types - don't skip factions!
@@ -22,28 +31,28 @@ system: |
   For each tension from brainstorm, create a TensionDecision:
   ```json
   {
-    "tension_id": "tension_id_from_brainstorm",
-    "explored": ["alt_id_1", "alt_id_2"],  // Alternatives that become threads
-    "implicit": ["alt_id_3"]                // Alternatives NOT explored
+    "tension_id": "tension::host_benevolent_or_selfish",
+    "considered": ["protector", "manipulator"],
+    "implicit": []
   }
   ```
   NOTES:
-  - The default path alternative (is_default_path=true) MUST be in "explored", never in "implicit".
-  - **Arc Count**: At least 2 tensions should have BOTH alternatives in "explored" for proper IF branching.
+  - The default path alternative (is_default_path=true) MUST be in "considered", never in "implicit".
+  - **Arc Count**: At least 2 tensions should have BOTH alternatives in "considered" for proper IF branching.
   - Tensions with only canonical alternative explored don't contribute to branching.
 
   ### 3. threads (Plot Threads)
   For each explored alternative, create a Thread:
   ```json
   {
-    "thread_id": "unique_thread_id",
+    "thread_id": "thread::host_motive",
     "name": "Human Readable Thread Name",
-    "tension_id": "which_tension",
-    "alternative_id": "which_alternative_this_explores",
-    "unexplored_alternative_ids": ["unexplored_alt_ids"],  // Implicit alternatives
-    "thread_importance": "major" or "minor",
+    "tension_id": "tension::host_benevolent_or_selfish",
+    "alternative_id": "protector",
+    "unexplored_alternative_ids": ["manipulator"],
+    "thread_importance": "major",
     "description": "What this thread is about",
-    "consequence_ids": ["consequence_id_1", "consequence_id_2"]
+    "consequence_ids": ["host_revealed"]
   }
   ```
 
@@ -51,8 +60,8 @@ system: |
   For each thread, create its Consequences:
   ```json
   {
-    "consequence_id": "unique_consequence_id",
-    "thread_id": "which_thread_this_belongs_to",
+    "consequence_id": "host_revealed",
+    "thread_id": "thread::host_motive",
     "description": "What happens narratively",
     "narrative_effects": ["story effect 1", "story effect 2"]
   }
@@ -62,19 +71,19 @@ system: |
   Create 2-4 InitialBeat objects PER THREAD. With 3 threads, expect 6-12 beats total.
   ```json
   {
-    "beat_id": "unique_beat_id",
+    "beat_id": "host_motive_beat_01",
     "summary": "What happens in this beat",
-    "threads": ["thread_id_1", "thread_id_2"],
+    "threads": ["thread::host_motive"],
     "tension_impacts": [
       {
-        "tension_id": "which_tension",
-        "effect": "advances" or "reveals" or "commits" or "complicates",
+        "tension_id": "tension::host_benevolent_or_selfish",
+        "effect": "advances",
         "note": "Explanation of the impact"
       }
     ],
-    "entities": ["entity_id_1", "entity_id_2"],
-    "location": "location_entity_id" or null,
-    "location_alternatives": ["other_location_id"]
+    "entities": ["entity::butler", "entity::guest"],
+    "location": "entity::manor",
+    "location_alternatives": ["entity::garden"]
   }
   ```
 
@@ -101,11 +110,11 @@ system: |
 
   - Extract ALL information from the brief - do not invent new details
   - Use snake_case for all IDs
-  - Entity and tension IDs must match those shown in the brief (use the IDs as displayed)
-  - Every thread must reference a valid tension_id and alternative_id
-  - Every consequence must reference a valid thread_id
+  - Copy IDs EXACTLY as shown in the brief, INCLUDING the type prefix
+  - Every thread must reference a valid tension_id (with `tension::` prefix) and alternative_id
+  - Every consequence must reference a valid thread_id (with `thread::` prefix)
   - Create 2-4 initial_beats PER THREAD (not 1 per thread!)
-  - Every initial_beat must reference valid thread IDs
+  - Every initial_beat must reference valid thread IDs (with `thread::` prefix)
   - thread_importance must be exactly "major" or "minor" (lowercase)
   - effect must be exactly "advances", "reveals", "commits", or "complicates"
   - disposition must be exactly "retained" or "cut"

--- a/prompts/templates/serialize_seed_sections.yaml
+++ b/prompts/templates/serialize_seed_sections.yaml
@@ -216,8 +216,20 @@ consequences_prompt: |
   Note: `consequence_id` is a raw ID without prefix (local identifier).
   `thread_id` MUST include the `thread::` prefix.
 
+  ## Consequence ID Naming Convention
+
+  Use descriptive names that capture the narrative outcome:
+  - FORMAT: `[subject]_[outcome]` (e.g., `host_revealed`, `trust_broken`, `secret_exposed`)
+  - Keep IDs short and descriptive (2-4 words joined by underscores)
+  - Avoid generic names like `consequence_1` or `result_a`
+
+  EXAMPLES:
+  - `vault_sealed` - The vault is permanently sealed
+  - `alliance_formed` - Characters form an alliance
+  - `identity_exposed` - A hidden identity is revealed
+
   ## Rules
-  - consequence_id must be unique (raw ID, no prefix)
+  - consequence_id must be unique (raw ID, no prefix, following naming convention above)
   - thread_id must include the `thread::` prefix and reference a thread from the VALID THREAD IDs list
   - narrative_effects: Array of story effects this consequence implies
   - Generate at least one consequence for EACH thread
@@ -225,7 +237,7 @@ consequences_prompt: |
   ## What NOT to Do
   - Do NOT reference thread IDs that don't exist
   - Do NOT leave any thread without consequences
-  - Do NOT invent consequence_ids that don't follow the naming convention
+  - Do NOT use generic consequence IDs like `consequence_1` (use descriptive names)
   - Do NOT omit the `thread::` prefix from thread_id
 
   ## Output

--- a/prompts/templates/serialize_seed_sections.yaml
+++ b/prompts/templates/serialize_seed_sections.yaml
@@ -10,14 +10,22 @@ entities_prompt: |
   Missing items WILL cause validation failure. This is NOT extraction - you must
   generate decisions for ALL entities, even if the brief doesn't mention them explicitly.
 
+  ## Scoped ID Format (CRITICAL)
+  All IDs use type prefixes for disambiguation. Copy IDs EXACTLY as shown in the manifest,
+  including the `entity::` prefix.
+
   ## Schema
   Return a JSON object with an "entities" array. Each item is an EntityDecision:
   ```json
   {
     "entities": [
       {
-        "entity_id": "entity_id_from_brainstorm",
-        "disposition": "retained" or "cut"
+        "entity_id": "entity::butler",
+        "disposition": "retained"
+      },
+      {
+        "entity_id": "entity::manor",
+        "disposition": "cut"
       }
     ]
   }
@@ -25,13 +33,14 @@ entities_prompt: |
 
   ## Rules
   - disposition must be exactly "retained" or "cut" (lowercase)
-  - entity_id must match EXACTLY an ID from the Entity IDs manifest
+  - entity_id must include the `entity::` prefix and match EXACTLY an ID from the manifest
   - Generate a decision for EVERY entity in the manifest
 
   ## What NOT to Do
   - Do NOT skip entities because they aren't mentioned in the brief
   - Do NOT invent entities not in the manifest
   - Do NOT partially complete the list
+  - Do NOT omit the `entity::` prefix from IDs
 
   ## Output
   Return ONLY valid JSON with the "entities" array.
@@ -45,22 +54,29 @@ tensions_prompt: |
   Missing items WILL cause validation failure. This is NOT extraction - you must
   generate decisions for ALL tensions, even if the brief doesn't mention them explicitly.
 
+  ## Scoped ID Format (CRITICAL)
+  All IDs use type prefixes for disambiguation. Copy tension IDs EXACTLY as shown in
+  the manifest, including the `tension::` prefix.
+
   ## Schema
   Return a JSON object with a "tensions" array. Each item is a TensionDecision:
   ```json
   {
     "tensions": [
       {
-        "tension_id": "tension_id_from_brainstorm",
-        "considered": ["alt_id_1", "alt_id_2"],
-        "implicit": ["alt_id_3"]
+        "tension_id": "tension::host_benevolent_or_selfish",
+        "considered": ["protector", "manipulator"],
+        "implicit": []
       }
     ]
   }
   ```
 
+  Note: `considered` and `implicit` contain raw alternative IDs (no prefix) since
+  they are local to each tension.
+
   ## Rules
-  - tension_id must match EXACTLY an ID from the Tension IDs manifest
+  - tension_id must include the `tension::` prefix and match EXACTLY an ID from the manifest
   - considered: Alternative IDs to explore as threads (MUST include the default path)
   - implicit: Alternative IDs NOT explored (become shadows)
   - Generate a decision for EVERY tension in the manifest
@@ -79,6 +95,7 @@ tensions_prompt: |
   - Do NOT invent tensions not in the manifest
   - Do NOT partially complete the list
   - Do NOT leave `considered` empty if you plan to create threads for that tension
+  - Do NOT omit the `tension::` prefix from tension_id
 
   ## Output
   Return ONLY valid JSON with the "tensions" array.
@@ -90,6 +107,13 @@ threads_prompt: |
   ## Generation Requirements (CRITICAL)
   For each "considered" alternative in the tension decisions, you MUST generate a thread.
   Each thread represents one storyline path that will be developed in the story.
+
+  ## Scoped ID Format (CRITICAL)
+  All IDs use type prefixes for disambiguation:
+  - thread_id: Use `thread::` prefix (e.g., `thread::host_motive`)
+  - tension_id: Use `tension::` prefix (e.g., `tension::host_benevolent_or_selfish`)
+
+  Copy IDs EXACTLY as shown in the manifest, including the prefixes.
 
   ## CRITICAL INVARIANT: alternative_id MUST match considered
   Each thread's `alternative_id` MUST be one of the IDs listed in the tension's
@@ -104,35 +128,40 @@ threads_prompt: |
   {
     "threads": [
       {
-        "thread_id": "unique_thread_id",
-        "name": "Human Readable Thread Name",
-        "tension_id": "which_tension",
-        "alternative_id": "which_alternative_this_explores",
-        "unexplored_alternative_ids": ["unexplored_alt_ids"],
-        "thread_importance": "major" or "minor",
+        "thread_id": "thread::host_motive",
+        "name": "The Host's Hidden Motive",
+        "tension_id": "tension::host_benevolent_or_selfish",
+        "alternative_id": "protector",
+        "unexplored_alternative_ids": ["manipulator"],
+        "thread_importance": "major",
         "description": "What this thread is about",
-        "consequence_ids": ["consequence_id_1"]
+        "consequence_ids": ["host_revealed"]
       }
     ]
   }
   ```
 
+  Note: `alternative_id`, `unexplored_alternative_ids`, and `consequence_ids` are raw
+  IDs without prefixes since they are local identifiers.
+
   ## Thread ID Naming (CRITICAL)
 
-  Thread IDs must be DIFFERENT from tension IDs. Use short descriptive names.
+  Thread IDs must be DIFFERENT from tension IDs. Use short descriptive names WITH the
+  `thread::` prefix.
 
   FORMAT:
-  - Tension: `[subject]_[optionA]_or_[optionB]` (the binary question)
-  - Thread: `[subject]_[aspect]` (short storyline name)
+  - Tension: `tension::[subject]_[optionA]_or_[optionB]` (the binary question)
+  - Thread: `thread::[subject]_[aspect]` (short storyline name)
 
   Pattern examples (generate YOUR OWN based on your story):
-  - Tension about character loyalty → Thread: `[character]_loyalty`
-  - Tension about artifact's nature → Thread: `[artifact]_secret`
-  - Tension about faction's agenda → Thread: `[faction]_agenda`
+  - Tension about character loyalty → Thread: `thread::[character]_loyalty`
+  - Tension about artifact's nature → Thread: `thread::[artifact]_secret`
+  - Tension about faction's agenda → Thread: `thread::[faction]_agenda`
 
   BAD patterns (will cause validation failures):
   - Using the SAME ID for both tension and thread
   - Using the tension_id as the thread_id
+  - Omitting the `thread::` prefix
 
   Thread IDs should be short names for the storyline, NOT the binary question.
 
@@ -144,12 +173,15 @@ threads_prompt: |
   - consequence_ids: References to consequences for this thread
   - Generate a thread for EACH considered alternative from tension decisions
   - alternative_id MUST be one of the IDs from the tension's `considered` array
+  - thread_id MUST include the `thread::` prefix
+  - tension_id MUST include the `tension::` prefix
 
   ## What NOT to Do
   - Do NOT reuse tension IDs as thread IDs
   - Do NOT skip alternatives marked as "considered"
   - Do NOT create threads for "implicit" alternatives (they become shadows, not threads)
   - Do NOT use an alternative_id that isn't in the tension's `considered` list
+  - Do NOT omit the `thread::` or `tension::` prefixes
 
   ## Output
   Return ONLY valid JSON with the "threads" array.
@@ -162,14 +194,18 @@ consequences_prompt: |
   Every thread MUST have at least one consequence. Consequences describe the narrative
   outcomes that result from following a particular thread's storyline.
 
+  ## Scoped ID Format (CRITICAL)
+  Thread IDs use the `thread::` prefix for disambiguation.
+  Copy thread IDs EXACTLY as shown in the VALID THREAD IDs list.
+
   ## Schema
   Return a JSON object with a "consequences" array. Each item is a Consequence:
   ```json
   {
     "consequences": [
       {
-        "consequence_id": "unique_consequence_id",
-        "thread_id": "which_thread_this_belongs_to",
+        "consequence_id": "host_revealed",
+        "thread_id": "thread::host_motive",
         "description": "What happens narratively",
         "narrative_effects": ["story effect 1", "story effect 2"]
       }
@@ -177,9 +213,12 @@ consequences_prompt: |
   }
   ```
 
+  Note: `consequence_id` is a raw ID without prefix (local identifier).
+  `thread_id` MUST include the `thread::` prefix.
+
   ## Rules
-  - consequence_id must be unique
-  - thread_id must reference a thread from the VALID THREAD IDs list
+  - consequence_id must be unique (raw ID, no prefix)
+  - thread_id must include the `thread::` prefix and reference a thread from the VALID THREAD IDs list
   - narrative_effects: Array of story effects this consequence implies
   - Generate at least one consequence for EACH thread
 
@@ -187,6 +226,7 @@ consequences_prompt: |
   - Do NOT reference thread IDs that don't exist
   - Do NOT leave any thread without consequences
   - Do NOT invent consequence_ids that don't follow the naming convention
+  - Do NOT omit the `thread::` prefix from thread_id
 
   ## Output
   Return ONLY valid JSON with the "consequences" array.

--- a/prompts/templates/serialize_seed_sections.yaml
+++ b/prompts/templates/serialize_seed_sections.yaml
@@ -377,10 +377,34 @@ beats_prompt: |
 per_thread_beats_prompt: |
   You are generating INITIAL BEATS for ONE SPECIFIC THREAD.
 
-  ## YOUR THREAD (CRITICAL - read first!)
-  You are generating beats ONLY for this thread:
-  - Thread ID: {thread_id}
-  - Parent tension: {tension_id}
+  ## YOUR THREAD ID (MEMORIZE THIS)
+
+  You are generating beats for thread: `{thread_id}`
+
+  The `threads` field in EVERY beat MUST contain EXACTLY: `["{thread_id}"]`
+
+  ## COMMON MISTAKE - DO NOT MAKE THIS ERROR
+
+  Thread IDs are SHORT (e.g., `thread::ai_hostile`).
+  Tension IDs are LONG and contain `_or_` (e.g., `tension::ai_orion_benevolent_or_hostile`).
+
+  WRONG OUTPUT (will fail validation):
+  ```json
+  "threads": ["{tension_id}"]  // WRONG! This is a TENSION ID (has _or_)
+  ```
+
+  CORRECT OUTPUT:
+  ```json
+  "threads": ["{thread_id}"]  // RIGHT! This is the THREAD ID (short, no _or_)
+  ```
+
+  RULE: If the ID contains `_or_`, it's a TENSION. Never put it in `threads`.
+
+  ## YOUR TENSION ID (for tension_impacts only)
+
+  Parent tension: `{tension_id}`
+
+  This goes in `tension_impacts[].tension_id`, NOT in `threads`.
 
   ## BEAT ID NAMING (CRITICAL - ensures uniqueness)
 
@@ -450,6 +474,15 @@ per_thread_beats_prompt: |
   - Do NOT reference other tension_ids in your first tension_impact
   - Do NOT skip the commits beat
   - Do NOT use IDs not in the manifest
+  - Do NOT put the tension ID in the `threads` field (see COMMON MISTAKE above)
+
+  ## FINAL VERIFICATION (check before outputting)
+
+  For EACH beat you generate, verify:
+  1. `threads` contains `{thread_id}` (SHORT id, NO `_or_` in it)
+  2. `tension_impacts[0].tension_id` is `{tension_id}` (LONG id, HAS `_or_`)
+
+  If you see `_or_` in your `threads` value, YOU MADE A MISTAKE. Fix it.
 
   ## Output
   Return ONLY valid JSON with the "initial_beats" array (2-4 beats).

--- a/src/questfoundry/artifacts/enrichment.py
+++ b/src/questfoundry/artifacts/enrichment.py
@@ -134,8 +134,8 @@ def _enrich_tensions(graph: Graph, tension_decisions: list[dict[str, Any]]) -> l
         if value := node.get("central_entity_ids"):
             enriched["central_entity_ids"] = [eid.split("::")[-1] for eid in value]
 
-        # Add SEED decision fields
-        enriched["explored"] = decision.get("explored", [])
+        # Add SEED decision fields (support both old 'explored' and new 'considered')
+        enriched["considered"] = decision.get("considered", decision.get("explored", []))
         enriched["implicit"] = decision.get("implicit", [])
 
         enriched_tensions.append(enriched)

--- a/src/questfoundry/graph/seed_pruning.py
+++ b/src/questfoundry/graph/seed_pruning.py
@@ -13,6 +13,7 @@ The pruning process:
 
 from __future__ import annotations
 
+from questfoundry.graph.context import strip_scope_prefix
 from questfoundry.graph.tension_scoring import select_tensions_for_full_exploration
 from questfoundry.models.seed import (
     Consequence,
@@ -94,25 +95,36 @@ def _prune_demoted_tensions(
     after SEED - it records the LLM's original intent. Development state
     (committed vs deferred) is derived from thread existence, not stored fields.
 
+    NOTE: All ID comparisons use strip_scope_prefix() to handle both scoped
+    (thread::foo) and raw (foo) ID formats consistently. This is part of the
+    "scoped everywhere" standardization (see issue #219, PR #220).
+
     Args:
         seed_output: The full SEED output.
-        demoted_tension_ids: Set of tension IDs to demote.
+        demoted_tension_ids: Set of tension IDs to demote (may be scoped or raw).
 
     Returns:
         Pruned SeedOutput with threads removed but tensions unchanged.
     """
-    # Build lookup of which threads to drop
+    # Normalize demoted_tension_ids to raw format for consistent comparison
+    demoted_raw_ids = {strip_scope_prefix(tid) for tid in demoted_tension_ids}
+
+    # Build lookup of which threads to drop (using raw IDs for comparison)
     threads_to_drop: set[str] = set()
-    tension_lookup: dict[str, TensionDecision] = {t.tension_id: t for t in seed_output.tensions}
+    tension_lookup: dict[str, TensionDecision] = {
+        strip_scope_prefix(t.tension_id): t for t in seed_output.tensions
+    }
 
     for thread in seed_output.threads:
-        if thread.tension_id in demoted_tension_ids:
-            tension = tension_lookup.get(thread.tension_id)
+        raw_tension_id = strip_scope_prefix(thread.tension_id)
+        if raw_tension_id in demoted_raw_ids:
+            tension = tension_lookup.get(raw_tension_id)
             if tension:
                 canonical_alt = _get_canonical_alternative(tension)
                 # Drop if not the canonical alternative
                 if thread.alternative_id != canonical_alt:
-                    threads_to_drop.add(thread.thread_id)
+                    # Store raw thread ID for consistent comparison
+                    threads_to_drop.add(strip_scope_prefix(thread.thread_id))
 
     log.info(
         "pruning_seed_output",
@@ -124,21 +136,23 @@ def _prune_demoted_tensions(
     # Tensions are NOT modified - considered field is immutable
     # Development state is derived from thread existence
 
-    # 1. Filter threads
+    # 1. Filter threads (compare raw IDs)
     pruned_threads: list[Thread] = [
-        t for t in seed_output.threads if t.thread_id not in threads_to_drop
+        t for t in seed_output.threads if strip_scope_prefix(t.thread_id) not in threads_to_drop
     ]
 
-    # 3. Filter consequences
+    # 3. Filter consequences (compare raw IDs)
     pruned_consequences: list[Consequence] = [
-        c for c in seed_output.consequences if c.thread_id not in threads_to_drop
+        c
+        for c in seed_output.consequences
+        if strip_scope_prefix(c.thread_id) not in threads_to_drop
     ]
 
     # 4. Filter and update beats
     pruned_beats: list[InitialBeat] = []
     for beat in seed_output.initial_beats:
-        # Get threads that aren't being dropped
-        kept_threads = [t for t in beat.threads if t not in threads_to_drop]
+        # Get threads that aren't being dropped (compare raw IDs, keep original format)
+        kept_threads = [t for t in beat.threads if strip_scope_prefix(t) not in threads_to_drop]
 
         if kept_threads:
             # Beat serves at least one kept thread
@@ -194,10 +208,10 @@ def compute_arc_count(seed_output: SeedOutput) -> int:
     Returns:
         The number of arcs this seed would produce.
     """
-    # Count threads per tension
+    # Count threads per tension (using raw IDs for grouping)
     threads_per_tension: dict[str, int] = {}
     for thread in seed_output.threads:
-        tid = thread.tension_id
+        tid = strip_scope_prefix(thread.tension_id)
         threads_per_tension[tid] = threads_per_tension.get(tid, 0) + 1
 
     # Fully developed = has 2+ threads

--- a/tests/unit/test_enrichment.py
+++ b/tests/unit/test_enrichment.py
@@ -223,7 +223,7 @@ class TestEnrichTensions:
             "tensions": [
                 {
                     "tension_id": "host_motivation",
-                    "explored": ["benevolent"],
+                    "considered": ["benevolent"],
                     "implicit": ["self_serving"],
                 },
             ],
@@ -237,14 +237,14 @@ class TestEnrichTensions:
         assert tension["why_it_matters"] == "Determines whether protagonist can trust their guide"
         # Entity IDs should have prefix stripped
         assert tension["central_entity_ids"] == ["the_host", "the_manor"]
-        assert tension["explored"] == ["benevolent"]
+        assert tension["considered"] == ["benevolent"]
         assert tension["implicit"] == ["self_serving"]
 
     def test_handles_unknown_tension(self, graph_with_tensions: Graph) -> None:
         """Enrichment handles tensions not in graph gracefully."""
         artifact = {
             "tensions": [
-                {"tension_id": "unknown_tension", "explored": ["option_a"], "implicit": []},
+                {"tension_id": "unknown_tension", "considered": ["option_a"], "implicit": []},
             ],
         }
 
@@ -254,7 +254,7 @@ class TestEnrichTensions:
         assert tension["tension_id"] == "unknown_tension"
         assert "question" not in tension
         assert "why_it_matters" not in tension
-        assert tension["explored"] == ["option_a"]
+        assert tension["considered"] == ["option_a"]
 
     def test_handles_prefixed_tension_ids(self, graph_with_tensions: Graph) -> None:
         """Enrichment strips prefix from tension_id for graph lookup."""
@@ -262,7 +262,7 @@ class TestEnrichTensions:
             "tensions": [
                 {
                     "tension_id": "tension::host_motivation",
-                    "explored": ["benevolent"],
+                    "considered": ["benevolent"],
                     "implicit": [],
                 },
             ],
@@ -276,14 +276,14 @@ class TestEnrichTensions:
         # But graph lookup succeeds with prefix stripped
         assert tension["question"] == "Is the host benevolent or self-serving?"
         assert tension["why_it_matters"] == "Determines whether protagonist can trust their guide"
-        assert tension["explored"] == ["benevolent"]
+        assert tension["considered"] == ["benevolent"]
 
     def test_enriches_multiple_tensions(self, graph_with_tensions: Graph) -> None:
         """Enrichment works for multiple tensions."""
         artifact = {
             "tensions": [
-                {"tension_id": "host_motivation", "explored": ["benevolent"], "implicit": []},
-                {"tension_id": "killer_identity", "explored": ["suspect_a"], "implicit": []},
+                {"tension_id": "host_motivation", "considered": ["benevolent"], "implicit": []},
+                {"tension_id": "killer_identity", "considered": ["suspect_a"], "implicit": []},
             ],
         }
 


### PR DESCRIPTION
## Problem

The seed pruning module had an ID prefix mismatch bug (discovered in grow-6) where:
- `threads_to_drop` contained raw IDs (e.g., `mira_fabrication`)
- `beat.threads` contained scoped IDs (e.g., `thread::mira_fabrication`)
- Comparison failed, causing incorrect pruning behavior

This is part of the broader "scoped everywhere" standardization (issue #219, PR #220).

## Changes

### Core Fix: seed_pruning.py
- Use `strip_scope_prefix()` consistently in `_prune_demoted_tensions()`
- Normalize `demoted_tension_ids` to raw format for comparison
- Update `compute_arc_count()` to use raw IDs for grouping
- All ID comparisons now handle both scoped and raw formats

### Prompt Updates: serialize_seed*.yaml
- Updated entity, tension, thread, and consequence prompts to explicitly require scope prefixes
- Added scoped ID examples in all JSON schemas
- Added clear guidance: "Copy IDs EXACTLY as shown in the manifest, including the prefix"

### Tests: test_ontology_considered.py
- Added `TestScopedIdStandardization` class with 4 tests:
  - `test_pruning_handles_scoped_thread_ids_in_beats`
  - `test_pruning_handles_scoped_thread_ids_in_consequences`
  - `test_pruning_handles_mixed_scoped_and_raw_ids`
  - `test_compute_arc_count_handles_scoped_tension_ids`

## Not Included / Future PRs

- Validation-side changes to require scope prefixes (backward compatible for now)
- Migration for existing artifacts with raw IDs

## Test Plan

```bash
uv run pytest tests/unit/test_ontology_considered.py -v  # 19 tests pass
uv run pytest tests/unit/ -v  # 1314 tests pass
uv run mypy src/questfoundry/graph/seed_pruning.py  # No issues
uv run ruff check  # All checks passed
```

## Risk / Rollback

- **Backward compatible**: Comparisons use `strip_scope_prefix()` so both scoped and raw IDs work
- **Prompt changes**: LLMs should now output scoped IDs, but validation accepts either format
- **Rollback**: Revert this commit if issues arise

🤖 Generated with [Claude Code](https://claude.com/claude-code)