### PR TITLE
fix(grow): reorder phases and enforce no-conditional-prerequisites invariant

### DIFF
--- a/src/questfoundry/pipeline/stages/grow.py
+++ b/src/questfoundry/pipeline/stages/grow.py
@@ -147,13 +147,19 @@ class GrowStage:
             All phases are async and accept (graph, model) parameters.
             Deterministic phases ignore the model parameter.
         """
+        # Gap detection (4a/4b/4c) runs BEFORE intersections (3) so that
+        # each path is fully elaborated before cross-path weaving.  This
+        # prevents "conditional prerequisites" — a shared beat depending on
+        # a path-specific gap beat — which would cause silent `requires`
+        # edge drops during arc enumeration and passage DAG cycles.
+        # See: check_intersection_compatibility() invariant, #357/#358/#359.
         return [
             (self._phase_1_validate_dag, "validate_dag"),
             (self._phase_2_path_agnostic, "path_agnostic"),
-            (self._phase_3_intersections, "intersections"),
             (self._phase_4a_scene_types, "scene_types"),
             (self._phase_4b_narrative_gaps, "narrative_gaps"),
             (self._phase_4c_pacing_gaps, "pacing_gaps"),
+            (self._phase_3_intersections, "intersections"),
             (self._phase_5_enumerate_arcs, "enumerate_arcs"),
             (self._phase_6_divergence, "divergence"),
             (self._phase_7_convergence, "convergence"),

--- a/tests/fixtures/grow_fixtures.py
+++ b/tests/fixtures/grow_fixtures.py
@@ -642,3 +642,44 @@ def make_intersection_candidate_graph() -> Graph:
     )
 
     return graph
+
+
+def make_conditional_prerequisite_graph() -> Graph:
+    """Create a graph where an intersection candidate has a path-specific prerequisite.
+
+    Extends ``make_intersection_candidate_graph`` by adding a gap beat that
+    belongs to only one path and is required by one of the intersection
+    candidates.
+
+    Structure:
+        beat::gap_1: belongs to path::mentor_trust_canonical only
+        beat::mentor_meet requires beat::gap_1
+
+    This creates a conditional prerequisite: if mentor_meet and
+    artifact_discover are proposed as an intersection, the intersection
+    would span all 4 paths but gap_1 exists on only 1 path.  The
+    ``check_intersection_compatibility`` invariant should reject this.
+
+    Returns:
+        Graph with a path-specific prerequisite on an intersection candidate.
+    """
+    graph = make_intersection_candidate_graph()
+
+    # Add a gap beat belonging to only one path
+    graph.create_node(
+        "beat::gap_1",
+        {
+            "type": "beat",
+            "raw_id": "gap_1",
+            "summary": "A transition gap beat.",
+            "scene_type": "sequel",
+            "paths": ["mentor_trust_canonical"],
+            "is_gap_beat": True,
+        },
+    )
+    graph.add_edge("belongs_to", "beat::gap_1", "path::mentor_trust_canonical")
+
+    # mentor_meet requires gap_1 (gap_1 must come first)
+    graph.add_edge("requires", "beat::mentor_meet", "beat::gap_1")
+
+    return graph

--- a/tests/unit/test_grow_stage.py
+++ b/tests/unit/test_grow_stage.py
@@ -134,10 +134,10 @@ class TestGrowStagePhaseOrder:
         assert names == [
             "validate_dag",
             "path_agnostic",
-            "intersections",
             "scene_types",
             "narrative_gaps",
             "pacing_gaps",
+            "intersections",
             "enumerate_arcs",
             "divergence",
             "convergence",


### PR DESCRIPTION
## Problem

GROW validation fails with `passage_dag_cycles` because shared (intersection) beats can acquire `requires` edges to path-specific gap beats. When arc enumeration builds beat sets for arcs that don't include the gap beat's path, the `requires` edge is silently dropped, producing contradictory successor orderings across arcs and cycles in the passage DAG. Additionally, seed pruning was not updating `considered`/`implicit` fields on demoted dilemmas, causing a validation mismatch.

## Changes

**Commit 1** (existing): Update `considered`/`implicit` when pruning demoted dilemmas

**Commit 2** (new):
- Reorder `_phase_order()` in `grow.py`: gap detection (4a/4b/4c) now runs before intersection detection (3), so each path is fully elaborated before cross-path weaving
- Add no-conditional-prerequisites invariant to `check_intersection_compatibility()`: rejects intersections where a shared beat would depend on a path-specific beat (`paths(prerequisite) ⊇ paths(dependent_after_merge)`)
- Add `make_conditional_prerequisite_graph()` test fixture
- Add `TestConditionalPrerequisiteInvariant` with 6 regression tests
- Update `docs/design/procedures/grow.md` with execution order note, invariant spec, and references to future alternatives (#360, #361)

## Not Included / Future PRs

- **Lift prerequisites into shared set** (#360): merge prerequisite beat into all intersection paths
- **Split path-specific lead-ins** (#361): create path-specific copies of the shared beat
- Both are referenced in code comments and design docs

## Test Plan

```bash
uv run mypy src/questfoundry/  # ✅ clean
uv run ruff check src/         # ✅ clean
uv run pytest tests/unit/test_grow_algorithms.py -x -q  # ✅ 130 passed
uv run pytest tests/unit/test_grow_validation.py -x -q  # ✅ 33 passed
pre-commit run --files ...     # ✅ all passed
```

New tests:
- `test_rejects_intersection_with_conditional_prerequisite`
- `test_accepts_intersection_without_conditional_prerequisites`
- `test_accepts_when_prerequisite_spans_all_paths`
- `test_phase_order_gaps_before_intersections`
- `test_rejects_when_prerequisite_has_no_paths`
- `test_reports_multiple_conditional_prerequisites`

## Risk / Rollback

- Phase reordering is safe: architect review confirmed no data dependencies from phases 4a/4b/4c on phase 3 output
- The invariant check is additive (new rejection, no existing behavior changed)
- Rollback: revert both commits; issues #357/#358/#359 would need reopening

Closes #357, closes #358, closes #359

🤖 Generated with [Claude Code](https://claude.com/claude-code)