### PR TITLE
feat(providers): add ImageProvider protocol with OpenAI implementation

### DIFF
--- a/src/questfoundry/providers/__init__.py
+++ b/src/questfoundry/providers/__init__.py
@@ -10,6 +10,17 @@ from questfoundry.providers.factory import (
     create_chat_model,
     create_model_for_structured_output,
 )
+from questfoundry.providers.image import (
+    ImageContentPolicyError,
+    ImageProvider,
+    ImageProviderConnectionError,
+    ImageProviderError,
+    ImageResult,
+)
+from questfoundry.providers.image_openai import (
+    OpenAIImageProvider,
+    create_image_provider,
+)
 from questfoundry.providers.model_info import (
     ModelInfo,
     get_model_info,
@@ -21,13 +32,20 @@ from questfoundry.providers.structured_output import (
 )
 
 __all__ = [
+    "ImageContentPolicyError",
+    "ImageProvider",
+    "ImageProviderConnectionError",
+    "ImageProviderError",
+    "ImageResult",
     "ModelInfo",
+    "OpenAIImageProvider",
     "ProviderConnectionError",
     "ProviderError",
     "ProviderModelError",
     "ProviderRateLimitError",
     "StructuredOutputStrategy",
     "create_chat_model",
+    "create_image_provider",
     "create_model_for_structured_output",
     "get_default_strategy",
     "get_model_info",

--- a/src/questfoundry/providers/image.py
+++ b/src/questfoundry/providers/image.py
@@ -1,0 +1,106 @@
+"""Image generation provider protocol and types.
+
+Defines the ImageProvider protocol for image generation backends.
+LangChain has no BaseImageModel, so we define our own thin protocol.
+
+Implementations:
+    - OpenAIImageProvider (image_openai.py) — gpt-image-1 / dall-e-3
+"""
+
+from __future__ import annotations
+
+import base64
+from dataclasses import dataclass, field
+from typing import Any, Protocol, runtime_checkable
+
+
+@dataclass(frozen=True)
+class ImageResult:
+    """Result of an image generation call.
+
+    Attributes:
+        image_data: Raw image bytes.
+        content_type: MIME type (e.g., ``image/png``).
+        provider_metadata: Provider-specific metadata (model, revised prompt, etc.).
+    """
+
+    image_data: bytes
+    content_type: str = "image/png"
+    provider_metadata: dict[str, Any] = field(default_factory=dict)
+
+    @property
+    def size_bytes(self) -> int:
+        """Size of image data in bytes."""
+        return len(self.image_data)
+
+    @classmethod
+    def from_base64(
+        cls,
+        b64_data: str,
+        content_type: str = "image/png",
+        **metadata: Any,
+    ) -> ImageResult:
+        """Create from base64-encoded image data.
+
+        Args:
+            b64_data: Base64-encoded image string.
+            content_type: MIME type of the image.
+            **metadata: Additional provider metadata.
+
+        Returns:
+            ImageResult with decoded bytes.
+        """
+        return cls(
+            image_data=base64.b64decode(b64_data),
+            content_type=content_type,
+            provider_metadata=metadata,
+        )
+
+
+@runtime_checkable
+class ImageProvider(Protocol):
+    """Protocol for image generation backends.
+
+    All image providers must implement the ``generate`` method.
+    The protocol is runtime-checkable for isinstance() validation.
+    """
+
+    async def generate(
+        self,
+        prompt: str,
+        *,
+        negative_prompt: str | None = None,
+        aspect_ratio: str = "1:1",
+        quality: str = "standard",
+    ) -> ImageResult:
+        """Generate an image from a text prompt.
+
+        Args:
+            prompt: Positive text prompt describing the desired image.
+            negative_prompt: Things to avoid in the image (provider support varies).
+            aspect_ratio: Desired aspect ratio (e.g., ``16:9``, ``1:1``).
+            quality: Quality level (``standard``, ``hd``).
+
+        Returns:
+            ImageResult with generated image data.
+
+        Raises:
+            ImageProviderError: If generation fails.
+        """
+        ...
+
+
+class ImageProviderError(Exception):
+    """Base exception for image provider errors."""
+
+    def __init__(self, provider: str, message: str) -> None:
+        self.provider = provider
+        super().__init__(f"[{provider}] {message}")
+
+
+class ImageContentPolicyError(ImageProviderError):
+    """Raised when image generation is rejected by content policy."""
+
+
+class ImageProviderConnectionError(ImageProviderError):
+    """Raised when the image provider is unreachable."""

--- a/src/questfoundry/providers/image_openai.py
+++ b/src/questfoundry/providers/image_openai.py
@@ -1,0 +1,236 @@
+"""OpenAI image generation provider.
+
+Supports gpt-image-1 and dall-e-3 via the OpenAI Images API.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import TYPE_CHECKING, Any, NoReturn
+
+from questfoundry.observability.logging import get_logger
+from questfoundry.providers.image import (
+    ImageContentPolicyError,
+    ImageProviderConnectionError,
+    ImageProviderError,
+    ImageResult,
+)
+
+if TYPE_CHECKING:
+    from openai import AsyncOpenAI
+
+log = get_logger(__name__)
+
+# Aspect ratio → OpenAI size mapping
+_ASPECT_RATIO_TO_SIZE: dict[str, str] = {
+    "1:1": "1024x1024",
+    "16:9": "1792x1024",
+    "9:16": "1024x1792",
+    "3:2": "1536x1024",
+    "2:3": "1024x1536",
+}
+
+# Output format → MIME type mapping
+_FORMAT_TO_CONTENT_TYPE: dict[str, str] = {
+    "png": "image/png",
+    "jpeg": "image/jpeg",
+    "webp": "image/webp",
+}
+
+
+class OpenAIImageProvider:
+    """Image generation via OpenAI's Images API.
+
+    Args:
+        model: Model name (e.g., ``gpt-image-1``, ``dall-e-3``).
+        api_key: OpenAI API key. Falls back to ``OPENAI_API_KEY`` env var.
+        output_format: Image format (``png``, ``jpeg``, ``webp``).
+    """
+
+    def __init__(
+        self,
+        model: str = "gpt-image-1",
+        api_key: str | None = None,
+        output_format: str = "png",
+    ) -> None:
+        self._model = model
+        self._api_key = api_key or os.getenv("OPENAI_API_KEY")
+        self._output_format = output_format
+
+        if not self._api_key:
+            raise ImageProviderError(
+                "openai",
+                "API key required. Set OPENAI_API_KEY environment variable.",
+            )
+
+        if output_format not in _FORMAT_TO_CONTENT_TYPE:
+            supported = ", ".join(sorted(_FORMAT_TO_CONTENT_TYPE))
+            msg = f"Unsupported output_format '{output_format}'. Supported: {supported}"
+            raise ImageProviderError("openai", msg)
+
+        self._content_type = _FORMAT_TO_CONTENT_TYPE[output_format]
+
+        # Create client once, reuse across calls
+        self._client: AsyncOpenAI = self._create_client()
+
+    def _create_client(self) -> AsyncOpenAI:
+        """Create the AsyncOpenAI client (deferred import to keep openai optional)."""
+        try:
+            from openai import AsyncOpenAI as _AsyncOpenAI
+        except ImportError as e:
+            raise ImageProviderError(
+                "openai", "openai package not installed. Run: uv add openai"
+            ) from e
+        return _AsyncOpenAI(api_key=self._api_key)
+
+    async def generate(
+        self,
+        prompt: str,
+        *,
+        negative_prompt: str | None = None,
+        aspect_ratio: str = "1:1",
+        quality: str = "standard",
+    ) -> ImageResult:
+        """Generate an image via OpenAI Images API.
+
+        OpenAI has no separate negative_prompt parameter, so negative
+        content is appended to the prompt as an avoidance clause.
+
+        Args:
+            prompt: Positive text prompt.
+            negative_prompt: Appended as "Avoid: ..." to the prompt.
+            aspect_ratio: Maps to OpenAI size parameter. Must be a supported
+                ratio (1:1, 16:9, 9:16, 3:2, 2:3).
+            quality: Passed directly to API (``standard``, ``hd``).
+
+        Returns:
+            ImageResult with generated image.
+
+        Raises:
+            ImageProviderError: On API errors or unsupported aspect_ratio.
+            ImageContentPolicyError: On content policy rejection.
+            ImageProviderConnectionError: On network errors.
+        """
+        # Build effective prompt
+        effective_prompt = prompt
+        if negative_prompt:
+            effective_prompt = f"{prompt}\n\nAvoid: {negative_prompt}"
+
+        # Map aspect ratio to size — reject unknown ratios
+        size = _ASPECT_RATIO_TO_SIZE.get(aspect_ratio)
+        if size is None:
+            supported = ", ".join(sorted(_ASPECT_RATIO_TO_SIZE))
+            msg = f"Unsupported aspect_ratio '{aspect_ratio}'. Supported: {supported}"
+            raise ImageProviderError("openai", msg)
+
+        log.debug(
+            "image_generate_start",
+            model=self._model,
+            size=size,
+            quality=quality,
+            prompt_length=len(effective_prompt),
+        )
+
+        try:
+            # Build kwargs — use Any to avoid Literal type mismatches
+            # from dynamic values (size comes from dict lookup, quality from caller)
+            api_kwargs: dict[str, Any] = {
+                "model": self._model,
+                "prompt": effective_prompt,
+                "n": 1,
+                "size": size,
+                "quality": quality,
+                "response_format": "b64_json",
+                "output_format": self._output_format,
+            }
+            response = await self._client.images.generate(**api_kwargs)
+        except ImageProviderError:
+            raise
+        except Exception as e:
+            self._handle_error(e)
+
+        # Extract image data from response
+        if not response.data:
+            raise ImageProviderError("openai", "Empty response from image API")
+
+        image_item = response.data[0]
+        b64_data = image_item.b64_json
+        if not b64_data:
+            raise ImageProviderError("openai", "No image data in response")
+
+        # Collect metadata
+        metadata: dict[str, Any] = {
+            "model": self._model,
+            "size": size,
+            "quality": quality,
+        }
+        revised_prompt = getattr(image_item, "revised_prompt", None)
+        if revised_prompt:
+            metadata["revised_prompt"] = revised_prompt
+
+        log.info(
+            "image_generate_complete",
+            model=self._model,
+            size=size,
+        )
+
+        return ImageResult.from_base64(
+            b64_data,
+            content_type=self._content_type,
+            **metadata,
+        )
+
+    def _handle_error(self, error: Exception) -> NoReturn:
+        """Convert OpenAI exceptions to ImageProvider exceptions.
+
+        Uses OpenAI typed exceptions when available, falls back to
+        string matching for untyped errors.
+        """
+        try:
+            from openai import APIConnectionError, APIStatusError
+        except ImportError:
+            # If openai isn't available, fall back to string matching
+            raise ImageProviderError("openai", f"Image generation failed: {error}") from error
+
+        if isinstance(error, APIConnectionError):
+            raise ImageProviderConnectionError("openai", f"Connection error: {error}") from error
+
+        if isinstance(error, APIStatusError):
+            status = error.status_code
+            if status == 400 and "content_policy" in str(error).lower():
+                raise ImageContentPolicyError(
+                    "openai", f"Content policy rejection: {error}"
+                ) from error
+            raise ImageProviderError("openai", f"API error (HTTP {status}): {error}") from error
+
+        raise ImageProviderError("openai", f"Image generation failed: {error}") from error
+
+
+def create_image_provider(
+    provider_spec: str,
+    **kwargs: Any,
+) -> OpenAIImageProvider:
+    """Factory: create an image provider from a spec string.
+
+    Args:
+        provider_spec: Format ``provider/model`` (e.g., ``openai/gpt-image-1``).
+        **kwargs: Additional provider options.
+
+    Returns:
+        Configured image provider.
+
+    Raises:
+        ImageProviderError: If provider is unknown.
+    """
+    if "/" in provider_spec:
+        provider, model = provider_spec.split("/", 1)
+    else:
+        provider = provider_spec
+        model = "gpt-image-1"
+
+    provider_lower = provider.lower()
+
+    if provider_lower == "openai":
+        return OpenAIImageProvider(model=model, **kwargs)
+
+    raise ImageProviderError(provider_lower, f"Unknown image provider: {provider_lower}")

--- a/tests/unit/test_image_provider.py
+++ b/tests/unit/test_image_provider.py
@@ -1,0 +1,266 @@
+"""Tests for ImageProvider protocol, ImageResult, and factory."""
+
+from __future__ import annotations
+
+import base64
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from questfoundry.providers.image import (
+    ImageContentPolicyError,
+    ImageProvider,
+    ImageProviderConnectionError,
+    ImageProviderError,
+    ImageResult,
+)
+
+# ---------------------------------------------------------------------------
+# ImageResult
+# ---------------------------------------------------------------------------
+
+
+class TestImageResult:
+    def test_basic_creation(self) -> None:
+        result = ImageResult(image_data=b"png_bytes", content_type="image/png")
+        assert result.image_data == b"png_bytes"
+        assert result.content_type == "image/png"
+        assert result.provider_metadata == {}
+
+    def test_size_bytes(self) -> None:
+        result = ImageResult(image_data=b"12345")
+        assert result.size_bytes == 5
+
+    def test_from_base64(self) -> None:
+        original = b"test image data"
+        b64 = base64.b64encode(original).decode()
+        result = ImageResult.from_base64(b64, content_type="image/webp", model="test")
+        assert result.image_data == original
+        assert result.content_type == "image/webp"
+        assert result.provider_metadata["model"] == "test"
+
+    def test_frozen(self) -> None:
+        result = ImageResult(image_data=b"data")
+        with pytest.raises(AttributeError):
+            result.image_data = b"other"  # type: ignore[misc]
+
+
+# ---------------------------------------------------------------------------
+# Protocol conformance
+# ---------------------------------------------------------------------------
+
+
+class TestImageProviderProtocol:
+    def test_openai_provider_conforms(self) -> None:
+        """OpenAIImageProvider satisfies the ImageProvider protocol."""
+        from questfoundry.providers.image_openai import OpenAIImageProvider
+
+        with patch.dict("os.environ", {"OPENAI_API_KEY": "test-key"}):
+            provider = OpenAIImageProvider(model="gpt-image-1")
+
+        assert isinstance(provider, ImageProvider)
+
+
+# ---------------------------------------------------------------------------
+# Exception hierarchy
+# ---------------------------------------------------------------------------
+
+
+class TestExceptions:
+    def test_base_error(self) -> None:
+        err = ImageProviderError("openai", "something failed")
+        assert err.provider == "openai"
+        assert "[openai]" in str(err)
+
+    def test_content_policy_inherits(self) -> None:
+        err = ImageContentPolicyError("openai", "rejected")
+        assert isinstance(err, ImageProviderError)
+
+    def test_connection_error_inherits(self) -> None:
+        err = ImageProviderConnectionError("openai", "timeout")
+        assert isinstance(err, ImageProviderError)
+
+
+# ---------------------------------------------------------------------------
+# OpenAIImageProvider
+# ---------------------------------------------------------------------------
+
+
+class TestOpenAIImageProvider:
+    def test_missing_api_key_raises(self) -> None:
+        from questfoundry.providers.image_openai import OpenAIImageProvider
+
+        with (
+            patch.dict("os.environ", {}, clear=True),
+            pytest.raises(ImageProviderError, match="API key"),
+        ):
+            OpenAIImageProvider(api_key=None)
+
+    def test_explicit_api_key(self) -> None:
+        from questfoundry.providers.image_openai import OpenAIImageProvider
+
+        provider = OpenAIImageProvider(api_key="sk-test")
+        assert provider._api_key == "sk-test"
+
+    def test_env_api_key(self) -> None:
+        from questfoundry.providers.image_openai import OpenAIImageProvider
+
+        with patch.dict("os.environ", {"OPENAI_API_KEY": "sk-env"}):
+            provider = OpenAIImageProvider()
+
+        assert provider._api_key == "sk-env"
+
+    def test_invalid_output_format_raises(self) -> None:
+        from questfoundry.providers.image_openai import OpenAIImageProvider
+
+        with pytest.raises(ImageProviderError, match="Unsupported output_format"):
+            OpenAIImageProvider(api_key="sk-test", output_format="bmp")
+
+    @pytest.mark.asyncio()
+    async def test_generate_success(self) -> None:
+        from questfoundry.providers.image_openai import OpenAIImageProvider
+
+        # Create mock response matching OpenAI API structure
+        mock_image_item = type(
+            "ImageItem",
+            (),
+            {
+                "b64_json": base64.b64encode(b"fake_png_data").decode(),
+                "revised_prompt": "A beautiful scene",
+            },
+        )()
+        mock_response = type(
+            "ImagesResponse",
+            (),
+            {
+                "data": [mock_image_item],
+            },
+        )()
+
+        provider = OpenAIImageProvider(api_key="sk-test", model="gpt-image-1")
+        provider._client = AsyncMock()
+        provider._client.images.generate = AsyncMock(return_value=mock_response)
+
+        result = await provider.generate(
+            "A watercolor landscape",
+            negative_prompt="photorealistic",
+            aspect_ratio="16:9",
+            quality="hd",
+        )
+
+        assert result.image_data == b"fake_png_data"
+        assert result.content_type == "image/png"
+        assert result.provider_metadata["model"] == "gpt-image-1"
+        assert result.provider_metadata["revised_prompt"] == "A beautiful scene"
+        assert result.provider_metadata["size"] == "1792x1024"
+
+        # Verify API was called with correct params
+        call_kwargs = provider._client.images.generate.call_args
+        assert "Avoid: photorealistic" in call_kwargs.kwargs["prompt"]
+        assert call_kwargs.kwargs["size"] == "1792x1024"
+
+    @pytest.mark.asyncio()
+    async def test_generate_content_policy_error(self) -> None:
+        from openai import APIStatusError
+
+        from questfoundry.providers.image_openai import OpenAIImageProvider
+
+        # Create a real APIStatusError for content policy
+        mock_request = type(
+            "Request",
+            (),
+            {
+                "url": "https://api.openai.com/v1/images/generations",
+                "method": "POST",
+                "headers": {},
+            },
+        )()
+        mock_response = type(
+            "Response", (), {"status_code": 400, "headers": {}, "request": mock_request}
+        )()
+        error = APIStatusError(
+            message="content_policy_violation: unsafe content",
+            response=mock_response,  # type: ignore[arg-type]
+            body=None,
+        )
+
+        provider = OpenAIImageProvider(api_key="sk-test")
+        provider._client = AsyncMock()
+        provider._client.images.generate = AsyncMock(side_effect=error)
+
+        with pytest.raises(ImageContentPolicyError):
+            await provider.generate("test prompt")
+
+    @pytest.mark.asyncio()
+    async def test_generate_connection_error(self) -> None:
+        from openai import APIConnectionError
+
+        from questfoundry.providers.image_openai import OpenAIImageProvider
+
+        error = APIConnectionError(request=AsyncMock())
+
+        provider = OpenAIImageProvider(api_key="sk-test")
+        provider._client = AsyncMock()
+        provider._client.images.generate = AsyncMock(side_effect=error)
+
+        with pytest.raises(ImageProviderConnectionError):
+            await provider.generate("test prompt")
+
+    @pytest.mark.asyncio()
+    async def test_generate_empty_response(self) -> None:
+        from questfoundry.providers.image_openai import OpenAIImageProvider
+
+        mock_response = type("ImagesResponse", (), {"data": []})()
+
+        provider = OpenAIImageProvider(api_key="sk-test")
+        provider._client = AsyncMock()
+        provider._client.images.generate = AsyncMock(return_value=mock_response)
+
+        with pytest.raises(ImageProviderError, match="Empty response"):
+            await provider.generate("test prompt")
+
+    @pytest.mark.asyncio()
+    async def test_invalid_aspect_ratio_raises(self) -> None:
+        from questfoundry.providers.image_openai import OpenAIImageProvider
+
+        provider = OpenAIImageProvider(api_key="sk-test")
+
+        with pytest.raises(ImageProviderError, match="Unsupported aspect_ratio"):
+            await provider.generate("test prompt", aspect_ratio="4:3")
+
+
+# ---------------------------------------------------------------------------
+# Factory
+# ---------------------------------------------------------------------------
+
+
+class TestCreateImageProvider:
+    def test_openai_with_model(self) -> None:
+        from questfoundry.providers.image_openai import create_image_provider
+
+        with patch.dict("os.environ", {"OPENAI_API_KEY": "sk-test"}):
+            provider = create_image_provider("openai/gpt-image-1")
+
+        assert isinstance(provider, ImageProvider)
+        assert provider._model == "gpt-image-1"
+
+    def test_openai_default_model(self) -> None:
+        from questfoundry.providers.image_openai import create_image_provider
+
+        with patch.dict("os.environ", {"OPENAI_API_KEY": "sk-test"}):
+            provider = create_image_provider("openai")
+
+        assert provider._model == "gpt-image-1"
+
+    def test_unknown_provider_raises(self) -> None:
+        from questfoundry.providers.image_openai import create_image_provider
+
+        with pytest.raises(ImageProviderError, match="Unknown image provider"):
+            create_image_provider("midjourney/v6")
+
+    def test_aspect_ratio_mapping(self) -> None:
+        from questfoundry.providers.image_openai import _ASPECT_RATIO_TO_SIZE
+
+        assert _ASPECT_RATIO_TO_SIZE["1:1"] == "1024x1024"
+        assert _ASPECT_RATIO_TO_SIZE["16:9"] == "1792x1024"
+        assert _ASPECT_RATIO_TO_SIZE["9:16"] == "1024x1792"


### PR DESCRIPTION
Stacked PRs:
 * #450
 * #449
 * #448
 * #447
 * #446
 * __->__#445
 * #444
 * #443
 * #442


--- --- ---

### feat(providers): add ImageProvider protocol with OpenAI implementation


Add ImageProvider protocol (runtime-checkable) and ImageResult dataclass
for image generation backends. LangChain has no BaseImageModel, so we
define our own thin protocol.

Add OpenAIImageProvider supporting gpt-image-1 and dall-e-3 via the
OpenAI Images API with aspect ratio mapping, negative prompt support,
and structured error handling (content policy, connection, general).

Add create_image_provider() factory for provider/model spec strings.

Closes #417

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>