### PR TITLE
feat(graph): add FILL context formatters — voice, sliding window, lookahead

### DIFF
--- a/src/questfoundry/graph/fill_context.py
+++ b/src/questfoundry/graph/fill_context.py
@@ -296,6 +296,8 @@ def format_shadow_states(
     if not arc_node:
         return ""
     active_paths = set(arc_node.get("paths", []))
+    if not active_paths:
+        return ""
 
     # Find shadow arcs (other arcs containing this beat)
     lines: list[str] = []
@@ -435,17 +437,16 @@ def format_scene_types_summary(graph: Graph) -> str:
         Summary string with counts per scene type.
     """
     beats = graph.get_nodes_by_type("beat")
-    counts: dict[str, int] = {"scene": 0, "sequel": 0, "micro_beat": 0}
+    counts: dict[str, int] = {}
     for beat_data in beats.values():
         scene_type = beat_data.get("scene_type", "scene")
-        if scene_type in counts:
-            counts[scene_type] += 1
+        counts[scene_type] = counts.get(scene_type, 0) + 1
 
     total = sum(counts.values())
     if total == 0:
         return "(no beats with scene types)"
 
-    parts = [f"{count} {stype}" for stype, count in counts.items() if count > 0]
+    parts = [f"{count} {stype}" for stype, count in sorted(counts.items()) if count > 0]
     return f"{total} beats total: {', '.join(parts)}"
 
 

--- a/src/questfoundry/graph/fill_context.py
+++ b/src/questfoundry/graph/fill_context.py
@@ -1,0 +1,534 @@
+"""Context formatting for FILL stage LLM phases.
+
+Provides functions to format graph data (voice doc, passages, entities,
+arcs) as context strings for FILL's prose generation and review phases.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import yaml
+
+if TYPE_CHECKING:
+    from questfoundry.graph.graph import Graph
+
+
+def get_spine_arc_id(graph: Graph) -> str | None:
+    """Find the spine arc's node ID in the graph.
+
+    Args:
+        graph: Graph containing GROW arc nodes.
+
+    Returns:
+        The spine arc node ID (e.g., ``arc::spine_0_0``), or None if
+        no spine arc exists.
+    """
+    arcs = graph.get_nodes_by_type("arc")
+    for arc_id, arc_data in arcs.items():
+        if arc_data.get("arc_type") == "spine":
+            return arc_id
+    return None
+
+
+def get_arc_passage_order(graph: Graph, arc_id: str) -> list[str]:
+    """Get passage IDs in traversal order for an arc.
+
+    Follows the arc's beat sequence and maps each beat to its passage
+    via ``passage_from`` edges.
+
+    Args:
+        graph: Graph containing arc, beat, and passage nodes.
+        arc_id: The arc node ID (e.g., ``arc::spine_0_0``).
+
+    Returns:
+        Ordered list of passage node IDs. Beats without passages are
+        silently skipped.
+    """
+    arc_node = graph.get_node(arc_id)
+    if not arc_node:
+        return []
+
+    sequence = arc_node.get("sequence", [])
+    if not sequence:
+        return []
+
+    # Build beat→passage lookup from passage_from edges
+    beat_to_passage: dict[str, str] = {}
+    for edge in graph.get_edges(edge_type="passage_from"):
+        beat_to_passage[edge["to"]] = edge["from"]
+
+    passages = []
+    for beat_id in sequence:
+        passage_id = beat_to_passage.get(beat_id)
+        if passage_id:
+            passages.append(passage_id)
+
+    return passages
+
+
+def format_voice_context(graph: Graph) -> str:
+    """Format the voice document node as a YAML string for LLM context.
+
+    Args:
+        graph: Graph containing a ``voice`` type node.
+
+    Returns:
+        YAML-formatted voice document, or empty string if no voice node.
+    """
+    voice_nodes = graph.get_nodes_by_type("voice")
+    if not voice_nodes:
+        return ""
+
+    # Take the first (and only expected) voice node
+    voice_data = next(iter(voice_nodes.values()))
+
+    # Extract voice fields (exclude graph metadata)
+    voice_fields = {
+        k: v for k, v in voice_data.items() if k not in ("type", "raw_id") and v is not None
+    }
+
+    if not voice_fields:
+        return ""
+
+    return yaml.dump(voice_fields, default_flow_style=False, sort_keys=False).strip()
+
+
+def format_passage_context(graph: Graph, passage_id: str) -> str:
+    """Format a single passage's context for prose generation.
+
+    Includes beat summary, scene type, and entity states.
+
+    Args:
+        graph: Graph containing passage, beat, and entity nodes.
+        passage_id: The passage node ID.
+
+    Returns:
+        Formatted context string, or empty string if passage not found.
+    """
+    passage = graph.get_node(passage_id)
+    if not passage:
+        return ""
+
+    beat_id = passage.get("from_beat", "")
+    beat = graph.get_node(beat_id) if beat_id else None
+
+    lines: list[str] = []
+
+    # Beat summary
+    summary = passage.get("summary", "")
+    if not summary and beat:
+        summary = beat.get("summary", "")
+    if summary:
+        lines.append(f"**Summary:** {summary}")
+
+    # Scene type from beat
+    if beat:
+        scene_type = beat.get("scene_type", "scene")
+        lines.append(f"**Scene Type:** {scene_type}")
+
+    # Entities present in passage
+    entities = passage.get("entities", [])
+    if entities:
+        entity_details = []
+        for eid in entities:
+            enode = graph.get_node(eid)
+            if enode:
+                name = enode.get("raw_id", eid)
+                concept = enode.get("concept", "")
+                detail = f"- {name}: {concept}" if concept else f"- {name}"
+                entity_details.append(detail)
+        if entity_details:
+            lines.append("**Entities:**")
+            lines.extend(entity_details)
+
+    return "\n".join(lines)
+
+
+def format_sliding_window(
+    graph: Graph,
+    arc_id: str,
+    current_idx: int,
+    window_size: int = 3,
+) -> str:
+    """Format the sliding window of recent passages with prose.
+
+    Returns the last N passages (before the current one) that have
+    prose populated, formatted for voice consistency context.
+
+    Args:
+        graph: Graph containing passage nodes.
+        arc_id: The arc being traversed.
+        current_idx: Index of the current passage in the arc's order.
+        window_size: Number of recent passages to include.
+
+    Returns:
+        Formatted sliding window, or "(no previous passages)" if empty.
+    """
+    passage_order = get_arc_passage_order(graph, arc_id)
+    if not passage_order or current_idx <= 0:
+        return "(no previous passages)"
+
+    # Collect recent passages with prose
+    start = max(0, current_idx - window_size)
+    window_passages = passage_order[start:current_idx]
+
+    lines: list[str] = []
+    for pid in window_passages:
+        pnode = graph.get_node(pid)
+        if not pnode:
+            continue
+        prose = pnode.get("prose", "")
+        if not prose:
+            continue
+        raw_id = pnode.get("raw_id", pid)
+        lines.append(f"### {raw_id}")
+        lines.append(prose)
+        lines.append("")
+
+    return "\n".join(lines).strip() if lines else "(no previous passages)"
+
+
+def format_lookahead_context(
+    graph: Graph,
+    passage_id: str,
+    arc_id: str,
+) -> str:
+    """Format lookahead context for structural junctures.
+
+    At convergence points: includes beat summaries of connecting branches.
+    At divergence points: includes the divergence passage prose.
+
+    Args:
+        graph: Graph containing arc, passage, and beat nodes.
+        passage_id: The current passage being generated.
+        arc_id: The arc being traversed.
+
+    Returns:
+        Formatted lookahead context, or empty string if no lookahead needed.
+    """
+    arc_node = graph.get_node(arc_id)
+    if not arc_node:
+        return ""
+
+    passage = graph.get_node(passage_id)
+    if not passage:
+        return ""
+
+    beat_id = passage.get("from_beat", "")
+    lines: list[str] = []
+
+    # Check if this beat is a convergence point for any arc
+    convergence_arcs = []
+    all_arcs = graph.get_nodes_by_type("arc")
+    for aid, adata in all_arcs.items():
+        if adata.get("converges_at") == beat_id and aid != arc_id:
+            convergence_arcs.append((aid, adata))
+
+    if convergence_arcs:
+        lines.append("**Convergence — branches arriving here:**")
+        for aid, adata in convergence_arcs:
+            arc_raw = adata.get("raw_id", aid)
+            # Get the last few beats from the arriving arc
+            seq = adata.get("sequence", [])
+            if seq:
+                last_beats = seq[-3:]  # last 3 beats for context
+                for bid in last_beats:
+                    bnode = graph.get_node(bid)
+                    if bnode:
+                        summary = bnode.get("summary", "")
+                        if summary:
+                            lines.append(f"- [{arc_raw}] {summary}")
+        lines.append("")
+
+    # Check if this is a divergence point — include divergence passage prose
+    if arc_node.get("arc_type") == "branch":
+        diverge_beat = arc_node.get("diverges_at")
+        if diverge_beat == beat_id or _is_first_branch_beat(graph, arc_id, beat_id):
+            # Find the divergence passage prose
+            diverge_passage = _find_passage_for_beat(graph, diverge_beat) if diverge_beat else None
+            if diverge_passage:
+                dpnode = graph.get_node(diverge_passage)
+                if dpnode:
+                    prose = dpnode.get("prose", "")
+                    if prose:
+                        lines.append("**Divergence — continue from this passage:**")
+                        lines.append(prose)
+                        lines.append("")
+
+    return "\n".join(lines).strip()
+
+
+def format_shadow_states(
+    graph: Graph,
+    passage_id: str,
+    arc_id: str,
+) -> str:
+    """Format shadow state context for poly-state prose.
+
+    For shared beats (path-agnostic), shows which other paths reach
+    this beat and what their active state implies.
+
+    Args:
+        graph: Graph containing passage, beat, path, and dilemma nodes.
+        passage_id: The current passage.
+        arc_id: The arc being generated (defines the "active" state).
+
+    Returns:
+        Formatted shadow states, or empty string if not a shared beat.
+    """
+    passage = graph.get_node(passage_id)
+    if not passage:
+        return ""
+
+    beat_id = passage.get("from_beat", "")
+    beat = graph.get_node(beat_id) if beat_id else None
+    if not beat:
+        return ""
+
+    # Check if beat is path-agnostic (shared across paths)
+    agnostic_for = beat.get("path_agnostic_for", [])
+    if not agnostic_for:
+        return ""
+
+    # Get the active arc's paths
+    arc_node = graph.get_node(arc_id)
+    if not arc_node:
+        return ""
+    active_paths = set(arc_node.get("paths", []))
+
+    # Find shadow arcs (other arcs containing this beat)
+    lines: list[str] = []
+    lines.append("**This is a shared beat.** Write prose compatible with ALL states below.")
+    lines.append("")
+    lines.append(f"**Active state** (arc being generated): paths {sorted(active_paths)}")
+
+    all_arcs = graph.get_nodes_by_type("arc")
+    shadow_arcs = []
+    for aid, adata in all_arcs.items():
+        if aid == arc_id:
+            continue
+        arc_seq = adata.get("sequence", [])
+        if beat_id in arc_seq:
+            shadow_paths = set(adata.get("paths", []))
+            shadow_arcs.append((aid, adata, shadow_paths))
+
+    if shadow_arcs:
+        lines.append("")
+        lines.append("**Shadow states** (other arcs reaching this beat):")
+        for aid, adata, spaths in shadow_arcs:
+            arc_raw = adata.get("raw_id", aid)
+            lines.append(f"- {arc_raw}: paths {sorted(spaths)}")
+
+    return "\n".join(lines)
+
+
+def format_entity_states(graph: Graph, passage_id: str) -> str:
+    """Format entity states relevant to a passage.
+
+    Lists entities present in the passage with their base details
+    and any applicable overlays.
+
+    Args:
+        graph: Graph containing entity and passage nodes.
+        passage_id: The passage being generated.
+
+    Returns:
+        Formatted entity states, or "(no entities)" if none.
+    """
+    passage = graph.get_node(passage_id)
+    if not passage:
+        return "(no entities)"
+
+    entities = passage.get("entities", [])
+    if not entities:
+        return "(no entities)"
+
+    lines: list[str] = []
+    for eid in entities:
+        enode = graph.get_node(eid)
+        if not enode:
+            continue
+        raw_id = enode.get("raw_id", eid)
+        concept = enode.get("concept", "")
+        lines.append(f"**{raw_id}**: {concept}" if concept else f"**{raw_id}**")
+
+        # Include overlays if any
+        overlays = enode.get("overlays", [])
+        if overlays:
+            for overlay in overlays:
+                when = overlay.get("when", [])
+                details = overlay.get("details", {})
+                if details:
+                    conds = ", ".join(str(w) for w in when)
+                    for field, value in details.items():
+                        lines.append(f"  - [{conds}] {field}: {value}")
+
+    return "\n".join(lines) if lines else "(no entities)"
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _find_passage_for_beat(graph: Graph, beat_id: str | None) -> str | None:
+    """Find the passage node ID for a given beat.
+
+    Args:
+        graph: Graph with passage_from edges.
+        beat_id: The beat node ID.
+
+    Returns:
+        Passage node ID, or None if not found.
+    """
+    if not beat_id:
+        return None
+    for edge in graph.get_edges(to_id=beat_id, edge_type="passage_from"):
+        return str(edge["from"])
+    return None
+
+
+def _is_first_branch_beat(graph: Graph, arc_id: str, beat_id: str) -> bool:
+    """Check if a beat is the first branch-specific beat in an arc.
+
+    The first branch-specific beat is the one right after the divergence
+    point — the first beat in the arc's sequence that is NOT in the spine.
+
+    Args:
+        graph: Graph with arc nodes.
+        arc_id: The branch arc ID.
+        beat_id: The beat to check.
+
+    Returns:
+        True if this is the first branch-specific beat.
+    """
+    arc_node = graph.get_node(arc_id)
+    if not arc_node or arc_node.get("arc_type") != "branch":
+        return False
+
+    spine_id = get_spine_arc_id(graph)
+    if not spine_id:
+        return False
+
+    spine_node = graph.get_node(spine_id)
+    if not spine_node:
+        return False
+
+    spine_beats = set(spine_node.get("sequence", []))
+    sequence = arc_node.get("sequence", [])
+
+    for bid in sequence:
+        if bid not in spine_beats:
+            return bool(bid == beat_id)
+
+    return False
+
+
+def format_scene_types_summary(graph: Graph) -> str:
+    """Summarize scene type distribution for voice determination.
+
+    Args:
+        graph: Graph containing beat nodes with scene_type.
+
+    Returns:
+        Summary string with counts per scene type.
+    """
+    beats = graph.get_nodes_by_type("beat")
+    counts: dict[str, int] = {"scene": 0, "sequel": 0, "micro_beat": 0}
+    for beat_data in beats.values():
+        scene_type = beat_data.get("scene_type", "scene")
+        if scene_type in counts:
+            counts[scene_type] += 1
+
+    total = sum(counts.values())
+    if total == 0:
+        return "(no beats with scene types)"
+
+    parts = [f"{count} {stype}" for stype, count in counts.items() if count > 0]
+    return f"{total} beats total: {', '.join(parts)}"
+
+
+def format_grow_summary(graph: Graph) -> str:
+    """Summarize GROW output for voice determination context.
+
+    Provides arc count, passage count, and structural overview.
+
+    Args:
+        graph: Graph containing GROW data.
+
+    Returns:
+        Summary string.
+    """
+    arcs = graph.get_nodes_by_type("arc")
+    passages = graph.get_nodes_by_type("passage")
+    beats = graph.get_nodes_by_type("beat")
+
+    spine_count = sum(1 for a in arcs.values() if a.get("arc_type") == "spine")
+    branch_count = sum(1 for a in arcs.values() if a.get("arc_type") == "branch")
+
+    lines = [
+        f"Arcs: {len(arcs)} ({spine_count} spine, {branch_count} branch)",
+        f"Passages: {len(passages)}",
+        f"Beats: {len(beats)}",
+    ]
+
+    return "\n".join(lines)
+
+
+def format_dream_vision(graph: Graph) -> str:
+    """Extract DREAM vision context from graph.
+
+    Args:
+        graph: Graph containing dream artifact data.
+
+    Returns:
+        Formatted DREAM vision, or empty string if not found.
+    """
+    dream_nodes = graph.get_nodes_by_type("dream")
+    if not dream_nodes:
+        return ""
+
+    dream_data = next(iter(dream_nodes.values()))
+    lines: list[str] = []
+
+    for field in ("genre", "tone", "themes", "setting_sketch"):
+        value = dream_data.get(field)
+        if value:
+            if isinstance(value, list):
+                lines.append(f"**{field}:** {', '.join(str(v) for v in value)}")
+            else:
+                lines.append(f"**{field}:** {value}")
+
+    return "\n".join(lines)
+
+
+def format_passages_batch(
+    graph: Graph,
+    passage_ids: list[str],
+) -> str:
+    """Format a batch of passages for review context.
+
+    Args:
+        graph: Graph containing passage nodes.
+        passage_ids: Passages to include in the batch.
+
+    Returns:
+        Formatted batch string.
+    """
+    lines: list[str] = []
+    for pid in passage_ids:
+        pnode = graph.get_node(pid)
+        if not pnode:
+            continue
+        raw_id = pnode.get("raw_id", pid)
+        prose = pnode.get("prose", "")
+        beat_id = pnode.get("from_beat", "")
+        beat = graph.get_node(beat_id) if beat_id else None
+        scene_type = beat.get("scene_type", "unknown") if beat else "unknown"
+
+        lines.append(f"### {raw_id} (scene_type: {scene_type})")
+        lines.append(prose if prose else "(no prose)")
+        lines.append("")
+
+    return "\n".join(lines).strip()

--- a/tests/unit/test_fill_context.py
+++ b/tests/unit/test_fill_context.py
@@ -1,0 +1,435 @@
+"""Tests for FILL context formatting functions."""
+
+from __future__ import annotations
+
+import pytest
+
+from questfoundry.graph.fill_context import (
+    format_dream_vision,
+    format_entity_states,
+    format_grow_summary,
+    format_lookahead_context,
+    format_passage_context,
+    format_passages_batch,
+    format_scene_types_summary,
+    format_shadow_states,
+    format_sliding_window,
+    format_voice_context,
+    get_arc_passage_order,
+    get_spine_arc_id,
+)
+from questfoundry.graph.graph import Graph
+
+
+@pytest.fixture
+def fill_graph() -> Graph:
+    """Create a minimal GROW-completed graph for testing FILL context."""
+    g = Graph.empty()
+
+    # Dream node
+    g.create_node(
+        "dream::vision",
+        {
+            "type": "dream",
+            "raw_id": "vision",
+            "genre": "dark fantasy",
+            "tone": "atmospheric and tense",
+            "themes": ["trust", "power", "sacrifice"],
+            "setting_sketch": "A crumbling tower at the edge of civilization",
+        },
+    )
+
+    # Entities
+    g.create_node(
+        "entity::kay",
+        {
+            "type": "entity",
+            "raw_id": "kay",
+            "entity_type": "character",
+            "concept": "A young wanderer seeking answers",
+            "overlays": [
+                {
+                    "when": ["codeword::betrayal_committed"],
+                    "details": {"mood": "bitter", "trust": "broken"},
+                }
+            ],
+        },
+    )
+    g.create_node(
+        "entity::mentor",
+        {
+            "type": "entity",
+            "raw_id": "mentor",
+            "entity_type": "character",
+            "concept": "An enigmatic guide with hidden motives",
+        },
+    )
+
+    # Beats
+    g.create_node(
+        "beat::opening",
+        {
+            "type": "beat",
+            "raw_id": "opening",
+            "summary": "Kay enters the tower and meets the mentor",
+            "scene_type": "scene",
+            "entities": ["entity::kay", "entity::mentor"],
+        },
+    )
+    g.create_node(
+        "beat::explanation",
+        {
+            "type": "beat",
+            "raw_id": "explanation",
+            "summary": "Mentor explains the artifact's power",
+            "scene_type": "scene",
+            "path_agnostic_for": ["dilemma::mentor_trust"],
+        },
+    )
+    g.create_node(
+        "beat::aftermath",
+        {
+            "type": "beat",
+            "raw_id": "aftermath",
+            "summary": "Kay reflects on choices made",
+            "scene_type": "sequel",
+        },
+    )
+    g.create_node(
+        "beat::branch_reveal",
+        {
+            "type": "beat",
+            "raw_id": "branch_reveal",
+            "summary": "Mentor's true nature is exposed",
+            "scene_type": "scene",
+        },
+    )
+
+    # Passages
+    g.create_node(
+        "passage::p_opening",
+        {
+            "type": "passage",
+            "raw_id": "p_opening",
+            "from_beat": "beat::opening",
+            "summary": "Kay enters the tower and meets the mentor",
+            "entities": ["entity::kay", "entity::mentor"],
+            "prose": "The tower stairs wound upward into darkness.",
+        },
+    )
+    g.create_node(
+        "passage::p_explanation",
+        {
+            "type": "passage",
+            "raw_id": "p_explanation",
+            "from_beat": "beat::explanation",
+            "summary": "Mentor explains the artifact's power",
+            "entities": ["entity::kay", "entity::mentor"],
+            "prose": "The artifact lay on the table between them.",
+        },
+    )
+    g.create_node(
+        "passage::p_aftermath",
+        {
+            "type": "passage",
+            "raw_id": "p_aftermath",
+            "from_beat": "beat::aftermath",
+            "summary": "Kay reflects on choices made",
+            "entities": ["entity::kay"],
+        },
+    )
+    g.create_node(
+        "passage::p_branch_reveal",
+        {
+            "type": "passage",
+            "raw_id": "p_branch_reveal",
+            "from_beat": "beat::branch_reveal",
+            "summary": "Mentor's true nature is exposed",
+            "entities": ["entity::mentor"],
+        },
+    )
+
+    # Passage-from edges
+    g.add_edge("passage_from", "passage::p_opening", "beat::opening")
+    g.add_edge("passage_from", "passage::p_explanation", "beat::explanation")
+    g.add_edge("passage_from", "passage::p_aftermath", "beat::aftermath")
+    g.add_edge("passage_from", "passage::p_branch_reveal", "beat::branch_reveal")
+
+    # Arcs
+    g.create_node(
+        "arc::spine_0_0",
+        {
+            "type": "arc",
+            "raw_id": "spine_0_0",
+            "arc_type": "spine",
+            "paths": ["path::mentor_trust__protector"],
+            "sequence": ["beat::opening", "beat::explanation", "beat::aftermath"],
+        },
+    )
+    g.create_node(
+        "arc::branch_1_0",
+        {
+            "type": "arc",
+            "raw_id": "branch_1_0",
+            "arc_type": "branch",
+            "paths": ["path::mentor_trust__manipulator"],
+            "sequence": [
+                "beat::opening",
+                "beat::explanation",
+                "beat::branch_reveal",
+                "beat::aftermath",
+            ],
+            "diverges_from": "arc::spine_0_0",
+            "diverges_at": "beat::explanation",
+            "converges_at": "beat::aftermath",
+        },
+    )
+
+    return g
+
+
+# ---------------------------------------------------------------------------
+# get_spine_arc_id
+# ---------------------------------------------------------------------------
+
+
+class TestGetSpineArcId:
+    def test_finds_spine(self, fill_graph: Graph) -> None:
+        assert get_spine_arc_id(fill_graph) == "arc::spine_0_0"
+
+    def test_no_arcs(self) -> None:
+        g = Graph.empty()
+        assert get_spine_arc_id(g) is None
+
+
+# ---------------------------------------------------------------------------
+# get_arc_passage_order
+# ---------------------------------------------------------------------------
+
+
+class TestGetArcPassageOrder:
+    def test_spine_order(self, fill_graph: Graph) -> None:
+        order = get_arc_passage_order(fill_graph, "arc::spine_0_0")
+        assert order == [
+            "passage::p_opening",
+            "passage::p_explanation",
+            "passage::p_aftermath",
+        ]
+
+    def test_branch_order(self, fill_graph: Graph) -> None:
+        order = get_arc_passage_order(fill_graph, "arc::branch_1_0")
+        assert order == [
+            "passage::p_opening",
+            "passage::p_explanation",
+            "passage::p_branch_reveal",
+            "passage::p_aftermath",
+        ]
+
+    def test_nonexistent_arc(self, fill_graph: Graph) -> None:
+        assert get_arc_passage_order(fill_graph, "arc::nonexistent") == []
+
+
+# ---------------------------------------------------------------------------
+# format_voice_context
+# ---------------------------------------------------------------------------
+
+
+class TestFormatVoiceContext:
+    def test_no_voice_node(self, fill_graph: Graph) -> None:
+        assert format_voice_context(fill_graph) == ""
+
+    def test_with_voice_node(self, fill_graph: Graph) -> None:
+        fill_graph.create_node(
+            "voice::main",
+            {
+                "type": "voice",
+                "raw_id": "main",
+                "pov": "third_limited",
+                "tense": "past",
+                "voice_register": "literary",
+            },
+        )
+        result = format_voice_context(fill_graph)
+        assert "pov: third_limited" in result
+        assert "tense: past" in result
+        assert "voice_register: literary" in result
+        # Should not include graph metadata
+        assert "type:" not in result
+        assert "raw_id:" not in result
+
+
+# ---------------------------------------------------------------------------
+# format_passage_context
+# ---------------------------------------------------------------------------
+
+
+class TestFormatPassageContext:
+    def test_passage_with_entities(self, fill_graph: Graph) -> None:
+        result = format_passage_context(fill_graph, "passage::p_opening")
+        assert "Kay enters the tower" in result
+        assert "Scene Type" in result
+        assert "kay" in result
+
+    def test_nonexistent_passage(self, fill_graph: Graph) -> None:
+        assert format_passage_context(fill_graph, "passage::none") == ""
+
+
+# ---------------------------------------------------------------------------
+# format_sliding_window
+# ---------------------------------------------------------------------------
+
+
+class TestFormatSlidingWindow:
+    def test_first_passage_no_window(self, fill_graph: Graph) -> None:
+        result = format_sliding_window(fill_graph, "arc::spine_0_0", 0)
+        assert result == "(no previous passages)"
+
+    def test_second_passage_has_window(self, fill_graph: Graph) -> None:
+        result = format_sliding_window(fill_graph, "arc::spine_0_0", 1)
+        assert "p_opening" in result
+        assert "tower stairs" in result
+
+    def test_window_size_limits(self, fill_graph: Graph) -> None:
+        result = format_sliding_window(fill_graph, "arc::spine_0_0", 2, window_size=1)
+        # Should only include the immediately preceding passage
+        assert "p_explanation" in result
+        assert "p_opening" not in result
+
+    def test_no_prose_skipped(self, fill_graph: Graph) -> None:
+        # p_aftermath has no prose — window should skip it
+        result = format_sliding_window(fill_graph, "arc::spine_0_0", 2, window_size=3)
+        assert "p_opening" in result
+        assert "p_explanation" in result
+
+
+# ---------------------------------------------------------------------------
+# format_lookahead_context
+# ---------------------------------------------------------------------------
+
+
+class TestFormatLookaheadContext:
+    def test_convergence_point(self, fill_graph: Graph) -> None:
+        # p_aftermath is convergence point for branch_1_0
+        result = format_lookahead_context(fill_graph, "passage::p_aftermath", "arc::spine_0_0")
+        assert "Convergence" in result or result == ""
+
+    def test_no_lookahead_needed(self, fill_graph: Graph) -> None:
+        result = format_lookahead_context(fill_graph, "passage::p_opening", "arc::spine_0_0")
+        assert result == ""
+
+
+# ---------------------------------------------------------------------------
+# format_shadow_states
+# ---------------------------------------------------------------------------
+
+
+class TestFormatShadowStates:
+    def test_shared_beat(self, fill_graph: Graph) -> None:
+        # beat::explanation is path_agnostic_for mentor_trust
+        result = format_shadow_states(fill_graph, "passage::p_explanation", "arc::spine_0_0")
+        assert "shared beat" in result
+        assert "Active state" in result
+        assert "Shadow states" in result
+
+    def test_non_shared_beat(self, fill_graph: Graph) -> None:
+        result = format_shadow_states(fill_graph, "passage::p_opening", "arc::spine_0_0")
+        assert result == ""
+
+
+# ---------------------------------------------------------------------------
+# format_entity_states
+# ---------------------------------------------------------------------------
+
+
+class TestFormatEntityStates:
+    def test_passage_with_entities(self, fill_graph: Graph) -> None:
+        result = format_entity_states(fill_graph, "passage::p_opening")
+        assert "kay" in result
+        assert "mentor" in result
+
+    def test_entity_with_overlays(self, fill_graph: Graph) -> None:
+        result = format_entity_states(fill_graph, "passage::p_opening")
+        assert "betrayal_committed" in result or "mood" in result
+
+    def test_no_entities(self, fill_graph: Graph) -> None:
+        # Create a passage with no entities
+        fill_graph.create_node(
+            "passage::empty",
+            {"type": "passage", "raw_id": "empty", "from_beat": "", "summary": ""},
+        )
+        result = format_entity_states(fill_graph, "passage::empty")
+        assert result == "(no entities)"
+
+
+# ---------------------------------------------------------------------------
+# format_scene_types_summary
+# ---------------------------------------------------------------------------
+
+
+class TestFormatSceneTypesSummary:
+    def test_scene_type_counts(self, fill_graph: Graph) -> None:
+        result = format_scene_types_summary(fill_graph)
+        assert "4 beats total" in result
+        assert "3 scene" in result
+        assert "1 sequel" in result
+
+    def test_empty_graph(self) -> None:
+        g = Graph.empty()
+        result = format_scene_types_summary(g)
+        assert "(no beats with scene types)" in result
+
+
+# ---------------------------------------------------------------------------
+# format_grow_summary
+# ---------------------------------------------------------------------------
+
+
+class TestFormatGrowSummary:
+    def test_summary_counts(self, fill_graph: Graph) -> None:
+        result = format_grow_summary(fill_graph)
+        assert "2" in result  # 2 arcs
+        assert "1 spine" in result
+        assert "1 branch" in result
+        assert "4" in result  # 4 passages or beats
+
+
+# ---------------------------------------------------------------------------
+# format_dream_vision
+# ---------------------------------------------------------------------------
+
+
+class TestFormatDreamVision:
+    def test_extracts_vision(self, fill_graph: Graph) -> None:
+        result = format_dream_vision(fill_graph)
+        assert "dark fantasy" in result
+        assert "atmospheric" in result
+        assert "trust" in result
+
+    def test_no_dream(self) -> None:
+        g = Graph.empty()
+        assert format_dream_vision(g) == ""
+
+
+# ---------------------------------------------------------------------------
+# format_passages_batch
+# ---------------------------------------------------------------------------
+
+
+class TestFormatPassagesBatch:
+    def test_batch_formatting(self, fill_graph: Graph) -> None:
+        result = format_passages_batch(
+            fill_graph,
+            ["passage::p_opening", "passage::p_explanation"],
+        )
+        assert "p_opening" in result
+        assert "p_explanation" in result
+        assert "tower stairs" in result
+        assert "scene_type: scene" in result
+
+    def test_empty_batch(self, fill_graph: Graph) -> None:
+        result = format_passages_batch(fill_graph, [])
+        assert result == ""
+
+    def test_passage_without_prose(self, fill_graph: Graph) -> None:
+        result = format_passages_batch(fill_graph, ["passage::p_aftermath"])
+        assert "(no prose)" in result

--- a/tests/unit/test_fill_context.py
+++ b/tests/unit/test_fill_context.py
@@ -311,7 +311,8 @@ class TestFormatLookaheadContext:
     def test_convergence_point(self, fill_graph: Graph) -> None:
         # p_aftermath is convergence point for branch_1_0
         result = format_lookahead_context(fill_graph, "passage::p_aftermath", "arc::spine_0_0")
-        assert "Convergence" in result or result == ""
+        assert "Convergence" in result
+        assert "branch_1_0" in result
 
     def test_no_lookahead_needed(self, fill_graph: Graph) -> None:
         result = format_lookahead_context(fill_graph, "passage::p_opening", "arc::spine_0_0")
@@ -349,7 +350,8 @@ class TestFormatEntityStates:
 
     def test_entity_with_overlays(self, fill_graph: Graph) -> None:
         result = format_entity_states(fill_graph, "passage::p_opening")
-        assert "betrayal_committed" in result or "mood" in result
+        assert "betrayal_committed" in result
+        assert "mood" in result
 
     def test_no_entities(self, fill_graph: Graph) -> None:
         # Create a passage with no entities


### PR DESCRIPTION
## Problem

The FILL stage needs context formatting functions to assemble LLM prompts. Each prose generation call requires voice document, sliding window of recent passages, entity states, lookahead for convergence/divergence, and shadow states for poly-state prose.

## Changes

- **New `src/questfoundry/graph/fill_context.py`** — 13 public functions:
  - `get_spine_arc_id()` / `get_arc_passage_order()` — arc traversal helpers
  - `format_voice_context()` — voice doc node as YAML string
  - `format_passage_context()` — beat summary, scene type, entities for a single passage
  - `format_sliding_window()` — last N passages with prose for voice consistency
  - `format_lookahead_context()` — convergence/divergence awareness at structural junctures
  - `format_shadow_states()` — poly-state context for shared beats
  - `format_entity_states()` — entity details with overlay conditions
  - `format_scene_types_summary()` / `format_grow_summary()` / `format_dream_vision()` — Phase 0 context
  - `format_passages_batch()` — batch formatting for Phase 2 review
- **New `tests/unit/test_fill_context.py`** — 28 tests with shared graph fixture

## Not Included / Future PRs

- FILL stage skeleton that calls these formatters (PR 5 / #386)
- FILL models imported by this module's callers (PR 2 / #383 — already submitted)

## Test Plan

```
uv run mypy src/                                      # ✅ no issues
uv run ruff check src/                                # ✅ all checks passed
uv run pytest tests/unit/test_fill_context.py -x -q   # ✅ 28 passed
```

## Risk / Rollback

- **New file only** — no existing code modified. Safe to revert by removing `fill_context.py`.
- Functions are pure (read from graph, return strings) — no side effects.

Closes #384
Part of #381

🤖 Generated with [Claude Code](https://claude.com/claude-code)