### PR TITLE
fix(pruning): use is_default_path from graph instead of explored[0]

### DIFF
--- a/src/questfoundry/graph/context.py
+++ b/src/questfoundry/graph/context.py
@@ -161,6 +161,31 @@ def strip_scope_prefix(scoped_id: str) -> str:
     return raw_id
 
 
+def get_default_answer_from_graph(graph: Graph, dilemma_id: str) -> str | None:
+    """Look up the default (canonical) answer for a dilemma from the graph.
+
+    Uses the ``is_default_path`` flag on answer nodes rather than relying on
+    the ordering of the ``explored`` list, which LLMs do not guarantee.
+
+    Args:
+        graph: The story graph containing dilemma and answer nodes.
+        dilemma_id: Raw or scoped dilemma ID.
+
+    Returns:
+        The raw answer ID marked as default, or None if not found.
+    """
+    raw_did = strip_scope_prefix(dilemma_id)
+    prefixed_did = f"dilemma::{raw_did}"
+    alt_edges = graph.get_edges(from_id=prefixed_did, edge_type="has_answer")
+    for edge in alt_edges:
+        alt_node = graph.get_node(edge["to"])
+        if alt_node and alt_node.get("is_default_path"):
+            raw_id = alt_node.get("raw_id")
+            if raw_id:
+                return str(raw_id)
+    return None
+
+
 def format_scoped_id(scope: str, raw_id: str) -> str:
     """Format a raw ID with its scope prefix.
 

--- a/src/questfoundry/graph/dilemma_scoring.py
+++ b/src/questfoundry/graph/dilemma_scoring.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
+from questfoundry.graph.context import get_default_answer_from_graph
 from questfoundry.observability.logging import get_logger
 
 if TYPE_CHECKING:
@@ -53,8 +54,6 @@ def _get_paths_for_dilemma(
 
     Returns (canonical_path, noncanonical_path).
     """
-    from questfoundry.graph.seed_pruning import get_default_answer_from_graph
-
     # Find dilemma decision to get canonical answer
     dilemma_decision = next(
         (d for d in seed_output.dilemmas if d.dilemma_id == dilemma_id),

--- a/src/questfoundry/graph/dilemma_scoring.py
+++ b/src/questfoundry/graph/dilemma_scoring.py
@@ -20,6 +20,7 @@ from typing import TYPE_CHECKING
 from questfoundry.observability.logging import get_logger
 
 if TYPE_CHECKING:
+    from questfoundry.graph.graph import Graph
     from questfoundry.models.seed import (
         Consequence,
         InitialBeat,
@@ -43,12 +44,17 @@ class ScoredDilemma:
 
 
 def _get_paths_for_dilemma(
-    seed_output: SeedOutput, dilemma_id: str
+    seed_output: SeedOutput, dilemma_id: str, graph: Graph | None = None
 ) -> tuple[Path | None, Path | None]:
     """Get canonical and non-canonical paths for a dilemma.
 
+    When a graph is provided, uses ``is_default_path`` to determine which
+    answer is canonical. Falls back to ``explored[0]`` without a graph.
+
     Returns (canonical_path, noncanonical_path).
     """
+    from questfoundry.graph.seed_pruning import get_default_answer_from_graph
+
     # Find dilemma decision to get canonical answer
     dilemma_decision = next(
         (d for d in seed_output.dilemmas if d.dilemma_id == dilemma_id),
@@ -63,8 +69,12 @@ def _get_paths_for_dilemma(
     if not paths:
         return None, None
 
-    # Assume first explored answer is canonical (typical pattern)
-    canonical_ans = dilemma_decision.explored[0] if dilemma_decision.explored else None
+    # Determine canonical answer: prefer graph lookup over explored ordering
+    canonical_ans: str | None = None
+    if graph is not None:
+        canonical_ans = get_default_answer_from_graph(graph, dilemma_id)
+    if canonical_ans is None:
+        canonical_ans = dilemma_decision.explored[0] if dilemma_decision.explored else None
 
     canonical_path = None
     noncanonical_path = None
@@ -88,7 +98,9 @@ def _get_consequences_for_path(seed_output: SeedOutput, path_id: str) -> list[Co
     return [c for c in seed_output.consequences if c.path_id == path_id]
 
 
-def score_dilemma(seed_output: SeedOutput, dilemma_id: str) -> ScoredDilemma:
+def score_dilemma(
+    seed_output: SeedOutput, dilemma_id: str, graph: Graph | None = None
+) -> ScoredDilemma:
     """Score a dilemma's value for full exploration.
 
     Higher scores indicate dilemmas more worth exploring both answers.
@@ -98,6 +110,7 @@ def score_dilemma(seed_output: SeedOutput, dilemma_id: str) -> ScoredDilemma:
     Args:
         seed_output: The full SEED output to analyze.
         dilemma_id: The dilemma to score.
+        graph: Story graph for canonical answer lookup via is_default_path.
 
     Returns:
         ScoredDilemma with computed score and rationale.
@@ -121,7 +134,7 @@ def score_dilemma(seed_output: SeedOutput, dilemma_id: str) -> ScoredDilemma:
             noncanonical_path_id=None,
         )
 
-    canonical_path, noncanonical_path = _get_paths_for_dilemma(seed_output, dilemma_id)
+    canonical_path, noncanonical_path = _get_paths_for_dilemma(seed_output, dilemma_id, graph)
 
     # is_fully_explored is derived from actual path existence, not from explored field
     # A dilemma is fully explored when BOTH canonical and non-canonical paths exist
@@ -217,6 +230,7 @@ def score_dilemma(seed_output: SeedOutput, dilemma_id: str) -> ScoredDilemma:
 
 def rank_dilemmas_for_exploration(
     seed_output: SeedOutput,
+    graph: Graph | None = None,
 ) -> list[ScoredDilemma]:
     """Rank all dilemmas by their exploration value.
 
@@ -225,6 +239,7 @@ def rank_dilemmas_for_exploration(
 
     Args:
         seed_output: The full SEED output to analyze.
+        graph: Story graph for canonical answer lookup via is_default_path.
 
     Returns:
         List of ScoredDilemma objects sorted by score descending.
@@ -232,7 +247,7 @@ def rank_dilemmas_for_exploration(
     scored_dilemmas: list[ScoredDilemma] = []
 
     for dilemma_decision in seed_output.dilemmas:
-        scored = score_dilemma(seed_output, dilemma_decision.dilemma_id)
+        scored = score_dilemma(seed_output, dilemma_decision.dilemma_id, graph)
         scored_dilemmas.append(scored)
 
     # Sort by score descending
@@ -251,6 +266,7 @@ def rank_dilemmas_for_exploration(
 def select_dilemmas_for_full_exploration(
     seed_output: SeedOutput,
     max_fully_explored: int = 4,
+    graph: Graph | None = None,
 ) -> tuple[list[str], list[str]]:
     """Select which dilemmas should have both answers explored.
 
@@ -260,13 +276,14 @@ def select_dilemmas_for_full_exploration(
     Args:
         seed_output: The full SEED output to analyze.
         max_fully_explored: Maximum dilemmas to fully explore (default 4 = 16 arcs).
+        graph: Story graph for canonical answer lookup via is_default_path.
 
     Returns:
         Tuple of (selected_dilemma_ids, demoted_dilemma_ids).
         - selected: Dilemmas that should keep both answers
         - demoted: Dilemmas that should have non-canonical moved to implicit
     """
-    ranked = rank_dilemmas_for_exploration(seed_output)
+    ranked = rank_dilemmas_for_exploration(seed_output, graph)
 
     # Filter to only dilemmas that have non-canonical paths (fully explored)
     fully_explored = [d for d in ranked if d.is_fully_explored]

--- a/src/questfoundry/graph/seed_pruning.py
+++ b/src/questfoundry/graph/seed_pruning.py
@@ -13,6 +13,8 @@ The pruning process:
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 from questfoundry.graph.context import strip_scope_prefix
 from questfoundry.graph.dilemma_scoring import select_dilemmas_for_full_exploration
 from questfoundry.models.seed import (
@@ -24,24 +26,59 @@ from questfoundry.models.seed import (
 )
 from questfoundry.observability.logging import get_logger
 
+if TYPE_CHECKING:
+    from questfoundry.graph.graph import Graph
+
 log = get_logger(__name__)
 
 
-def _get_canonical_answer(dilemma: DilemmaDecision) -> str | None:
-    """Get the canonical (first) answer for a dilemma."""
+def get_default_answer_from_graph(graph: Graph, dilemma_id: str) -> str | None:
+    """Look up the default (canonical) answer for a dilemma from the graph.
+
+    Uses the ``is_default_path`` flag on answer nodes rather than relying on
+    the ordering of the ``explored`` list, which LLMs do not guarantee.
+
+    Args:
+        graph: The story graph containing dilemma and answer nodes.
+        dilemma_id: Raw or scoped dilemma ID.
+
+    Returns:
+        The raw answer ID marked as default, or None if not found.
+    """
+    raw_did = strip_scope_prefix(dilemma_id)
+    prefixed_did = f"dilemma::{raw_did}"
+    alt_edges = graph.get_edges(from_id=prefixed_did, edge_type="has_answer")
+    for edge in alt_edges:
+        alt_node = graph.get_node(edge["to"])
+        if alt_node and alt_node.get("is_default_path"):
+            raw_id: str = alt_node.get("raw_id", "")
+            return raw_id
+    return None
+
+
+def _get_canonical_answer(dilemma: DilemmaDecision, graph: Graph | None = None) -> str | None:
+    """Get the canonical (default) answer for a dilemma.
+
+    When a graph is provided, looks up ``is_default_path`` for a reliable
+    determination. Falls back to ``explored[0]`` when no graph is available.
+    """
+    if graph is not None:
+        default = get_default_answer_from_graph(graph, dilemma.dilemma_id)
+        if default is not None:
+            return default
     return dilemma.explored[0] if dilemma.explored else None
 
 
-def _get_noncanonical_answers(dilemma: DilemmaDecision) -> list[str]:
-    """Get non-canonical answers (all explored except first)."""
-    if len(dilemma.explored) <= 1:
-        return []
-    return dilemma.explored[1:]
+def _get_noncanonical_answers(dilemma: DilemmaDecision, graph: Graph | None = None) -> list[str]:
+    """Get non-canonical answers (all explored except the canonical one)."""
+    canonical = _get_canonical_answer(dilemma, graph)
+    return [a for a in dilemma.explored if a != canonical]
 
 
 def prune_to_arc_limit(
     seed_output: SeedOutput,
     max_arcs: int = 16,
+    graph: Graph | None = None,
 ) -> SeedOutput:
     """Prune seed output to stay within arc count limits.
 
@@ -52,6 +89,7 @@ def prune_to_arc_limit(
     Args:
         seed_output: The full SEED output (potentially over-generated).
         max_arcs: Maximum number of arcs to allow (default 16 = 4 fully explored).
+        graph: Story graph for looking up canonical answers via is_default_path.
 
     Returns:
         Pruned SeedOutput with arc count within limits.
@@ -64,6 +102,7 @@ def prune_to_arc_limit(
     selected, demoted = select_dilemmas_for_full_exploration(
         seed_output,
         max_fully_explored=max_fully_explored,
+        graph=graph,
     )
 
     if not demoted:
@@ -76,12 +115,13 @@ def prune_to_arc_limit(
         return seed_output
 
     # Prune the output
-    return _prune_demoted_dilemmas(seed_output, set(demoted))
+    return _prune_demoted_dilemmas(seed_output, set(demoted), graph=graph)
 
 
 def _prune_demoted_dilemmas(
     seed_output: SeedOutput,
     demoted_dilemma_ids: set[str],
+    graph: Graph | None = None,
 ) -> SeedOutput:
     """Remove non-canonical content for demoted dilemmas.
 
@@ -129,7 +169,7 @@ def _prune_demoted_dilemmas(
         if raw_dilemma_id in demoted_raw_ids:
             dilemma = dilemma_lookup.get(raw_dilemma_id)
             if dilemma:
-                canonical_answer = _get_canonical_answer(dilemma)
+                canonical_answer = _get_canonical_answer(dilemma, graph)
                 # Drop if not the canonical answer
                 if path.answer_id != canonical_answer:
                     # Store raw path ID for consistent comparison
@@ -147,8 +187,8 @@ def _prune_demoted_dilemmas(
     for dilemma in seed_output.dilemmas:
         raw_did = strip_scope_prefix(dilemma.dilemma_id)
         if raw_did in demoted_raw_ids and len(dilemma.explored) > 1:
-            canonical = _get_canonical_answer(dilemma)
-            noncanonical = _get_noncanonical_answers(dilemma)
+            canonical = _get_canonical_answer(dilemma, graph)
+            noncanonical = _get_noncanonical_answers(dilemma, graph)
             merged_unexplored = list(dict.fromkeys([*dilemma.unexplored, *noncanonical]))
             pruned_dilemmas.append(
                 DilemmaDecision(

--- a/src/questfoundry/pipeline/stages/seed.py
+++ b/src/questfoundry/pipeline/stages/seed.py
@@ -428,7 +428,7 @@ class SeedStage:
         # LLM may have explored more dilemmas than the arc limit allows.
         # Instead of retrying, we programmatically select the best dilemmas.
         original_arc_count = compute_arc_count(result.artifact)
-        pruned_artifact = prune_to_arc_limit(result.artifact, max_arcs=16)
+        pruned_artifact = prune_to_arc_limit(result.artifact, max_arcs=16, graph=graph)
         final_arc_count = compute_arc_count(pruned_artifact)
 
         if original_arc_count != final_arc_count:

--- a/tests/unit/test_ontology_explored.py
+++ b/tests/unit/test_ontology_explored.py
@@ -15,13 +15,13 @@ from questfoundry.graph.context import (
     STATE_DEFERRED,
     STATE_LATENT,
     count_paths_per_dilemma,
+    get_default_answer_from_graph,
     get_dilemma_development_states,
 )
 from questfoundry.graph.graph import Graph
 from questfoundry.graph.seed_pruning import (
     _prune_demoted_dilemmas,
     compute_arc_count,
-    get_default_answer_from_graph,
     prune_to_arc_limit,
 )
 from questfoundry.models.seed import (

--- a/tests/unit/test_ontology_explored.py
+++ b/tests/unit/test_ontology_explored.py
@@ -17,9 +17,11 @@ from questfoundry.graph.context import (
     count_paths_per_dilemma,
     get_dilemma_development_states,
 )
+from questfoundry.graph.graph import Graph
 from questfoundry.graph.seed_pruning import (
     _prune_demoted_dilemmas,
     compute_arc_count,
+    get_default_answer_from_graph,
     prune_to_arc_limit,
 )
 from questfoundry.models.seed import (
@@ -685,3 +687,145 @@ class TestScopedIdStandardization:
         # Should correctly count 2 paths for t1 → 2^1 = 2 arcs
         arc_count = compute_arc_count(seed)
         assert arc_count == 2
+
+
+def _make_graph_with_dilemma(
+    dilemma_id: str,
+    answers: list[tuple[str, bool]],
+) -> Graph:
+    """Create a minimal graph with a dilemma node and answer nodes.
+
+    Args:
+        dilemma_id: Raw dilemma ID (without prefix).
+        answers: List of (answer_id, is_default_path) tuples.
+    """
+    graph = Graph()
+    prefixed = f"dilemma::{dilemma_id}"
+    graph.create_node(prefixed, {"type": "dilemma", "raw_id": dilemma_id})
+    for answer_id, is_default in answers:
+        alt_id = f"{prefixed}::alt::{answer_id}"
+        graph.create_node(
+            alt_id,
+            {"type": "alternative", "raw_id": answer_id, "is_default_path": is_default},
+        )
+        graph.add_edge("has_answer", prefixed, alt_id)
+    return graph
+
+
+class TestCanonicalAnswerFromGraph:
+    """Test that pruning uses is_default_path from the graph."""
+
+    def test_get_default_answer_from_graph(self) -> None:
+        """get_default_answer_from_graph returns the answer with is_default_path."""
+        graph = _make_graph_with_dilemma("t1", [("alt_a", True), ("alt_b", False)])
+        assert get_default_answer_from_graph(graph, "t1") == "alt_a"
+
+    def test_get_default_answer_returns_none_when_missing(self) -> None:
+        """Returns None when no answer has is_default_path."""
+        graph = _make_graph_with_dilemma("t1", [("alt_a", False), ("alt_b", False)])
+        assert get_default_answer_from_graph(graph, "t1") is None
+
+    def test_get_default_answer_handles_scoped_dilemma_id(self) -> None:
+        """Works with scoped dilemma ID input."""
+        graph = _make_graph_with_dilemma("t1", [("alt_a", False), ("alt_b", True)])
+        assert get_default_answer_from_graph(graph, "dilemma::t1") == "alt_b"
+
+    def test_pruning_uses_graph_default_not_explored_order(self) -> None:
+        """When graph says alt_b is default but explored=[alt_a, alt_b],
+        pruning keeps alt_b (the actual default) not alt_a (first in list)."""
+        # Graph: alt_b is the default answer
+        graph = _make_graph_with_dilemma("t1", [("alt_a", False), ("alt_b", True)])
+
+        # LLM put alt_a first in explored (the bug scenario)
+        seed = SeedOutput(
+            dilemmas=[
+                DilemmaDecision(
+                    dilemma_id="t1",
+                    explored=["alt_a", "alt_b"],
+                    unexplored=[],
+                ),
+            ],
+            paths=[
+                Path(
+                    path_id="path_a",
+                    name="Path A",
+                    dilemma_id="t1",
+                    answer_id="alt_a",
+                    path_importance="major",
+                    description="desc",
+                ),
+                Path(
+                    path_id="path_b",
+                    name="Path B",
+                    dilemma_id="t1",
+                    answer_id="alt_b",
+                    path_importance="major",
+                    description="desc",
+                ),
+            ],
+            initial_beats=[
+                InitialBeat(
+                    beat_id="beat_1",
+                    summary="Test",
+                    paths=["path_a", "path_b"],
+                    dilemma_impacts=[{"dilemma_id": "t1", "effect": "commits", "note": "n"}],
+                ),
+            ],
+        )
+
+        # Demote t1 WITH graph - should keep alt_b (default), drop alt_a
+        pruned = _prune_demoted_dilemmas(seed, {"t1"}, graph=graph)
+
+        path_ids = [p.path_id for p in pruned.paths]
+        assert "path_b" in path_ids, "Default path (alt_b) should be kept"
+        assert "path_a" not in path_ids, "Non-default path (alt_a) should be dropped"
+
+        # Dilemma should have alt_b in explored, alt_a in unexplored
+        pruned_dilemma = pruned.dilemmas[0]
+        assert pruned_dilemma.explored == ["alt_b"]
+        assert "alt_a" in pruned_dilemma.unexplored
+
+    def test_pruning_without_graph_uses_explored_order(self) -> None:
+        """Without graph, pruning falls back to explored[0] as canonical."""
+        seed = SeedOutput(
+            dilemmas=[
+                DilemmaDecision(
+                    dilemma_id="t1",
+                    explored=["alt_a", "alt_b"],
+                    unexplored=[],
+                ),
+            ],
+            paths=[
+                Path(
+                    path_id="path_a",
+                    name="Path A",
+                    dilemma_id="t1",
+                    answer_id="alt_a",
+                    path_importance="major",
+                    description="desc",
+                ),
+                Path(
+                    path_id="path_b",
+                    name="Path B",
+                    dilemma_id="t1",
+                    answer_id="alt_b",
+                    path_importance="major",
+                    description="desc",
+                ),
+            ],
+            initial_beats=[
+                InitialBeat(
+                    beat_id="beat_1",
+                    summary="Test",
+                    paths=["path_a", "path_b"],
+                    dilemma_impacts=[{"dilemma_id": "t1", "effect": "commits", "note": "n"}],
+                ),
+            ],
+        )
+
+        # Demote t1 WITHOUT graph - should keep alt_a (first in explored)
+        pruned = _prune_demoted_dilemmas(seed, {"t1"})
+
+        path_ids = [p.path_id for p in pruned.paths]
+        assert "path_a" in path_ids, "explored[0] should be kept without graph"
+        assert "path_b" not in path_ids


### PR DESCRIPTION
## Problem

Pruning assumed `explored[0]` was the canonical (default) answer for a dilemma. LLMs don't guarantee any particular ordering of the `explored` list. In test project `test-20260130T0349`, the LLM placed dramatic answers first in `explored`, while the actual default answer (`is_default_path=True` in the graph) was second.

When pruning demotes a dilemma, it keeps the "canonical" answer and moves the rest to `unexplored`. With the wrong answer identified as canonical:
1. The actual default answer gets moved to `unexplored`
2. Check 11d catches this post-write (default answer in unexplored)
3. Stage fails at the orchestrator level, too late for retry

Fixes #378

## Changes

- Added `get_default_answer_from_graph()` helper in `seed_pruning.py` that looks up `is_default_path` from answer nodes via the graph
- Modified `_get_canonical_answer()` and `_get_noncanonical_answers()` to accept an optional `graph` parameter
- Modified `_get_paths_for_dilemma()` in `dilemma_scoring.py` to accept an optional `graph` parameter
- Threaded `graph` through the entire call chain: `prune_to_arc_limit` → `select_dilemmas_for_full_exploration` → `rank_dilemmas_for_exploration` → `score_dilemma` → `_get_paths_for_dilemma`
- Updated caller in `seed.py` to pass `graph=graph`
- All functions fall back to `explored[0]` when no graph is provided (backward compatible)

## Not Included / Future PRs

- Fixing the serialize loop to also use graph-based canonical answer determination (serialize doesn't prune)
- Adding the graph parameter to `compute_arc_count()` (it doesn't need canonical answer info)

## Test Plan

- `uv run pytest tests/unit/test_ontology_explored.py -x -q` — 24 passed
- `uv run pytest tests/unit/test_mutations.py -x -q` — 153 passed
- `uv run mypy src/` — no issues
- `uv run ruff check src/` — all passed

New tests:
- `test_get_default_answer_from_graph` — graph lookup returns correct default
- `test_get_default_answer_returns_none_when_missing` — returns None when no default flagged
- `test_get_default_answer_handles_scoped_dilemma_id` — works with scoped IDs
- `test_pruning_uses_graph_default_not_explored_order` — **key test**: verifies pruning keeps the graph's default answer, not explored[0]
- `test_pruning_without_graph_uses_explored_order` — backward compat: falls back to explored[0]

## Risk / Rollback

- Low risk: all `graph` parameters are optional with `None` default, so existing callers continue to work unchanged
- The only production caller (`seed.py:431`) already has `graph` in scope

🤖 Generated with [Claude Code](https://claude.com/claude-code)