### PR TITLE
chore: remove legacy tension/thread/knot compatibility

### DIFF
--- a/docs/architecture/graph-referential-integrity.md
+++ b/docs/architecture/graph-referential-integrity.md
@@ -415,7 +415,7 @@ def _format_seed_valid_ids(graph: Graph) -> str:
             for raw_id in sorted(by_category[category]):
                 lines.append(f"  - `{raw_id}`")
 
-    # Tensions with alternatives
+    # Dilemmas with alternatives
     lines.append("")
     lines.append("### Dilemma IDs with their Answer IDs")
     lines.append("Format: dilemma_id → [answer_ids]")

--- a/docs/design/00-spec.md
+++ b/docs/design/00-spec.md
@@ -981,7 +981,7 @@ SHIP reads from the graph, ignoring working nodes.
 | Ending passages | Passages with no outgoing Choice edges |
 
 **Ignored by SHIP:**
-- Tensions, paths, beats, arcs
+- Dilemmas, paths, beats, arcs
 - `from_beat`, `summary` on passages
 - `requires` edges between beats
 - All working edges

--- a/src/questfoundry/artifacts/enrichment.py
+++ b/src/questfoundry/artifacts/enrichment.py
@@ -53,9 +53,8 @@ def enrich_seed_artifact(graph: Graph, artifact: dict[str, Any]) -> dict[str, An
     # Enrich entities
     enriched["entities"] = _enrich_entities(graph, artifact.get("entities", []))
 
-    # Enrich dilemmas (artifact may use "dilemmas" or legacy "tensions")
-    dilemma_decisions = artifact.get("dilemmas", artifact.get("tensions", []))
-    enriched["dilemmas"] = _enrich_dilemmas(graph, dilemma_decisions)
+    # Enrich dilemmas
+    enriched["dilemmas"] = _enrich_dilemmas(graph, artifact.get("dilemmas", []))
 
     return enriched
 
@@ -116,7 +115,7 @@ def _enrich_dilemmas(graph: Graph, dilemma_decisions: list[dict[str, Any]]) -> l
 
     enriched_dilemmas = []
     for decision in dilemma_decisions:
-        dilemma_id = decision.get("dilemma_id") or decision.get("tension_id", "")
+        dilemma_id = decision.get("dilemma_id", "")
         # Strip prefix if present (e.g., "dilemma::host_motivation" -> "host_motivation")
         lookup_id = dilemma_id.split("::")[-1]
         node = dilemma_data.get(lookup_id, {}) if lookup_id else {}

--- a/src/questfoundry/cli.py
+++ b/src/questfoundry/cli.py
@@ -570,7 +570,7 @@ def _preview_dream_artifact(artifact: dict[str, Any]) -> None:
 def _preview_brainstorm_artifact(artifact: dict[str, Any]) -> None:
     """Display preview of BRAINSTORM artifact."""
     entities = artifact.get("entities", [])
-    dilemmas = artifact.get("dilemmas", artifact.get("tensions", []))
+    dilemmas = artifact.get("dilemmas", [])
 
     console.print(f"  Entities: [bold]{len(entities)}[/bold]")
 
@@ -594,7 +594,7 @@ def _preview_brainstorm_artifact(artifact: dict[str, Any]) -> None:
 def _preview_seed_artifact(artifact: dict[str, Any]) -> None:
     """Display preview of SEED artifact."""
     entities = artifact.get("entities", [])
-    paths = artifact.get("paths", artifact.get("threads", []))
+    paths = artifact.get("paths", [])
     beats = artifact.get("initial_beats", [])
 
     # Count retained vs cut entities
@@ -605,7 +605,7 @@ def _preview_seed_artifact(artifact: dict[str, Any]) -> None:
 
     console.print(f"  Paths: [bold]{len(paths)}[/bold]")
     for path in paths[:3]:
-        importance = path.get("path_importance", path.get("thread_importance", "?"))
+        importance = path.get("path_importance", "?")
         importance_style = "bold green" if importance == "major" else "dim"
         console.print(
             f"    • [{importance_style}]{importance}[/{importance_style}] {path.get('name', '?')}"

--- a/src/questfoundry/graph/dilemma_scoring.py
+++ b/src/questfoundry/graph/dilemma_scoring.py
@@ -42,10 +42,6 @@ class ScoredDilemma:
     noncanonical_path_id: str | None
 
 
-# Backward compatibility alias
-ScoredTension = ScoredDilemma
-
-
 def _get_paths_for_dilemma(
     seed_output: SeedOutput, dilemma_id: str
 ) -> tuple[Path | None, Path | None]:

--- a/src/questfoundry/models/brainstorm.py
+++ b/src/questfoundry/models/brainstorm.py
@@ -121,19 +121,11 @@ class Dilemma(BaseModel):
 
     @model_validator(mode="before")
     @classmethod
-    def migrate_tension_fields(cls, data: dict[str, Any]) -> dict[str, Any]:
-        """Migrate old field names for backward compatibility.
-
-        This handles migrating the following fields:
-        - 'tension_id' -> 'dilemma_id'
-        - 'alternatives' -> 'answers'
-        """
-        if isinstance(data, dict):
+    def migrate_alternatives_field(cls, data: dict[str, Any]) -> dict[str, Any]:
+        """Migrate old 'alternatives' field to 'answers'."""
+        if isinstance(data, dict) and "alternatives" in data and "answers" not in data:
             data = dict(data)
-            if "tension_id" in data and "dilemma_id" not in data:
-                data["dilemma_id"] = data.pop("tension_id")
-            if "alternatives" in data and "answers" not in data:
-                data["answers"] = data.pop("alternatives")
+            data["answers"] = data.pop("alternatives")
         return data
 
     @model_validator(mode="after")
@@ -144,12 +136,6 @@ class Dilemma(BaseModel):
             msg = f"Dilemma '{self.dilemma_id}' must have exactly one default path answer, found {default_count}"
             raise ValueError(msg)
         return self
-
-    # Backward compatibility properties
-    @property
-    def tension_id(self) -> str:
-        """Deprecated: Use 'dilemma_id' instead."""
-        return self.dilemma_id
 
     @property
     def alternatives(self) -> list[Answer]:
@@ -179,18 +165,3 @@ class BrainstormOutput(BaseModel):
         default_factory=list,
         description="Generated dramatic dilemmas",
     )
-
-    @model_validator(mode="before")
-    @classmethod
-    def migrate_tensions_field(cls, data: dict[str, Any]) -> dict[str, Any]:
-        """Migrate old 'tensions' field to 'dilemmas'."""
-        if isinstance(data, dict) and "tensions" in data and "dilemmas" not in data:
-            data = dict(data)
-            data["dilemmas"] = data.pop("tensions")
-        return data
-
-    # Backward compatibility property
-    @property
-    def tensions(self) -> list[Dilemma]:
-        """Deprecated: Use 'dilemmas' instead."""
-        return self.dilemmas

--- a/src/questfoundry/models/grow.py
+++ b/src/questfoundry/models/grow.py
@@ -18,9 +18,9 @@ Terminology (v5):
 
 from __future__ import annotations
 
-from typing import Any, Literal
+from typing import Literal
 
-from pydantic import BaseModel, Field, model_validator
+from pydantic import BaseModel, Field
 
 # ---------------------------------------------------------------------------
 # Graph node types
@@ -43,21 +43,6 @@ class Arc(BaseModel):
     diverges_at: str | None = None
     converges_to: str | None = None
     converges_at: str | None = None
-
-    @model_validator(mode="before")
-    @classmethod
-    def migrate_threads(cls, data: dict[str, Any]) -> dict[str, Any]:
-        """Migrate old 'threads' field to 'paths'."""
-        if isinstance(data, dict) and "threads" in data and "paths" not in data:
-            data = dict(data)
-            data["paths"] = data.pop("threads")
-        return data
-
-    # Backward compatibility property
-    @property
-    def threads(self) -> list[str]:
-        """Deprecated: Use 'paths' instead."""
-        return self.paths
 
 
 class Passage(BaseModel):
@@ -134,21 +119,6 @@ class Phase3Output(BaseModel):
 
     intersections: list[IntersectionProposal] = Field(default_factory=list)
 
-    @model_validator(mode="before")
-    @classmethod
-    def migrate_knots(cls, data: dict[str, Any]) -> dict[str, Any]:
-        """Migrate old 'knots' field to 'intersections'."""
-        if isinstance(data, dict) and "knots" in data and "intersections" not in data:
-            data = dict(data)
-            data["intersections"] = data.pop("knots")
-        return data
-
-    # Backward compatibility property
-    @property
-    def knots(self) -> list[IntersectionProposal]:
-        """Deprecated: Use 'intersections' instead."""
-        return self.intersections
-
 
 class SceneTypeTag(BaseModel):
     """Phase 4a: Tags beats with scene type classification."""
@@ -171,21 +141,6 @@ class GapProposal(BaseModel):
     before_beat: str | None = None
     summary: str = Field(min_length=1)
     scene_type: Literal["scene", "sequel", "micro_beat"] = "sequel"
-
-    @model_validator(mode="before")
-    @classmethod
-    def migrate_thread_id(cls, data: dict[str, Any]) -> dict[str, Any]:
-        """Migrate old 'thread_id' field to 'path_id'."""
-        if isinstance(data, dict) and "thread_id" in data and "path_id" not in data:
-            data = dict(data)
-            data["path_id"] = data.pop("thread_id")
-        return data
-
-    # Backward compatibility property
-    @property
-    def thread_id(self) -> str:
-        """Deprecated: Use 'path_id' instead."""
-        return self.path_id
 
 
 class Phase4bOutput(BaseModel):

--- a/src/questfoundry/pipeline/stages/brainstorm.py
+++ b/src/questfoundry/pipeline/stages/brainstorm.py
@@ -292,7 +292,7 @@ class BrainstormStage:
 
         # Log summary statistics
         entity_count = len(artifact_data.get("entities", []))
-        dilemma_count = len(artifact_data.get("dilemmas", artifact_data.get("tensions", [])))
+        dilemma_count = len(artifact_data.get("dilemmas", []))
         if on_phase_progress is not None:
             on_phase_progress("serialize entities", "completed", f"{entity_count} entities")
             on_phase_progress("serialize dilemmas", "completed", f"{dilemma_count} dilemmas")

--- a/tests/integration/test_grow_e2e.py
+++ b/tests/integration/test_grow_e2e.py
@@ -134,7 +134,7 @@ class TestGrowFullPipeline:
             )
 
     def test_arc_enumeration(self, pipeline_result: dict[str, Any]) -> None:
-        """Verify 4 arcs are enumerated from 2 tensions x 2 paths."""
+        """Verify 4 arcs are enumerated from 2 dilemmas x 2 paths."""
         result_dict = pipeline_result["result_dict"]
         assert result_dict["arc_count"] == 4
         assert result_dict["spine_arc_id"] is not None

--- a/tests/unit/test_enrichment.py
+++ b/tests/unit/test_enrichment.py
@@ -49,7 +49,7 @@ def graph_with_entities() -> Graph:
 
 
 @pytest.fixture
-def graph_with_tensions() -> Graph:
+def graph_with_dilemmas() -> Graph:
     """Graph with BRAINSTORM dilemma data."""
     graph = Graph()
     # Add dilemma as BRAINSTORM would
@@ -217,19 +217,19 @@ class TestEnrichSeedArtifact:
 class TestEnrichDilemmas:
     """Tests for dilemma enrichment."""
 
-    def test_enriches_dilemma_with_full_details(self, graph_with_tensions: Graph) -> None:
+    def test_enriches_dilemma_with_full_details(self, graph_with_dilemmas: Graph) -> None:
         """Enrichment adds question, why_it_matters, central_entity_ids from graph."""
         artifact = {
-            "tensions": [  # Input uses legacy "tensions" key
+            "dilemmas": [  # Input uses legacy "dilemmas" key
                 {
-                    "tension_id": "host_motivation",
+                    "dilemma_id": "host_motivation",
                     "considered": ["benevolent"],
                     "implicit": ["self_serving"],
                 },
             ],
         }
 
-        result = enrich_seed_artifact(graph_with_tensions, artifact)
+        result = enrich_seed_artifact(graph_with_dilemmas, artifact)
 
         dilemma = result["dilemmas"][0]
         assert dilemma["dilemma_id"] == "host_motivation"
@@ -240,15 +240,15 @@ class TestEnrichDilemmas:
         assert dilemma["considered"] == ["benevolent"]
         assert dilemma["implicit"] == ["self_serving"]
 
-    def test_handles_unknown_dilemma(self, graph_with_tensions: Graph) -> None:
+    def test_handles_unknown_dilemma(self, graph_with_dilemmas: Graph) -> None:
         """Enrichment handles dilemmas not in graph gracefully."""
         artifact = {
-            "tensions": [
-                {"tension_id": "unknown_dilemma", "considered": ["option_a"], "implicit": []},
+            "dilemmas": [
+                {"dilemma_id": "unknown_dilemma", "considered": ["option_a"], "implicit": []},
             ],
         }
 
-        result = enrich_seed_artifact(graph_with_tensions, artifact)
+        result = enrich_seed_artifact(graph_with_dilemmas, artifact)
 
         dilemma = result["dilemmas"][0]
         assert dilemma["dilemma_id"] == "unknown_dilemma"
@@ -256,19 +256,19 @@ class TestEnrichDilemmas:
         assert "why_it_matters" not in dilemma
         assert dilemma["considered"] == ["option_a"]
 
-    def test_handles_prefixed_dilemma_ids(self, graph_with_tensions: Graph) -> None:
+    def test_handles_prefixed_dilemma_ids(self, graph_with_dilemmas: Graph) -> None:
         """Enrichment strips prefix from dilemma_id for graph lookup."""
         artifact = {
-            "tensions": [
+            "dilemmas": [
                 {
-                    "tension_id": "dilemma::host_motivation",
+                    "dilemma_id": "dilemma::host_motivation",
                     "considered": ["benevolent"],
                     "implicit": [],
                 },
             ],
         }
 
-        result = enrich_seed_artifact(graph_with_tensions, artifact)
+        result = enrich_seed_artifact(graph_with_dilemmas, artifact)
 
         dilemma = result["dilemmas"][0]
         # Original prefixed ID preserved in output
@@ -278,25 +278,25 @@ class TestEnrichDilemmas:
         assert dilemma["why_it_matters"] == "Determines whether protagonist can trust their guide"
         assert dilemma["considered"] == ["benevolent"]
 
-    def test_enriches_multiple_dilemmas(self, graph_with_tensions: Graph) -> None:
+    def test_enriches_multiple_dilemmas(self, graph_with_dilemmas: Graph) -> None:
         """Enrichment works for multiple dilemmas."""
         artifact = {
-            "tensions": [
-                {"tension_id": "host_motivation", "considered": ["benevolent"], "implicit": []},
-                {"tension_id": "killer_identity", "considered": ["suspect_a"], "implicit": []},
+            "dilemmas": [
+                {"dilemma_id": "host_motivation", "considered": ["benevolent"], "implicit": []},
+                {"dilemma_id": "killer_identity", "considered": ["suspect_a"], "implicit": []},
             ],
         }
 
-        result = enrich_seed_artifact(graph_with_tensions, artifact)
+        result = enrich_seed_artifact(graph_with_dilemmas, artifact)
 
         assert len(result["dilemmas"]) == 2
         assert result["dilemmas"][0]["question"] == "Is the host benevolent or self-serving?"
         assert result["dilemmas"][1]["question"] == "Who committed the murder?"
 
-    def test_empty_dilemmas_list(self, graph_with_tensions: Graph) -> None:
+    def test_empty_dilemmas_list(self, graph_with_dilemmas: Graph) -> None:
         """Enrichment handles empty dilemmas list."""
-        artifact = {"tensions": []}  # Input uses legacy key
+        artifact = {"dilemmas": []}  # Input uses legacy key
 
-        result = enrich_seed_artifact(graph_with_tensions, artifact)
+        result = enrich_seed_artifact(graph_with_dilemmas, artifact)
 
         assert result["dilemmas"] == []

--- a/tests/unit/test_graph.py
+++ b/tests/unit/test_graph.py
@@ -291,15 +291,15 @@ class TestEdgeOperations:
     def test_add_edge(self) -> None:
         """Can add edges between existing nodes."""
         graph = Graph.empty()
-        graph.create_node("tension_001", {"type": "dilemma"})
+        graph.create_node("dilemma_001", {"type": "dilemma"})
         graph.create_node("alt_001", {"type": "alternative"})
 
-        graph.add_edge("has_answer", "tension_001", "alt_001")
+        graph.add_edge("has_answer", "dilemma_001", "alt_001")
 
         edges = graph.get_edges()
         assert len(edges) == 1
         assert edges[0]["type"] == "has_answer"
-        assert edges[0]["from"] == "tension_001"
+        assert edges[0]["from"] == "dilemma_001"
         assert edges[0]["to"] == "alt_001"
 
     def test_add_edge_with_props(self) -> None:

--- a/tests/unit/test_grow_algorithms.py
+++ b/tests/unit/test_grow_algorithms.py
@@ -126,7 +126,7 @@ class TestValidateBeatDag:
         errors = validate_beat_dag(graph)
         assert errors == []
 
-    def test_two_tension_graph_valid(self) -> None:
+    def test_two_dilemma_graph_valid(self) -> None:
         graph = make_two_dilemma_graph()
         errors = validate_beat_dag(graph)
         assert errors == []
@@ -143,7 +143,7 @@ class TestValidateCommitsBeats:
         errors = validate_commits_beats(graph)
         assert errors == []
 
-    def test_two_tension_complete(self) -> None:
+    def test_two_dilemma_complete(self) -> None:
         graph = make_two_dilemma_graph()
         errors = validate_commits_beats(graph)
         assert errors == []
@@ -283,7 +283,7 @@ class TestTopologicalSortBeats:
 
 
 class TestEnumerateArcs:
-    def test_single_tension_two_threads(self) -> None:
+    def test_single_dilemma_two_threads(self) -> None:
         graph = make_single_dilemma_graph()
         arcs = enumerate_arcs(graph)
 
@@ -299,13 +299,13 @@ class TestEnumerateArcs:
         arcs = enumerate_arcs(graph)
         assert arcs[0].arc_type == "spine"
 
-    def test_two_tensions_four_arcs(self) -> None:
+    def test_two_dilemmas_four_arcs(self) -> None:
         graph = make_two_dilemma_graph()
         arcs = enumerate_arcs(graph)
         # 2 paths x 2 paths = 4 arcs
         assert len(arcs) == 4
 
-    def test_two_tensions_one_spine(self) -> None:
+    def test_two_dilemmas_one_spine(self) -> None:
         graph = make_two_dilemma_graph()
         arcs = enumerate_arcs(graph)
         spine_arcs = [a for a in arcs if a.arc_type == "spine"]
@@ -987,7 +987,7 @@ class TestPhase8aIntegration:
         assert len(passage_from_edges) == len(passage_nodes)
 
     @pytest.mark.asyncio
-    async def test_passages_from_two_tension_graph(self) -> None:
+    async def test_passages_from_two_dilemma_graph(self) -> None:
         from questfoundry.pipeline.stages.grow import GrowStage
 
         graph = make_two_dilemma_graph()
@@ -1073,7 +1073,7 @@ class TestPhase8bIntegration:
             assert cw_id.endswith("_committed")
 
     @pytest.mark.asyncio
-    async def test_two_tension_codewords(self) -> None:
+    async def test_two_dilemma_codewords(self) -> None:
         from questfoundry.pipeline.stages.grow import GrowStage
 
         graph = make_two_dilemma_graph()
@@ -1286,7 +1286,7 @@ class TestBuildKnotCandidates:
         assert "beat::mentor_meet" in market_candidate.beat_ids
         assert "beat::artifact_discover" in market_candidate.beat_ids
 
-    def test_single_tension_no_candidates(self) -> None:
+    def test_single_dilemma_no_candidates(self) -> None:
         """No candidates when all beats belong to same dilemma."""
         from questfoundry.graph.grow_algorithms import build_intersection_candidates
 
@@ -1307,7 +1307,7 @@ class TestBuildKnotCandidates:
 
 
 class TestCheckKnotCompatibility:
-    def test_compatible_cross_tension_beats(self) -> None:
+    def test_compatible_cross_dilemma_beats(self) -> None:
         """Beats from different dilemmas with no requires are compatible."""
         from questfoundry.graph.grow_algorithms import check_intersection_compatibility
         from tests.fixtures.grow_fixtures import make_intersection_candidate_graph
@@ -1318,7 +1318,7 @@ class TestCheckKnotCompatibility:
         )
         assert errors == []
 
-    def test_incompatible_same_tension(self) -> None:
+    def test_incompatible_same_dilemma(self) -> None:
         """Beats from same dilemma are incompatible."""
         from questfoundry.graph.grow_algorithms import check_intersection_compatibility
 
@@ -1602,7 +1602,7 @@ class TestPhaseIntegrationEndToEnd:
         assert result_dict["choice_count"] > 0
 
     @pytest.mark.asyncio
-    async def test_single_tension_full_run(self, tmp_path: Path) -> None:
+    async def test_single_dilemma_full_run(self, tmp_path: Path) -> None:
         from questfoundry.pipeline.stages.grow import GrowStage
 
         graph = make_single_dilemma_graph()

--- a/tests/unit/test_grow_models.py
+++ b/tests/unit/test_grow_models.py
@@ -228,16 +228,14 @@ class TestIntersectionProposal:
 
 
 class TestPhase3Output:
-    def test_knots_migration(self) -> None:
-        """Verify backward compat: 'knots' field migrates to 'intersections'."""
+    def test_knots_field_is_ignored(self) -> None:
+        """Legacy 'knots' field is ignored (no backward-compat migration)."""
         output = Phase3Output(
             knots=[  # type: ignore[call-arg]
                 {"beat_ids": ["b1", "b2"], "rationale": "test"},
             ]
         )
-        assert len(output.intersections) == 1
-        # Backward compat property still works
-        assert len(output.knots) == 1
+        assert output.intersections == []
 
 
 class TestSceneTypeTag:
@@ -283,15 +281,13 @@ class TestGapProposal:
         with pytest.raises(ValidationError, match="summary"):
             GapProposal(path_id="t1", summary="")
 
-    def test_thread_id_migration(self) -> None:
-        """Verify backward compat: 'thread_id' field migrates to 'path_id'."""
-        gap = GapProposal(
-            thread_id="thread_main",  # type: ignore[call-arg]
-            summary="A scene.",
-        )
-        assert gap.path_id == "thread_main"
-        # Backward compat property still works
-        assert gap.thread_id == "thread_main"
+    def test_thread_id_rejected(self) -> None:
+        """Legacy 'thread_id' field is rejected (no backward-compat migration)."""
+        with pytest.raises(ValidationError, match="path_id"):
+            GapProposal(  # type: ignore[call-arg]
+                thread_id="thread_main",
+                summary="A scene.",
+            )
 
 
 class TestOverlayProposal:

--- a/tests/unit/test_grow_stage.py
+++ b/tests/unit/test_grow_stage.py
@@ -660,7 +660,7 @@ class TestPhase3Knots:
         stage = GrowStage()
 
         # opening requires mentor_meet — these have a requires dependency
-        # But they're also from different tensions in this graph.
+        # But they're also from different dilemmas in this graph.
         # Add a cross-dilemma requires to test: artifact_discover requires mentor_meet
         graph.add_edge("requires", "beat::artifact_discover", "beat::mentor_meet")
 
@@ -765,8 +765,8 @@ class TestPhase4aSceneTypes:
 
 
 class TestValidateAndInsertGaps:
-    def test_unprefixed_thread_id_gets_warning_and_prefix(self) -> None:
-        """Helper auto-prefixes thread_id and logs warning."""
+    def test_unprefixed_path_id_gets_warning_and_prefix(self) -> None:
+        """Helper auto-prefixes path_id and logs warning."""
         from questfoundry.models.grow import GapProposal
         from tests.fixtures.grow_fixtures import make_single_dilemma_graph
 
@@ -775,7 +775,7 @@ class TestValidateAndInsertGaps:
 
         gaps = [
             GapProposal(
-                thread_id="mentor_trust_canonical",  # Missing "path::" prefix
+                path_id="mentor_trust_canonical",  # Missing "path::" prefix
                 after_beat="beat::opening",
                 before_beat="beat::mentor_meet",
                 summary="Auto-prefixed gap",
@@ -793,8 +793,8 @@ class TestValidateAndInsertGaps:
         gap_beats = [bid for bid in beat_nodes if "gap" in bid]
         assert len(gap_beats) == 1
 
-    def test_invalid_thread_id_skipped(self) -> None:
-        """Helper skips gaps with thread_ids not in valid set."""
+    def test_invalid_path_id_skipped(self) -> None:
+        """Helper skips gaps with path_ids not in valid set."""
         from questfoundry.models.grow import GapProposal
         from tests.fixtures.grow_fixtures import make_single_dilemma_graph
 
@@ -803,7 +803,7 @@ class TestValidateAndInsertGaps:
 
         gaps = [
             GapProposal(
-                thread_id="path::nonexistent",
+                path_id="path::nonexistent",
                 after_beat="beat::opening",
                 before_beat="beat::mentor_meet",
                 summary="Invalid path",
@@ -826,7 +826,7 @@ class TestValidateAndInsertGaps:
 
         gaps = [
             GapProposal(
-                thread_id="path::mentor_trust_canonical",
+                path_id="path::mentor_trust_canonical",
                 after_beat="beat::mentor_commits_canonical",  # Comes AFTER mentor_meet
                 before_beat="beat::mentor_meet",  # Comes BEFORE commits
                 summary="Wrong order gap",
@@ -849,7 +849,7 @@ class TestValidateAndInsertGaps:
 
         gaps = [
             GapProposal(
-                thread_id="path::mentor_trust_canonical",
+                path_id="path::mentor_trust_canonical",
                 after_beat="beat::phantom",
                 before_beat="beat::mentor_meet",
                 summary="Phantom after_beat",
@@ -872,7 +872,7 @@ class TestValidateAndInsertGaps:
 
         gaps = [
             GapProposal(
-                thread_id="path::mentor_trust_canonical",
+                path_id="path::mentor_trust_canonical",
                 after_beat="beat::opening",
                 before_beat="beat::phantom_before",
                 summary="Phantom before_beat",
@@ -897,7 +897,7 @@ class TestValidateAndInsertGaps:
         # not path::mentor_trust_canonical's sequence
         gaps = [
             GapProposal(
-                thread_id="path::mentor_trust_canonical",
+                path_id="path::mentor_trust_canonical",
                 after_beat="beat::opening",
                 before_beat="beat::mentor_commits_alt",
                 summary="Beat not in this path sequence",
@@ -920,7 +920,7 @@ class TestValidateAndInsertGaps:
 
         gaps = [
             GapProposal(
-                thread_id="path::mentor_trust_canonical",
+                path_id="path::mentor_trust_canonical",
                 after_beat="beat::opening",
                 before_beat=None,
                 summary="Gap after opening only",
@@ -951,7 +951,7 @@ class TestPhase4bNarrativeGaps:
         phase4b_output = Phase4bOutput(
             gaps=[
                 GapProposal(
-                    thread_id="path::mentor_trust_canonical",
+                    path_id="path::mentor_trust_canonical",
                     after_beat="beat::mentor_meet",
                     before_beat="beat::mentor_commits_canonical",
                     summary="Hero reflects on mentor's words",
@@ -977,7 +977,7 @@ class TestPhase4bNarrativeGaps:
         assert len(gap_beats) == 1
 
     @pytest.mark.asyncio
-    async def test_phase_4b_skips_invalid_thread(self) -> None:
+    async def test_phase_4b_skips_invalid_path(self) -> None:
         """Phase 4b skips gap proposals with invalid path IDs."""
         from questfoundry.models.grow import GapProposal, Phase4bOutput
         from tests.fixtures.grow_fixtures import make_single_dilemma_graph
@@ -988,7 +988,7 @@ class TestPhase4bNarrativeGaps:
         phase4b_output = Phase4bOutput(
             gaps=[
                 GapProposal(
-                    thread_id="path::nonexistent",
+                    path_id="path::nonexistent",
                     after_beat="beat::opening",
                     before_beat="beat::mentor_meet",
                     summary="Invalid path gap",
@@ -1008,7 +1008,7 @@ class TestPhase4bNarrativeGaps:
         assert "0" in result.detail
 
     @pytest.mark.asyncio
-    async def test_phase_4b_no_threads(self) -> None:
+    async def test_phase_4b_no_paths(self) -> None:
         """Phase 4b returns completed when no paths exist."""
         from questfoundry.graph.graph import Graph
 
@@ -1072,7 +1072,7 @@ class TestPhase4cPacingGaps:
         phase4c_output = Phase4bOutput(
             gaps=[
                 GapProposal(
-                    thread_id="path::main",
+                    path_id="path::main",
                     after_beat="beat::b1",
                     before_beat="beat::b2",
                     summary="Moment of reflection after first action",

--- a/tests/unit/test_grow_validation.py
+++ b/tests/unit/test_grow_validation.py
@@ -251,7 +251,7 @@ class TestDilemmasResolved:
         assert result.severity == "fail"
         assert "th1/t1" in result.message
 
-    def test_dilemmas_resolved_with_prefixed_tension_id(self) -> None:
+    def test_dilemmas_resolved_with_prefixed_dilemma_id(self) -> None:
         """Works when path nodes use prefixed dilemma_id (real SEED output)."""
         from tests.fixtures.grow_fixtures import make_two_dilemma_graph
 

--- a/tests/unit/test_mutations.py
+++ b/tests/unit/test_mutations.py
@@ -286,7 +286,7 @@ class TestBrainstormMutations:
         ):
             apply_brainstorm_mutations(graph, output)
 
-    def test_tension_missing_id_raises(self) -> None:
+    def test_dilemma_missing_id_raises(self) -> None:
         """Raises MutationError when dilemma missing dilemma_id."""
         graph = Graph.empty()
         output = {
@@ -304,7 +304,7 @@ class TestBrainstormMutations:
             "entities": [],
             "dilemmas": [
                 {
-                    "dilemma_id": "tension_001",
+                    "dilemma_id": "dilemma_001",
                     "question": "Test?",
                     "answers": [
                         {"description": "Option A", "is_default_path": True}
@@ -315,7 +315,7 @@ class TestBrainstormMutations:
 
         with pytest.raises(
             MutationError,
-            match="Answer at index 0 in dilemma 'tension_001' missing answer_id",
+            match="Answer at index 0 in dilemma 'dilemma_001' missing answer_id",
         ):
             apply_brainstorm_mutations(graph, output)
 
@@ -355,7 +355,7 @@ class TestBrainstormMutations:
         assert archive is not None
         assert archive["entity_type"] == "location"
 
-    def test_creates_tension_with_alternatives(self) -> None:
+    def test_creates_dilemma_with_alternatives(self) -> None:
         """Creates dilemma nodes with linked answers."""
         graph = Graph.empty()
         output = {
@@ -393,7 +393,7 @@ class TestBrainstormMutations:
         # central_entity_ids list is prefixed in storage
         assert dilemma["central_entity_ids"] == ["entity::kay", "entity::mentor"]
 
-        # Alternative IDs: dilemma::tension_id::alt::alt_id
+        # Alternative IDs: dilemma::dilemma_id::alt::alt_id
         protector = graph.get_node("dilemma::mentor_trust::alt::protector")
         assert protector is not None
         assert protector["type"] == "answer"
@@ -566,7 +566,7 @@ class TestValidateBrainstormMutations:
         # Should find: 2 phantom entity errors + 1 no default error
         assert len(errors) == 3
 
-    def test_empty_tensions_valid(self) -> None:
+    def test_empty_dilemmas_valid(self) -> None:
         """Empty dilemmas list is valid."""
         output = {
             "entities": [
@@ -1101,7 +1101,7 @@ class TestSeedCompletenessValidation:
         assert any("character" in e.issue for e in entity_errors)
         assert any("location" in e.issue for e in entity_errors)
 
-    def test_missing_tension_decision_detected(self) -> None:
+    def test_missing_dilemma_decision_detected(self) -> None:
         """Detects when dilemma from BRAINSTORM has no decision in SEED."""
         graph = Graph.empty()
         # Add dilemmas from BRAINSTORM
@@ -1252,7 +1252,7 @@ class TestSeedCompletenessValidation:
         thread_errors = [e for e in errors if "has no path" in e.issue]
         assert thread_errors == []
 
-    def test_scoped_tension_id_in_thread_satisfies_completeness(self) -> None:
+    def test_scoped_dilemma_id_in_thread_satisfies_completeness(self) -> None:
         """Scoped dilemma_id (dilemma::trust) in path satisfies completeness."""
         graph = Graph.empty()
         graph.create_node("dilemma::trust", {"type": "dilemma", "raw_id": "trust"})
@@ -1392,7 +1392,7 @@ class TestSeedCompletenessValidation:
         assert "nonexistent" in invalid_errors[0].provided
 
 
-class TestBeatTensionAlignment:
+class TestBeatDilemmaAlignment:
     """Test SEED validation checks 12 and 13: beat-path-dilemma alignment."""
 
     def _make_graph(self) -> Graph:
@@ -1429,7 +1429,7 @@ class TestBeatTensionAlignment:
             "initial_beats": [],
         }
 
-    def test_beat_wrong_tension_detected(self) -> None:
+    def test_beat_wrong_dilemma_detected(self) -> None:
         """Beat referencing wrong dilemma triggers semantic error."""
         graph = self._make_graph()
         output = self._base_output()
@@ -1492,7 +1492,7 @@ class TestBeatTensionAlignment:
         assert "trust_arc" in commits_errors[0].issue
         assert commits_errors[0].category == SeedErrorCategory.COMPLETENESS
 
-    def test_beat_with_additional_tensions_allowed(self) -> None:
+    def test_beat_with_additional_dilemmas_allowed(self) -> None:
         """Beat can reference additional dilemmas beyond its own path's dilemma."""
         graph = self._make_graph()
         output = self._base_output()
@@ -1629,7 +1629,7 @@ class TestSeedDuplicateValidation:
         assert "hero" in dup_errors[0].issue
         assert "2 times" in dup_errors[0].issue
 
-    def test_duplicate_tension_id_detected(self) -> None:
+    def test_duplicate_dilemma_id_detected(self) -> None:
         """Detects when the same dilemma_id appears multiple times in output."""
         graph = Graph.empty()
         graph.create_node("dilemma::trust", {"type": "dilemma", "raw_id": "trust"})
@@ -1839,7 +1839,7 @@ class TestCategorizeError:
         error = SeedValidationError(
             field_path="paths.0.dilemma_id",
             issue="Dilemma 'phantom' not in BRAINSTORM",
-            available=["real_tension"],
+            available=["real_dilemma"],
             provided="phantom",
         )
         assert categorize_error(error) == SeedErrorCategory.SEMANTIC
@@ -2008,7 +2008,7 @@ class TestNormalizeId:
         assert normalized == "hero"
         assert error is None
 
-    def test_tension_scope_accepted(self) -> None:
+    def test_dilemma_scope_accepted(self) -> None:
         """Dilemma scope is handled correctly."""
         normalized, error = _normalize_id("dilemma::mentor_trust", "dilemma")
         assert normalized == "mentor_trust"
@@ -2070,7 +2070,7 @@ class TestScopedIdValidation:
 
         assert errors == []
 
-    def test_scoped_tension_id_accepted(self) -> None:
+    def test_scoped_dilemma_id_accepted(self) -> None:
         """Scoped dilemma IDs (dilemma::trust) are accepted in dilemma decisions."""
         graph = Graph.empty()
         graph.create_node("dilemma::trust", {"type": "dilemma", "raw_id": "trust"})
@@ -2161,7 +2161,7 @@ class TestScopedIdValidation:
         assert "entity::" in scope_errors[0].issue
         assert "dilemma::" in scope_errors[0].issue
 
-    def test_wrong_scope_detected_for_tension(self) -> None:
+    def test_wrong_scope_detected_for_dilemma(self) -> None:
         """Wrong scope (entity:: instead of dilemma::) is detected."""
         graph = Graph.empty()
         graph.create_node("dilemma::trust", {"type": "dilemma", "raw_id": "trust"})
@@ -2324,7 +2324,7 @@ class TestScopedIdValidation:
         # No errors expected
         assert errors == []
 
-    def test_scoped_tension_in_dilemma_impacts(self) -> None:
+    def test_scoped_dilemma_in_dilemma_impacts(self) -> None:
         """Scoped dilemma IDs work in beat.dilemma_impacts."""
         graph = Graph.empty()
         graph.create_node("entity::hero", {"type": "entity", "raw_id": "hero"})
@@ -2773,7 +2773,7 @@ class TestFormatSemanticErrorsAsContent:
             SeedValidationError(
                 field_path="paths.0.dilemma_id",
                 issue="Dilemma 'unknown' not in BRAINSTORM",
-                available=["main_tension"],
+                available=["main_dilemma"],
                 provided="unknown",
             ),
         ]
@@ -2811,7 +2811,7 @@ class TestTypeAwareFeedback:
     the generic "not in BRAINSTORM" message.
     """
 
-    def test_type_aware_feedback_entity_as_tension(self) -> None:
+    def test_type_aware_feedback_entity_as_dilemma(self) -> None:
         """Entity faction name used as dilemma_id gives helpful message."""
         graph = Graph.empty()
         # isolation_protocol is a faction entity in brainstorm
@@ -2852,7 +2852,7 @@ class TestTypeAwareFeedback:
         assert "is an entity (faction), not a dilemma" in dilemma_impact_errors[0].issue
         assert "subject_X_or_Y" in dilemma_impact_errors[0].issue
 
-    def test_type_aware_feedback_thread_as_tension(self) -> None:
+    def test_type_aware_feedback_thread_as_dilemma(self) -> None:
         """Path ID used as dilemma_id gives helpful message."""
         graph = Graph.empty()
         graph.create_node(
@@ -3141,7 +3141,7 @@ class TestBackfillConsideredFromThreads:
 
         assert output["dilemmas"][0]["considered"] == ["existing_value"]
 
-    def test_handles_scoped_tension_ids(self) -> None:
+    def test_handles_scoped_dilemma_ids(self) -> None:
         """Handles dilemma IDs with scope prefix (dilemma::id)."""
         output = {
             "dilemmas": [
@@ -3228,17 +3228,17 @@ class TestBackfillConsideredFromThreads:
 
         assert output["dilemmas"][0]["considered"] == []
 
-    def test_multiple_tensions_independently_backfilled(self) -> None:
+    def test_multiple_dilemmas_independently_backfilled(self) -> None:
         """Each dilemma is backfilled from its own paths."""
         output = {
             "dilemmas": [
-                {"dilemma_id": "tension_one", "considered": []},
-                {"dilemma_id": "tension_two", "considered": []},
+                {"dilemma_id": "dilemma_one", "considered": []},
+                {"dilemma_id": "dilemma_two", "considered": []},
             ],
             "paths": [
-                {"path_id": "t1", "dilemma_id": "tension_one", "answer_id": "opt_a"},
-                {"path_id": "t2", "dilemma_id": "tension_two", "answer_id": "opt_x"},
-                {"path_id": "t3", "dilemma_id": "tension_two", "answer_id": "opt_y"},
+                {"path_id": "t1", "dilemma_id": "dilemma_one", "answer_id": "opt_a"},
+                {"path_id": "t2", "dilemma_id": "dilemma_two", "answer_id": "opt_x"},
+                {"path_id": "t3", "dilemma_id": "dilemma_two", "answer_id": "opt_y"},
             ],
         }
 
@@ -3427,7 +3427,7 @@ class TestValidation11cThreadAlternativeInConsidered:
         assert len(check_11c_errors) == 1
         assert "option_a" in check_11c_errors[0].issue
 
-    def test_scoped_tension_ids_matched_correctly(self) -> None:
+    def test_scoped_dilemma_ids_matched_correctly(self) -> None:
         """Scoped dilemma IDs are normalized for matching."""
         graph = Graph.empty()
         graph.create_node(
@@ -3555,6 +3555,6 @@ class TestBackfillIntegrationWithApplySeedMutations:
         apply_seed_mutations(graph, output)
 
         # Verify the dilemma node was updated with backfilled considered
-        tension_node = graph.get_node("dilemma::choice_a_or_b")
-        assert tension_node is not None
-        assert sorted(tension_node.get("considered", [])) == ["option_a", "option_b"]
+        dilemma_node = graph.get_node("dilemma::choice_a_or_b")
+        assert dilemma_node is not None
+        assert sorted(dilemma_node.get("considered", [])) == ["option_a", "option_b"]


### PR DESCRIPTION
Removes remaining legacy story terminology and backward-compat support for:\n- tension/tensions/tension_id\n- thread/threads/thread_id\n- knot/knots\n\nAlso updates docs/tests accordingly and removes fallback handling in previews/enrichment.