### PR TITLE
refactor(models): rename terminology (tension→dilemma, thread→path)

### DIFF
--- a/docs/design/procedures/fill.md
+++ b/docs/design/procedures/fill.md
@@ -207,7 +207,7 @@ fill_output:
   flag_reason: "Character's emotional state too divergent—suspicious path requires hostile body language incompatible with trusting path"
 ```
 
-Flagged beats return to GROW for splitting into separate path-specific passages.
+Flagged beats return to GROW for splitting into separate route-specific passages.
 
 **When to flag (guidance for LLM):**
 - Internal monologue requires contradictory knowledge

--- a/docs/design/procedures/fill.md
+++ b/docs/design/procedures/fill.md
@@ -207,7 +207,7 @@ fill_output:
   flag_reason: "Character's emotional state too divergent—suspicious path requires hostile body language incompatible with trusting path"
 ```
 
-Flagged beats return to GROW for splitting into separate route-specific passages.
+Flagged beats return to GROW for splitting into separate path-specific passages.
 
 **When to flag (guidance for LLM):**
 - Internal monologue requires contradictory knowledge

--- a/src/questfoundry/models/__init__.py
+++ b/src/questfoundry/models/__init__.py
@@ -6,14 +6,24 @@ and applied to the unified graph.
 
 The ontology (node types, relationships, lifecycle) is defined in
 docs/design/00-spec.md. These models are implementations of that ontology.
+
+Terminology (v5):
+- dilemma (was: tension): Binary dramatic questions
+- path (was: thread): Routes exploring specific answers to dilemmas
+- answer (was: alternative): Possible resolutions to dilemmas
+- intersection (was: knot): Beats serving multiple paths
+
+Old names are kept as aliases for backward compatibility.
 """
 
 from questfoundry.models.brainstorm import (
-    Alternative,
+    Alternative,  # Alias for Answer
+    Answer,
     BrainstormOutput,
+    Dilemma,
     Entity,
     EntityType,
-    Tension,
+    Tension,  # Alias for Dilemma
 )
 from questfoundry.models.dream import (
     ContentNotes,
@@ -29,9 +39,11 @@ from questfoundry.models.grow import (
     GapProposal,
     GrowPhaseResult,
     GrowResult,
-    KnotProposal,
+    IntersectionProposal,
+    KnotProposal,  # Alias for IntersectionProposal
     OverlayProposal,
     Passage,
+    PathAgnosticAssessment,
     Phase2Output,
     Phase3Output,
     Phase4aOutput,
@@ -39,24 +51,30 @@ from questfoundry.models.grow import (
     Phase8cOutput,
     Phase9Output,
     SceneTypeTag,
-    ThreadAgnosticAssessment,
+    ThreadAgnosticAssessment,  # Alias for PathAgnosticAssessment
 )
 from questfoundry.models.seed import (
     Consequence,
     ConvergenceSketch,
+    DilemmaDecision,
+    DilemmaEffect,
+    DilemmaImpact,
     EntityDecision,
     EntityDisposition,
     InitialBeat,
+    Path,
+    PathTier,
     SeedOutput,
-    TensionDecision,
-    TensionEffect,
-    TensionImpact,
-    Thread,
-    ThreadTier,
+    TensionDecision,  # Alias for DilemmaDecision
+    TensionEffect,  # Alias for DilemmaEffect
+    TensionImpact,  # Alias for DilemmaImpact
+    Thread,  # Alias for Path
+    ThreadTier,  # Alias for PathTier
 )
 
 __all__ = [
-    "Alternative",
+    "Alternative",  # Alias for Answer
+    "Answer",
     "Arc",
     "BrainstormOutput",
     "Choice",
@@ -65,6 +83,10 @@ __all__ = [
     "Consequence",
     "ContentNotes",
     "ConvergenceSketch",
+    "Dilemma",
+    "DilemmaDecision",
+    "DilemmaEffect",
+    "DilemmaImpact",
     "DreamArtifact",
     "Entity",
     "EntityDecision",
@@ -75,9 +97,13 @@ __all__ = [
     "GrowPhaseResult",
     "GrowResult",
     "InitialBeat",
-    "KnotProposal",
+    "IntersectionProposal",
+    "KnotProposal",  # Alias for IntersectionProposal
     "OverlayProposal",
     "Passage",
+    "Path",
+    "PathAgnosticAssessment",
+    "PathTier",
     "Phase2Output",
     "Phase3Output",
     "Phase4aOutput",
@@ -87,11 +113,11 @@ __all__ = [
     "SceneTypeTag",
     "Scope",
     "SeedOutput",
-    "Tension",
-    "TensionDecision",
-    "TensionEffect",
-    "TensionImpact",
-    "Thread",
-    "ThreadAgnosticAssessment",
-    "ThreadTier",
+    "Tension",  # Alias for Dilemma
+    "TensionDecision",  # Alias for DilemmaDecision
+    "TensionEffect",  # Alias for DilemmaEffect
+    "TensionImpact",  # Alias for DilemmaImpact
+    "Thread",  # Alias for Path
+    "ThreadAgnosticAssessment",  # Alias for PathAgnosticAssessment
+    "ThreadTier",  # Alias for PathTier
 ]

--- a/src/questfoundry/models/seed.py
+++ b/src/questfoundry/models/seed.py
@@ -1,12 +1,17 @@
 """Pydantic models for SEED stage output.
 
 SEED is the triage stage that transforms expansive brainstorm material into
-committed story structure. It curates entities, decides which alternatives
-to explore as threads, creates consequences, and defines initial beats.
+committed story structure. It curates entities, decides which answers
+to explore as paths, creates consequences, and defines initial beats.
 
-CRITICAL: THREAD FREEZE - No new threads can be created after SEED.
+CRITICAL: PATH FREEZE - No new paths can be created after SEED.
 
 See docs/design/00-spec.md for details.
+
+Terminology (v5):
+- dilemma (was: tension): Binary dramatic questions
+- path (was: thread): Routes exploring specific answers to dilemmas
+- answer (was: alternative): Possible resolutions to dilemmas
 """
 
 from __future__ import annotations
@@ -17,8 +22,12 @@ from pydantic import BaseModel, Field, model_validator
 
 # Type aliases for clarity
 EntityDisposition = Literal["retained", "cut"]
-ThreadTier = Literal["major", "minor"]
-TensionEffect = Literal["advances", "reveals", "commits", "complicates"]
+PathTier = Literal["major", "minor"]
+DilemmaEffect = Literal["advances", "reveals", "commits", "complicates"]
+
+# Backward compatibility aliases
+ThreadTier = PathTier
+TensionEffect = DilemmaEffect
 
 
 class EntityDecision(BaseModel):
@@ -42,161 +51,252 @@ class EntityDecision(BaseModel):
     )
 
 
-class TensionDecision(BaseModel):
-    """Tension exploration decision from SEED.
+class DilemmaDecision(BaseModel):
+    """Dilemma exploration decision from SEED.
 
-    Each tension has two alternatives. SEED decides which alternatives to
-    explore as threads. The canonical alternative is always explored (spine).
-    Non-canonical alternatives become branches only if explicitly explored.
+    Each dilemma has two answers. SEED decides which answers to
+    explore as paths. The canonical answer is always explored (spine).
+    Non-canonical answers become branches only if explicitly explored.
 
-    The `considered` field records the LLM's *intent* - which alternatives it
-    wanted to explore. Actual thread existence is derived at runtime from the
-    graph, not from this field. This separation allows pruning to drop threads
-    without modifying the tension's stored intent.
+    The `considered` field records the LLM's *intent* - which answers it
+    wanted to explore. Actual path existence is derived at runtime from the
+    graph, not from this field. This separation allows pruning to drop paths
+    without modifying the dilemma's stored intent.
 
     Development states (computed, not stored):
-    - committed: Alternative has a thread in the graph
-    - deferred: Alternative in `considered` but no thread (pruned)
-    - latent: Alternative not in `considered` (never intended for exploration)
+    - committed: Answer has a path in the graph
+    - deferred: Answer in `considered` but no path (pruned)
+    - latent: Answer not in `considered` (never intended for exploration)
 
     Attributes:
-        tension_id: Tension ID from BRAINSTORM.
-        considered: Alternative IDs the LLM intended to explore as threads.
-        implicit: Alternative IDs not explored (context for FILL shadows).
+        dilemma_id: Dilemma ID from BRAINSTORM.
+        considered: Answer IDs the LLM intended to explore as paths.
+        implicit: Answer IDs not explored (context for FILL shadows).
     """
 
-    tension_id: str = Field(min_length=1, description="Tension ID from BRAINSTORM")
+    dilemma_id: str = Field(min_length=1, description="Dilemma ID from BRAINSTORM")
     considered: list[str] = Field(
         min_length=1,
-        description="Alternative IDs the LLM intended to explore as threads",
+        description="Answer IDs the LLM intended to explore as paths",
     )
     implicit: list[str] = Field(
         default_factory=list,
-        description="Alternative IDs not explored (become shadows)",
+        description="Answer IDs not explored (become shadows)",
     )
 
     @model_validator(mode="before")
     @classmethod
-    def migrate_explored_to_considered(cls, data: dict[str, Any]) -> dict[str, Any]:
-        """Handle old graphs with 'explored' field.
+    def migrate_old_fields(cls, data: dict[str, Any]) -> dict[str, Any]:
+        """Handle old graphs with legacy field names.
 
-        Provides backward compatibility by migrating the old 'explored' field
-        to the new 'considered' field name. This allows reading graphs created
-        before the ontology change.
+        Provides backward compatibility by migrating:
+        - 'tension_id' -> 'dilemma_id'
+        - 'explored' -> 'considered'
         """
-        if isinstance(data, dict) and "explored" in data and "considered" not in data:
+        if isinstance(data, dict):
             data = dict(data)  # Avoid mutating input
-            data["considered"] = data.pop("explored")
+            if "tension_id" in data and "dilemma_id" not in data:
+                data["dilemma_id"] = data.pop("tension_id")
+            if "explored" in data and "considered" not in data:
+                data["considered"] = data.pop("explored")
         return data
+
+    # Backward compatibility property
+    @property
+    def tension_id(self) -> str:
+        """Deprecated: Use 'dilemma_id' instead."""
+        return self.dilemma_id
+
+
+# Backward compatibility alias
+TensionDecision = DilemmaDecision
 
 
 class Consequence(BaseModel):
-    """Narrative consequence of a thread choice.
+    """Narrative consequence of a path choice.
 
-    Consequences bridge the gap between "what this path represents" (alternative)
+    Consequences bridge the gap between "what this path represents" (answer)
     and "how we track it" (codeword). GROW creates codewords to track when
     consequences become active.
 
     Attributes:
         consequence_id: Unique identifier for the consequence.
-        thread_id: Thread this consequence belongs to.
+        path_id: Path this consequence belongs to.
         description: What happens narratively.
         narrative_effects: Story effects this implies.
     """
 
     consequence_id: str = Field(min_length=1, description="Unique identifier for this consequence")
-    thread_id: str = Field(
-        min_length=1, description="Thread this belongs to (references thread_id)"
-    )
+    path_id: str = Field(min_length=1, description="Path this belongs to (references path_id)")
     description: str = Field(min_length=1, description="Narrative meaning of this path")
     narrative_effects: list[str] = Field(
         default_factory=list,
         description="Story effects this consequence implies (cascading impacts)",
     )
 
+    @model_validator(mode="before")
+    @classmethod
+    def migrate_thread_id(cls, data: dict[str, Any]) -> dict[str, Any]:
+        """Migrate old 'thread_id' field to 'path_id'."""
+        if isinstance(data, dict) and "thread_id" in data and "path_id" not in data:
+            data = dict(data)
+            data["path_id"] = data.pop("thread_id")
+        return data
 
-class Thread(BaseModel):
-    """Plot thread exploring one alternative from a tension.
+    # Backward compatibility property
+    @property
+    def thread_id(self) -> str:
+        """Deprecated: Use 'path_id' instead."""
+        return self.path_id
 
-    Threads are the core structural units of the branching story. Threads
-    from the same tension are automatically exclusive (choosing one means
+
+class Path(BaseModel):
+    """Plot path exploring one answer from a dilemma.
+
+    Paths are the core structural units of the branching story. Paths
+    from the same dilemma are automatically exclusive (choosing one means
     not choosing the other).
 
+    Path IDs use hierarchical format: p::dilemma_id__answer_id
+    This embeds the parent dilemma in the ID, making the relationship explicit.
+
     Attributes:
-        thread_id: Unique identifier for the thread.
+        path_id: Unique identifier (format: p::dilemma_id__answer_id).
         name: Human-readable name.
-        tension_id: The tension this thread explores.
-        alternative_id: The specific alternative this thread explores.
-        unexplored_alternative_ids: IDs of unexplored alternatives (context for FILL).
-        thread_importance: Major threads interweave; minor threads support.
-        description: What this thread is about.
-        consequence_ids: IDs of consequences for this thread.
+        dilemma_id: The dilemma this path explores (derivable from path_id).
+        answer_id: The specific answer this path explores.
+        unexplored_answer_ids: IDs of unexplored answers (context for FILL).
+        path_importance: Major paths interweave; minor paths support.
+        description: What this path is about.
+        consequence_ids: IDs of consequences for this path.
     """
 
-    thread_id: str = Field(min_length=1, description="Unique identifier for this thread")
+    path_id: str = Field(
+        min_length=1, description="Unique identifier (format: p::dilemma_id__answer_id)"
+    )
     name: str = Field(min_length=1, description="Human-readable name")
-    tension_id: str = Field(
-        min_length=1, description="Tension this explores (references tension_id)"
+    dilemma_id: str = Field(
+        min_length=1, description="Dilemma this explores (references dilemma_id)"
     )
-    alternative_id: str = Field(
-        min_length=1, description="Alternative this explores (references alternative_id)"
-    )
-    unexplored_alternative_ids: list[str] = Field(
+    answer_id: str = Field(min_length=1, description="Answer this explores (references answer_id)")
+    unexplored_answer_ids: list[str] = Field(
         default_factory=list,
-        description="IDs of unexplored alternatives from same tension (context for FILL)",
+        description="IDs of unexplored answers from same dilemma (context for FILL)",
     )
-    thread_importance: ThreadTier = Field(
-        description="Thread importance: major (interweaves) or minor (supports)"
+    path_importance: PathTier = Field(
+        description="Path importance: major (interweaves) or minor (supports)"
     )
-    description: str = Field(min_length=1, description="What this thread is about")
+    description: str = Field(min_length=1, description="What this path is about")
     consequence_ids: list[str] = Field(
         default_factory=list,
-        description="Consequence IDs for this thread (references consequence_id)",
+        description="Consequence IDs for this path (references consequence_id)",
     )
 
+    @model_validator(mode="before")
+    @classmethod
+    def migrate_old_fields(cls, data: dict[str, Any]) -> dict[str, Any]:
+        """Migrate old field names to new names."""
+        if isinstance(data, dict):
+            data = dict(data)
+            if "thread_id" in data and "path_id" not in data:
+                data["path_id"] = data.pop("thread_id")
+            if "tension_id" in data and "dilemma_id" not in data:
+                data["dilemma_id"] = data.pop("tension_id")
+            if "alternative_id" in data and "answer_id" not in data:
+                data["answer_id"] = data.pop("alternative_id")
+            if "unexplored_alternative_ids" in data and "unexplored_answer_ids" not in data:
+                data["unexplored_answer_ids"] = data.pop("unexplored_alternative_ids")
+            if "thread_importance" in data and "path_importance" not in data:
+                data["path_importance"] = data.pop("thread_importance")
+        return data
 
-class TensionImpact(BaseModel):
-    """How a beat affects a tension.
+    # Backward compatibility properties
+    @property
+    def thread_id(self) -> str:
+        """Deprecated: Use 'path_id' instead."""
+        return self.path_id
 
-    Each beat can impact one or more tensions, moving the story forward
+    @property
+    def tension_id(self) -> str:
+        """Deprecated: Use 'dilemma_id' instead."""
+        return self.dilemma_id
+
+    @property
+    def alternative_id(self) -> str:
+        """Deprecated: Use 'answer_id' instead."""
+        return self.answer_id
+
+    @property
+    def thread_importance(self) -> PathTier:
+        """Deprecated: Use 'path_importance' instead."""
+        return self.path_importance
+
+
+# Backward compatibility alias
+Thread = Path
+
+
+class DilemmaImpact(BaseModel):
+    """How a beat affects a dilemma.
+
+    Each beat can impact one or more dilemmas, moving the story forward
     in various ways.
 
     Attributes:
-        tension_id: Tension being impacted.
-        effect: How the beat affects the tension.
+        dilemma_id: Dilemma being impacted.
+        effect: How the beat affects the dilemma.
         note: Explanation of the impact.
     """
 
-    tension_id: str = Field(min_length=1, description="Tension being impacted")
-    effect: TensionEffect = Field(description="How the beat affects the tension")
+    dilemma_id: str = Field(min_length=1, description="Dilemma being impacted")
+    effect: DilemmaEffect = Field(description="How the beat affects the dilemma")
     note: str = Field(min_length=1, description="Explanation of the impact")
+
+    @model_validator(mode="before")
+    @classmethod
+    def migrate_tension_id(cls, data: dict[str, Any]) -> dict[str, Any]:
+        """Migrate old 'tension_id' field to 'dilemma_id'."""
+        if isinstance(data, dict) and "tension_id" in data and "dilemma_id" not in data:
+            data = dict(data)
+            data["dilemma_id"] = data.pop("tension_id")
+        return data
+
+    # Backward compatibility property
+    @property
+    def tension_id(self) -> str:
+        """Deprecated: Use 'dilemma_id' instead."""
+        return self.dilemma_id
+
+
+# Backward compatibility alias
+TensionImpact = DilemmaImpact
 
 
 class InitialBeat(BaseModel):
     """Initial beat created by SEED.
 
-    Beats are narrative units belonging to one or more threads. SEED creates
-    the initial beats for each thread; GROW mutates and adds more.
+    Beats are narrative units belonging to one or more paths. SEED creates
+    the initial beats for each path; GROW mutates and adds more.
 
     Attributes:
         id: Unique identifier for the beat.
         summary: What happens in this beat.
-        threads: Thread IDs this beat serves.
-        tension_impacts: How this beat affects tensions.
+        paths: Path IDs this beat serves.
+        dilemma_impacts: How this beat affects dilemmas.
         entities: Entity IDs present in this beat.
         location: Primary location entity ID.
-        location_alternatives: Other valid locations (enables knot flexibility).
+        location_alternatives: Other valid locations (enables intersection flexibility).
     """
 
     beat_id: str = Field(min_length=1, description="Unique identifier for this beat")
     summary: str = Field(min_length=1, description="What happens in this beat")
-    threads: list[str] = Field(
+    paths: list[str] = Field(
         min_length=1,
-        description="Thread IDs this beat serves",
+        description="Path IDs this beat serves",
     )
-    tension_impacts: list[TensionImpact] = Field(
+    dilemma_impacts: list[DilemmaImpact] = Field(
         default_factory=list,
-        description="How this beat affects tensions",
+        description="How this beat affects dilemmas",
     )
     entities: list[str] = Field(
         default_factory=list,
@@ -208,24 +308,47 @@ class InitialBeat(BaseModel):
     )
     location_alternatives: list[str] = Field(
         default_factory=list,
-        description="Other valid locations for knot flexibility",
+        description="Other valid locations for intersection flexibility",
     )
+
+    @model_validator(mode="before")
+    @classmethod
+    def migrate_old_fields(cls, data: dict[str, Any]) -> dict[str, Any]:
+        """Migrate old field names to new names."""
+        if isinstance(data, dict):
+            data = dict(data)
+            if "threads" in data and "paths" not in data:
+                data["paths"] = data.pop("threads")
+            if "tension_impacts" in data and "dilemma_impacts" not in data:
+                data["dilemma_impacts"] = data.pop("tension_impacts")
+        return data
+
+    # Backward compatibility properties
+    @property
+    def threads(self) -> list[str]:
+        """Deprecated: Use 'paths' instead."""
+        return self.paths
+
+    @property
+    def tension_impacts(self) -> list[DilemmaImpact]:
+        """Deprecated: Use 'dilemma_impacts' instead."""
+        return self.dilemma_impacts
 
 
 class ConvergenceSketch(BaseModel):
-    """Informal guidance for GROW about thread convergence.
+    """Informal guidance for GROW about path convergence.
 
-    Provides hints about where threads should merge and what differences
+    Provides hints about where paths should merge and what differences
     should persist after convergence.
 
     Attributes:
-        convergence_points: Where threads should merge.
+        convergence_points: Where paths should merge.
         residue_notes: What differences persist after convergence.
     """
 
     convergence_points: list[str] = Field(
         default_factory=list,
-        description="Where threads should merge (e.g., 'by act 2 climax')",
+        description="Where paths should merge (e.g., 'by act 2 climax')",
     )
     residue_notes: list[str] = Field(
         default_factory=list,
@@ -237,14 +360,14 @@ class SeedOutput(BaseModel):
     """Complete output of the SEED stage.
 
     SEED transforms brainstorm material into committed story structure.
-    After SEED, no new threads can be created (THREAD FREEZE).
+    After SEED, no new paths can be created (PATH FREEZE).
 
     Attributes:
         entities: Entity curation decisions.
-        tensions: Tension exploration decisions.
-        threads: Created plot threads.
-        consequences: Narrative consequences for threads.
-        initial_beats: Initial beats for each thread.
+        dilemmas: Dilemma exploration decisions.
+        paths: Created plot paths.
+        consequences: Narrative consequences for paths.
+        initial_beats: Initial beats for each path.
         convergence_sketch: Guidance for GROW about convergence.
     """
 
@@ -252,26 +375,49 @@ class SeedOutput(BaseModel):
         default_factory=list,
         description="Entity curation decisions",
     )
-    tensions: list[TensionDecision] = Field(
+    dilemmas: list[DilemmaDecision] = Field(
         default_factory=list,
-        description="Tension exploration decisions",
+        description="Dilemma exploration decisions",
     )
-    threads: list[Thread] = Field(
+    paths: list[Path] = Field(
         default_factory=list,
-        description="Created plot threads",
+        description="Created plot paths",
     )
     consequences: list[Consequence] = Field(
         default_factory=list,
-        description="Narrative consequences for threads",
+        description="Narrative consequences for paths",
     )
     initial_beats: list[InitialBeat] = Field(
         default_factory=list,
-        description="Initial beats for each thread",
+        description="Initial beats for each path",
     )
     convergence_sketch: ConvergenceSketch = Field(
         default_factory=ConvergenceSketch,
-        description="Guidance for GROW about thread convergence",
+        description="Guidance for GROW about path convergence",
     )
+
+    @model_validator(mode="before")
+    @classmethod
+    def migrate_old_fields(cls, data: dict[str, Any]) -> dict[str, Any]:
+        """Migrate old field names to new names."""
+        if isinstance(data, dict):
+            data = dict(data)
+            if "tensions" in data and "dilemmas" not in data:
+                data["dilemmas"] = data.pop("tensions")
+            if "threads" in data and "paths" not in data:
+                data["paths"] = data.pop("threads")
+        return data
+
+    # Backward compatibility properties
+    @property
+    def tensions(self) -> list[DilemmaDecision]:
+        """Deprecated: Use 'dilemmas' instead."""
+        return self.dilemmas
+
+    @property
+    def threads(self) -> list[Path]:
+        """Deprecated: Use 'paths' instead."""
+        return self.paths
 
 
 # Section wrapper models for iterative serialization
@@ -287,22 +433,30 @@ class EntitiesSection(BaseModel):
     )
 
 
-class TensionsSection(BaseModel):
-    """Wrapper for serializing tension decisions separately."""
+class DilemmasSection(BaseModel):
+    """Wrapper for serializing dilemma decisions separately."""
 
-    tensions: list[TensionDecision] = Field(
+    dilemmas: list[DilemmaDecision] = Field(
         default_factory=list,
-        description="Tension exploration decisions",
+        description="Dilemma exploration decisions",
     )
 
 
-class ThreadsSection(BaseModel):
-    """Wrapper for serializing threads separately."""
+# Backward compatibility alias
+TensionsSection = DilemmasSection
 
-    threads: list[Thread] = Field(
+
+class PathsSection(BaseModel):
+    """Wrapper for serializing paths separately."""
+
+    paths: list[Path] = Field(
         default_factory=list,
-        description="Created plot threads",
+        description="Created plot paths",
     )
+
+
+# Backward compatibility alias
+ThreadsSection = PathsSection
 
 
 class ConsequencesSection(BaseModel):
@@ -310,7 +464,7 @@ class ConsequencesSection(BaseModel):
 
     consequences: list[Consequence] = Field(
         default_factory=list,
-        description="Narrative consequences for threads",
+        description="Narrative consequences for paths",
     )
 
 
@@ -319,24 +473,28 @@ class BeatsSection(BaseModel):
 
     initial_beats: list[InitialBeat] = Field(
         default_factory=list,
-        description="Initial beats for each thread",
+        description="Initial beats for each path",
     )
 
 
-class ThreadBeatsSection(BaseModel):
-    """Wrapper for serializing beats for a single thread.
+class PathBeatsSection(BaseModel):
+    """Wrapper for serializing beats for a single path.
 
-    Used by per-thread beat serialization to constrain the LLM to generating
-    beats for exactly one thread with a fixed tension_id. This makes the
-    thread→tension alignment trivial since the context only contains one valid
-    tension for tension_impacts.
+    Used by per-path beat serialization to constrain the LLM to generating
+    beats for exactly one path with a fixed dilemma_id. This makes the
+    path→dilemma alignment trivial since the context only contains one valid
+    dilemma for dilemma_impacts.
     """
 
     initial_beats: list[InitialBeat] = Field(
         min_length=2,
         max_length=4,
-        description="2-4 initial beats for this specific thread",
+        description="2-4 initial beats for this specific path",
     )
+
+
+# Backward compatibility alias
+ThreadBeatsSection = PathBeatsSection
 
 
 class ConvergenceSection(BaseModel):
@@ -344,5 +502,5 @@ class ConvergenceSection(BaseModel):
 
     convergence_sketch: ConvergenceSketch = Field(
         default_factory=ConvergenceSketch,
-        description="Guidance for GROW about thread convergence",
+        description="Guidance for GROW about path convergence",
     )

--- a/tests/unit/test_brainstorm_stage.py
+++ b/tests/unit/test_brainstorm_stage.py
@@ -131,7 +131,7 @@ async def test_execute_calls_all_three_phases() -> None:
 
         # Verify result
         assert len(artifact["entities"]) == 1
-        assert len(artifact["tensions"]) == 1
+        assert len(artifact["dilemmas"]) == 1
         assert llm_calls == 4  # 2 discuss + 1 summarize + 1 serialize
         assert tokens == 800  # 500 + 100 + 200
 
@@ -299,7 +299,7 @@ async def test_execute_returns_artifact_as_dict() -> None:
 
         assert isinstance(artifact, dict)
         assert artifact["entities"][0]["entity_id"] == "kay"
-        assert artifact["tensions"][0]["tension_id"] == "trust"
+        assert artifact["dilemmas"][0]["dilemma_id"] == "trust"
 
 
 # --- Vision Context Formatting Tests ---

--- a/tests/unit/test_grow_models.py
+++ b/tests/unit/test_grow_models.py
@@ -52,9 +52,9 @@ class TestArc:
         with pytest.raises(ValidationError, match="arc_id"):
             Arc(arc_id="", arc_type="spine", threads=["t1"])
 
-    def test_empty_threads_rejected(self) -> None:
-        with pytest.raises(ValidationError, match="threads"):
-            Arc(arc_id="test", arc_type="spine", threads=[])
+    def test_empty_paths_rejected(self) -> None:
+        with pytest.raises(ValidationError, match="paths"):
+            Arc(arc_id="test", arc_type="spine", paths=[])
 
     def test_invalid_arc_type_rejected(self) -> None:
         with pytest.raises(ValidationError, match="arc_type"):

--- a/tests/unit/test_grow_models.py
+++ b/tests/unit/test_grow_models.py
@@ -14,11 +14,12 @@ from questfoundry.models.grow import (
     GapProposal,
     GrowPhaseResult,
     GrowResult,
-    KnotProposal,
+    IntersectionProposal,
     OverlayProposal,
     Passage,
+    PathAgnosticAssessment,
+    Phase3Output,
     SceneTypeTag,
-    ThreadAgnosticAssessment,
 )
 
 
@@ -27,7 +28,7 @@ class TestArc:
         arc = Arc(
             arc_id="mentor_trust+artifact_quest",
             arc_type="spine",
-            threads=["mentor_trust_canonical", "artifact_quest_canonical"],
+            paths=["mentor_trust_canonical", "artifact_quest_canonical"],
             sequence=["beat_1", "beat_2", "beat_3"],
         )
         assert arc.arc_id == "mentor_trust+artifact_quest"
@@ -39,7 +40,7 @@ class TestArc:
         arc = Arc(
             arc_id="mentor_trust+artifact_quest",
             arc_type="branch",
-            threads=["mentor_trust_alt", "artifact_quest_canonical"],
+            paths=["mentor_trust_alt", "artifact_quest_canonical"],
             sequence=["beat_1", "beat_4"],
             diverges_from="arc::spine",
             diverges_at="beat_2",
@@ -50,7 +51,7 @@ class TestArc:
 
     def test_empty_arc_id_rejected(self) -> None:
         with pytest.raises(ValidationError, match="arc_id"):
-            Arc(arc_id="", arc_type="spine", threads=["t1"])
+            Arc(arc_id="", arc_type="spine", paths=["t1"])
 
     def test_empty_paths_rejected(self) -> None:
         with pytest.raises(ValidationError, match="paths"):
@@ -58,22 +59,33 @@ class TestArc:
 
     def test_invalid_arc_type_rejected(self) -> None:
         with pytest.raises(ValidationError, match="arc_type"):
-            Arc(arc_id="test", arc_type="invalid", threads=["t1"])  # type: ignore[arg-type]
+            Arc(arc_id="test", arc_type="invalid", paths=["t1"])  # type: ignore[arg-type]
 
     def test_empty_sequence_allowed(self) -> None:
-        arc = Arc(arc_id="test", arc_type="spine", threads=["t1"])
+        arc = Arc(arc_id="test", arc_type="spine", paths=["t1"])
         assert arc.sequence == []
 
     def test_convergence_fields(self) -> None:
         arc = Arc(
             arc_id="test",
             arc_type="branch",
-            threads=["t1"],
+            paths=["t1"],
             converges_to="arc::spine",
             converges_at="beat_5",
         )
         assert arc.converges_to == "arc::spine"
         assert arc.converges_at == "beat_5"
+
+    def test_threads_migration(self) -> None:
+        """Verify backward compat: 'threads' field migrates to 'paths'."""
+        arc = Arc(
+            arc_id="test",
+            arc_type="spine",
+            threads=["path_a", "path_b"],  # type: ignore[call-arg]
+        )
+        assert arc.paths == ["path_a", "path_b"]
+        # Backward compat property still works
+        assert arc.threads == ["path_a", "path_b"]
 
 
 class TestPassage:
@@ -173,46 +185,59 @@ class TestEntityOverlay:
         assert overlay.details == {}
 
 
-class TestThreadAgnosticAssessment:
+class TestPathAgnosticAssessment:
     def test_valid_assessment(self) -> None:
-        ta = ThreadAgnosticAssessment(
+        ta = PathAgnosticAssessment(
             beat_id="beat_1",
-            agnostic_for=["tension_mentor_trust"],
+            agnostic_for=["dilemma_mentor_trust"],
         )
         assert ta.beat_id == "beat_1"
-        assert ta.agnostic_for == ["tension_mentor_trust"]
+        assert ta.agnostic_for == ["dilemma_mentor_trust"]
 
     def test_empty_agnostic_for_allowed(self) -> None:
-        ta = ThreadAgnosticAssessment(beat_id="b1")
+        ta = PathAgnosticAssessment(beat_id="b1")
         assert ta.agnostic_for == []
 
     def test_empty_beat_id_rejected(self) -> None:
         with pytest.raises(ValidationError, match="beat_id"):
-            ThreadAgnosticAssessment(beat_id="")
+            PathAgnosticAssessment(beat_id="")
 
 
-class TestKnotProposal:
-    def test_valid_knot(self) -> None:
-        knot = KnotProposal(
+class TestIntersectionProposal:
+    def test_valid_intersection(self) -> None:
+        intersection = IntersectionProposal(
             beat_ids=["beat_1", "beat_2", "beat_3"],
             resolved_location="beat_4",
             rationale="Shared location signal",
         )
-        assert len(knot.beat_ids) == 3
-        assert knot.resolved_location == "beat_4"
-        assert knot.rationale == "Shared location signal"
+        assert len(intersection.beat_ids) == 3
+        assert intersection.resolved_location == "beat_4"
+        assert intersection.rationale == "Shared location signal"
 
     def test_single_beat_rejected(self) -> None:
         with pytest.raises(ValidationError, match="beat_ids"):
-            KnotProposal(beat_ids=["beat_1"])
+            IntersectionProposal(beat_ids=["beat_1"], rationale="test")
 
     def test_empty_beat_ids_rejected(self) -> None:
         with pytest.raises(ValidationError, match="beat_ids"):
-            KnotProposal(beat_ids=[])
+            IntersectionProposal(beat_ids=[], rationale="test")
 
     def test_no_resolved_location_allowed(self) -> None:
-        knot = KnotProposal(beat_ids=["b1", "b2"], rationale="Entity overlap")
-        assert knot.resolved_location is None
+        intersection = IntersectionProposal(beat_ids=["b1", "b2"], rationale="Entity overlap")
+        assert intersection.resolved_location is None
+
+
+class TestPhase3Output:
+    def test_knots_migration(self) -> None:
+        """Verify backward compat: 'knots' field migrates to 'intersections'."""
+        output = Phase3Output(
+            knots=[  # type: ignore[call-arg]
+                {"beat_ids": ["b1", "b2"], "rationale": "test"},
+            ]
+        )
+        assert len(output.intersections) == 1
+        # Backward compat property still works
+        assert len(output.knots) == 1
 
 
 class TestSceneTypeTag:
@@ -236,27 +261,37 @@ class TestSceneTypeTag:
 class TestGapProposal:
     def test_valid_gap(self) -> None:
         gap = GapProposal(
-            thread_id="thread_main",
+            path_id="path_main",
             after_beat="beat_2",
             before_beat="beat_3",
             summary="Hero reflects on the battle.",
             scene_type="sequel",
         )
-        assert gap.thread_id == "thread_main"
+        assert gap.path_id == "path_main"
         assert gap.scene_type == "sequel"
 
     def test_default_scene_type_is_sequel(self) -> None:
-        gap = GapProposal(thread_id="t1", summary="A transition.")
+        gap = GapProposal(path_id="t1", summary="A transition.")
         assert gap.scene_type == "sequel"
 
     def test_no_before_after_allowed(self) -> None:
-        gap = GapProposal(thread_id="t1", summary="Opening scene.")
+        gap = GapProposal(path_id="t1", summary="Opening scene.")
         assert gap.after_beat is None
         assert gap.before_beat is None
 
     def test_empty_summary_rejected(self) -> None:
         with pytest.raises(ValidationError, match="summary"):
-            GapProposal(thread_id="t1", summary="")
+            GapProposal(path_id="t1", summary="")
+
+    def test_thread_id_migration(self) -> None:
+        """Verify backward compat: 'thread_id' field migrates to 'path_id'."""
+        gap = GapProposal(
+            thread_id="thread_main",  # type: ignore[call-arg]
+            summary="A scene.",
+        )
+        assert gap.path_id == "thread_main"
+        # Backward compat property still works
+        assert gap.thread_id == "thread_main"
 
 
 class TestOverlayProposal:
@@ -328,11 +363,11 @@ class TestGrowResult:
                 GrowPhaseResult(phase="validate", status="completed"),
                 GrowPhaseResult(phase="arcs", status="completed"),
             ],
-            spine_arc_id="arc::thread_a+thread_b",
+            spine_arc_id="arc::path_a+path_b",
         )
         assert result.arc_count == 4
         assert len(result.phases_completed) == 2
-        assert result.spine_arc_id == "arc::thread_a+thread_b"
+        assert result.spine_arc_id == "arc::path_a+path_b"
 
     def test_model_dump_roundtrip(self) -> None:
         result = GrowResult(

--- a/tests/unit/test_seed_stage.py
+++ b/tests/unit/test_seed_stage.py
@@ -134,7 +134,7 @@ async def test_execute_calls_all_three_phases() -> None:
 
         # Verify result
         assert len(artifact["entities"]) == 1
-        assert len(artifact["threads"]) == 1
+        assert len(artifact["paths"]) == 1
         assert len(artifact["initial_beats"]) == 1
         # Stage counts: 2 discuss + 1 summarize + 6 (hardcoded for iterative serialize)
         # Note: This tests the stage's call accounting, not internal serialize behavior
@@ -342,7 +342,7 @@ async def test_execute_returns_artifact_as_dict() -> None:
 
         assert isinstance(artifact, dict)
         assert artifact["entities"][0]["entity_id"] == "kay"
-        assert artifact["threads"][0]["thread_id"] == "thread1"
+        assert artifact["paths"][0]["path_id"] == "thread1"
         assert artifact["initial_beats"][0]["beat_id"] == "beat1"
 
 


### PR DESCRIPTION
## Problem

Part of #338. Updates Pydantic models with new terminology for better LLM comprehension.

## Changes

- Rename `Tension` → `Dilemma`, `Alternative` → `Answer` in brainstorm.py
- Rename `Thread` → `Path`, `TensionDecision` → `DilemmaDecision` in seed.py  
- Add backward compatibility aliases for all renamed classes
- Add migration validators for old field names (`tension_id` → `dilemma_id`, etc.)
- Update all tests

## Not Included / Future PRs

- Graph constants update (PR #341)
- Mutations/GROW update (PR #342)
- Prompt templates (PR #343)
- Cleanup/alias removal (PR #344)

## Test Plan

```
uv run pytest  # All 191 tests pass
uv run mypy src/  # No errors
uv run ruff check src/  # No issues
```

## Risk / Rollback

Backward compatibility maintained via aliases. Old code continues to work.

Supersedes #340 (closed due to base branch deletion)

🤖 Generated with [Claude Code](https://claude.com/claude-code)