### PR TITLE
feat(prompts): add FILL prompt templates for all phases

### DIFF
--- a/prompts/templates/fill_phase0_voice.yaml
+++ b/prompts/templates/fill_phase0_voice.yaml
@@ -47,8 +47,11 @@ user: |
   Based on the creative vision and story structure above, propose a voice document.
 
   CRITICAL REMINDERS:
-  - Match POV/tense to genre conventions
-  - tone_words must be distilled from DREAM themes, not generic
+  - Match POV/tense to genre conventions (fantasy → third_limited past; horror → second present)
+  - voice_register must match DREAM tone — dark stories need literary or sparse, NOT conversational
+  - tone_words must be distilled from DREAM themes, not generic filler
+  - avoid_words and avoid_patterns should target the genre's common pitfalls
+  - Consider scene type distribution — micro_beat-heavy stories need a register that works for brevity
   - Return ONLY a valid JSON object. Do NOT add prose before or after the JSON.
 
 components: []

--- a/prompts/templates/fill_phase0_voice.yaml
+++ b/prompts/templates/fill_phase0_voice.yaml
@@ -1,0 +1,51 @@
+name: fill_phase0_voice
+description: Determine the voice document for prose generation
+
+system: |
+  You are establishing the voice and style for an interactive fiction story.
+  Your task is to create a voice document — a concrete contract that governs
+  how every passage in the story will be written.
+
+  ## Creative Vision (from DREAM)
+  {dream_vision}
+
+  ## Story Structure Summary (from GROW)
+  {grow_summary}
+
+  ## Scene Type Distribution
+  {scene_types_summary}
+
+  ## Voice Document Fields
+
+  Create a voice document with these fields:
+
+  - **pov**: Point of view. One of: first, second, third_limited, third_omniscient
+  - **pov_character**: Whose perspective (required for first/third_limited, empty for omniscient/second)
+  - **tense**: One of: past, present
+  - **voice_register**: One of: formal, conversational, literary, sparse
+  - **sentence_rhythm**: One of: varied, punchy, flowing
+  - **tone_words**: 3-5 adjectives describing the voice (e.g. terse, wry, melancholic, atmospheric)
+  - **avoid_words**: Words/phrases to never use (e.g. suddenly, very, really)
+  - **avoid_patterns**: Patterns to avoid (e.g. adverb-heavy dialogue tags, excessive internal monologue)
+  - **exemplar_passages**: Leave empty (will be generated separately if needed)
+
+  ## Guidelines
+
+  - Match POV and tense to genre conventions (fantasy often uses third_limited past;
+    horror can use second present; literary fiction varies)
+  - The register should match the DREAM tone — dark stories need literary or sparse,
+    not conversational
+  - Tone words should be distilled from DREAM themes, not generic
+  - Avoid words/patterns should target the genre's common pitfalls
+  - Consider the scene type distribution — a story heavy on micro_beats needs a
+    register that works for brevity
+
+  ## Output Format
+  Return a JSON object with a "voice" field containing the voice document.
+
+user: |
+  Based on the creative vision and story structure above, propose a voice document.
+
+  REMINDER: Return ONLY a valid JSON object. Do NOT add prose before or after the JSON.
+
+components: []

--- a/prompts/templates/fill_phase0_voice.yaml
+++ b/prompts/templates/fill_phase0_voice.yaml
@@ -46,6 +46,9 @@ system: |
 user: |
   Based on the creative vision and story structure above, propose a voice document.
 
-  REMINDER: Return ONLY a valid JSON object. Do NOT add prose before or after the JSON.
+  CRITICAL REMINDERS:
+  - Match POV/tense to genre conventions
+  - tone_words must be distilled from DREAM themes, not generic
+  - Return ONLY a valid JSON object. Do NOT add prose before or after the JSON.
 
 components: []

--- a/prompts/templates/fill_phase1_prose.yaml
+++ b/prompts/templates/fill_phase1_prose.yaml
@@ -71,6 +71,11 @@ user: |
   Write the prose for passage {passage_id} following the voice document and
   scene type guidance above.
 
-  REMINDER: Return ONLY a valid JSON object. Do NOT add prose before or after the JSON.
+  CRITICAL REMINDERS:
+  - Follow the voice document EXACTLY — POV, tense, register, rhythm, tone
+  - Match scene type guidance for structure and length
+  - Cover beat summary content — do NOT invent major plot points
+  - For shared beats, prose must work for ALL arriving states (active + shadows)
+  - Return ONLY a valid JSON object. Do NOT add prose before or after the JSON.
 
 components: []

--- a/prompts/templates/fill_phase1_prose.yaml
+++ b/prompts/templates/fill_phase1_prose.yaml
@@ -1,0 +1,76 @@
+name: fill_phase1_prose
+description: Generate prose for a single passage
+
+system: |
+  You are writing prose for an interactive fiction passage. Follow the voice
+  document exactly — it is a binding contract for style, POV, tense, and tone.
+
+  ## Voice Document
+  {voice_document}
+
+  ## Current Passage
+  **Passage ID:** {passage_id}
+  **Beat Summary:** {beat_summary}
+  **Scene Type:** {scene_type}
+
+  ## Scene Type Guidance
+  - **scene**: Full dramatic structure (goal, obstacle, outcome). 3+ paragraphs.
+    Lead with sensory grounding, build through conflict, close with stakes clarified.
+  - **sequel**: Reactive processing (reaction, dilemma, decision). 2-3 paragraphs.
+    Breathing room after intensity.
+  - **micro_beat**: Brief transition. 1 paragraph. Functional prose that moves
+    the story forward without dwelling.
+
+  ## Entity States
+  {entity_states}
+
+  ## Recent Passages (Sliding Window)
+  {sliding_window}
+
+  ## Lookahead
+  {lookahead}
+
+  ## Shadow States (Poly-State Context)
+  {shadow_states}
+
+  ## Rules
+
+  1. Follow the voice document for POV, tense, register, rhythm, and tone
+  2. Match the scene type guidance for length and structure
+  3. Cover the beat summary content — do not invent major plot points
+  4. Maintain continuity with the sliding window passages
+  5. If this is a shared beat, write prose that works for ALL arriving states
+     (active + shadows). Use ambiguous phrasing when states diverge.
+
+  ## Poly-State Failure
+
+  If you CANNOT write prose compatible with all shadow states because:
+  - Internal monologue requires contradictory knowledge
+  - Body language only makes sense for one state
+  - Dialogue would reveal path-specific information
+  - Emotional register is fundamentally different (rage vs warmth)
+
+  Then set flag to "incompatible_states" and explain in flag_reason.
+  Leave prose empty.
+
+  ## Entity Updates
+
+  If your prose introduces micro-details about entities (appearance, mannerisms,
+  voice), list them in entity_updates so they persist for later passages.
+  Only update EXISTING entities — do not create new ones.
+
+  ## Output Format
+  Return a JSON object with a "passage" field containing:
+  - passage_id: the passage ID
+  - prose: the generated text
+  - flag: "ok" or "incompatible_states"
+  - flag_reason: explanation if flagged (empty otherwise)
+  - entity_updates: list of {entity_id, field, value} (may be empty)
+
+user: |
+  Write the prose for passage {passage_id} following the voice document and
+  scene type guidance above.
+
+  REMINDER: Return ONLY a valid JSON object. Do NOT add prose before or after the JSON.
+
+components: []

--- a/prompts/templates/fill_phase1_prose.yaml
+++ b/prompts/templates/fill_phase1_prose.yaml
@@ -42,6 +42,12 @@ system: |
   5. If this is a shared beat, write prose that works for ALL arriving states
      (active + shadows). Use ambiguous phrasing when states diverge.
 
+  ## Poly-State Examples (CRITICAL for shared beats)
+  GOOD: "The stranger's expression was unreadable" (works for trust or betrayal)
+  GOOD: "Something had shifted between them" (ambiguous emotional change)
+  BAD: "Kay trusted the mentor completely" (only works for one path state)
+  BAD: "The betrayal still burned in Kay's mind" (reveals path-specific knowledge)
+
   ## Poly-State Failure
 
   If you CANNOT write prose compatible with all shadow states because:

--- a/prompts/templates/fill_phase2_review.yaml
+++ b/prompts/templates/fill_phase2_review.yaml
@@ -40,6 +40,11 @@ system: |
 user: |
   Review the passages above against the voice document. Flag any quality issues.
 
-  REMINDER: Return ONLY a valid JSON object. Do NOT add prose before or after the JSON.
+  CRITICAL REMINDERS:
+  - Be selective — flag real problems, not stylistic preferences
+  - issue_type must be one of: voice_drift, scene_type_mismatch, summary_deviation,
+    continuity_break, convergence_awkwardness, flat_prose
+  - An empty flags list is fine if no issues found
+  - Return ONLY a valid JSON object. Do NOT add prose before or after the JSON.
 
 components: []

--- a/prompts/templates/fill_phase2_review.yaml
+++ b/prompts/templates/fill_phase2_review.yaml
@@ -1,0 +1,45 @@
+name: fill_phase2_review
+description: Review a batch of passages for quality issues
+
+system: |
+  You are reviewing a batch of interactive fiction passages for quality issues.
+  Compare each passage against the voice document and its surrounding context.
+
+  ## Voice Document
+  {voice_document}
+
+  ## Passages to Review
+  {passages_batch}
+
+  ## Review Criteria
+
+  Flag passages that have any of these issues:
+
+  | Issue Type | What to Look For |
+  |------------|-----------------|
+  | voice_drift | Passage sounds different from surrounding prose — wrong register, tense slip, rhythm break |
+  | scene_type_mismatch | Full scene crammed into one paragraph, or micro_beat sprawling across three |
+  | summary_deviation | Prose doesn't match the beat summary content — missing key events or adding invented ones |
+  | continuity_break | Details contradict earlier passages (wrong name, changed appearance, impossible geography) |
+  | convergence_awkwardness | Passage doesn't work for one of the arriving branches |
+  | flat_prose | Lacks sensory detail, dilemma tension, or emotional engagement — reads as summary not prose |
+
+  ## Guidelines
+
+  - Be selective. Flag real problems, not stylistic preferences.
+  - A passage can have multiple issues — create separate flags for each.
+  - Not every passage will have issues. An empty flags list is fine.
+  - Focus on issues that would break immersion for a reader.
+
+  ## Output Format
+  Return a JSON object with a "flags" array. Each flag has:
+  - passage_id: the passage with the issue
+  - issue: clear description of the problem
+  - issue_type: one of the types from the table above
+
+user: |
+  Review the passages above against the voice document. Flag any quality issues.
+
+  REMINDER: Return ONLY a valid JSON object. Do NOT add prose before or after the JSON.
+
+components: []

--- a/prompts/templates/fill_phase3_revision.yaml
+++ b/prompts/templates/fill_phase3_revision.yaml
@@ -1,0 +1,59 @@
+name: fill_phase3_revision
+description: Revise a flagged passage to address a specific issue
+
+system: |
+  You are revising a single interactive fiction passage to fix a specific quality
+  issue. Follow the voice document exactly and address the flagged problem.
+
+  ## Voice Document
+  {voice_document}
+
+  ## Issue to Fix
+  **Passage ID:** {passage_id}
+  **Issue Type:** {issue_type}
+  **Issue Description:** {issue_description}
+
+  ## Current Prose
+  {current_prose}
+
+  ## Extended Sliding Window
+  {extended_window}
+
+  ## Revision Guidance by Issue Type
+
+  - **voice_drift**: Match register, rhythm, and tone to surrounding passages.
+    Read the sliding window carefully — your revision should be indistinguishable
+    in style from its neighbors.
+  - **scene_type_mismatch**: Restructure to match the scene type. Scenes need
+    3+ paragraphs with conflict. Sequels need 2-3 paragraphs of reflection.
+    Micro_beats need exactly 1 paragraph.
+  - **summary_deviation**: Re-read the beat summary and ensure all key events
+    appear. Remove invented events not in the summary.
+  - **continuity_break**: Check the sliding window for the contradicted detail
+    and correct your version to match.
+  - **convergence_awkwardness**: Rewrite to work for all arriving paths. Use
+    ambiguous phrasing. Avoid path-specific knowledge.
+  - **flat_prose**: Add sensory detail, emotional interiority, and dilemma
+    tension. Show, don't tell. Ground the reader in the moment.
+
+  ## Rules
+
+  1. Fix the flagged issue specifically — don't rewrite from scratch unless necessary
+  2. Maintain consistency with the sliding window
+  3. Follow the voice document
+  4. Preserve entity details from the original prose unless they caused the issue
+
+  ## Output Format
+  Return a JSON object with a "passage" field containing:
+  - passage_id: the passage ID
+  - prose: the revised text
+  - flag: "ok" (revision should resolve the issue)
+  - flag_reason: empty string
+  - entity_updates: list of {entity_id, field, value} (may be empty)
+
+user: |
+  Revise passage {passage_id} to fix the {issue_type} issue described above.
+
+  REMINDER: Return ONLY a valid JSON object. Do NOT add prose before or after the JSON.
+
+components: []

--- a/prompts/templates/fill_phase3_revision.yaml
+++ b/prompts/templates/fill_phase3_revision.yaml
@@ -54,6 +54,10 @@ system: |
 user: |
   Revise passage {passage_id} to fix the {issue_type} issue described above.
 
-  REMINDER: Return ONLY a valid JSON object. Do NOT add prose before or after the JSON.
+  CRITICAL REMINDERS:
+  - Fix the flagged issue specifically — do not rewrite from scratch unless necessary
+  - Follow the voice document EXACTLY — POV, tense, register, rhythm, tone
+  - Maintain continuity with the sliding window
+  - Return ONLY a valid JSON object. Do NOT add prose before or after the JSON.
 
 components: []


### PR DESCRIPTION
## Problem

The FILL stage needs prompt templates for voice determination, prose generation, review, and revision. These templates define the LLM contract for each phase.

## Changes

- **`prompts/templates/fill_phase0_voice.yaml`** — Voice determination prompt. Variables: `{dream_vision}`, `{grow_summary}`, `{scene_types_summary}`
- **`prompts/templates/fill_phase1_prose.yaml`** — Per-passage prose generation. Variables: `{voice_document}`, `{passage_id}`, `{beat_summary}`, `{scene_type}`, `{entity_states}`, `{sliding_window}`, `{lookahead}`, `{shadow_states}`
- **`prompts/templates/fill_phase2_review.yaml`** — Batch review for quality issues. Variables: `{voice_document}`, `{passages_batch}`
- **`prompts/templates/fill_phase3_revision.yaml`** — Targeted revision. Variables: `{voice_document}`, `{passage_id}`, `{issue_type}`, `{issue_description}`, `{current_prose}`, `{extended_window}`

## Not Included / Future PRs

- Context formatter functions that populate these variables (PR 3 / #384)
- FILL stage implementation that calls these templates (PR 5+ / #386+)

## Test Plan

```
python3 -c "import yaml; [yaml.safe_load(open(f'prompts/templates/fill_{p}.yaml')) for p in ['phase0_voice','phase1_prose','phase2_review','phase3_revision']]"  # ✅ all parse
```

All templates follow the established `name/description/system/user/components` YAML format.

## Risk / Rollback

- **YAML only** — no runtime code. Safe to revert by removing the 4 files.
- Templates will be iterated during FILL integration (PR 6+).

Closes #385
Part of #381

🤖 Generated with [Claude Code](https://claude.com/claude-code)