### PR TITLE
feat(graph): add DRESS context formatters for LLM phases

### DIFF
--- a/src/questfoundry/graph/dress_context.py
+++ b/src/questfoundry/graph/dress_context.py
@@ -1,0 +1,251 @@
+"""Context formatting for DRESS stage LLM phases.
+
+Provides functions to format graph data (vision, entities, art direction,
+passages) as context strings for DRESS's art direction, illustration brief,
+and codex generation phases.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import yaml
+
+from questfoundry.graph.context import strip_scope_prefix
+from questfoundry.graph.fill_context import format_dream_vision
+
+if TYPE_CHECKING:
+    from questfoundry.graph.graph import Graph
+
+
+def format_vision_and_entities(graph: Graph) -> str:
+    """Format DREAM vision + entity list for art direction discussion.
+
+    Provides the creative foundation (genre, tone, themes) alongside
+    a categorized list of entities that need visual profiles.
+
+    Args:
+        graph: Graph containing DREAM vision and BRAINSTORM entities.
+
+    Returns:
+        Formatted context string, or empty string if no vision found.
+    """
+    lines: list[str] = []
+
+    # Vision context
+    vision = format_dream_vision(graph)
+    if vision:
+        lines.append("## Creative Vision")
+        lines.append(vision)
+        lines.append("")
+
+    # Entity list grouped by type
+    entities = graph.get_nodes_by_type("entity")
+    if entities:
+        by_type: dict[str, list[tuple[str, str]]] = {}
+        for eid, edata in entities.items():
+            entity_type = edata.get("entity_type", "unknown")
+            raw_id = edata.get("raw_id", strip_scope_prefix(eid))
+            concept = edata.get("concept", "")
+            by_type.setdefault(entity_type, []).append((raw_id, concept))
+
+        lines.append("## Entities Requiring Visual Profiles")
+        lines.append("")
+        for etype in ("character", "location", "object", "faction"):
+            items = by_type.get(etype, [])
+            if items:
+                lines.append(f"### {etype.title()}s")
+                for raw_id, concept in sorted(items):
+                    if concept:
+                        lines.append(f"- `entity::{raw_id}`: {concept}")
+                    else:
+                        lines.append(f"- `entity::{raw_id}`")
+                lines.append("")
+
+    return "\n".join(lines).strip()
+
+
+def format_art_direction_context(graph: Graph) -> str:
+    """Format the ArtDirection node as YAML context for brief/codex prompts.
+
+    Args:
+        graph: Graph containing an ``art_direction`` type node.
+
+    Returns:
+        YAML-formatted art direction, or empty string if not found.
+    """
+    ad_node = graph.get_node("art_direction::main")
+    if not ad_node:
+        return ""
+
+    # Extract art direction fields (exclude graph metadata)
+    ad_fields = {k: v for k, v in ad_node.items() if k not in ("type", "raw_id") and v is not None}
+
+    if not ad_fields:
+        return ""
+
+    return yaml.dump(ad_fields, default_flow_style=False, sort_keys=False).strip()
+
+
+def format_passage_for_brief(graph: Graph, passage_id: str) -> str:
+    """Format a passage's prose + metadata for illustration brief generation.
+
+    Includes the passage prose, scene type, entities present, and
+    structural position (choices, convergence/divergence).
+
+    Args:
+        graph: Graph containing passage, beat, and entity nodes.
+        passage_id: The passage node ID (e.g., ``passage::opening``).
+
+    Returns:
+        Formatted context string, or empty string if passage not found.
+    """
+    passage = graph.get_node(passage_id)
+    if not passage:
+        return ""
+
+    lines: list[str] = []
+
+    # Prose
+    prose = passage.get("prose", "")
+    if prose:
+        lines.append("### Prose")
+        lines.append(prose)
+        lines.append("")
+
+    # Beat metadata
+    beat_id = passage.get("from_beat", "")
+    beat = graph.get_node(beat_id) if beat_id else None
+
+    if beat:
+        scene_type = beat.get("scene_type", "scene")
+        lines.append(f"**Scene type:** {scene_type}")
+
+        summary = beat.get("summary", "")
+        if summary:
+            lines.append(f"**Summary:** {summary}")
+
+    # Entities in passage
+    entity_ids = passage.get("entities", [])
+    if entity_ids:
+        entity_parts: list[str] = []
+        for eid in entity_ids:
+            enode = graph.get_node(eid)
+            if enode:
+                concept = enode.get("concept", "")
+                if concept:
+                    entity_parts.append(f"- `{eid}`: {concept}")
+                else:
+                    entity_parts.append(f"- `{eid}`")
+        if entity_parts:
+            lines.append("")
+            lines.append("**Entities present:**")
+            lines.extend(entity_parts)
+
+    # Choices (divergence point)
+    choices = graph.get_edges(from_id=passage_id, edge_type="choice")
+    if choices:
+        lines.append("")
+        lines.append(f"**Divergence point:** {len(choices)} choices")
+
+    return "\n".join(lines).strip()
+
+
+def format_entity_for_codex(graph: Graph, entity_id: str) -> str:
+    """Format entity details + related codewords for codex generation.
+
+    Provides the entity's full profile and any codewords that could
+    gate codex tiers (e.g., meeting a character unlocks deeper lore).
+
+    Args:
+        graph: Graph containing entity and codeword nodes.
+        entity_id: Entity node ID (e.g., ``entity::aldric``).
+
+    Returns:
+        Formatted context string, or empty string if entity not found.
+    """
+    entity = graph.get_node(entity_id)
+    if not entity:
+        return ""
+
+    raw_id = entity.get("raw_id", strip_scope_prefix(entity_id))
+    lines: list[str] = []
+
+    lines.append(f"## Entity: {raw_id}")
+    lines.append("")
+
+    # Basic info
+    entity_type = entity.get("entity_type", "unknown")
+    lines.append(f"**Type:** {entity_type}")
+
+    concept = entity.get("concept", "")
+    if concept:
+        lines.append(f"**Concept:** {concept}")
+
+    # Entity visual profile (if exists)
+    visual_id = f"entity_visual::{strip_scope_prefix(entity_id)}"
+    visual = graph.get_node(visual_id)
+    if visual:
+        lines.append("")
+        lines.append("### Visual Profile")
+        desc = visual.get("description", "")
+        if desc:
+            lines.append(f"**Appearance:** {desc}")
+        features = visual.get("distinguishing_features", [])
+        if features:
+            lines.append(f"**Features:** {', '.join(features)}")
+
+    # Related codewords
+    codewords = graph.get_nodes_by_type("codeword")
+    related: list[tuple[str, str]] = []
+    for cw_id, cw_data in codewords.items():
+        # Check if codeword mentions this entity in its trigger or description
+        trigger = cw_data.get("trigger", "")
+        cw_raw = cw_data.get("raw_id", strip_scope_prefix(cw_id))
+        if raw_id.lower() in trigger.lower() or raw_id.lower() in cw_raw.lower():
+            related.append((cw_raw, trigger))
+
+    if related:
+        lines.append("")
+        lines.append("### Related Codewords (potential codex gates)")
+        for cw_raw, trigger in sorted(related):
+            if trigger:
+                lines.append(f"- `{cw_raw}`: {trigger}")
+            else:
+                lines.append(f"- `{cw_raw}`")
+
+    return "\n".join(lines).strip()
+
+
+def format_entity_visuals_for_passage(graph: Graph, passage_id: str) -> str:
+    """Format entity visual profiles for entities present in a passage.
+
+    Used by illustration brief generation to include reference prompt
+    fragments for visual consistency.
+
+    Args:
+        graph: Graph containing passage, entity, and entity_visual nodes.
+        passage_id: The passage node ID.
+
+    Returns:
+        Formatted visual reference strings, or empty string if none.
+    """
+    passage = graph.get_node(passage_id)
+    if not passage:
+        return ""
+
+    entity_ids = passage.get("entities", [])
+    if not entity_ids:
+        return ""
+
+    lines: list[str] = []
+    for eid in entity_ids:
+        raw_eid = strip_scope_prefix(eid)
+        visual_id = f"entity_visual::{raw_eid}"
+        visual = graph.get_node(visual_id)
+        if visual:
+            fragment = visual.get("reference_prompt_fragment", "")
+            if fragment:
+                lines.append(f"- **{raw_eid}**: {fragment}")
+
+    return "\n".join(lines) if lines else ""

--- a/tests/unit/test_dress_context.py
+++ b/tests/unit/test_dress_context.py
@@ -1,0 +1,180 @@
+"""Tests for DRESS stage context formatters."""
+
+from __future__ import annotations
+
+import pytest
+
+from questfoundry.graph.graph import Graph
+
+
+@pytest.fixture()
+def dress_graph() -> Graph:
+    """Graph with entities, passages, and codewords for DRESS testing."""
+    g = Graph()
+    g.create_node(
+        "vision::main",
+        {
+            "type": "vision",
+            "genre": "dark fantasy",
+            "tone": "brooding",
+            "themes": ["betrayal", "redemption"],
+        },
+    )
+    g.create_node(
+        "entity::protagonist",
+        {
+            "type": "entity",
+            "raw_id": "protagonist",
+            "entity_type": "character",
+            "concept": "A young scholar seeking forbidden knowledge",
+        },
+    )
+    g.create_node(
+        "entity::aldric",
+        {
+            "type": "entity",
+            "raw_id": "aldric",
+            "entity_type": "character",
+            "concept": "A former court advisor with hidden motives",
+        },
+    )
+    g.create_node(
+        "entity::bridge",
+        {
+            "type": "entity",
+            "raw_id": "bridge",
+            "entity_type": "location",
+            "concept": "Ancient stone bridge spanning a chasm",
+        },
+    )
+    g.create_node(
+        "beat::opening",
+        {
+            "type": "beat",
+            "raw_id": "opening",
+            "summary": "Scholar arrives at bridge",
+            "scene_type": "establishing",
+        },
+    )
+    g.create_node(
+        "passage::opening",
+        {
+            "type": "passage",
+            "raw_id": "opening",
+            "from_beat": "beat::opening",
+            "prose": "The wind howled across the ancient stone bridge...",
+            "entities": ["entity::protagonist", "entity::bridge"],
+        },
+    )
+    g.create_node(
+        "codeword::met_aldric",
+        {
+            "type": "codeword",
+            "raw_id": "met_aldric",
+            "trigger": "Player meets aldric at the bridge",
+        },
+    )
+    return g
+
+
+class TestFormatVisionAndEntities:
+    def test_includes_vision(self, dress_graph: Graph) -> None:
+        from questfoundry.graph.dress_context import format_vision_and_entities
+
+        result = format_vision_and_entities(dress_graph)
+        assert "Creative Vision" in result
+        assert "dark fantasy" in result
+
+    def test_includes_entities_by_type(self, dress_graph: Graph) -> None:
+        from questfoundry.graph.dress_context import format_vision_and_entities
+
+        result = format_vision_and_entities(dress_graph)
+        assert "Characters" in result
+        assert "entity::protagonist" in result
+        assert "Locations" in result
+        assert "entity::bridge" in result
+
+    def test_empty_graph(self) -> None:
+        from questfoundry.graph.dress_context import format_vision_and_entities
+
+        assert format_vision_and_entities(Graph()) == ""
+
+
+class TestFormatArtDirectionContext:
+    def test_formats_art_direction(self, dress_graph: Graph) -> None:
+        from questfoundry.graph.dress_context import format_art_direction_context
+
+        dress_graph.create_node(
+            "art_direction::main",
+            {
+                "type": "art_direction",
+                "style": "watercolor",
+                "medium": "traditional",
+                "palette": ["indigo", "rust"],
+            },
+        )
+        result = format_art_direction_context(dress_graph)
+        assert "watercolor" in result
+        assert "indigo" in result
+
+    def test_no_art_direction(self) -> None:
+        from questfoundry.graph.dress_context import format_art_direction_context
+
+        assert format_art_direction_context(Graph()) == ""
+
+
+class TestFormatPassageForBrief:
+    def test_includes_prose_and_metadata(self, dress_graph: Graph) -> None:
+        from questfoundry.graph.dress_context import format_passage_for_brief
+
+        result = format_passage_for_brief(dress_graph, "passage::opening")
+        assert "wind howled" in result
+        assert "establishing" in result
+        assert "entity::protagonist" in result
+
+    def test_nonexistent_passage(self, dress_graph: Graph) -> None:
+        from questfoundry.graph.dress_context import format_passage_for_brief
+
+        assert format_passage_for_brief(dress_graph, "passage::nonexistent") == ""
+
+
+class TestFormatEntityForCodex:
+    def test_includes_entity_details(self, dress_graph: Graph) -> None:
+        from questfoundry.graph.dress_context import format_entity_for_codex
+
+        result = format_entity_for_codex(dress_graph, "entity::aldric")
+        assert "aldric" in result
+        assert "character" in result
+        assert "court advisor" in result
+
+    def test_includes_related_codewords(self, dress_graph: Graph) -> None:
+        from questfoundry.graph.dress_context import format_entity_for_codex
+
+        result = format_entity_for_codex(dress_graph, "entity::aldric")
+        assert "met_aldric" in result
+
+    def test_nonexistent_entity(self, dress_graph: Graph) -> None:
+        from questfoundry.graph.dress_context import format_entity_for_codex
+
+        assert format_entity_for_codex(dress_graph, "entity::nonexistent") == ""
+
+
+class TestFormatEntityVisualsForPassage:
+    def test_includes_visual_fragments(self, dress_graph: Graph) -> None:
+        from questfoundry.graph.dress_context import format_entity_visuals_for_passage
+
+        dress_graph.create_node(
+            "entity_visual::protagonist",
+            {
+                "type": "entity_visual",
+                "reference_prompt_fragment": "young woman, short dark hair",
+            },
+        )
+        result = format_entity_visuals_for_passage(dress_graph, "passage::opening")
+        assert "young woman, short dark hair" in result
+        assert "protagonist" in result
+
+    def test_no_visuals(self, dress_graph: Graph) -> None:
+        from questfoundry.graph.dress_context import format_entity_visuals_for_passage
+
+        assert format_entity_visuals_for_passage(dress_graph, "passage::opening") == ""


### PR DESCRIPTION
feat(graph): add DRESS context formatters for LLM phases

Add dress_context.py with formatters for vision+entities,
art direction, passage-for-brief, entity-for-codex, and
entity visual fragments. Used by DRESS stage to build
LLM prompt context.

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>