### PR TITLE
feat(graph): add DRESS node/edge mutations and Graph.remove_edge

### DIFF
--- a/src/questfoundry/graph/dress_mutations.py
+++ b/src/questfoundry/graph/dress_mutations.py
@@ -1,0 +1,279 @@
+"""DRESS stage graph mutation helpers.
+
+DRESS manages its own graph directly (like FILL and GROW), not through
+the orchestrator's ``apply_mutations()`` dispatch. These helper functions
+create DRESS-specific nodes and edges in the graph.
+
+Node ID conventions:
+    art_direction::main          — singleton global visual identity
+    entity_visual::{entity_id}   — per-entity visual profile
+    illustration_brief::{pass_id} — per-passage image prompt
+    codex::{entity_id}_rank{N}   — per-entity codex tier
+    illustration::{pass_id}      — rendered image asset
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from questfoundry.graph.context import strip_scope_prefix
+
+if TYPE_CHECKING:
+    from questfoundry.graph.graph import Graph
+
+
+# ---------------------------------------------------------------------------
+# Art Direction (Phase 0)
+# ---------------------------------------------------------------------------
+
+
+def apply_dress_art_direction(
+    graph: Graph,
+    art_dir: dict[str, Any],
+    entity_visuals: list[dict[str, Any]],
+) -> None:
+    """Create ArtDirection node, EntityVisual nodes, and describes_visual edges.
+
+    Uses ``upsert_node`` for ArtDirection to allow re-running Phase 0.
+    Uses ``create_node`` for EntityVisuals (duplicates are an error).
+
+    Args:
+        graph: Story graph to mutate.
+        art_dir: ArtDirection fields (style, medium, palette, etc.).
+        entity_visuals: List of dicts with ``entity_id`` plus EntityVisual fields.
+
+    Raises:
+        NodeExistsError: If an EntityVisual node already exists for an entity.
+        NodeNotFoundError: If a referenced entity doesn't exist in the graph.
+    """
+    # Singleton art direction node
+    ad_data = {"type": "art_direction", **_clean_dict(art_dir)}
+    graph.upsert_node("art_direction::main", ad_data)
+
+    # Per-entity visual profiles
+    for ev in entity_visuals:
+        ev = dict(ev)  # copy to avoid mutating caller's data
+        entity_id = strip_scope_prefix(ev.pop("entity_id"))
+        node_id = f"entity_visual::{entity_id}"
+        ev_data = {"type": "entity_visual", **_clean_dict(ev)}
+        graph.upsert_node(node_id, ev_data)
+        # Edge: entity_visual → entity
+        entity_ref = graph.ref("entity", entity_id)
+        # Remove existing edge if re-running
+        _remove_edges(graph, from_id=node_id, edge_type="describes_visual")
+        graph.add_edge("describes_visual", node_id, entity_ref)
+
+
+# ---------------------------------------------------------------------------
+# Illustration Briefs (Phase 1)
+# ---------------------------------------------------------------------------
+
+
+def apply_dress_brief(
+    graph: Graph,
+    passage_id: str,
+    brief: dict[str, Any],
+    priority: int,
+) -> str:
+    """Create an IllustrationBrief node and targets edge.
+
+    Args:
+        graph: Story graph to mutate.
+        passage_id: Scoped or raw passage ID (e.g., ``passage::opening``).
+        brief: IllustrationBrief fields (subject, composition, mood, etc.).
+        priority: Final computed priority (1-3).
+
+    Returns:
+        The created brief node ID.
+
+    Raises:
+        NodeNotFoundError: If the passage doesn't exist.
+    """
+    raw_passage_id = strip_scope_prefix(passage_id)
+    node_id = f"illustration_brief::{raw_passage_id}"
+    brief_data = {
+        "type": "illustration_brief",
+        "priority": priority,
+        **_clean_dict(brief),
+    }
+    graph.upsert_node(node_id, brief_data)
+
+    # Edge: brief → passage
+    passage_ref = graph.ref("passage", raw_passage_id)
+    _remove_edges(graph, from_id=node_id, edge_type="targets")
+    graph.add_edge("targets", node_id, passage_ref)
+
+    return node_id
+
+
+# ---------------------------------------------------------------------------
+# Codex Entries (Phase 2)
+# ---------------------------------------------------------------------------
+
+
+def apply_dress_codex(
+    graph: Graph,
+    entity_id: str,
+    entries: list[dict[str, Any]],
+) -> list[str]:
+    """Create CodexEntry nodes and HasEntry edges for one entity.
+
+    Args:
+        graph: Story graph to mutate.
+        entity_id: Scoped or raw entity ID.
+        entries: List of CodexEntry dicts (rank, visible_when, content).
+
+    Returns:
+        List of created codex node IDs.
+
+    Raises:
+        NodeNotFoundError: If the entity doesn't exist.
+    """
+    raw_entity_id = strip_scope_prefix(entity_id)
+    entity_ref = graph.ref("entity", raw_entity_id)
+    created_ids: list[str] = []
+
+    for entry in entries:
+        rank = entry.get("rank", 1)
+        node_id = f"codex::{raw_entity_id}_rank{rank}"
+        entry_data = {"type": "codex_entry", **_clean_dict(entry)}
+        graph.upsert_node(node_id, entry_data)
+
+        # Edge: codex_entry → entity
+        _remove_edges(graph, from_id=node_id, edge_type="HasEntry")
+        graph.add_edge("HasEntry", node_id, entity_ref)
+        created_ids.append(node_id)
+
+    return created_ids
+
+
+# ---------------------------------------------------------------------------
+# Illustrations (Phase 4)
+# ---------------------------------------------------------------------------
+
+
+def apply_dress_illustration(
+    graph: Graph,
+    brief_id: str,
+    asset_path: str,
+    caption: str,
+    category: str,
+) -> str:
+    """Create an Illustration node with Depicts and from_brief edges.
+
+    Args:
+        graph: Story graph to mutate.
+        brief_id: IllustrationBrief node ID that was rendered.
+        asset_path: Relative path to the image file.
+        caption: Diegetic caption from the brief.
+        category: Image category (scene, portrait, vista, item_detail).
+
+    Returns:
+        The created illustration node ID.
+
+    Raises:
+        NodeNotFoundError: If the brief doesn't exist.
+    """
+    # Derive passage ID from brief's targets edge
+    targets_edges = graph.get_edges(from_id=brief_id, edge_type="targets")
+    if not targets_edges:
+        msg = f"Brief {brief_id} has no targets edge to a passage"
+        raise ValueError(msg)
+
+    passage_id = targets_edges[0]["to"]
+    raw_passage_id = strip_scope_prefix(passage_id)
+    node_id = f"illustration::{raw_passage_id}"
+
+    illust_data = {
+        "type": "illustration",
+        "asset": asset_path,
+        "caption": caption,
+        "category": category,
+    }
+    graph.upsert_node(node_id, illust_data)
+
+    # Edge: illustration → passage
+    _remove_edges(graph, from_id=node_id, edge_type="Depicts")
+    graph.add_edge("Depicts", node_id, passage_id)
+
+    # Edge: illustration → brief (traceability)
+    _remove_edges(graph, from_id=node_id, edge_type="from_brief")
+    graph.add_edge("from_brief", node_id, brief_id)
+
+    return node_id
+
+
+# ---------------------------------------------------------------------------
+# Validation
+# ---------------------------------------------------------------------------
+
+
+def validate_dress_codex_entries(
+    graph: Graph,
+    entity_id: str,
+    entries: list[dict[str, Any]],
+) -> list[str]:
+    """Validate codex entries before applying to graph.
+
+    Checks:
+    - At least one entry exists
+    - Entry with rank=1 exists (base tier, always visible)
+    - Codeword IDs in visible_when exist in graph
+    - Ranks are unique per entity
+
+    Args:
+        graph: Story graph for codeword validation.
+        entity_id: Entity these entries belong to.
+        entries: List of CodexEntry dicts.
+
+    Returns:
+        List of error messages (empty if valid).
+    """
+    errors: list[str] = []
+
+    if not entries:
+        errors.append(f"Entity {entity_id}: no codex entries provided")
+        return errors
+
+    ranks = [e.get("rank", 0) for e in entries]
+    if 1 not in ranks:
+        errors.append(f"Entity {entity_id}: missing rank=1 base tier (always visible)")
+
+    rank_counts: dict[int, int] = {}
+    for r in ranks:
+        rank_counts[r] = rank_counts.get(r, 0) + 1
+    for r, count in rank_counts.items():
+        if count > 1:
+            errors.append(f"Entity {entity_id}: duplicate rank={r} ({count} entries)")
+
+    # Validate codeword references
+    codewords = graph.get_nodes_by_type("codeword")
+    codeword_ids = {strip_scope_prefix(cid) for cid in codewords}
+
+    for entry in entries:
+        for cw in entry.get("visible_when", []):
+            raw_cw = strip_scope_prefix(cw)
+            if raw_cw not in codeword_ids:
+                errors.append(
+                    f"Entity {entity_id}: codex rank={entry.get('rank')} "
+                    f"references unknown codeword '{cw}'"
+                )
+
+    return errors
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _clean_dict(data: dict[str, Any]) -> dict[str, Any]:
+    """Remove None values from a dictionary for cleaner storage."""
+    return {k: v for k, v in data.items() if v is not None}
+
+
+def _remove_edges(graph: Graph, from_id: str, edge_type: str) -> None:
+    """Remove all edges of a given type from a node (for idempotent re-runs)."""
+    existing = graph.get_edges(from_id=from_id, edge_type=edge_type)
+    for edge in existing:
+        graph.remove_edge(edge["type"], edge["from"], edge["to"])

--- a/src/questfoundry/graph/graph.py
+++ b/src/questfoundry/graph/graph.py
@@ -423,6 +423,35 @@ class Graph:
         }
         self._data["edges"].append(edge)
 
+    def remove_edge(
+        self,
+        edge_type: str,
+        from_id: str,
+        to_id: str,
+    ) -> bool:
+        """Remove a specific edge by type and endpoints.
+
+        Removes the first matching edge. If no matching edge exists,
+        returns False without raising an error.
+
+        Args:
+            edge_type: Type of edge (e.g., "describes_visual", "targets").
+            from_id: Source node ID.
+            to_id: Target node ID.
+
+        Returns:
+            True if an edge was removed, False if no match found.
+        """
+        for i, edge in enumerate(self._data["edges"]):
+            if (
+                edge.get("type") == edge_type
+                and edge.get("from") == from_id
+                and edge.get("to") == to_id
+            ):
+                self._data["edges"].pop(i)
+                return True
+        return False
+
     def get_edges(
         self,
         from_id: str | None = None,

--- a/tests/unit/test_dress_mutations.py
+++ b/tests/unit/test_dress_mutations.py
@@ -1,0 +1,441 @@
+"""Tests for DRESS stage graph mutations."""
+
+from __future__ import annotations
+
+import pytest
+
+from questfoundry.graph.graph import Graph
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def dress_graph() -> Graph:
+    """Graph with entities, passages, and codewords for DRESS testing."""
+    g = Graph()
+    g.create_node(
+        "entity::protagonist",
+        {
+            "type": "entity",
+            "raw_id": "protagonist",
+            "entity_type": "character",
+            "concept": "A young scholar",
+        },
+    )
+    g.create_node(
+        "entity::aldric",
+        {
+            "type": "entity",
+            "raw_id": "aldric",
+            "entity_type": "character",
+            "concept": "A former court advisor",
+        },
+    )
+    g.create_node(
+        "entity::bridge",
+        {
+            "type": "entity",
+            "raw_id": "bridge",
+            "entity_type": "location",
+            "concept": "Ancient stone bridge",
+        },
+    )
+    g.create_node(
+        "beat::opening",
+        {
+            "type": "beat",
+            "raw_id": "opening",
+            "summary": "Scholar arrives at bridge",
+            "scene_type": "establishing",
+        },
+    )
+    g.create_node(
+        "passage::opening",
+        {
+            "type": "passage",
+            "raw_id": "opening",
+            "from_beat": "beat::opening",
+            "prose": "The wind howled across the bridge...",
+            "entities": ["entity::protagonist", "entity::bridge"],
+        },
+    )
+    g.create_node(
+        "codeword::met_aldric",
+        {
+            "type": "codeword",
+            "raw_id": "met_aldric",
+            "trigger": "Player meets aldric at the bridge",
+        },
+    )
+    g.create_node(
+        "codeword::found_tome",
+        {
+            "type": "codeword",
+            "raw_id": "found_tome",
+            "trigger": "Player discovers the ancient tome",
+        },
+    )
+    return g
+
+
+# ---------------------------------------------------------------------------
+# Graph.remove_edge
+# ---------------------------------------------------------------------------
+
+
+class TestRemoveEdge:
+    def test_remove_existing_edge(self) -> None:
+        g = Graph()
+        g.create_node("a::1", {"type": "a"})
+        g.create_node("b::1", {"type": "b"})
+        g.add_edge("links", "a::1", "b::1")
+
+        assert g.remove_edge("links", "a::1", "b::1") is True
+        assert len(g.get_edges()) == 0
+
+    def test_remove_nonexistent_returns_false(self) -> None:
+        assert Graph().remove_edge("links", "a::1", "b::1") is False
+
+    def test_remove_only_matching_edge(self) -> None:
+        g = Graph()
+        g.create_node("a::1", {"type": "a"})
+        g.create_node("b::1", {"type": "b"})
+        g.create_node("b::2", {"type": "b"})
+        g.add_edge("links", "a::1", "b::1")
+        g.add_edge("links", "a::1", "b::2")
+
+        g.remove_edge("links", "a::1", "b::1")
+        remaining = g.get_edges()
+        assert len(remaining) == 1
+        assert remaining[0]["to"] == "b::2"
+
+    def test_type_mismatch_not_removed(self) -> None:
+        g = Graph()
+        g.create_node("a::1", {"type": "a"})
+        g.create_node("b::1", {"type": "b"})
+        g.add_edge("links", "a::1", "b::1")
+
+        assert g.remove_edge("other_type", "a::1", "b::1") is False
+        assert len(g.get_edges()) == 1
+
+
+# ---------------------------------------------------------------------------
+# Art Direction (Phase 0)
+# ---------------------------------------------------------------------------
+
+
+class TestApplyDressArtDirection:
+    def test_creates_nodes_and_edges(self, dress_graph: Graph) -> None:
+        from questfoundry.graph.dress_mutations import apply_dress_art_direction
+
+        apply_dress_art_direction(
+            dress_graph,
+            art_dir={
+                "style": "watercolor",
+                "medium": "traditional",
+                "palette": ["indigo", "rust"],
+                "composition_notes": "wide shots",
+                "negative_defaults": "photorealistic",
+            },
+            entity_visuals=[
+                {
+                    "entity_id": "protagonist",
+                    "description": "Young woman, short dark hair",
+                    "distinguishing_features": ["jade pendant"],
+                    "reference_prompt_fragment": "young woman, jade pendant",
+                }
+            ],
+        )
+
+        ad = dress_graph.get_node("art_direction::main")
+        assert ad is not None
+        assert ad["style"] == "watercolor"
+
+        ev = dress_graph.get_node("entity_visual::protagonist")
+        assert ev is not None
+        assert ev["type"] == "entity_visual"
+
+        edges = dress_graph.get_edges(
+            from_id="entity_visual::protagonist",
+            edge_type="describes_visual",
+        )
+        assert len(edges) == 1
+        assert edges[0]["to"] == "entity::protagonist"
+
+    def test_scoped_entity_id_stripped(self, dress_graph: Graph) -> None:
+        from questfoundry.graph.dress_mutations import apply_dress_art_direction
+
+        apply_dress_art_direction(
+            dress_graph,
+            art_dir={
+                "style": "ink",
+                "medium": "d",
+                "palette": ["b"],
+                "composition_notes": "c",
+                "negative_defaults": "n",
+            },
+            entity_visuals=[
+                {
+                    "entity_id": "entity::aldric",
+                    "description": "d",
+                    "distinguishing_features": ["f"],
+                    "reference_prompt_fragment": "frag",
+                }
+            ],
+        )
+
+        assert dress_graph.get_node("entity_visual::aldric") is not None
+
+    def test_idempotent_rerun(self, dress_graph: Graph) -> None:
+        from questfoundry.graph.dress_mutations import apply_dress_art_direction
+
+        kwargs: dict = {
+            "art_dir": {
+                "style": "ink",
+                "medium": "d",
+                "palette": ["b"],
+                "composition_notes": "c",
+                "negative_defaults": "n",
+            },
+            "entity_visuals": [
+                {
+                    "entity_id": "protagonist",
+                    "description": "d",
+                    "distinguishing_features": ["f"],
+                    "reference_prompt_fragment": "frag",
+                }
+            ],
+        }
+        apply_dress_art_direction(dress_graph, **kwargs)
+        apply_dress_art_direction(dress_graph, **kwargs)
+
+        edges = dress_graph.get_edges(
+            from_id="entity_visual::protagonist",
+            edge_type="describes_visual",
+        )
+        assert len(edges) == 1
+
+    def test_nonexistent_entity_raises(self) -> None:
+        from questfoundry.graph.dress_mutations import apply_dress_art_direction
+        from questfoundry.graph.errors import NodeNotFoundError
+
+        with pytest.raises(NodeNotFoundError):
+            apply_dress_art_direction(
+                Graph(),
+                art_dir={
+                    "style": "ink",
+                    "medium": "d",
+                    "palette": ["b"],
+                    "composition_notes": "c",
+                    "negative_defaults": "n",
+                },
+                entity_visuals=[
+                    {
+                        "entity_id": "nonexistent",
+                        "description": "d",
+                        "distinguishing_features": ["f"],
+                        "reference_prompt_fragment": "frag",
+                    }
+                ],
+            )
+
+
+# ---------------------------------------------------------------------------
+# Illustration Briefs (Phase 1)
+# ---------------------------------------------------------------------------
+
+
+class TestApplyDressBrief:
+    def test_creates_brief_node_and_edge(self, dress_graph: Graph) -> None:
+        from questfoundry.graph.dress_mutations import apply_dress_brief
+
+        node_id = apply_dress_brief(
+            dress_graph,
+            passage_id="passage::opening",
+            brief={
+                "category": "scene",
+                "subject": "Scholar on bridge",
+                "composition": "wide",
+                "mood": "ominous",
+                "caption": "The bridge awaits",
+            },
+            priority=1,
+        )
+
+        assert node_id == "illustration_brief::opening"
+        node = dress_graph.get_node(node_id)
+        assert node is not None
+        assert node["priority"] == 1
+
+        edges = dress_graph.get_edges(from_id=node_id, edge_type="targets")
+        assert len(edges) == 1
+        assert edges[0]["to"] == "passage::opening"
+
+    def test_idempotent_rerun(self, dress_graph: Graph) -> None:
+        from questfoundry.graph.dress_mutations import apply_dress_brief
+
+        kwargs: dict = {
+            "passage_id": "opening",
+            "priority": 2,
+            "brief": {
+                "category": "scene",
+                "subject": "s",
+                "composition": "c",
+                "mood": "m",
+                "caption": "cap",
+            },
+        }
+        apply_dress_brief(dress_graph, **kwargs)
+        apply_dress_brief(dress_graph, **kwargs)
+
+        edges = dress_graph.get_edges(from_id="illustration_brief::opening", edge_type="targets")
+        assert len(edges) == 1
+
+
+# ---------------------------------------------------------------------------
+# Codex Entries (Phase 2)
+# ---------------------------------------------------------------------------
+
+
+class TestApplyDressCodex:
+    def test_creates_codex_nodes_and_edges(self, dress_graph: Graph) -> None:
+        from questfoundry.graph.dress_mutations import apply_dress_codex
+
+        created = apply_dress_codex(
+            dress_graph,
+            entity_id="entity::aldric",
+            entries=[
+                {"rank": 1, "content": "A traveling scholar."},
+                {"rank": 2, "visible_when": ["met_aldric"], "content": "Former court advisor."},
+            ],
+        )
+
+        assert created == ["codex::aldric_rank1", "codex::aldric_rank2"]
+        node = dress_graph.get_node("codex::aldric_rank1")
+        assert node is not None
+        assert node["type"] == "codex_entry"
+
+        edges = dress_graph.get_edges(from_id="codex::aldric_rank1", edge_type="HasEntry")
+        assert len(edges) == 1
+        assert edges[0]["to"] == "entity::aldric"
+
+    def test_idempotent_rerun(self, dress_graph: Graph) -> None:
+        from questfoundry.graph.dress_mutations import apply_dress_codex
+
+        kwargs: dict = {"entity_id": "aldric", "entries": [{"rank": 1, "content": "c"}]}
+        apply_dress_codex(dress_graph, **kwargs)
+        apply_dress_codex(dress_graph, **kwargs)
+
+        edges = dress_graph.get_edges(from_id="codex::aldric_rank1", edge_type="HasEntry")
+        assert len(edges) == 1
+
+
+# ---------------------------------------------------------------------------
+# Illustrations (Phase 4)
+# ---------------------------------------------------------------------------
+
+
+class TestApplyDressIllustration:
+    def test_creates_illustration_with_edges(self, dress_graph: Graph) -> None:
+        from questfoundry.graph.dress_mutations import apply_dress_brief, apply_dress_illustration
+
+        brief_id = apply_dress_brief(
+            dress_graph,
+            passage_id="opening",
+            brief={
+                "category": "scene",
+                "subject": "s",
+                "composition": "c",
+                "mood": "m",
+                "caption": "cap",
+            },
+            priority=1,
+        )
+        illust_id = apply_dress_illustration(
+            dress_graph,
+            brief_id=brief_id,
+            asset_path="assets/abc123.png",
+            caption="The bridge",
+            category="scene",
+        )
+
+        assert illust_id == "illustration::opening"
+        node = dress_graph.get_node(illust_id)
+        assert node is not None
+        assert node["asset"] == "assets/abc123.png"
+
+        depicts = dress_graph.get_edges(from_id=illust_id, edge_type="Depicts")
+        assert len(depicts) == 1
+        assert depicts[0]["to"] == "passage::opening"
+
+        from_brief = dress_graph.get_edges(from_id=illust_id, edge_type="from_brief")
+        assert len(from_brief) == 1
+        assert from_brief[0]["to"] == brief_id
+
+    def test_brief_without_targets_raises(self, dress_graph: Graph) -> None:
+        from questfoundry.graph.dress_mutations import apply_dress_illustration
+
+        dress_graph.create_node("illustration_brief::orphan", {"type": "illustration_brief"})
+        with pytest.raises(ValueError, match="no targets edge"):
+            apply_dress_illustration(
+                dress_graph,
+                brief_id="illustration_brief::orphan",
+                asset_path="assets/x.png",
+                caption="c",
+                category="scene",
+            )
+
+
+# ---------------------------------------------------------------------------
+# Validation
+# ---------------------------------------------------------------------------
+
+
+class TestValidateDressCodexEntries:
+    def test_valid_entries(self, dress_graph: Graph) -> None:
+        from questfoundry.graph.dress_mutations import validate_dress_codex_entries
+
+        errors = validate_dress_codex_entries(
+            dress_graph,
+            "aldric",
+            [
+                {"rank": 1, "content": "Base knowledge"},
+                {"rank": 2, "visible_when": ["met_aldric"], "content": "Deeper knowledge"},
+            ],
+        )
+        assert errors == []
+
+    def test_empty_entries(self, dress_graph: Graph) -> None:
+        from questfoundry.graph.dress_mutations import validate_dress_codex_entries
+
+        errors = validate_dress_codex_entries(dress_graph, "aldric", [])
+        assert "no codex entries" in errors[0]
+
+    def test_missing_rank_1(self, dress_graph: Graph) -> None:
+        from questfoundry.graph.dress_mutations import validate_dress_codex_entries
+
+        errors = validate_dress_codex_entries(dress_graph, "aldric", [{"rank": 2, "content": "c"}])
+        assert any("rank=1" in e for e in errors)
+
+    def test_duplicate_ranks(self, dress_graph: Graph) -> None:
+        from questfoundry.graph.dress_mutations import validate_dress_codex_entries
+
+        errors = validate_dress_codex_entries(
+            dress_graph, "aldric", [{"rank": 1, "content": "a"}, {"rank": 1, "content": "b"}]
+        )
+        assert any("duplicate rank=1" in e for e in errors)
+
+    def test_unknown_codeword(self, dress_graph: Graph) -> None:
+        from questfoundry.graph.dress_mutations import validate_dress_codex_entries
+
+        errors = validate_dress_codex_entries(
+            dress_graph,
+            "aldric",
+            [
+                {"rank": 1, "content": "base"},
+                {"rank": 2, "visible_when": ["nonexistent_cw"], "content": "gated"},
+            ],
+        )
+        assert any("unknown codeword" in e for e in errors)


### PR DESCRIPTION
feat(graph): add DRESS node/edge mutations and Graph.remove_edge

Add Graph.remove_edge() for idempotent edge cleanup on re-runs.
Add dress_mutations.py with helpers for art direction, illustration
briefs, codex entries, illustration nodes, and codex validation.

Closes #416

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>