### PR TITLE
feat(cli): add fill command and stage registration

### DIFF
--- a/src/questfoundry/cli.py
+++ b/src/questfoundry/cli.py
@@ -656,30 +656,26 @@ def _preview_grow_artifact(artifact: dict[str, Any]) -> None:
 def _preview_fill_artifact(artifact: dict[str, Any]) -> None:
     """Display preview of FILL artifact.
 
-    Reads FillResult fields (passages_filled, passages_flagged,
-    entity_updates_applied, review_cycles, phases_completed).
+    Reads extract_fill_artifact fields (voice_document, passages,
+    review_summary) — not FillResult telemetry.
     """
-    filled = artifact.get("passages_filled", 0)
-    flagged = artifact.get("passages_flagged", 0)
-    entity_updates = artifact.get("entity_updates_applied", 0)
-    review_cycles = artifact.get("review_cycles", 0)
+    voice = artifact.get("voice_document", {})
+    if voice:
+        pov = voice.get("pov", "?")
+        tense = voice.get("tense", "?")
+        register = voice.get("voice_register", "?")
+        console.print(f"  Voice: [bold]{pov}[/bold] {tense}, {register}")
+        tone_words = voice.get("tone_words", [])
+        if tone_words:
+            console.print(f"  Tone: {', '.join(str(w) for w in tone_words)}")
 
-    console.print(f"  Passages filled: [bold]{filled}[/bold]")
+    passages = artifact.get("passages", [])
+    console.print(f"  Passages with prose: [bold]{len(passages)}[/bold]")
+
+    review = artifact.get("review_summary", {})
+    flagged = review.get("passages_flagged", 0)
     if flagged:
-        console.print(f"  [yellow]Passages flagged: {flagged}[/yellow]")
-    if entity_updates:
-        console.print(f"  Entity updates: {entity_updates}")
-    if review_cycles:
-        console.print(f"  Review cycles: {review_cycles}")
-
-    # Show phase summary
-    phases = artifact.get("phases_completed", [])
-    if phases:
-        failed = [p for p in phases if p.get("status") == "failed"]
-        if failed:
-            console.print(f"  [red]Failed phases: {len(failed)}[/red]")
-        else:
-            console.print(f"  Phases: [green]{len(phases)} completed[/green]")
+        console.print(f"  [yellow]Flagged passages: {flagged}[/yellow]")
 
 
 # Stage preview function mapping (defined after functions exist)

--- a/src/questfoundry/cli.py
+++ b/src/questfoundry/cli.py
@@ -654,24 +654,23 @@ def _preview_grow_artifact(artifact: dict[str, Any]) -> None:
 
 
 def _preview_fill_artifact(artifact: dict[str, Any]) -> None:
-    """Display preview of FILL artifact."""
-    voice = artifact.get("voice_document", {})
-    if voice:
-        pov = voice.get("pov", "?")
-        tense = voice.get("tense", "?")
-        register = voice.get("voice_register", "?")
-        console.print(f"  Voice: [bold]{pov}[/bold] {tense}, {register}")
-        tone_words = voice.get("tone_words", [])
-        if tone_words:
-            console.print(f"  Tone: {', '.join(str(w) for w in tone_words)}")
+    """Display preview of FILL artifact.
 
-    passages = artifact.get("passages", [])
-    console.print(f"  Passages with prose: [bold]{len(passages)}[/bold]")
+    Reads FillResult fields (passages_filled, passages_flagged,
+    entity_updates_applied, review_cycles, phases_completed).
+    """
+    filled = artifact.get("passages_filled", 0)
+    flagged = artifact.get("passages_flagged", 0)
+    entity_updates = artifact.get("entity_updates_applied", 0)
+    review_cycles = artifact.get("review_cycles", 0)
 
-    review = artifact.get("review_summary", {})
-    flagged = review.get("passages_flagged", 0)
+    console.print(f"  Passages filled: [bold]{filled}[/bold]")
     if flagged:
-        console.print(f"  [yellow]Flagged passages: {flagged}[/yellow]")
+        console.print(f"  [yellow]Passages flagged: {flagged}[/yellow]")
+    if entity_updates:
+        console.print(f"  Entity updates: {entity_updates}")
+    if review_cycles:
+        console.print(f"  Review cycles: {review_cycles}")
 
     # Show phase summary
     phases = artifact.get("phases_completed", [])

--- a/src/questfoundry/pipeline/stages/__init__.py
+++ b/src/questfoundry/pipeline/stages/__init__.py
@@ -15,6 +15,12 @@ from questfoundry.pipeline.stages.brainstorm import (
     create_brainstorm_stage,
 )
 from questfoundry.pipeline.stages.dream import DreamStage, dream_stage
+from questfoundry.pipeline.stages.fill import (
+    FillStage,
+    FillStageError,
+    create_fill_stage,
+    fill_stage,
+)
 from questfoundry.pipeline.stages.grow import (
     GrowStage,
     GrowStageError,
@@ -33,11 +39,14 @@ register_stage(dream_stage)
 register_stage(brainstorm_stage)
 register_stage(seed_stage)
 register_stage(grow_stage)
+register_stage(fill_stage)
 
 __all__ = [
     "BrainstormStage",
     "BrainstormStageError",
     "DreamStage",
+    "FillStage",
+    "FillStageError",
     "GrowStage",
     "GrowStageError",
     "SeedStage",
@@ -45,9 +54,11 @@ __all__ = [
     "Stage",
     "brainstorm_stage",
     "create_brainstorm_stage",
+    "create_fill_stage",
     "create_grow_stage",
     "create_seed_stage",
     "dream_stage",
+    "fill_stage",
     "get_stage",
     "grow_stage",
     "list_stages",

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -1117,6 +1117,17 @@ def test_grow_command_exists() -> None:
     assert "--provider" in output
 
 
+def test_fill_command_exists() -> None:
+    """Test qf fill command is registered and shows help."""
+    result = runner.invoke(app, ["fill", "--help"])
+    output = _strip_ansi(result.stdout)
+
+    assert result.exit_code == 0
+    assert "prose" in output.lower()
+    assert "--project" in output
+    assert "--provider" in output
+
+
 def test_grow_no_project_fails() -> None:
     """Test qf grow fails without project.yaml."""
     with runner.isolated_filesystem():

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -582,7 +582,7 @@ def test_seed_no_prompt_noninteractive_uses_default(tmp_path: Path) -> None:
 
 def test_stage_order_constant() -> None:
     """Test STAGE_ORDER contains expected stages in order."""
-    assert STAGE_ORDER == ["dream", "brainstorm", "seed", "grow"]
+    assert STAGE_ORDER == ["dream", "brainstorm", "seed", "grow", "fill"]
 
 
 def test_stage_prompts_has_all_stages() -> None:

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -1128,6 +1128,15 @@ def test_fill_command_exists() -> None:
     assert "--provider" in output
 
 
+def test_fill_no_project_fails() -> None:
+    """Test qf fill fails without project.yaml."""
+    with runner.isolated_filesystem():
+        result = runner.invoke(app, ["fill"])
+
+        assert result.exit_code == 1
+        assert "No project.yaml found" in result.stdout
+
+
 def test_grow_no_project_fails() -> None:
     """Test qf grow fails without project.yaml."""
     with runner.isolated_filesystem():


### PR DESCRIPTION
## Problem

The FILL stage implementation (PRs #403–#405) needs to be wired into the CLI and stage registry so users can run `qf fill` (PR 10 in the FILL plan, #381).

## Changes

- **Stage registration** (`stages/__init__.py`): Import and register `FillStage`, `FillStageError`, `create_fill_stage`, `fill_stage`
- **CLI command** (`cli.py`): Add `qf fill` command following GROW pattern — non-interactive, phase-by-phase progress, `--resume-from` support
- **Stage order**: Add "fill" to `STAGE_ORDER` and `STAGE_PROMPTS`
- **Preview function**: `_preview_fill_artifact()` showing voice document (POV/tense/register/tone), passage count, flagged passages, phase summary
- **Progress display**: FILL uses same phase-by-phase display as GROW (not spinner)
- **Run command**: Updated help text to include "fill" in stage list

## Not Included / Future PRs

- SHIP stage (deferred)
- Quality bars doc update (PR 11)

## Test Plan

```bash
uv run mypy src/questfoundry/cli.py src/questfoundry/pipeline/stages/__init__.py  # clean
uv run ruff check src/  # clean
```

Note: CLI commands are validated by CI's type checking and linting. Integration testing of `qf fill` requires a project with completed GROW stage.

## Risk / Rollback

- Low risk: additive changes only. FILL stage registration depends on FillStage class existing (merged in prior PRs).
- If FillStage is not yet merged, `__init__.py` import will fail at import time — CI will catch this.

Closes #391

🤖 Generated with [Claude Code](https://claude.com/claude-code)