### PR TITLE
fix(seed): surface CROSS_REFERENCE errors in retry feedback loop

### DIFF
--- a/src/questfoundry/agents/serialize.py
+++ b/src/questfoundry/agents/serialize.py
@@ -1060,7 +1060,7 @@ def _format_section_corrections(errors: list[SeedValidationError]) -> str:
 
         # Handle CROSS_REFERENCE errors (bucket misplacement, answer not in explored)
         if category == SeedErrorCategory.CROSS_REFERENCE:
-            cross_ref_items.append(f"- MOVE TO EXPLORED: {error.issue}")
+            cross_ref_items.append(f"- MOVE '{error.provided}' TO EXPLORED. Reason: {error.issue}")
             continue
 
         # Handle COMPLETENESS errors (missing decisions)

--- a/src/questfoundry/agents/serialize.py
+++ b/src/questfoundry/agents/serialize.py
@@ -1053,8 +1053,15 @@ def _format_section_corrections(errors: list[SeedValidationError]) -> str:
     corrections: list[str] = []
     missing_items: list[str] = []
 
+    cross_ref_items: list[str] = []
+
     for error in errors:
         category = categorize_error(error)
+
+        # Handle CROSS_REFERENCE errors (bucket misplacement, answer not in explored)
+        if category == SeedErrorCategory.CROSS_REFERENCE:
+            cross_ref_items.append(f"- MOVE TO EXPLORED: {error.issue}")
+            continue
 
         # Handle COMPLETENESS errors (missing decisions)
         if category == SeedErrorCategory.COMPLETENESS:
@@ -1093,12 +1100,26 @@ def _format_section_corrections(errors: list[SeedValidationError]) -> str:
         else:
             corrections.append(f"- '{error.provided}' is INVALID. {suggestion}")
 
-    if not corrections and not missing_items:
+    if not corrections and not missing_items and not cross_ref_items:
         return ""
 
     lines: list[str] = []
 
+    if cross_ref_items:
+        lines.extend(
+            [
+                "## BUCKET MISPLACEMENT (CRITICAL)",
+                "The following answers are in the WRONG bucket. Fix them EXACTLY as described:",
+                "",
+                *cross_ref_items,
+                "",
+                "Move these answers between explored/unexplored as instructed above.",
+            ]
+        )
+
     if corrections:
+        if lines:
+            lines.append("")
         lines.extend(
             [
                 "## MANDATORY CORRECTIONS",
@@ -1404,18 +1425,26 @@ async def serialize_seed_as_function(
 
             # Handle beats separately - not in sections list but generated per-path
             if "beats" in section_errors:
+                beat_corrections = _format_section_corrections(section_errors["beats"])
                 log.debug(
                     "serialize_beats_retry",
                     attempt=semantic_attempt,
                     error_count=len(section_errors["beats"]),
+                    has_corrections=bool(beat_corrections),
                 )
+                # Append corrections to the per-path prompt so the LLM
+                # receives feedback about what went wrong (e.g., missing
+                # commits beats for specific paths).
+                beat_prompt = prompts["per_path_beats"]
+                if beat_corrections:
+                    beat_prompt = f"{beat_prompt}\n\n{beat_corrections}"
                 try:
                     # Re-generate all beats with current (possibly corrected) paths.
                     # If paths is empty, _serialize_beats_per_path returns ([], 0) gracefully.
                     beats, beats_tokens = await _serialize_beats_per_path(
                         model=model,
                         paths=collected["paths"],
-                        per_path_prompt=prompts["per_path_beats"],
+                        per_path_prompt=beat_prompt,
                         entity_context=entity_context,
                         provider_name=provider_name,
                         max_retries=max_retries,

--- a/src/questfoundry/graph/mutations.py
+++ b/src/questfoundry/graph/mutations.py
@@ -1634,6 +1634,16 @@ def format_semantic_errors_as_content(errors: list[SeedValidationError]) -> str:
         if len(semantic_errors) > _MAX_ERRORS_DISPLAY:
             lines.append(f"  ... and {len(semantic_errors) - _MAX_ERRORS_DISPLAY} more")
 
+    # Cross-reference errors (bucket misplacement, answer not in explored)
+    cross_ref_errors = by_category.get(SeedErrorCategory.CROSS_REFERENCE, [])
+    if cross_ref_errors:
+        lines.append("")
+        lines.append("**Bucket misplacement** - these answers are in the wrong list:")
+        for e in cross_ref_errors[:_MAX_ERRORS_DISPLAY]:
+            lines.append(f"  - {e.issue}")
+        if len(cross_ref_errors) > _MAX_ERRORS_DISPLAY:
+            lines.append(f"  ... and {len(cross_ref_errors) - _MAX_ERRORS_DISPLAY} more")
+
     # Inner/structural errors (rarely should make it to outer loop, but handle gracefully)
     inner_errors = by_category.get(SeedErrorCategory.INNER, [])
     if inner_errors:

--- a/tests/unit/test_mutations.py
+++ b/tests/unit/test_mutations.py
@@ -2979,6 +2979,55 @@ class TestFormatSemanticErrorsAsContent:
         assert "ensuring you only reference" in result
         assert "BRAINSTORM" in result
 
+    def test_formats_cross_reference_errors(self) -> None:
+        """Should format CROSS_REFERENCE errors in Bucket misplacement section."""
+        from questfoundry.graph.mutations import format_semantic_errors_as_content
+
+        errors = [
+            SeedValidationError(
+                field_path="dilemmas",
+                issue=(
+                    "Dilemma 'loyalty': default answer 'trusts_council' is in "
+                    "unexplored but MUST be in explored. Move it from unexplored "
+                    "to explored."
+                ),
+                available=["betrays_council"],
+                provided="trusts_council",
+                category=SeedErrorCategory.CROSS_REFERENCE,
+            ),
+        ]
+
+        result = format_semantic_errors_as_content(errors)
+
+        assert "Bucket misplacement" in result
+        assert "trusts_council" in result
+        assert "Move it from unexplored" in result
+
+    def test_formats_mixed_with_cross_reference(self) -> None:
+        """Should handle CROSS_REFERENCE alongside other error categories."""
+        from questfoundry.graph.mutations import format_semantic_errors_as_content
+
+        errors = [
+            SeedValidationError(
+                field_path="entities",
+                issue="Missing decision for entity 'hero'",
+                available=[],
+                provided="",
+            ),
+            SeedValidationError(
+                field_path="dilemmas",
+                issue="Default answer 'X' is in unexplored but MUST be in explored.",
+                available=[],
+                provided="X",
+                category=SeedErrorCategory.CROSS_REFERENCE,
+            ),
+        ]
+
+        result = format_semantic_errors_as_content(errors)
+
+        assert "Missing items" in result
+        assert "Bucket misplacement" in result
+
 
 class TestTypeAwareFeedback:
     """Tests for type-aware cross-type error messages in validate_seed_mutations.


### PR DESCRIPTION
## Problem

SEED retry loop silently dropped `CROSS_REFERENCE` validation errors, causing two persistent failure modes that never self-corrected across 6 retry attempts:

- Default answer placed in "unexplored" instead of "explored" (check 11d)
- Paths missing a beat with `effect="commits"` (check 13)

Root cause: three compounding gaps in the error feedback pipeline.

## Changes

- **`format_semantic_errors_as_content()`** (mutations.py) — added `CROSS_REFERENCE` category handling so outer retry feedback includes "bucket misplacement" errors with their already-descriptive issue text
- **`_format_section_corrections()`** (serialize.py) — added `CROSS_REFERENCE` branch that produces "MOVE TO EXPLORED" instructions instead of falling through to the SEMANTIC handler which misleadingly says "X is INVALID, use Y"
- **Beat retry** (serialize.py) — formats beat-specific errors via `_format_section_corrections()` and appends them to the per-path prompt, so the LLM receives feedback about missing commits beats instead of re-running the identical prompt

## Not Included / Future PRs

- Prompt-level improvements to `serialize_seed.yaml` (already has strong commits instructions)
- Valid IDs context explanation for `(default)` label meaning

## Test Plan

- `uv run mypy src/questfoundry/graph/mutations.py src/questfoundry/agents/serialize.py` — passes
- `uv run ruff check` — passes
- `uv run pytest tests/unit/test_mutations.py -x -q` — 153 passed
- `uv run pytest tests/unit/test_serialize*.py -x -q` — 52 passed
- Pre-commit hooks pass

## Risk / Rollback

Low risk — changes only affect error feedback strings sent to the LLM during retry. No schema changes, no graph mutations, no new dependencies. Safe to revert by reverting this single commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)