### PR TITLE
feat(seed): inject valid answer IDs before paths serialization (#364)

### DIFF
--- a/src/questfoundry/agents/serialize.py
+++ b/src/questfoundry/agents/serialize.py
@@ -18,6 +18,7 @@ from questfoundry.artifacts.validator import strip_null_values
 from questfoundry.graph.context import (
     SCOPE_DILEMMA,
     SCOPE_PATH,
+    format_answer_ids_by_dilemma,
     format_path_ids_context,
     format_retained_entity_ids,
     format_valid_ids_context,
@@ -1197,6 +1198,17 @@ async def serialize_seed_as_function(
                 "retained_entity_context_updated",
                 entity_decisions=len(collected["entities"]),
             )
+
+        # After dilemmas are serialized, inject answer ID manifest so the
+        # paths section knows which answer_ids are valid per dilemma.
+        if section_name == "dilemmas" and collected.get("dilemmas"):
+            answer_ids_context = format_answer_ids_by_dilemma(collected["dilemmas"])
+            if answer_ids_context:
+                enhanced_brief = f"{enhanced_brief}\n\n{answer_ids_context}"
+                log.debug(
+                    "answer_ids_context_injected",
+                    dilemma_count=len(collected["dilemmas"]),
+                )
 
         # After paths are serialized:
         # 1. Inject path IDs for subsequent sections (consequences)

--- a/src/questfoundry/graph/context.py
+++ b/src/questfoundry/graph/context.py
@@ -245,6 +245,44 @@ def format_hierarchical_path_id(dilemma_id: str, answer_id: str) -> str:
     return f"{SCOPE_PATH}::{dilemma_raw}__{answer_id}"
 
 
+def format_answer_ids_by_dilemma(dilemmas: list[dict[str, Any]]) -> str:
+    """Format answer IDs per dilemma as context for paths serialization.
+
+    After dilemmas are serialized, each dilemma has ``considered`` and
+    ``implicit`` answer lists.  Injecting these before the paths section
+    lets the model know exactly which answer_id values are valid for each
+    dilemma, preventing phantom answer references.
+
+    Args:
+        dilemmas: List of dilemma decision dicts from serialized output.
+
+    Returns:
+        Formatted manifest string, or empty string if no dilemmas.
+    """
+    if not dilemmas:
+        return ""
+
+    lines = [
+        "## Valid Answer IDs per Dilemma",
+        "",
+        "Each path's `answer_id` MUST be one of the `considered` IDs below.",
+        "Do NOT invent answer IDs or use `implicit` IDs as path answer_ids.",
+        "",
+    ]
+
+    for d in sorted(dilemmas, key=lambda x: x.get("dilemma_id", "")):
+        dilemma_id = d.get("dilemma_id", "")
+        if not dilemma_id:
+            continue
+        scoped = normalize_scoped_id(strip_scope_prefix(dilemma_id), SCOPE_DILEMMA)
+        considered = d.get("considered", [])
+        implicit = d.get("implicit", [])
+        lines.append(f"- `{scoped}` -> considered: {considered}, implicit: {implicit}")
+
+    lines.append("")
+    return "\n".join(lines)
+
+
 def format_path_ids_context(paths: list[dict[str, Any]]) -> str:
     """Format path IDs for beat serialization with inline constraints.
 

--- a/tests/unit/test_graph_context.py
+++ b/tests/unit/test_graph_context.py
@@ -8,6 +8,7 @@ from questfoundry.graph.context import (
     SCOPE_ENTITY,
     SCOPE_PATH,
     check_structural_completeness,
+    format_answer_ids_by_dilemma,
     format_hierarchical_path_id,
     format_path_ids_context,
     format_scoped_id,
@@ -1143,3 +1144,67 @@ class TestFormatHierarchicalPathId:
         dilemma_id, answer_id = parse_hierarchical_path_id(original)
         reformatted = format_hierarchical_path_id(dilemma_id, answer_id)
         assert reformatted == original
+
+
+class TestFormatAnswerIdsByDilemma:
+    """Tests for format_answer_ids_by_dilemma function."""
+
+    def test_empty_dilemmas_returns_empty(self) -> None:
+        """Empty list returns empty string."""
+        assert format_answer_ids_by_dilemma([]) == ""
+
+    def test_single_dilemma_with_considered_and_implicit(self) -> None:
+        """Single dilemma formats considered and implicit lists."""
+        dilemmas = [
+            {
+                "dilemma_id": "dilemma::host_benevolent_or_selfish",
+                "considered": ["protector", "manipulator"],
+                "implicit": ["neutral"],
+            }
+        ]
+        result = format_answer_ids_by_dilemma(dilemmas)
+        assert "Valid Answer IDs per Dilemma" in result
+        assert "dilemma::host_benevolent_or_selfish" in result
+        assert "['protector', 'manipulator']" in result
+        assert "['neutral']" in result
+
+    def test_multiple_dilemmas_all_listed(self) -> None:
+        """Multiple dilemmas are all included in output."""
+        dilemmas = [
+            {
+                "dilemma_id": "dilemma::mentor_trust_or_betray",
+                "considered": ["trust"],
+                "implicit": ["betray"],
+            },
+            {
+                "dilemma_id": "dilemma::artifact_blessed_or_cursed",
+                "considered": ["blessed", "cursed"],
+                "implicit": [],
+            },
+        ]
+        result = format_answer_ids_by_dilemma(dilemmas)
+        assert "dilemma::mentor_trust_or_betray" in result
+        assert "dilemma::artifact_blessed_or_cursed" in result
+
+    def test_dilemma_without_id_skipped(self) -> None:
+        """Dilemmas with empty or missing ID are skipped."""
+        dilemmas = [
+            {"dilemma_id": "", "considered": ["a"], "implicit": []},
+            {"considered": ["b"], "implicit": []},
+        ]
+        result = format_answer_ids_by_dilemma(dilemmas)
+        # Header still present but no dilemma lines
+        assert "Valid Answer IDs per Dilemma" in result
+        assert "dilemma::" not in result
+
+    def test_unscoped_dilemma_id_gets_prefix(self) -> None:
+        """Dilemma IDs without scope prefix get normalized."""
+        dilemmas = [
+            {
+                "dilemma_id": "host_benevolent_or_selfish",
+                "considered": ["protector"],
+                "implicit": [],
+            }
+        ]
+        result = format_answer_ids_by_dilemma(dilemmas)
+        assert "dilemma::host_benevolent_or_selfish" in result


### PR DESCRIPTION
## Problem
SEED serialization produces "phantom ID" errors where the LLM invents answer IDs not present in any dilemma. The serialize loop injects valid entity IDs and path IDs before their respective sections, but answer IDs per dilemma are not provided, leaving the LLM to guess.

## Changes
- `context.py`: Add `format_answer_ids_by_dilemma()` — builds a manifest of valid answer IDs (considered + implicit) per dilemma
- `serialize.py`: Inject the answer ID manifest into `enhanced_brief` after dilemmas section is serialized, before paths section

## Not Included / Future PRs
- Cross-reference validation timing (#363)
- GROW quality gates (#365)

## Test Plan
- `uv run pytest tests/unit/test_graph_context.py -x -q` — 5 new tests for `format_answer_ids_by_dilemma`
- `uv run mypy src/ && uv run ruff check src/`

## Risk / Rollback
- Low risk: additive change, injects additional context into the serialize prompt
- Rollback: remove the injection block in serialize.py

Closes #364

> **Stack**: 2/6 — [#368](#368) → this PR → [#370](#370) → [#371](#371) → [#372](#372) → [#373](#373)

🤖 Generated with [Claude Code](https://claude.com/claude-code)