### PR TITLE
feat(prompts): strengthen brainstorm/seed prompts for interconnection (#366)

### DIFF
--- a/prompts/templates/discuss_brainstorm.yaml
+++ b/prompts/templates/discuss_brainstorm.yaml
@@ -21,6 +21,17 @@ system: |
   - If something has a physical space where scenes can occur, consider making it a location not an object
   - A story with only 1-2 locations feels confined; more settings enable natural scene variation and convergence points
 
+  ## Interconnection Guidance
+  Dilemmas should NOT be isolated storylines. Build interconnection into the material:
+  - **Shared locations across dilemmas**: At least 2-3 locations should be relevant to multiple dilemmas
+    (e.g., an archive is where both the trust investigation AND the artifact mystery converge)
+  - **Position-based contradictions**: Characters who appear trustworthy under one dilemma
+    but suspicious under another create natural cross-dilemma tension
+  - **Dual-purpose locations**: A location that serves one function for one dilemma and a
+    different function for another (e.g., a garden is a meeting place AND a hiding spot)
+  - **Avoid isolated investigators**: If a character is central to only one dilemma with no
+    connection to others, the story will fragment into parallel tracks that never intersect
+
   2. **Dilemmas** - Binary dramatic questions that drive the story
      - Each dilemma is a yes/no question (e.g., "Can the mentor be trusted?")
      - Each dilemma has exactly TWO answers (not more, not less)

--- a/prompts/templates/discuss_seed.yaml
+++ b/prompts/templates/discuss_seed.yaml
@@ -87,9 +87,26 @@ system: |
   - Vary locations (not all beats in one place)
   - Impact dilemmas (advance, reveal, commit, complicate)
 
-  ### 5. Sketch Convergence
+  ### 5. Design Convergence Points
 
-  Hint at where paths should merge and what differences persist after convergence.
+  Paths MUST converge at specific physical locations, not abstract narrative moments.
+  Design 2-4 convergence points where characters from different dilemmas are forced
+  into the same scene:
+
+  - **Location-based convergence**: Name the specific location where paths meet
+    (e.g., "all paths converge at the archive_vault for the final confrontation")
+  - **Investigation chain**: Define a forced sequence: discovery location -> evidence location -> confrontation location
+  - **Cross-dilemma presence**: At each convergence point, characters from at least
+    2 different dilemmas must be present and affected
+
+  GOOD convergence: "Paths converge at the archive_vault where the mentor's loyalty
+  and the artifact's nature are both revealed through the same evidence."
+
+  BAD convergence: "Paths eventually merge as the story reaches its climax."
+  BAD convergence: "The emotional arcs align thematically in the final act."
+
+  Also note what differences persist after convergence - what residue remains from
+  the path choices the player made.
 
   ## ID Rules (Prevent Validation Failures)
 

--- a/prompts/templates/serialize_seed_sections.yaml
+++ b/prompts/templates/serialize_seed_sections.yaml
@@ -498,23 +498,41 @@ per_path_beats_prompt: |
 
 # Section 6: Convergence Sketch
 convergence_prompt: |
-  You are extracting the CONVERGENCE SKETCH from a SEED stage brief.
+  You are generating the CONVERGENCE SKETCH from a SEED stage brief.
+
+  ## What Makes Good Convergence
+
+  Convergence points must be **location-based and concrete**, not abstract narrative moments.
+
+  GOOD convergence points:
+  - "paths converge at archive_vault where evidence from both dilemmas is revealed"
+  - "all characters are forced to the council_chamber for a confrontation"
+  - "investigation trails from separate dilemmas lead to the same lighthouse"
+
+  BAD convergence points:
+  - "paths merge emotionally in the final act" (abstract, no location)
+  - "the story reaches a climax" (no specific convergence mechanism)
+  - "thematic arcs align" (not actionable for scene generation)
+
+  Each convergence point should name a specific location (from your entity list)
+  and explain which dilemma storylines are forced together there.
 
   ## Schema
   Return a JSON object with a "convergence_sketch" object:
   ```json
   {
     "convergence_sketch": {
-      "convergence_points": ["where paths should merge"],
+      "convergence_points": ["location-based convergence description"],
       "residue_notes": ["differences that persist after convergence"]
     }
   }
   ```
 
   ## Rules
-  - convergence_points: Where paths should merge (e.g., "by act 2 climax")
-  - residue_notes: What differences persist after convergence
-  - Both can be empty arrays if not specified in brief
+  - convergence_points: Where paths physically converge (name the location and which dilemmas meet)
+  - residue_notes: What differences persist after convergence (path-specific consequences)
+  - convergence_points should have at least 1-2 entries referencing specific locations
+  - residue_notes can be empty if not specified in brief
 
   ## Output
   Return ONLY valid JSON with the "convergence_sketch" object.


### PR DESCRIPTION
## Problem
Test project analysis (test-3, test-4) showed SEED produces stories with isolated dilemmas and abstract convergence statements instead of concrete location-based intersections. The brainstorm and seed prompts lack explicit guidance for interconnection.

## Changes
- `discuss_brainstorm.yaml`: Add "Interconnection Guidance" section requiring shared locations across dilemmas, position-based contradictions, dual-purpose locations
- `discuss_seed.yaml`: Replace weak "Hint at where paths should merge" with explicit convergence requirements (2-4 location-based convergence points, forced investigation chain)
- `serialize_seed_sections.yaml`: Enhance convergence_prompt with GOOD/BAD examples requiring location-based convergence points

## Not Included / Future PRs
- Code changes to enforce convergence (see #363, #364, #365)
- GROW-side intersection improvements (see #360, #361)

## Test Plan
- `uv run mypy src/ && uv run ruff check src/` (prompts don't have unit tests)
- Prompt-only changes; no behavioral code modified

## Risk / Rollback
- Low risk: prompt-only changes, no code behavior affected
- Rollback: revert prompt files

Closes #366

> **Stack**: 1/6 — base: `main` → [#369](#369) → [#370](#370) → [#371](#371) → [#372](#372) → [#373](#373)

🤖 Generated with [Claude Code](https://claude.com/claude-code)