### PR TITLE
refactor(graph): rename constants and functions to new terminology (#338)

### DIFF
--- a/docs/design/procedures/brainstorm.md
+++ b/docs/design/procedures/brainstorm.md
@@ -171,7 +171,7 @@ For a typical story targeting 15-25 entities, aim for a balanced mix:
 | Type | Range | Purpose |
 |------|-------|---------|
 | Characters | 6-10 | Protagonist, antagonist, allies, suspects, supporting cast |
-| Locations | 4-6 | Scene settings; enables knot formation and scene variety |
+| Locations | 4-6 | Scene settings; enables intersection formation and scene variety |
 | Objects | 4-6 | Puzzles, MacGuffins, clues, symbolic items |
 | Factions | 1-3 | Organizations, groups, collectives |
 

--- a/docs/design/procedures/brainstorm.md
+++ b/docs/design/procedures/brainstorm.md
@@ -8,7 +8,7 @@
 - `01-dream.yaml` (approved vision)
 
 **Output artifacts:**
-- `02-brainstorm.yaml` (entities, tensions with alternatives)
+- `02-brainstorm.yaml` (entities, dilemmas with answers)
 
 **Mode:** LLM-heavy with human guidance. Discuss → Summarize → Serialize.
 
@@ -41,8 +41,8 @@ Inject for LLM:
 
 BRAINSTORM is deliberately expansive. The goal is to generate more material than needed—SEED will triage it. Don't self-censor during BRAINSTORM.
 
-**Good BRAINSTORM:** 20 entities, 8 tensions, rich notes
-**Bad BRAINSTORM:** 5 entities, 2 tensions, minimal notes
+**Good BRAINSTORM:** 20 entities, 8 dilemmas, rich notes
+**Bad BRAINSTORM:** 5 entities, 2 dilemmas, minimal notes
 
 More raw material gives SEED more options.
 
@@ -52,39 +52,39 @@ BRAINSTORM follows a three-phase pattern:
 
 1. **Discuss (High Temperature):** Free-form creative exploration. Riff on possibilities. No structure yet.
 
-2. **Summarize (Consolidate):** Extract structured elements from discussion. Identify entities, tensions, relationships.
+2. **Summarize (Consolidate):** Extract structured elements from discussion. Identify entities, dilemmas, relationships.
 
 3. **Serialize (Low Temperature):** Convert to YAML. No creativity—just formatting.
 
 This separation keeps creative exploration separate from structural commitment.
 
-### Binary Tensions
+### Binary Dilemmas
 
-Every tension has exactly two alternatives. This keeps contrasts crisp and decisions meaningful.
+Every dilemma has exactly two answers. This keeps contrasts crisp and decisions meaningful.
 
-**Good tension:**
+**Good dilemma:**
 - Question: "Can the mentor be trusted?"
-- Alternative A: "Mentor is genuine protector" (canonical)
-- Alternative B: "Mentor is manipulating Kay" (non-canonical)
+- Answer A: "Mentor is genuine protector" (canonical)
+- Answer B: "Mentor is manipulating Kay" (non-canonical)
 
-**Bad tension:**
+**Bad dilemma:**
 - Question: "What is the mentor's nature?"
-- Alternative A: "Protector"
-- Alternative B: "Manipulator"
-- Alternative C: "Well-meaning but flawed"
-- Alternative D: "Secretly the antagonist"
+- Answer A: "Protector"
+- Answer B: "Manipulator"
+- Answer C: "Well-meaning but flawed"
+- Answer D: "Secretly the antagonist"
 
-For nuanced situations, use multiple binary tensions:
-- Tension 1: Mentor alignment (benevolent vs selfish)
-- Tension 2: Mentor competence (capable vs flawed)
+For nuanced situations, use multiple binary dilemmas:
+- Dilemma 1: Mentor alignment (benevolent vs selfish)
+- Dilemma 2: Mentor competence (capable vs flawed)
 
-This yields four combinations while each tension remains binary.
+This yields four combinations while each dilemma remains binary.
 
 ### Creative Freedom (No Anchors)
 
 BRAINSTORM generates freely. Entities, locations, and events emerge naturally from creative exploration—don't constrain them for later stage convenience.
 
-Location flexibility for knot formation is handled in SEED, not here. BRAINSTORM's job is creative richness, not structural optimization.
+Location flexibility for intersection formation is handled in SEED, not here. BRAINSTORM's job is creative richness, not structural optimization.
 
 ---
 
@@ -181,7 +181,7 @@ For a typical story targeting 15-25 entities, aim for a balanced mix:
 
 Example: "the_clock_in_the_hallway" implies the hallway is a location; the clock is an object within it. If scenes will happen in the hallway, create it as a location.
 
-**Why locations matter:** SEED requires at least 2 different locations for scene variety. A story with only 1 location limits scene pacing and prevents natural knot formation in GROW.
+**Why locations matter:** SEED requires at least 2 different locations for scene variety. A story with only 1 location limits scene pacing and prevents natural intersection formation in GROW.
 
 **Human Gate:** Yes
 
@@ -199,19 +199,19 @@ Human reviews entity list:
 
 ---
 
-### Phase 3: Tension Formation
+### Phase 3: Dilemma Formation
 
-**Purpose:** Frame dramatic questions as binary tensions.
+**Purpose:** Frame dramatic questions as binary dilemmas.
 
 **LLM Involvement:** Summarize
 
-LLM reviews discussion and proposes tensions:
+LLM reviews discussion and proposes dilemmas:
 
 ```yaml
-tensions:
-  - id: mentor_trust
+dilemmas:
+  - id: d::mentor_trust
     question: "Can the mentor be trusted?"
-    alternatives:
+    answers:
       - id: mentor_protector
         description: "Mentor is genuinely protecting Kay from forces she doesn't understand"
         canonical: true
@@ -221,9 +221,9 @@ tensions:
     involves: [mentor, kay]
     why_it_matters: "Trust determines whether Kay has an ally or is alone against the conspiracy"
 
-  - id: archive_nature
+  - id: d::archive_nature
     question: "Is the archive's knowledge salvation or corruption?"
-    alternatives:
+    answers:
       - id: archive_salvation
         description: "The forbidden knowledge can save the world if used wisely"
         canonical: true
@@ -234,30 +234,30 @@ tensions:
     why_it_matters: "Determines whether Kay's quest is heroic or tragic"
 ```
 
-**For each tension:**
-- `id`: Short identifier
+**For each dilemma:**
+- `id`: Short identifier with `d::` prefix
 - `question`: The dramatic question (ends with ?)
-- `alternatives`: Exactly two (canonical + non-canonical)
-- `involves`: Which entities are central to this tension
+- `answers`: Exactly two (canonical + non-canonical)
+- `involves`: Which entities are central to this dilemma
 - `why_it_matters`: Thematic stakes
 
-**Canonical flag:** One alternative is marked `canonical: true`. This becomes the spine path. The non-canonical alternative may become a branch if explored in SEED.
+**Canonical flag:** One answer is marked `canonical: true`. This becomes the spine path. The non-canonical answer may become a branch if explored in SEED.
 
 **Human Gate:** Yes
 
-Human reviews tensions:
+Human reviews dilemmas:
 - Are questions genuinely dramatic? (Stakes matter)
-- Are alternatives genuine contrasts? (Not shades of gray)
+- Are answers genuine contrasts? (Not shades of gray)
 - Is canonical choice appropriate? (Best default story)
 - Are entity involvements correct?
 
 **Artifacts Modified:**
-- Tension list (working draft)
+- Dilemma list (working draft)
 
 **Completion Criteria:**
-- All major dramatic questions captured as tensions
-- Each tension has exactly two alternatives
-- Human has reviewed and approved tensions
+- All major dramatic questions captured as dilemmas
+- Each dilemma has exactly two answers
+- Human has reviewed and approved dilemmas
 
 ---
 
@@ -267,7 +267,7 @@ Human reviews tensions:
 
 **LLM Involvement:** None (deterministic formatting)
 
-Take approved entities and tensions, format as `02-brainstorm.yaml`:
+Take approved entities and dilemmas, format as `02-brainstorm.yaml`:
 
 ```yaml
 brainstorm:
@@ -278,10 +278,10 @@ brainstorm:
       notes: "Curious, principled, out of her depth..."
     # ... all entities
 
-  tensions:
-    - id: mentor_trust
+  dilemmas:
+    - id: d::mentor_trust
       question: "Can the mentor be trusted?"
-      alternatives:
+      answers:
         - id: mentor_protector
           description: "Mentor is genuinely protecting Kay..."
           canonical: true
@@ -290,7 +290,7 @@ brainstorm:
           canonical: false
       involves: [mentor, kay]
       why_it_matters: "Trust determines..."
-    # ... all tensions
+    # ... all dilemmas
 ```
 
 **Human Gate:** No (deterministic)
@@ -305,7 +305,7 @@ brainstorm:
 |-------|------|----------|
 | 1 | Discussion | Light: "enough material?" |
 | 2 | Entity Extraction | Review entity list |
-| 3 | Tension Formation | Review tensions |
+| 3 | Dilemma Formation | Review dilemmas |
 | 4 | Serialization | None (deterministic) |
 
 ---
@@ -321,8 +321,8 @@ Normal flow: Phase 1 → 2 → 3 → 4
 | From Phase | To Phase | Trigger |
 |------------|----------|---------|
 | 2 (Entities) | 1 (Discussion) | Major gaps in entity coverage |
-| 3 (Tensions) | 1 (Discussion) | No clear dramatic questions emerged |
-| 3 (Tensions) | 2 (Entities) | Tension involves entity not in list |
+| 3 (Dilemmas) | 1 (Discussion) | No clear dramatic questions emerged |
+| 3 (Dilemmas) | 2 (Entities) | Dilemma involves entity not in list |
 
 ### Maximum Iterations
 
@@ -357,16 +357,16 @@ If discussion is very long:
 | 1. Discussion | Ideas too generic | Human judgment | Push for specificity, add constraints |
 | 2. Entities | Missing important entity | Human review | Add manually, note source |
 | 2. Entities | Too many entities | Human review | Note as cut candidates for SEED |
-| 3. Tensions | Non-binary tension | Validation | Split into multiple binary tensions |
-| 3. Tensions | Weak contrast | Human review | Sharpen alternatives or cut tension |
-| 3. Tensions | No canonical obvious | Human review | Human decides canonical |
+| 3. Dilemmas | Non-binary dilemma | Validation | Split into multiple binary dilemmas |
+| 3. Dilemmas | Weak contrast | Human review | Sharpen answers or cut dilemma |
+| 3. Dilemmas | No canonical obvious | Human review | Human decides canonical |
 
 ### Escalation to DREAM
 
 Return to DREAM if:
 - Brainstormed content doesn't fit DREAM vision
 - Genre/tone mismatch emerges
-- Constraints prove too restrictive for interesting tensions
+- Constraints prove too restrictive for interesting dilemmas
 
 ---
 
@@ -410,15 +410,15 @@ LLM extracts from discussion:
 
 Human reviews: Approves all, notes "Predecessor might merge with another character in SEED"
 
-### Phase 3: Tension Formation
+### Phase 3: Dilemma Formation
 
 LLM proposes:
-- mentor_trust: "Can the mentor be trusted?"
-- archive_nature: "Is the knowledge salvation or corruption?"
-- predecessor_fate: "What happened to Kay's predecessor?"
-- conspiracy_goals: "Is the conspiracy protecting or hoarding?"
+- d::mentor_trust: "Can the mentor be trusted?"
+- d::archive_nature: "Is the knowledge salvation or corruption?"
+- d::predecessor_fate: "What happened to Kay's predecessor?"
+- d::conspiracy_goals: "Is the conspiracy protecting or hoarding?"
 
-Human reviews: Approves first three, marks conspiracy_goals as "may cut in SEED—overlaps with mentor_trust"
+Human reviews: Approves first three, marks d::conspiracy_goals as "may cut in SEED—overlaps with d::mentor_trust"
 
 ### Phase 4: Serialization
 
@@ -434,7 +434,7 @@ SEED exists to triage. Don't pre-triage in BRAINSTORM.
 
 **LLM should:**
 - Propose many entities, even minor ones
-- Surface multiple possible tensions
+- Surface multiple possible dilemmas
 - Include rich notes from discussion
 - Err on the side of inclusion
 
@@ -452,10 +452,10 @@ Before BRAINSTORM is complete, verify:
 
 - [ ] Discussion generated sufficient raw material
 - [ ] All significant entities captured with concept and notes
-- [ ] All dramatic questions framed as binary tensions
-- [ ] Each tension has canonical and non-canonical alternatives
-- [ ] Entity involvement marked on tensions
-- [ ] why_it_matters populated for each tension
+- [ ] All dramatic questions framed as binary dilemmas
+- [ ] Each dilemma has canonical and non-canonical answers
+- [ ] Entity involvement marked on dilemmas
+- [ ] why_it_matters populated for each dilemma
 - [ ] `02-brainstorm.yaml` written
 
 ---
@@ -467,7 +467,7 @@ BRAINSTORM transforms DREAM vision into raw creative material:
 | Input | Output |
 |-------|--------|
 | Genre, tone, themes | 15-25 entities |
-| Constraints | 4-8 tensions (binary) |
-| Core tensions (informal) | Rich notes throughout |
+| Constraints | 4-8 dilemmas (binary) |
+| Core dilemmas (informal) | Rich notes throughout |
 
 BRAINSTORM generates freely. SEED triages. This separation keeps creative exploration unconstrained while ensuring eventual structure.

--- a/docs/design/procedures/dream.md
+++ b/docs/design/procedures/dream.md
@@ -52,9 +52,9 @@ DREAM captures **what kind of story** (vision), not **what happens in the story*
 | DREAM (Vision) | BRAINSTORM (Structure) |
 |----------------|------------------------|
 | "Dark fantasy mystery" | Characters, locations, factions |
-| "Themes of trust and sacrifice" | "Can the mentor be trusted?" tension |
+| "Themes of trust and sacrifice" | "Can the mentor be trusted?" dilemma |
 | "Morally ambiguous tone" | Specific moral dilemmas |
-| "Short length" | ~15 entities, ~6 tensions |
+| "Short length" | ~15 entities, ~6 dilemmas |
 
 DREAM stays abstract. BRAINSTORM makes it concrete.
 

--- a/docs/design/procedures/fill.md
+++ b/docs/design/procedures/fill.md
@@ -207,7 +207,7 @@ fill_output:
   flag_reason: "Character's emotional state too divergent—suspicious path requires hostile body language incompatible with trusting path"
 ```
 
-Flagged beats return to GROW for splitting into separate route-specific passages.
+Flagged beats return to GROW for splitting into separate path-specific passages.
 
 **When to flag (guidance for LLM):**
 - Internal monologue requires contradictory knowledge

--- a/docs/design/procedures/fill.md
+++ b/docs/design/procedures/fill.md
@@ -63,7 +63,7 @@ FILL generates passages one at a time, in order. Not parallel.
 
 **Why spine first?**
 
-The spine arc is the canonical path—all canonical thread alternatives. It establishes:
+The spine arc is the canonical route—all canonical path answers. It establishes:
 - The baseline voice
 - The canonical version of convergence passages
 - The reference point for branch variations
@@ -95,7 +95,7 @@ At structural junctures (divergence and convergence points), the LLM needs aware
 
 When writing a convergence passage during spine generation, branches haven't been written yet. But their beat summaries exist. Include:
 - Beat summaries of all connecting branches
-- Thread context (which alternatives arrive here)
+- Path context (which answers arrive here)
 
 This lets the convergence passage be written with awareness of all arrivals, even without their prose.
 
@@ -166,7 +166,7 @@ If prose reveals that a new recurring entity is needed, FILL should flag and pau
 
 ### Poly-State Prose (Shared Beats)
 
-Shared beats (thread-agnostic) appear in multiple arcs. When writing shared beats, FILL must produce **poly-state prose**: prose that is diegetically accurate for the active state but compatible with all shadow states.
+Shared beats (path-agnostic) appear in multiple arcs. When writing shared beats, FILL must produce **poly-state prose**: prose that is diegetically accurate for the active state but compatible with all shadow states.
 
 **The challenge:**
 
@@ -207,7 +207,7 @@ fill_output:
   flag_reason: "Character's emotional state too divergent—suspicious path requires hostile body language incompatible with trusting path"
 ```
 
-Flagged beats return to GROW for splitting into separate path-specific passages.
+Flagged beats return to GROW for splitting into separate route-specific passages.
 
 **When to flag (guidance for LLM):**
 - Internal monologue requires contradictory knowledge
@@ -268,7 +268,7 @@ Flagged beats return to GROW for splitting into separate path-specific passages.
 - Passages with summaries and scene_type
 - Arc structure (traversal order)
 - Entity states (computed from codewords)
-- Thread definitions (for shadows)
+- Path definitions (for shadows)
 
 **Traversal Order:**
 
@@ -286,10 +286,10 @@ Flagged beats return to GROW for splitting into separate path-specific passages.
 | Beat summary | Current passage's summary |
 | Scene type | `scene`, `sequel`, or `micro_beat` |
 | Entity states | Relevant entities at this point (base + applicable overlays) |
-| Shadows | Unexplored alternatives for active tensions |
+| Shadows | Unexplored answers for active dilemmas |
 | Sliding window | Last N passages of generated prose (recommended 3-5) |
 | Lookahead | See lookahead strategy in Core Concepts |
-| Thread context | For knots: which threads this beat serves |
+| Path context | For intersections: which paths this beat serves |
 
 **Per-Passage Operations:**
 
@@ -551,7 +551,7 @@ The procedure specifies *what* to include, not exact sizes. Implementation shoul
 
 ### Setup
 
-**Story:** 2 tensions, 4 arcs total
+**Story:** 2 dilemmas, 4 arcs total
 - Mentor trust: protector (canonical) vs manipulator
 - Artifact nature: saves (canonical) vs corrupts
 

--- a/docs/design/procedures/seed.md
+++ b/docs/design/procedures/seed.md
@@ -2,14 +2,14 @@
 
 ## Summary
 
-**Purpose:** Triage BRAINSTORM output into committed story structure. This is the thread creation gate—after SEED, no new threads or entities can be created.
+**Purpose:** Triage BRAINSTORM output into committed story structure. This is the path creation gate—after SEED, no new paths or entities can be created.
 
 **Input artifacts:**
-- `02-brainstorm.yaml` (entities, tensions with alternatives)
+- `02-brainstorm.yaml` (entities, dilemmas with answers)
 - `01-dream.yaml` (vision context)
 
 **Output artifacts:**
-- `03-seed.yaml` (curated entities, threads with consequences, initial beats, convergence sketch)
+- `03-seed.yaml` (curated entities, paths with consequences, initial beats, convergence sketch)
 
 **Mode:** LLM-heavy generation with human critique gates. LLM proposes complete artifacts; human reviews, critiques, and approves.
 
@@ -22,12 +22,12 @@
 | File | Required State |
 |------|----------------|
 | `01-dream.yaml` | Complete (approved vision) |
-| `02-brainstorm.yaml` | Complete (approved entities and tensions) |
+| `02-brainstorm.yaml` | Complete (approved entities and dilemmas) |
 
 ### Required Human Decisions from Prior Stages
 
 - DREAM vision approved
-- BRAINSTORM entities and tensions approved
+- BRAINSTORM entities and dilemmas approved
 
 ### Knowledge Context
 
@@ -40,19 +40,19 @@ Inject for LLM:
 
 ## Core Concepts
 
-### Thread Freeze
+### Path Freeze
 
 SEED is the last stage where structural elements can be created. After SEED approval:
-- No new threads
+- No new paths
 - No new entities
-- No new tensions
+- No new dilemmas
 
-GROW can mutate beats, create knots, derive passages—but works within the structure SEED defines.
+GROW can mutate beats, create intersections, derive passages—but works within the structure SEED defines.
 
 ### Consequence as Narrative Bridge
 
-A **Consequence** describes the narrative meaning of choosing a thread. It bridges the gap between:
-- **Alternative** (what this path represents): "Mentor is genuine protector"
+A **Consequence** describes the narrative meaning of choosing a path. It bridges the gap between:
+- **Answer** (what this path represents): "Mentor is genuine protector"
 - **Codeword** (how we track it): `mentor_protector_committed`
 
 Consequences declare *what changes* in the story world. GROW later implements these with codewords and entity overlays.
@@ -60,7 +60,7 @@ Consequences declare *what changes* in the story world. GROW later implements th
 ```yaml
 consequence:
   id: mentor_ally
-  thread_id: mentor_protector_thread
+  path_id: p::mentor_trust__protector
   description: "Mentor becomes protective ally"
   ripples:
     - "Shields Kay in confrontation"
@@ -73,7 +73,7 @@ Sustainable branching requires convergence. Key insight: a story that branches a
 
 **Branch and bottleneck pattern:**
 - Paths diverge at choice points
-- Paths reconverge at key story beats (knots)
+- Paths reconverge at key story beats (intersections)
 - Residue (codewords, overlays) carries forward after convergence
 
 SEED sketches where convergence should happen. GROW implements it.
@@ -81,9 +81,9 @@ SEED sketches where convergence should happen. GROW implements it.
 ### Viability Analysis
 
 Combinatorial complexity depends on:
-- Number of tensions with both alternatives explored: 2^n potential arcs
+- Number of dilemmas with both answers explored: 2^n potential arcs
 - Convergence factor: how much content is shared vs unique
-- Thread interactions: do threads have natural knot points?
+- Path interactions: do paths have natural intersection points?
 
 SEED surfaces this complexity early so humans can scope appropriately.
 
@@ -91,20 +91,20 @@ SEED surfaces this complexity early so humans can scope appropriately.
 
 LLMs are poor at counting and self-constraint. Instead of teaching the LLM to stay within arc limits, QuestFoundry uses an **over-generate-and-select** pattern:
 
-1. **LLM generates freely** - The LLM explores all alternatives it finds compelling without worrying about arc limits
-2. **Runtime scores tensions** - Each tension is scored by quality criteria:
-   - Beat richness: How many beats explore the non-canonical thread
-   - Consequence depth: How many narrative effects cascade from the thread
+1. **LLM generates freely** - The LLM explores all answers it finds compelling without worrying about arc limits
+2. **Runtime scores dilemmas** - Each dilemma is scored by quality criteria:
+   - Beat richness: How many beats explore the non-canonical path
+   - Consequence depth: How many narrative effects cascade from the path
    - Entity coverage: How many unique entities appear in beats
-   - Location variety: How many distinct locations the thread uses
-   - Thread tier: Major threads score higher than minor
+   - Location variety: How many distinct locations the path uses
+   - Path tier: Major paths score higher than minor
    - Content distinctiveness: How different the paths are (Jaccard distance)
-3. **Runtime selects top N** - The highest-scoring tensions are kept fully explored (up to 4 tensions = 16 arcs)
-4. **Runtime prunes excess** - Demoted tensions have their threads, consequences, and beats removed
+3. **Runtime selects top N** - The highest-scoring dilemmas are kept fully explored (up to 4 dilemmas = 16 arcs)
+4. **Runtime prunes excess** - Demoted dilemmas have their paths, consequences, and beats removed
 
-**Key invariant: The `considered` field is immutable after SEED.** Pruning only drops threads; it never modifies the tension's `considered` field. This separation between "LLM intent" (stored as `considered`) and "runtime state" (derived from thread existence) ensures:
+**Key invariant: The `considered` field is immutable after SEED.** Pruning only drops paths; it never modifies the dilemma's `considered` field. This separation between "LLM intent" (stored as `considered`) and "runtime state" (derived from path existence) ensures:
 - The pruning operation is idempotent
-- Arc count is derived from actual threads, not potentially stale metadata
+- Arc count is derived from actual paths, not potentially stale metadata
 - Debugging is simpler—you can see what the LLM originally intended vs what survived pruning
 
 This pattern:
@@ -142,59 +142,59 @@ Human reviews ranking, makes final in/out decisions. May add entities missed in 
 
 ---
 
-### Phase 2: Alternative Selection
+### Phase 2: Answer Selection
 
-**Operation:** For each tension, decide which alternatives to explore.
+**Operation:** For each dilemma, decide which answers to explore.
 
 **LLM Involvement:** Generate
 
-LLM proposes exploration map per tension:
+LLM proposes exploration map per dilemma:
 
 ```yaml
-tension_exploration:
-  - tension_id: mentor_trust
+dilemma_exploration:
+  - dilemma_id: d::mentor_trust
     considered:
-      - alternative_id: mentor_protector    # canonical, always considered
+      - answer_id: mentor_protector    # canonical, always considered
         rationale: "Spine path - mentor as ally"
-      - alternative_id: mentor_manipulator  # non-canonical
+      - answer_id: mentor_manipulator  # non-canonical
         rationale: "Dark branch - doubles content but adds replayability"
         recommendation: explore | shadow
     scope_impact: "Exploring both adds ~15 beats, creates 2 major arcs"
 ```
 
-For each non-canonical alternative, LLM provides:
+For each non-canonical answer, LLM provides:
 - Recommendation (explore or leave as shadow)
 - Rationale
 - Scope impact estimate
 
 **Human Gate:** Yes
 
-Human decides which alternatives become threads. May override LLM recommendations.
+Human decides which answers become paths. May override LLM recommendations.
 
 **Artifacts Modified:**
-- Exploration decisions per tension
+- Exploration decisions per dilemma
 
 **Completion Criteria:**
-- Every tension has exploration decision
+- Every dilemma has exploration decision
 - Human understands scope implications
 - Human has approved exploration map
 
 ---
 
-### Phase 3: Thread Construction
+### Phase 3: Path Construction
 
-**Operation:** Generate complete thread definitions with consequences.
+**Operation:** Generate complete path definitions with consequences.
 
 **LLM Involvement:** Generate
 
-For each explored alternative, LLM generates:
+For each explored answer, LLM generates:
 
 ```yaml
-thread:
-  id: mentor_protector_thread
+path:
+  id: p::mentor_trust__protector          # hierarchical ID
   name: "The Mentor's Protection"
-  tension_id: mentor_trust
-  alternative_id: mentor_protector
+  dilemma_id: d::mentor_trust             # derivable from path_id
+  answer_id: mentor_protector
   shadows: [mentor_manipulator]
   tier: major
   description: "Kay discovers the mentor has been protecting them all along..."
@@ -203,7 +203,7 @@ thread:
 
 consequences:
   - id: mentor_ally
-    thread_id: mentor_protector_thread
+    path_id: p::mentor_trust__protector
     description: "Mentor becomes protective ally"
     ripples:
       - "Mentor shields Kay during confrontation with antagonist"
@@ -211,15 +211,15 @@ consequences:
       - "Mentor's knowledge becomes available resource"
 ```
 
-LLM also generates 2-4 initial beats per thread:
+LLM also generates 2-4 initial beats per path:
 
 ```yaml
 initial_beats:
   - id: mentor_warning
     summary: "Mentor delivers cryptic warning about the investigation"
-    threads: [mentor_protector_thread]
-    tension_impacts:
-      - tension_id: mentor_trust
+    paths: [p::mentor_trust__protector]
+    dilemma_impacts:
+      - dilemma_id: d::mentor_trust
         effect: advances
         note: "Warning could be protective or manipulative"
     entities: [mentor, kay]
@@ -229,31 +229,31 @@ initial_beats:
 
 **Human Gate:** Yes
 
-Human reviews complete thread artifacts:
-- Thread descriptions accurate?
+Human reviews complete path artifacts:
+- Path descriptions accurate?
 - Consequences capture narrative meaning?
 - Ripples are plausible story effects?
-- Initial beats cover thread arc?
+- Initial beats cover path arc?
 - Tier assignments correct?
 
 Human may request regeneration, edits, or additions.
 
 **Artifacts Modified:**
-- Thread definitions
+- Path definitions
 - Consequence definitions
 - Initial beat list
 
 **Completion Criteria:**
-- All threads have complete definitions
-- All threads have consequences with ripples
-- All threads have initial beats
-- Human has approved thread artifacts
+- All paths have complete definitions
+- All paths have consequences with ripples
+- All paths have initial beats
+- Human has approved path artifacts
 
 ---
 
 ### Phase 3b: Location Flexibility Analysis
 
-**Operation:** For each beat, consider alternative locations to enable knot formation.
+**Operation:** For each beat, consider alternative locations to enable intersection formation.
 
 **LLM Involvement:** Generate
 
@@ -281,15 +281,15 @@ beat:
 
 **Key principle:** Only mark locations as alternatives if the dramatic function is preserved. "Meet spy at Market" (crowded, public) vs "Meet spy at Docks" (shadowy, dangerous) may have different narrative texture—only mark as flexible if truly fungible.
 
-**Knot enablement:** LLM notes which flexibility enables knots:
-- "If spy_meeting moves to Docks, can merge with crate_discovery from Thread B"
+**Intersection enablement:** LLM notes which flexibility enables intersections:
+- "If spy_meeting moves to Docks, can merge with crate_discovery from Path B"
 - "Both beats become one scene: Kay meets spy while searching for crate"
 
 **Human Gate:** Yes
 
 Human reviews flexibility annotations:
 - Is the flexibility genuine (dramatic function preserved)?
-- Do the enabled knots make narrative sense?
+- Do the enabled intersections make narrative sense?
 - Any beats that should stay location-fixed?
 
 **Artifacts Modified:**
@@ -303,26 +303,26 @@ Human reviews flexibility annotations:
 
 ### Phase 4: Convergence Sketching
 
-**Operation:** Identify where threads should reconverge.
+**Operation:** Identify where paths should reconverge.
 
 **LLM Involvement:** Generate
 
-LLM analyzes threads and proposes convergence strategy:
+LLM analyzes paths and proposes convergence strategy:
 
 ```yaml
 convergence_sketch:
   convergence_points:
-    - "Major threads should converge by act 2 climax"
-    - "mentor_trust resolution before final confrontation"
+    - "Major paths should converge by act 2 climax"
+    - "d::mentor_trust resolution before final confrontation"
 
   residue_notes:
-    - "After mentor_trust convergence: mentor demeanor differs based on path"
+    - "After d::mentor_trust convergence: mentor demeanor differs based on path"
     - "Kay's dialogue options vary based on mentor relationship"
 ```
 
 LLM flags potential issues:
-- Threads that never naturally intersect (even with location flexibility)
-- Threads with incompatible timelines
+- Paths that never naturally intersect (even with location flexibility)
+- Paths with incompatible timelines
 - Excessive divergence (too little shared content)
 
 **Human Gate:** Yes
@@ -338,7 +338,7 @@ May loop back to Phase 2 to reduce scope if convergence is problematic.
 - Convergence sketch
 
 **Completion Criteria:**
-- All major thread pairs have convergence strategy
+- All major path pairs have convergence strategy
 - Residue effects identified
 - Human has approved convergence approach
 
@@ -354,7 +354,7 @@ LLM produces complexity report:
 
 ```yaml
 viability_analysis:
-  arc_count: 4                    # 2^n where n = tensions with both explored
+  arc_count: 4                    # 2^n where n = dilemmas with both explored
 
   content_estimate:
     shared_beats: 45              # beats in all arcs
@@ -365,8 +365,8 @@ viability_analysis:
 
   risk_flags:
     - severity: warning
-      issue: "romance_thread and gadget_thread never interact"
-      suggestion: "Consider shared entity or cut one thread"
+      issue: "romance_path and gadget_path never interact"
+      suggestion: "Consider shared entity or cut one path"
 
     - severity: info
       issue: "High unique content ratio increases writing effort"
@@ -375,7 +375,7 @@ viability_analysis:
   recommendation: "Scope is sustainable for medium-length story"
 ```
 
-**Note on Arc Limits:** The runtime enforces arc limits programmatically via the over-generate-and-select pattern (see Core Concepts). If the LLM generates more than 4 fully-explored tensions (16+ arcs), the runtime automatically selects the best tensions by quality score and demotes the rest. This removes the need for LLM self-constraint on arc counts.
+**Note on Arc Limits:** The runtime enforces arc limits programmatically via the over-generate-and-select pattern (see Core Concepts). If the LLM generates more than 4 fully-explored dilemmas (16+ arcs), the runtime automatically selects the best dilemmas by quality score and demotes the rest. This removes the need for LLM self-constraint on arc counts.
 
 **Human Gate:** Yes
 
@@ -396,16 +396,16 @@ May loop back to Phase 2 to reduce scope.
 
 ---
 
-### Phase 6: Final Review & Thread Freeze
+### Phase 6: Final Review & Path Freeze
 
 **Operation:** Final approval and serialization.
 
 **LLM Involvement:** Validate
 
 LLM performs final consistency checks:
-- All threads reference valid tensions and alternatives
-- All consequences reference valid threads
-- All initial beats reference valid threads and entities
+- All paths reference valid dilemmas and answers
+- All consequences reference valid paths
+- All initial beats reference valid paths and entities
 - No orphan references
 
 **Human Gate:** Yes (CRITICAL)
@@ -413,8 +413,8 @@ LLM performs final consistency checks:
 Human performs final review of complete SEED output:
 - `03-seed.yaml` with all sections
 
-**This is the Thread Freeze gate.** After approval:
-- No new threads can be created
+**This is the Path Freeze gate.** After approval:
+- No new paths can be created
 - No new entities can be created
 - GROW begins working within this structure
 
@@ -424,7 +424,7 @@ Human performs final review of complete SEED output:
 **Completion Criteria:**
 - Validation passes
 - Human has approved complete SEED output
-- Thread Freeze is in effect
+- Path Freeze is in effect
 
 ---
 
@@ -433,12 +433,12 @@ Human performs final review of complete SEED output:
 | Phase | Gate | Decision |
 |-------|------|----------|
 | 1 | Entity Triage | In/out for each entity |
-| 2 | Alternative Selection | Explore/shadow for each non-canonical alternative |
-| 3 | Thread Construction | Approve thread definitions, consequences, initial beats |
+| 2 | Answer Selection | Explore/shadow for each non-canonical answer |
+| 3 | Path Construction | Approve path definitions, consequences, initial beats |
 | 3b | Location Flexibility | Approve location alternatives for beats |
 | 4 | Convergence Sketching | Approve convergence strategy |
 | 5 | Viability Analysis | Accept scope or loop back |
-| 6 | Thread Freeze | Final approval, SEED complete |
+| 6 | Path Freeze | Final approval, SEED complete |
 
 ---
 
@@ -452,21 +452,21 @@ Normal flow: Phase 1 → 2 → 3 → 3b → 4 → 5 → 6
 
 | From Phase | To Phase | Trigger |
 |------------|----------|---------|
-| 3 (Thread Construction) | 2 (Alternative Selection) | Thread proves unworkable |
-| 4 (Convergence Sketching) | 2 (Alternative Selection) | Threads don't converge naturally |
-| 5 (Viability Analysis) | 2 (Alternative Selection) | Scope too large |
+| 3 (Path Construction) | 2 (Answer Selection) | Path proves unworkable |
+| 4 (Convergence Sketching) | 2 (Answer Selection) | Paths don't converge naturally |
+| 5 (Viability Analysis) | 2 (Answer Selection) | Scope too large |
 | Any | 1 (Entity Triage) | Missing critical entity discovered |
 
 ### Escalation to BRAINSTORM
 
 Return to BRAINSTORM if:
-- Tensions prove poorly formed (alternatives don't create meaningful contrast)
+- Dilemmas prove poorly formed (answers don't create meaningful contrast)
 - Critical entities missing from BRAINSTORM output
 - Vision mismatch (BRAINSTORM doesn't serve DREAM)
 
 ### Maximum Iterations
 
-- Phase 3 regeneration: Max 3 attempts per thread
+- Phase 3 regeneration: Max 3 attempts per path
 - Overall SEED: No hard cap, but persistent issues indicate BRAINSTORM problems
 
 ---
@@ -478,10 +478,10 @@ Return to BRAINSTORM if:
 | Phase | Context Includes |
 |-------|------------------|
 | 1 | DREAM vision, all BRAINSTORM entities |
-| 2 | DREAM vision, all BRAINSTORM tensions, curated entities |
+| 2 | DREAM vision, all BRAINSTORM dilemmas, curated entities |
 | 3 | DREAM vision, exploration decisions, curated entities |
-| 4 | All threads with consequences, initial beats |
-| 5 | Complete thread structure, convergence sketch |
+| 4 | All paths with consequences, initial beats |
+| 5 | Complete path structure, convergence sketch |
 | 6 | Full SEED output for validation |
 
 ### Token Budget Guidance
@@ -492,8 +492,8 @@ SEED operates on summaries and structure, not prose. Estimated context per phase
 |-----------|-------------|
 | DREAM vision | ~200-400 |
 | Entity list (15-20 entities) | ~800-1,200 |
-| Tension list (4-6 tensions) | ~400-600 |
-| Thread definitions (8-12 threads) | ~1,000-1,500 |
+| Dilemma list (4-6 dilemmas) | ~400-600 |
+| Path definitions (8-12 paths) | ~1,000-1,500 |
 | Initial beats (40-60 beats) | ~4,000-6,000 |
 | **Typical total** | **~7,000-10,000** |
 
@@ -503,49 +503,49 @@ Fits comfortably in modern context windows.
 
 ## Failure Modes
 
-### Failure: Thread Explosion
+### Failure: Path Explosion
 
-**Symptom:** Too many threads, unmanageable arc count
+**Symptom:** Too many paths, unmanageable arc count
 
-**Cause:** Exploring too many non-canonical alternatives
+**Cause:** Exploring too many non-canonical answers
 
 **Recovery:** In most cases, the runtime's over-generate-and-select pattern handles this automatically by:
-1. Scoring tensions by quality criteria
-2. Selecting the top N tensions for full exploration (up to 4 = 16 arcs)
-3. Demoting excess tensions (moving non-canonical to `implicit`)
+1. Scoring dilemmas by quality criteria
+2. Selecting the top N dilemmas for full exploration (up to 4 = 16 arcs)
+3. Demoting excess dilemmas (moving non-canonical to `implicit`)
 
 If automatic pruning produces unsatisfactory results:
 1. Return to Phase 2
-2. Manually specify which alternatives to explore
+2. Manually specify which answers to explore
 3. Focus on most narratively distinct branches
 
-### Failure: Disconnected Threads
+### Failure: Disconnected Paths
 
-**Symptom:** Threads have no natural intersection points
+**Symptom:** Paths have no natural intersection points
 
-**Cause:** Tensions don't share entities or narrative space
+**Cause:** Dilemmas don't share entities or narrative space
 
 **Recovery:**
-1. Return to Phase 2, consider dropping one thread
+1. Return to Phase 2, consider dropping one path
 2. Or return to BRAINSTORM, add connecting entity
-3. Or accept threads as parallel tracks (reduced interweaving in GROW)
+3. Or accept paths as parallel tracks (reduced interweaving in GROW)
 
 ### Failure: Shallow Consequences
 
 **Symptom:** Consequences don't have meaningful ripples
 
-**Cause:** Alternative doesn't actually change story significantly
+**Cause:** Answer doesn't actually change story significantly
 
 **Recovery:**
-1. Reconsider if alternative is worth exploring
+1. Reconsider if answer is worth exploring
 2. Deepen consequence ripples
-3. Or demote thread to shadow
+3. Or demote path to shadow
 
 ### Failure: Convergence Impossible
 
-**Symptom:** Threads diverge too far to reconverge naturally
+**Symptom:** Paths diverge too far to reconverge naturally
 
-**Cause:** Alternatives are fundamentally incompatible story states
+**Cause:** Answers are fundamentally incompatible story states
 
 **Recovery:**
 1. Accept as parallel endings (multiple story conclusions)
@@ -554,7 +554,7 @@ If automatic pruning produces unsatisfactory results:
 
 ### Failure: Entity Mismatch
 
-**Symptom:** Thread needs entity not in curated list
+**Symptom:** Path needs entity not in curated list
 
 **Cause:** Entity triaged out but actually necessary
 
@@ -570,7 +570,7 @@ If automatic pruning produces unsatisfactory results:
 
 BRAINSTORM produced:
 - 18 entities (characters, locations, objects)
-- 4 tensions with alternatives
+- 4 dilemmas with answers
 - Various notes from discussion
 
 ### Phase 1: Entity Triage
@@ -579,7 +579,7 @@ LLM proposes:
 ```
 CORE (essential):
 - Kay (protagonist)
-- Mentor (central to trust tension)
+- Mentor (central to trust dilemma)
 - Antagonist (opposes Kay)
 - The Archive (central location)
 
@@ -595,9 +595,9 @@ CUT CANDIDATES:
 
 Human approves, cutting 7 generic entities. 11 entities remain.
 
-### Phase 2: Alternative Selection
+### Phase 2: Answer Selection
 
-LLM proposes for `mentor_trust` tension:
+LLM proposes for `d::mentor_trust` dilemma:
 ```
 mentor_protector (canonical): Always explore - spine path
 mentor_manipulator (non-canonical):
@@ -606,28 +606,28 @@ mentor_manipulator (non-canonical):
   Scope impact: +12 beats, +1 major arc
 ```
 
-Human approves exploring both alternatives.
+Human approves exploring both answers.
 
-For `archive_nature` tension:
+For `d::archive_nature` dilemma:
 ```
 archive_benign (canonical): Always explore
 archive_dangerous (non-canonical):
   Recommendation: SHADOW
-  Rationale: Less narrative impact than mentor tension
+  Rationale: Less narrative impact than mentor dilemma
   Scope impact: Would add +15 beats, +2 arcs
 ```
 
 Human accepts shadow recommendation.
 
-### Phase 3: Thread Construction
+### Phase 3: Path Construction
 
-LLM generates `mentor_protector_thread`:
+LLM generates `p::mentor_trust__protector`:
 ```yaml
-thread:
-  id: mentor_protector_thread
+path:
+  id: p::mentor_trust__protector
   name: "The Mentor's Protection"
-  tension_id: mentor_trust
-  alternative_id: mentor_protector
+  dilemma_id: d::mentor_trust
+  answer_id: mentor_protector
   shadows: [mentor_manipulator]
   tier: major
   description: "Kay gradually realizes the mentor's cryptic behavior
@@ -637,7 +637,7 @@ thread:
 
 consequences:
   - id: mentor_ally
-    thread_id: mentor_protector_thread
+    path_id: p::mentor_trust__protector
     description: "Mentor becomes trusted ally"
     ripples:
       - "Mentor shields Kay during antagonist confrontation"
@@ -655,12 +655,12 @@ LLM regenerates with 3 ripples. Human approves.
 LLM proposes:
 ```yaml
 convergence_sketch:
-  knot_candidates:
+  intersection_candidates:
     - "mentor_reveal + archive_discovery - mentor leads Kay to archive truth"
-    - "confrontation beats from both mentor threads - same scene, different mentor role"
+    - "confrontation beats from both mentor paths - same scene, different mentor role"
 
   convergence_points:
-    - "Mentor threads converge at archive climax"
+    - "Mentor paths converge at archive climax"
     - "Both paths lead to same confrontation, different dynamics"
 
   residue_notes:
@@ -675,7 +675,7 @@ Human approves.
 LLM produces:
 ```yaml
 viability_analysis:
-  arc_count: 2                    # only mentor_trust has both explored
+  arc_count: 2                    # only d::mentor_trust has both explored
   content_estimate:
     shared_beats: 35
     unique_beats: 20
@@ -687,13 +687,13 @@ viability_analysis:
 
 Human approves scope.
 
-### Phase 6: Thread Freeze
+### Phase 6: Path Freeze
 
 LLM validates: No orphan references, all links valid.
 
 Human performs final review of `03-seed.yaml`.
 
-**THREAD FREEZE.** SEED complete. GROW begins.
+**PATH FREEZE.** SEED complete. GROW begins.
 
 ---
 
@@ -708,8 +708,8 @@ SEED follows "LLM proposes complete artifacts, human reviews and critiques" rath
 - Human stays in decision-maker role, not construction role
 
 **LLM should:**
-- Generate complete thread definitions, not ask "what should the thread be called?"
-- Propose convergence strategy, not ask "where should threads converge?"
+- Generate complete path definitions, not ask "what should the path be called?"
+- Propose convergence strategy, not ask "where should paths converge?"
 - Surface risks proactively, not wait for human to discover them
 
 **Human should:**
@@ -724,14 +724,14 @@ SEED follows "LLM proposes complete artifacts, human reviews and critiques" rath
 Before SEED is complete, verify:
 
 - [ ] All BRAINSTORM entities have disposition (in/out)
-- [ ] All tensions have exploration decisions
-- [ ] All explored alternatives have thread definitions
-- [ ] All threads have consequences with ripples
-- [ ] All threads have initial beats (2-4 each)
+- [ ] All dilemmas have exploration decisions
+- [ ] All explored answers have path definitions
+- [ ] All paths have consequences with ripples
+- [ ] All paths have initial beats (2-4 each)
 - [ ] Convergence sketch exists
 - [ ] Viability analysis reviewed
 - [ ] No orphan references
-- [ ] Human has approved Thread Freeze
+- [ ] Human has approved Path Freeze
 - [ ] `03-seed.yaml` written
 
 ---
@@ -743,9 +743,9 @@ SEED transforms BRAINSTORM possibilities into committed structure:
 | Input | Output |
 |-------|--------|
 | ~20 entities | ~10-15 curated entities |
-| 4-6 tensions with alternatives | Exploration map |
-| — | Threads with consequences |
+| 4-6 dilemmas with answers | Exploration map |
+| — | Paths with consequences |
 | — | Initial beats |
 | — | Convergence sketch |
 
-After SEED: Thread Freeze. GROW works within this structure.
+After SEED: Path Freeze. GROW works within this structure.

--- a/src/questfoundry/graph/__init__.py
+++ b/src/questfoundry/graph/__init__.py
@@ -8,14 +8,18 @@ See docs/architecture/graph-storage.md for architecture details.
 """
 
 from questfoundry.graph.context import (
+    SCOPE_DILEMMA,
     SCOPE_ENTITY,
-    SCOPE_TENSION,
-    SCOPE_THREAD,
+    SCOPE_PATH,
+    SCOPE_TENSION,  # Backward compat alias for SCOPE_DILEMMA
+    SCOPE_THREAD,  # Backward compat alias for SCOPE_PATH
     check_structural_completeness,
+    format_hierarchical_path_id,
     format_scoped_id,
     format_summarize_manifest,
     format_valid_ids_context,
     normalize_scoped_id,
+    parse_hierarchical_path_id,
     parse_scoped_id,
 )
 from questfoundry.graph.errors import (
@@ -54,7 +58,9 @@ from questfoundry.graph.snapshots import (
 )
 
 __all__ = [
+    "SCOPE_DILEMMA",
     "SCOPE_ENTITY",
+    "SCOPE_PATH",
     "SCOPE_TENSION",
     "SCOPE_THREAD",
     "BrainstormMutationError",
@@ -80,12 +86,14 @@ __all__ = [
     "categorize_error",
     "categorize_errors",
     "check_structural_completeness",
+    "format_hierarchical_path_id",
     "format_scoped_id",
     "format_summarize_manifest",
     "format_valid_ids_context",
     "has_mutation_handler",
     "list_snapshots",
     "normalize_scoped_id",
+    "parse_hierarchical_path_id",
     "parse_scoped_id",
     "rollback_to_snapshot",
     "save_snapshot",

--- a/src/questfoundry/graph/context.py
+++ b/src/questfoundry/graph/context.py
@@ -176,7 +176,7 @@ def format_scoped_id(scope: str, raw_id: str) -> str:
     """Format a raw ID with its scope prefix.
 
     Args:
-        scope: The scope type (e.g., 'entity', 'tension', 'thread').
+        scope: The scope type (e.g., 'entity', 'dilemma', 'path').
         raw_id: The raw ID without scope.
 
     Returns:

--- a/src/questfoundry/graph/grow_context.py
+++ b/src/questfoundry/graph/grow_context.py
@@ -1,6 +1,6 @@
 """Context formatting for GROW stage LLM phases.
 
-Provides functions to format graph data (beats, threads, tensions) as
+Provides functions to format graph data (beats, paths, dilemmas) as
 context strings for GROW's LLM-powered phases.
 """
 
@@ -22,8 +22,8 @@ def format_grow_valid_ids(graph: Graph) -> dict[str, str]:
         graph: Graph containing nodes from SEED stage.
 
     Returns:
-        Dict with keys 'valid_beat_ids', 'valid_thread_ids',
-        'valid_tension_ids', 'valid_entity_ids'. Each value is a
+        Dict with keys 'valid_beat_ids', 'valid_path_ids',
+        'valid_dilemma_ids', 'valid_entity_ids'. Each value is a
         comma-separated string of scoped IDs, or empty string if none.
     """
 
@@ -33,8 +33,9 @@ def format_grow_valid_ids(graph: Graph) -> dict[str, str]:
 
     return {
         "valid_beat_ids": _get_sorted_ids("beat"),
-        "valid_thread_ids": _get_sorted_ids("thread"),
-        "valid_tension_ids": _get_sorted_ids("tension"),
+        # Graph still stores paths as "thread" and dilemmas as "tension"
+        "valid_path_ids": _get_sorted_ids("thread"),
+        "valid_dilemma_ids": _get_sorted_ids("tension"),
         "valid_entity_ids": _get_sorted_ids("entity"),
         "valid_passage_ids": _get_sorted_ids("passage"),
         "valid_choice_ids": _get_sorted_ids("choice"),

--- a/src/questfoundry/models/__init__.py
+++ b/src/questfoundry/models/__init__.py
@@ -6,14 +6,24 @@ and applied to the unified graph.
 
 The ontology (node types, relationships, lifecycle) is defined in
 docs/design/00-spec.md. These models are implementations of that ontology.
+
+Terminology (v5):
+- dilemma (was: tension): Binary dramatic questions
+- path (was: thread): Routes exploring specific answers to dilemmas
+- answer (was: alternative): Possible resolutions to dilemmas
+- intersection (was: knot): Beats serving multiple paths
+
+Old names are kept as aliases for backward compatibility.
 """
 
 from questfoundry.models.brainstorm import (
-    Alternative,
+    Alternative,  # Alias for Answer
+    Answer,
     BrainstormOutput,
+    Dilemma,
     Entity,
     EntityType,
-    Tension,
+    Tension,  # Alias for Dilemma
 )
 from questfoundry.models.dream import (
     ContentNotes,
@@ -29,9 +39,11 @@ from questfoundry.models.grow import (
     GapProposal,
     GrowPhaseResult,
     GrowResult,
-    KnotProposal,
+    IntersectionProposal,
+    KnotProposal,  # Alias for IntersectionProposal
     OverlayProposal,
     Passage,
+    PathAgnosticAssessment,
     Phase2Output,
     Phase3Output,
     Phase4aOutput,
@@ -39,24 +51,30 @@ from questfoundry.models.grow import (
     Phase8cOutput,
     Phase9Output,
     SceneTypeTag,
-    ThreadAgnosticAssessment,
+    ThreadAgnosticAssessment,  # Alias for PathAgnosticAssessment
 )
 from questfoundry.models.seed import (
     Consequence,
     ConvergenceSketch,
+    DilemmaDecision,
+    DilemmaEffect,
+    DilemmaImpact,
     EntityDecision,
     EntityDisposition,
     InitialBeat,
+    Path,
+    PathTier,
     SeedOutput,
-    TensionDecision,
-    TensionEffect,
-    TensionImpact,
-    Thread,
-    ThreadTier,
+    TensionDecision,  # Alias for DilemmaDecision
+    TensionEffect,  # Alias for DilemmaEffect
+    TensionImpact,  # Alias for DilemmaImpact
+    Thread,  # Alias for Path
+    ThreadTier,  # Alias for PathTier
 )
 
 __all__ = [
-    "Alternative",
+    "Alternative",  # Alias for Answer
+    "Answer",
     "Arc",
     "BrainstormOutput",
     "Choice",
@@ -65,6 +83,10 @@ __all__ = [
     "Consequence",
     "ContentNotes",
     "ConvergenceSketch",
+    "Dilemma",
+    "DilemmaDecision",
+    "DilemmaEffect",
+    "DilemmaImpact",
     "DreamArtifact",
     "Entity",
     "EntityDecision",
@@ -75,9 +97,13 @@ __all__ = [
     "GrowPhaseResult",
     "GrowResult",
     "InitialBeat",
-    "KnotProposal",
+    "IntersectionProposal",
+    "KnotProposal",  # Alias for IntersectionProposal
     "OverlayProposal",
     "Passage",
+    "Path",
+    "PathAgnosticAssessment",
+    "PathTier",
     "Phase2Output",
     "Phase3Output",
     "Phase4aOutput",
@@ -87,11 +113,11 @@ __all__ = [
     "SceneTypeTag",
     "Scope",
     "SeedOutput",
-    "Tension",
-    "TensionDecision",
-    "TensionEffect",
-    "TensionImpact",
-    "Thread",
-    "ThreadAgnosticAssessment",
-    "ThreadTier",
+    "Tension",  # Alias for Dilemma
+    "TensionDecision",  # Alias for DilemmaDecision
+    "TensionEffect",  # Alias for DilemmaEffect
+    "TensionImpact",  # Alias for DilemmaImpact
+    "Thread",  # Alias for Path
+    "ThreadAgnosticAssessment",  # Alias for PathAgnosticAssessment
+    "ThreadTier",  # Alias for PathTier
 ]

--- a/src/questfoundry/models/seed.py
+++ b/src/questfoundry/models/seed.py
@@ -1,12 +1,17 @@
 """Pydantic models for SEED stage output.
 
 SEED is the triage stage that transforms expansive brainstorm material into
-committed story structure. It curates entities, decides which alternatives
-to explore as threads, creates consequences, and defines initial beats.
+committed story structure. It curates entities, decides which answers
+to explore as paths, creates consequences, and defines initial beats.
 
-CRITICAL: THREAD FREEZE - No new threads can be created after SEED.
+CRITICAL: PATH FREEZE - No new paths can be created after SEED.
 
 See docs/design/00-spec.md for details.
+
+Terminology (v5):
+- dilemma (was: tension): Binary dramatic questions
+- path (was: thread): Routes exploring specific answers to dilemmas
+- answer (was: alternative): Possible resolutions to dilemmas
 """
 
 from __future__ import annotations
@@ -17,8 +22,12 @@ from pydantic import BaseModel, Field, model_validator
 
 # Type aliases for clarity
 EntityDisposition = Literal["retained", "cut"]
-ThreadTier = Literal["major", "minor"]
-TensionEffect = Literal["advances", "reveals", "commits", "complicates"]
+PathTier = Literal["major", "minor"]
+DilemmaEffect = Literal["advances", "reveals", "commits", "complicates"]
+
+# Backward compatibility aliases
+ThreadTier = PathTier
+TensionEffect = DilemmaEffect
 
 
 class EntityDecision(BaseModel):
@@ -42,161 +51,252 @@ class EntityDecision(BaseModel):
     )
 
 
-class TensionDecision(BaseModel):
-    """Tension exploration decision from SEED.
+class DilemmaDecision(BaseModel):
+    """Dilemma exploration decision from SEED.
 
-    Each tension has two alternatives. SEED decides which alternatives to
-    explore as threads. The canonical alternative is always explored (spine).
-    Non-canonical alternatives become branches only if explicitly explored.
+    Each dilemma has two answers. SEED decides which answers to
+    explore as paths. The canonical answer is always explored (spine).
+    Non-canonical answers become branches only if explicitly explored.
 
-    The `considered` field records the LLM's *intent* - which alternatives it
-    wanted to explore. Actual thread existence is derived at runtime from the
-    graph, not from this field. This separation allows pruning to drop threads
-    without modifying the tension's stored intent.
+    The `considered` field records the LLM's *intent* - which answers it
+    wanted to explore. Actual path existence is derived at runtime from the
+    graph, not from this field. This separation allows pruning to drop paths
+    without modifying the dilemma's stored intent.
 
     Development states (computed, not stored):
-    - committed: Alternative has a thread in the graph
-    - deferred: Alternative in `considered` but no thread (pruned)
-    - latent: Alternative not in `considered` (never intended for exploration)
+    - committed: Answer has a path in the graph
+    - deferred: Answer in `considered` but no path (pruned)
+    - latent: Answer not in `considered` (never intended for exploration)
 
     Attributes:
-        tension_id: Tension ID from BRAINSTORM.
-        considered: Alternative IDs the LLM intended to explore as threads.
-        implicit: Alternative IDs not explored (context for FILL shadows).
+        dilemma_id: Dilemma ID from BRAINSTORM.
+        considered: Answer IDs the LLM intended to explore as paths.
+        implicit: Answer IDs not explored (context for FILL shadows).
     """
 
-    tension_id: str = Field(min_length=1, description="Tension ID from BRAINSTORM")
+    dilemma_id: str = Field(min_length=1, description="Dilemma ID from BRAINSTORM")
     considered: list[str] = Field(
         min_length=1,
-        description="Alternative IDs the LLM intended to explore as threads",
+        description="Answer IDs the LLM intended to explore as paths",
     )
     implicit: list[str] = Field(
         default_factory=list,
-        description="Alternative IDs not explored (become shadows)",
+        description="Answer IDs not explored (become shadows)",
     )
 
     @model_validator(mode="before")
     @classmethod
-    def migrate_explored_to_considered(cls, data: dict[str, Any]) -> dict[str, Any]:
-        """Handle old graphs with 'explored' field.
+    def migrate_old_fields(cls, data: dict[str, Any]) -> dict[str, Any]:
+        """Handle old graphs with legacy field names.
 
-        Provides backward compatibility by migrating the old 'explored' field
-        to the new 'considered' field name. This allows reading graphs created
-        before the ontology change.
+        Provides backward compatibility by migrating:
+        - 'tension_id' -> 'dilemma_id'
+        - 'explored' -> 'considered'
         """
-        if isinstance(data, dict) and "explored" in data and "considered" not in data:
+        if isinstance(data, dict):
             data = dict(data)  # Avoid mutating input
-            data["considered"] = data.pop("explored")
+            if "tension_id" in data and "dilemma_id" not in data:
+                data["dilemma_id"] = data.pop("tension_id")
+            if "explored" in data and "considered" not in data:
+                data["considered"] = data.pop("explored")
         return data
+
+    # Backward compatibility property
+    @property
+    def tension_id(self) -> str:
+        """Deprecated: Use 'dilemma_id' instead."""
+        return self.dilemma_id
+
+
+# Backward compatibility alias
+TensionDecision = DilemmaDecision
 
 
 class Consequence(BaseModel):
-    """Narrative consequence of a thread choice.
+    """Narrative consequence of a path choice.
 
-    Consequences bridge the gap between "what this path represents" (alternative)
+    Consequences bridge the gap between "what this path represents" (answer)
     and "how we track it" (codeword). GROW creates codewords to track when
     consequences become active.
 
     Attributes:
         consequence_id: Unique identifier for the consequence.
-        thread_id: Thread this consequence belongs to.
+        path_id: Path this consequence belongs to.
         description: What happens narratively.
         narrative_effects: Story effects this implies.
     """
 
     consequence_id: str = Field(min_length=1, description="Unique identifier for this consequence")
-    thread_id: str = Field(
-        min_length=1, description="Thread this belongs to (references thread_id)"
-    )
+    path_id: str = Field(min_length=1, description="Path this belongs to (references path_id)")
     description: str = Field(min_length=1, description="Narrative meaning of this path")
     narrative_effects: list[str] = Field(
         default_factory=list,
         description="Story effects this consequence implies (cascading impacts)",
     )
 
+    @model_validator(mode="before")
+    @classmethod
+    def migrate_thread_id(cls, data: dict[str, Any]) -> dict[str, Any]:
+        """Migrate old 'thread_id' field to 'path_id'."""
+        if isinstance(data, dict) and "thread_id" in data and "path_id" not in data:
+            data = dict(data)
+            data["path_id"] = data.pop("thread_id")
+        return data
 
-class Thread(BaseModel):
-    """Plot thread exploring one alternative from a tension.
+    # Backward compatibility property
+    @property
+    def thread_id(self) -> str:
+        """Deprecated: Use 'path_id' instead."""
+        return self.path_id
 
-    Threads are the core structural units of the branching story. Threads
-    from the same tension are automatically exclusive (choosing one means
+
+class Path(BaseModel):
+    """Plot path exploring one answer from a dilemma.
+
+    Paths are the core structural units of the branching story. Paths
+    from the same dilemma are automatically exclusive (choosing one means
     not choosing the other).
 
+    Path IDs use hierarchical format: p::dilemma_id__answer_id
+    This embeds the parent dilemma in the ID, making the relationship explicit.
+
     Attributes:
-        thread_id: Unique identifier for the thread.
+        path_id: Unique identifier (format: p::dilemma_id__answer_id).
         name: Human-readable name.
-        tension_id: The tension this thread explores.
-        alternative_id: The specific alternative this thread explores.
-        unexplored_alternative_ids: IDs of unexplored alternatives (context for FILL).
-        thread_importance: Major threads interweave; minor threads support.
-        description: What this thread is about.
-        consequence_ids: IDs of consequences for this thread.
+        dilemma_id: The dilemma this path explores (derivable from path_id).
+        answer_id: The specific answer this path explores.
+        unexplored_answer_ids: IDs of unexplored answers (context for FILL).
+        path_importance: Major paths interweave; minor paths support.
+        description: What this path is about.
+        consequence_ids: IDs of consequences for this path.
     """
 
-    thread_id: str = Field(min_length=1, description="Unique identifier for this thread")
+    path_id: str = Field(
+        min_length=1, description="Unique identifier (format: p::dilemma_id__answer_id)"
+    )
     name: str = Field(min_length=1, description="Human-readable name")
-    tension_id: str = Field(
-        min_length=1, description="Tension this explores (references tension_id)"
+    dilemma_id: str = Field(
+        min_length=1, description="Dilemma this explores (references dilemma_id)"
     )
-    alternative_id: str = Field(
-        min_length=1, description="Alternative this explores (references alternative_id)"
-    )
-    unexplored_alternative_ids: list[str] = Field(
+    answer_id: str = Field(min_length=1, description="Answer this explores (references answer_id)")
+    unexplored_answer_ids: list[str] = Field(
         default_factory=list,
-        description="IDs of unexplored alternatives from same tension (context for FILL)",
+        description="IDs of unexplored answers from same dilemma (context for FILL)",
     )
-    thread_importance: ThreadTier = Field(
-        description="Thread importance: major (interweaves) or minor (supports)"
+    path_importance: PathTier = Field(
+        description="Path importance: major (interweaves) or minor (supports)"
     )
-    description: str = Field(min_length=1, description="What this thread is about")
+    description: str = Field(min_length=1, description="What this path is about")
     consequence_ids: list[str] = Field(
         default_factory=list,
-        description="Consequence IDs for this thread (references consequence_id)",
+        description="Consequence IDs for this path (references consequence_id)",
     )
 
+    @model_validator(mode="before")
+    @classmethod
+    def migrate_old_fields(cls, data: dict[str, Any]) -> dict[str, Any]:
+        """Migrate old field names to new names."""
+        if isinstance(data, dict):
+            data = dict(data)
+            if "thread_id" in data and "path_id" not in data:
+                data["path_id"] = data.pop("thread_id")
+            if "tension_id" in data and "dilemma_id" not in data:
+                data["dilemma_id"] = data.pop("tension_id")
+            if "alternative_id" in data and "answer_id" not in data:
+                data["answer_id"] = data.pop("alternative_id")
+            if "unexplored_alternative_ids" in data and "unexplored_answer_ids" not in data:
+                data["unexplored_answer_ids"] = data.pop("unexplored_alternative_ids")
+            if "thread_importance" in data and "path_importance" not in data:
+                data["path_importance"] = data.pop("thread_importance")
+        return data
 
-class TensionImpact(BaseModel):
-    """How a beat affects a tension.
+    # Backward compatibility properties
+    @property
+    def thread_id(self) -> str:
+        """Deprecated: Use 'path_id' instead."""
+        return self.path_id
 
-    Each beat can impact one or more tensions, moving the story forward
+    @property
+    def tension_id(self) -> str:
+        """Deprecated: Use 'dilemma_id' instead."""
+        return self.dilemma_id
+
+    @property
+    def alternative_id(self) -> str:
+        """Deprecated: Use 'answer_id' instead."""
+        return self.answer_id
+
+    @property
+    def thread_importance(self) -> PathTier:
+        """Deprecated: Use 'path_importance' instead."""
+        return self.path_importance
+
+
+# Backward compatibility alias
+Thread = Path
+
+
+class DilemmaImpact(BaseModel):
+    """How a beat affects a dilemma.
+
+    Each beat can impact one or more dilemmas, moving the story forward
     in various ways.
 
     Attributes:
-        tension_id: Tension being impacted.
-        effect: How the beat affects the tension.
+        dilemma_id: Dilemma being impacted.
+        effect: How the beat affects the dilemma.
         note: Explanation of the impact.
     """
 
-    tension_id: str = Field(min_length=1, description="Tension being impacted")
-    effect: TensionEffect = Field(description="How the beat affects the tension")
+    dilemma_id: str = Field(min_length=1, description="Dilemma being impacted")
+    effect: DilemmaEffect = Field(description="How the beat affects the dilemma")
     note: str = Field(min_length=1, description="Explanation of the impact")
+
+    @model_validator(mode="before")
+    @classmethod
+    def migrate_tension_id(cls, data: dict[str, Any]) -> dict[str, Any]:
+        """Migrate old 'tension_id' field to 'dilemma_id'."""
+        if isinstance(data, dict) and "tension_id" in data and "dilemma_id" not in data:
+            data = dict(data)
+            data["dilemma_id"] = data.pop("tension_id")
+        return data
+
+    # Backward compatibility property
+    @property
+    def tension_id(self) -> str:
+        """Deprecated: Use 'dilemma_id' instead."""
+        return self.dilemma_id
+
+
+# Backward compatibility alias
+TensionImpact = DilemmaImpact
 
 
 class InitialBeat(BaseModel):
     """Initial beat created by SEED.
 
-    Beats are narrative units belonging to one or more threads. SEED creates
-    the initial beats for each thread; GROW mutates and adds more.
+    Beats are narrative units belonging to one or more paths. SEED creates
+    the initial beats for each path; GROW mutates and adds more.
 
     Attributes:
         id: Unique identifier for the beat.
         summary: What happens in this beat.
-        threads: Thread IDs this beat serves.
-        tension_impacts: How this beat affects tensions.
+        paths: Path IDs this beat serves.
+        dilemma_impacts: How this beat affects dilemmas.
         entities: Entity IDs present in this beat.
         location: Primary location entity ID.
-        location_alternatives: Other valid locations (enables knot flexibility).
+        location_alternatives: Other valid locations (enables intersection flexibility).
     """
 
     beat_id: str = Field(min_length=1, description="Unique identifier for this beat")
     summary: str = Field(min_length=1, description="What happens in this beat")
-    threads: list[str] = Field(
+    paths: list[str] = Field(
         min_length=1,
-        description="Thread IDs this beat serves",
+        description="Path IDs this beat serves",
     )
-    tension_impacts: list[TensionImpact] = Field(
+    dilemma_impacts: list[DilemmaImpact] = Field(
         default_factory=list,
-        description="How this beat affects tensions",
+        description="How this beat affects dilemmas",
     )
     entities: list[str] = Field(
         default_factory=list,
@@ -208,24 +308,47 @@ class InitialBeat(BaseModel):
     )
     location_alternatives: list[str] = Field(
         default_factory=list,
-        description="Other valid locations for knot flexibility",
+        description="Other valid locations for intersection flexibility",
     )
+
+    @model_validator(mode="before")
+    @classmethod
+    def migrate_old_fields(cls, data: dict[str, Any]) -> dict[str, Any]:
+        """Migrate old field names to new names."""
+        if isinstance(data, dict):
+            data = dict(data)
+            if "threads" in data and "paths" not in data:
+                data["paths"] = data.pop("threads")
+            if "tension_impacts" in data and "dilemma_impacts" not in data:
+                data["dilemma_impacts"] = data.pop("tension_impacts")
+        return data
+
+    # Backward compatibility properties
+    @property
+    def threads(self) -> list[str]:
+        """Deprecated: Use 'paths' instead."""
+        return self.paths
+
+    @property
+    def tension_impacts(self) -> list[DilemmaImpact]:
+        """Deprecated: Use 'dilemma_impacts' instead."""
+        return self.dilemma_impacts
 
 
 class ConvergenceSketch(BaseModel):
-    """Informal guidance for GROW about thread convergence.
+    """Informal guidance for GROW about path convergence.
 
-    Provides hints about where threads should merge and what differences
+    Provides hints about where paths should merge and what differences
     should persist after convergence.
 
     Attributes:
-        convergence_points: Where threads should merge.
+        convergence_points: Where paths should merge.
         residue_notes: What differences persist after convergence.
     """
 
     convergence_points: list[str] = Field(
         default_factory=list,
-        description="Where threads should merge (e.g., 'by act 2 climax')",
+        description="Where paths should merge (e.g., 'by act 2 climax')",
     )
     residue_notes: list[str] = Field(
         default_factory=list,
@@ -237,14 +360,14 @@ class SeedOutput(BaseModel):
     """Complete output of the SEED stage.
 
     SEED transforms brainstorm material into committed story structure.
-    After SEED, no new threads can be created (THREAD FREEZE).
+    After SEED, no new paths can be created (PATH FREEZE).
 
     Attributes:
         entities: Entity curation decisions.
-        tensions: Tension exploration decisions.
-        threads: Created plot threads.
-        consequences: Narrative consequences for threads.
-        initial_beats: Initial beats for each thread.
+        dilemmas: Dilemma exploration decisions.
+        paths: Created plot paths.
+        consequences: Narrative consequences for paths.
+        initial_beats: Initial beats for each path.
         convergence_sketch: Guidance for GROW about convergence.
     """
 
@@ -252,26 +375,49 @@ class SeedOutput(BaseModel):
         default_factory=list,
         description="Entity curation decisions",
     )
-    tensions: list[TensionDecision] = Field(
+    dilemmas: list[DilemmaDecision] = Field(
         default_factory=list,
-        description="Tension exploration decisions",
+        description="Dilemma exploration decisions",
     )
-    threads: list[Thread] = Field(
+    paths: list[Path] = Field(
         default_factory=list,
-        description="Created plot threads",
+        description="Created plot paths",
     )
     consequences: list[Consequence] = Field(
         default_factory=list,
-        description="Narrative consequences for threads",
+        description="Narrative consequences for paths",
     )
     initial_beats: list[InitialBeat] = Field(
         default_factory=list,
-        description="Initial beats for each thread",
+        description="Initial beats for each path",
     )
     convergence_sketch: ConvergenceSketch = Field(
         default_factory=ConvergenceSketch,
-        description="Guidance for GROW about thread convergence",
+        description="Guidance for GROW about path convergence",
     )
+
+    @model_validator(mode="before")
+    @classmethod
+    def migrate_old_fields(cls, data: dict[str, Any]) -> dict[str, Any]:
+        """Migrate old field names to new names."""
+        if isinstance(data, dict):
+            data = dict(data)
+            if "tensions" in data and "dilemmas" not in data:
+                data["dilemmas"] = data.pop("tensions")
+            if "threads" in data and "paths" not in data:
+                data["paths"] = data.pop("threads")
+        return data
+
+    # Backward compatibility properties
+    @property
+    def tensions(self) -> list[DilemmaDecision]:
+        """Deprecated: Use 'dilemmas' instead."""
+        return self.dilemmas
+
+    @property
+    def threads(self) -> list[Path]:
+        """Deprecated: Use 'paths' instead."""
+        return self.paths
 
 
 # Section wrapper models for iterative serialization
@@ -287,22 +433,30 @@ class EntitiesSection(BaseModel):
     )
 
 
-class TensionsSection(BaseModel):
-    """Wrapper for serializing tension decisions separately."""
+class DilemmasSection(BaseModel):
+    """Wrapper for serializing dilemma decisions separately."""
 
-    tensions: list[TensionDecision] = Field(
+    dilemmas: list[DilemmaDecision] = Field(
         default_factory=list,
-        description="Tension exploration decisions",
+        description="Dilemma exploration decisions",
     )
 
 
-class ThreadsSection(BaseModel):
-    """Wrapper for serializing threads separately."""
+# Backward compatibility alias
+TensionsSection = DilemmasSection
 
-    threads: list[Thread] = Field(
+
+class PathsSection(BaseModel):
+    """Wrapper for serializing paths separately."""
+
+    paths: list[Path] = Field(
         default_factory=list,
-        description="Created plot threads",
+        description="Created plot paths",
     )
+
+
+# Backward compatibility alias
+ThreadsSection = PathsSection
 
 
 class ConsequencesSection(BaseModel):
@@ -310,7 +464,7 @@ class ConsequencesSection(BaseModel):
 
     consequences: list[Consequence] = Field(
         default_factory=list,
-        description="Narrative consequences for threads",
+        description="Narrative consequences for paths",
     )
 
 
@@ -319,24 +473,28 @@ class BeatsSection(BaseModel):
 
     initial_beats: list[InitialBeat] = Field(
         default_factory=list,
-        description="Initial beats for each thread",
+        description="Initial beats for each path",
     )
 
 
-class ThreadBeatsSection(BaseModel):
-    """Wrapper for serializing beats for a single thread.
+class PathBeatsSection(BaseModel):
+    """Wrapper for serializing beats for a single path.
 
-    Used by per-thread beat serialization to constrain the LLM to generating
-    beats for exactly one thread with a fixed tension_id. This makes the
-    thread→tension alignment trivial since the context only contains one valid
-    tension for tension_impacts.
+    Used by per-path beat serialization to constrain the LLM to generating
+    beats for exactly one path with a fixed dilemma_id. This makes the
+    path→dilemma alignment trivial since the context only contains one valid
+    dilemma for dilemma_impacts.
     """
 
     initial_beats: list[InitialBeat] = Field(
         min_length=2,
         max_length=4,
-        description="2-4 initial beats for this specific thread",
+        description="2-4 initial beats for this specific path",
     )
+
+
+# Backward compatibility alias
+ThreadBeatsSection = PathBeatsSection
 
 
 class ConvergenceSection(BaseModel):
@@ -344,5 +502,5 @@ class ConvergenceSection(BaseModel):
 
     convergence_sketch: ConvergenceSketch = Field(
         default_factory=ConvergenceSketch,
-        description="Guidance for GROW about thread convergence",
+        description="Guidance for GROW about path convergence",
     )

--- a/tests/integration/test_grow_e2e.py
+++ b/tests/integration/test_grow_e2e.py
@@ -187,16 +187,16 @@ class TestGrowContextFormatting:
         ids = format_grow_valid_ids(graph)
 
         assert "valid_beat_ids" in ids
-        assert "valid_thread_ids" in ids
-        assert "valid_tension_ids" in ids
+        assert "valid_path_ids" in ids
+        assert "valid_dilemma_ids" in ids
         assert "valid_entity_ids" in ids
         assert "valid_passage_ids" in ids
         assert "valid_choice_ids" in ids
 
         # Before GROW runs, only SEED-stage IDs should be populated
         assert ids["valid_beat_ids"] != ""
-        assert ids["valid_thread_ids"] != ""
-        assert ids["valid_tension_ids"] != ""
+        assert ids["valid_path_ids"] != ""
+        assert ids["valid_dilemma_ids"] != ""
         assert ids["valid_entity_ids"] != ""
         # Passages and choices are created during GROW
         assert ids["valid_passage_ids"] == ""
@@ -211,8 +211,8 @@ class TestGrowContextFormatting:
 
         assert "VALID IDs FOR GROW PHASES" in context
         assert "Beat IDs" in context
-        assert "Thread IDs" in context
-        assert "Tension IDs" in context
+        assert "Path IDs" in context
+        assert "Dilemma IDs" in context
 
     def test_empty_graph_context(self) -> None:
         """Verify context formatting handles empty graph gracefully."""

--- a/tests/unit/test_brainstorm_stage.py
+++ b/tests/unit/test_brainstorm_stage.py
@@ -131,7 +131,7 @@ async def test_execute_calls_all_three_phases() -> None:
 
         # Verify result
         assert len(artifact["entities"]) == 1
-        assert len(artifact["tensions"]) == 1
+        assert len(artifact["dilemmas"]) == 1
         assert llm_calls == 4  # 2 discuss + 1 summarize + 1 serialize
         assert tokens == 800  # 500 + 100 + 200
 
@@ -299,7 +299,7 @@ async def test_execute_returns_artifact_as_dict() -> None:
 
         assert isinstance(artifact, dict)
         assert artifact["entities"][0]["entity_id"] == "kay"
-        assert artifact["tensions"][0]["tension_id"] == "trust"
+        assert artifact["dilemmas"][0]["dilemma_id"] == "trust"
 
 
 # --- Vision Context Formatting Tests ---

--- a/tests/unit/test_grow_models.py
+++ b/tests/unit/test_grow_models.py
@@ -52,9 +52,9 @@ class TestArc:
         with pytest.raises(ValidationError, match="arc_id"):
             Arc(arc_id="", arc_type="spine", threads=["t1"])
 
-    def test_empty_threads_rejected(self) -> None:
-        with pytest.raises(ValidationError, match="threads"):
-            Arc(arc_id="test", arc_type="spine", threads=[])
+    def test_empty_paths_rejected(self) -> None:
+        with pytest.raises(ValidationError, match="paths"):
+            Arc(arc_id="test", arc_type="spine", paths=[])
 
     def test_invalid_arc_type_rejected(self) -> None:
         with pytest.raises(ValidationError, match="arc_type"):

--- a/tests/unit/test_seed_stage.py
+++ b/tests/unit/test_seed_stage.py
@@ -134,7 +134,7 @@ async def test_execute_calls_all_three_phases() -> None:
 
         # Verify result
         assert len(artifact["entities"]) == 1
-        assert len(artifact["threads"]) == 1
+        assert len(artifact["paths"]) == 1
         assert len(artifact["initial_beats"]) == 1
         # Stage counts: 2 discuss + 1 summarize + 6 (hardcoded for iterative serialize)
         # Note: This tests the stage's call accounting, not internal serialize behavior
@@ -342,7 +342,7 @@ async def test_execute_returns_artifact_as_dict() -> None:
 
         assert isinstance(artifact, dict)
         assert artifact["entities"][0]["entity_id"] == "kay"
-        assert artifact["threads"][0]["thread_id"] == "thread1"
+        assert artifact["paths"][0]["path_id"] == "thread1"
         assert artifact["initial_beats"][0]["beat_id"] == "beat1"
 
 


### PR DESCRIPTION
## Problem
LLM-facing context strings still use old terminology (tension, thread, alternative). This is PR #3 in the stacked PR series for issue #338.

**Stacked on**: PR #340

## Changes

### Constants (with backward compat aliases)
- `SCOPE_TENSION` → `SCOPE_DILEMMA`
- `SCOPE_THREAD` → `SCOPE_PATH`

### Functions (with backward compat aliases)
- `count_threads_per_tension` → `count_paths_per_dilemma`
- `get_tension_development_states` → `get_dilemma_development_states`
- `format_thread_ids_context` → `format_path_ids_context`

### New Hierarchical ID Functions
- `parse_hierarchical_path_id()` - extract dilemma_id from `p::X__Y`
- `format_hierarchical_path_id()` - create `p::dilemma__answer` format

### Context Output Updates
- All LLM-facing strings updated (Tension IDs → Dilemma IDs, etc.)
- `get_expected_counts()` returns `dilemmas` key instead of `tensions`
- `format_summarize_manifest()` returns `dilemma_manifest` key
- `check_structural_completeness()` checks `dilemmas` field

### grow_context.py
- Return keys: `valid_thread_ids` → `valid_path_ids`
- Return keys: `valid_tension_ids` → `valid_dilemma_ids`

## Not Included / Future PRs
- PR #4: Graph mutations & validation
- PRs #5-9: Remaining terminology updates

## Test Plan
```bash
uv run pytest tests/unit/test_graph_context.py  # 82 tests pass
uv run pytest tests/integration/test_grow_e2e.py  # 10 tests pass
uv run mypy src/questfoundry/graph/
uv run ruff check src/questfoundry/graph/
```

## Risk / Rollback
- All old constants and functions remain as aliases
- Graph still stores nodes as "tension" and "thread" types
- Can revert without breaking existing functionality

🤖 Generated with [Claude Code](https://claude.com/claude-code)