### PR TITLE
refactor(graph): update mutations, GROW, pipeline terminology (#338)

### DIFF
--- a/src/questfoundry/graph/grow_algorithms.py
+++ b/src/questfoundry/graph/grow_algorithms.py
@@ -33,28 +33,37 @@ if TYPE_CHECKING:
 _MAX_ARC_COUNT = 64
 
 
-def build_tension_threads(graph: Graph) -> dict[str, list[str]]:
-    """Build tension → threads mapping from thread node tension_id properties.
+def build_dilemma_paths(graph: Graph) -> dict[str, list[str]]:
+    """Build dilemma → paths mapping from path node dilemma_id properties.
 
-    Uses the tension_id property on thread nodes instead of explores edges,
-    since explores edges point to alternatives (not tensions) in real SEED output.
+    Uses the dilemma_id property (stored as tension_id in graph) on path nodes
+    instead of explores edges, since explores edges point to answers (not dilemmas)
+    in real SEED output.
+
+    Note: Graph stores paths as "thread" nodes and dilemmas as "tension" nodes
+    for backward compatibility.
 
     Args:
-        graph: Graph containing tension and thread nodes.
+        graph: Graph containing dilemma and path nodes.
 
     Returns:
-        Dict mapping tension node ID → list of thread node IDs.
+        Dict mapping dilemma node ID → list of path node IDs.
     """
-    tension_nodes = graph.get_nodes_by_type("tension")
-    thread_nodes = graph.get_nodes_by_type("thread")
-    tension_threads: dict[str, list[str]] = defaultdict(list)
-    for thread_id, thread_data in thread_nodes.items():
-        tension_id = thread_data.get("tension_id")
-        if tension_id:
-            prefixed = normalize_scoped_id(tension_id, "tension")
-            if prefixed in tension_nodes:
-                tension_threads[prefixed].append(thread_id)
-    return tension_threads
+    # Graph uses "tension" for dilemmas and "thread" for paths
+    dilemma_nodes = graph.get_nodes_by_type("tension")
+    path_nodes = graph.get_nodes_by_type("thread")
+    dilemma_paths: dict[str, list[str]] = defaultdict(list)
+    for path_id, path_data in path_nodes.items():
+        dilemma_id = path_data.get("tension_id")
+        if dilemma_id:
+            prefixed = normalize_scoped_id(dilemma_id, "tension")
+            if prefixed in dilemma_nodes:
+                dilemma_paths[prefixed].append(path_id)
+    return dilemma_paths
+
+
+# Backward compatibility alias - will be removed in a future version
+build_tension_threads = build_dilemma_paths
 
 
 @dataclass

--- a/src/questfoundry/graph/grow_algorithms.py
+++ b/src/questfoundry/graph/grow_algorithms.py
@@ -337,7 +337,7 @@ def enumerate_arcs(graph: Graph) -> list[Arc]:
             Arc(
                 arc_id=arc_id,
                 arc_type="spine" if is_spine else "branch",
-                threads=thread_raw_ids,
+                paths=thread_raw_ids,  # paths is the new field name (was threads)
                 sequence=sequence,
             )
         )

--- a/src/questfoundry/graph/grow_validators.py
+++ b/src/questfoundry/graph/grow_validators.py
@@ -27,13 +27,13 @@ if TYPE_CHECKING:
 def validate_phase2_output(
     result: Phase2Output,
     valid_beat_ids: set[str],
-    valid_tension_ids: set[str],
+    valid_dilemma_ids: set[str],
 ) -> list[GrowValidationError]:
-    """Validate Phase 2 thread-agnostic assessments.
+    """Validate Phase 2 path-agnostic assessments.
 
     Checks:
     - beat_id exists in graph
-    - agnostic_for tension IDs exist
+    - agnostic_for dilemma IDs exist
     """
     errors: list[GrowValidationError] = []
     for i, assessment in enumerate(result.assessments):
@@ -46,14 +46,14 @@ def validate_phase2_output(
                     available=sorted(valid_beat_ids)[:10],
                 )
             )
-        for tension_id in assessment.agnostic_for:
-            if tension_id not in valid_tension_ids:
+        for dilemma_id in assessment.agnostic_for:
+            if dilemma_id not in valid_dilemma_ids:
                 errors.append(
                     GrowValidationError(
                         field_path=f"assessments.{i}.agnostic_for",
-                        issue=f"Tension ID not found: {tension_id}",
-                        provided=tension_id,
-                        available=sorted(valid_tension_ids)[:10],
+                        issue=f"Dilemma ID not found: {dilemma_id}",
+                        provided=dilemma_id,
+                        available=sorted(valid_dilemma_ids)[:10],
                     )
                 )
     return errors
@@ -63,16 +63,16 @@ def validate_phase3_output(
     result: Phase3Output,
     valid_beat_ids: set[str],
 ) -> list[GrowValidationError]:
-    """Validate Phase 3 knot proposals.
+    """Validate Phase 3 intersection proposals.
 
     Checks:
     - beat_ids exist in graph
-    - No beat reused across multiple knots
+    - No beat reused across multiple intersections
     """
     errors: list[GrowValidationError] = []
     seen_beats: set[str] = set()
-    for i, knot in enumerate(result.knots):
-        for beat_id in knot.beat_ids:
+    for i, intersection in enumerate(result.knots):
+        for beat_id in intersection.beat_ids:
             if beat_id not in valid_beat_ids:
                 errors.append(
                     GrowValidationError(
@@ -86,7 +86,7 @@ def validate_phase3_output(
                 errors.append(
                     GrowValidationError(
                         field_path=f"knots.{i}.beat_ids",
-                        issue=f"Beat reused across knots: {beat_id}",
+                        issue=f"Beat reused across intersections: {beat_id}",
                         provided=beat_id,
                     )
                 )

--- a/src/questfoundry/graph/seed_pruning.py
+++ b/src/questfoundry/graph/seed_pruning.py
@@ -5,10 +5,10 @@ Instead of teaching LLMs to self-constrain, we let them generate freely and
 programmatically select the best content.
 
 The pruning process:
-1. Rank tensions by quality score (see tension_scoring.py)
-2. Select top N tensions for full exploration (N determined by arc limit)
-3. Demote remaining tensions: move non-canonical to implicit
-4. Drop threads, consequences, and beats for demoted non-canonical alternatives
+1. Rank dilemmas by quality score (see tension_scoring.py)
+2. Select top N dilemmas for full exploration (N determined by arc limit)
+3. Demote remaining dilemmas: move non-canonical to implicit
+4. Drop paths, consequences, and beats for demoted non-canonical answers
 """
 
 from __future__ import annotations
@@ -27,16 +27,16 @@ from questfoundry.observability.logging import get_logger
 log = get_logger(__name__)
 
 
-def _get_canonical_alternative(tension: TensionDecision) -> str | None:
-    """Get the canonical (first) alternative for a tension."""
-    return tension.considered[0] if tension.considered else None
+def _get_canonical_answer(dilemma: TensionDecision) -> str | None:
+    """Get the canonical (first) answer for a dilemma."""
+    return dilemma.considered[0] if dilemma.considered else None
 
 
-def _get_noncanonical_alternatives(tension: TensionDecision) -> list[str]:
-    """Get non-canonical alternatives (all considered except first)."""
-    if len(tension.considered) <= 1:
+def _get_noncanonical_answers(dilemma: TensionDecision) -> list[str]:
+    """Get non-canonical answers (all considered except first)."""
+    if len(dilemma.considered) <= 1:
         return []
-    return tension.considered[1:]
+    return dilemma.considered[1:]
 
 
 def prune_to_arc_limit(
@@ -76,113 +76,111 @@ def prune_to_arc_limit(
         return seed_output
 
     # Prune the output
-    return _prune_demoted_tensions(seed_output, set(demoted))
+    return _prune_demoted_dilemmas(seed_output, set(demoted))
 
 
-def _prune_demoted_tensions(
+def _prune_demoted_dilemmas(
     seed_output: SeedOutput,
-    demoted_tension_ids: set[str],
+    demoted_dilemma_ids: set[str],
 ) -> SeedOutput:
-    """Remove non-canonical content for demoted tensions.
+    """Remove non-canonical content for demoted dilemmas.
 
-    For each demoted tension:
-    1. Remove the non-canonical thread(s)
-    2. Remove consequences linked to demoted threads
-    3. Remove beats that ONLY belong to demoted threads
-    4. Update beats that belong to both demoted and kept threads
+    For each demoted dilemma:
+    1. Remove the non-canonical path(s)
+    2. Remove consequences linked to demoted paths
+    3. Remove beats that ONLY belong to demoted paths
+    4. Update beats that belong to both demoted and kept paths
 
-    IMPORTANT: Tensions are NOT mutated. The `considered` field is immutable
+    IMPORTANT: Dilemmas are NOT mutated. The `considered` field is immutable
     after SEED - it records the LLM's original intent. Development state
-    (committed vs deferred) is derived from thread existence, not stored fields.
+    (committed vs deferred) is derived from path existence, not stored fields.
 
     NOTE: All ID comparisons use strip_scope_prefix() to handle both scoped
-    (thread::foo) and raw (foo) ID formats consistently. This is part of the
+    (path::foo) and raw (foo) ID formats consistently. This is part of the
     "scoped everywhere" standardization (see issue #219, PR #220).
 
     Args:
         seed_output: The full SEED output.
-        demoted_tension_ids: Set of tension IDs to demote (may be scoped or raw).
+        demoted_dilemma_ids: Set of dilemma IDs to demote (may be scoped or raw).
 
     Returns:
-        Pruned SeedOutput with threads removed but tensions unchanged.
+        Pruned SeedOutput with paths removed but dilemmas unchanged.
     """
-    # Normalize demoted_tension_ids to raw format for consistent comparison
-    demoted_raw_ids = {strip_scope_prefix(tid) for tid in demoted_tension_ids}
+    # Normalize demoted_dilemma_ids to raw format for consistent comparison
+    demoted_raw_ids = {strip_scope_prefix(did) for did in demoted_dilemma_ids}
 
-    # Build lookup of which threads to drop (using raw IDs for comparison)
-    threads_to_drop: set[str] = set()
-    tension_lookup: dict[str, TensionDecision] = {
-        strip_scope_prefix(t.tension_id): t for t in seed_output.tensions
+    # Build lookup of which paths to drop (using raw IDs for comparison)
+    paths_to_drop: set[str] = set()
+    dilemma_lookup: dict[str, TensionDecision] = {
+        strip_scope_prefix(d.dilemma_id): d for d in seed_output.dilemmas
     }
 
     # Defensive check: ensure no ID collisions after stripping scope prefixes
-    if len(tension_lookup) != len(seed_output.tensions):
+    if len(dilemma_lookup) != len(seed_output.dilemmas):
         log.warning(
-            "tension_id_collision_detected",
-            expected=len(seed_output.tensions),
-            actual=len(tension_lookup),
+            "dilemma_id_collision_detected",
+            expected=len(seed_output.dilemmas),
+            actual=len(dilemma_lookup),
         )
 
-    for thread in seed_output.threads:
-        raw_tension_id = strip_scope_prefix(thread.tension_id)
-        if raw_tension_id in demoted_raw_ids:
-            tension = tension_lookup.get(raw_tension_id)
-            if tension:
-                canonical_alt = _get_canonical_alternative(tension)
-                # Drop if not the canonical alternative
-                if thread.alternative_id != canonical_alt:
-                    # Store raw thread ID for consistent comparison
-                    threads_to_drop.add(strip_scope_prefix(thread.thread_id))
+    for path in seed_output.paths:
+        raw_dilemma_id = strip_scope_prefix(path.dilemma_id)
+        if raw_dilemma_id in demoted_raw_ids:
+            dilemma = dilemma_lookup.get(raw_dilemma_id)
+            if dilemma:
+                canonical_answer = _get_canonical_answer(dilemma)
+                # Drop if not the canonical answer
+                if path.answer_id != canonical_answer:
+                    # Store raw path ID for consistent comparison
+                    paths_to_drop.add(strip_scope_prefix(path.path_id))
 
     log.info(
         "pruning_seed_output",
-        demoted_tensions=len(demoted_tension_ids),
-        threads_to_drop=len(threads_to_drop),
-        dropped_thread_ids=list(threads_to_drop)[:5],  # Log first 5
+        demoted_dilemmas=len(demoted_dilemma_ids),
+        paths_to_drop=len(paths_to_drop),
+        dropped_path_ids=list(paths_to_drop)[:5],  # Log first 5
     )
 
-    # Tensions are NOT modified - considered field is immutable
-    # Development state is derived from thread existence
+    # Dilemmas are NOT modified - considered field is immutable
+    # Development state is derived from path existence
 
-    # 1. Filter threads (compare raw IDs)
-    pruned_threads: list[Thread] = [
-        t for t in seed_output.threads if strip_scope_prefix(t.thread_id) not in threads_to_drop
+    # 1. Filter paths (compare raw IDs)
+    pruned_paths: list[Thread] = [
+        p for p in seed_output.paths if strip_scope_prefix(p.path_id) not in paths_to_drop
     ]
 
     # 2. Filter consequences (compare raw IDs)
     pruned_consequences: list[Consequence] = [
-        c
-        for c in seed_output.consequences
-        if strip_scope_prefix(c.thread_id) not in threads_to_drop
+        c for c in seed_output.consequences if strip_scope_prefix(c.path_id) not in paths_to_drop
     ]
 
     # 3. Filter and update beats
     pruned_beats: list[InitialBeat] = []
     for beat in seed_output.initial_beats:
-        # Get threads that aren't being dropped (compare raw IDs).
+        # Get paths that aren't being dropped (compare raw IDs).
         # Original ID format (scoped or raw) is intentionally preserved to maintain
         # consistency with how the artifact was originally generated.
-        kept_threads = [t for t in beat.threads if strip_scope_prefix(t) not in threads_to_drop]
+        kept_paths = [p for p in beat.paths if strip_scope_prefix(p) not in paths_to_drop]
 
-        if kept_threads:
-            # Beat serves at least one kept thread
-            if len(kept_threads) < len(beat.threads):
-                # Some threads were dropped - update the beat
+        if kept_paths:
+            # Beat serves at least one kept path
+            if len(kept_paths) < len(beat.paths):
+                # Some paths were dropped - update the beat
                 pruned_beats.append(
                     InitialBeat(
                         beat_id=beat.beat_id,
                         summary=beat.summary,
-                        threads=kept_threads,
-                        tension_impacts=beat.tension_impacts,
+                        paths=kept_paths,
+                        dilemma_impacts=beat.dilemma_impacts,
                         entities=beat.entities,
                         location=beat.location,
                         location_alternatives=beat.location_alternatives,
                     )
                 )
             else:
-                # All threads kept - use as-is
+                # All paths kept - use as-is
                 pruned_beats.append(beat)
-        # else: beat only served dropped threads - discard it
+        # else: beat only served dropped paths - discard it
 
     dropped_beat_count = len(seed_output.initial_beats) - len(pruned_beats)
     if dropped_beat_count > 0:
@@ -195,8 +193,8 @@ def _prune_demoted_tensions(
 
     return SeedOutput(
         entities=seed_output.entities,
-        tensions=list(seed_output.tensions),  # Tensions are immutable - keep as-is
-        threads=pruned_threads,
+        dilemmas=list(seed_output.dilemmas),  # Dilemmas are immutable - keep as-is
+        paths=pruned_paths,
         consequences=pruned_consequences,
         initial_beats=pruned_beats,
         convergence_sketch=seed_output.convergence_sketch,
@@ -206,11 +204,11 @@ def _prune_demoted_tensions(
 def compute_arc_count(seed_output: SeedOutput) -> int:
     """Compute the arc count for a seed output.
 
-    Arc count = 2^n where n = tensions with 2+ threads (fully developed).
+    Arc count = 2^n where n = dilemmas with 2+ paths (fully developed).
 
-    IMPORTANT: This is derived from actual thread existence, NOT from the
+    IMPORTANT: This is derived from actual path existence, NOT from the
     `considered` field. The `considered` field records LLM intent; actual
-    thread existence determines what will become story arcs.
+    path existence determines what will become story arcs.
 
     Args:
         seed_output: The SEED output to analyze.
@@ -218,12 +216,12 @@ def compute_arc_count(seed_output: SeedOutput) -> int:
     Returns:
         The number of arcs this seed would produce.
     """
-    # Count threads per tension (using raw IDs for grouping)
-    threads_per_tension: dict[str, int] = {}
-    for thread in seed_output.threads:
-        tid = strip_scope_prefix(thread.tension_id)
-        threads_per_tension[tid] = threads_per_tension.get(tid, 0) + 1
+    # Count paths per dilemma (using raw IDs for grouping)
+    paths_per_dilemma: dict[str, int] = {}
+    for path in seed_output.paths:
+        did = strip_scope_prefix(path.dilemma_id)
+        paths_per_dilemma[did] = paths_per_dilemma.get(did, 0) + 1
 
-    # Fully developed = has 2+ threads
-    fully_developed_count = sum(1 for count in threads_per_tension.values() if count >= 2)
+    # Fully developed = has 2+ paths
+    fully_developed_count = sum(1 for count in paths_per_dilemma.values() if count >= 2)
     return 2**fully_developed_count if fully_developed_count > 0 else 1

--- a/src/questfoundry/pipeline/stages/brainstorm.py
+++ b/src/questfoundry/pipeline/stages/brainstorm.py
@@ -1,7 +1,7 @@
 """BRAINSTORM stage implementation.
 
 The BRAINSTORM stage generates raw creative material: entities (characters,
-locations, objects, factions) and tensions (binary dramatic questions).
+locations, objects, factions) and dilemmas (binary dramatic questions).
 
 Uses the LangChain-native 3-phase pattern:
 Discuss → Summarize → Serialize.
@@ -96,14 +96,14 @@ def _format_vision_context(vision_node: dict[str, Any]) -> str:
 
 
 class BrainstormStage:
-    """BRAINSTORM stage - generate entities and tensions.
+    """BRAINSTORM stage - generate entities and dilemmas.
 
     This stage takes the creative vision from DREAM and generates raw
     creative material: entities (characters, locations, objects, factions)
-    and tensions (binary dramatic questions with two alternatives each).
+    and dilemmas (binary dramatic questions with two answers each).
 
     Uses the LangChain-native 3-phase pattern:
-    - Discuss: Brainstorm entities and tensions with research tools
+    - Discuss: Brainstorm entities and dilemmas with research tools
     - Summarize: Condense discussion into structured summary
     - Serialize: Convert to BrainstormOutput artifact
 
@@ -283,14 +283,14 @@ class BrainstormStage:
 
         # Log summary statistics
         entity_count = len(artifact_data.get("entities", []))
-        tension_count = len(artifact_data.get("tensions", []))
+        dilemma_count = len(artifact_data.get("dilemmas", artifact_data.get("tensions", [])))
 
         log.info(
             "brainstorm_stage_completed",
             llm_calls=total_llm_calls,
             tokens=total_tokens,
             entities=entity_count,
-            tensions=tension_count,
+            dilemmas=dilemma_count,
         )
 
         return artifact_data, total_llm_calls, total_tokens

--- a/src/questfoundry/pipeline/stages/grow.py
+++ b/src/questfoundry/pipeline/stages/grow.py
@@ -605,7 +605,7 @@ class GrowStage:
         validator = partial(
             validate_phase2_output,
             valid_beat_ids=set(valid_beat_ids),
-            valid_tension_ids=set(valid_tension_ids),
+            valid_dilemma_ids=set(valid_tension_ids),  # valid_tension_ids var contains dilemma IDs
         )
         try:
             result, llm_calls, tokens = await self._grow_llm_call(

--- a/src/questfoundry/pipeline/stages/grow.py
+++ b/src/questfoundry/pipeline/stages/grow.py
@@ -531,17 +531,15 @@ class GrowStage:
                 detail="No tensions/threads/beats to assess",
             )
 
-        # Build tension → threads mapping from thread node tension_id properties
-        from questfoundry.graph.grow_algorithms import build_tension_threads
+        # Build dilemma → paths mapping from path node dilemma_id properties
+        from questfoundry.graph.grow_algorithms import build_dilemma_paths
 
-        tension_threads = build_tension_threads(graph)
+        dilemma_paths = build_dilemma_paths(graph)
 
-        # Only assess tensions with multiple threads
-        multi_thread_tensions = {
-            tid: threads for tid, threads in tension_threads.items() if len(threads) > 1
-        }
+        # Only assess dilemmas with multiple paths
+        multi_path_dilemmas = {did: paths for did, paths in dilemma_paths.items() if len(paths) > 1}
 
-        if not multi_thread_tensions:
+        if not multi_path_dilemmas:
             return GrowPhaseResult(
                 phase="thread_agnostic",
                 status="completed",
@@ -562,7 +560,7 @@ class GrowStage:
         for beat_id, beat_threads in beat_thread_map.items():
             if beat_id not in beat_nodes:
                 continue
-            for tension_id, tension_thread_list in multi_thread_tensions.items():
+            for tension_id, tension_thread_list in multi_path_dilemmas.items():
                 # Count how many of this tension's threads the beat belongs to
                 shared = [t for t in beat_threads if t in tension_thread_list]
                 if len(shared) > 1:

--- a/src/questfoundry/pipeline/stages/grow.py
+++ b/src/questfoundry/pipeline/stages/grow.py
@@ -1208,7 +1208,7 @@ class GrowStage:
             arc = ArcModel(
                 arc_id=arc_data["raw_id"],
                 arc_type=arc_data["arc_type"],
-                threads=arc_data.get("threads", []),
+                paths=arc_data.get("threads", []),  # Graph uses "threads", model uses "paths"
                 sequence=arc_data.get("sequence", []),
             )
             arcs.append(arc)
@@ -1269,7 +1269,7 @@ class GrowStage:
             arc = ArcModel(
                 arc_id=arc_data["raw_id"],
                 arc_type=arc_data["arc_type"],
-                threads=arc_data.get("threads", []),
+                paths=arc_data.get("threads", []),  # Graph uses "threads", model uses "paths"
                 sequence=arc_data.get("sequence", []),
             )
             arcs.append(arc)

--- a/src/questfoundry/pipeline/stages/seed.py
+++ b/src/questfoundry/pipeline/stages/seed.py
@@ -330,9 +330,9 @@ class SeedStage:
         summarize_prompt = get_seed_summarize_prompt(
             brainstorm_context=brainstorm_context,
             entity_count=counts["entities"],
-            tension_count=counts["tensions"],
+            tension_count=counts["dilemmas"],  # Using new key name from context.py
             entity_manifest=manifests["entity_manifest"],
-            tension_manifest=manifests["tension_manifest"],
+            tension_manifest=manifests["dilemma_manifest"],  # Using new key name from context.py
         )
 
         # Outer loop: conversation-level retry for semantic errors

--- a/tests/unit/test_enrichment.py
+++ b/tests/unit/test_enrichment.py
@@ -194,7 +194,7 @@ class TestEnrichSeedArtifact:
         result = enrich_seed_artifact(graph_with_entities, artifact)
 
         assert result["entities"] == []
-        assert result["tensions"] == []
+        assert result["dilemmas"] == []
         assert result["threads"] == []
 
     def test_field_order_consistent(self, graph_with_entities: Graph) -> None:
@@ -214,13 +214,13 @@ class TestEnrichSeedArtifact:
         assert keys == expected_order
 
 
-class TestEnrichTensions:
-    """Tests for tension enrichment."""
+class TestEnrichDilemmas:
+    """Tests for dilemma enrichment."""
 
-    def test_enriches_tension_with_full_details(self, graph_with_tensions: Graph) -> None:
+    def test_enriches_dilemma_with_full_details(self, graph_with_tensions: Graph) -> None:
         """Enrichment adds question, why_it_matters, central_entity_ids from graph."""
         artifact = {
-            "tensions": [
+            "tensions": [  # Input uses legacy "tensions" key
                 {
                     "tension_id": "host_motivation",
                     "considered": ["benevolent"],
@@ -231,33 +231,33 @@ class TestEnrichTensions:
 
         result = enrich_seed_artifact(graph_with_tensions, artifact)
 
-        tension = result["tensions"][0]
-        assert tension["tension_id"] == "host_motivation"
-        assert tension["question"] == "Is the host benevolent or self-serving?"
-        assert tension["why_it_matters"] == "Determines whether protagonist can trust their guide"
+        dilemma = result["dilemmas"][0]
+        assert dilemma["dilemma_id"] == "host_motivation"
+        assert dilemma["question"] == "Is the host benevolent or self-serving?"
+        assert dilemma["why_it_matters"] == "Determines whether protagonist can trust their guide"
         # Entity IDs should have prefix stripped
-        assert tension["central_entity_ids"] == ["the_host", "the_manor"]
-        assert tension["considered"] == ["benevolent"]
-        assert tension["implicit"] == ["self_serving"]
+        assert dilemma["central_entity_ids"] == ["the_host", "the_manor"]
+        assert dilemma["considered"] == ["benevolent"]
+        assert dilemma["implicit"] == ["self_serving"]
 
-    def test_handles_unknown_tension(self, graph_with_tensions: Graph) -> None:
-        """Enrichment handles tensions not in graph gracefully."""
+    def test_handles_unknown_dilemma(self, graph_with_tensions: Graph) -> None:
+        """Enrichment handles dilemmas not in graph gracefully."""
         artifact = {
             "tensions": [
-                {"tension_id": "unknown_tension", "considered": ["option_a"], "implicit": []},
+                {"tension_id": "unknown_dilemma", "considered": ["option_a"], "implicit": []},
             ],
         }
 
         result = enrich_seed_artifact(graph_with_tensions, artifact)
 
-        tension = result["tensions"][0]
-        assert tension["tension_id"] == "unknown_tension"
-        assert "question" not in tension
-        assert "why_it_matters" not in tension
-        assert tension["considered"] == ["option_a"]
+        dilemma = result["dilemmas"][0]
+        assert dilemma["dilemma_id"] == "unknown_dilemma"
+        assert "question" not in dilemma
+        assert "why_it_matters" not in dilemma
+        assert dilemma["considered"] == ["option_a"]
 
-    def test_handles_prefixed_tension_ids(self, graph_with_tensions: Graph) -> None:
-        """Enrichment strips prefix from tension_id for graph lookup."""
+    def test_handles_prefixed_dilemma_ids(self, graph_with_tensions: Graph) -> None:
+        """Enrichment strips prefix from dilemma_id for graph lookup."""
         artifact = {
             "tensions": [
                 {
@@ -270,16 +270,16 @@ class TestEnrichTensions:
 
         result = enrich_seed_artifact(graph_with_tensions, artifact)
 
-        tension = result["tensions"][0]
+        dilemma = result["dilemmas"][0]
         # Original prefixed ID preserved in output
-        assert tension["tension_id"] == "tension::host_motivation"
+        assert dilemma["dilemma_id"] == "tension::host_motivation"
         # But graph lookup succeeds with prefix stripped
-        assert tension["question"] == "Is the host benevolent or self-serving?"
-        assert tension["why_it_matters"] == "Determines whether protagonist can trust their guide"
-        assert tension["considered"] == ["benevolent"]
+        assert dilemma["question"] == "Is the host benevolent or self-serving?"
+        assert dilemma["why_it_matters"] == "Determines whether protagonist can trust their guide"
+        assert dilemma["considered"] == ["benevolent"]
 
-    def test_enriches_multiple_tensions(self, graph_with_tensions: Graph) -> None:
-        """Enrichment works for multiple tensions."""
+    def test_enriches_multiple_dilemmas(self, graph_with_tensions: Graph) -> None:
+        """Enrichment works for multiple dilemmas."""
         artifact = {
             "tensions": [
                 {"tension_id": "host_motivation", "considered": ["benevolent"], "implicit": []},
@@ -289,14 +289,14 @@ class TestEnrichTensions:
 
         result = enrich_seed_artifact(graph_with_tensions, artifact)
 
-        assert len(result["tensions"]) == 2
-        assert result["tensions"][0]["question"] == "Is the host benevolent or self-serving?"
-        assert result["tensions"][1]["question"] == "Who committed the murder?"
+        assert len(result["dilemmas"]) == 2
+        assert result["dilemmas"][0]["question"] == "Is the host benevolent or self-serving?"
+        assert result["dilemmas"][1]["question"] == "Who committed the murder?"
 
-    def test_empty_tensions_list(self, graph_with_tensions: Graph) -> None:
-        """Enrichment handles empty tensions list."""
-        artifact = {"tensions": []}
+    def test_empty_dilemmas_list(self, graph_with_tensions: Graph) -> None:
+        """Enrichment handles empty dilemmas list."""
+        artifact = {"tensions": []}  # Input uses legacy key
 
         result = enrich_seed_artifact(graph_with_tensions, artifact)
 
-        assert result["tensions"] == []
+        assert result["dilemmas"] == []

--- a/tests/unit/test_grow_validators.py
+++ b/tests/unit/test_grow_validators.py
@@ -37,7 +37,7 @@ class TestValidatePhase2Output:
         errors = validate_phase2_output(
             result,
             valid_beat_ids={"beat::b1", "beat::b2"},
-            valid_tension_ids={"t1", "t2"},
+            valid_dilemma_ids={"t1", "t2"},
         )
         assert errors == []
 
@@ -50,7 +50,7 @@ class TestValidatePhase2Output:
         errors = validate_phase2_output(
             result,
             valid_beat_ids={"beat::b1", "beat::b2"},
-            valid_tension_ids=set(),
+            valid_dilemma_ids=set(),
         )
         assert len(errors) == 1
         assert errors[0].field_path == "assessments.0.beat_id"
@@ -66,7 +66,7 @@ class TestValidatePhase2Output:
         errors = validate_phase2_output(
             result,
             valid_beat_ids={"beat::b1"},
-            valid_tension_ids={"t1", "t2"},
+            valid_dilemma_ids={"t1", "t2"},
         )
         assert len(errors) == 1
         assert errors[0].field_path == "assessments.0.agnostic_for"
@@ -81,7 +81,7 @@ class TestValidatePhase2Output:
         errors = validate_phase2_output(
             result,
             valid_beat_ids={"beat::b1"},
-            valid_tension_ids={"t1"},
+            valid_dilemma_ids={"t1"},
         )
         # 1 bad beat_id + 2 bad tension_ids = 3 errors
         assert len(errors) == 3
@@ -91,7 +91,7 @@ class TestValidatePhase2Output:
         errors = validate_phase2_output(
             result,
             valid_beat_ids={"beat::b1"},
-            valid_tension_ids={"t1"},
+            valid_dilemma_ids={"t1"},
         )
         assert errors == []
 

--- a/tests/unit/test_ontology_considered.py
+++ b/tests/unit/test_ontology_considered.py
@@ -18,7 +18,7 @@ from questfoundry.graph.context import (
     get_tension_development_states,
 )
 from questfoundry.graph.seed_pruning import (
-    _prune_demoted_tensions,
+    _prune_demoted_dilemmas,
     compute_arc_count,
     prune_to_arc_limit,
 )
@@ -514,7 +514,7 @@ class TestScopedIdStandardization:
 
         # Demote the tension - should drop non-canonical (crafted) thread
         demoted = {"tension::artifact_origin"}
-        pruned = _prune_demoted_tensions(seed, demoted)
+        pruned = _prune_demoted_dilemmas(seed, demoted)
 
         # Non-canonical thread should be dropped
         thread_ids = [t.thread_id for t in pruned.threads]
@@ -582,7 +582,7 @@ class TestScopedIdStandardization:
         )
 
         # Demote t1 - should drop non-canonical (alt_b / th_b) thread and its consequence
-        pruned = _prune_demoted_tensions(seed, {"t1"})
+        pruned = _prune_demoted_dilemmas(seed, {"t1"})
 
         # Thread B and its consequence should be dropped
         thread_ids = [t.thread_id for t in pruned.threads]
@@ -638,7 +638,7 @@ class TestScopedIdStandardization:
         )
 
         # Demote using RAW ID (as might come from tension scoring)
-        pruned = _prune_demoted_tensions(seed, {"keeper_trust"})  # Raw!
+        pruned = _prune_demoted_dilemmas(seed, {"keeper_trust"})  # Raw!
 
         # Non-canonical thread should still be dropped
         thread_ids = [t.thread_id for t in pruned.threads]

--- a/tests/unit/test_seed_stage.py
+++ b/tests/unit/test_seed_stage.py
@@ -252,10 +252,10 @@ async def test_execute_uses_seed_summarize_prompt() -> None:
         MockGraph.load.return_value = mock_graph
         mock_tools.return_value = []
         mock_prompt.return_value = "Seed summarize prompt"
-        mock_counts.return_value = {"entities": 1, "tensions": 0}
+        mock_counts.return_value = {"entities": 1, "dilemmas": 0}
         mock_manifest.return_value = {
             "entity_manifest": "**Characters:**\n  - `hero`",
-            "tension_manifest": "(No tensions)",
+            "dilemma_manifest": "(No dilemmas)",
         }
         mock_discuss.return_value = ([], 1, 100)
         mock_summarize.return_value = ("Brief", 50)
@@ -278,9 +278,11 @@ async def test_execute_uses_seed_summarize_prompt() -> None:
         mock_prompt.assert_called_once()
         call_kwargs = mock_prompt.call_args.kwargs
         assert call_kwargs["entity_count"] == 1
-        assert call_kwargs["tension_count"] == 0
+        assert call_kwargs["tension_count"] == 0  # Still uses tension_count param name (legacy)
         assert "hero" in call_kwargs["entity_manifest"]
-        assert call_kwargs["tension_manifest"] == "(No tensions)"
+        assert (
+            call_kwargs["tension_manifest"] == "(No dilemmas)"
+        )  # Value changed to dilemma terminology
 
         # Verify summarize was called with seed prompt
         assert mock_summarize.call_args.kwargs["system_prompt"] == "Seed summarize prompt"


### PR DESCRIPTION
## Problem

Continuing the terminology rename for issue #338. This PR updates the remaining graph modules, GROW stage, and pipeline stages to use the new terminology (tension→dilemma, thread→path, alternative→answer, knot→intersection).

## Changes

### Graph Modules
- **seed_pruning.py**: Renamed functions (`_prune_demoted_tensions` → `_prune_demoted_dilemmas`, `_get_canonical_alternative` → `_get_canonical_answer`); updated variable names and docstrings
- **mutations.py**: Updated docstrings, error messages, and variable names in `apply_seed_mutations` and `format_semantic_errors_as_content`

### GROW Stage
- **grow_algorithms.py**: Renamed `build_tension_threads` → `build_dilemma_paths` with backward compatibility alias
- **grow_validation.py**: Renamed `check_tensions_resolved` → `check_dilemmas_resolved` with backward compatibility alias; updated docstrings and error messages
- **grow_validators.py**: Updated `validate_phase2_output` parameter from `valid_tension_ids` to `valid_dilemma_ids`; updated intersection terminology

### Pipeline Stages
- **brainstorm.py**: Updated module and class docstrings to use "dilemmas"
- **seed.py**: Updated to use new key names from context.py (`counts["dilemmas"]`, `manifests["dilemma_manifest"]`)
- **grow.py**: Fixed Arc model field name mapping; updated validator call

### Artifacts
- **enrichment.py**: Renamed `_enrich_tensions` → `_enrich_dilemmas`; output now uses "dilemmas" key

### Tests Updated
- test_mutations.py, test_ontology_considered.py, test_seed_stage.py, test_grow_validators.py, test_enrichment.py

## Not Included / Future PRs
- Prompt templates update (PR #7)
- serialize.py extensive refactor (PR #7 or separate)
- tension_scoring.py → dilemma_scoring.py rename (PR #9 cleanup)

## Test Plan
- `uv run pytest tests/unit/` - All 1325 tests pass
- `uv run mypy src/questfoundry/` - No issues
- `uv run ruff check src/questfoundry/` - All checks passed

## Risk / Rollback
- Backward compatibility maintained via function aliases
- Graph storage still uses legacy node types for compatibility

🤖 Generated with [Claude Code](https://claude.com/claude-code)