### PR TITLE
refactor(dream): simplify Scope to just story_size

### DIFF
--- a/prompts/templates/serialize.yaml
+++ b/prompts/templates/serialize.yaml
@@ -25,14 +25,11 @@ system: |
   detailed content, include ONLY:
   - genre, subgenre, tone, audience, themes (high-level descriptors)
   - style_notes (prose guidance, 50-200 chars, NOT plot summaries)
-  - scope: ALWAYS include this object. Map the brief's size/scope language to:
-    {"story_size": "<preset>", "branching_depth": "<depth>", "estimated_passages": <int>, "target_word_count": <int>}
-    Valid story_size: "vignette", "short", "standard", "long".
-    Match branching_depth to size: vignette="light", short="light", standard="moderate", long="heavy".
-    If the brief says "vignette" → story_size="vignette", estimated_passages=10, target_word_count=3500.
-    If the brief says "short" → story_size="short", estimated_passages=22, target_word_count=10000.
-    If the brief says "long" → story_size="long", estimated_passages=90, target_word_count=45000.
-    If no size is mentioned → story_size="standard", estimated_passages=45, target_word_count=22500.
+  - scope: ALWAYS include. Set story_size to one of: "vignette", "short", "standard", "long".
+    If the brief mentions "vignette" → {"story_size": "vignette"}
+    If the brief mentions "short" → {"story_size": "short"}
+    If the brief mentions "long" → {"story_size": "long"}
+    If no size is mentioned → {"story_size": "standard"}
   - content_notes (warnings/guidance, NOT specific scenes or character arcs)
 
   Do NOT serialize specific characters, scenes, endings, or mechanics into

--- a/src/questfoundry/models/dream.py
+++ b/src/questfoundry/models/dream.py
@@ -24,27 +24,17 @@ class ContentNotes(BaseModel):
 
 
 class Scope(BaseModel):
-    """Story scope constraints."""
+    """Story scope — just the size preset.
+
+    Numeric ranges (passages, word count, branching) are derived from
+    PRESETS in ``pipeline/size.py`` at runtime. The LLM only needs to
+    pick one word.
+    """
 
     story_size: Literal["vignette", "short", "standard", "long"] = Field(
         default="standard",
-        description=(
-            'Story size preset: "vignette" (5-15 passages, tight single-thread), '
-            '"short" (15-30 passages, modest branching), '
-            '"standard" (30-60 passages, full branching), '
-            '"long" (60-120 passages, extensive branching)'
-        ),
+        description='Story size preset: "vignette", "short", "standard", or "long"',
     )
-    branching_depth: str = Field(
-        default="moderate",
-        description="Branching complexity (e.g., light, moderate, heavy, extensive)",
-        min_length=1,
-    )
-    estimated_passages: int = Field(default=45, description="Target scene count", ge=5)
-    estimated_playtime_minutes: int | None = Field(
-        default=None, description="Target reading time", ge=1
-    )
-    target_word_count: int = Field(default=20000, description="Approximate final length", ge=1000)
 
 
 class DreamArtifact(BaseModel):

--- a/tests/unit/test_validator_helpers.py
+++ b/tests/unit/test_validator_helpers.py
@@ -110,7 +110,7 @@ class TestPathToFieldName:
 
     def test_nested_field(self) -> None:
         """Nested field path with dot notation."""
-        assert _path_to_field_name(("scope", "target_word_count")) == "scope.target_word_count"
+        assert _path_to_field_name(("scope", "story_size")) == "scope.story_size"
 
     def test_strips_list_indices(self) -> None:
         """List indices are stripped from path."""
@@ -311,7 +311,7 @@ class TestDreamArtifactErrors:
             "tone": ["epic"],
             "audience": "adult",
             "themes": ["heroism"],
-            "scope": {"target_word_count": 100},  # Below minimum of 1000
+            "scope": {"story_size": "tiny"},  # Invalid value
         }
         try:
             DreamArtifact.model_validate(data)
@@ -319,9 +319,8 @@ class TestDreamArtifactErrors:
         except ValidationError as e:
             details = pydantic_errors_to_details(e.errors(), data)
 
-        # Should have error for scope.target_word_count and missing estimated_passages
         fields = {d.field for d in details}
-        assert "scope.target_word_count" in fields or "scope.estimated_passages" in fields
+        assert "scope.story_size" in fields
 
     def test_dream_list_item_error(self) -> None:
         """List item validation errors reference parent field without indices."""
@@ -476,9 +475,7 @@ class TestGetAllFieldPaths:
         assert "content_notes" in paths
 
         # Nested scope fields
-        assert "scope.target_word_count" in paths
-        assert "scope.estimated_passages" in paths
-        assert "scope.branching_depth" in paths
+        assert "scope.story_size" in paths
 
         # Nested content_notes fields
         assert "content_notes.includes" in paths


### PR DESCRIPTION
## Problem

DREAM serialize asks the LLM to fill in 5 fields for scope: `story_size`, `branching_depth`, `estimated_passages`, `target_word_count`, `estimated_playtime_minutes`. But only `story_size` is read at runtime — `resolve_size_from_graph()` maps the single word to a `SizeProfile` from PRESETS, ignoring all numeric fields.

In `test-20260131T1435`, user asked for "A vignette-length pulp space opera" but the LLM output `story_size: standard` — distracted by having to fill in numeric fields it got the one important word wrong.

## Changes

- **`dream.py`**: Strip `Scope` down to just `story_size: Literal["vignette", "short", "standard", "long"]`. Remove `branching_depth`, `estimated_passages`, `target_word_count`, `estimated_playtime_minutes`.
- **`serialize.yaml`**: Replace verbose scope instructions (8 lines of numeric mappings) with 5 lines: pick one of 4 words based on what the brief says.
- **`test_artifacts.py`**: Remove tests for deleted fields, simplify remaining scope tests. Replace `test_scope_invalid_word_count` and `test_scope_invalid_branching_depth` with `test_scope_invalid_story_size`.

## Not Included / Future PRs

- No changes to `resolve_size_from_graph()` or PRESETS — they already only read `story_size`
- Existing project graph.json files with old scope fields will still work (extra keys are ignored)

## Test Plan

- `uv run mypy src/questfoundry/models/dream.py` — passes
- `uv run pytest tests/unit/test_artifacts.py tests/unit/test_size.py -x -q` — 51 passed
- Pre-commit hooks pass

## Risk / Rollback

Low risk. Removes unused fields only. Existing projects with old-format scope in graph.json continue working since `resolve_size_from_graph` reads `scope.get("story_size")` which ignores extra keys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)