### PR TITLE
feat(cli): phase-level progress for early stages

### DIFF
--- a/src/questfoundry/pipeline/stages/base.py
+++ b/src/questfoundry/pipeline/stages/base.py
@@ -40,6 +40,7 @@ class Stage(Protocol):
         on_assistant_message: AssistantMessageFn | None = None,
         on_llm_start: LLMCallbackFn | None = None,
         on_llm_end: LLMCallbackFn | None = None,
+        on_phase_progress: PhaseProgressFn | None = None,
         summarize_model: BaseChatModel | None = None,
         serialize_model: BaseChatModel | None = None,
         summarize_provider_name: str | None = None,


### PR DESCRIPTION
Closes #298.\n\nAdds phase-level progress output for DREAM, BRAINSTORM, and SEED using the existing  callback infrastructure. SEED now also reports section-level serialization progress plus per-path beat serialization progress, and surfaces outer-loop retries.