### PR TITLE
fix(prompts): remove Human: prefix from system prompts

### DIFF
--- a/prompts/templates/serialize_seed.yaml
+++ b/prompts/templates/serialize_seed.yaml
@@ -20,21 +20,21 @@ system: |
   ### 1. entities (Entity Decisions)
   For EVERY entity from brainstorm (characters, locations, objects, AND factions), create an EntityDecision:
   ```json
-  {
+  {{
     "entity_id": "entity::butler",
     "disposition": "retained"
-  }
+  }}
   ```
   IMPORTANT: Include ALL entity types - don't skip factions!
 
   ### 2. dilemmas (Dilemma Decisions)
   For each dilemma from brainstorm, create a DilemmaDecision:
   ```json
-  {
+  {{
     "dilemma_id": "dilemma::host_benevolent_or_selfish",
     "explored": ["protector", "manipulator"],
     "unexplored": []
-  }
+  }}
   ```
   NOTES:
   - The default path answer (is_default_path=true) MUST be in "explored", never in "unexplored".
@@ -44,7 +44,7 @@ system: |
   ### 3. paths (Story Paths)
   For each explored answer, create a Path:
   ```json
-  {
+  {{
     "path_id": "path::host_benevolent_or_selfish__protector",
     "name": "Human Readable Path Name",
     "dilemma_id": "dilemma::host_benevolent_or_selfish",
@@ -53,46 +53,46 @@ system: |
     "path_importance": "major",
     "description": "What this path is about",
     "consequence_ids": ["host_revealed"]
-  }
+  }}
   ```
 
   ### 4. consequences (Narrative Consequences)
   For each path, create its Consequences:
   ```json
-  {
+  {{
     "consequence_id": "host_revealed",
     "path_id": "path::host_benevolent_or_selfish__protector",
     "description": "What happens narratively",
     "narrative_effects": ["story effect 1", "story effect 2"]
-  }
+  }}
   ```
 
   ### 5. initial_beats (Initial Beats - {size_beats_per_path} per path)
   Create {size_beats_per_path} InitialBeat objects PER PATH (e.g., with 3 paths and a "2-4" range, expect 6-12 beats total).
   ```json
-  {
+  {{
     "beat_id": "host_motive_beat_01",
     "summary": "What happens in this beat",
     "paths": ["path::host_benevolent_or_selfish__protector"],
     "dilemma_impacts": [
-      {
+      {{
         "dilemma_id": "dilemma::host_benevolent_or_selfish",
         "effect": "advances",
         "note": "Explanation of the impact"
-      }
+      }}
     ],
     "entities": ["entity::butler", "entity::guest"],
     "location": "entity::manor",
     "location_alternatives": ["entity::garden"]
-  }
+  }}
   ```
 
   ### 6. convergence_sketch
   ```json
-  {
+  {{
     "convergence_points": ["where paths should merge"],
     "residue_notes": ["differences that persist after convergence"]
-  }
+  }}
   ```
 
   ## Mapping Rules

--- a/src/questfoundry/agents/prompts.py
+++ b/src/questfoundry/agents/prompts.py
@@ -1,6 +1,6 @@
 """Prompt templates for agents.
 
-Uses LangChain's ChatPromptTemplate for variable injection, with templates
+Uses LangChain's PromptTemplate for variable injection, with templates
 stored externally in YAML files under prompts/templates/.
 """
 
@@ -9,7 +9,7 @@ from __future__ import annotations
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
-from langchain_core.prompts import ChatPromptTemplate
+from langchain_core.prompts import PromptTemplate
 
 from questfoundry.pipeline.size import size_template_vars
 from questfoundry.prompts.loader import PromptLoader
@@ -145,7 +145,7 @@ def _render_discuss_template(
     size_presets_section = raw_data.get("size_presets_section", "")
 
     system_template = raw_data.get("system", "")
-    prompt = ChatPromptTemplate.from_template(system_template)
+    prompt = PromptTemplate.from_template(system_template)
 
     return prompt.format(
         research_tools_section=research_section,
@@ -195,7 +195,7 @@ def get_brainstorm_summarize_prompt(
     """
     loader = _get_loader()
     template = loader.load("summarize_brainstorm")
-    prompt = ChatPromptTemplate.from_template(template.system)
+    prompt = PromptTemplate.from_template(template.system)
     return prompt.format(**size_template_vars(size_profile))
 
 
@@ -255,7 +255,7 @@ def get_seed_summarize_prompt(
 
     # Render the system template with brainstorm context and manifest info
     system_template = raw_data.get("system", "")
-    prompt = ChatPromptTemplate.from_template(system_template)
+    prompt = PromptTemplate.from_template(system_template)
     return prompt.format(
         brainstorm_context=brainstorm_context,
         entity_count=entity_count,
@@ -298,5 +298,5 @@ def get_seed_serialize_prompt(
     """
     loader = _get_loader()
     template = loader.load("serialize_seed")
-    prompt = ChatPromptTemplate.from_template(template.system)
+    prompt = PromptTemplate.from_template(template.system)
     return prompt.format(**size_template_vars(size_profile))

--- a/src/questfoundry/cli.py
+++ b/src/questfoundry/cli.py
@@ -256,13 +256,21 @@ def _ensure_project(
     name = project_path.name
 
     if auto_init:
-        project_path = _init_project(name, project_path.parent, provider=provider)
+        # For simple names (no path separators), default to _projects_dir
+        # so that `qf run --init --project foo` creates projects/foo/
+        parent = project_path.parent
+        if len(project_path.parts) == 1:
+            parent = _projects_dir
+        project_path = _init_project(name, parent, provider=provider)
         console.print(f"[green]✓[/green] Created project: [bold]{name}[/bold]")
         return project_path
 
     if _is_interactive_tty():
         if typer.confirm(f"Project '{name}' doesn't exist. Create it?", default=True):
-            project_path = _init_project(name, project_path.parent, provider=provider)
+            parent = project_path.parent
+            if len(project_path.parts) == 1:
+                parent = _projects_dir
+            project_path = _init_project(name, parent, provider=provider)
             console.print(f"[green]✓[/green] Created project: [bold]{name}[/bold]")
             return project_path
         raise typer.Exit(0)

--- a/tests/unit/test_prompt_human_prefix.py
+++ b/tests/unit/test_prompt_human_prefix.py
@@ -1,0 +1,78 @@
+"""Regression tests: prompt functions must not inject role prefixes.
+
+ChatPromptTemplate.from_template().format() prepends "Human: " to the
+rendered string.  When that string is later wrapped in a SystemMessage,
+the LLM sees conflicting role signals and degrades output quality.
+
+PromptTemplate.from_template().format() does NOT add a prefix.
+These tests guard against accidentally switching back.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from questfoundry.agents.prompts import (
+    get_brainstorm_discuss_prompt,
+    get_brainstorm_summarize_prompt,
+    get_seed_serialize_prompt,
+    get_seed_summarize_prompt,
+)
+
+HUMAN_PREFIX = "Human:"
+
+
+class TestNoHumanPrefix:
+    """Every prompt builder must return raw text, never 'Human: …'."""
+
+    def test_brainstorm_discuss_prompt(self) -> None:
+        result = get_brainstorm_discuss_prompt(
+            vision_context="test vision",
+            research_tools_available=False,
+            interactive=False,
+        )
+        assert not result.startswith(HUMAN_PREFIX), (
+            f"get_brainstorm_discuss_prompt() starts with '{HUMAN_PREFIX}'"
+        )
+
+    def test_brainstorm_summarize_prompt(self) -> None:
+        result = get_brainstorm_summarize_prompt()
+        assert not result.startswith(HUMAN_PREFIX), (
+            f"get_brainstorm_summarize_prompt() starts with '{HUMAN_PREFIX}'"
+        )
+
+    def test_seed_summarize_prompt(self) -> None:
+        result = get_seed_summarize_prompt(brainstorm_context="test context")
+        assert not result.startswith(HUMAN_PREFIX), (
+            f"get_seed_summarize_prompt() starts with '{HUMAN_PREFIX}'"
+        )
+
+    def test_seed_serialize_prompt(self) -> None:
+        result = get_seed_serialize_prompt()
+        assert not result.startswith(HUMAN_PREFIX), (
+            f"get_seed_serialize_prompt() starts with '{HUMAN_PREFIX}'"
+        )
+
+    @pytest.mark.parametrize(
+        "func,kwargs",
+        [
+            pytest.param(
+                get_brainstorm_discuss_prompt,
+                {"vision_context": "v", "research_tools_available": False, "interactive": False},
+                id="brainstorm_discuss",
+            ),
+            pytest.param(get_brainstorm_summarize_prompt, {}, id="brainstorm_summarize"),
+            pytest.param(
+                get_seed_summarize_prompt, {"brainstorm_context": "c"}, id="seed_summarize"
+            ),
+            pytest.param(get_seed_serialize_prompt, {}, id="seed_serialize"),
+        ],
+    )
+    def test_no_role_prefix_anywhere(self, func: object, kwargs: dict) -> None:
+        """No prompt should contain any role prefix as a line start."""
+        result = func(**kwargs)  # type: ignore[operator]
+        for line in result.splitlines():
+            stripped = line.strip()
+            assert not stripped.startswith("Human:"), (
+                f"{func.__name__}() contains a line starting with 'Human:': {stripped[:80]}"
+            )

--- a/tests/unit/test_prompt_human_prefix.py
+++ b/tests/unit/test_prompt_human_prefix.py
@@ -19,39 +19,9 @@ from questfoundry.agents.prompts import (
     get_seed_summarize_prompt,
 )
 
-HUMAN_PREFIX = "Human:"
-
 
 class TestNoHumanPrefix:
     """Every prompt builder must return raw text, never 'Human: …'."""
-
-    def test_brainstorm_discuss_prompt(self) -> None:
-        result = get_brainstorm_discuss_prompt(
-            vision_context="test vision",
-            research_tools_available=False,
-            interactive=False,
-        )
-        assert not result.startswith(HUMAN_PREFIX), (
-            f"get_brainstorm_discuss_prompt() starts with '{HUMAN_PREFIX}'"
-        )
-
-    def test_brainstorm_summarize_prompt(self) -> None:
-        result = get_brainstorm_summarize_prompt()
-        assert not result.startswith(HUMAN_PREFIX), (
-            f"get_brainstorm_summarize_prompt() starts with '{HUMAN_PREFIX}'"
-        )
-
-    def test_seed_summarize_prompt(self) -> None:
-        result = get_seed_summarize_prompt(brainstorm_context="test context")
-        assert not result.startswith(HUMAN_PREFIX), (
-            f"get_seed_summarize_prompt() starts with '{HUMAN_PREFIX}'"
-        )
-
-    def test_seed_serialize_prompt(self) -> None:
-        result = get_seed_serialize_prompt()
-        assert not result.startswith(HUMAN_PREFIX), (
-            f"get_seed_serialize_prompt() starts with '{HUMAN_PREFIX}'"
-        )
 
     @pytest.mark.parametrize(
         "func,kwargs",


### PR DESCRIPTION
## Problem

Two bugs from recent PRs:

1. **Human: prefix in system prompts** — The size-profile PR (`511b51a`) changed
   `get_brainstorm_summarize_prompt()` and `get_seed_serialize_prompt()` to use
   `ChatPromptTemplate.from_template().format()` for template variable substitution.
   `ChatPromptTemplate.format()` prepends `"Human: "` to the rendered string. When
   that string is then inserted into a `SystemMessage`, the LLM sees conflicting role
   signals, degrading summary quality. This caused brainstorm serialization failures
   (phantom entity IDs) in the Jan 31 test run.

2. **--init creates projects at CWD** — `qf run --init --project foo` created the
   project at the repo root instead of under `projects/`. `_resolve_project_path`
   returned the name as-is for non-existent paths, and `_ensure_project` used the
   CWD as the parent directory.

## Changes

- Replace `ChatPromptTemplate` with `PromptTemplate` in all 4 locations in
  `src/questfoundry/agents/prompts.py` — `PromptTemplate.format()` returns the
  plain formatted string without any role prefix
- Escape literal JSON `{`/`}` as `{{`/`}}` in `serialize_seed.yaml` — latent crash
  when the template engine tries to parse JSON examples as variables
- Add regression tests verifying no prompt function returns strings starting with `"Human:"`
- Fix `_ensure_project` to use `_projects_dir` for simple project names, matching
  the behavior of `qf init`

## Test Plan

```bash
uv run pytest tests/unit/test_prompt_human_prefix.py -x -q     # 8 passed
uv run pytest tests/unit/test_seed_prompts.py tests/unit/test_discuss_agent.py tests/unit/test_summarize.py -x -q  # 48 passed
uv run mypy src/questfoundry/agents/prompts.py src/questfoundry/cli.py  # Success
uv run ruff check src/ tests/                                  # All checks passed
```

## Risk / Rollback

- Low risk: `PromptTemplate` is a drop-in replacement with identical template parsing
  but without the role-prefix side effect
- Template brace escaping produces identical output text for the LLM
- The `--init` fix only affects the auto-creation path, not existing projects

🤖 Generated with [Claude Code](https://claude.com/claude-code)