### PR TITLE
feat(fill): implement Phase 2/3 — review and revision cycle

### DIFF
--- a/src/questfoundry/pipeline/stages/fill.py
+++ b/src/questfoundry/pipeline/stages/fill.py
@@ -29,6 +29,7 @@ from questfoundry.graph.fill_context import (
     format_entity_states,
     format_grow_summary,
     format_lookahead_context,
+    format_passages_batch,
     format_scene_types_summary,
     format_shadow_states,
     format_sliding_window,
@@ -40,6 +41,7 @@ from questfoundry.graph.graph import Graph
 from questfoundry.models.fill import (
     FillPhase0Output,
     FillPhase1Output,
+    FillPhase2Output,
     FillPhaseResult,
     FillResult,
 )
@@ -628,27 +630,179 @@ class FillStage:
             tokens_used=total_tokens,
         )
 
+    REVIEW_BATCH_SIZE = 8
+
     async def _phase_2_review(
         self,
-        graph: Graph,  # noqa: ARG002
-        model: BaseChatModel,  # noqa: ARG002
+        graph: Graph,
+        model: BaseChatModel,
     ) -> FillPhaseResult:
         """Phase 2: Review.
 
-        Reviews passages for quality issues.
+        Reviews passages in batches for quality issues. Collects
+        ReviewFlag objects that Phase 3 will use for targeted revision.
         """
-        return FillPhaseResult(phase="review", status="skipped", detail="not yet implemented")
+        passage_nodes = graph.get_nodes_by_type("passage")
+        filled_ids = [
+            pid
+            for pid, pdata in passage_nodes.items()
+            if pdata.get("prose") and pdata.get("flag") != "incompatible_states"
+        ]
+        if not filled_ids:
+            return FillPhaseResult(
+                phase="review", status="completed", detail="no passages to review"
+            )
+
+        voice_context = format_voice_context(graph)
+        all_flags: list[dict[str, str]] = []
+        total_llm_calls = 0
+        total_tokens = 0
+
+        # Process in batches
+        for i in range(0, len(filled_ids), self.REVIEW_BATCH_SIZE):
+            batch_ids = filled_ids[i : i + self.REVIEW_BATCH_SIZE]
+            batch_context = format_passages_batch(graph, batch_ids)
+
+            output, llm_calls, tokens = await self._fill_llm_call(
+                model,
+                "fill_phase2_review",
+                {"voice_document": voice_context, "passages_batch": batch_context},
+                FillPhase2Output,
+            )
+            total_llm_calls += llm_calls
+            total_tokens += tokens
+
+            for flag in output.flags:
+                all_flags.append(
+                    {
+                        "passage_id": flag.passage_id,
+                        "issue": flag.issue,
+                        "issue_type": flag.issue_type,
+                    }
+                )
+
+        # Store flags on passage nodes for Phase 3
+        for flag_data in all_flags:
+            pid = flag_data["passage_id"]
+            # Find the full passage node ID
+            full_pid = pid if pid.startswith("passage::") else f"passage::{pid}"
+            node = graph.get_node(full_pid)
+            if node:
+                existing_flags = node.get("review_flags", [])
+                existing_flags.append(flag_data)
+                graph.update_node(full_pid, review_flags=existing_flags)
+
+        log.info("review_complete", flags_found=len(all_flags))
+
+        return FillPhaseResult(
+            phase="review",
+            status="completed",
+            detail=f"{len(all_flags)} issues found across {len(filled_ids)} passages",
+            llm_calls=total_llm_calls,
+            tokens_used=total_tokens,
+        )
 
     async def _phase_3_revision(
         self,
-        graph: Graph,  # noqa: ARG002
-        model: BaseChatModel,  # noqa: ARG002
+        graph: Graph,
+        model: BaseChatModel,
     ) -> FillPhaseResult:
         """Phase 3: Revision.
 
-        Regenerates flagged passages.
+        Regenerates flagged passages with extended context and
+        specific issue guidance.
         """
-        return FillPhaseResult(phase="revision", status="skipped", detail="not yet implemented")
+        # Collect passages with review flags
+        passage_nodes = graph.get_nodes_by_type("passage")
+        flagged: list[tuple[str, dict[str, str]]] = []
+        for pid, pdata in passage_nodes.items():
+            for flag_data in pdata.get("review_flags", []):
+                flagged.append((pid, flag_data))
+
+        if not flagged:
+            return FillPhaseResult(
+                phase="revision", status="completed", detail="no passages to revise"
+            )
+
+        voice_context = format_voice_context(graph)
+        total_llm_calls = 0
+        total_tokens = 0
+        revised = 0
+
+        for passage_id, flag_data in flagged:
+            passage = graph.get_node(passage_id)
+            if not passage:
+                continue
+
+            # Find arc for extended window
+            arc_id = self._find_arc_for_passage(graph, passage_id)
+            current_idx = 0
+            if arc_id:
+                order = get_arc_passage_order(graph, arc_id)
+                if passage_id in order:
+                    current_idx = order.index(passage_id)
+
+            context = {
+                "voice_document": voice_context,
+                "passage_id": passage.get("raw_id", passage_id),
+                "issue_type": flag_data.get("issue_type", ""),
+                "issue_description": flag_data.get("issue", ""),
+                "current_prose": passage.get("prose", ""),
+                "extended_window": format_sliding_window(
+                    graph, arc_id or "", current_idx, window_size=5
+                ),
+            }
+
+            output, llm_calls, tokens = await self._fill_llm_call(
+                model,
+                "fill_phase3_revision",
+                context,
+                FillPhase1Output,  # Reuse — same passage output format
+            )
+            total_llm_calls += llm_calls
+            total_tokens += tokens
+
+            if output.passage.prose:
+                graph.update_node(passage_id, prose=output.passage.prose)
+                revised += 1
+                log.debug("passage_revised", passage_id=passage_id)
+
+                # Apply entity updates from revision
+                for update in output.passage.entity_updates:
+                    entity_node = graph.get_node(f"entity::{update.entity_id}")
+                    if entity_node:
+                        graph.update_node(
+                            f"entity::{update.entity_id}",
+                            **{update.field: update.value},
+                        )
+
+        # Clear review flags after revision
+        for pid, pdata in passage_nodes.items():
+            if pdata.get("review_flags"):
+                graph.update_node(pid, review_flags=[])
+
+        return FillPhaseResult(
+            phase="revision",
+            status="completed",
+            detail=f"{revised} passages revised from {len(flagged)} flags",
+            llm_calls=total_llm_calls,
+            tokens_used=total_tokens,
+        )
+
+    def _find_arc_for_passage(self, graph: Graph, passage_id: str) -> str | None:
+        """Find the first arc containing a passage's beat."""
+        passage = graph.get_node(passage_id)
+        if not passage:
+            return None
+        beat_id = passage.get("from_beat", "")
+        if not beat_id:
+            return None
+
+        all_arcs = graph.get_nodes_by_type("arc")
+        for arc_id, arc_data in all_arcs.items():
+            if beat_id in arc_data.get("sequence", []):
+                return str(arc_id)
+        return None
 
 
 # -------------------------------------------------------------------------

--- a/tests/unit/test_fill_stage.py
+++ b/tests/unit/test_fill_stage.py
@@ -13,7 +13,9 @@ from questfoundry.models.fill import (
     FillPassageOutput,
     FillPhase0Output,
     FillPhase1Output,
+    FillPhase2Output,
     FillPhaseResult,
+    ReviewFlag,
     VoiceDocument,
 )
 from questfoundry.pipeline.gates import AutoApprovePhaseGate, PhaseGateHook
@@ -92,8 +94,22 @@ def _mock_implemented_phases(stage: FillStage) -> None:
     ) -> FillPhaseResult:
         return FillPhaseResult(phase="generate", status="completed", llm_calls=2, tokens_used=1000)
 
+    async def _fake_phase_2(
+        graph: Graph,  # noqa: ARG001
+        model: MagicMock,  # noqa: ARG001
+    ) -> FillPhaseResult:
+        return FillPhaseResult(phase="review", status="completed", llm_calls=1, tokens_used=200)
+
+    async def _fake_phase_3(
+        graph: Graph,  # noqa: ARG001
+        model: MagicMock,  # noqa: ARG001
+    ) -> FillPhaseResult:
+        return FillPhaseResult(phase="revision", status="completed", llm_calls=0, tokens_used=0)
+
     stage._phase_0_voice = _fake_phase_0  # type: ignore[method-assign]
     stage._phase_1_generate = _fake_phase_1  # type: ignore[method-assign]
+    stage._phase_2_review = _fake_phase_2  # type: ignore[method-assign]
+    stage._phase_3_revision = _fake_phase_3  # type: ignore[method-assign]
 
 
 class TestFillStageExecute:
@@ -127,14 +143,12 @@ class TestFillStageExecute:
         phases = result_dict["phases_completed"]
         assert len(phases) == 4
         assert [p["phase"] for p in phases] == ["voice", "generate", "review", "revision"]
-        # Phases 0-1 are completed; phases 2-3 are still skipped
-        assert phases[0]["status"] == "completed"
-        assert phases[1]["status"] == "completed"
-        assert all(p["status"] == "skipped" for p in phases[2:])
+        # All phases are completed
+        assert all(p["status"] == "completed" for p in phases)
 
-        # Phase 0 + Phase 1 contribute LLM calls
-        assert llm_calls == 3
-        assert tokens == 1500
+        # Sum of all phase LLM calls (1 + 2 + 1 + 0 = 4)
+        assert llm_calls == 4
+        assert tokens == 1700
 
     @pytest.mark.asyncio
     async def test_sets_last_stage(
@@ -622,20 +636,132 @@ class TestGenerationOrder:
         assert passage_ids.count("passage::p2") == 1
 
 
-class TestSkeletonPhases:
+def _make_reviewed_graph() -> Graph:
+    """Create a graph with filled passages for Phase 2/3 testing."""
+    g = _make_prose_graph()
+    g.update_node("passage::p1", prose="Kay entered the tower.")
+    g.update_node("passage::p2", prose="The hall stretched before Kay.")
+    return g
+
+
+class TestPhase2Review:
     @pytest.mark.asyncio
-    async def test_phase_2_review_skipped(self) -> None:
+    async def test_review_finds_flags(self) -> None:
+        graph = _make_reviewed_graph()
         stage = FillStage()
-        result = await stage._phase_2_review(Graph.empty(), MagicMock())
+
+        async def mock_llm_call(
+            model: MagicMock,  # noqa: ARG001
+            template_name: str,  # noqa: ARG001
+            context: dict,  # noqa: ARG001
+            output_schema: type,  # noqa: ARG001
+            max_retries: int = 3,  # noqa: ARG001
+        ) -> tuple:
+            return (
+                FillPhase2Output(
+                    flags=[
+                        ReviewFlag(
+                            passage_id="p1",
+                            issue="Voice drift detected",
+                            issue_type="voice_drift",
+                        )
+                    ]
+                ),
+                1,
+                200,
+            )
+
+        stage._fill_llm_call = mock_llm_call  # type: ignore[method-assign]
+        result = await stage._phase_2_review(graph, MagicMock())
+
         assert result.phase == "review"
-        assert result.status == "skipped"
+        assert result.status == "completed"
+        assert "1 issues" in (result.detail or "")
+
+        # Flag should be stored on passage node
+        p1 = graph.get_node("passage::p1")
+        assert p1 is not None
+        assert len(p1.get("review_flags", [])) == 1
 
     @pytest.mark.asyncio
-    async def test_phase_3_revision_skipped(self) -> None:
+    async def test_no_passages_to_review(self) -> None:
+        graph = Graph.empty()
         stage = FillStage()
-        result = await stage._phase_3_revision(Graph.empty(), MagicMock())
+        result = await stage._phase_2_review(graph, MagicMock())
+        assert result.status == "completed"
+        assert result.llm_calls == 0
+
+    @pytest.mark.asyncio
+    async def test_empty_flags_is_fine(self) -> None:
+        graph = _make_reviewed_graph()
+        stage = FillStage()
+
+        async def mock_llm_call(
+            model: MagicMock,  # noqa: ARG001
+            template_name: str,  # noqa: ARG001
+            context: dict,  # noqa: ARG001
+            output_schema: type,  # noqa: ARG001
+            max_retries: int = 3,  # noqa: ARG001
+        ) -> tuple:
+            return FillPhase2Output(flags=[]), 1, 200
+
+        stage._fill_llm_call = mock_llm_call  # type: ignore[method-assign]
+        result = await stage._phase_2_review(graph, MagicMock())
+
+        assert result.status == "completed"
+        assert "0 issues" in (result.detail or "")
+
+
+class TestPhase3Revision:
+    @pytest.mark.asyncio
+    async def test_revises_flagged_passage(self) -> None:
+        graph = _make_reviewed_graph()
+        # Add review flags manually
+        graph.update_node(
+            "passage::p1",
+            review_flags=[
+                {"passage_id": "p1", "issue": "Voice drift", "issue_type": "voice_drift"}
+            ],
+        )
+        stage = FillStage()
+
+        async def mock_llm_call(
+            model: MagicMock,  # noqa: ARG001
+            template_name: str,  # noqa: ARG001
+            context: dict,  # noqa: ARG001
+            output_schema: type,  # noqa: ARG001
+            max_retries: int = 3,  # noqa: ARG001
+        ) -> tuple:
+            return (
+                FillPhase1Output(
+                    passage=FillPassageOutput(passage_id="p1", prose="Revised prose for Kay.")
+                ),
+                1,
+                300,
+            )
+
+        stage._fill_llm_call = mock_llm_call  # type: ignore[method-assign]
+        result = await stage._phase_3_revision(graph, MagicMock())
+
         assert result.phase == "revision"
-        assert result.status == "skipped"
+        assert result.status == "completed"
+        assert "1 passages revised" in (result.detail or "")
+
+        # Prose should be updated
+        p1 = graph.get_node("passage::p1")
+        assert p1 is not None
+        assert p1["prose"] == "Revised prose for Kay."
+
+        # Review flags should be cleared
+        assert p1.get("review_flags") == []
+
+    @pytest.mark.asyncio
+    async def test_no_flags_returns_completed(self) -> None:
+        graph = _make_reviewed_graph()
+        stage = FillStage()
+        result = await stage._phase_3_revision(graph, MagicMock())
+        assert result.status == "completed"
+        assert result.llm_calls == 0
 
 
 class TestModuleLevelHelpers:


### PR DESCRIPTION
## Problem

FILL Phase 1 generates prose but has no quality control. Phase 2 (review) and Phase 3 (revision) close the loop by detecting quality issues and revising flagged passages, implementing the review-revise cycle from the FILL plan (#388).

Supersedes #405 (auto-closed when base branch was deleted after squash merge of PR #404).

## Changes

- **Phase 2 (`_phase_2_review`)**: Batched review of filled passages (configurable batch size, default 8). Calls LLM with `fill_phase2_review` template per batch. Stores `ReviewFlag` objects on passage nodes as `review_flags` field.
- **Phase 3 (`_phase_3_revision`)**: Iterates passages with `review_flags`, assembles extended context (voice doc, current prose, extended sliding window, issue details), calls LLM with `fill_phase3_revision` template. Updates prose and clears `review_flags` after revision.
- **`_find_arc_for_passage()` helper**: Finds the arc containing a passage's beat for context assembly.
- **5 new tests**: `TestPhase2Review` (3 tests), `TestPhase3Revision` (2 tests). Removes skeleton stub tests.
- **Updated execute-level mock**: `_mock_implemented_phases` now covers all 4 phases.

## Not Included / Future PRs

- Review-revision cycle count limiting (max 2 cycles) — will be wired in PR 10 (CLI/registration)
- FILL artifact extraction (PR #406)
- CLI `qf fill` command (PR #407)

## Test Plan

```bash
uv run pytest tests/unit/test_fill_stage.py -x -q  # 38 passed
uv run mypy src/questfoundry/pipeline/stages/fill.py  # clean
uv run ruff check src/  # clean
```

## Risk / Rollback

- Low risk: adds new methods and tests, no changes to existing behavior
- Phase 2/3 are called sequentially by `execute()` which already has checkpoint/rollback logic

## Review Guide

1. Start with `_phase_2_review()` (~40 lines) — straightforward batched LLM call
2. Then `_phase_3_revision()` (~55 lines) — per-passage revision with extended context
3. `_find_arc_for_passage()` (~15 lines) — helper for arc lookup
4. Tests in `TestPhase2Review` and `TestPhase3Revision`

Closes #388

🤖 Generated with [Claude Code](https://claude.com/claude-code)