### PR TITLE
refactor(prompts): update terminology in LLM prompts (#338)

### DIFF
--- a/prompts/templates/discuss_brainstorm.yaml
+++ b/prompts/templates/discuss_brainstorm.yaml
@@ -1,5 +1,5 @@
 name: discuss_brainstorm
-description: Creative exploration phase for generating story entities and tensions
+description: Creative exploration phase for generating story entities and dilemmas
 
 system: |
   You are a creative collaborator helping to brainstorm story elements for an interactive fiction project.
@@ -21,27 +21,27 @@ system: |
   - If something has a physical space where scenes can occur, consider making it a location not an object
   - A story with only 1-2 locations feels confined; more settings enable natural scene variation and convergence points
 
-  2. **Tensions** - Binary dramatic questions that drive the story
-     - Each tension is a yes/no question (e.g., "Can the mentor be trusted?")
-     - Each tension has exactly TWO alternatives (not more, not less)
-     - One alternative should be marked as the "default path" (the canonical story outcome)
-     - For nuanced concepts, use MULTIPLE binary tensions rather than one multi-way choice
-     - Each tension must list its **central entities by ID** (e.g., "Central entities: [entity_id_1], [entity_id_2]")
+  2. **Dilemmas** - Binary dramatic questions that drive the story
+     - Each dilemma is a yes/no question (e.g., "Can the mentor be trusted?")
+     - Each dilemma has exactly TWO answers (not more, not less)
+     - One answer should be marked as the "default path" (the canonical story outcome)
+     - For nuanced concepts, use MULTIPLE binary dilemmas rather than one multi-way choice
+     - Each dilemma must list its **central entities by ID** (e.g., "Central entities: [entity_id_1], [entity_id_2]")
 
   ## Guidelines
-  - Be expansive! Generate MORE material than needed (15-25 entities, 4-8 tensions is good)
+  - Be expansive! Generate MORE material than needed (15-25 entities, 4-8 dilemmas is good)
   - Include rich notes from discussion - preserve creative context
-  - Every tension must explicitly list central entity IDs (use the same IDs you gave the entities)
-  - Every tension needs a "why_it_matters" explaining thematic stakes
+  - Every dilemma must explicitly list central entity IDs (use the same IDs you gave the entities)
+  - Every dilemma needs a "why_it_matters" explaining thematic stakes
   - Don't self-censor - SEED stage will filter later
   {research_tools_section}
 
-  ## Binary Tension Examples
+  ## Binary Dilemma Examples
   Good: "Is the mentor benevolent or self-serving?" (yes/no)
   Good: "Is the archive's knowledge salvation or corruption?" (binary choice)
   Bad: "What is the mentor's alignment?" (open-ended, not binary)
 
-  ## Tension ID Naming
+  ## Dilemma ID Naming
   Use descriptive binary format: `[subject]_[optionA]_or_[optionB]`
 
   FORMAT: `[subject]_[optionA]_or_[optionB]`
@@ -50,16 +50,16 @@ system: |
   - Fantasy: `mentor_benevolent_or_manipulative`, `artifact_blessed_or_cursed`
   - Sci-fi: `ai_helpful_or_hostile`, `colony_thriving_or_doomed`
 
-  BAD: `t1`, `character_motivation`, `trust_issue` (too short or ambiguous)
+  BAD: `d1`, `character_motivation`, `trust_issue` (too short or ambiguous)
 
-  **DO NOT copy example IDs** - generate IDs specific to YOUR story's characters and tensions.
+  **DO NOT copy example IDs** - generate IDs specific to YOUR story's characters and dilemmas.
 
   ## What NOT to Do
   - Do NOT write prose paragraphs with backstories - use concise notes
   - Do NOT include atmospheric descriptions - save prose for FILL stage
   - Do NOT end with "let me know if you need..." - this is not a chat
   - Do NOT ask clarifying questions in non-interactive mode
-  - Do NOT use short codes like `t1`, `t2` for tension IDs - use descriptive names
+  - Do NOT use short codes like `d1`, `d2` for dilemma IDs - use descriptive names
 
   ## Output Format Examples
 

--- a/prompts/templates/discuss_seed.yaml
+++ b/prompts/templates/discuss_seed.yaml
@@ -3,7 +3,7 @@ description: Curate brainstorm material into committed story structure
 
 system: |
   You are a story architect transforming brainstormed material into committed
-  story structure. This is the SEED stage - the last point where new threads
+  story structure. This is the SEED stage - the last point where new paths
   can be created.
 
   ## What You're Working With
@@ -16,13 +16,13 @@ system: |
 
   Every entity needs exactly ONE decision (retain or cut). No entity can be skipped.
 
-  **Tensions** are binary dramatic questions with two mutually exclusive alternatives:
+  **Dilemmas** are binary dramatic questions with two mutually exclusive answers:
   - One is **canonical** (marked `is_default_path: true`) - the spine/default story
   - One is **non-canonical** - exploring it creates a branch
 
-  **Threads** are storylines you commit to developing from explored alternatives.
-  The canonical alternative ALWAYS becomes a thread. You decide which non-canonical
-  alternatives ALSO become threads.
+  **Paths** are storylines you commit to developing from explored answers.
+  The canonical answer ALWAYS becomes a path. You decide which non-canonical
+  answers ALSO become paths.
 
   ## Brainstorm Context
   {brainstorm_context}
@@ -34,7 +34,7 @@ system: |
   For each entity, decide: retain or cut?
 
   Ask these questions:
-  - Is it central to a tension? (Check `central_entity_ids`)
+  - Is it central to a dilemma? (Check `central_entity_ids`)
   - Will it appear in scenes?
   - Is it redundant with another entity?
   - Does cutting it reduce location variety too much? (Keep 3-5 locations)
@@ -42,9 +42,9 @@ system: |
   Remember: Factions serve different narrative functions than characters - don't cut
   a faction just because a character represents it.
 
-  ### 2. Choose Which Alternatives to Explore
+  ### 2. Choose Which Answers to Explore
 
-  Explore both alternatives when the tension is:
+  Explore both answers when the dilemma is:
 
   - **Identity-defining**: Does this shape WHO the protagonist is or their core values?
     - YES: "Betray friend vs stay loyal"
@@ -54,48 +54,48 @@ system: |
     - GOOD: "Save village but lose trail" vs "Pursue kidnapper while village burns"
     - BAD: "Help innocent" vs "Be pointlessly cruel" (obvious answer)
 
-  - **Distinct in content**: Do alternatives lead to genuinely different scenes?
-    - GOOD: Alternative A = confrontation, Alternative B = investigation
+  - **Distinct in content**: Do answers lead to genuinely different scenes?
+    - GOOD: Answer A = confrontation, Answer B = investigation
     - BAD: Both lead to same scene with slightly different dialogue
 
   Leave as implicit (shadow) when:
-  - The alternative is atmospheric, not plot-changing
+  - The answer is atmospheric, not plot-changing
   - One side is clearly "right" (no real dilemma)
   - The content would be similar either way
 
-  **The Power of Shadows**: Implicit alternatives are NOT failures - they create
+  **The Power of Shadows**: Implicit answers are NOT failures - they create
   narrative depth. A story where Mentor is benevolent becomes MORE powerful when
   the player COULD have discovered he was manipulative - but didn't. The shadow
   enriches the text without adding complexity.
 
-  Explore all alternatives you find compelling. The system will balance scope
+  Explore all answers you find compelling. The system will balance scope
   automatically - you don't need to count arcs or worry about limits.
 
-  ### 3. Create Threads from Explored Alternatives
+  ### 3. Create Paths from Explored Answers
 
-  For each explored alternative, create a thread with:
-  - A short, distinct ID (different from the tension ID!)
+  For each explored answer, create a path with:
+  - A short, distinct ID (different from the dilemma ID!)
   - A tier: **major** (interweaves with other majors) or **minor** (supports)
   - A description of what this storyline explores
   - Consequences: what this path means narratively
 
-  ### 4. Create Initial Beats for Each Thread
+  ### 4. Create Initial Beats for Each Path
 
-  Each thread needs opening beats (2-4 per thread). Beats are scenes or moments that:
-  - Establish the thread's premise
+  Each path needs opening beats (2-4 per path). Beats are scenes or moments that:
+  - Establish the path's premise
   - Feature relevant entities from your retained list
   - Vary locations (not all beats in one place)
-  - Impact tensions (advance, reveal, commit, complicate)
+  - Impact dilemmas (advance, reveal, commit, complicate)
 
   ### 5. Sketch Convergence
 
-  Hint at where threads should merge and what differences persist after convergence.
+  Hint at where paths should merge and what differences persist after convergence.
 
   ## ID Rules (Prevent Validation Failures)
 
-  **Thread IDs vs Tension IDs** must be different:
-  - Tension: `mentor_trust_or_betray` (the binary question)
-  - Thread: `mentor_loyalty` (the storyline exploring it)
+  **Path IDs vs Dilemma IDs** must be different:
+  - Dilemma: `mentor_trust_or_betray` (the binary question)
+  - Path: `mentor_loyalty` (the storyline exploring it)
 
   **Entity IDs** - use EXACTLY as they appear in BRAINSTORM:
   - Use `dr_elara_voss`, not `elara` or `dr_voss`
@@ -108,37 +108,37 @@ system: |
   ## Example: Reasoning Through Decisions
 
   **Entity Triage**:
-  - `lighthouse_keeper`: Central to keeper tension? Yes. Appears in scenes? Yes. → RETAIN
-  - `supply_boat`: Central to tensions? No. Have 4 other locations. → CUT
+  - `lighthouse_keeper`: Central to keeper dilemma? Yes. Appears in scenes? Yes. → RETAIN
+  - `supply_boat`: Central to dilemmas? No. Have 4 other locations. → CUT
 
-  **Alternative Exploration**:
-  - Tension `keeper_honest_or_hiding`:
+  **Answer Exploration**:
+  - Dilemma `keeper_honest_or_hiding`:
     - Identity-defining? Yes (trust is core to mystery)
     - Genuine dilemma? Yes (both paths compelling)
     - Distinct content? Yes (ally vs obstacle)
     - → EXPLORE BOTH
 
-  - Tension `weather_storm_or_clear`:
+  - Dilemma `weather_storm_or_clear`:
     - Identity-defining? No (atmosphere only)
     - → EXPLORE CANONICAL ONLY (storm as shadow adds stakes)
 
-  **Thread Creation** (from `keeper_hiding` alternative):
+  **Path Creation** (from `keeper_hiding` answer):
   ```
-  Thread: keeper_secret
+  Path: keeper_secret
   Tier: major
   Description: The keeper conceals evidence of a shipwreck, forcing investigation
   Consequences: keeper_confrontation, evidence_hidden
   ```
 
-  ## Tension Impact Effects
+  ## Dilemma Impact Effects
   - **advances**: Moves toward resolution without revealing answer
   - **reveals**: Surfaces information bearing on the question
-  - **commits**: Point of no return - alternative is locked in
+  - **commits**: Point of no return - answer is locked in
   - **complicates**: Introduces doubt or new dimension
 
   ## What NOT to Do
-  - Do NOT skip beat creation - every thread needs beats
-  - Do NOT reuse tension IDs as thread IDs
+  - Do NOT skip beat creation - every path needs beats
+  - Do NOT reuse dilemma IDs as path IDs
   - Do NOT invent locations not in BRAINSTORM
   - Do NOT use objects as locations (objects are NOT places)
   - Do NOT ask clarifying questions in non-interactive mode

--- a/prompts/templates/grow_phase2_agnostic.yaml
+++ b/prompts/templates/grow_phase2_agnostic.yaml
@@ -1,60 +1,60 @@
 name: grow_phase2_agnostic
-description: Assess which beats are thread-agnostic for their tensions
+description: Assess which beats are path-agnostic for their dilemmas
 
 system: |
-  You are analyzing story beats to determine which ones are "thread-agnostic".
+  You are analyzing story beats to determine which ones are "path-agnostic".
 
-  ## What is Thread-Agnostic?
-  A beat is thread-agnostic for a tension when its prose would read the same
-  regardless of which thread (path) the reader is on for that tension.
+  ## What is Path-Agnostic?
+  A beat is path-agnostic for a dilemma when its prose would read the same
+  regardless of which path the reader is on for that dilemma.
 
   This is about PROSE COMPATIBILITY, not logical compatibility:
-  - A beat describing "the hero enters the tavern" is thread-agnostic if it
-    doesn't reference any thread-specific choices or consequences.
+  - A beat describing "the hero enters the tavern" is path-agnostic if it
+    doesn't reference any path-specific choices or consequences.
   - A beat describing "the hero, grateful for the mentor's guidance" is NOT
-    thread-agnostic for the mentor_trust tension, because it assumes the
+    path-agnostic for the mentor_trust dilemma, because it assumes the
     trust path was chosen.
 
   ## Examples
 
-  THREAD-AGNOSTIC:
-  - "The hero arrives at the crossroads" (no thread-specific references)
+  PATH-AGNOSTIC:
+  - "The hero arrives at the crossroads" (no path-specific references)
   - "Night falls over the village" (purely environmental)
   - "The artifact glows faintly" (describes object without path-dependent context)
 
-  NOT THREAD-AGNOSTIC:
+  NOT PATH-AGNOSTIC:
   - "The mentor smiles, pleased with the hero's trust" (references trust path)
   - "Having rejected the artifact, the hero feels lighter" (references specific choice)
   - "The ally they saved earlier returns" (references specific path outcome)
 
   ## Your Task
   For each beat listed below, assess whether its prose would be compatible
-  across all threads of each tension it belongs to. If yes, mark it as
-  agnostic for that tension.
+  across all paths of each dilemma it belongs to. If yes, mark it as
+  agnostic for that dilemma.
 
   ## Candidate Beats
   {beat_summaries}
 
   ## Valid IDs
   Valid beat_ids: {valid_beat_ids}
-  Valid tension IDs for agnostic_for: {valid_tension_ids}
+  Valid dilemma IDs for agnostic_for: {valid_dilemma_ids}
 
   ## What NOT to Do
   - Do NOT use partial beat IDs like "opening" (must include "beat::" prefix)
-  - Do NOT invent tension IDs not listed in the Valid IDs section
+  - Do NOT invent dilemma IDs not listed in the Valid IDs section
   - Do NOT include beats with empty agnostic_for arrays
-  - Do NOT include beats that are NOT thread-agnostic for any tension
+  - Do NOT include beats that are NOT path-agnostic for any dilemma
 
   ## Output Format
   Return a JSON object with an "assessments" array. Each assessment has:
   - beat_id: the full beat ID (e.g., "beat::opening")
-  - agnostic_for: list of tension raw_ids this beat is agnostic for
+  - agnostic_for: list of dilemma raw_ids this beat is agnostic for
 
-  Only include beats that ARE thread-agnostic for at least one tension.
-  Omit beats that are NOT thread-agnostic for any tension.
+  Only include beats that ARE path-agnostic for at least one dilemma.
+  Omit beats that are NOT path-agnostic for any dilemma.
 
 user: |
-  Analyze the candidate beats above and return your thread-agnostic assessments.
+  Analyze the candidate beats above and return your path-agnostic assessments.
 
   REMINDER: Return ONLY a valid JSON object. Use ONLY IDs from the Valid IDs section. Do NOT add prose before or after the JSON.
 

--- a/prompts/templates/grow_phase3_knots.yaml
+++ b/prompts/templates/grow_phase3_knots.yaml
@@ -1,30 +1,30 @@
-name: grow_phase3_knots
-description: Cluster beats from different tensions into knot scenes
+name: grow_phase3_intersections
+description: Cluster beats from different dilemmas into intersection scenes
 
 system: |
-  You are analyzing story beats to find "knots" -- scenes where multiple
-  narrative tensions intersect in the same location or moment.
+  You are analyzing story beats to find "intersections" -- scenes where multiple
+  narrative dilemmas meet in the same location or moment.
 
-  ## What is a Knot?
-  A knot occurs when beats from DIFFERENT tensions naturally occur in the
+  ## What is an Intersection?
+  An intersection occurs when beats from DIFFERENT dilemmas naturally occur in the
   same scene. For example:
-  - The hero meets the mentor (mentor_trust tension) at the market where
-    the artifact is displayed (artifact_quest tension). These beats form a knot.
+  - The hero meets the mentor (mentor_trust dilemma) at the market where
+    the artifact is displayed (artifact_quest dilemma). These beats form an intersection.
 
   ## Clustering Rules
-  1. Each knot must contain beats from at least 2 DIFFERENT tensions
-  2. Beats in a knot should share a plausible location or moment
+  1. Each intersection must contain beats from at least 2 DIFFERENT dilemmas
+  2. Beats in an intersection should share a plausible location or moment
   3. Prefer location overlap as the strongest signal for clustering
   4. Entity overlap (same character in both beats) is a secondary signal
-  5. CRITICAL: Each beat can appear in at most ONE knot. Never assign the
-     same beat to multiple knots.
+  5. CRITICAL: Each beat can appear in at most ONE intersection. Never assign the
+     same beat to multiple intersections.
 
   ## What NOT to Do
-  - Do NOT group beats from the same tension (those are alternatives, not knots)
-  - Do NOT propose knots with only 1 beat
+  - Do NOT group beats from the same dilemma (those are paths, not intersections)
+  - Do NOT propose intersections with only 1 beat
   - Do NOT use beat IDs not listed in the Valid IDs section
-  - Do NOT force knots where there is no natural scene overlap
-  - Do NOT reuse a beat ID across multiple knot proposals
+  - Do NOT force intersections where there is no natural scene overlap
+  - Do NOT reuse a beat ID across multiple intersection proposals
 
   ## Candidate Beats
   {beat_summaries}
@@ -34,17 +34,17 @@ system: |
   Total candidates: {candidate_count}
 
   ## Output Format
-  Return a JSON object with a "knots" array. Each knot has:
-  - beat_ids: list of beat IDs that form the knot (minimum 2)
+  Return a JSON object with an "intersections" array. Each intersection has:
+  - beat_ids: list of beat IDs that form the intersection (minimum 2)
   - resolved_location: the location where this combined scene takes place (or null)
   - rationale: a concise sentence explaining why these beats form a natural scene
     (e.g., "Both beats occur at the market and involve the hero interacting with key NPCs")
 
-  Only propose knots where the beats genuinely share a scene context.
-  If no natural knots exist, return an empty knots array.
+  Only propose intersections where the beats genuinely share a scene context.
+  If no natural intersections exist, return an empty intersections array.
 
 user: |
-  Analyze the candidate beats above and propose knot groupings.
+  Analyze the candidate beats above and propose intersection groupings.
 
   REMINDER: Return ONLY a valid JSON object. Use ONLY IDs from the Valid IDs section. Do NOT add prose before or after the JSON.
 

--- a/prompts/templates/grow_phase4a_scene_types.yaml
+++ b/prompts/templates/grow_phase4a_scene_types.yaml
@@ -13,7 +13,7 @@ system: |
     observation) that connects larger beats without standalone drama.
 
   ## Classification Guidelines
-  1. Beats with tension_impacts (commits/escalates) are scenes — they drive conflict forward
+  1. Beats with dilemma_impacts (commits/escalates) are scenes — they drive conflict forward
   2. Opening/setup beats are scenes (they introduce conflict or establish stakes)
   3. Beats after major decisions are sequels (processing the choice, emotional reaction)
   4. Short connecting beats with no named characters acting are micro_beats

--- a/prompts/templates/grow_phase4b_narrative_gaps.yaml
+++ b/prompts/templates/grow_phase4b_narrative_gaps.yaml
@@ -1,19 +1,19 @@
 name: grow_phase4b_narrative_gaps
-description: Identify missing beats in thread sequences
+description: Identify missing beats in path sequences
 
 system: |
-  You are analyzing thread beat sequences to find narrative gaps --
+  You are analyzing path beat sequences to find narrative gaps --
   places where the story jumps too abruptly between beats.
 
   ## What is a Narrative Gap?
-  A gap occurs when a thread's beat sequence lacks a natural transition.
+  A gap occurs when a path's beat sequence lacks a natural transition.
   For example:
   - Setup directly to climax (missing development/escalation)
   - Decision directly to consequence (missing reaction/processing)
   - Introduction directly to commitment (missing exploration)
 
-  ## Thread Sequences (in execution order)
-  {thread_sequences}
+  ## Path Sequences (in execution order)
+  {path_sequences}
 
   ## Gap Detection Rules
   1. Look for jumps in narrative intensity (setup to climax with nothing between)
@@ -25,28 +25,28 @@ system: |
   5. Gap beats should be concise transitions, not major story events
 
   ## What NOT to Do
-  - Do NOT propose gaps for threads with only 1-2 beats (those are minimal by design)
+  - Do NOT propose gaps for paths with only 1-2 beats (those are minimal by design)
   - Do NOT propose gaps between beats that already flow naturally
   - Do NOT use IDs not listed in the Valid IDs section
-  - Do NOT propose more than 2 gap beats per thread
+  - Do NOT propose more than 2 gap beats per path
   - Do NOT add explanatory prose before or after the JSON output
 
   ## Valid IDs
-  Valid thread_ids: {valid_thread_ids}
+  Valid path_ids: {valid_path_ids}
   Valid beat_ids (for after_beat/before_beat): {valid_beat_ids}
 
   ## Output Format
   Return a JSON object with a "gaps" array. Each gap has:
-  - thread_id: the thread this gap belongs to (use prefixed form, e.g., "thread::name")
-  - after_beat: the beat this gap comes after (or null for start of thread)
-  - before_beat: the beat this gap comes before (or null for end of thread)
+  - path_id: the path this gap belongs to (use prefixed form, e.g., "p::dilemma__answer")
+  - after_beat: the beat this gap comes after (or null for start of path)
+  - before_beat: the beat this gap comes before (or null for end of path)
   - summary: a concise description of the gap beat (1 sentence)
   - scene_type: "scene", "sequel", or "micro_beat" (default: "sequel")
 
   If no gaps are needed, return an empty gaps array.
 
 user: |
-  Analyze the thread sequences above and propose gap beats where needed.
+  Analyze the path sequences above and propose gap beats where needed.
 
   REMINDER: Return ONLY a valid JSON object. Use ONLY IDs from the Valid IDs section. Do NOT add prose before or after the JSON.
 

--- a/prompts/templates/grow_phase4c_pacing_gaps.yaml
+++ b/prompts/templates/grow_phase4c_pacing_gaps.yaml
@@ -2,7 +2,7 @@ name: grow_phase4c_pacing_gaps
 description: Fix pacing issues with correction beats
 
 system: |
-  You are fixing pacing issues in story threads. Pacing problems occur
+  You are fixing pacing issues in story paths. Pacing problems occur
   when 3 or more consecutive beats have the same scene type (all scenes,
   all sequels, or all micro_beats).
 
@@ -29,13 +29,13 @@ system: |
   - Do NOT add explanatory prose before or after the JSON output
 
   ## Valid IDs
-  Valid thread_ids: {valid_thread_ids}
+  Valid path_ids: {valid_path_ids}
   Valid beat_ids: {valid_beat_ids}
   Issues to fix: {issue_count}
 
   ## Output Format
   Return a JSON object with a "gaps" array. Each gap has:
-  - thread_id: the thread this correction belongs to (use prefixed form)
+  - path_id: the path this correction belongs to (use prefixed form)
   - after_beat: the beat this correction comes after
   - before_beat: the beat this correction comes before
   - summary: a concise description of the correction beat (1 sentence)

--- a/prompts/templates/serialize_brainstorm.yaml
+++ b/prompts/templates/serialize_brainstorm.yaml
@@ -21,19 +21,19 @@ system: |
   - `concept`: One-line essence from the brief
   - `notes`: Optional additional context from the brief
 
-  ## Tension Structure
+  ## Dilemma Structure
 
-  Tensions represent binary dramatic questions with exactly TWO alternatives:
-  - `tension_id`: Descriptive snake_case identifier showing the binary choice
+  Dilemmas represent binary dramatic questions with exactly TWO answers:
+  - `dilemma_id`: Descriptive snake_case identifier showing the binary choice
   - `question`: The dramatic question (should end with "?")
-  - `alternatives`: Exactly 2 items, each with:
-    - `alternative_id`: Unique short identifier for THIS alternative (e.g., "guilty", "framed", "dagger", "poison")
+  - `answers`: Exactly 2 items, each with:
+    - `answer_id`: Unique short identifier for THIS answer (e.g., "guilty", "framed", "dagger", "poison")
     - `description`: Full description
-    - `is_default_path`: true for ONE alternative (the default path), false for the other
-  - `central_entity_ids`: List of entity_id values related to this tension
+    - `is_default_path`: true for ONE answer (the default path), false for the other
+  - `central_entity_ids`: List of entity_id values related to this dilemma
   - `why_it_matters`: Thematic stakes
 
-  ## Tension ID Naming (CRITICAL)
+  ## Dilemma ID Naming (CRITICAL)
 
   Use descriptive binary format that shows both options: `subject_optionA_or_optionB`
 
@@ -45,30 +45,30 @@ system: |
   - `[faction]_[stance1]_or_[stance2]` for group conflicts
 
   BAD examples (will cause downstream failures):
-  - `t1`, `t2`, `tension_a` (too short, not descriptive)
-  - `character_motivation` (ambiguous, could be confused with thread name)
+  - `d1`, `d2`, `dilemma_a` (too short, not descriptive)
+  - `character_motivation` (ambiguous, could be confused with path name)
   - `trust_issue` (too vague)
-  - `single_word` (could be mistaken for a thread ID)
+  - `single_word` (could be mistaken for a path ID)
 
   **DO NOT copy IDs from other stories** - generate IDs specific to YOUR story.
 
-  The tension_id should clearly show the binary choice being made.
+  The dilemma_id should clearly show the binary choice being made.
 
   ## Guidelines
 
   - Extract ALL characters, locations, objects, and factions from the brief as entities
-  - Extract ALL tensions/dramatic questions mentioned
+  - Extract ALL dilemmas/dramatic questions mentioned
   - Do NOT invent new details - only structure what's in the brief
   - Use snake_case for all IDs (lowercase with underscores)
-  - Each tension must have exactly ONE alternative with is_default_path=true
-  - CRITICAL: alternative_id must be UNIQUE identifiers (e.g., "guilty", "framed"), NOT entity references
+  - Each dilemma must have exactly ONE answer with is_default_path=true
+  - CRITICAL: answer_id must be UNIQUE identifiers (e.g., "guilty", "framed"), NOT entity references
 
   ## Output
 
   Return ONLY valid JSON matching BrainstormOutput schema:
   {
     "entities": [...],
-    "tensions": [...]
+    "dilemmas": [...]
   }
 
 components: []

--- a/prompts/templates/serialize_seed.yaml
+++ b/prompts/templates/serialize_seed.yaml
@@ -8,8 +8,8 @@ system: |
 
   All IDs use type prefixes for disambiguation. Copy IDs EXACTLY as shown in the brief:
   - Entity IDs: `entity::butler`, `entity::manor`
-  - Tension IDs: `tension::host_benevolent_or_selfish`
-  - Thread IDs: `thread::host_motive`
+  - Dilemma IDs: `d::host_benevolent_or_selfish`
+  - Path IDs: `p::host_benevolent_or_selfish__protector` (hierarchical format: dilemma__answer)
 
   The manifest shows which IDs are valid - copy them with their prefixes.
 
@@ -27,56 +27,56 @@ system: |
   ```
   IMPORTANT: Include ALL entity types - don't skip factions!
 
-  ### 2. tensions (Tension Decisions)
-  For each tension from brainstorm, create a TensionDecision:
+  ### 2. dilemmas (Dilemma Decisions)
+  For each dilemma from brainstorm, create a DilemmaDecision:
   ```json
   {
-    "tension_id": "tension::host_benevolent_or_selfish",
+    "dilemma_id": "d::host_benevolent_or_selfish",
     "considered": ["protector", "manipulator"],
     "implicit": []
   }
   ```
   NOTES:
-  - The default path alternative (is_default_path=true) MUST be in "considered", never in "implicit".
-  - **Arc Count**: At least 2 tensions should have BOTH alternatives in "considered" for proper IF branching.
-  - Tensions with only canonical alternative explored don't contribute to branching.
+  - The default path answer (is_default_path=true) MUST be in "considered", never in "implicit".
+  - **Arc Count**: At least 2 dilemmas should have BOTH answers in "considered" for proper IF branching.
+  - Dilemmas with only canonical answer explored don't contribute to branching.
 
-  ### 3. threads (Plot Threads)
-  For each explored alternative, create a Thread:
+  ### 3. paths (Story Paths)
+  For each explored answer, create a Path:
   ```json
   {
-    "thread_id": "thread::host_motive",
-    "name": "Human Readable Thread Name",
-    "tension_id": "tension::host_benevolent_or_selfish",
-    "alternative_id": "protector",
-    "unexplored_alternative_ids": ["manipulator"],
-    "thread_importance": "major",
-    "description": "What this thread is about",
+    "path_id": "p::host_benevolent_or_selfish__protector",
+    "name": "Human Readable Path Name",
+    "dilemma_id": "d::host_benevolent_or_selfish",
+    "answer_id": "protector",
+    "unexplored_answer_ids": ["manipulator"],
+    "path_importance": "major",
+    "description": "What this path is about",
     "consequence_ids": ["host_revealed"]
   }
   ```
 
   ### 4. consequences (Narrative Consequences)
-  For each thread, create its Consequences:
+  For each path, create its Consequences:
   ```json
   {
     "consequence_id": "host_revealed",
-    "thread_id": "thread::host_motive",
+    "path_id": "p::host_benevolent_or_selfish__protector",
     "description": "What happens narratively",
     "narrative_effects": ["story effect 1", "story effect 2"]
   }
   ```
 
-  ### 5. initial_beats (Initial Beats - 2-4 per thread)
-  Create 2-4 InitialBeat objects PER THREAD. With 3 threads, expect 6-12 beats total.
+  ### 5. initial_beats (Initial Beats - 2-4 per path)
+  Create 2-4 InitialBeat objects PER PATH. With 3 paths, expect 6-12 beats total.
   ```json
   {
     "beat_id": "host_motive_beat_01",
     "summary": "What happens in this beat",
-    "threads": ["thread::host_motive"],
-    "tension_impacts": [
+    "paths": ["p::host_benevolent_or_selfish__protector"],
+    "dilemma_impacts": [
       {
-        "tension_id": "tension::host_benevolent_or_selfish",
+        "dilemma_id": "d::host_benevolent_or_selfish",
         "effect": "advances",
         "note": "Explanation of the impact"
       }
@@ -90,7 +90,7 @@ system: |
   ### 6. convergence_sketch
   ```json
   {
-    "convergence_points": ["where threads should merge"],
+    "convergence_points": ["where paths should merge"],
     "residue_notes": ["differences that persist after convergence"]
   }
   ```
@@ -100,8 +100,8 @@ system: |
   | Brief Section      | SeedOutput Field    |
   |--------------------|---------------------|
   | Entity Decisions   | entities            |
-  | Tension Decisions  | tensions            |
-  | Threads            | threads             |
+  | Dilemma Decisions  | dilemmas            |
+  | Paths              | paths               |
   | Consequences       | consequences        |
   | Initial Beats      | initial_beats       |
   | Convergence Sketch | convergence_sketch  |
@@ -111,11 +111,11 @@ system: |
   - Extract ALL information from the brief - do not invent new details
   - Use snake_case for all IDs
   - Copy IDs EXACTLY as shown in the brief, INCLUDING the type prefix
-  - Every thread must reference a valid tension_id (with `tension::` prefix) and alternative_id
-  - Every consequence must reference a valid thread_id (with `thread::` prefix)
-  - Create 2-4 initial_beats PER THREAD (not 1 per thread!)
-  - Every initial_beat must reference valid thread IDs (with `thread::` prefix)
-  - thread_importance must be exactly "major" or "minor" (lowercase)
+  - Every path must reference a valid dilemma_id (with `d::` prefix) and answer_id
+  - Every consequence must reference a valid path_id (with `p::` prefix)
+  - Create 2-4 initial_beats PER PATH (not 1 per path!)
+  - Every initial_beat must reference valid path IDs (with `p::` prefix)
+  - path_importance must be exactly "major" or "minor" (lowercase)
   - effect must be exactly "advances", "reveals", "commits", or "complicates"
   - disposition must be exactly "retained" or "cut"
 

--- a/prompts/templates/serialize_seed_sections.yaml
+++ b/prompts/templates/serialize_seed_sections.yaml
@@ -45,26 +45,26 @@ entities_prompt: |
   ## Output
   Return ONLY valid JSON with the "entities" array.
 
-# Section 2: Tension Decisions
-tensions_prompt: |
-  You are generating TENSION DECISIONS for a SEED stage.
+# Section 2: Dilemma Decisions
+dilemmas_prompt: |
+  You are generating DILEMMA DECISIONS for a SEED stage.
 
   ## Generation Requirements (CRITICAL)
-  You MUST generate a decision for EVERY tension ID in the manifest below.
+  You MUST generate a decision for EVERY dilemma ID in the manifest below.
   Missing items WILL cause validation failure. This is NOT extraction - you must
-  generate decisions for ALL tensions, even if the brief doesn't mention them explicitly.
+  generate decisions for ALL dilemmas, even if the brief doesn't mention them explicitly.
 
   ## Scoped ID Format (CRITICAL)
-  All IDs use type prefixes for disambiguation. Copy tension IDs EXACTLY as shown in
-  the manifest, including the `tension::` prefix.
+  All IDs use type prefixes for disambiguation. Copy dilemma IDs EXACTLY as shown in
+  the manifest, including the `d::` prefix.
 
   ## Schema
-  Return a JSON object with a "tensions" array. Each item is a TensionDecision:
+  Return a JSON object with a "dilemmas" array. Each item is a DilemmaDecision:
   ```json
   {
-    "tensions": [
+    "dilemmas": [
       {
-        "tension_id": "tension::host_benevolent_or_selfish",
+        "dilemma_id": "d::host_benevolent_or_selfish",
         "considered": ["protector", "manipulator"],
         "implicit": []
       }
@@ -72,131 +72,128 @@ tensions_prompt: |
   }
   ```
 
-  Note: `considered` and `implicit` contain raw alternative IDs (no prefix) since
-  they are local to each tension.
+  Note: `considered` and `implicit` contain raw answer IDs (no prefix) since
+  they are local to each dilemma.
 
   ## Rules
-  - tension_id must include the `tension::` prefix and match EXACTLY an ID from the manifest
-  - considered: Alternative IDs to explore as threads (MUST include the default path)
-  - implicit: Alternative IDs NOT explored (become shadows)
-  - Generate a decision for EVERY tension in the manifest
+  - dilemma_id must include the `d::` prefix and match EXACTLY an ID from the manifest
+  - considered: Answer IDs to explore as paths (MUST include the default path)
+  - implicit: Answer IDs NOT explored (become shadows)
+  - Generate a decision for EVERY dilemma in the manifest
 
-  ## CRITICAL INVARIANT: considered ↔ threads linkage
-  The `considered` array defines which alternatives will have threads created.
-  For EACH alternative_id in `considered`, you MUST create a thread later.
-  The thread's `alternative_id` field MUST match an entry in `considered`.
+  ## CRITICAL INVARIANT: considered ↔ paths linkage
+  The `considered` array defines which answers will have paths created.
+  For EACH answer_id in `considered`, you MUST create a path later.
+  The path's `answer_id` field MUST match an entry in `considered`.
 
-  WRONG: `considered: []` with threads that have `alternative_id` values
-  WRONG: `considered: ["opt_a"]` but thread uses `alternative_id: "opt_b"`
-  RIGHT: `considered: ["opt_a", "opt_b"]` and threads use those exact IDs
+  WRONG: `considered: []` with paths that have `answer_id` values
+  WRONG: `considered: ["opt_a"]` but path uses `answer_id: "opt_b"`
+  RIGHT: `considered: ["opt_a", "opt_b"]` and paths use those exact IDs
 
   ## What NOT to Do
-  - Do NOT skip tensions because they aren't mentioned in the brief
-  - Do NOT invent tensions not in the manifest
+  - Do NOT skip dilemmas because they aren't mentioned in the brief
+  - Do NOT invent dilemmas not in the manifest
   - Do NOT partially complete the list
-  - Do NOT leave `considered` empty if you plan to create threads for that tension
-  - Do NOT omit the `tension::` prefix from tension_id
+  - Do NOT leave `considered` empty if you plan to create paths for that dilemma
+  - Do NOT omit the `d::` prefix from dilemma_id
 
   ## Output
-  Return ONLY valid JSON with the "tensions" array.
+  Return ONLY valid JSON with the "dilemmas" array.
 
-# Section 3: Threads
-threads_prompt: |
-  You are generating THREADS for a SEED stage based on tension decisions.
+# Section 3: Paths
+paths_prompt: |
+  You are generating PATHS for a SEED stage based on dilemma decisions.
 
   ## Generation Requirements (CRITICAL)
-  For each "considered" alternative in the tension decisions, you MUST generate a thread.
-  Each thread represents one storyline path that will be developed in the story.
+  For each "considered" answer in the dilemma decisions, you MUST generate a path.
+  Each path represents one storyline that will be developed in the story.
 
   ## Scoped ID Format (CRITICAL)
   All IDs use type prefixes for disambiguation:
-  - thread_id: Use `thread::` prefix (e.g., `thread::host_motive`)
-  - tension_id: Use `tension::` prefix (e.g., `tension::host_benevolent_or_selfish`)
+  - path_id: Use hierarchical `p::` prefix (e.g., `p::host_benevolent_or_selfish__protector`)
+  - dilemma_id: Use `d::` prefix (e.g., `d::host_benevolent_or_selfish`)
+
+  Path IDs embed their parent dilemma: `p::[dilemma_name]__[answer_id]`
 
   Copy IDs EXACTLY as shown in the manifest, including the prefixes.
 
-  ## CRITICAL INVARIANT: alternative_id MUST match considered
-  Each thread's `alternative_id` MUST be one of the IDs listed in the tension's
+  ## CRITICAL INVARIANT: answer_id MUST match considered
+  Each path's `answer_id` MUST be one of the IDs listed in the dilemma's
   `considered` array. This is a hard constraint enforced by validation.
 
-  WRONG: Thread with `alternative_id: "option_b"` when tension has `considered: ["option_a"]`
-  RIGHT: Thread with `alternative_id: "option_a"` when tension has `considered: ["option_a", "option_b"]`
+  WRONG: Path with `answer_id: "option_b"` when dilemma has `considered: ["option_a"]`
+  RIGHT: Path with `answer_id: "option_a"` when dilemma has `considered: ["option_a", "option_b"]`
 
   ## Schema
-  Return a JSON object with a "threads" array. Each item is a Thread:
+  Return a JSON object with a "paths" array. Each item is a Path:
   ```json
   {
-    "threads": [
+    "paths": [
       {
-        "thread_id": "thread::host_motive",
+        "path_id": "p::host_benevolent_or_selfish__protector",
         "name": "The Host's Hidden Motive",
-        "tension_id": "tension::host_benevolent_or_selfish",
-        "alternative_id": "protector",
-        "unexplored_alternative_ids": ["manipulator"],
-        "thread_importance": "major",
-        "description": "What this thread is about",
+        "dilemma_id": "d::host_benevolent_or_selfish",
+        "answer_id": "protector",
+        "unexplored_answer_ids": ["manipulator"],
+        "path_importance": "major",
+        "description": "What this path is about",
         "consequence_ids": ["host_revealed"]
       }
     ]
   }
   ```
 
-  Note: `alternative_id`, `unexplored_alternative_ids`, and `consequence_ids` are raw
+  Note: `answer_id`, `unexplored_answer_ids`, and `consequence_ids` are raw
   IDs without prefixes since they are local identifiers.
 
-  ## Thread ID Naming (CRITICAL)
+  ## Path ID Naming (CRITICAL)
 
-  Thread IDs must be DIFFERENT from tension IDs. Use short descriptive names WITH the
-  `thread::` prefix.
+  Path IDs use hierarchical format that embeds the parent dilemma:
+  `p::[dilemma_name]__[answer_id]`
 
-  FORMAT:
-  - Tension: `tension::[subject]_[optionA]_or_[optionB]` (the binary question)
-  - Thread: `thread::[subject]_[aspect]` (short storyline name)
+  This prevents misreferences since the parent dilemma is embedded in the ID.
 
   Pattern examples (generate YOUR OWN based on your story):
-  - Tension about character loyalty → Thread: `thread::[character]_loyalty`
-  - Tension about artifact's nature → Thread: `thread::[artifact]_secret`
-  - Tension about faction's agenda → Thread: `thread::[faction]_agenda`
+  - Dilemma `d::mentor_trust_or_betray` with answer `trust` → Path: `p::mentor_trust_or_betray__trust`
+  - Dilemma `d::artifact_blessed_or_cursed` with answer `blessed` → Path: `p::artifact_blessed_or_cursed__blessed`
 
   BAD patterns (will cause validation failures):
-  - Using the SAME ID for both tension and thread
-  - Using the tension_id as the thread_id
-  - Omitting the `thread::` prefix
-
-  Thread IDs should be short names for the storyline, NOT the binary question.
+  - Using the SAME ID for both dilemma and path
+  - Missing the `__` separator
+  - Omitting the `p::` prefix
 
   **DO NOT copy example IDs** - generate IDs specific to YOUR story.
 
   ## Rules
-  - thread_importance must be exactly "major" or "minor" (lowercase)
-  - unexplored_alternative_ids: IDs of alternatives NOT explored (implicit ones)
-  - consequence_ids: References to consequences for this thread
-  - Generate a thread for EACH considered alternative from tension decisions
-  - alternative_id MUST be one of the IDs from the tension's `considered` array
-  - thread_id MUST include the `thread::` prefix
-  - tension_id MUST include the `tension::` prefix
+  - path_importance must be exactly "major" or "minor" (lowercase)
+  - unexplored_answer_ids: IDs of answers NOT explored (implicit ones)
+  - consequence_ids: References to consequences for this path
+  - Generate a path for EACH considered answer from dilemma decisions
+  - answer_id MUST be one of the IDs from the dilemma's `considered` array
+  - path_id MUST include the `p::` prefix and use hierarchical format
+  - dilemma_id MUST include the `d::` prefix
 
   ## What NOT to Do
-  - Do NOT reuse tension IDs as thread IDs
-  - Do NOT skip alternatives marked as "considered"
-  - Do NOT create threads for "implicit" alternatives (they become shadows, not threads)
-  - Do NOT use an alternative_id that isn't in the tension's `considered` list
-  - Do NOT omit the `thread::` or `tension::` prefixes
+  - Do NOT reuse dilemma IDs as path IDs
+  - Do NOT skip answers marked as "considered"
+  - Do NOT create paths for "implicit" answers (they become shadows, not paths)
+  - Do NOT use an answer_id that isn't in the dilemma's `considered` list
+  - Do NOT omit the `p::` or `d::` prefixes
 
   ## Output
-  Return ONLY valid JSON with the "threads" array.
+  Return ONLY valid JSON with the "paths" array.
 
 # Section 4: Consequences
 consequences_prompt: |
-  You are generating CONSEQUENCES for a SEED stage based on threads.
+  You are generating CONSEQUENCES for a SEED stage based on paths.
 
   ## Generation Requirements (CRITICAL)
-  Every thread MUST have at least one consequence. Consequences describe the narrative
-  outcomes that result from following a particular thread's storyline.
+  Every path MUST have at least one consequence. Consequences describe the narrative
+  outcomes that result from following a particular path's storyline.
 
   ## Scoped ID Format (CRITICAL)
-  Thread IDs use the `thread::` prefix for disambiguation.
-  Copy thread IDs EXACTLY as shown in the VALID THREAD IDs list.
+  Path IDs use the `p::` prefix for disambiguation.
+  Copy path IDs EXACTLY as shown in the VALID PATH IDs list.
 
   ## Schema
   Return a JSON object with a "consequences" array. Each item is a Consequence:
@@ -205,7 +202,7 @@ consequences_prompt: |
     "consequences": [
       {
         "consequence_id": "host_revealed",
-        "thread_id": "thread::host_motive",
+        "path_id": "p::host_benevolent_or_selfish__protector",
         "description": "What happens narratively",
         "narrative_effects": ["story effect 1", "story effect 2"]
       }
@@ -214,7 +211,7 @@ consequences_prompt: |
   ```
 
   Note: `consequence_id` is a raw ID without prefix (local identifier).
-  `thread_id` MUST include the `thread::` prefix.
+  `path_id` MUST include the `p::` prefix.
 
   ## Consequence ID Naming Convention
 
@@ -230,15 +227,15 @@ consequences_prompt: |
 
   ## Rules
   - consequence_id must be unique (raw ID, no prefix, following naming convention above)
-  - thread_id must include the `thread::` prefix and reference a thread from the VALID THREAD IDs list
+  - path_id must include the `p::` prefix and reference a path from the VALID PATH IDs list
   - narrative_effects: Array of story effects this consequence implies
-  - Generate at least one consequence for EACH thread
+  - Generate at least one consequence for EACH path
 
   ## What NOT to Do
-  - Do NOT reference thread IDs that don't exist
-  - Do NOT leave any thread without consequences
+  - Do NOT reference path IDs that don't exist
+  - Do NOT leave any path without consequences
   - Do NOT use generic consequence IDs like `consequence_1` (use descriptive names)
-  - Do NOT omit the `thread::` prefix from thread_id
+  - Do NOT omit the `p::` prefix from path_id
 
   ## Output
   Return ONLY valid JSON with the "consequences" array.
@@ -248,20 +245,20 @@ beats_prompt: |
   You are generating INITIAL BEATS for a SEED stage.
 
   ## Generation Requirements (CRITICAL)
-  Generate 2-4 initial beats PER THREAD. If there are 3 threads, expect 6-12 beats total.
+  Generate 2-4 initial beats PER PATH. If there are 3 paths, expect 6-12 beats total.
   Beats must use ONLY valid IDs from the manifest - no invented or derived IDs.
 
   ## CRITICAL: ID CONSTRAINTS (read first!)
 
   The brief contains valid ID lists. You MUST copy IDs exactly from these lists:
-  - `## VALID THREAD IDs` - use ONLY these in `threads` arrays
+  - `## VALID PATH IDs` - use ONLY these in `paths` arrays
   - `### Entity IDs` - use ONLY these in `entities` and `location` fields
 
   WRONG examples that WILL FAIL:
-  - `"clock_distortion"` - NOT a valid thread (derived from concept)
+  - `"clock_distortion"` - NOT a valid path (derived from concept)
   - `"the_garden"` - WRONG, use `"garden"` (no prefix)
-  - `"murder_intent"` - This is a tension ID, not a thread ID
-  - `"seed_of_stillness"` as tension_id - WRONG, this is an entity (no `_or_` = not a tension)
+  - `"murder_intent"` - This is a dilemma ID, not a path ID
+  - `"seed_of_stillness"` as dilemma_id - WRONG, this is an entity (no `_or_` = not a dilemma)
 
   ## Schema
   Return a JSON object with an "initial_beats" array:
@@ -271,10 +268,10 @@ beats_prompt: |
       {
         "beat_id": "unique_beat_id",
         "summary": "What happens in this beat",
-        "threads": ["thread::[your_thread_id]", "thread::[another_thread]"],
-        "tension_impacts": [
+        "paths": ["p::[your_path_id]", "p::[another_path]"],
+        "dilemma_impacts": [
           {
-            "tension_id": "tension::[your_tension_id]",
+            "dilemma_id": "d::[your_dilemma_id]",
             "effect": "advances",
             "note": "Explanation of the impact"
           }
@@ -293,41 +290,41 @@ beats_prompt: |
   - effect must be exactly "advances", "reveals", "commits", or "complicates"
   - All ID fields must use the correct type (see FIELD → ID TYPE MAPPING below)
   - location can be null; location_alternatives can be empty array
-  - Generate 2-4 beats for EACH thread in the VALID THREAD IDs list
-  - tension_impacts MUST use tension IDs from the Tension IDs list — NOT entity names
+  - Generate 2-4 beats for EACH path in the VALID PATH IDs list
+  - dilemma_impacts MUST use dilemma IDs from the Dilemma IDs list — NOT entity names
 
-  ## TENSION IMPACT CONSTRAINT (MOST IMPORTANT RULE)
+  ## DILEMMA IMPACT CONSTRAINT (MOST IMPORTANT RULE)
 
-  Every beat belongs to a thread. Every thread has a PARENT TENSION (shown in the
-  THREAD → TENSION MAPPING in your brief). The beat's tension_impacts MUST include
-  the parent tension of the beat's thread.
+  Every beat belongs to a path. Every path has a PARENT DILEMMA (shown in the
+  PATH → DILEMMA MAPPING in your brief). The beat's dilemma_impacts MUST include
+  the parent dilemma of the beat's path.
 
-  RULE: Look up the beat's thread in THREAD → TENSION MAPPING. Use THAT tension_id.
+  RULE: Look up the beat's path in PATH → DILEMMA MAPPING. Use THAT dilemma_id.
 
   EXAMPLE (format only - use YOUR story's IDs):
-  - If thread `thread::keeper_loyalty` maps to `tension::keeper_faithful_or_corrupt`
-  - Then ALL beats in `thread::keeper_loyalty` MUST have a tension_impact with
-    `tension_id: "tension::keeper_faithful_or_corrupt"`
+  - If path `p::keeper_faithful_or_corrupt__faithful` maps to `d::keeper_faithful_or_corrupt`
+  - Then ALL beats in that path MUST have a dilemma_impact with
+    `dilemma_id: "d::keeper_faithful_or_corrupt"`
 
-  WRONG: Picking a tension because it "feels related" to the beat's content.
-  WRONG: Using the same tension for all beats regardless of thread.
-  RIGHT: Using the THREAD → TENSION MAPPING to find the correct tension.
+  WRONG: Picking a dilemma because it "feels related" to the beat's content.
+  WRONG: Using the same dilemma for all beats regardless of path.
+  RIGHT: Using the PATH → DILEMMA MAPPING to find the correct dilemma.
 
-  A beat MAY have additional tension_impacts for other tensions, but the FIRST
-  tension_impact MUST be the thread's parent tension.
+  A beat MAY have additional dilemma_impacts for other dilemmas, but the FIRST
+  dilemma_impact MUST be the path's parent dilemma.
 
   ## COMMITS BEATS REQUIREMENT (CRITICAL)
 
-  Each thread MUST have at least one beat with `effect: "commits"` — and that
-  commits beat MUST reference the thread's OWN parent tension (from the mapping).
+  Each path MUST have at least one beat with `effect: "commits"` — and that
+  commits beat MUST reference the path's OWN parent dilemma (from the mapping).
 
-  WRONG: All commits beats using the same tension_id.
-  RIGHT: Each thread's commits beat uses that thread's own parent tension.
+  WRONG: All commits beats using the same dilemma_id.
+  RIGHT: Each path's commits beat uses that path's own parent dilemma.
 
   EXAMPLE (format only):
-  - Thread `thread::keeper_loyalty` → commits beat uses `tension::keeper_faithful_or_corrupt`
-  - Thread `thread::artifact_origin` → commits beat uses `tension::artifact_natural_or_crafted`
-  - Each thread resolves ITS OWN tension, not someone else's.
+  - Path `p::keeper_faithful_or_corrupt__faithful` → commits beat uses `d::keeper_faithful_or_corrupt`
+  - Path `p::artifact_natural_or_crafted__natural` → commits beat uses `d::artifact_natural_or_crafted`
+  - Each path resolves ITS OWN dilemma, not someone else's.
 
   ## FIELD → ID TYPE MAPPING (prevents all ID confusion)
 
@@ -335,22 +332,22 @@ beats_prompt: |
 
   | Field | Prefix | Source List | Shape |
   |-------|--------|-------------|-------|
-  | `threads[]` | `thread::` | VALID THREAD IDs | short: `thing_nature` |
-  | `tension_impacts.tension_id` | `tension::` | Tension IDs | long: `subject_X_or_Y` |
+  | `paths[]` | `p::` | VALID PATH IDs | hierarchical: `dilemma__answer` |
+  | `dilemma_impacts.dilemma_id` | `d::` | Dilemma IDs | long: `subject_X_or_Y` |
   | `entities[]` | `entity::` | Entity IDs (characters, objects, factions) | varies |
   | `location` | `entity::` | Entity IDs (locations only) | varies |
 
-  Thread IDs are SHORT storyline names. Tension IDs are LONG binary questions.
+  Path IDs are hierarchical (dilemma__answer). Dilemma IDs are binary questions.
 
-  ## HOW TO TELL TENSION IDs FROM ENTITY IDs (CRITICAL)
+  ## HOW TO TELL DILEMMA IDs FROM ENTITY IDs (CRITICAL)
 
-  Tension IDs ALWAYS contain `_or_` in their name (e.g., `host_benevolent_or_selfish`).
+  Dilemma IDs ALWAYS contain `_or_` in their name (e.g., `host_benevolent_or_selfish`).
   Entity IDs NEVER contain `_or_`.
 
-  If an ID does NOT have `_or_` in it, it is an ENTITY — not a tension.
-  Do NOT use entity IDs like `seed_of_stillness` as tension_ids — `_of_` is NOT `_or_`.
+  If an ID does NOT have `_or_` in it, it is an ENTITY — not a dilemma.
+  Do NOT use entity IDs like `seed_of_stillness` as dilemma_ids — `_of_` is NOT `_or_`.
 
-  Do NOT put a thread ID in tension_impacts or a tension ID in threads.
+  Do NOT put a path ID in dilemma_impacts or a dilemma ID in paths.
   Do NOT put a location in entities or a non-location in location.
   Do NOT invent IDs - copy exactly from the manifest.
 
@@ -358,24 +355,24 @@ beats_prompt: |
 
   If you receive validation feedback about invalid IDs, DO NOT reduce your beat count.
   Fix ONLY the invalid ID references using the table above.
-  Your beat count should stay at 2-4 beats per thread.
+  Your beat count should stay at 2-4 beats per path.
 
   ## What NOT to Do
-  - Do NOT use entity IDs as tension_ids (entity IDs lack `_or_`)
-  - Do NOT derive thread IDs from tension names or concepts
+  - Do NOT use entity IDs as dilemma_ids (entity IDs lack `_or_`)
+  - Do NOT derive path IDs from dilemma names or concepts
   - Do NOT add prefixes like "the_" to entity IDs
-  - Do NOT generate fewer than 2 beats per thread
+  - Do NOT generate fewer than 2 beats per path
   - Do NOT reference IDs not in the manifest lists
 
   ## FINAL CHECK (verify before output)
   Before returning JSON, check each beat one by one:
-  1. Every `threads` item appears in VALID THREAD IDs (short names)
-  2. Every `tension_impacts.tension_id` appears in Tension IDs (long binary questions)
-  3. Every `tension_impacts.tension_id` contains `_or_` — if it doesn't, you used an entity ID by mistake
-  4. For EACH beat: look up the beat's thread in THREAD → TENSION MAPPING.
-     Does the beat's tension_impacts include that mapped tension? If NO, fix it.
-  5. For EACH thread: does at least one of its beats have `effect: "commits"`
-     with that thread's parent tension? If NO, add or fix one.
+  1. Every `paths` item appears in VALID PATH IDs (hierarchical format)
+  2. Every `dilemma_impacts.dilemma_id` appears in Dilemma IDs (long binary questions)
+  3. Every `dilemma_impacts.dilemma_id` contains `_or_` — if it doesn't, you used an entity ID by mistake
+  4. For EACH beat: look up the beat's path in PATH → DILEMMA MAPPING.
+     Does the beat's dilemma_impacts include that mapped dilemma? If NO, fix it.
+  5. For EACH path: does at least one of its beats have `effect: "commits"`
+     with that path's parent dilemma? If NO, add or fix one.
   6. Every `entities` item appears in Entity IDs (characters, objects, factions)
   7. `location` is a location-category entity from Entity IDs
   8. No invented IDs - copy-paste from the manifest, don't retype
@@ -383,61 +380,61 @@ beats_prompt: |
   ## Output
   Return ONLY valid JSON with the "initial_beats" array.
 
-# Section 5b: Per-Thread Initial Beats (used by per-thread serialization)
-# This prompt generates beats for a single thread with a fixed tension_id.
-# The thread_id, tension_id, and entity context are injected at runtime.
-per_thread_beats_prompt: |
-  You are generating INITIAL BEATS for ONE SPECIFIC THREAD.
+# Section 5b: Per-Path Initial Beats (used by per-path serialization)
+# This prompt generates beats for a single path with a fixed dilemma_id.
+# The path_id, dilemma_id, and entity context are injected at runtime.
+per_path_beats_prompt: |
+  You are generating INITIAL BEATS for ONE SPECIFIC PATH.
 
-  ## YOUR THREAD ID (MEMORIZE THIS)
+  ## YOUR PATH ID (MEMORIZE THIS)
 
-  You are generating beats for thread: `{thread_id}`
+  You are generating beats for path: `{path_id}`
 
-  The `threads` field in EVERY beat MUST contain EXACTLY: `["{thread_id}"]`
+  The `paths` field in EVERY beat MUST contain EXACTLY: `["{path_id}"]`
 
   ## COMMON MISTAKE - DO NOT MAKE THIS ERROR
 
-  Thread IDs are SHORT (e.g., `thread::ai_hostile`).
-  Tension IDs are LONG and contain `_or_` (e.g., `tension::ai_orion_benevolent_or_hostile`).
+  Path IDs are hierarchical (e.g., `p::ai_benevolent_or_hostile__hostile`).
+  Dilemma IDs are just the question (e.g., `d::ai_benevolent_or_hostile`).
 
   WRONG OUTPUT (will fail validation):
   ```json
-  "threads": ["{tension_id}"]  // WRONG! This is a TENSION ID (has _or_)
+  "paths": ["{dilemma_id}"]  // WRONG! This is a DILEMMA ID (use d:: prefix)
   ```
 
   CORRECT OUTPUT:
   ```json
-  "threads": ["{thread_id}"]  // RIGHT! This is the THREAD ID (short, no _or_)
+  "paths": ["{path_id}"]  // RIGHT! This is the PATH ID (p:: prefix with __answer)
   ```
 
-  RULE: If the ID contains `_or_`, it's a TENSION. Never put it in `threads`.
+  RULE: If the ID starts with `d::`, it's a DILEMMA. Never put it in `paths`.
 
-  ## YOUR TENSION ID (for tension_impacts only)
+  ## YOUR DILEMMA ID (for dilemma_impacts only)
 
-  Parent tension: `{tension_id}`
+  Parent dilemma: `{dilemma_id}`
 
-  This goes in `tension_impacts[].tension_id`, NOT in `threads`.
+  This goes in `dilemma_impacts[].dilemma_id`, NOT in `paths`.
 
   ## BEAT ID NAMING (CRITICAL - ensures uniqueness)
 
-  Beat IDs MUST be derived from your thread ID to ensure global uniqueness.
+  Beat IDs MUST be derived from your path name to ensure global uniqueness.
 
-  FORMAT: `{thread_name}_beat_[number]`
+  FORMAT: `{path_name}_beat_[number]`
 
-  Your thread name is `{thread_name}`. Use it as prefix with `_beat_01`, `_beat_02`, etc.
+  Your path name is `{path_name}`. Use it as prefix with `_beat_01`, `_beat_02`, etc.
 
-  EXAMPLES (for illustration only - use YOUR thread name):
-  - Thread `keeper_loyalty` → beat IDs: `keeper_loyalty_beat_01`, `keeper_loyalty_beat_02`
-  - Thread `artifact_origin` → beat IDs: `artifact_origin_beat_01`, `artifact_origin_beat_02`
+  EXAMPLES (for illustration only - use YOUR path name):
+  - Path `keeper_loyal` → beat IDs: `keeper_loyal_beat_01`, `keeper_loyal_beat_02`
+  - Path `artifact_natural` → beat IDs: `artifact_natural_beat_01`, `artifact_natural_beat_02`
 
-  WRONG: `beat_001`, `beat_01`, `initial_beat_1` (no thread prefix = collision)
-  RIGHT: `{thread_name}_beat_01` (thread prefix = globally unique)
+  WRONG: `beat_001`, `beat_01`, `initial_beat_1` (no path prefix = collision)
+  RIGHT: `{path_name}_beat_01` (path prefix = globally unique)
 
   ALL beats you generate MUST:
-  1. Have beat_id starting with `{thread_name}_beat_` (see BEAT ID NAMING above)
-  2. Have `threads: ["{thread_id}"]` (exactly this thread ID)
-  3. Have at least one tension_impact with `tension_id: "{tension_id}"`
-  4. Include at least one beat with `effect: "commits"` for `{tension_id}`
+  1. Have beat_id starting with `{path_name}_beat_` (see BEAT ID NAMING above)
+  2. Have `paths: ["{path_id}"]` (exactly this path ID)
+  3. Have at least one dilemma_impact with `dilemma_id: "{dilemma_id}"`
+  4. Include at least one beat with `effect: "commits"` for `{dilemma_id}`
 
   ## Schema
   Return a JSON object with an "initial_beats" array of 2-4 beats:
@@ -445,12 +442,12 @@ per_thread_beats_prompt: |
   {{
     "initial_beats": [
       {{
-        "beat_id": "{thread_name}_beat_01",
+        "beat_id": "{path_name}_beat_01",
         "summary": "What happens in this beat",
-        "threads": ["{thread_id}"],
-        "tension_impacts": [
+        "paths": ["{path_id}"],
+        "dilemma_impacts": [
           {{
-            "tension_id": "{tension_id}",
+            "dilemma_id": "{dilemma_id}",
             "effect": "advances",
             "note": "Explanation"
           }}
@@ -464,37 +461,37 @@ per_thread_beats_prompt: |
   ```
 
   ## Rules
-  - Generate exactly 2-4 beats for thread `{thread_id}`
-  - Beat IDs MUST start with `{thread_name}_beat_` (e.g., `{thread_name}_beat_01`)
-  - EVERY beat must include `{thread_id}` in its `threads` array
-  - EVERY beat must have at least one tension_impact for `{tension_id}`
-  - At least ONE beat must have `effect: "commits"` for `{tension_id}`
+  - Generate exactly 2-4 beats for path `{path_id}`
+  - Beat IDs MUST start with `{path_name}_beat_` (e.g., `{path_name}_beat_01`)
+  - EVERY beat must include `{path_id}` in its `paths` array
+  - EVERY beat must have at least one dilemma_impact for `{dilemma_id}`
+  - At least ONE beat must have `effect: "commits"` for `{dilemma_id}`
   - effect must be "advances", "reveals", "commits", or "complicates"
   - Use entity IDs from the Entity IDs list only
   - Use location IDs from the Entity IDs list (location category only)
 
   ## COMMITS BEAT REQUIREMENT
-  You MUST include exactly one beat with `effect: "commits"` for `{tension_id}`.
-  This beat represents the moment where this thread's tension is locked in.
+  You MUST include exactly one beat with `effect: "commits"` for `{dilemma_id}`.
+  This beat represents the moment where this path's dilemma is locked in.
 
   WRONG: Generating only "advances" and "reveals" beats.
   RIGHT: Including one beat with `effect: "commits"`.
 
   ## What NOT to Do
-  - Do NOT use generic beat IDs like `beat_001` (must include thread name prefix)
-  - Do NOT generate beats for other threads
-  - Do NOT reference other tension_ids in your first tension_impact
+  - Do NOT use generic beat IDs like `beat_001` (must include path name prefix)
+  - Do NOT generate beats for other paths
+  - Do NOT reference other dilemma_ids in your first dilemma_impact
   - Do NOT skip the commits beat
   - Do NOT use IDs not in the manifest
-  - Do NOT put the tension ID in the `threads` field (see COMMON MISTAKE above)
+  - Do NOT put the dilemma ID in the `paths` field (see COMMON MISTAKE above)
 
   ## FINAL VERIFICATION (check before outputting)
 
   For EACH beat you generate, verify:
-  1. `threads` contains `{thread_id}` (SHORT id, NO `_or_` in it)
-  2. `tension_impacts[0].tension_id` is `{tension_id}` (LONG id, HAS `_or_`)
+  1. `paths` contains `{path_id}` (p:: prefix with __answer)
+  2. `dilemma_impacts[0].dilemma_id` is `{dilemma_id}` (d:: prefix)
 
-  If you see `_or_` in your `threads` value, YOU MADE A MISTAKE. Fix it.
+  If you see `d::` in your `paths` value, YOU MADE A MISTAKE. Fix it.
 
   ## Output
   Return ONLY valid JSON with the "initial_beats" array (2-4 beats).
@@ -508,14 +505,14 @@ convergence_prompt: |
   ```json
   {
     "convergence_sketch": {
-      "convergence_points": ["where threads should merge"],
+      "convergence_points": ["where paths should merge"],
       "residue_notes": ["differences that persist after convergence"]
     }
   }
   ```
 
   ## Rules
-  - convergence_points: Where threads should merge (e.g., "by act 2 climax")
+  - convergence_points: Where paths should merge (e.g., "by act 2 climax")
   - residue_notes: What differences persist after convergence
   - Both can be empty arrays if not specified in brief
 

--- a/prompts/templates/summarize_brainstorm.yaml
+++ b/prompts/templates/summarize_brainstorm.yaml
@@ -30,19 +30,19 @@ system: |
   - What they are and their goals
   - Key members or relationships
 
-  ### Dramatic Tensions (aim for 4-8)
-  For each tension, describe in prose:
+  ### Dramatic Dilemmas (aim for 4-8)
+  For each dilemma, describe in prose:
   - The central question or conflict
   - The two possible answers/outcomes (one being the "default path")
   - **Central entity IDs**: List the exact entity IDs involved (e.g., "[character_id], [location_id]")
-  - Why this tension matters thematically
+  - Why this dilemma matters thematically
 
   ## Guidelines
   - Write in flowing prose, not schema fields
-  - Capture ALL entities and tensions mentioned in discussion
+  - Capture ALL entities and dilemmas mentioned in discussion
   - Preserve rich context and reasoning - this helps the serializer
-  - Be specific about which alternative is the "default path"
-  - IMPORTANT: For each tension, list the central entity IDs exactly as defined in the entities section
+  - Be specific about which answer is the "default path"
+  - IMPORTANT: For each dilemma, list the central entity IDs exactly as defined in the entities section
   - If something wasn't discussed, don't invent it
 
   ## Output Format

--- a/prompts/templates/summarize_seed.yaml
+++ b/prompts/templates/summarize_seed.yaml
@@ -8,29 +8,29 @@ system: |
   ## CRITICAL: Manifest Completeness
   Your summary MUST include explicit decisions for:
   - ALL {entity_count} entities listed below
-  - ALL {tension_count} tensions listed below
+  - ALL {dilemma_count} dilemmas listed below
 
-  This is GENERATION, not extraction. Even if an entity/tension wasn't discussed,
+  This is GENERATION, not extraction. Even if an entity/dilemma wasn't discussed,
   you must still include a decision for it (use your judgment to retain or cut).
 
   ## Summarization Priority Order
 
   1. **Completeness over elegance** - Missing an entity is worse than verbose descriptions
   2. **Exact ID matching** - Use IDs exactly as they appear in BRAINSTORM (copy-paste)
-  3. **Transformation clarity** - Show how alternatives became threads
+  3. **Transformation clarity** - Show how answers became paths
 
   ## Common Errors to Avoid
 
   - **Typos in IDs**: `dr_elara_vinoss` vs `dr_elara_voss` - these FAIL validation
   - **Invented locations**: Only BRAINSTORM locations exist
-  - **Duplicate decisions**: Each entity/tension gets ONE decision
+  - **Duplicate decisions**: Each entity/dilemma gets ONE decision
   - **Missing factions**: Check you have decisions for ALL faction entities
 
   ## Required Entity IDs ({entity_count} total)
   {entity_manifest}
 
-  ## Required Tension IDs ({tension_count} total)
-  {tension_manifest}
+  ## Required Dilemma IDs ({dilemma_count} total)
+  {dilemma_manifest}
 
   ## Brainstorm Reference
   {brainstorm_context}
@@ -43,40 +43,40 @@ system: |
   - id: the entity ID from brainstorm
   - disposition: "retained" or "cut"
 
-  ### Tension Decisions
-  For each tension from brainstorm:
-  - tension_id: the tension ID from brainstorm
-  - explored: list of alternative IDs that become threads (MUST include canonical)
-  - implicit: list of alternative IDs NOT explored (shadows for narrative depth)
+  ### Dilemma Decisions
+  For each dilemma from brainstorm:
+  - dilemma_id: the dilemma ID from brainstorm
+  - considered: list of answer IDs that become paths (MUST include canonical)
+  - implicit: list of answer IDs NOT explored (shadows for narrative depth)
 
-  Include all alternatives you explored in the discussion. The system will
+  Include all answers you explored in the discussion. The system will
   balance scope automatically if needed.
 
-  ### Threads
-  For each explored alternative:
-  - id: unique thread identifier (different from tension ID!)
+  ### Paths
+  For each explored answer:
+  - id: unique path identifier (different from dilemma ID!)
   - name: human-readable name
-  - tension_id: which tension this explores
-  - alternative_id: which alternative this explores
-  - shadows: IDs of unexplored alternatives (for FILL context)
+  - dilemma_id: which dilemma this explores
+  - answer_id: which answer this explores
+  - shadows: IDs of unexplored answers (for FILL context)
   - tier: "major" or "minor"
-  - description: what this thread is about
+  - description: what this path is about
   - consequences: list of consequence IDs
 
   ### Consequences
-  For each thread's narrative consequences:
+  For each path's narrative consequences:
   - id: unique consequence identifier
-  - thread_id: which thread this belongs to
+  - path_id: which path this belongs to
   - description: what happens narratively
   - ripples: story effects this implies
 
-  ### Initial Beats (2-4 per thread)
+  ### Initial Beats (2-4 per path)
   For each opening beat:
   - id: unique beat identifier
   - summary: what happens in this beat
-  - threads: list of thread IDs this beat serves
-  - tension_impacts: how this beat affects tensions
-    - tension_id: which tension
+  - paths: list of path IDs this beat serves
+  - dilemma_impacts: how this beat affects dilemmas
+    - dilemma_id: which dilemma
     - effect: "advances", "reveals", "commits", or "complicates"
     - note: explanation of the impact
   - entities: entity IDs present in this beat
@@ -86,7 +86,7 @@ system: |
   **Location Diversity**: Use at least 2 different locations across your beats.
 
   ### Convergence Sketch
-  - convergence_points: where threads should merge
+  - convergence_points: where paths should merge
   - residue_notes: what differences persist after convergence
 
   ## Location Constraint (CRITICAL)
@@ -115,12 +115,12 @@ system: |
   ```
   VERIFY: Your list should have exactly {entity_count} items.
 
-  ### Tension Decisions Manifest
-  List EVERY tension ID with its decision:
+  ### Dilemma Decisions Manifest
+  List EVERY dilemma ID with its decision:
   ```
-  - trust_or_betray: explored=[trust, betray], implicit=[]
-  - weather_storm_clear: explored=[storm], implicit=[clear]
+  - trust_or_betray: considered=[trust, betray], implicit=[]
+  - weather_storm_clear: considered=[storm], implicit=[clear]
   ```
-  VERIFY: Your list should have exactly {tension_count} items.
+  VERIFY: Your list should have exactly {dilemma_count} items.
 
 components: []

--- a/src/questfoundry/pipeline/stages/grow.py
+++ b/src/questfoundry/pipeline/stages/grow.py
@@ -594,7 +594,7 @@ class GrowStage:
         context = {
             "beat_summaries": "\n".join(beat_summaries),
             "valid_beat_ids": ", ".join(valid_beat_ids),
-            "valid_tension_ids": ", ".join(valid_tension_ids),
+            "valid_dilemma_ids": ", ".join(valid_tension_ids),  # variable still uses old name
         }
 
         # Call LLM with semantic validation
@@ -967,8 +967,8 @@ class GrowStage:
                 detail="No threads to check for gaps",
             )
 
-        # Build thread sequences with summaries
-        thread_sequences: list[str] = []
+        # Build path sequences with summaries
+        path_sequences: list[str] = []
         valid_beat_ids: set[str] = set()
         for tid in sorted(thread_nodes.keys()):
             sequence = get_thread_beat_sequence(graph, tid)
@@ -982,18 +982,18 @@ class GrowStage:
                 beat_list.append(f"    {bid} [{scene_type}]: {summary}")
                 valid_beat_ids.add(bid)
             raw_tid = thread_nodes[tid].get("raw_id", tid)
-            thread_sequences.append(f"  Thread: {raw_tid} ({tid})\n" + "\n".join(beat_list))
+            path_sequences.append(f"  Path: {raw_tid} ({tid})\n" + "\n".join(beat_list))
 
-        if not thread_sequences:
+        if not path_sequences:
             return GrowPhaseResult(
                 phase="narrative_gaps",
                 status="completed",
-                detail="No threads with 2+ beats to check",
+                detail="No paths with 2+ beats to check",
             )
 
         context = {
-            "thread_sequences": "\n\n".join(thread_sequences),
-            "valid_thread_ids": ", ".join(sorted(thread_nodes.keys())),
+            "path_sequences": "\n\n".join(path_sequences),
+            "valid_path_ids": ", ".join(sorted(thread_nodes.keys())),
             "valid_beat_ids": ", ".join(sorted(valid_beat_ids)),
         }
 
@@ -1076,7 +1076,7 @@ class GrowStage:
         thread_nodes = graph.get_nodes_by_type("thread")
         context = {
             "pacing_issues": "\n\n".join(issue_descriptions),
-            "valid_thread_ids": ", ".join(sorted(thread_nodes.keys())),
+            "valid_path_ids": ", ".join(sorted(thread_nodes.keys())),
             "valid_beat_ids": ", ".join(sorted(beat_nodes.keys())),
             "issue_count": str(len(issues)),
         }


### PR DESCRIPTION
## Problem

LLM-facing prompts still use old terminology (tension, thread, alternative, knot) which needs to be updated to match the new ontology from the design docs.

## Changes

Updated all stage prompt templates to use new terminology:
- `tension` → `dilemma` (with `d::` prefix)
- `thread` → `path` (with hierarchical `p::dilemma__answer` format)
- `alternative` → `answer`
- `knot` → `intersection`
- `tension_impacts` → `dilemma_impacts`
- `thread-agnostic` → `path-agnostic`

### Templates Updated (12 files)
- `serialize_brainstorm.yaml` - dilemma/answer terminology
- `discuss_brainstorm.yaml` - dilemma/answer terminology
- `summarize_brainstorm.yaml` - dilemma terminology
- `serialize_seed.yaml` - dilemma/path/answer terminology
- `serialize_seed_sections.yaml` - full terminology update across all sections
- `discuss_seed.yaml` - dilemma/path/answer terminology
- `summarize_seed.yaml` - dilemma/path terminology
- `grow_phase2_agnostic.yaml` - path-agnostic, dilemma terminology
- `grow_phase3_knots.yaml` - intersections, dilemma terminology
- `grow_phase4a_scene_types.yaml` - dilemma_impacts
- `grow_phase4b_narrative_gaps.yaml` - path terminology
- `grow_phase4c_pacing_gaps.yaml` - path terminology

### Code Updates (1 file)
- `grow.py` - Updated context key names to match templates:
  - `valid_tension_ids` → `valid_dilemma_ids`
  - `thread_sequences` → `path_sequences`
  - `valid_thread_ids` → `valid_path_ids`

## Not Included / Future PRs

- Test file updates (PR #8)
- Cleanup and CLAUDE.md updates (PR #9)

## Test Plan

```bash
uv run pytest tests/unit/test_grow_validators.py tests/unit/test_enrichment.py tests/unit/test_mutations.py -v
# 191 passed
```

## Risk / Rollback

- Low risk - prompt templates are self-contained
- Context key renames must match template placeholders exactly
- Backward compatibility maintained through model aliases

🤖 Generated with [Claude Code](https://claude.com/claude-code)