### PR TITLE
feat(dress): implement review gate, image generation, and asset storage (Phases 3-4)

### DIFF
--- a/src/questfoundry/artifacts/assets.py
+++ b/src/questfoundry/artifacts/assets.py
@@ -1,0 +1,69 @@
+"""Asset storage for generated images and other binary content.
+
+Provides hash-based deduplication and organized storage under the
+project's ``assets/`` directory.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from typing import TYPE_CHECKING
+
+from questfoundry.observability.logging import get_logger
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+log = get_logger(__name__)
+
+# Extension mapping from MIME content types
+_CONTENT_TYPE_TO_EXT: dict[str, str] = {
+    "image/png": ".png",
+    "image/jpeg": ".jpg",
+    "image/webp": ".webp",
+}
+
+
+class AssetManager:
+    """Manage binary assets (images) for a project.
+
+    Stores files in ``{project_path}/assets/`` with hash-based naming
+    for automatic deduplication.
+
+    Args:
+        project_path: Root path of the project directory.
+    """
+
+    def __init__(self, project_path: Path) -> None:
+        self.assets_dir = project_path / "assets"
+
+    def store(self, data: bytes, content_type: str = "image/png") -> str:
+        """Store binary data and return relative path.
+
+        Uses SHA-256 hash prefix for filename deduplication — storing
+        the same image twice returns the same path without writing.
+
+        Args:
+            data: Raw binary data to store.
+            content_type: MIME type for file extension mapping.
+
+        Returns:
+            Relative path from project root (e.g., ``assets/a1b2c3d4e5f6.png``).
+        """
+        ext = _CONTENT_TYPE_TO_EXT.get(content_type)
+        if ext is None:
+            supported = ", ".join(sorted(_CONTENT_TYPE_TO_EXT))
+            msg = f"Unsupported content_type '{content_type}'. Supported: {supported}"
+            raise ValueError(msg)
+        digest = hashlib.sha256(data).hexdigest()[:16]
+        filename = f"{digest}{ext}"
+        path = self.assets_dir / filename
+
+        if path.exists():
+            log.debug("asset_deduplicated", filename=filename)
+            return f"assets/{filename}"
+
+        self.assets_dir.mkdir(parents=True, exist_ok=True)
+        path.write_bytes(data)
+        log.debug("asset_stored", filename=filename, size_bytes=len(data))
+        return f"assets/{filename}"

--- a/tests/unit/test_dress_stage.py
+++ b/tests/unit/test_dress_stage.py
@@ -24,6 +24,7 @@ from questfoundry.models.dress import (
 from questfoundry.pipeline.stages.dress import (
     DressStage,
     DressStageError,
+    assemble_image_prompt,
     compute_structural_score,
     create_dress_stage,
     dress_stage,
@@ -231,18 +232,15 @@ class TestPhase0ArtDirection:
                     (mock_codex_out, 1, 50),  # Phase 2: aldric
                 ],
             ),
-            # Phases 0-2 succeed, Phase 3 raises NotImplementedError
-            pytest.raises(NotImplementedError, match="PR 6"),
         ):
             await stage.execute(MagicMock(), "Establish art direction")
 
-        # Verify graph was updated (checkpoint before review has all results)
-        checkpoint = tmp_path / "snapshots" / "dress-pre-review.json"
-        assert checkpoint.exists()
-        graph = Graph.load_from_file(checkpoint)
+        # Verify graph was updated (final graph has all phase results)
+        graph = Graph.load(tmp_path)
         assert graph.get_node("art_direction::main") is not None
         assert graph.get_node("entity_visual::protagonist") is not None
         assert graph.get_node("entity_visual::aldric") is not None
+        assert graph.get_last_stage() == "dress"
 
     @pytest.mark.asyncio()
     async def test_phase0_counts_metrics(
@@ -327,22 +325,144 @@ class TestPhase0ArtDirection:
 
 
 # ---------------------------------------------------------------------------
-# Phase stubs (3-4 remain)
+# Phase 3: Review Gate
 # ---------------------------------------------------------------------------
 
 
-class TestPhaseStubs:
+class TestPhase3Review:
     @pytest.mark.asyncio()
-    async def test_phase3_not_implemented(self) -> None:
+    async def test_selects_all_briefs(self) -> None:
+        """Auto-approve mode selects all briefs sorted by priority."""
+        g = Graph()
+        g.create_node(
+            "illustration_brief::opening",
+            {"type": "illustration_brief", "priority": 2, "subject": "Opening scene"},
+        )
+        g.create_node(
+            "illustration_brief::climax",
+            {"type": "illustration_brief", "priority": 1, "subject": "Climax"},
+        )
+
         stage = DressStage()
-        with pytest.raises(NotImplementedError, match="PR 6"):
-            await stage._phase_3_review(Graph(), MagicMock())
+        result = await stage._phase_3_review(g, MagicMock())
+
+        assert result.status == "completed"
+        assert "2 of 2" in result.detail
+
+        selection = g.get_node("dress_meta::selection")
+        assert selection is not None
+        # Should be sorted by priority (1 first)
+        assert selection["selected_briefs"][0] == "illustration_brief::climax"
 
     @pytest.mark.asyncio()
-    async def test_phase4_not_implemented(self) -> None:
+    async def test_no_briefs(self) -> None:
+        g = Graph()
         stage = DressStage()
-        with pytest.raises(NotImplementedError, match="PR 6"):
-            await stage._phase_4_generate(Graph(), MagicMock())
+        result = await stage._phase_3_review(g, MagicMock())
+        assert result.detail == "no briefs to review"
+
+
+# ---------------------------------------------------------------------------
+# Phase 4: Image Generation
+# ---------------------------------------------------------------------------
+
+
+class TestPhase4Generate:
+    @pytest.mark.asyncio()
+    async def test_generates_images(self, tmp_path: Path) -> None:
+        """Phase 4 generates images and creates illustration nodes."""
+        g = Graph()
+        g.create_node(
+            "art_direction::main",
+            {"type": "art_direction", "style": "ink", "aspect_ratio": "16:9"},
+        )
+        g.create_node(
+            "illustration_brief::opening",
+            {
+                "type": "illustration_brief",
+                "subject": "Opening scene",
+                "composition": "Wide shot",
+                "mood": "foreboding",
+                "caption": "The wind howled.",
+                "category": "scene",
+                "entities": [],
+            },
+        )
+        g.create_node("passage::opening", {"type": "passage"})
+        g.add_edge("targets", "illustration_brief::opening", "passage::opening")
+        g.upsert_node(
+            "dress_meta::selection",
+            {
+                "type": "dress_meta",
+                "selected_briefs": ["illustration_brief::opening"],
+                "total_briefs": 1,
+            },
+        )
+
+        mock_result = MagicMock()
+        mock_result.image_data = b"fake_png_data"
+        mock_result.content_type = "image/png"
+
+        mock_provider = AsyncMock()
+        mock_provider.generate = AsyncMock(return_value=mock_result)
+
+        stage = DressStage(project_path=tmp_path, image_provider="openai/gpt-image-1")
+
+        with patch(
+            "questfoundry.pipeline.stages.dress.create_image_provider",
+            return_value=mock_provider,
+        ):
+            result = await stage._phase_4_generate(g, MagicMock())
+
+        assert result.status == "completed"
+        assert "1 images generated" in result.detail
+        assert g.get_node("illustration::opening") is not None
+
+    @pytest.mark.asyncio()
+    async def test_no_provider_skips(self) -> None:
+        """Phase 4 skips gracefully when no image provider configured."""
+        g = Graph()
+        stage = DressStage()
+        result = await stage._phase_4_generate(g, MagicMock())
+        assert "no image provider" in result.detail
+
+    @pytest.mark.asyncio()
+    async def test_no_selection_skips(self) -> None:
+        stage = DressStage(image_provider="openai/gpt-image-1")
+        g = Graph()
+        result = await stage._phase_4_generate(g, MagicMock())
+        assert "no selection metadata" in result.detail
+
+    @pytest.mark.asyncio()
+    async def test_provider_error_continues(self, tmp_path: Path) -> None:
+        """ImageProviderError on one brief doesn't stop others."""
+        from questfoundry.providers.image import ImageProviderError
+
+        g = Graph()
+        g.create_node("art_direction::main", {"type": "art_direction", "style": "ink"})
+        g.create_node(
+            "illustration_brief::fail",
+            {"type": "illustration_brief", "subject": "Fail", "entities": []},
+        )
+        g.upsert_node(
+            "dress_meta::selection",
+            {"type": "dress_meta", "selected_briefs": ["illustration_brief::fail"]},
+        )
+
+        mock_provider = AsyncMock()
+        mock_provider.generate = AsyncMock(
+            side_effect=ImageProviderError("openai", "content policy")
+        )
+
+        stage = DressStage(project_path=tmp_path, image_provider="openai/test")
+
+        with patch(
+            "questfoundry.pipeline.stages.dress.create_image_provider",
+            return_value=mock_provider,
+        ):
+            result = await stage._phase_4_generate(g, MagicMock())
+
+        assert "0 images generated, 1 failed" in result.detail
 
 
 # ---------------------------------------------------------------------------
@@ -678,3 +798,98 @@ class TestPhase2Codex:
 
         assert result.status == "completed"
         assert g.get_node("codex::protagonist_rank1") is not None
+
+
+# ---------------------------------------------------------------------------
+# AssetManager
+# ---------------------------------------------------------------------------
+
+
+class TestAssetManager:
+    def test_store_creates_file(self, tmp_path: Path) -> None:
+        from questfoundry.artifacts.assets import AssetManager
+
+        mgr = AssetManager(tmp_path)
+        path = mgr.store(b"fake_png_data", "image/png")
+
+        assert path.startswith("assets/")
+        assert path.endswith(".png")
+        assert (tmp_path / path).exists()
+        assert (tmp_path / path).read_bytes() == b"fake_png_data"
+
+    def test_deduplication(self, tmp_path: Path) -> None:
+        from questfoundry.artifacts.assets import AssetManager
+
+        mgr = AssetManager(tmp_path)
+        path1 = mgr.store(b"same_data", "image/png")
+        path2 = mgr.store(b"same_data", "image/png")
+
+        assert path1 == path2
+
+    def test_webp_extension(self, tmp_path: Path) -> None:
+        from questfoundry.artifacts.assets import AssetManager
+
+        mgr = AssetManager(tmp_path)
+        path = mgr.store(b"webp_data", "image/webp")
+        assert path.endswith(".webp")
+
+
+# ---------------------------------------------------------------------------
+# Image prompt assembly
+# ---------------------------------------------------------------------------
+
+
+class TestAssembleImagePrompt:
+    def test_combines_art_direction_and_brief(self) -> None:
+        g = Graph()
+        g.create_node(
+            "art_direction::main",
+            {
+                "type": "art_direction",
+                "style": "watercolor",
+                "medium": "traditional paper",
+                "palette": ["deep indigo", "gold"],
+                "negative_defaults": "photorealism",
+            },
+        )
+
+        brief = {
+            "subject": "Scholar at the bridge",
+            "composition": "Wide shot",
+            "mood": "foreboding",
+            "negative": "modern elements",
+            "entities": [],
+        }
+
+        positive, negative = assemble_image_prompt(g, brief)
+
+        assert "Scholar at the bridge" in positive
+        assert "watercolor" in positive
+        assert "deep indigo" in positive
+        assert negative is not None
+        assert "modern elements" in negative
+        assert "photorealism" in negative
+
+    def test_includes_entity_visuals(self) -> None:
+        g = Graph()
+        g.create_node("art_direction::main", {"type": "art_direction", "style": "ink"})
+        g.create_node(
+            "entity_visual::hero",
+            {
+                "type": "entity_visual",
+                "reference_prompt_fragment": "tall warrior, scarred face",
+            },
+        )
+
+        brief = {"subject": "Battle scene", "entities": ["hero"]}
+        positive, _negative = assemble_image_prompt(g, brief)
+
+        assert "tall warrior, scarred face" in positive
+
+    def test_no_art_direction(self) -> None:
+        g = Graph()
+        brief = {"subject": "A simple scene", "entities": []}
+        positive, negative = assemble_image_prompt(g, brief)
+
+        assert "A simple scene" in positive
+        assert negative is None


### PR DESCRIPTION
Stacked PRs:
 * #450
 * __->__#449
 * #448
 * #447
 * #446
 * #445
 * #444
 * #443
 * #442


--- --- ---

### feat(dress): implement review gate, image generation, and asset storage (Phases 3-4)


Add Phase 3 review gate that selects briefs by priority, Phase 4
image generation via ImageProvider with AssetManager for hash-based
dedup storage, and assemble_image_prompt for combining art direction
with brief details. All five DRESS phases now execute end-to-end.

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>