### PR TITLE
feat(fill): implement FillStage skeleton — phase dispatch, checkpointing, LLM helper

### DIFF
--- a/src/questfoundry/pipeline/stages/fill.py
+++ b/src/questfoundry/pipeline/stages/fill.py
@@ -1,0 +1,479 @@
+"""FILL stage implementation.
+
+The FILL stage generates prose for all passages in the story graph.
+It takes a validated graph from GROW (with passages, arcs, choices)
+and populates each passage with prose text following a voice document.
+
+FILL manages its own graph: it loads, mutates, and saves the graph
+within execute(). The orchestrator should skip post-execute
+apply_mutations() for FILL.
+
+Phase dispatch is sequential async method calls — same pattern as GROW.
+LLM phases use direct structured output: context from graph state →
+single LLM call → validate → retry (max 3).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, TypeVar
+
+from langchain_core.messages import HumanMessage, SystemMessage
+from pydantic import BaseModel, ValidationError
+
+from questfoundry.agents.serialize import extract_tokens
+from questfoundry.artifacts.validator import get_all_field_paths
+from questfoundry.graph.graph import Graph
+from questfoundry.models.fill import FillPhaseResult, FillResult
+from questfoundry.observability.logging import get_logger
+from questfoundry.observability.tracing import traceable
+from questfoundry.pipeline.gates import AutoApprovePhaseGate
+from questfoundry.providers.structured_output import with_structured_output
+
+if TYPE_CHECKING:
+    from langchain_core.callbacks import BaseCallbackHandler
+    from langchain_core.language_models import BaseChatModel
+
+    from questfoundry.pipeline.gates import PhaseGateHook
+    from questfoundry.pipeline.stages.base import (
+        AssistantMessageFn,
+        LLMCallbackFn,
+        PhaseProgressFn,
+        UserInputFn,
+    )
+
+T = TypeVar("T", bound=BaseModel)
+
+
+def _get_prompts_path() -> Path:
+    """Get the prompts directory path.
+
+    Returns prompts from package first, then falls back to project root.
+    """
+    pkg_path = Path(__file__).parents[4] / "prompts"
+    if pkg_path.exists():
+        return pkg_path
+    return Path.cwd() / "prompts"
+
+
+log = get_logger(__name__)
+
+
+class FillStageError(ValueError):
+    """Error raised when FILL stage cannot proceed."""
+
+    pass
+
+
+class FillStage:
+    """FILL stage: generates prose for all passages.
+
+    Executes phases sequentially, with gate hooks between phases
+    for review/rollback capability.
+
+    Attributes:
+        name: Stage name for registry.
+    """
+
+    name = "fill"
+
+    def __init__(
+        self,
+        project_path: Path | None = None,
+        gate: PhaseGateHook | None = None,
+    ) -> None:
+        """Initialize FILL stage.
+
+        Args:
+            project_path: Path to project directory for graph access.
+            gate: Phase gate hook for inter-phase approval.
+                Defaults to AutoApprovePhaseGate.
+        """
+        self.project_path = project_path
+        self.gate = gate or AutoApprovePhaseGate()
+        self._callbacks: list[BaseCallbackHandler] | None = None
+        self._provider_name: str | None = None
+        self._serialize_model: BaseChatModel | None = None
+        self._serialize_provider_name: str | None = None
+
+    CHECKPOINT_DIR = "snapshots"
+
+    # Type for async phase functions: (Graph, BaseChatModel) -> FillPhaseResult
+    PhaseFunc = Callable[["Graph", "BaseChatModel"], Awaitable[FillPhaseResult]]
+
+    def _get_checkpoint_path(self, project_path: Path, phase_name: str) -> Path:
+        """Return the checkpoint file path for a given phase."""
+        return project_path / self.CHECKPOINT_DIR / f"fill-pre-{phase_name}.json"
+
+    def _save_checkpoint(self, graph: Graph, project_path: Path, phase_name: str) -> None:
+        """Save graph state before a phase runs."""
+        path = self._get_checkpoint_path(project_path, phase_name)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        graph.save(path)
+        log.debug("checkpoint_saved", phase=phase_name, path=str(path))
+
+    def _load_checkpoint(self, project_path: Path, phase_name: str) -> Graph:
+        """Load graph state from a checkpoint.
+
+        Raises:
+            FillStageError: If checkpoint file doesn't exist.
+        """
+        path = self._get_checkpoint_path(project_path, phase_name)
+        if not path.exists():
+            raise FillStageError(
+                f"No checkpoint found for phase '{phase_name}'. Expected at: {path}"
+            )
+        log.info("checkpoint_loaded", phase=phase_name, path=str(path))
+        return Graph.load_from_file(path)
+
+    def _phase_order(self) -> list[tuple[PhaseFunc, str]]:
+        """Return ordered list of (phase_function, phase_name) tuples.
+
+        Returns:
+            List of phase functions with their names, in execution order.
+        """
+        return [
+            (self._phase_0_voice, "voice"),
+            (self._phase_1_generate, "generate"),
+            (self._phase_2_review, "review"),
+            (self._phase_3_revision, "revision"),
+        ]
+
+    @traceable(name="FILL Stage", run_type="chain", tags=["stage:fill"])
+    async def execute(
+        self,
+        model: BaseChatModel,
+        user_prompt: str,  # noqa: ARG002
+        provider_name: str | None = None,
+        *,
+        interactive: bool = False,  # noqa: ARG002
+        user_input_fn: UserInputFn | None = None,  # noqa: ARG002
+        on_assistant_message: AssistantMessageFn | None = None,  # noqa: ARG002
+        on_llm_start: LLMCallbackFn | None = None,  # noqa: ARG002
+        on_llm_end: LLMCallbackFn | None = None,  # noqa: ARG002
+        project_path: Path | None = None,
+        callbacks: list[BaseCallbackHandler] | None = None,
+        summarize_model: BaseChatModel | None = None,  # noqa: ARG002
+        serialize_model: BaseChatModel | None = None,
+        summarize_provider_name: str | None = None,  # noqa: ARG002
+        serialize_provider_name: str | None = None,
+        resume_from: str | None = None,
+        on_phase_progress: PhaseProgressFn | None = None,
+        **kwargs: Any,  # noqa: ARG002
+    ) -> tuple[dict[str, Any], int, int]:
+        """Execute the FILL stage.
+
+        Loads the graph, runs phases sequentially with gate checks,
+        saves the graph, and returns the result.
+
+        Args:
+            model: LangChain chat model for prose generation.
+            user_prompt: User guidance (unused in FILL).
+            provider_name: Provider name for structured output strategy.
+            interactive: Interactive mode flag (unused).
+            user_input_fn: User input function (unused).
+            on_assistant_message: Assistant message callback (unused).
+            on_llm_start: LLM start callback (unused).
+            on_llm_end: LLM end callback (unused).
+            project_path: Override for project path.
+            callbacks: LangChain callback handlers.
+            summarize_model: Summarize model (unused).
+            serialize_model: Model for structured output (falls back to model).
+            summarize_provider_name: Summarize provider name (unused).
+            serialize_provider_name: Provider name for structured output strategy.
+            resume_from: Phase name to resume from (skips earlier phases).
+            on_phase_progress: Callback for phase progress.
+            **kwargs: Additional keyword arguments (ignored).
+
+        Returns:
+            Tuple of (FillResult dict, total_llm_calls, total_tokens).
+
+        Raises:
+            FillStageError: If project_path is not provided or GROW not completed.
+        """
+        resolved_path = project_path or self.project_path
+        if resolved_path is None:
+            raise FillStageError(
+                "project_path is required for FILL stage. "
+                "Provide it in constructor or execute() call."
+            )
+
+        self._callbacks = callbacks
+        self._provider_name = provider_name
+        self._serialize_model = serialize_model
+        self._serialize_provider_name = serialize_provider_name
+        log.info("stage_start", stage="fill")
+
+        phases = self._phase_order()
+        phase_map = {name: i for i, (_, name) in enumerate(phases)}
+        start_idx = 0
+
+        if resume_from:
+            if resume_from not in phase_map:
+                raise FillStageError(
+                    f"Unknown phase: '{resume_from}'. Valid phases: {', '.join(phase_map)}"
+                )
+            start_idx = phase_map[resume_from]
+            graph = self._load_checkpoint(resolved_path, resume_from)
+            log.info(
+                "resume_from_checkpoint",
+                phase=resume_from,
+                skipped=start_idx,
+            )
+        else:
+            graph = Graph.load(resolved_path)
+
+        # Verify GROW has completed before running FILL
+        last_stage = graph.get_last_stage()
+        if last_stage != "grow":
+            raise FillStageError(
+                f"FILL requires completed GROW stage. Current last_stage: '{last_stage}'. "
+                f"Run GROW before FILL."
+            )
+
+        phase_results: list[FillPhaseResult] = []
+        total_llm_calls = 0
+        total_tokens = 0
+
+        for idx, (phase_fn, phase_name) in enumerate(phases):
+            if idx < start_idx:
+                continue
+
+            self._save_checkpoint(graph, resolved_path, phase_name)
+            log.debug("phase_start", phase=phase_name)
+            snapshot = graph.to_dict()
+
+            result = await phase_fn(graph, model)
+            phase_results.append(result)
+            total_llm_calls += result.llm_calls
+            total_tokens += result.tokens_used
+
+            if result.status == "failed":
+                log.error("phase_failed", phase=phase_name, detail=result.detail)
+                break
+
+            decision = await self.gate.on_phase_complete("fill", phase_name, result)
+            if decision == "reject":
+                log.info("phase_rejected", phase=phase_name)
+                graph = Graph.from_dict(snapshot)
+                break
+
+            log.debug("phase_complete", phase=phase_name, status=result.status)
+
+            if on_phase_progress is not None:
+                on_phase_progress(phase_name, result.status, result.detail)
+
+        graph.set_last_stage("fill")
+        graph.save(resolved_path / "graph.json")
+
+        # Count results
+        passage_nodes = graph.get_nodes_by_type("passage")
+        passages_filled = sum(1 for p in passage_nodes.values() if p.get("prose"))
+        passages_flagged = sum(
+            1 for p in passage_nodes.values() if p.get("flag") == "incompatible_states"
+        )
+
+        fill_result = FillResult(
+            passages_filled=passages_filled,
+            passages_flagged=passages_flagged,
+            phases_completed=phase_results,
+        )
+
+        log.info(
+            "stage_complete",
+            stage="fill",
+            passages_filled=fill_result.passages_filled,
+            passages_flagged=fill_result.passages_flagged,
+        )
+
+        return fill_result.model_dump(), total_llm_calls, total_tokens
+
+    # -------------------------------------------------------------------------
+    # LLM helper
+    # -------------------------------------------------------------------------
+
+    @traceable(name="FILL LLM Call", run_type="llm", tags=["stage:fill"])
+    async def _fill_llm_call(
+        self,
+        model: BaseChatModel,
+        template_name: str,
+        context: dict[str, Any],
+        output_schema: type[T],
+        max_retries: int = 3,
+    ) -> tuple[T, int, int]:
+        """Call LLM with structured output and retry on validation failure.
+
+        Loads prompt template, injects context, calls model.with_structured_output(),
+        validates with Pydantic, retries with error feedback on failure.
+
+        Args:
+            model: LangChain chat model.
+            template_name: Name of the prompt template (without .yaml).
+            context: Variables to inject into the prompt template.
+            output_schema: Pydantic model class for structured output.
+            max_retries: Maximum retry attempts on validation failure.
+
+        Returns:
+            Tuple of (validated_result, llm_calls, tokens_used).
+
+        Raises:
+            FillStageError: After max_retries exhausted.
+        """
+        from questfoundry.observability.tracing import build_runnable_config
+        from questfoundry.prompts.loader import PromptLoader
+
+        loader = PromptLoader(_get_prompts_path())
+        template = loader.load(template_name)
+
+        system_text = template.system.format(**context) if context else template.system
+        user_text = template.user.format(**context) if template.user else None
+
+        effective_model = self._serialize_model or model
+        effective_provider = self._serialize_provider_name or self._provider_name
+        structured_model = with_structured_output(
+            effective_model, output_schema, provider_name=effective_provider
+        )
+
+        messages: list[SystemMessage | HumanMessage] = [SystemMessage(content=system_text)]
+        if user_text:
+            messages.append(HumanMessage(content=user_text))
+
+        config = build_runnable_config(
+            run_name=f"fill_{template_name}",
+            metadata={"stage": "fill", "phase": template_name},
+            callbacks=self._callbacks,
+        )
+
+        llm_calls = 0
+        total_tokens = 0
+        base_messages = list(messages)
+
+        for attempt in range(max_retries):
+            log.debug(
+                "fill_llm_call",
+                template=template_name,
+                attempt=attempt + 1,
+                max_retries=max_retries,
+            )
+
+            try:
+                result = await structured_model.ainvoke(messages, config=config)
+                llm_calls += 1
+                total_tokens += extract_tokens(result)
+
+                validated = (
+                    result
+                    if isinstance(result, output_schema)
+                    else output_schema.model_validate(result)
+                )
+                log.debug("fill_llm_validation_pass", template=template_name)
+                return validated, llm_calls, total_tokens
+
+            except (ValidationError, TypeError) as e:
+                log.warning(
+                    "fill_llm_validation_fail",
+                    template=template_name,
+                    attempt=attempt + 1,
+                    error=str(e),
+                )
+
+                if attempt < max_retries - 1:
+                    error_msg = self._build_error_feedback(e, output_schema)
+                    messages = list(base_messages)
+                    messages.append(HumanMessage(content=error_msg))
+
+        raise FillStageError(
+            f"LLM call for {template_name} failed after {max_retries} attempts. "
+            f"Could not produce valid {output_schema.__name__} output."
+        )
+
+    def _build_error_feedback(self, error: Exception, output_schema: type[BaseModel]) -> str:
+        """Build structured error feedback for LLM retry.
+
+        Args:
+            error: The validation error.
+            output_schema: The expected schema.
+
+        Returns:
+            Formatted error feedback string.
+        """
+        expected = get_all_field_paths(output_schema)
+        return (
+            f"Your response failed validation:\n{error}\n\n"
+            f"Expected fields: {', '.join(expected)}\n"
+            f"Please fix the errors and try again."
+        )
+
+    # -------------------------------------------------------------------------
+    # Phase implementations (skeleton — all return skipped)
+    # -------------------------------------------------------------------------
+
+    async def _phase_0_voice(
+        self,
+        graph: Graph,  # noqa: ARG002
+        model: BaseChatModel,  # noqa: ARG002
+    ) -> FillPhaseResult:
+        """Phase 0: Voice determination.
+
+        Establishes the voice document governing all prose generation.
+        """
+        return FillPhaseResult(phase="voice", status="skipped", detail="not yet implemented")
+
+    async def _phase_1_generate(
+        self,
+        graph: Graph,  # noqa: ARG002
+        model: BaseChatModel,  # noqa: ARG002
+    ) -> FillPhaseResult:
+        """Phase 1: Sequential prose generation.
+
+        Generates prose for all passages in arc traversal order.
+        """
+        return FillPhaseResult(phase="generate", status="skipped", detail="not yet implemented")
+
+    async def _phase_2_review(
+        self,
+        graph: Graph,  # noqa: ARG002
+        model: BaseChatModel,  # noqa: ARG002
+    ) -> FillPhaseResult:
+        """Phase 2: Review.
+
+        Reviews passages for quality issues.
+        """
+        return FillPhaseResult(phase="review", status="skipped", detail="not yet implemented")
+
+    async def _phase_3_revision(
+        self,
+        graph: Graph,  # noqa: ARG002
+        model: BaseChatModel,  # noqa: ARG002
+    ) -> FillPhaseResult:
+        """Phase 3: Revision.
+
+        Regenerates flagged passages.
+        """
+        return FillPhaseResult(phase="revision", status="skipped", detail="not yet implemented")
+
+
+# -------------------------------------------------------------------------
+# Module-level helpers for registration (PR 10 will wire into __init__.py)
+# -------------------------------------------------------------------------
+
+
+def create_fill_stage(
+    project_path: Path | None = None,
+    gate: PhaseGateHook | None = None,
+) -> FillStage:
+    """Create a FillStage instance.
+
+    Args:
+        project_path: Path to project directory.
+        gate: Phase gate hook for inter-phase approval.
+
+    Returns:
+        Configured FillStage.
+    """
+    return FillStage(project_path=project_path, gate=gate)
+
+
+# Singleton instance for registration (project_path provided at execution)
+fill_stage = FillStage()

--- a/tests/unit/test_fill_stage.py
+++ b/tests/unit/test_fill_stage.py
@@ -1,0 +1,280 @@
+"""Tests for FILL stage skeleton."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from questfoundry.graph.graph import Graph
+from questfoundry.models.fill import FillPhaseResult
+from questfoundry.pipeline.gates import AutoApprovePhaseGate, PhaseGateHook
+from questfoundry.pipeline.stages.fill import (
+    FillStage,
+    FillStageError,
+    create_fill_stage,
+    fill_stage,
+)
+
+
+@pytest.fixture
+def grow_graph(tmp_path: Path) -> Graph:
+    """Create a minimal GROW-completed graph."""
+    g = Graph.empty()
+    g.set_last_stage("grow")
+
+    # Minimal passage for counting
+    g.create_node(
+        "passage::p1",
+        {"type": "passage", "raw_id": "p1", "from_beat": "", "summary": "test"},
+    )
+
+    g.save(tmp_path / "graph.json")
+    return g
+
+
+@pytest.fixture
+def mock_model() -> MagicMock:
+    """Create a mock LangChain model."""
+    return MagicMock()
+
+
+class TestFillStageInit:
+    def test_default_gate(self) -> None:
+        stage = FillStage()
+        assert isinstance(stage.gate, AutoApprovePhaseGate)
+
+    def test_custom_gate(self) -> None:
+        gate = MagicMock(spec=PhaseGateHook)
+        stage = FillStage(gate=gate)
+        assert stage.gate is gate
+
+    def test_name(self) -> None:
+        assert FillStage.name == "fill"
+
+    def test_project_path(self) -> None:
+        stage = FillStage(project_path=Path("/tmp/test"))
+        assert stage.project_path == Path("/tmp/test")
+
+
+class TestFillStageExecute:
+    @pytest.mark.asyncio
+    async def test_requires_project_path(self, mock_model: MagicMock) -> None:
+        stage = FillStage()
+        with pytest.raises(FillStageError, match="project_path is required"):
+            await stage.execute(mock_model, "")
+
+    @pytest.mark.asyncio
+    async def test_requires_grow_completed(self, mock_model: MagicMock, tmp_path: Path) -> None:
+        g = Graph.empty()
+        g.set_last_stage("seed")
+        g.save(tmp_path / "graph.json")
+
+        stage = FillStage(project_path=tmp_path)
+        with pytest.raises(FillStageError, match="FILL requires completed GROW"):
+            await stage.execute(mock_model, "")
+
+    @pytest.mark.asyncio
+    async def test_skeleton_runs_all_phases(
+        self,
+        mock_model: MagicMock,
+        grow_graph: Graph,  # noqa: ARG002
+        tmp_path: Path,
+    ) -> None:
+        stage = FillStage(project_path=tmp_path)
+        result_dict, llm_calls, tokens = await stage.execute(mock_model, "")
+
+        # All skeleton phases return "skipped"
+        phases = result_dict["phases_completed"]
+        assert len(phases) == 4
+        assert all(p["status"] == "skipped" for p in phases)
+        assert [p["phase"] for p in phases] == ["voice", "generate", "review", "revision"]
+
+        # No LLM calls in skeleton
+        assert llm_calls == 0
+        assert tokens == 0
+
+    @pytest.mark.asyncio
+    async def test_sets_last_stage(
+        self,
+        mock_model: MagicMock,
+        grow_graph: Graph,  # noqa: ARG002
+        tmp_path: Path,
+    ) -> None:
+        stage = FillStage(project_path=tmp_path)
+        await stage.execute(mock_model, "")
+
+        saved = Graph.load(tmp_path)
+        assert saved.get_last_stage() == "fill"
+
+    @pytest.mark.asyncio
+    async def test_resume_from_phase(
+        self,
+        mock_model: MagicMock,
+        grow_graph: Graph,  # noqa: ARG002
+        tmp_path: Path,
+    ) -> None:
+        stage = FillStage(project_path=tmp_path)
+
+        # First run to create checkpoints
+        await stage.execute(mock_model, "")
+
+        # Resume from review phase
+        result_dict, _, _ = await stage.execute(
+            mock_model, "", resume_from="review", project_path=tmp_path
+        )
+
+        # Should only have review and revision phases
+        phases = result_dict["phases_completed"]
+        assert len(phases) == 2
+        assert phases[0]["phase"] == "review"
+        assert phases[1]["phase"] == "revision"
+
+    @pytest.mark.asyncio
+    async def test_resume_invalid_phase(
+        self,
+        mock_model: MagicMock,
+        grow_graph: Graph,  # noqa: ARG002
+        tmp_path: Path,
+    ) -> None:
+        stage = FillStage(project_path=tmp_path)
+        with pytest.raises(FillStageError, match="Unknown phase"):
+            await stage.execute(mock_model, "", resume_from="nonexistent", project_path=tmp_path)
+
+    @pytest.mark.asyncio
+    async def test_gate_reject_rolls_back(
+        self,
+        mock_model: MagicMock,
+        grow_graph: Graph,  # noqa: ARG002
+        tmp_path: Path,
+    ) -> None:
+        gate = MagicMock()
+        gate.on_phase_complete = AsyncMock(return_value="reject")
+
+        stage = FillStage(project_path=tmp_path, gate=gate)
+        result_dict, _, _ = await stage.execute(mock_model, "")
+
+        # Should stop after first phase (voice) is rejected
+        phases = result_dict["phases_completed"]
+        assert len(phases) == 1
+        assert phases[0]["phase"] == "voice"
+
+    @pytest.mark.asyncio
+    async def test_progress_callback(
+        self,
+        mock_model: MagicMock,
+        grow_graph: Graph,  # noqa: ARG002
+        tmp_path: Path,
+    ) -> None:
+        progress_calls: list[tuple[str, str, str | None]] = []
+
+        def on_progress(phase: str, status: str, detail: str | None) -> None:
+            progress_calls.append((phase, status, detail))
+
+        stage = FillStage(project_path=tmp_path)
+        await stage.execute(mock_model, "", on_phase_progress=on_progress)
+
+        assert len(progress_calls) == 4
+        assert progress_calls[0][0] == "voice"
+
+    @pytest.mark.asyncio
+    async def test_project_path_override(
+        self,
+        mock_model: MagicMock,
+        grow_graph: Graph,  # noqa: ARG002
+        tmp_path: Path,
+    ) -> None:
+        stage = FillStage(project_path=Path("/nonexistent"))
+        # Override with tmp_path
+        result_dict, _, _ = await stage.execute(mock_model, "", project_path=tmp_path)
+        assert result_dict["passages_filled"] == 0
+
+
+class TestPhaseOrder:
+    def test_four_phases(self) -> None:
+        stage = FillStage()
+        phases = stage._phase_order()
+        assert len(phases) == 4
+
+    def test_phase_names(self) -> None:
+        stage = FillStage()
+        names = [name for _, name in stage._phase_order()]
+        assert names == ["voice", "generate", "review", "revision"]
+
+
+class TestCheckpointing:
+    def test_checkpoint_path(self) -> None:
+        stage = FillStage()
+        path = stage._get_checkpoint_path(Path("/proj"), "voice")
+        assert path == Path("/proj/snapshots/fill-pre-voice.json")
+
+    def test_save_and_load_checkpoint(self, tmp_path: Path) -> None:
+        stage = FillStage()
+        g = Graph.empty()
+        g.set_last_stage("grow")
+
+        stage._save_checkpoint(g, tmp_path, "voice")
+        loaded = stage._load_checkpoint(tmp_path, "voice")
+        assert loaded.get_last_stage() == "grow"
+
+    def test_load_missing_checkpoint(self, tmp_path: Path) -> None:
+        stage = FillStage()
+        with pytest.raises(FillStageError, match="No checkpoint found"):
+            stage._load_checkpoint(tmp_path, "nonexistent")
+
+
+class TestSkeletonPhases:
+    @pytest.mark.asyncio
+    async def test_phase_0_voice_skipped(self) -> None:
+        stage = FillStage()
+        result = await stage._phase_0_voice(Graph.empty(), MagicMock())
+        assert result.phase == "voice"
+        assert result.status == "skipped"
+
+    @pytest.mark.asyncio
+    async def test_phase_1_generate_skipped(self) -> None:
+        stage = FillStage()
+        result = await stage._phase_1_generate(Graph.empty(), MagicMock())
+        assert result.phase == "generate"
+        assert result.status == "skipped"
+
+    @pytest.mark.asyncio
+    async def test_phase_2_review_skipped(self) -> None:
+        stage = FillStage()
+        result = await stage._phase_2_review(Graph.empty(), MagicMock())
+        assert result.phase == "review"
+        assert result.status == "skipped"
+
+    @pytest.mark.asyncio
+    async def test_phase_3_revision_skipped(self) -> None:
+        stage = FillStage()
+        result = await stage._phase_3_revision(Graph.empty(), MagicMock())
+        assert result.phase == "revision"
+        assert result.status == "skipped"
+
+
+class TestModuleLevelHelpers:
+    def test_fill_stage_singleton(self) -> None:
+        assert fill_stage.name == "fill"
+        assert isinstance(fill_stage, FillStage)
+
+    def test_create_fill_stage_defaults(self) -> None:
+        stage = create_fill_stage()
+        assert isinstance(stage, FillStage)
+        assert stage.project_path is None
+        assert isinstance(stage.gate, AutoApprovePhaseGate)
+
+    def test_create_fill_stage_with_args(self, tmp_path: Path) -> None:
+        gate = MagicMock(spec=PhaseGateHook)
+        stage = create_fill_stage(project_path=tmp_path, gate=gate)
+        assert stage.project_path == tmp_path
+        assert stage.gate is gate
+
+
+class TestFillPhaseResultInheritance:
+    def test_fill_phase_result_is_phase_result(self) -> None:
+        from questfoundry.models.pipeline import PhaseResult
+
+        result = FillPhaseResult(phase="voice", status="completed")
+        assert isinstance(result, PhaseResult)


### PR DESCRIPTION
## Problem

The FILL stage needs a skeleton class with the phase dispatch loop, checkpointing, gate hooks, and LLM helper — the same infrastructure pattern established by GrowStage.

## Changes

- **New `src/questfoundry/pipeline/stages/fill.py`** — FillStage class:
  - `execute()`: loads graph, verifies `last_stage == "grow"`, runs phases sequentially, saves graph
  - `_phase_order()`: voice → generate → review → revision
  - `_fill_llm_call()`: structured output with validation retry (same pattern as `_grow_llm_call()`)
  - Checkpoint save/load per phase (`fill-pre-{phase}.json`)
  - Gate hook integration with rollback on reject
  - Resume from phase support
  - `FillStageError` for error handling
  - `fill_stage` singleton and `create_fill_stage()` factory
  - All 4 phase methods return `skipped` (implemented in PRs 6-8)

- **New `tests/unit/test_fill_stage.py`** — 26 tests covering:
  - Init with default/custom gate
  - Execute requires project_path and completed GROW
  - Skeleton runs all 4 phases (all skipped)
  - Sets `last_stage` to "fill"
  - Resume from phase
  - Gate reject with rollback
  - Progress callback
  - Checkpointing save/load
  - Module-level helpers

## Not Included / Future PRs

- Phase implementations: voice (PR 6), generate (PR 7), review/revision (PR 8)
- Registration in `__init__.py` (PR 10)
- CLI `fill` command (PR 10)

## Test Plan

```
uv run mypy src/                                      # ✅ no issues
uv run ruff check src/ tests/unit/test_fill_stage.py  # ✅ all checks passed
uv run pytest tests/unit/test_fill_stage.py -x -q     # ✅ 26 passed
```

## Risk / Rollback

- **New file only** — no existing code modified. Safe to revert.
- Not registered in `__init__.py` — no import side effects until PR 10.

Closes #386
Part of #381

🤖 Generated with [Claude Code](https://claude.com/claude-code)