### PR TITLE
Normalize scoped IDs in brainstorm ingestion and seed manifests

### DIFF
--- a/src/questfoundry/graph/context.py
+++ b/src/questfoundry/graph/context.py
@@ -275,7 +275,7 @@ def format_path_ids_context(paths: list[dict[str, Any]]) -> str:
         return ""
 
     # Pipe-delimited for easy scanning, with path:: scope prefix
-    id_list = " | ".join(f"`{format_scoped_id(SCOPE_PATH, pid)}`" for pid in path_ids)
+    id_list = " | ".join(f"`{normalize_scoped_id(pid, SCOPE_PATH)}`" for pid in path_ids)
 
     lines = [
         "## VALID PATH IDs (copy exactly, no modifications)",
@@ -302,8 +302,8 @@ def format_path_ids_context(paths: list[dict[str, Any]]) -> str:
         lines.append("")
         for pid, dilemma in path_dilemma_pairs:
             lines.append(
-                f"  - `{format_scoped_id(SCOPE_PATH, pid)}` → "
-                f"`{format_scoped_id(SCOPE_DILEMMA, dilemma)}`"
+                f"  - `{normalize_scoped_id(pid, SCOPE_PATH)}` → "
+                f"`{normalize_scoped_id(dilemma, SCOPE_DILEMMA)}`"
             )
         lines.append("")
 
@@ -425,7 +425,7 @@ def _format_seed_valid_ids(graph: Graph) -> str:
                 cat_count = len(by_category[category])
                 lines.append(f"**{category.title()}s ({cat_count}):**")
                 for raw_id in sorted(by_category[category]):
-                    lines.append(f"  - `{format_scoped_id(SCOPE_ENTITY, raw_id)}`")
+                    lines.append(f"  - `{normalize_scoped_id(raw_id, SCOPE_ENTITY)}`")
                 lines.append("")
 
     # Dilemmas with answers
@@ -461,7 +461,7 @@ def _format_seed_valid_ids(graph: Graph) -> str:
                 # Sort answers for deterministic output
                 answers.sort()
                 lines.append(
-                    f"- `{format_scoped_id(SCOPE_DILEMMA, raw_id)}` → [{', '.join(answers)}]"
+                    f"- `{normalize_scoped_id(raw_id, SCOPE_DILEMMA)}` → [{', '.join(answers)}]"
                 )
 
         lines.append("")
@@ -566,7 +566,7 @@ def format_retained_entity_ids(
             cat_count = len(by_category[category])
             lines.append(f"**{category.title()}s ({cat_count}):**")
             for raw_id in sorted(by_category[category]):
-                lines.append(f"  - `{format_scoped_id(SCOPE_ENTITY, raw_id)}`")
+                lines.append(f"  - `{normalize_scoped_id(raw_id, SCOPE_ENTITY)}`")
             lines.append("")
 
     return "\n".join(lines)
@@ -604,7 +604,7 @@ def format_summarize_manifest(graph: Graph) -> dict[str, str]:
         if category in by_category:
             entity_lines.append(f"**{category.title()}s:**")
             for raw_id in sorted(by_category[category]):
-                entity_lines.append(f"  - `{format_scoped_id(SCOPE_ENTITY, raw_id)}`")
+                entity_lines.append(f"  - `{normalize_scoped_id(raw_id, SCOPE_ENTITY)}`")
             entity_lines.append("")  # Blank line between categories
 
     # Collect dilemma IDs
@@ -613,7 +613,7 @@ def format_summarize_manifest(graph: Graph) -> dict[str, str]:
     for _did, ddata in sorted(dilemmas.items()):
         raw_id = ddata.get("raw_id")
         if raw_id:
-            dilemma_lines.append(f"- `{format_scoped_id(SCOPE_DILEMMA, raw_id)}`")
+            dilemma_lines.append(f"- `{normalize_scoped_id(raw_id, SCOPE_DILEMMA)}`")
 
     return {
         "entity_manifest": "\n".join(entity_lines) if entity_lines else "(No entities)",

--- a/src/questfoundry/graph/mutations.py
+++ b/src/questfoundry/graph/mutations.py
@@ -697,8 +697,8 @@ def apply_brainstorm_mutations(graph: Graph, output: dict[str, Any]) -> None:
     # Add entities
     for i, entity in enumerate(output.get("entities", [])):
         raw_id = _require_field(entity, "entity_id", f"Entity at index {i}")
-        raw_id = strip_scope_prefix(raw_id)
         entity_id = _prefix_id("entity", raw_id)
+        raw_id = strip_scope_prefix(entity_id)
         node_data = {
             "type": "entity",
             "raw_id": raw_id,  # Store unscoped ID for reference
@@ -716,8 +716,8 @@ def apply_brainstorm_mutations(graph: Graph, output: dict[str, Any]) -> None:
         raw_id = dilemma.get("dilemma_id")
         if not raw_id:
             raise MutationError(f"Dilemma at index {i} missing dilemma_id")
-        raw_id = strip_scope_prefix(raw_id)
         dilemma_node_id = _prefix_id("dilemma", raw_id)
+        raw_id = strip_scope_prefix(dilemma_node_id)
 
         # Prefix entity references in central_entity_ids list
         raw_central_entities = dilemma.get("central_entity_ids", [])
@@ -739,7 +739,7 @@ def apply_brainstorm_mutations(graph: Graph, output: dict[str, Any]) -> None:
             answer_local_id = answer.get("answer_id")
             if not answer_local_id:
                 raise MutationError(f"Answer at index {j} in dilemma '{raw_id}' missing answer_id")
-            answer_local_id = strip_scope_prefix(answer_local_id)
+            answer_local_id = strip_scope_prefix(_prefix_id("answer", answer_local_id))
             # Answer ID format: dilemma::dilemma_raw_id::alt::answer_local_id
             answer_node_id = f"{dilemma_node_id}::alt::{answer_local_id}"
             answer_data = {


### PR DESCRIPTION
## Summary
- normalize scoped entity/dilemma/answer IDs when applying BRAINSTORM mutations
- accept scoped IDs in brainstorm validation
- avoid double-scoping in seed manifests and valid-ID context
- add tests for scoped brainstorm IDs

## Testing
- pre-commit hooks (ruff/format/mypy) via `git commit`
- `uv run ruff check src/questfoundry/graph/mutations.py src/questfoundry/graph/context.py tests/unit/test_mutations.py`
- `uv run pytest tests/unit/test_mutations.py tests/unit/test_graph_context.py`

## Context
Fixes seed feedback loops where prompts list `dilemma::dilemma::...` due to scoped raw IDs (see issues #219, #338).