### PR TITLE
refactor(models): extract PhaseResult from GrowPhaseResult for shared use

### DIFF
--- a/src/questfoundry/models/__init__.py
+++ b/src/questfoundry/models/__init__.py
@@ -47,6 +47,7 @@ from questfoundry.models.grow import (
     Phase9Output,
     SceneTypeTag,
 )
+from questfoundry.models.pipeline import PhaseResult
 from questfoundry.models.seed import (
     Consequence,
     ConvergenceSketch,
@@ -97,6 +98,7 @@ __all__ = [
     "Phase4bOutput",
     "Phase8cOutput",
     "Phase9Output",
+    "PhaseResult",
     "SceneTypeTag",
     "Scope",
     "SeedOutput",

--- a/src/questfoundry/models/grow.py
+++ b/src/questfoundry/models/grow.py
@@ -22,6 +22,8 @@ from typing import Literal
 
 from pydantic import BaseModel, Field
 
+from questfoundry.models.pipeline import PhaseResult
+
 # ---------------------------------------------------------------------------
 # Graph node types
 # ---------------------------------------------------------------------------
@@ -182,14 +184,13 @@ class Phase9Output(BaseModel):
 # ---------------------------------------------------------------------------
 
 
-class GrowPhaseResult(BaseModel):
-    """Result of a single GROW phase execution."""
+class GrowPhaseResult(PhaseResult):
+    """Result of a single GROW phase execution.
 
-    phase: str = Field(min_length=1)
-    status: Literal["completed", "skipped", "failed"]
-    detail: str = ""
-    llm_calls: int = 0
-    tokens_used: int = 0
+    Inherits all fields from PhaseResult. Currently identical,
+    but allows GROW-specific fields to be added without affecting
+    other stages.
+    """
 
 
 class GrowResult(BaseModel):

--- a/src/questfoundry/models/pipeline.py
+++ b/src/questfoundry/models/pipeline.py
@@ -1,0 +1,26 @@
+"""Shared pipeline models used across multiple stages.
+
+These models provide common types for stage phase execution,
+allowing infrastructure like PhaseGateHook to be reused by
+any stage with a multi-phase algorithm (GROW, FILL, etc.).
+"""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import BaseModel, Field
+
+
+class PhaseResult(BaseModel):
+    """Result of a single phase execution within a stage.
+
+    Used by any stage with a multi-phase algorithm (GROW, FILL).
+    Captures phase name, completion status, and resource usage.
+    """
+
+    phase: str = Field(min_length=1)
+    status: Literal["completed", "skipped", "failed"]
+    detail: str = ""
+    llm_calls: int = 0
+    tokens_used: int = 0

--- a/src/questfoundry/pipeline/gates.py
+++ b/src/questfoundry/pipeline/gates.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Literal, Protocol
 
 if TYPE_CHECKING:
-    from questfoundry.models.grow import GrowPhaseResult
+    from questfoundry.models.pipeline import PhaseResult
     from questfoundry.pipeline.orchestrator import StageResult
 
 
@@ -79,18 +79,18 @@ class RequireSuccessGate:
 
 
 class PhaseGateHook(Protocol):
-    """Protocol for intra-stage phase gates used by GROW.
+    """Protocol for intra-stage phase gates used by multi-phase stages.
 
     Unlike GateHook which gates between pipeline stages, PhaseGateHook
-    gates between phases within a single stage. This allows stopping
-    execution mid-stage and rolling back to a previous phase snapshot.
+    gates between phases within a single stage (GROW, FILL). This allows
+    stopping execution mid-stage and rolling back to a previous phase snapshot.
     """
 
     async def on_phase_complete(
         self,
         stage: str,
         phase: str,
-        result: GrowPhaseResult,
+        result: PhaseResult,
     ) -> Literal["approve", "reject"]:
         """Called when a phase within a stage completes.
 
@@ -108,14 +108,14 @@ class PhaseGateHook(Protocol):
 class AutoApprovePhaseGate:
     """Phase gate that automatically approves all phase transitions.
 
-    Default gate for GROW phases where human review is not yet implemented.
+    Default gate for multi-phase stages where human review is not yet implemented.
     """
 
     async def on_phase_complete(
         self,
         _stage: str,
         _phase: str,
-        _result: GrowPhaseResult,
+        _result: PhaseResult,
     ) -> Literal["approve", "reject"]:
         """Automatically approve all completed phases.
 


### PR DESCRIPTION
## Problem

`PhaseGateHook` and `AutoApprovePhaseGate` are hard-wired to GROW's `GrowPhaseResult`. The upcoming FILL stage needs the same phase-gate infrastructure, so the base phase result model must be shared.

## Changes

- **New `src/questfoundry/models/pipeline.py`** — `PhaseResult` base model with `phase`, `status`, `detail`, `llm_calls`, `tokens_used` fields
- **`models/grow.py`** — `GrowPhaseResult` now inherits from `PhaseResult` (no field duplication)
- **`pipeline/gates.py`** — `PhaseGateHook` and `AutoApprovePhaseGate` type hints use `PhaseResult` instead of `GrowPhaseResult`; docstrings updated to reflect multi-stage usage
- **`models/__init__.py`** — Exports `PhaseResult`
- **`tests/unit/test_grow_gates.py`** — Added `TestPhaseResult` class (4 tests: creation, all fields, inheritance check, isinstance check); added test for `GrowPhaseResult` accepted where `PhaseResult` expected

## Not Included / Future PRs

- FILL models (PR 2 / #383)
- FILL stage implementation (PR 5+ / #386+)

## Test Plan

```
uv run mypy src/                                    # ✅ no issues
uv run ruff check src/                              # ✅ all checks passed
uv run pytest tests/unit/test_grow_gates.py -x -q   # ✅ 27 passed
```

## Risk / Rollback

- **Zero behavior change** — `GrowPhaseResult` inherits all the same fields; existing code is fully backward-compatible
- Safe to revert by inlining `PhaseResult` fields back into `GrowPhaseResult`

Closes #382
Part of #381

🤖 Generated with [Claude Code](https://claude.com/claude-code)