### PR TITLE
fix(dream): make scope required so DREAM always sets story_size

### DIFF
--- a/prompts/templates/serialize.yaml
+++ b/prompts/templates/serialize.yaml
@@ -29,9 +29,10 @@ system: |
     {"story_size": "<preset>", "branching_depth": "<depth>", "estimated_passages": <int>, "target_word_count": <int>}
     Valid story_size: "vignette", "short", "standard", "long".
     Match branching_depth to size: vignette="light", short="light", standard="moderate", long="heavy".
-    If the brief says "vignette" → story_size="vignette", estimated_passages=10, target_word_count=3000.
-    If the brief says "short" → story_size="short", estimated_passages=20, target_word_count=10000.
-    If no size is mentioned → story_size="standard", estimated_passages=45, target_word_count=20000.
+    If the brief says "vignette" → story_size="vignette", estimated_passages=10, target_word_count=3500.
+    If the brief says "short" → story_size="short", estimated_passages=22, target_word_count=10000.
+    If the brief says "long" → story_size="long", estimated_passages=90, target_word_count=45000.
+    If no size is mentioned → story_size="standard", estimated_passages=45, target_word_count=22500.
   - content_notes (warnings/guidance, NOT specific scenes or character arcs)
 
   Do NOT serialize specific characters, scenes, endings, or mechanics into

--- a/prompts/templates/serialize.yaml
+++ b/prompts/templates/serialize.yaml
@@ -25,7 +25,13 @@ system: |
   detailed content, include ONLY:
   - genre, subgenre, tone, audience, themes (high-level descriptors)
   - style_notes (prose guidance, 50-200 chars, NOT plot summaries)
-  - scope (story_size preset, word count, passages, branching complexity)
+  - scope: ALWAYS include this object. Map the brief's size/scope language to:
+    {"story_size": "<preset>", "branching_depth": "<depth>", "estimated_passages": <int>, "target_word_count": <int>}
+    Valid story_size: "vignette", "short", "standard", "long".
+    Match branching_depth to size: vignette="light", short="light", standard="moderate", long="heavy".
+    If the brief says "vignette" → story_size="vignette", estimated_passages=10, target_word_count=3000.
+    If the brief says "short" → story_size="short", estimated_passages=20, target_word_count=10000.
+    If no size is mentioned → story_size="standard", estimated_passages=45, target_word_count=20000.
   - content_notes (warnings/guidance, NOT specific scenes or character arcs)
 
   Do NOT serialize specific characters, scenes, endings, or mechanics into

--- a/src/questfoundry/models/dream.py
+++ b/src/questfoundry/models/dream.py
@@ -40,11 +40,11 @@ class Scope(BaseModel):
         description="Branching complexity (e.g., light, moderate, heavy, extensive)",
         min_length=1,
     )
-    estimated_passages: int = Field(description="Target scene count", ge=5)
+    estimated_passages: int = Field(default=45, description="Target scene count", ge=5)
     estimated_playtime_minutes: int | None = Field(
         default=None, description="Target reading time", ge=1
     )
-    target_word_count: int = Field(description="Approximate final length", ge=1000)
+    target_word_count: int = Field(default=20000, description="Approximate final length", ge=1000)
 
 
 class DreamArtifact(BaseModel):
@@ -57,7 +57,7 @@ class DreamArtifact(BaseModel):
         default=None, description="Content advisory notes for inclusions and exclusions"
     )
     genre: str = Field(description="Primary genre", min_length=1)
-    scope: Scope | None = Field(default=None)
+    scope: Scope = Field(default_factory=Scope)
     style_notes: str | None = Field(default=None, description="Style guidance", min_length=1)
     subgenre: str | None = Field(
         default=None, description="Optional genre refinement", min_length=1

--- a/tests/unit/test_artifacts.py
+++ b/tests/unit/test_artifacts.py
@@ -448,11 +448,11 @@ def test_scope_defaults_to_standard() -> None:
     assert scope.target_word_count == 3000
 
 
-def test_optional_scope_is_none_by_default() -> None:
-    """DreamArtifact.scope defaults to None.
+def test_scope_defaults_when_omitted() -> None:
+    """DreamArtifact.scope defaults to standard preset when omitted.
 
-    The scope field is optional in DreamArtifact - it can be omitted entirely.
-    This is different from scope's internal required fields.
+    The scope field uses default_factory=Scope, so it's always present
+    with standard preset values even when not explicitly provided.
     """
     artifact = DreamArtifact(
         genre="mystery",

--- a/tests/unit/test_artifacts.py
+++ b/tests/unit/test_artifacts.py
@@ -30,7 +30,7 @@ def test_dream_artifact_valid_minimal() -> None:
     assert artifact.version == 1
     assert artifact.genre == "mystery"
     assert artifact.subgenre is None
-    assert artifact.scope is None
+    assert artifact.scope.story_size == "standard"
 
 
 def test_dream_artifact_valid_full() -> None:
@@ -429,26 +429,23 @@ def test_roundtrip_preserves_data(tmp_path: Path) -> None:
     assert loaded.scope.target_word_count == original.scope.target_word_count
 
 
-def test_scope_requires_word_count_and_passages() -> None:
-    """Scope model requires target_word_count and estimated_passages.
+def test_scope_defaults_to_standard() -> None:
+    """Scope model defaults to standard preset values.
 
-    These fields have no defaults in the Pydantic model, so they must
-    be provided when creating a Scope instance.
+    All fields have sensible defaults so Scope() is valid without arguments,
+    enabling DreamArtifact to always include a scope.
     """
-    # Missing target_word_count should fail
-    with pytest.raises(ValidationError) as exc_info:
-        Scope(estimated_passages=10)  # type: ignore[call-arg]
-    assert "target_word_count" in str(exc_info.value)
+    scope = Scope()
+    assert scope.story_size == "standard"
+    assert scope.branching_depth == "moderate"
+    assert scope.estimated_passages == 45
+    assert scope.target_word_count == 20000
 
-    # Missing estimated_passages should fail
-    with pytest.raises(ValidationError) as exc_info:
-        Scope(target_word_count=10000)  # type: ignore[call-arg]
-    assert "estimated_passages" in str(exc_info.value)
-
-    # Both provided should succeed
-    scope = Scope(target_word_count=10000, estimated_passages=10)
-    assert scope.target_word_count == 10000
+    # Explicit values override defaults
+    scope = Scope(story_size="vignette", estimated_passages=10, target_word_count=3000)
+    assert scope.story_size == "vignette"
     assert scope.estimated_passages == 10
+    assert scope.target_word_count == 3000
 
 
 def test_optional_scope_is_none_by_default() -> None:
@@ -462,6 +459,7 @@ def test_optional_scope_is_none_by_default() -> None:
         tone=["dark"],
         audience="adult",
         themes=["betrayal"],
-        # scope not provided
+        # scope not provided — gets default Scope with standard values
     )
-    assert artifact.scope is None
+    assert artifact.scope.story_size == "standard"
+    assert artifact.scope.estimated_passages == 45


### PR DESCRIPTION
## Problem
When a user requests a specific story size (e.g. "vignette-length"), the DREAM discuss and summarize phases capture it in prose ("Vignette-Length Pulp Space Opera"), but the serialize phase omits the `scope` field because:

1. `scope: Scope | None = None` in `DreamArtifact` — optional, so LLM skips it
2. The serialize prompt mentions "scope" but never shows the Scope object structure
3. `resolve_size_from_graph()` silently falls back to "standard"

**Result**: User asks for vignette → all downstream stages use standard size ranges.

## Changes
- Give all `Scope` fields sensible defaults (standard preset values) so `Scope()` is valid without arguments
- Change `DreamArtifact.scope` from `Scope | None = None` to `Scope = Field(default_factory=Scope)`
- Add explicit Scope schema example to serialize prompt with size-to-values mapping
- Update tests to reflect scope always being present with default values

## Not Included / Future PRs
- No changes to `resolve_size_from_graph()` (already reads `vision.scope.story_size` correctly)
- No changes to discuss/summarize prompts (already mention size presets)

## Test Plan
- `uv run mypy src/questfoundry/models/dream.py` — passes
- `uv run pytest tests/unit/test_artifacts.py tests/unit/test_dream_stage.py tests/unit/test_mutations.py tests/unit/test_size.py -x -q` — 218 passed

## Risk / Rollback
- Low risk — Scope defaults match the previous fallback behavior ("standard")
- Existing projects without scope in graph.json are unaffected (`resolve_size_from_graph` still falls back gracefully)

🤖 Generated with [Claude Code](https://claude.com/claude-code)