### PR TITLE
fix(grow): write proper story artifact and update meta.last_stage

### DIFF
--- a/src/questfoundry/artifacts/enrichment.py
+++ b/src/questfoundry/artifacts/enrichment.py
@@ -247,8 +247,14 @@ def _extract_choices(graph: Graph) -> list[dict[str, Any]]:
             "label": data.get("label", ""),
         }
         if from_edges:
+            if len(from_edges) > 1:
+                log.warning(
+                    "multiple_choice_from_edges", choice_id=choice_id, count=len(from_edges)
+                )
             entry["from_passage"] = from_edges[0]["to"]
         if to_edges:
+            if len(to_edges) > 1:
+                log.warning("multiple_choice_to_edges", choice_id=choice_id, count=len(to_edges))
             entry["to_passage"] = to_edges[0]["to"]
         if requires_edges:
             entry["requires"] = sorted(e["to"] for e in requires_edges)
@@ -268,6 +274,8 @@ def _extract_codewords(graph: Graph) -> list[dict[str, Any]]:
             "codeword_id": cw_id,
         }
         if tracks_edges:
+            if len(tracks_edges) > 1:
+                log.warning("multiple_tracks_edges", codeword_id=cw_id, count=len(tracks_edges))
             entry["tracks"] = tracks_edges[0]["to"]
         if grants_edges:
             entry["granted_by"] = sorted(e["from"] for e in grants_edges)

--- a/src/questfoundry/pipeline/stages/grow.py
+++ b/src/questfoundry/pipeline/stages/grow.py
@@ -304,6 +304,7 @@ class GrowStage:
             if on_phase_progress is not None:
                 on_phase_progress(phase_name, result.status, result.detail)
 
+        graph.set_last_stage("grow")
         graph.save(resolved_path / "graph.json")
 
         # Count created nodes
@@ -330,6 +331,13 @@ class GrowStage:
             phases_completed=phase_results,
             spine_arc_id=spine_arc_id,
         )
+
+        # Write human-readable artifact (story data extracted from graph)
+        from questfoundry.artifacts.enrichment import extract_grow_artifact
+        from questfoundry.artifacts.writer import ArtifactWriter
+
+        artifact_data = extract_grow_artifact(graph)
+        ArtifactWriter(resolved_path).write(artifact_data, "grow")
 
         log.info(
             "stage_complete",
@@ -1370,6 +1378,7 @@ class GrowStage:
                     "from_beat": beat_id,
                     "summary": beat_data.get("summary", ""),
                     "entities": beat_data.get("entities", []),
+                    "prose": None,
                 },
             )
             graph.add_edge("passage_from", passage_id, beat_id)


### PR DESCRIPTION
## Problem

GROW stage had three issues discovered during test project analysis:

1. `grow.yaml` contained only execution telemetry (phase counts, status) instead of story data like other stage artifacts
2. `meta.last_stage` was stuck on `"seed"` after GROW because GROW bypasses the orchestrator mutation path (`_MUTATION_STAGES`)
3. Passage nodes in graph.json lacked the optional `prose` field defined in the spec

## Changes

- Add `extract_grow_artifact()` to `artifacts/enrichment.py` — extracts arcs, beats, passages, choices, and codewords from graph nodes/edges into a human-readable artifact dict
- Write artifact via `ArtifactWriter` in `grow.py` after all phases complete
- Call `graph.set_last_stage("grow")` before `graph.save()`
- Add `"prose": None` to passage nodes during creation (populated later by FILL)

Retroactively generated proper grow artifacts for all 5 existing test projects (via one-off script, not included in PR).

## Not Included / Future PRs

- No changes to the `GrowResult` model — it still returns counts + phases to the orchestrator for `StageResult`
- Passage prose population is deferred to FILL stage implementation

## Test Plan

- `uv run mypy src/` — 63 files, no issues
- `uv run ruff check src/` — all passed
- `uv run pytest tests/unit/test_enrichment.py -x -q` — 14 passed
- `uv run pytest tests/unit/test_grow_stage.py -x -q` — 84 passed
- Pre-commit hooks all passed
- Verified generated `grow.yaml` for test-20260130T0801: 2100+ lines with 16 arcs, 45 beats, 45 passages, 51 choices, 11 codewords

## Risk / Rollback

- Low risk: additive changes only, no existing behavior modified
- GROW already saved graph directly; this adds artifact write alongside it
- `set_last_stage` is a new call but follows the exact pattern used by the orchestrator for other stages

🤖 Generated with [Claude Code](https://claude.com/claude-code)