### PR TITLE
feat(size): add size profiles + CLI improvements

### DIFF
--- a/prompts/templates/discuss.yaml
+++ b/prompts/templates/discuss.yaml
@@ -10,9 +10,9 @@ system: |
   - Genre and tone
   - Themes and motifs
   - Target audience
-  - Scope and complexity
+  - Scope and complexity (story size preset)
   - Style notes
-
+  {size_presets_section}
   ## Guidelines
   - Ask clarifying questions to understand the vision
   - Suggest possibilities but respect the user's preferences
@@ -90,5 +90,16 @@ research_tools_section: |
     ]
   )
   ```
+
+size_presets_section: |
+  ## Story Size Presets
+  When discussing scope, guide the user toward one of these size presets:
+  - **vignette**: 5-15 passages, 2000-5000 words. Tight single-scene exploration with minimal branching.
+  - **short**: 15-30 passages, 5000-15000 words. Focused story with limited branching paths.
+  - **standard** (default): 30-60 passages, 15000-30000 words. Full branching narrative with multiple paths.
+  - **long**: 60-120 passages, 30000-60000 words. Expansive world with deep branching and many characters.
+
+  The chosen preset determines entity counts, word targets, and branching complexity
+  for all downstream stages. If the user doesn't express a preference, default to "standard".
 
 components: []

--- a/src/questfoundry/agents/prompts.py
+++ b/src/questfoundry/agents/prompts.py
@@ -142,6 +142,7 @@ def _render_discuss_template(
         raw_data.get("research_tools_section", "") if research_tools_available else ""
     )
     mode_section = raw_data.get("non_interactive_section", "") if not interactive else ""
+    size_presets_section = raw_data.get("size_presets_section", "")
 
     system_template = raw_data.get("system", "")
     prompt = ChatPromptTemplate.from_template(system_template)
@@ -149,6 +150,7 @@ def _render_discuss_template(
     return prompt.format(
         research_tools_section=research_section,
         mode_section=mode_section,
+        size_presets_section=size_presets_section,
         **kwargs,
     )
 

--- a/src/questfoundry/graph/fill_context.py
+++ b/src/questfoundry/graph/fill_context.py
@@ -490,11 +490,11 @@ def format_dream_vision(graph: Graph) -> str:
     if not vision_nodes:
         return ""
 
-    dream_data = next(iter(vision_nodes.values()))
+    vision_data = next(iter(vision_nodes.values()))
     lines: list[str] = []
 
     for field in ("genre", "tone", "themes", "style_notes"):
-        value = dream_data.get(field)
+        value = vision_data.get(field)
         if value:
             if isinstance(value, list):
                 lines.append(f"**{field}:** {', '.join(str(v) for v in value)}")

--- a/src/questfoundry/models/dream.py
+++ b/src/questfoundry/models/dream.py
@@ -26,7 +26,7 @@ class ContentNotes(BaseModel):
 class Scope(BaseModel):
     """Story scope constraints."""
 
-    story_size: str = Field(
+    story_size: Literal["vignette", "short", "standard", "long"] = Field(
         default="standard",
         description=(
             'Story size preset: "vignette" (5-15 passages, tight single-thread), '
@@ -34,7 +34,6 @@ class Scope(BaseModel):
             '"standard" (30-60 passages, full branching), '
             '"long" (60-120 passages, extensive branching)'
         ),
-        min_length=1,
     )
     branching_depth: str = Field(
         default="moderate",

--- a/src/questfoundry/pipeline/size.py
+++ b/src/questfoundry/pipeline/size.py
@@ -15,7 +15,7 @@ Presets:
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from questfoundry.graph.graph import Graph
@@ -221,17 +221,12 @@ def resolve_size_from_graph(graph: Graph) -> SizeProfile:
     Returns:
         Resolved SizeProfile.
     """
-    vision = graph.get_node("vision")
-    if vision is None:
-        return get_size_profile("standard")
-
-    scope: dict[str, Any] | None = vision.get("scope")
-    if scope is None:
-        return get_size_profile("standard")
-
+    vision = graph.get_node("vision") or {}
+    scope = vision.get("scope") or {}
     story_size = scope.get("story_size", "standard")
+
     if story_size not in PRESETS:
-        return get_size_profile("standard")
+        story_size = "standard"
 
     return get_size_profile(story_size)
 

--- a/src/questfoundry/pipeline/stages/seed.py
+++ b/src/questfoundry/pipeline/stages/seed.py
@@ -33,6 +33,7 @@ from questfoundry.graph.mutations import format_semantic_errors_as_content
 from questfoundry.graph.seed_pruning import compute_arc_count, prune_to_arc_limit
 from questfoundry.observability.logging import get_logger
 from questfoundry.observability.tracing import get_current_run_tree, traceable
+from questfoundry.pipeline.size import get_size_profile
 from questfoundry.tools.langchain_tools import (
     get_all_research_tools,
     get_interactive_tools,
@@ -432,8 +433,8 @@ class SeedStage:
         # LLM may have explored more dilemmas than the arc limit allows.
         # Instead of retrying, we programmatically select the best dilemmas.
         original_arc_count = compute_arc_count(result.artifact)
-        size_profile = kwargs.get("size_profile")
-        max_arcs = size_profile.max_arcs if size_profile else 16
+        size_profile = kwargs.get("size_profile") or get_size_profile("standard")
+        max_arcs = size_profile.max_arcs
         pruned_artifact = prune_to_arc_limit(result.artifact, max_arcs=max_arcs, graph=graph)
         final_arc_count = compute_arc_count(pruned_artifact)
 

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -73,9 +73,24 @@ def test_init_project_yaml_content(tmp_path: Path) -> None:
 
     assert config["name"] == "test_project"
     assert config["version"] == 1
-    assert "stages" in config["pipeline"]
-    assert "dream" in config["pipeline"]["stages"]
+    assert "pipeline" not in config  # Stages are no longer written to project.yaml
     assert "default" in config["providers"]
+
+
+def test_init_with_provider(tmp_path: Path) -> None:
+    """Test qf init --provider sets provider in project.yaml."""
+    import yaml
+
+    runner.invoke(
+        app,
+        ["init", "test_project", "--path", str(tmp_path), "--provider", "openai/gpt-4o"],
+    )
+
+    config_file = tmp_path / "test_project" / "project.yaml"
+    with config_file.open() as f:
+        config = yaml.safe_load(f)
+
+    assert config["providers"]["default"] == "openai/gpt-4o"
 
 
 def test_init_existing_directory_fails(tmp_path: Path) -> None:

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -25,6 +25,8 @@ from questfoundry.cli import (
 if TYPE_CHECKING:
     from pathlib import Path
 
+    import pytest
+
 runner = CliRunner()
 
 
@@ -1116,6 +1118,122 @@ def test_run_help_shows_phase_provider_flags() -> None:
     # Rich may truncate long option names in help
     assert "--provider-summari" in output or "--provider-summarize" in output
     assert "--provider-seriali" in output or "--provider-serialize" in output
+
+
+# --- Run --init Tests ---
+
+
+def test_run_init_creates_project(tmp_path: Path) -> None:
+    """Test qf run --init creates project when it doesn't exist."""
+    project_path = tmp_path / "new-project"
+
+    result = runner.invoke(
+        app,
+        [
+            "run",
+            "--to",
+            "dream",
+            "--prompt",
+            "test",
+            "--project",
+            str(project_path),
+            "--init",
+            "--no-interactive",
+        ],
+    )
+
+    # The project should have been created (run may still fail on LLM, but init succeeds)
+    assert (project_path / "project.yaml").exists()
+    assert (project_path / "artifacts").is_dir()
+    assert "Created project" in result.stdout
+
+
+def test_run_init_existing_project_continues(tmp_path: Path) -> None:
+    """Test qf run --init with existing project proceeds normally."""
+    runner.invoke(app, ["init", "test", "--path", str(tmp_path)])
+    project_path = tmp_path / "test"
+
+    # Should not error about project already existing
+    result = runner.invoke(
+        app,
+        [
+            "run",
+            "--to",
+            "dream",
+            "--prompt",
+            "test",
+            "--project",
+            str(project_path),
+            "--init",
+            "--no-interactive",
+        ],
+    )
+
+    # Should proceed to stage execution (may fail on LLM, but not on init)
+    assert "already exists" not in result.stdout
+
+
+def test_run_no_init_no_project_fails_non_interactive() -> None:
+    """Test qf run without --init fails when project doesn't exist."""
+    with runner.isolated_filesystem():
+        result = runner.invoke(app, ["run", "--to", "dream", "--prompt", "test"])
+
+        assert result.exit_code == 1
+        assert "No project.yaml found" in result.stdout
+
+
+def test_run_init_interactive_prompt_decline(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Test qf run without --init prompts in interactive mode and user declines."""
+    project_path = tmp_path / "new-project"
+
+    # Mock TTY detection to return True
+    monkeypatch.setattr("questfoundry.cli._is_interactive_tty", lambda: True)
+
+    result = runner.invoke(
+        app,
+        [
+            "run",
+            "--to",
+            "dream",
+            "--prompt",
+            "test",
+            "--project",
+            str(project_path),
+        ],
+        input="n\n",
+    )
+
+    assert result.exit_code == 0
+    assert not (project_path / "project.yaml").exists()
+
+
+def test_run_init_interactive_prompt_accept(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Test qf run without --init prompts in interactive mode and user accepts."""
+    project_path = tmp_path / "new-project"
+
+    # Mock TTY detection to return True
+    monkeypatch.setattr("questfoundry.cli._is_interactive_tty", lambda: True)
+
+    result = runner.invoke(
+        app,
+        [
+            "run",
+            "--to",
+            "dream",
+            "--prompt",
+            "test",
+            "--project",
+            str(project_path),
+        ],
+        input="y\n",
+    )
+
+    assert (project_path / "project.yaml").exists()
+    assert "Created project" in result.stdout
 
 
 # --- GROW Command Tests ---


### PR DESCRIPTION
## Problem
Story generation needs coordinated size control across all pipeline stages, and the CLI
lacks convenience features for project initialization and batch execution.

## Changes

### Size Profile System (core feature)
- Add `SizeProfile` dataclass with 4 presets: vignette, short, standard, long
- Add `story_size` field to DREAM `Scope` model
- Parameterize BRAINSTORM, SEED, GROW, and FILL templates with size-aware ranges
- Apply size limits to code-side algorithms (grow beat caps, fill vision context)
- Fix FILL vision context bug (was passing raw graph node instead of formatted string)

### CLI Improvements (3 commits)
- **DREAM preset guidance**: Add size preset descriptions to discuss prompt so the LLM
  can guide users toward the right story size during DREAM
- **`qf init --provider`**: Add `--provider` flag, remove redundant `pipeline.stages`
  from project.yaml, extract `_init_project()` helper
- **`qf run --init`**: Auto-create projects with `--init` flag, interactive Y/n prompt
  in TTY mode, or hard fail in non-interactive mode

## Not Included / Future PRs
- DREAM-specific serialize prompt with explicit preset validation
- "epic" preset for large models
- Per-project size range overrides in project.yaml

## Test Plan
- `uv run pytest tests/unit/test_size.py -x -q` — 259 lines of size profile tests (all pass)
- `uv run pytest tests/unit/test_cli.py -x -q` — 71 tests including new --provider, --init tests (all pass)
- `uv run pytest tests/unit/test_discuss_agent.py -x -q` — discuss prompt tests (all pass)
- `uv run mypy src/questfoundry/` — clean
- `uv run ruff check src/` — clean
- All pre-commit hooks pass on every commit

## Risk / Rollback
- **Backward compatible**: Existing projects with `pipeline.stages` in YAML still work
  (field is parsed but ignored; config defaults to `DEFAULT_STAGES`)
- Size profiles use template variables — if a template doesn't reference them, they're
  silently unused (no runtime errors)
- `--init` flag is opt-in; default behavior unchanged for `qf run`

## Review Guide
Suggested review order:
1. `src/questfoundry/pipeline/size.py` + `tests/unit/test_size.py` — core data model
2. `src/questfoundry/models/dream.py` — `story_size` field addition
3. `prompts/templates/*.yaml` — template parameterization
4. `src/questfoundry/agents/prompts.py` — size var injection
5. `src/questfoundry/cli.py` + `tests/unit/test_cli.py` — CLI improvements

🤖 Generated with [Claude Code](https://claude.com/claude-code)