### PR TITLE
feat(cli): add qf dress command and register DRESS stage

### DIFF
--- a/src/questfoundry/pipeline/orchestrator.py
+++ b/src/questfoundry/pipeline/orchestrator.py
@@ -505,6 +505,11 @@ class PipelineOrchestrator:
             if on_phase_progress:
                 stage_kwargs["on_phase_progress"] = on_phase_progress
 
+            # Stage-specific options
+            image_provider = context.get("image_provider")
+            if image_provider:
+                stage_kwargs["image_provider"] = image_provider
+
             # Resolve size profile from DREAM vision node (for post-DREAM stages)
             if stage_name != "dream":
                 try:

--- a/src/questfoundry/pipeline/stages/__init__.py
+++ b/src/questfoundry/pipeline/stages/__init__.py
@@ -15,6 +15,12 @@ from questfoundry.pipeline.stages.brainstorm import (
     create_brainstorm_stage,
 )
 from questfoundry.pipeline.stages.dream import DreamStage, dream_stage
+from questfoundry.pipeline.stages.dress import (
+    DressStage,
+    DressStageError,
+    create_dress_stage,
+    dress_stage,
+)
 from questfoundry.pipeline.stages.fill import (
     FillStage,
     FillStageError,
@@ -40,11 +46,14 @@ register_stage(brainstorm_stage)
 register_stage(seed_stage)
 register_stage(grow_stage)
 register_stage(fill_stage)
+register_stage(dress_stage)
 
 __all__ = [
     "BrainstormStage",
     "BrainstormStageError",
     "DreamStage",
+    "DressStage",
+    "DressStageError",
     "FillStage",
     "FillStageError",
     "GrowStage",
@@ -54,10 +63,12 @@ __all__ = [
     "Stage",
     "brainstorm_stage",
     "create_brainstorm_stage",
+    "create_dress_stage",
     "create_fill_stage",
     "create_grow_stage",
     "create_seed_stage",
     "dream_stage",
+    "dress_stage",
     "fill_stage",
     "get_stage",
     "grow_stage",

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -599,7 +599,7 @@ def test_seed_no_prompt_noninteractive_uses_default(tmp_path: Path) -> None:
 
 def test_stage_order_constant() -> None:
     """Test STAGE_ORDER contains expected stages in order."""
-    assert STAGE_ORDER == ["dream", "brainstorm", "seed", "grow", "fill"]
+    assert STAGE_ORDER == ["dream", "brainstorm", "seed", "grow", "fill", "dress"]
 
 
 def test_stage_prompts_has_all_stages() -> None:


### PR DESCRIPTION
Stacked PRs:
 * __->__#450
 * #449
 * #448
 * #447
 * #446
 * #445
 * #444
 * #443
 * #442


--- --- ---

### feat(cli): add qf dress command and register DRESS stage


Register DressStage in the pipeline stage registry, add the `qf dress`
CLI command with --image-provider option, preview function for DRESS
artifacts, and orchestrator support for image_provider context.

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>