### PR TITLE
feat: SEED/GROW quality improvements (#360, #361, #363, #364, #365, #366)

### DIFF
--- a/prompts/templates/discuss_brainstorm.yaml
+++ b/prompts/templates/discuss_brainstorm.yaml
@@ -21,6 +21,17 @@ system: |
   - If something has a physical space where scenes can occur, consider making it a location not an object
   - A story with only 1-2 locations feels confined; more settings enable natural scene variation and convergence points
 
+  ## Interconnection Guidance
+  Dilemmas should NOT be isolated storylines. Build interconnection into the material:
+  - **Shared locations across dilemmas**: At least 2-3 locations should be relevant to multiple dilemmas
+    (e.g., an archive is where both the trust investigation AND the artifact mystery converge)
+  - **Position-based contradictions**: Characters who appear trustworthy under one dilemma
+    but suspicious under another create natural cross-dilemma tension
+  - **Dual-purpose locations**: A location that serves one function for one dilemma and a
+    different function for another (e.g., a garden is a meeting place AND a hiding spot)
+  - **Avoid isolated investigators**: If a character is central to only one dilemma with no
+    connection to others, the story will fragment into parallel tracks that never intersect
+
   2. **Dilemmas** - Binary dramatic questions that drive the story
      - Each dilemma is a yes/no question (e.g., "Can the mentor be trusted?")
      - Each dilemma has exactly TWO answers (not more, not less)

--- a/prompts/templates/discuss_seed.yaml
+++ b/prompts/templates/discuss_seed.yaml
@@ -87,9 +87,26 @@ system: |
   - Vary locations (not all beats in one place)
   - Impact dilemmas (advance, reveal, commit, complicate)
 
-  ### 5. Sketch Convergence
+  ### 5. Design Convergence Points
 
-  Hint at where paths should merge and what differences persist after convergence.
+  Paths MUST converge at specific physical locations, not abstract narrative moments.
+  Design 2-4 convergence points where characters from different dilemmas are forced
+  into the same scene:
+
+  - **Location-based convergence**: Name the specific location where paths meet
+    (e.g., "all paths converge at the archive_vault for the final confrontation")
+  - **Investigation chain**: Define a forced sequence: discovery location -> evidence location -> confrontation location
+  - **Cross-dilemma presence**: At each convergence point, characters from at least
+    2 different dilemmas must be present and affected
+
+  GOOD convergence: "Paths converge at the archive_vault where the mentor's loyalty
+  and the artifact's nature are both revealed through the same evidence."
+
+  BAD convergence: "Paths eventually merge as the story reaches its climax."
+  BAD convergence: "The emotional arcs align thematically in the final act."
+
+  Also note what differences persist after convergence - what residue remains from
+  the path choices the player made.
 
   ## ID Rules (Prevent Validation Failures)
 

--- a/prompts/templates/serialize_seed_sections.yaml
+++ b/prompts/templates/serialize_seed_sections.yaml
@@ -498,23 +498,41 @@ per_path_beats_prompt: |
 
 # Section 6: Convergence Sketch
 convergence_prompt: |
-  You are extracting the CONVERGENCE SKETCH from a SEED stage brief.
+  You are generating the CONVERGENCE SKETCH from a SEED stage brief.
+
+  ## What Makes Good Convergence
+
+  Convergence points must be **location-based and concrete**, not abstract narrative moments.
+
+  GOOD convergence points:
+  - "paths converge at archive_vault where evidence from both dilemmas is revealed"
+  - "all characters are forced to the council_chamber for a confrontation"
+  - "investigation trails from separate dilemmas lead to the same lighthouse"
+
+  BAD convergence points:
+  - "paths merge emotionally in the final act" (abstract, no location)
+  - "the story reaches a climax" (no specific convergence mechanism)
+  - "thematic arcs align" (not actionable for scene generation)
+
+  Each convergence point should name a specific location (from your entity list)
+  and explain which dilemma storylines are forced together there.
 
   ## Schema
   Return a JSON object with a "convergence_sketch" object:
   ```json
   {
     "convergence_sketch": {
-      "convergence_points": ["where paths should merge"],
+      "convergence_points": ["location-based convergence description"],
       "residue_notes": ["differences that persist after convergence"]
     }
   }
   ```
 
   ## Rules
-  - convergence_points: Where paths should merge (e.g., "by act 2 climax")
-  - residue_notes: What differences persist after convergence
-  - Both can be empty arrays if not specified in brief
+  - convergence_points: Where paths physically converge (name the location and which dilemmas meet)
+  - residue_notes: What differences persist after convergence (path-specific consequences)
+  - convergence_points should have at least 1-2 entries referencing specific locations
+  - residue_notes can be empty if not specified in brief
 
   ## Output
   Return ONLY valid JSON with the "convergence_sketch" object.

--- a/src/questfoundry/agents/serialize.py
+++ b/src/questfoundry/agents/serialize.py
@@ -18,6 +18,7 @@ from questfoundry.artifacts.validator import strip_null_values
 from questfoundry.graph.context import (
     SCOPE_DILEMMA,
     SCOPE_PATH,
+    format_answer_ids_by_dilemma,
     format_path_ids_context,
     format_retained_entity_ids,
     format_valid_ids_context,
@@ -1197,6 +1198,17 @@ async def serialize_seed_as_function(
                 "retained_entity_context_updated",
                 entity_decisions=len(collected["entities"]),
             )
+
+        # After dilemmas are serialized, inject answer ID manifest so the
+        # paths section knows which answer_ids are valid per dilemma.
+        if section_name == "dilemmas" and collected.get("dilemmas"):
+            answer_ids_context = format_answer_ids_by_dilemma(collected["dilemmas"])
+            if answer_ids_context:
+                enhanced_brief = f"{enhanced_brief}\n\n{answer_ids_context}"
+                log.debug(
+                    "answer_ids_context_injected",
+                    dilemma_count=len(collected["dilemmas"]),
+                )
 
         # After paths are serialized:
         # 1. Inject path IDs for subsequent sections (consequences)

--- a/src/questfoundry/graph/context.py
+++ b/src/questfoundry/graph/context.py
@@ -262,14 +262,7 @@ def format_answer_ids_by_dilemma(dilemmas: list[dict[str, Any]]) -> str:
     if not dilemmas:
         return ""
 
-    lines = [
-        "## Valid Answer IDs per Dilemma",
-        "",
-        "Each path's `answer_id` MUST be one of the `considered` IDs below.",
-        "Do NOT invent answer IDs or use `implicit` IDs as path answer_ids.",
-        "",
-    ]
-
+    dilemma_lines = []
     for d in sorted(dilemmas, key=lambda x: x.get("dilemma_id", "")):
         dilemma_id = d.get("dilemma_id", "")
         if not dilemma_id:
@@ -277,9 +270,20 @@ def format_answer_ids_by_dilemma(dilemmas: list[dict[str, Any]]) -> str:
         scoped = normalize_scoped_id(strip_scope_prefix(dilemma_id), SCOPE_DILEMMA)
         considered = d.get("considered", [])
         implicit = d.get("implicit", [])
-        lines.append(f"- `{scoped}` -> considered: {considered}, implicit: {implicit}")
+        dilemma_lines.append(f"- `{scoped}` -> considered: {considered}, implicit: {implicit}")
 
-    lines.append("")
+    if not dilemma_lines:
+        return ""
+
+    lines = [
+        "## Valid Answer IDs per Dilemma",
+        "",
+        "Each path's `answer_id` MUST be one of the `considered` IDs below.",
+        "Do NOT invent answer IDs or use `implicit` IDs as path answer_ids.",
+        "",
+        *dilemma_lines,
+        "",
+    ]
     return "\n".join(lines)
 
 

--- a/src/questfoundry/graph/context.py
+++ b/src/questfoundry/graph/context.py
@@ -245,6 +245,44 @@ def format_hierarchical_path_id(dilemma_id: str, answer_id: str) -> str:
     return f"{SCOPE_PATH}::{dilemma_raw}__{answer_id}"
 
 
+def format_answer_ids_by_dilemma(dilemmas: list[dict[str, Any]]) -> str:
+    """Format answer IDs per dilemma as context for paths serialization.
+
+    After dilemmas are serialized, each dilemma has ``considered`` and
+    ``implicit`` answer lists.  Injecting these before the paths section
+    lets the model know exactly which answer_id values are valid for each
+    dilemma, preventing phantom answer references.
+
+    Args:
+        dilemmas: List of dilemma decision dicts from serialized output.
+
+    Returns:
+        Formatted manifest string, or empty string if no dilemmas.
+    """
+    if not dilemmas:
+        return ""
+
+    lines = [
+        "## Valid Answer IDs per Dilemma",
+        "",
+        "Each path's `answer_id` MUST be one of the `considered` IDs below.",
+        "Do NOT invent answer IDs or use `implicit` IDs as path answer_ids.",
+        "",
+    ]
+
+    for d in sorted(dilemmas, key=lambda x: x.get("dilemma_id", "")):
+        dilemma_id = d.get("dilemma_id", "")
+        if not dilemma_id:
+            continue
+        scoped = normalize_scoped_id(strip_scope_prefix(dilemma_id), SCOPE_DILEMMA)
+        considered = d.get("considered", [])
+        implicit = d.get("implicit", [])
+        lines.append(f"- `{scoped}` -> considered: {considered}, implicit: {implicit}")
+
+    lines.append("")
+    return "\n".join(lines)
+
+
 def format_path_ids_context(paths: list[dict[str, Any]]) -> str:
     """Format path IDs for beat serialization with inline constraints.
 

--- a/src/questfoundry/graph/grow_algorithms.py
+++ b/src/questfoundry/graph/grow_algorithms.py
@@ -835,14 +835,20 @@ def _try_split_beat(
     if beat_data is None:
         return None
 
-    variant_id = f"{beat_id}_split"
+    # Use prereq ID in suffix to disambiguate multiple splits on the same beat.
+    prereq_suffix = prereq_id.rsplit("::", 1)[-1] if "::" in prereq_id else prereq_id
+    variant_id = f"{beat_id}_split_{prereq_suffix}"
     if graph.has_node(variant_id):
-        return None  # Name collision — can't split
+        # Fall back to generic suffix
+        variant_id = f"{beat_id}_split"
+        if graph.has_node(variant_id):
+            return None  # Name collision — can't split
 
     # Create variant with same data but different ID
+    raw_variant = variant_id.rsplit("::", 1)[-1] if "::" in variant_id else variant_id
     variant_data = {
         **beat_data,
-        "raw_id": f"{beat_data.get('raw_id', beat_id)}_split",
+        "raw_id": raw_variant,
         "split_from": beat_id,
     }
     graph.create_node(variant_id, variant_data)

--- a/src/questfoundry/graph/grow_algorithms.py
+++ b/src/questfoundry/graph/grow_algorithms.py
@@ -22,6 +22,9 @@ from typing import TYPE_CHECKING, Any
 from questfoundry.graph.context import normalize_scoped_id
 from questfoundry.graph.mutations import GrowErrorCategory, GrowValidationError
 from questfoundry.models.grow import Arc
+from questfoundry.observability.logging import get_logger
+
+log = get_logger(__name__)
 
 if TYPE_CHECKING:
     from questfoundry.graph.graph import Graph
@@ -735,6 +738,142 @@ def _filter_different_dilemmas(
     return sorted(beat_ids)
 
 
+# Maximum transitive closure depth for prerequisite lifting.
+# Beyond this depth, the dependency chain is too deep to safely widen.
+_MAX_LIFT_DEPTH = 3
+
+
+def _try_lift_prerequisite(
+    graph: Graph,
+    prereq_id: str,
+    target_paths: set[str],
+    beat_paths: dict[str, set[str]],
+    *,
+    _depth: int = 0,
+) -> bool:
+    """Try to widen a prerequisite beat to cover all target paths.
+
+    Adds ``belongs_to`` edges so the prerequisite (and its own
+    prerequisites, transitively) spans all paths in the intersection.
+
+    Args:
+        graph: Graph to mutate if lift succeeds.
+        prereq_id: The prerequisite beat to widen.
+        target_paths: The set of paths the intersection spans.
+        beat_paths: Mutable mapping of beat_id → set of path IDs.
+        _depth: Current recursion depth (internal).
+
+    Returns:
+        True if the prerequisite was successfully lifted to cover
+        all target_paths; False if lifting would be unsafe.
+    """
+    if _depth > _MAX_LIFT_DEPTH:
+        return False
+
+    current_paths = beat_paths.get(prereq_id, set())
+    missing_paths = target_paths - current_paths
+
+    if not missing_paths:
+        return True  # Already covers all target paths
+
+    # Check for cycles: if any target_path beat has a requires edge
+    # TO this prereq through the intersection beats, lifting would
+    # create a cycle. Simple check: does the prereq transitively
+    # require any beat that already belongs to all target_paths?
+    # (This is a conservative check — full cycle detection is expensive.)
+
+    # First, transitively lift this prereq's own prerequisites
+    for edge in graph.get_edges(from_id=prereq_id, to_id=None, edge_type="requires"):
+        sub_prereq_id = edge["to"]
+        sub_paths = beat_paths.get(sub_prereq_id, set())
+        if not sub_paths >= target_paths and not _try_lift_prerequisite(
+            graph, sub_prereq_id, target_paths, beat_paths, _depth=_depth + 1
+        ):
+            return False
+
+    # All transitive prereqs lifted successfully — now lift this one
+    for path_id in missing_paths:
+        graph.add_edge("belongs_to", prereq_id, path_id)
+
+    beat_paths[prereq_id] = current_paths | missing_paths
+
+    log.debug(
+        "prerequisite_lifted",
+        prereq_id=prereq_id,
+        added_paths=sorted(missing_paths),
+        depth=_depth,
+    )
+    return True
+
+
+def _try_split_beat(
+    graph: Graph,
+    beat_id: str,
+    prereq_id: str,
+    narrow_paths: set[str],
+    wide_paths: set[str],
+    beat_paths: dict[str, set[str]],
+) -> str | None:
+    """Split a beat into two variants for different path sets.
+
+    Creates a new beat variant for the narrow paths (keeping the
+    prerequisite), and narrows the original to the wide paths
+    (without the prerequisite).
+
+    Args:
+        graph: Graph to mutate.
+        beat_id: The intersection beat to split.
+        prereq_id: The prerequisite that can't be lifted.
+        narrow_paths: Paths where the prerequisite exists.
+        wide_paths: Paths where the prerequisite doesn't exist.
+        beat_paths: Mutable mapping of beat_id → set of path IDs.
+
+    Returns:
+        The variant beat ID if split succeeded, None if failed.
+    """
+    beat_data = graph.get_node(beat_id)
+    if beat_data is None:
+        return None
+
+    variant_id = f"{beat_id}_split"
+    if graph.has_node(variant_id):
+        return None  # Name collision — can't split
+
+    # Create variant with same data but different ID
+    variant_data = {
+        **beat_data,
+        "raw_id": f"{beat_data.get('raw_id', beat_id)}_split",
+        "split_from": beat_id,
+    }
+    graph.create_node(variant_id, variant_data)
+
+    # Variant gets belongs_to edges for narrow_paths only
+    for path_id in narrow_paths:
+        graph.add_edge("belongs_to", variant_id, path_id)
+
+    # Variant keeps the requires edge to the prereq
+    graph.add_edge("requires", variant_id, prereq_id)
+
+    # Remove the narrow_paths from the original beat's belongs_to
+    # (The original beat keeps the wide_paths.)
+    # Note: we can't remove edges from the graph directly, so we track
+    # in beat_paths which paths the original beat effectively covers.
+    # The actual belongs_to edges for narrow_paths remain but the
+    # intersection will use the variant for those paths.
+    beat_paths[variant_id] = narrow_paths
+    beat_paths[beat_id] = wide_paths
+
+    log.debug(
+        "beat_split_for_prerequisite",
+        original=beat_id,
+        variant=variant_id,
+        prereq=prereq_id,
+        narrow_paths=sorted(narrow_paths),
+        wide_paths=sorted(wide_paths),
+    )
+    return variant_id
+
+
 def check_intersection_compatibility(
     graph: Graph,
     beat_ids: list[str],
@@ -746,6 +885,15 @@ def check_intersection_compatibility(
     - Beats are from different dilemmas (not same dilemma)
     - No circular requires conflicts between the beats
     - At least 2 beats
+
+    For conditional prerequisites (beat requires a prerequisite that doesn't
+    span all intersection paths), attempts recovery strategies before rejecting:
+    1. **Lift**: widen the prerequisite to cover all intersection paths
+    2. **Split**: create a path-specific variant of the beat
+    3. **Reject**: if neither works, report the error
+
+    Note: lift and split may mutate the graph (adding edges/nodes). This is
+    intentional — the mutations are the recovery mechanism.
 
     Args:
         graph: Graph with beat and path nodes.
@@ -844,12 +992,26 @@ def check_intersection_compatibility(
                 # silently dropped in arcs missing the target's path,
                 # producing inconsistent orderings and passage DAG cycles.
                 #
-                # Current strategy: reject the intersection.
-                # Future alternatives that preserve the intersection:
-                #   - Lift prerequisites into shared set (see GitHub #360)
-                #   - Split into path-specific lead-ins (see GitHub #361)
+                # Recovery strategy (in order):
+                #   1. Lift: widen the prerequisite to all intersection paths
+                #   2. Split: create a path-specific variant of the beat
+                #   3. Reject: if neither works, reject the intersection
                 prereq_paths = beat_paths.get(to_id, set())
                 if not prereq_paths >= union_paths:
+                    # Try lift first: widen prerequisite to cover union_paths
+                    lifted = _try_lift_prerequisite(graph, to_id, union_paths, beat_paths)
+                    if lifted:
+                        continue
+
+                    # Try split: create variant for narrow paths
+                    narrow = prereq_paths & beat_paths.get(from_id, set())
+                    wide = union_paths - narrow
+                    if narrow and wide:
+                        variant = _try_split_beat(graph, from_id, to_id, narrow, wide, beat_paths)
+                        if variant is not None:
+                            continue
+
+                    # Neither strategy worked — reject
                     missing = sorted(union_paths - prereq_paths)
                     errors.append(
                         GrowValidationError(
@@ -860,8 +1022,7 @@ def check_intersection_compatibility(
                                 f"but the intersection would span "
                                 f"{sorted(union_paths)}. "
                                 f"Missing paths: {missing}. "
-                                f"This would cause silent edge drops during "
-                                f"arc enumeration (conditional prerequisite)."
+                                f"Lift and split strategies both failed."
                             ),
                             category=GrowErrorCategory.STRUCTURAL,
                         )

--- a/src/questfoundry/graph/grow_validation.py
+++ b/src/questfoundry/graph/grow_validation.py
@@ -551,6 +551,15 @@ def check_spine_arc_exists(graph: Graph) -> ValidationCheck:
     enumerate_arcs failed to find a complete path combination.
     """
     arc_nodes = graph.get_nodes_by_type("arc")
+
+    # No arcs at all is a degenerate case (empty story) — warn, not fail.
+    if not arc_nodes:
+        return ValidationCheck(
+            name="spine_arc_exists",
+            severity="warn",
+            message="No arcs exist — spine arc check skipped",
+        )
+
     for data in arc_nodes.values():
         if data.get("arc_type") == "spine":
             return ValidationCheck(

--- a/src/questfoundry/graph/grow_validation.py
+++ b/src/questfoundry/graph/grow_validation.py
@@ -543,6 +543,32 @@ def check_commits_timing(graph: Graph) -> list[ValidationCheck]:
     return checks
 
 
+def check_spine_arc_exists(graph: Graph) -> ValidationCheck:
+    """Verify that a spine arc exists in the graph.
+
+    The spine arc contains all canonical paths and is required for
+    pruning and reachability analysis. Its absence indicates that
+    enumerate_arcs failed to find a complete path combination.
+    """
+    arc_nodes = graph.get_nodes_by_type("arc")
+    for data in arc_nodes.values():
+        if data.get("arc_type") == "spine":
+            return ValidationCheck(
+                name="spine_arc_exists",
+                severity="pass",
+                message="Spine arc found",
+            )
+
+    return ValidationCheck(
+        name="spine_arc_exists",
+        severity="fail",
+        message=(
+            f"No spine arc among {len(arc_nodes)} arcs. "
+            f"Story has no complete canonical path through all dilemmas."
+        ),
+    )
+
+
 def run_all_checks(graph: Graph) -> ValidationReport:
     """Run all Phase 10 validation checks and aggregate results.
 
@@ -552,6 +578,7 @@ def run_all_checks(graph: Graph) -> ValidationReport:
         check_single_start(graph),
         check_all_passages_reachable(graph),
         check_all_endings_reachable(graph),
+        check_spine_arc_exists(graph),
         check_dilemmas_resolved(graph),
         check_gate_satisfiability(graph),
         check_passage_dag_cycles(graph),

--- a/src/questfoundry/graph/mutations.py
+++ b/src/questfoundry/graph/mutations.py
@@ -153,6 +153,9 @@ class SeedErrorCategory(Enum):
     INNER = auto()  # Schema/type error in a single section
     SEMANTIC = auto()  # Invalid ID reference (phantom IDs)
     COMPLETENESS = auto()  # Missing entity/dilemma decisions
+    CROSS_REFERENCE = (
+        auto()
+    )  # Cross-section ID mismatch (e.g. path answer_id not in dilemma considered)
     # FATAL is reserved for future use - e.g., graph corruption that requires
     # manual intervention. Currently no errors are classified as FATAL since
     # all known error types can be retried with appropriate feedback.
@@ -1246,7 +1249,7 @@ def validate_seed_mutations(graph: Graph, output: dict[str, Any]) -> list[SeedVa
                             ),
                             available=considered,
                             provided=raw_answer_id,
-                            category=SeedErrorCategory.SEMANTIC,
+                            category=SeedErrorCategory.CROSS_REFERENCE,
                         )
                     )
                 break

--- a/src/questfoundry/pipeline/stages/grow.py
+++ b/src/questfoundry/pipeline/stages/grow.py
@@ -806,7 +806,10 @@ class GrowStage:
                 status="failed",
                 detail=(
                     f"All {len(result.intersections)} proposed intersections rejected. "
-                    f"Story structure lacks cross-dilemma scene overlap."
+                    f"Story structure lacks cross-dilemma scene overlap. "
+                    f"Common causes: insufficient shared locations, isolated storylines, "
+                    f"or characters confined to a single dilemma. "
+                    f"Review brainstorm/seed for shared location convergence points."
                 ),
                 llm_calls=llm_calls,
                 tokens_used=tokens,

--- a/src/questfoundry/pipeline/stages/grow.py
+++ b/src/questfoundry/pipeline/stages/grow.py
@@ -798,6 +798,20 @@ class GrowStage:
                 location=location,
             )
 
+        # Fail if all proposed intersections were rejected — the story lacks
+        # cross-dilemma scene overlap and downstream phases will degrade.
+        if len(result.intersections) > 0 and applied_count == 0:
+            return GrowPhaseResult(
+                phase="intersections",
+                status="failed",
+                detail=(
+                    f"All {len(result.intersections)} proposed intersections rejected. "
+                    f"Story structure lacks cross-dilemma scene overlap."
+                ),
+                llm_calls=llm_calls,
+                tokens_used=tokens,
+            )
+
         return GrowPhaseResult(
             phase="intersections",
             status="completed",
@@ -1163,6 +1177,19 @@ class GrowStage:
                 phase="enumerate_arcs",
                 status="completed",
                 detail="No arcs to enumerate",
+            )
+
+        # Fail if no spine arc exists — the spine is required for pruning
+        # and reachability analysis in downstream phases.
+        spine_exists = any(arc.arc_type == "spine" for arc in arcs)
+        if not spine_exists:
+            return GrowPhaseResult(
+                phase="enumerate_arcs",
+                status="failed",
+                detail=(
+                    f"No spine arc created among {len(arcs)} arcs. "
+                    f"A spine arc (containing all canonical paths) is required."
+                ),
             )
 
         # Create arc nodes and arc_contains edges

--- a/tests/unit/test_graph_context.py
+++ b/tests/unit/test_graph_context.py
@@ -1187,15 +1187,14 @@ class TestFormatAnswerIdsByDilemma:
         assert "dilemma::artifact_blessed_or_cursed" in result
 
     def test_dilemma_without_id_skipped(self) -> None:
-        """Dilemmas with empty or missing ID are skipped."""
+        """Dilemmas with empty or missing ID produce empty string."""
         dilemmas = [
             {"dilemma_id": "", "considered": ["a"], "implicit": []},
             {"considered": ["b"], "implicit": []},
         ]
         result = format_answer_ids_by_dilemma(dilemmas)
-        # Header still present but no dilemma lines
-        assert "Valid Answer IDs per Dilemma" in result
-        assert "dilemma::" not in result
+        # No valid dilemmas → empty string (no header injected)
+        assert result == ""
 
     def test_unscoped_dilemma_id_gets_prefix(self) -> None:
         """Dilemma IDs without scope prefix get normalized."""

--- a/tests/unit/test_graph_context.py
+++ b/tests/unit/test_graph_context.py
@@ -8,6 +8,7 @@ from questfoundry.graph.context import (
     SCOPE_ENTITY,
     SCOPE_PATH,
     check_structural_completeness,
+    format_answer_ids_by_dilemma,
     format_hierarchical_path_id,
     format_path_ids_context,
     format_scoped_id,
@@ -1143,3 +1144,67 @@ class TestFormatHierarchicalPathId:
         dilemma_id, answer_id = parse_hierarchical_path_id(original)
         reformatted = format_hierarchical_path_id(dilemma_id, answer_id)
         assert reformatted == original
+
+
+class TestFormatAnswerIdsByDilemma:
+    """Tests for format_answer_ids_by_dilemma function."""
+
+    def test_empty_dilemmas_returns_empty(self) -> None:
+        """Empty list returns empty string."""
+        assert format_answer_ids_by_dilemma([]) == ""
+
+    def test_single_dilemma_with_considered_and_implicit(self) -> None:
+        """Single dilemma formats considered and implicit lists."""
+        dilemmas = [
+            {
+                "dilemma_id": "dilemma::host_benevolent_or_selfish",
+                "considered": ["protector", "manipulator"],
+                "implicit": ["neutral"],
+            }
+        ]
+        result = format_answer_ids_by_dilemma(dilemmas)
+        assert "Valid Answer IDs per Dilemma" in result
+        assert "dilemma::host_benevolent_or_selfish" in result
+        assert "['protector', 'manipulator']" in result
+        assert "['neutral']" in result
+
+    def test_multiple_dilemmas_all_listed(self) -> None:
+        """Multiple dilemmas are all included in output."""
+        dilemmas = [
+            {
+                "dilemma_id": "dilemma::mentor_trust_or_betray",
+                "considered": ["trust"],
+                "implicit": ["betray"],
+            },
+            {
+                "dilemma_id": "dilemma::artifact_blessed_or_cursed",
+                "considered": ["blessed", "cursed"],
+                "implicit": [],
+            },
+        ]
+        result = format_answer_ids_by_dilemma(dilemmas)
+        assert "dilemma::mentor_trust_or_betray" in result
+        assert "dilemma::artifact_blessed_or_cursed" in result
+
+    def test_dilemma_without_id_skipped(self) -> None:
+        """Dilemmas with empty or missing ID are skipped."""
+        dilemmas = [
+            {"dilemma_id": "", "considered": ["a"], "implicit": []},
+            {"considered": ["b"], "implicit": []},
+        ]
+        result = format_answer_ids_by_dilemma(dilemmas)
+        # Header still present but no dilemma lines
+        assert "Valid Answer IDs per Dilemma" in result
+        assert "dilemma::" not in result
+
+    def test_unscoped_dilemma_id_gets_prefix(self) -> None:
+        """Dilemma IDs without scope prefix get normalized."""
+        dilemmas = [
+            {
+                "dilemma_id": "host_benevolent_or_selfish",
+                "considered": ["protector"],
+                "implicit": [],
+            }
+        ]
+        result = format_answer_ids_by_dilemma(dilemmas)
+        assert "dilemma::host_benevolent_or_selfish" in result

--- a/tests/unit/test_grow_validation.py
+++ b/tests/unit/test_grow_validation.py
@@ -588,11 +588,11 @@ class TestSpineArcExists:
         assert "No spine arc" in result.message
 
     def test_no_arcs_at_all(self) -> None:
-        """Fails when graph has no arc nodes."""
+        """Warns (not fails) when graph has no arc nodes at all."""
         graph = Graph.empty()
         result = check_spine_arc_exists(graph)
-        assert result.severity == "fail"
-        assert "0 arcs" in result.message
+        assert result.severity == "warn"
+        assert "skipped" in result.message
 
 
 class TestRunAllChecks:

--- a/tests/unit/test_mutations.py
+++ b/tests/unit/test_mutations.py
@@ -3460,7 +3460,7 @@ class TestValidation11cPathAlternativeInConsidered:
         assert "option_b" in check_11c_errors[0].issue
         assert "choice_a_or_b" in check_11c_errors[0].issue
         assert check_11c_errors[0].field_path == "paths.1.answer_id"
-        assert check_11c_errors[0].category == SeedErrorCategory.SEMANTIC
+        assert check_11c_errors[0].category == SeedErrorCategory.CROSS_REFERENCE
 
     def test_empty_considered_detected(self) -> None:
         """Path with answer_id but empty considered fails validation."""


### PR DESCRIPTION
## Problem

Analysis of test projects (test-1 through test-5) revealed systemic quality issues in the SEED and GROW stages:
- SEED produces stories with isolated dilemmas and abstract convergence
- Cross-reference errors (phantom answer IDs) escape the serialize loop
- GROW silently succeeds when all intersections are rejected or no spine arc exists
- Conditional prerequisites cause unnecessary intersection rejections

## Changes

### Prompt improvements (#366)
- `discuss_brainstorm.yaml`: Add interconnection guidance (shared locations, position-based contradictions)
- `discuss_seed.yaml`: Replace weak convergence hints with explicit requirements (2-4 location-based convergence points)
- `serialize_seed_sections.yaml`: Add GOOD/BAD examples for convergence serialization

### Answer ID manifest injection (#364)
- `context.py`: Add `format_answer_ids_by_dilemma()` — manifest of valid answer IDs per dilemma
- `serialize.py`: Inject manifest after dilemmas section, before paths serialization

### Cross-reference error propagation (#363)
- `serialize.py`: Add `_propagate_cross_section_errors()` — detects check-11c errors in paths and creates synthetic dilemma errors for upstream retry
- `serialize.py`: Retry sections in dependency order (upstream first)
- `serialize.py`: Refresh answer ID context after dilemma retries (with dedup)

### GROW quality gates (#365)
- `grow.py`: Fail when all proposed intersections are rejected (0% acceptance)
- `grow.py`: Fail when no spine arc exists after arc enumeration
- `grow_validation.py`: Add `check_spine_arc_exists()` validation check

### Lift/split recovery for conditional prerequisites (#360, #361)
- `grow_algorithms.py`: Add `_try_lift_prerequisite()` — recursively widens prerequisite path membership (max depth 3)
- `grow_algorithms.py`: Add `_try_split_beat()` — creates path-specific beat variants with prereq-based naming
- `grow_algorithms.py`: Modified `check_intersection_compatibility()` to try lift → split → reject

### Review feedback addressed
- Return empty string (not empty header) when all dilemmas lack IDs
- Add `CROSS_REFERENCE` error category to replace fragile string matching
- Strip old answer ID context before refresh to prevent duplication on retry
- More informative error messages for intersection rejection
- Fix non-deterministic test by splitting into two deterministic tests
- Add split-strategy and propagation-function test coverage

## Not Included / Future PRs
- Cycle detection in lift strategy (conservative depth limit used instead)
- Graph edge removal for split (uses `beat_paths` dict tracking)
- FILL stage handling of `split_from` field on split beats

## Test Plan
- `uv run mypy src/` — clean
- `uv run ruff check src/` — clean
- `uv run pytest tests/unit/test_graph_context.py tests/unit/test_serialize.py tests/unit/test_grow_algorithms.py tests/unit/test_grow_stage.py tests/unit/test_grow_validation.py tests/unit/test_mutations.py -x -q` — 540 passed

## Risk / Rollback
- **Prompt changes**: Low risk, no code behavior change
- **Quality gates**: Medium risk — previously-passing GROW runs may now fail if they lack intersections or spine arcs. This is intentional.
- **Lift/split**: Medium risk — more permissive intersection acceptance. Graph mutations are additive.
- **Rollback**: Revert branch

## Review Guide

Suggested review order (by commit):
1. `cacc55f` — Prompt improvements (3 YAML files, no code)
2. `cb914ac` — Answer ID manifest injection (context.py + serialize.py)
3. `f6999aa` — Cross-reference error propagation (serialize.py)
4. `16dbfdf` — GROW quality gates (grow.py + grow_validation.py)
5. `715970f` — Lift/split recovery (grow_algorithms.py)
6. `fd5de6f` — Test updates for quality gates
7. `1601068` — Review feedback fixes

Closes #360, closes #361, closes #363, closes #364, closes #365, closes #366

🤖 Generated with [Claude Code](https://claude.com/claude-code)