### PR TITLE
refactor: rename considered/implicit to explored/unexplored (#376)

### DIFF
--- a/docs/analysis/model-comparison-2026-01-15.md
+++ b/docs/analysis/model-comparison-2026-01-15.md
@@ -131,7 +131,7 @@ Compare to qwen3:4b's consequence: "The diary reveals a hidden truth about a pas
 
 **Schema Compliance Issues:**
 - `central_entity_ids: []` on all dilemmas (empty arrays)
-- Several dilemmas have `considered: ['']` (empty strings)
+- Several dilemmas have `explored: ['']` (empty strings)
 - Consequence for "vault_of_truth" describes a booby-trap (logical inconsistency)
 
 **Notable:** Despite being a MoE model with only 3.6B active parameters, it produced richer output than GPT-4o. The routing mechanism appears to activate appropriate experts for creative writing tasks.
@@ -159,7 +159,7 @@ The pipeline's constrained prompts with clear schemas allow small models to punc
 Schema validation should catch:
 - Beat count < 2 per path
 - Empty `central_entity_ids` arrays on dilemmas
-- Empty strings in `considered` arrays
+- Empty strings in `explored` arrays
 - Logical inconsistencies between alternative selection and consequence description
 
 ### 4. Cost Optimization

--- a/docs/architecture/graph-referential-integrity.md
+++ b/docs/architecture/graph-referential-integrity.md
@@ -438,7 +438,7 @@ def _format_seed_valid_ids(graph: Graph) -> str:
         "",
         "### Rules",
         "- Every entity above needs a decision (retained/cut)",
-        "- Every dilemma above needs a decision (explored/implicit answers)",
+        "- Every dilemma above needs a decision (explored/unexplored answers)",
         "- Path answer_id must be from that dilemma's answers list",
     ])
 

--- a/docs/design/00-spec.md
+++ b/docs/design/00-spec.md
@@ -336,20 +336,20 @@ dilemma:
   involves: entity_id[]
   why_it_matters: string          # thematic stakes
   # Added by SEED:
-  considered: answer_id[]         # which answers LLM intended to explore
-  implicit: answer_id[]           # answers not explored (for FILL shadows)
+  explored: answer_id[]           # which answers LLM intended to explore
+  unexplored: answer_id[]         # answers not explored (for FILL shadows)
 ```
 
 **Lifecycle:** Created in BRAINSTORM, exploration decisions added in SEED. Not exported.
 
-**The `implicit` field** holds answers that are intentionally NOT explored as paths. These provide narrative context for the FILL stage—the "road not taken" that gives meaning to the chosen path. For example, if we explore "mentor is deceptive", the implicit "mentor is trustworthy" informs how the deception contrasts with what could have been.
+**The `unexplored` field** holds answers that are intentionally NOT explored as paths. These provide narrative context for the FILL stage—the "road not taken" that gives meaning to the chosen path. For example, if we explore "mentor is deceptive", the unexplored "mentor is trustworthy" informs how the deception contrasts with what could have been.
 
 **Derived development states** (computed from path existence, not stored):
 - **committed**: Answer has a path in the graph (will become a story path)
-- **deferred**: Answer in `considered` but no path (LLM intended to explore but was pruned)
-- **latent**: Answer not in `considered` (never intended for exploration, becomes shadow)
+- **deferred**: Answer in `explored` but no path (LLM intended to explore but was pruned)
+- **latent**: Answer not in `explored` (never intended for exploration, becomes shadow)
 
-The `considered` field records what the LLM *intended* to explore. Actual path existence determines what was *committed*. This separation allows pruning to drop paths without modifying the dilemma's stored intent, keeping the field immutable after SEED.
+The `explored` field records what the LLM *intended* to explore. Actual path existence determines what was *committed*. This separation allows pruning to drop paths without modifying the dilemma's stored intent, keeping the field immutable after SEED.
 
 **Binary constraint:** Exactly two answers per dilemma. This keeps contrasts crisp.
 
@@ -667,7 +667,7 @@ seed:
   dilemmas:
     - dilemma_id: string              # Format: dilemma::dilemma_name
       explored: answer_id[]           # always includes canonical; may include non-canonical
-      implicit: answer_id[]           # non-explored answers (context for FILL)
+      unexplored: answer_id[]         # non-explored answers (context for FILL)
 
   paths:
     - id: string                      # Format: path::dilemma_id__answer_id (hierarchical)

--- a/docs/design/procedures/seed.md
+++ b/docs/design/procedures/seed.md
@@ -102,7 +102,7 @@ LLMs are poor at counting and self-constraint. Instead of teaching the LLM to st
 3. **Runtime selects top N** - The highest-scoring dilemmas are kept fully explored (up to 4 dilemmas = 16 arcs)
 4. **Runtime prunes excess** - Demoted dilemmas have their paths, consequences, and beats removed
 
-**Key invariant: The `considered` field is immutable after SEED.** Pruning only drops paths; it never modifies the dilemma's `considered` field. This separation between "LLM intent" (stored as `considered`) and "runtime state" (derived from path existence) ensures:
+**Key invariant: The `explored` field is immutable after SEED.** Pruning only drops paths; it never modifies the dilemma's `explored` field. This separation between "LLM intent" (stored as `explored`) and "runtime state" (derived from path existence) ensures:
 - The pruning operation is idempotent
 - Arc count is derived from actual paths, not potentially stale metadata
 - Debugging is simpler—you can see what the LLM originally intended vs what survived pruning
@@ -153,8 +153,8 @@ LLM proposes exploration map per dilemma:
 ```yaml
 dilemma_exploration:
   - dilemma_id: dilemma::mentor_trust
-    considered:
-      - answer_id: mentor_protector    # canonical, always considered
+    explored:
+      - answer_id: mentor_protector    # canonical, always explored
         rationale: "Spine path - mentor as ally"
       - answer_id: mentor_manipulator  # non-canonical
         rationale: "Dark branch - doubles content but adds replayability"
@@ -512,7 +512,7 @@ Fits comfortably in modern context windows.
 **Recovery:** In most cases, the runtime's over-generate-and-select pattern handles this automatically by:
 1. Scoring dilemmas by quality criteria
 2. Selecting the top N dilemmas for full exploration (up to 4 = 16 arcs)
-3. Demoting excess dilemmas (moving non-canonical to `implicit`)
+3. Demoting excess dilemmas (moving non-canonical to `unexplored`)
 
 If automatic pruning produces unsatisfactory results:
 1. Return to Phase 2

--- a/prompts/templates/discuss_seed.yaml
+++ b/prompts/templates/discuss_seed.yaml
@@ -58,12 +58,12 @@ system: |
     - GOOD: Answer A = confrontation, Answer B = investigation
     - BAD: Both lead to same scene with slightly different dialogue
 
-  Leave as implicit (shadow) when:
+  Leave as unexplored (shadow) when:
   - The answer is atmospheric, not plot-changing
   - One side is clearly "right" (no real dilemma)
   - The content would be similar either way
 
-  **The Power of Shadows**: Implicit answers are NOT failures - they create
+  **The Power of Shadows**: Unexplored answers are NOT failures - they create
   narrative depth. A story where Mentor is benevolent becomes MORE powerful when
   the player COULD have discovered he was manipulative - but didn't. The shadow
   enriches the text without adding complexity.

--- a/prompts/templates/serialize_seed.yaml
+++ b/prompts/templates/serialize_seed.yaml
@@ -32,13 +32,13 @@ system: |
   ```json
   {
     "dilemma_id": "dilemma::host_benevolent_or_selfish",
-    "considered": ["protector", "manipulator"],
-    "implicit": []
+    "explored": ["protector", "manipulator"],
+    "unexplored": []
   }
   ```
   NOTES:
-  - The default path answer (is_default_path=true) MUST be in "considered", never in "implicit".
-  - **Arc Count**: At least 2 dilemmas should have BOTH answers in "considered" for proper IF branching.
+  - The default path answer (is_default_path=true) MUST be in "explored", never in "unexplored".
+  - **Arc Count**: At least 2 dilemmas should have BOTH answers in "explored" for proper IF branching.
   - Dilemmas with only canonical answer explored don't contribute to branching.
 
   ### 3. paths (Story Paths)

--- a/prompts/templates/serialize_seed_sections.yaml
+++ b/prompts/templates/serialize_seed_sections.yaml
@@ -65,36 +65,36 @@ dilemmas_prompt: |
     "dilemmas": [
       {
         "dilemma_id": "dilemma::host_benevolent_or_selfish",
-        "considered": ["protector", "manipulator"],
-        "implicit": []
+        "explored": ["protector", "manipulator"],
+        "unexplored": []
       }
     ]
   }
   ```
 
-  Note: `considered` and `implicit` contain raw answer IDs (no prefix) since
+  Note: `explored` and `unexplored` contain raw answer IDs (no prefix) since
   they are local to each dilemma.
 
   ## Rules
   - dilemma_id must include the `dilemma::` prefix and match EXACTLY an ID from the manifest
-  - considered: Answer IDs to explore as paths (MUST include the default path)
-  - implicit: Answer IDs NOT explored (become shadows)
+  - explored: Answer IDs to explore as paths (MUST include the default path)
+  - unexplored: Answer IDs NOT explored (become shadows)
   - Generate a decision for EVERY dilemma in the manifest
 
-  ## CRITICAL INVARIANT: considered ↔ paths linkage
-  The `considered` array defines which answers will have paths created.
-  For EACH answer_id in `considered`, you MUST create a path later.
-  The path's `answer_id` field MUST match an entry in `considered`.
+  ## CRITICAL INVARIANT: explored ↔ paths linkage
+  The `explored` array defines which answers will have paths created.
+  For EACH answer_id in `explored`, you MUST create a path later.
+  The path's `answer_id` field MUST match an entry in `explored`.
 
-  WRONG: `considered: []` with paths that have `answer_id` values
-  WRONG: `considered: ["opt_a"]` but path uses `answer_id: "opt_b"`
-  RIGHT: `considered: ["opt_a", "opt_b"]` and paths use those exact IDs
+  WRONG: `explored: []` with paths that have `answer_id` values
+  WRONG: `explored: ["opt_a"]` but path uses `answer_id: "opt_b"`
+  RIGHT: `explored: ["opt_a", "opt_b"]` and paths use those exact IDs
 
   ## What NOT to Do
   - Do NOT skip dilemmas because they aren't mentioned in the brief
   - Do NOT invent dilemmas not in the manifest
   - Do NOT partially complete the list
-  - Do NOT leave `considered` empty if you plan to create paths for that dilemma
+  - Do NOT leave `explored` empty if you plan to create paths for that dilemma
   - Do NOT omit the `dilemma::` prefix from dilemma_id
 
   ## Output
@@ -105,7 +105,7 @@ paths_prompt: |
   You are generating PATHS for a SEED stage based on dilemma decisions.
 
   ## Generation Requirements (CRITICAL)
-  For each "considered" answer in the dilemma decisions, you MUST generate a path.
+  For each "explored" answer in the dilemma decisions, you MUST generate a path.
   Each path represents one storyline that will be developed in the story.
 
   ## Scoped ID Format (CRITICAL)
@@ -117,12 +117,12 @@ paths_prompt: |
 
   Copy IDs EXACTLY as shown in the manifest, including the prefixes.
 
-  ## CRITICAL INVARIANT: answer_id MUST match considered
+  ## CRITICAL INVARIANT: answer_id MUST match explored
   Each path's `answer_id` MUST be one of the IDs listed in the dilemma's
-  `considered` array. This is a hard constraint enforced by validation.
+  `explored` array. This is a hard constraint enforced by validation.
 
-  WRONG: Path with `answer_id: "option_b"` when dilemma has `considered: ["option_a"]`
-  RIGHT: Path with `answer_id: "option_a"` when dilemma has `considered: ["option_a", "option_b"]`
+  WRONG: Path with `answer_id: "option_b"` when dilemma has `explored: ["option_a"]`
+  RIGHT: Path with `answer_id: "option_a"` when dilemma has `explored: ["option_a", "option_b"]`
 
   ## Schema
   Return a JSON object with a "paths" array. Each item is a Path:
@@ -166,18 +166,18 @@ paths_prompt: |
 
   ## Rules
   - path_importance must be exactly "major" or "minor" (lowercase)
-  - unexplored_answer_ids: IDs of answers NOT explored (implicit ones)
+  - unexplored_answer_ids: IDs of answers NOT explored (unexplored ones)
   - consequence_ids: References to consequences for this path
-  - Generate a path for EACH considered answer from dilemma decisions
-  - answer_id MUST be one of the IDs from the dilemma's `considered` array
+  - Generate a path for EACH explored answer from dilemma decisions
+  - answer_id MUST be one of the IDs from the dilemma's `explored` array
   - path_id MUST include the `path::` prefix and use hierarchical format
   - dilemma_id MUST include the `dilemma::` prefix
 
   ## What NOT to Do
   - Do NOT reuse dilemma IDs as path IDs
-  - Do NOT skip answers marked as "considered"
-  - Do NOT create paths for "implicit" answers (they become shadows, not paths)
-  - Do NOT use an answer_id that isn't in the dilemma's `considered` list
+  - Do NOT skip answers marked as "explored"
+  - Do NOT create paths for "unexplored" answers (they become shadows, not paths)
+  - Do NOT use an answer_id that isn't in the dilemma's `explored` list
   - Do NOT omit the `path::` or `dilemma::` prefixes
 
   ## Output

--- a/prompts/templates/summarize_seed.yaml
+++ b/prompts/templates/summarize_seed.yaml
@@ -46,8 +46,8 @@ system: |
   ### Dilemma Decisions
   For each dilemma from brainstorm:
   - dilemma_id: the dilemma ID from brainstorm
-  - considered: list of answer IDs that become paths (MUST include canonical)
-  - implicit: list of answer IDs NOT explored (shadows for narrative depth)
+  - explored: list of answer IDs that become paths (MUST include canonical)
+  - unexplored: list of answer IDs NOT explored (shadows for narrative depth)
 
   Include all answers you explored in the discussion. The system will
   balance scope automatically if needed.
@@ -118,8 +118,8 @@ system: |
   ### Dilemma Decisions Manifest
   List EVERY dilemma ID with its decision:
   ```
-  - trust_or_betray: considered=[trust, betray], implicit=[]
-  - weather_storm_clear: considered=[storm], implicit=[clear]
+  - trust_or_betray: explored=[trust, betray], unexplored=[]
+  - weather_storm_clear: explored=[storm], unexplored=[clear]
   ```
   VERIFY: Your list should have exactly {dilemma_count} items.
 

--- a/src/questfoundry/agents/serialize.py
+++ b/src/questfoundry/agents/serialize.py
@@ -986,7 +986,7 @@ def _group_errors_by_section(
     the root cause section is retried, not just the downstream section.
 
     For example, a path answer_id mismatch (check 11c) targets the "paths"
-    section but the root cause is often the dilemma's considered list.
+    section but the root cause is often the dilemma's explored list.
     This function adds the error to BOTH "paths" and "dilemmas" sections.
     """
     by_section: dict[str, list[SeedValidationError]] = {}
@@ -1007,8 +1007,8 @@ def _propagate_cross_section_errors(
 ) -> None:
     """Add upstream section entries for cross-reference errors.
 
-    When a paths error references dilemma considered lists, the dilemma
-    section should also be retried so its considered array can be fixed.
+    When a paths error references dilemma explored lists, the dilemma
+    section should also be retried so its explored array can be fixed.
 
     Currently only propagates ``paths → dilemmas`` errors (check 11c).
     Other cross-section dependencies (consequences→paths, beats→entities)
@@ -1019,12 +1019,12 @@ def _propagate_cross_section_errors(
     if not paths_errors:
         return
 
-    # Check 11c errors: path answer_id not in dilemma considered list.
+    # Check 11c errors: path answer_id not in dilemma explored list.
     # Uses the CROSS_REFERENCE category set in validate_seed_mutations().
     cross_ref_errors = [e for e in paths_errors if e.category == SeedErrorCategory.CROSS_REFERENCE]
     if cross_ref_errors:
         # Create dilemma-targeted corrections from the same errors.
-        # The dilemma section needs to know which answer IDs to add to considered.
+        # The dilemma section needs to know which answer IDs to add to explored.
         dilemma_errors = []
         for error in cross_ref_errors:
             dilemma_errors.append(
@@ -1032,7 +1032,7 @@ def _propagate_cross_section_errors(
                     field_path="dilemmas",
                     issue=(
                         f"A path uses answer_id '{error.provided}' but it is not in "
-                        f"the dilemma's considered list. Ensure considered includes "
+                        f"the dilemma's explored list. Ensure explored includes "
                         f"all answer IDs that will have paths."
                     ),
                     available=error.available,

--- a/src/questfoundry/artifacts/enrichment.py
+++ b/src/questfoundry/artifacts/enrichment.py
@@ -134,9 +134,9 @@ def _enrich_dilemmas(graph: Graph, dilemma_decisions: list[dict[str, Any]]) -> l
         if value := node.get("central_entity_ids"):
             enriched["central_entity_ids"] = [eid.split("::")[-1] for eid in value]
 
-        # Add SEED decision fields (support both old 'explored' and new 'considered')
-        enriched["considered"] = decision.get("considered", decision.get("explored", []))
-        enriched["implicit"] = decision.get("implicit", [])
+        # Add SEED decision fields (support both old 'considered' and new 'explored')
+        enriched["explored"] = decision.get("explored", decision.get("considered", []))
+        enriched["unexplored"] = decision.get("unexplored", decision.get("implicit", []))
 
         enriched_dilemmas.append(enriched)
 

--- a/src/questfoundry/artifacts/enrichment.py
+++ b/src/questfoundry/artifacts/enrichment.py
@@ -134,7 +134,7 @@ def _enrich_dilemmas(graph: Graph, dilemma_decisions: list[dict[str, Any]]) -> l
         if value := node.get("central_entity_ids"):
             enriched["central_entity_ids"] = [eid.split("::")[-1] for eid in value]
 
-        # Add SEED decision fields (support both old 'considered' and new 'explored')
+        # Add SEED decision fields (supports old 'considered' and 'implicit' field names)
         enriched["explored"] = decision.get("explored", decision.get("considered", []))
         enriched["unexplored"] = decision.get("unexplored", decision.get("implicit", []))
 

--- a/src/questfoundry/graph/dilemma_scoring.py
+++ b/src/questfoundry/graph/dilemma_scoring.py
@@ -37,7 +37,7 @@ class ScoredDilemma:
     dilemma_id: str
     score: float
     rationale: list[str]
-    is_fully_explored: bool  # Has 2+ answers in explored
+    is_fully_explored: bool  # Has 2+ answers explored as paths
     canonical_path_id: str | None
     noncanonical_path_id: str | None
 
@@ -63,8 +63,8 @@ def _get_paths_for_dilemma(
     if not paths:
         return None, None
 
-    # Assume first considered answer is canonical (typical pattern)
-    canonical_ans = dilemma_decision.considered[0] if dilemma_decision.considered else None
+    # Assume first explored answer is canonical (typical pattern)
+    canonical_ans = dilemma_decision.explored[0] if dilemma_decision.explored else None
 
     canonical_path = None
     noncanonical_path = None

--- a/src/questfoundry/graph/dilemma_scoring.py
+++ b/src/questfoundry/graph/dilemma_scoring.py
@@ -123,7 +123,7 @@ def score_dilemma(seed_output: SeedOutput, dilemma_id: str) -> ScoredDilemma:
 
     canonical_path, noncanonical_path = _get_paths_for_dilemma(seed_output, dilemma_id)
 
-    # is_fully_explored is derived from actual path existence, not from considered field
+    # is_fully_explored is derived from actual path existence, not from explored field
     # A dilemma is fully explored when BOTH canonical and non-canonical paths exist
     is_fully_explored = canonical_path is not None and noncanonical_path is not None
 

--- a/src/questfoundry/graph/mutations.py
+++ b/src/questfoundry/graph/mutations.py
@@ -155,7 +155,7 @@ class SeedErrorCategory(Enum):
     COMPLETENESS = auto()  # Missing entity/dilemma decisions
     CROSS_REFERENCE = (
         auto()
-    )  # Cross-section ID mismatch (e.g. path answer_id not in dilemma considered)
+    )  # Cross-section ID mismatch (e.g. path answer_id not in dilemma explored)
     # FATAL is reserved for future use - e.g., graph corruption that requires
     # manual intervention. Currently no errors are classified as FATAL since
     # all known error types can be retried with appropriate feedback.
@@ -455,15 +455,15 @@ def _clean_dict(data: dict[str, Any]) -> dict[str, Any]:
     return {k: v for k, v in data.items() if v is not None}
 
 
-def _backfill_considered_from_paths(output: dict[str, Any]) -> None:
-    """Backfill empty considered arrays from path answer_ids (in-place mutation).
+def _backfill_explored_from_paths(output: dict[str, Any]) -> None:
+    """Backfill empty explored arrays from path answer_ids (in-place mutation).
 
-    Handles cases where LLM serialized paths but left considered empty.
-    The path's answer_id IS what was considered - if a path exists for
-    an answer, that answer was necessarily considered.
+    Handles cases where LLM serialized paths but left explored empty.
+    The path's answer_id IS what was explored - if a path exists for
+    an answer, that answer was necessarily explored.
 
     This runs BEFORE validation to fix data integrity issues in
-    graphs where dilemmas have `considered: []` but paths exist
+    graphs where dilemmas have `explored: []` but paths exist
     with valid `answer_id` values.
 
     Args:
@@ -477,15 +477,15 @@ def _backfill_considered_from_paths(output: dict[str, Any]) -> None:
         if answer_id:
             path_answers.setdefault(dilemma_id, set()).add(answer_id)
 
-    # Backfill empty considered arrays
+    # Backfill empty explored arrays
     for dilemma in output.get("dilemmas", []):
-        considered = dilemma.get("considered", [])
         explored = dilemma.get("explored", [])
-        if not considered and not explored:
+        considered = dilemma.get("considered", [])
+        if not explored and not considered:
             dilemma_id = strip_scope_prefix(dilemma.get("dilemma_id", ""))
             path_answer_ids = path_answers.get(dilemma_id, set())
             if path_answer_ids:
-                dilemma["considered"] = sorted(path_answer_ids)
+                dilemma["explored"] = sorted(path_answer_ids)
 
 
 # Registry of stages with mutation handlers
@@ -1195,8 +1195,8 @@ def validate_seed_mutations(graph: Graph, output: dict[str, Any]) -> list[SeedVa
             )
         )
 
-    # 11b. Check each considered answer has a path
-    # For each dilemma decision, verify path count matches considered count
+    # 11b. Check each explored answer has a path
+    # For each dilemma decision, verify path count matches explored count
     for dilemma_decision in output.get("dilemmas", []):
         raw_did = dilemma_decision.get("dilemma_id")
         if not raw_did:
@@ -1205,27 +1205,27 @@ def validate_seed_mutations(graph: Graph, output: dict[str, Any]) -> list[SeedVa
         if scope_error:
             continue
 
-        considered = dilemma_decision.get("considered", [])
+        explored = dilemma_decision.get("explored", [])
         path_count = dilemma_path_counts.get(normalized_did, 0)
 
-        if len(considered) > path_count:
-            missing_count = len(considered) - path_count
+        if len(explored) > path_count:
+            missing_count = len(explored) - path_count
             errors.append(
                 SeedValidationError(
                     field_path="paths",
                     issue=(
-                        f"Dilemma '{normalized_did}' has {len(considered)} considered answers "
+                        f"Dilemma '{normalized_did}' has {len(explored)} explored answers "
                         f"but only {path_count} path(s). "
-                        f"Create {missing_count} more path(s) - one for EACH considered answer."
+                        f"Create {missing_count} more path(s) - one for EACH explored answer."
                     ),
-                    available=considered,
+                    available=explored,
                     provided=str(path_count),
                     category=SeedErrorCategory.COMPLETENESS,
                 )
             )
 
-    # 11c. Check each path's answer_id is in its dilemma's considered list
-    # This catches data integrity issues where paths exist but considered is empty/mismatched
+    # 11c. Check each path's answer_id is in its dilemma's explored list
+    # This catches data integrity issues where paths exist but explored is empty/mismatched
     for i, path in enumerate(output.get("paths", [])):
         raw_did = path.get("dilemma_id")
         raw_answer_id = path.get("answer_id")
@@ -1238,16 +1238,16 @@ def validate_seed_mutations(graph: Graph, output: dict[str, Any]) -> list[SeedVa
         for dilemma_decision in output.get("dilemmas", []):
             decision_did = strip_scope_prefix(dilemma_decision.get("dilemma_id", ""))
             if decision_did == normalized_did:
-                considered = dilemma_decision.get("considered", [])
-                if raw_answer_id not in considered:
+                explored = dilemma_decision.get("explored", [])
+                if raw_answer_id not in explored:
                     errors.append(
                         SeedValidationError(
                             field_path=f"paths.{i}.answer_id",
                             issue=(
                                 f"Path answer '{raw_answer_id}' is not in dilemma "
-                                f"'{normalized_did}' considered list: {considered}"
+                                f"'{normalized_did}' explored list: {explored}"
                             ),
-                            available=considered,
+                            available=explored,
                             provided=raw_answer_id,
                             category=SeedErrorCategory.CROSS_REFERENCE,
                         )
@@ -1331,7 +1331,7 @@ def apply_seed_mutations(graph: Graph, output: dict[str, Any]) -> None:
 
     First validates all cross-references, then applies mutations.
 
-    Updates entity dispositions, creates paths from considered dilemmas,
+    Updates entity dispositions, creates paths from explored dilemmas,
     creates consequences, and creates initial beats.
 
     Node IDs are prefixed by type to match BRAINSTORM's namespacing:
@@ -1349,9 +1349,9 @@ def apply_seed_mutations(graph: Graph, output: dict[str, Any]) -> None:
         SeedMutationError: If semantic validation fails (with feedback for retry).
         MutationError: If required id fields are missing.
     """
-    # Migration: backfill empty considered arrays from path answer_ids
-    # This fixes legacy data where LLM serialized paths but left considered empty
-    _backfill_considered_from_paths(output)
+    # Migration: backfill empty explored arrays from path answer_ids
+    # This fixes legacy data where LLM serialized paths but left explored empty
+    _backfill_explored_from_paths(output)
 
     # Validate cross-references first
     errors = validate_seed_mutations(graph, output)
@@ -1373,14 +1373,14 @@ def apply_seed_mutations(graph: Graph, output: dict[str, Any]) -> None:
         raw_id = _require_field(dilemma_decision, "dilemma_id", f"Dilemma decision at index {i}")
         dilemma_node_id = _prefix_id("dilemma", raw_id)
         if graph.has_node(dilemma_node_id):
-            considered = dilemma_decision.get("considered", [])
+            explored = dilemma_decision.get("explored", [])
             graph.update_node(
                 dilemma_node_id,
-                considered=considered,
-                implicit=dilemma_decision.get("implicit", []),
+                explored=explored,
+                unexplored=dilemma_decision.get("unexplored", []),
             )
 
-    # Create paths from considered dilemmas (must be created before consequences)
+    # Create paths from explored dilemmas (must be created before consequences)
     for i, path in enumerate(output.get("paths", [])):
         raw_id = _require_field(path, "path_id", f"Path at index {i}")
         path_node_id = _prefix_id("path", raw_id)

--- a/src/questfoundry/graph/mutations.py
+++ b/src/questfoundry/graph/mutations.py
@@ -480,8 +480,7 @@ def _backfill_explored_from_paths(output: dict[str, Any]) -> None:
     # Backfill empty explored arrays
     for dilemma in output.get("dilemmas", []):
         explored = dilemma.get("explored", [])
-        considered = dilemma.get("considered", [])
-        if not explored and not considered:
+        if not explored:
             dilemma_id = strip_scope_prefix(dilemma.get("dilemma_id", ""))
             path_answer_ids = path_answers.get(dilemma_id, set())
             if path_answer_ids:

--- a/src/questfoundry/graph/seed_pruning.py
+++ b/src/questfoundry/graph/seed_pruning.py
@@ -7,7 +7,7 @@ programmatically select the best content.
 The pruning process:
 1. Rank dilemmas by quality score (see dilemma_scoring.py)
 2. Select top N dilemmas for full exploration (N determined by arc limit)
-3. Demote remaining dilemmas: move non-canonical to implicit
+3. Demote remaining dilemmas: move non-canonical to unexplored
 4. Drop paths, consequences, and beats for demoted non-canonical answers
 """
 
@@ -29,14 +29,14 @@ log = get_logger(__name__)
 
 def _get_canonical_answer(dilemma: DilemmaDecision) -> str | None:
     """Get the canonical (first) answer for a dilemma."""
-    return dilemma.considered[0] if dilemma.considered else None
+    return dilemma.explored[0] if dilemma.explored else None
 
 
 def _get_noncanonical_answers(dilemma: DilemmaDecision) -> list[str]:
-    """Get non-canonical answers (all considered except first)."""
-    if len(dilemma.considered) <= 1:
+    """Get non-canonical answers (all explored except first)."""
+    if len(dilemma.explored) <= 1:
         return []
-    return dilemma.considered[1:]
+    return dilemma.explored[1:]
 
 
 def prune_to_arc_limit(
@@ -92,7 +92,7 @@ def _prune_demoted_dilemmas(
     4. Update beats that belong to both demoted and kept paths
 
     IMPORTANT: Dilemmas ARE updated for demoted items. Non-canonical answers
-    are moved from `considered` to `implicit` so validation reflects the
+    are moved from `explored` to `unexplored` so validation reflects the
     pruned path set. This preserves canonical intent while keeping graph
     integrity after pruning.
 
@@ -142,19 +142,19 @@ def _prune_demoted_dilemmas(
         dropped_path_ids=list(paths_to_drop)[:5],  # Log first 5
     )
 
-    # Update dilemma decisions: move non-canonical answers to implicit
+    # Update dilemma decisions: move non-canonical answers to unexplored
     pruned_dilemmas: list[DilemmaDecision] = []
     for dilemma in seed_output.dilemmas:
         raw_did = strip_scope_prefix(dilemma.dilemma_id)
-        if raw_did in demoted_raw_ids and len(dilemma.considered) > 1:
+        if raw_did in demoted_raw_ids and len(dilemma.explored) > 1:
             canonical = _get_canonical_answer(dilemma)
             noncanonical = _get_noncanonical_answers(dilemma)
-            merged_implicit = list(dict.fromkeys([*dilemma.implicit, *noncanonical]))
+            merged_unexplored = list(dict.fromkeys([*dilemma.unexplored, *noncanonical]))
             pruned_dilemmas.append(
                 DilemmaDecision(
                     dilemma_id=dilemma.dilemma_id,
-                    considered=[canonical] if canonical else [],
-                    implicit=merged_implicit,
+                    explored=[canonical] if canonical else [],
+                    unexplored=merged_unexplored,
                 )
             )
         else:

--- a/src/questfoundry/graph/seed_pruning.py
+++ b/src/questfoundry/graph/seed_pruning.py
@@ -223,7 +223,7 @@ def compute_arc_count(seed_output: SeedOutput) -> int:
     Arc count = 2^n where n = dilemmas with 2+ paths (fully developed).
 
     IMPORTANT: This is derived from actual path existence, NOT from the
-    `considered` field. The `considered` field records LLM intent; actual
+    `explored` field. The `explored` field records LLM intent; actual
     path existence determines what will become story arcs.
 
     Args:

--- a/src/questfoundry/pipeline/stages/seed.py
+++ b/src/questfoundry/pipeline/stages/seed.py
@@ -452,7 +452,7 @@ class SeedStage:
         # This indicates the LLM didn't generate enough branching content
         if final_arc_count < 4:
             dilemmas_fully_explored = sum(
-                1 for d in artifact_data.get("dilemmas", []) if len(d.get("considered", [])) >= 2
+                1 for d in artifact_data.get("dilemmas", []) if len(d.get("explored", [])) >= 2
             )
             log.warning(
                 "seed_low_arc_count",

--- a/tests/unit/test_enrichment.py
+++ b/tests/unit/test_enrichment.py
@@ -223,8 +223,8 @@ class TestEnrichDilemmas:
             "dilemmas": [  # Input uses legacy "dilemmas" key
                 {
                     "dilemma_id": "host_motivation",
-                    "considered": ["benevolent"],
-                    "implicit": ["self_serving"],
+                    "explored": ["benevolent"],
+                    "unexplored": ["self_serving"],
                 },
             ],
         }
@@ -237,14 +237,14 @@ class TestEnrichDilemmas:
         assert dilemma["why_it_matters"] == "Determines whether protagonist can trust their guide"
         # Entity IDs should have prefix stripped
         assert dilemma["central_entity_ids"] == ["the_host", "the_manor"]
-        assert dilemma["considered"] == ["benevolent"]
-        assert dilemma["implicit"] == ["self_serving"]
+        assert dilemma["explored"] == ["benevolent"]
+        assert dilemma["unexplored"] == ["self_serving"]
 
     def test_handles_unknown_dilemma(self, graph_with_dilemmas: Graph) -> None:
         """Enrichment handles dilemmas not in graph gracefully."""
         artifact = {
             "dilemmas": [
-                {"dilemma_id": "unknown_dilemma", "considered": ["option_a"], "implicit": []},
+                {"dilemma_id": "unknown_dilemma", "explored": ["option_a"], "unexplored": []},
             ],
         }
 
@@ -254,7 +254,7 @@ class TestEnrichDilemmas:
         assert dilemma["dilemma_id"] == "unknown_dilemma"
         assert "question" not in dilemma
         assert "why_it_matters" not in dilemma
-        assert dilemma["considered"] == ["option_a"]
+        assert dilemma["explored"] == ["option_a"]
 
     def test_handles_prefixed_dilemma_ids(self, graph_with_dilemmas: Graph) -> None:
         """Enrichment strips prefix from dilemma_id for graph lookup."""
@@ -262,8 +262,8 @@ class TestEnrichDilemmas:
             "dilemmas": [
                 {
                     "dilemma_id": "dilemma::host_motivation",
-                    "considered": ["benevolent"],
-                    "implicit": [],
+                    "explored": ["benevolent"],
+                    "unexplored": [],
                 },
             ],
         }
@@ -276,14 +276,14 @@ class TestEnrichDilemmas:
         # But graph lookup succeeds with prefix stripped
         assert dilemma["question"] == "Is the host benevolent or self-serving?"
         assert dilemma["why_it_matters"] == "Determines whether protagonist can trust their guide"
-        assert dilemma["considered"] == ["benevolent"]
+        assert dilemma["explored"] == ["benevolent"]
 
     def test_enriches_multiple_dilemmas(self, graph_with_dilemmas: Graph) -> None:
         """Enrichment works for multiple dilemmas."""
         artifact = {
             "dilemmas": [
-                {"dilemma_id": "host_motivation", "considered": ["benevolent"], "implicit": []},
-                {"dilemma_id": "killer_identity", "considered": ["suspect_a"], "implicit": []},
+                {"dilemma_id": "host_motivation", "explored": ["benevolent"], "unexplored": []},
+                {"dilemma_id": "killer_identity", "explored": ["suspect_a"], "unexplored": []},
             ],
         }
 

--- a/tests/unit/test_graph_context.py
+++ b/tests/unit/test_graph_context.py
@@ -1153,13 +1153,13 @@ class TestFormatAnswerIdsByDilemma:
         """Empty list returns empty string."""
         assert format_answer_ids_by_dilemma([]) == ""
 
-    def test_single_dilemma_with_considered_and_implicit(self) -> None:
-        """Single dilemma formats considered and implicit lists."""
+    def test_single_dilemma_with_explored_and_unexplored(self) -> None:
+        """Single dilemma formats explored and unexplored lists."""
         dilemmas = [
             {
                 "dilemma_id": "dilemma::host_benevolent_or_selfish",
-                "considered": ["protector", "manipulator"],
-                "implicit": ["neutral"],
+                "explored": ["protector", "manipulator"],
+                "unexplored": ["neutral"],
             }
         ]
         result = format_answer_ids_by_dilemma(dilemmas)
@@ -1173,13 +1173,13 @@ class TestFormatAnswerIdsByDilemma:
         dilemmas = [
             {
                 "dilemma_id": "dilemma::mentor_trust_or_betray",
-                "considered": ["trust"],
-                "implicit": ["betray"],
+                "explored": ["trust"],
+                "unexplored": ["betray"],
             },
             {
                 "dilemma_id": "dilemma::artifact_blessed_or_cursed",
-                "considered": ["blessed", "cursed"],
-                "implicit": [],
+                "explored": ["blessed", "cursed"],
+                "unexplored": [],
             },
         ]
         result = format_answer_ids_by_dilemma(dilemmas)
@@ -1189,8 +1189,8 @@ class TestFormatAnswerIdsByDilemma:
     def test_dilemma_without_id_skipped(self) -> None:
         """Dilemmas with empty or missing ID produce empty string."""
         dilemmas = [
-            {"dilemma_id": "", "considered": ["a"], "implicit": []},
-            {"considered": ["b"], "implicit": []},
+            {"dilemma_id": "", "explored": ["a"], "unexplored": []},
+            {"explored": ["b"], "unexplored": []},
         ]
         result = format_answer_ids_by_dilemma(dilemmas)
         # No valid dilemmas → empty string (no header injected)
@@ -1201,8 +1201,8 @@ class TestFormatAnswerIdsByDilemma:
         dilemmas = [
             {
                 "dilemma_id": "host_benevolent_or_selfish",
-                "considered": ["protector"],
-                "implicit": [],
+                "explored": ["protector"],
+                "unexplored": [],
             }
         ]
         result = format_answer_ids_by_dilemma(dilemmas)

--- a/tests/unit/test_mutations.py
+++ b/tests/unit/test_mutations.py
@@ -3356,8 +3356,12 @@ class TestBackfillExploredFromPaths:
 
         assert output["dilemmas"][0]["explored"] == ["option_a"]
 
-    def test_supports_old_considered_field(self) -> None:
-        """Checks both 'explored' and 'considered' for existing values."""
+    def test_backfills_when_only_old_considered_key_present(self) -> None:
+        """Old 'considered' key is ignored; backfill uses 'explored' only.
+
+        Pydantic migration handles considered→explored at the model layer.
+        The backfill function only checks 'explored'.
+        """
         output = {
             "dilemmas": [
                 {"dilemma_id": "choice_a_or_b", "considered": ["existing"]},
@@ -3373,9 +3377,8 @@ class TestBackfillExploredFromPaths:
 
         _backfill_explored_from_paths(output)
 
-        # considered is not empty, so no backfill
-        assert "explored" not in output["dilemmas"][0]
-        assert output["dilemmas"][0]["considered"] == ["existing"]
+        # 'explored' key absent means backfill triggers (old 'considered' ignored)
+        assert output["dilemmas"][0]["explored"] == ["option_a"]
 
     def test_no_paths_no_backfill(self) -> None:
         """Empty paths list does not modify dilemmas."""

--- a/tests/unit/test_seed_stage.py
+++ b/tests/unit/test_seed_stage.py
@@ -98,7 +98,7 @@ async def test_execute_calls_all_three_phases() -> None:
         mock_summarize.return_value = ("Brief summary", 100)
         mock_artifact = SeedOutput(
             entities=[{"entity_id": "kay", "disposition": "retained"}],
-            dilemmas=[{"dilemma_id": "trust", "explored": ["yes"], "implicit": ["no"]}],
+            dilemmas=[{"dilemma_id": "trust", "explored": ["yes"], "unexplored": ["no"]}],
             paths=[
                 {
                     "name": "Trust Arc",
@@ -460,7 +460,7 @@ def test_seed_output_model_validates() -> None:
     """SeedOutput model validates correctly."""
     output = SeedOutput(
         entities=[{"entity_id": "kay", "disposition": "retained"}],
-        dilemmas=[{"dilemma_id": "trust", "explored": ["yes"], "implicit": []}],
+        dilemmas=[{"dilemma_id": "trust", "explored": ["yes"], "unexplored": []}],
         paths=[
             {
                 "name": "Trust Arc",

--- a/tests/unit/test_serialize.py
+++ b/tests/unit/test_serialize.py
@@ -1476,7 +1476,7 @@ class TestPropagateCrossSectionErrors:
             "paths": [
                 SeedValidationError(
                     field_path="paths.0.answer_id",
-                    issue="Path answer 'x' is not in dilemma considered list",
+                    issue="Path answer 'x' is not in dilemma explored list",
                     available=["a", "b"],
                     provided="x",
                     category=SeedErrorCategory.CROSS_REFERENCE,
@@ -1522,13 +1522,13 @@ class TestPropagateCrossSectionErrors:
             "paths": [
                 SeedValidationError(
                     field_path="paths.0.answer_id",
-                    issue="not in considered",
+                    issue="not in explored",
                     provided="x",
                     category=SeedErrorCategory.CROSS_REFERENCE,
                 ),
                 SeedValidationError(
                     field_path="paths.1.answer_id",
-                    issue="not in considered",
+                    issue="not in explored",
                     provided="y",
                     category=SeedErrorCategory.CROSS_REFERENCE,
                 ),


### PR DESCRIPTION
## Problem

LLMs (especially qwen3:4b) systematically invert the `considered`/`implicit` terminology when generating SEED output. The model interprets "considered" as "worth considering" (dramatic, non-default) and "implicit" as "implied/obvious" (default). This causes all paths to have `is_canonical=False`, which fails the GROW spine arc quality gate. Discovered in test run `projects/test-20260129T2138`.

## Changes

**Commit 1: Mechanical rename** (`refactor(models)`)
- Rename `considered` → `explored` and `implicit` → `unexplored` across all source and test files
- Backward-compatible migration via Pydantic `model_validator` (old field names still accepted)
- Rename test file `test_ontology_considered.py` → `test_ontology_explored.py`

**Commit 2: Prompts and docs** (`docs(prompts)`)
- Update all 4 prompt templates: discuss_seed, serialize_seed, summarize_seed, serialize_seed_sections
- Update design docs: 00-spec.md, procedures/seed.md, graph-referential-integrity.md, model-comparison analysis

**Commit 3: Validation guardrail** (`feat(validation)`)
- Add check 11d: verify the default/canonical answer (`is_default_path=true`) is in `explored`, not `unexplored`
- Catches bucket inversion during the serialize validation loop, enabling automatic retry
- 3 new unit tests covering pass, fail, and skip conditions

## Not Included / Future PRs

- Re-running test projects to verify the fix in practice (manual verification)
- The other issues from the plan (#360, #361, #363, #364, #365, #366) are tracked separately

## Test Plan

- `uv run mypy src/` — clean
- `uv run ruff check src/` — clean
- `uv run pytest tests/unit/test_mutations.py tests/unit/test_ontology_explored.py tests/unit/test_graph_context.py tests/unit/test_serialize.py tests/unit/test_seed_stage.py tests/unit/test_enrichment.py -x -q` — 344 passed

## Risk / Rollback

- Backward compatible: Pydantic model_validator migrates old `considered`/`implicit` field names automatically
- Existing graph.json files with old field names will continue to load correctly
- Rollback: revert the branch; old field names are still supported via migration

## Review Guide

Review in commit order: mechanical rename first (verify completeness), then prompts/docs (verify terminology), then guardrail (verify logic).

🤖 Generated with [Claude Code](https://claude.com/claude-code)