### PR TITLE
fix(grow): add explicit dilemma tags to intersection beat summaries

### DIFF
--- a/prompts/templates/grow_phase3_intersections.yaml
+++ b/prompts/templates/grow_phase3_intersections.yaml
@@ -19,14 +19,22 @@ system: |
   5. CRITICAL: Each beat can appear in at most ONE intersection. Never assign the
      same beat to multiple intersections.
 
+  ## Dilemma Matching (CRITICAL)
+  Each beat below is tagged with `[dilemma: ...]`. Use this tag to ensure
+  every intersection mixes beats from DIFFERENT dilemmas:
+
+  GOOD: beat from [dilemma: dilemma::A] + beat from [dilemma: dilemma::B] = valid (2 different dilemmas)
+  BAD:  beat from [dilemma: dilemma::A] + beat from [dilemma: dilemma::A] = INVALID (same dilemma)
+
   ## What NOT to Do
-  - Do NOT group beats from the same dilemma (those are paths, not intersections)
+  - Do NOT group beats that share the same [dilemma: ...] tag
   - Do NOT propose intersections with only 1 beat
   - Do NOT use beat IDs not listed in the Valid IDs section
   - Do NOT force intersections where there is no natural scene overlap
   - Do NOT reuse a beat ID across multiple intersection proposals
 
   ## Candidate Beats
+  Each beat is tagged with its dilemma in [dilemma: ...]. Mix different dilemmas.
   {beat_summaries}
 
   ## Valid IDs

--- a/src/questfoundry/pipeline/stages/grow.py
+++ b/src/questfoundry/pipeline/stages/grow.py
@@ -727,8 +727,15 @@ class GrowStage:
                 alternatives = data.get("location_alternatives", [])
                 summary = data.get("summary", "")
                 entities = data.get("entities", [])
+                dilemma_ids = [
+                    impact["dilemma_id"]
+                    for impact in data.get("dilemma_impacts", [])
+                    if "dilemma_id" in impact
+                ]
+                dilemma_tag = dilemma_ids[0] if dilemma_ids else "unknown"
                 beat_info[bid] = (
-                    f'- {bid}: summary="{summary}", '
+                    f"- {bid} [dilemma: {dilemma_tag}]: "
+                    f'summary="{summary}", '
                     f'location="{location}", '
                     f"location_alternatives={alternatives}, "
                     f"entities={entities}"

--- a/src/questfoundry/pipeline/stages/grow.py
+++ b/src/questfoundry/pipeline/stages/grow.py
@@ -727,11 +727,13 @@ class GrowStage:
                 alternatives = data.get("location_alternatives", [])
                 summary = data.get("summary", "")
                 entities = data.get("entities", [])
-                dilemma_ids = [
-                    impact["dilemma_id"]
-                    for impact in data.get("dilemma_impacts", [])
-                    if "dilemma_id" in impact
-                ]
+                dilemma_ids = sorted(
+                    {
+                        impact["dilemma_id"]
+                        for impact in data.get("dilemma_impacts", [])
+                        if "dilemma_id" in impact
+                    }
+                )
                 dilemma_tag = dilemma_ids[0] if dilemma_ids else "unknown"
                 beat_info[bid] = (
                     f"- {bid} [dilemma: {dilemma_tag}]: "


### PR DESCRIPTION
## Problem
GROW Phase 3 (intersections) fails when the LLM groups beats by dilemma instead of cross-dilemma. The beat summaries sent to the LLM include beat ID, summary, location, and entities — but not which dilemma the beat belongs to.

The dilemma is only inferrable from the beat ID naming convention (`beat::dilemma_name__answer_beat_NN`), which qwen3:4b parses unreliably. The model groups beats sharing a name prefix (e.g. all `black_archive_*` beats) rather than mixing beats from different dilemmas as required.

**Evidence**: `test-20260131T1159` has 52 beats pre-intersection, 4 locations with cross-dilemma overlap, but all 10 LLM proposals were single-dilemma — rejected by the validator.

## Changes
- Extract primary dilemma ID from each beat's `dilemma_impacts` and include as `[dilemma: ...]` tag in the beat summary line
- Add "Dilemma Matching" section to intersection prompt with explicit good/bad examples
- Rephrase "What NOT to Do" to reference the dilemma tags directly

## Not Included / Future PRs
- No changes to the validator logic (already correctly rejects same-dilemma intersections)
- No changes to `build_intersection_candidates` algorithm

## Test Plan
- `uv run mypy src/questfoundry/pipeline/stages/grow.py` — passes
- `uv run pytest tests/unit/test_grow*.py -x -q` — 362 passed

## Risk / Rollback
- Low risk — only changes context sent to LLM, no logic changes
- Validator remains the safety net for invalid proposals

🤖 Generated with [Claude Code](https://claude.com/claude-code)