### PR TITLE
feat(fill): add dramatic question tracking from dilemma_impacts

### DIFF
--- a/prompts/templates/fill_phase1_prose.yaml
+++ b/prompts/templates/fill_phase1_prose.yaml
@@ -13,6 +13,9 @@ system: |
   **Beat Summary:** {beat_summary}
   **Scene Type:** {scene_type}
 
+  ## Open Dramatic Questions
+  {dramatic_questions}
+
   ## Scene Type Guidance
   - **scene**: Full dramatic structure (goal, obstacle, outcome). 3+ paragraphs.
     Lead with sensory grounding, build through conflict, close with stakes clarified.
@@ -39,7 +42,9 @@ system: |
   2. Match the scene type guidance for length and structure
   3. Cover the beat summary content — do not invent major plot points
   4. Maintain continuity with the sliding window passages
-  5. If this is a shared beat, write prose that works for ALL arriving states
+  5. Let open dramatic questions create subtext — do not resolve them unless
+     this beat commits to an answer
+  6. If this is a shared beat, write prose that works for ALL arriving states
      (active + shadows). Use ambiguous phrasing when states diverge.
 
   ## Poly-State Examples (CRITICAL for shared beats)

--- a/src/questfoundry/graph/fill_context.py
+++ b/src/questfoundry/graph/fill_context.py
@@ -556,7 +556,7 @@ def compute_open_questions(
             if effect == "commits":
                 dilemma_state[did]["closed"] = True
             else:
-                dilemma_state[did]["escalations"] = int(dilemma_state[did]["escalations"]) + 1
+                dilemma_state[did]["escalations"] += 1
 
     # Determine action at the current beat
     current_beat = graph.get_node(current_beat_id)
@@ -578,7 +578,7 @@ def compute_open_questions(
             {
                 "dilemma_id": did,
                 "question": question,
-                "escalations": int(state["escalations"]),
+                "escalations": state["escalations"],
                 "action_here": current_impacts.get(did, ""),
             }
         )

--- a/src/questfoundry/graph/fill_context.py
+++ b/src/questfoundry/graph/fill_context.py
@@ -504,6 +504,138 @@ def format_dream_vision(graph: Graph) -> str:
     return "\n".join(lines)
 
 
+def compute_open_questions(
+    graph: Graph,
+    arc_id: str,
+    current_beat_id: str,
+) -> list[dict[str, str | int]]:
+    """Compute open dramatic questions at a point in the arc.
+
+    Walks the arc's beat sequence up to (but not including) the current beat,
+    tracking dilemma_impacts. Each dilemma IS a dramatic question; impacts
+    determine whether the question is open, escalating, or closed.
+
+    Mapping:
+        - advances / reveals / complicates → question is open and escalating
+        - commits → question is closed (answered)
+
+    Args:
+        graph: Graph containing arc, beat, and dilemma nodes.
+        arc_id: The arc being traversed.
+        current_beat_id: The beat being generated (walk stops here).
+
+    Returns:
+        List of open question dicts, each with:
+        ``dilemma_id``, ``question``, ``escalations``, ``action_here``.
+        Sorted by escalation count (most escalated first).
+    """
+    arc_node = graph.get_node(arc_id)
+    if not arc_node:
+        return []
+
+    sequence = arc_node.get("sequence", [])
+    if not sequence:
+        return []
+
+    # Track state per dilemma: escalations count and whether committed
+    dilemma_state: dict[str, dict[str, int | bool]] = {}
+
+    for beat_id in sequence:
+        if beat_id == current_beat_id:
+            break
+        beat = graph.get_node(beat_id)
+        if not beat:
+            continue
+        for impact in beat.get("dilemma_impacts", []):
+            did = impact.get("dilemma_id", "")
+            if not did:
+                continue
+            if did not in dilemma_state:
+                dilemma_state[did] = {"escalations": 0, "closed": False}
+            effect = impact.get("effect", "")
+            if effect == "commits":
+                dilemma_state[did]["closed"] = True
+            else:
+                dilemma_state[did]["escalations"] = int(dilemma_state[did]["escalations"]) + 1
+
+    # Determine action at the current beat
+    current_beat = graph.get_node(current_beat_id)
+    current_impacts: dict[str, str] = {}
+    if current_beat:
+        for impact in current_beat.get("dilemma_impacts", []):
+            did = impact.get("dilemma_id", "")
+            if did:
+                current_impacts[did] = impact.get("effect", "")
+
+    # Build result: open questions only
+    open_questions: list[dict[str, str | int]] = []
+    for did, state in dilemma_state.items():
+        if state["closed"]:
+            continue
+        dilemma_node = graph.get_node(did)
+        question = dilemma_node.get("question", "") if dilemma_node else ""
+        open_questions.append(
+            {
+                "dilemma_id": did,
+                "question": question,
+                "escalations": int(state["escalations"]),
+                "action_here": current_impacts.get(did, ""),
+            }
+        )
+
+    # Sort by escalations descending (most developed questions first)
+    open_questions.sort(key=lambda q: int(q["escalations"]), reverse=True)
+    return open_questions
+
+
+def format_dramatic_questions(
+    graph: Graph,
+    arc_id: str,
+    current_beat_id: str,
+) -> str:
+    """Format open dramatic questions as context for prose generation.
+
+    Args:
+        graph: Graph containing arc, beat, and dilemma nodes.
+        arc_id: The arc being traversed.
+        current_beat_id: The beat being generated.
+
+    Returns:
+        Formatted dramatic questions string, or empty string if none.
+    """
+    questions = compute_open_questions(graph, arc_id, current_beat_id)
+    if not questions:
+        return ""
+
+    lines: list[str] = []
+    lines.append("These questions are UNRESOLVED. Let them create subtext in the prose.")
+
+    for q in questions:
+        question_text = q["question"]
+        escalations = int(q["escalations"])
+        action = q["action_here"]
+
+        if action == "commits":
+            note = "RESOLVING here — this question is being answered"
+        elif action == "complicates":
+            note = "complicating — new doubts introduced"
+        elif action in ("advances", "reveals"):
+            note = "advancing — tension building"
+        elif escalations > 2:
+            note = f"escalated {escalations}x — high tension"
+        elif escalations > 0:
+            note = f"escalated {escalations}x"
+        else:
+            note = "just opened"
+
+        lines.append(f'- "{question_text}" ({note})')
+
+    lines.append("")
+    lines.append("Do NOT resolve these unless this beat commits to an answer.")
+
+    return "\n".join(lines)
+
+
 def format_passages_batch(
     graph: Graph,
     passage_ids: list[str],

--- a/src/questfoundry/pipeline/stages/fill.py
+++ b/src/questfoundry/pipeline/stages/fill.py
@@ -25,6 +25,7 @@ from pydantic import BaseModel, ValidationError
 from questfoundry.agents.serialize import extract_tokens
 from questfoundry.artifacts.validator import get_all_field_paths
 from questfoundry.graph.fill_context import (
+    format_dramatic_questions,
     format_dream_vision,
     format_entity_states,
     format_grow_summary,
@@ -565,6 +566,7 @@ class FillStage:
                 "passage_id": passage.get("raw_id", passage_id),
                 "beat_summary": beat_summary,
                 "scene_type": scene_type,
+                "dramatic_questions": format_dramatic_questions(graph, arc_id, beat_id),
                 "entity_states": format_entity_states(graph, passage_id),
                 "sliding_window": format_sliding_window(graph, arc_id, current_idx),
                 "lookahead": format_lookahead_context(graph, passage_id, arc_id),

--- a/tests/unit/test_fill_context.py
+++ b/tests/unit/test_fill_context.py
@@ -624,7 +624,7 @@ class TestComputeOpenQuestions:
     def test_sorted_by_escalation(self, dq_graph: Graph) -> None:
         """Results are sorted by escalation count descending."""
         result = compute_open_questions(dq_graph, "arc::spine", "beat::b3")
-        assert result[0]["escalations"] >= result[1]["escalations"]
+        assert result[0]["escalations"] > result[1]["escalations"]
 
     def test_complicates_counts_as_escalation(self, dq_graph: Graph) -> None:
         """Complicates effect counts as an escalation."""

--- a/tests/unit/test_fill_context.py
+++ b/tests/unit/test_fill_context.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import pytest
 
 from questfoundry.graph.fill_context import (
+    compute_open_questions,
+    format_dramatic_questions,
     format_dream_vision,
     format_entity_states,
     format_grow_summary,
@@ -435,3 +437,231 @@ class TestFormatPassagesBatch:
     def test_passage_without_prose(self, fill_graph: Graph) -> None:
         result = format_passages_batch(fill_graph, ["passage::p_aftermath"])
         assert "(no prose)" in result
+
+
+# ---------------------------------------------------------------------------
+# Dramatic Question Tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def dq_graph() -> Graph:
+    """Graph with dilemmas and dilemma_impacts for dramatic question tests."""
+    g = Graph.empty()
+
+    # Dilemmas
+    g.create_node(
+        "dilemma::mentor_trust",
+        {
+            "type": "dilemma",
+            "raw_id": "mentor_trust",
+            "question": "Can the mentor be trusted?",
+        },
+    )
+    g.create_node(
+        "dilemma::artifact_cost",
+        {
+            "type": "dilemma",
+            "raw_id": "artifact_cost",
+            "question": "Is the artifact worth the cost?",
+        },
+    )
+
+    # Beats with dilemma_impacts
+    g.create_node(
+        "beat::b1",
+        {
+            "type": "beat",
+            "raw_id": "b1",
+            "summary": "Kay meets the mentor",
+            "scene_type": "scene",
+            "dilemma_impacts": [
+                {
+                    "dilemma_id": "dilemma::mentor_trust",
+                    "effect": "advances",
+                    "note": "First meeting establishes the question",
+                },
+            ],
+        },
+    )
+    g.create_node(
+        "beat::b2",
+        {
+            "type": "beat",
+            "raw_id": "b2",
+            "summary": "Mentor reveals the artifact",
+            "scene_type": "scene",
+            "dilemma_impacts": [
+                {
+                    "dilemma_id": "dilemma::mentor_trust",
+                    "effect": "reveals",
+                    "note": "More about the mentor's past",
+                },
+                {
+                    "dilemma_id": "dilemma::artifact_cost",
+                    "effect": "advances",
+                    "note": "Artifact's power is shown",
+                },
+            ],
+        },
+    )
+    g.create_node(
+        "beat::b3",
+        {
+            "type": "beat",
+            "raw_id": "b3",
+            "summary": "Kay discovers the mentor's secret",
+            "scene_type": "scene",
+            "dilemma_impacts": [
+                {
+                    "dilemma_id": "dilemma::mentor_trust",
+                    "effect": "complicates",
+                    "note": "Secret changes everything",
+                },
+            ],
+        },
+    )
+    g.create_node(
+        "beat::b4",
+        {
+            "type": "beat",
+            "raw_id": "b4",
+            "summary": "Kay commits to trusting the mentor",
+            "scene_type": "scene",
+            "dilemma_impacts": [
+                {
+                    "dilemma_id": "dilemma::mentor_trust",
+                    "effect": "commits",
+                    "note": "Trust is locked in",
+                },
+            ],
+        },
+    )
+    g.create_node(
+        "beat::b5",
+        {
+            "type": "beat",
+            "raw_id": "b5",
+            "summary": "Aftermath",
+            "scene_type": "sequel",
+            "dilemma_impacts": [],
+        },
+    )
+
+    # Arc with beat sequence
+    g.create_node(
+        "arc::spine",
+        {
+            "type": "arc",
+            "raw_id": "spine",
+            "arc_type": "spine",
+            "paths": ["path::trust"],
+            "sequence": ["beat::b1", "beat::b2", "beat::b3", "beat::b4", "beat::b5"],
+        },
+    )
+
+    return g
+
+
+class TestComputeOpenQuestions:
+    """Tests for compute_open_questions."""
+
+    def test_empty_arc(self) -> None:
+        """No questions when arc doesn't exist."""
+        g = Graph.empty()
+        result = compute_open_questions(g, "arc::nonexistent", "beat::b1")
+        assert result == []
+
+    def test_first_beat_no_prior(self, dq_graph: Graph) -> None:
+        """First beat has no open questions (no prior beats)."""
+        result = compute_open_questions(dq_graph, "arc::spine", "beat::b1")
+        assert result == []
+
+    def test_single_advance(self, dq_graph: Graph) -> None:
+        """After b1, mentor_trust should be open with 1 escalation."""
+        result = compute_open_questions(dq_graph, "arc::spine", "beat::b2")
+        assert len(result) == 1
+        assert result[0]["dilemma_id"] == "dilemma::mentor_trust"
+        assert result[0]["escalations"] == 1
+        assert result[0]["question"] == "Can the mentor be trusted?"
+
+    def test_multiple_dilemmas(self, dq_graph: Graph) -> None:
+        """After b2, both dilemmas should be open."""
+        result = compute_open_questions(dq_graph, "arc::spine", "beat::b3")
+        assert len(result) == 2
+        # mentor_trust has 2 escalations (advances + reveals), artifact_cost has 1
+        mentor = next(q for q in result if q["dilemma_id"] == "dilemma::mentor_trust")
+        artifact = next(q for q in result if q["dilemma_id"] == "dilemma::artifact_cost")
+        assert mentor["escalations"] == 2
+        assert artifact["escalations"] == 1
+
+    def test_escalation_count(self, dq_graph: Graph) -> None:
+        """After b3, mentor_trust should have 3 escalations."""
+        result = compute_open_questions(dq_graph, "arc::spine", "beat::b4")
+        mentor = next(q for q in result if q["dilemma_id"] == "dilemma::mentor_trust")
+        assert mentor["escalations"] == 3
+
+    def test_commits_closes_question(self, dq_graph: Graph) -> None:
+        """After b4 commits, mentor_trust should be closed."""
+        result = compute_open_questions(dq_graph, "arc::spine", "beat::b5")
+        dilemma_ids = [q["dilemma_id"] for q in result]
+        assert "dilemma::mentor_trust" not in dilemma_ids
+        # artifact_cost should still be open
+        assert "dilemma::artifact_cost" in dilemma_ids
+
+    def test_action_here_advances(self, dq_graph: Graph) -> None:
+        """Current beat's action is tracked."""
+        result = compute_open_questions(dq_graph, "arc::spine", "beat::b2")
+        # b2 has reveals on mentor_trust
+        assert result[0]["action_here"] == "reveals"
+
+    def test_action_here_commits(self, dq_graph: Graph) -> None:
+        """Commits action is tracked at current beat."""
+        result = compute_open_questions(dq_graph, "arc::spine", "beat::b4")
+        mentor = next(q for q in result if q["dilemma_id"] == "dilemma::mentor_trust")
+        assert mentor["action_here"] == "commits"
+
+    def test_sorted_by_escalation(self, dq_graph: Graph) -> None:
+        """Results are sorted by escalation count descending."""
+        result = compute_open_questions(dq_graph, "arc::spine", "beat::b3")
+        assert result[0]["escalations"] >= result[1]["escalations"]
+
+    def test_complicates_counts_as_escalation(self, dq_graph: Graph) -> None:
+        """Complicates effect counts as an escalation."""
+        result = compute_open_questions(dq_graph, "arc::spine", "beat::b4")
+        mentor = next(q for q in result if q["dilemma_id"] == "dilemma::mentor_trust")
+        # advances(1) + reveals(1) + complicates(1) = 3
+        assert mentor["escalations"] == 3
+
+
+class TestFormatDramaticQuestions:
+    """Tests for format_dramatic_questions."""
+
+    def test_empty_when_no_questions(self, dq_graph: Graph) -> None:
+        """Returns empty string when no open questions."""
+        result = format_dramatic_questions(dq_graph, "arc::spine", "beat::b1")
+        assert result == ""
+
+    def test_formats_open_questions(self, dq_graph: Graph) -> None:
+        """Formats open questions with escalation notes."""
+        result = format_dramatic_questions(dq_graph, "arc::spine", "beat::b3")
+        assert "Can the mentor be trusted?" in result
+        assert "Is the artifact worth the cost?" in result
+        assert "UNRESOLVED" in result
+
+    def test_commits_note(self, dq_graph: Graph) -> None:
+        """Shows resolving note when current beat commits."""
+        result = format_dramatic_questions(dq_graph, "arc::spine", "beat::b4")
+        assert "RESOLVING" in result
+
+    def test_complicates_note(self, dq_graph: Graph) -> None:
+        """Shows complicating note for complicates action."""
+        result = format_dramatic_questions(dq_graph, "arc::spine", "beat::b3")
+        # b3 complicates mentor_trust
+        assert "complicating" in result
+
+    def test_nonexistent_arc(self) -> None:
+        """Returns empty for nonexistent arc."""
+        g = Graph.empty()
+        result = format_dramatic_questions(g, "arc::nope", "beat::b1")
+        assert result == ""


### PR DESCRIPTION
## Problem
FILL generates prose per passage with no awareness of the story's unresolved dramatic questions. Each passage reads as a standalone vignette with no sense of building tension or narrative progression.

## Changes
- Add `compute_open_questions()` to `fill_context.py` — walks the arc beat sequence, tracking `dilemma_impacts` to determine which dramatic questions are open, how many times they've been escalated, and what action the current beat takes
- Add `format_dramatic_questions()` — formats open questions as prompt context with escalation notes ("escalated 3x — high tension", "RESOLVING here", "complicating — new doubts")
- Wire `dramatic_questions` into FILL Phase 1 context dict in `fill.py`
- Add `## Open Dramatic Questions` section to `fill_phase1_prose.yaml` (between Current Passage and Scene Type Guidance)
- Add rule: "Let open dramatic questions create subtext — do not resolve them unless this beat commits to an answer"
- 15 new unit tests covering all effect types, escalation counting, commits closure, sorting, and formatting

## Not Included / Future PRs
- `narrative_function` and `exit_mood` (#459)
- Deterministic `intensity`/`target_length` (#460)
- Full FILL prompt narrative context integration (#461)
- Atmospheric detail and entry states (#462)

## Test Plan
```
uv run pytest tests/unit/test_fill_context.py -x -q  # 43 passed
uv run mypy src/questfoundry/graph/fill_context.py src/questfoundry/pipeline/stages/fill.py  # clean
uv run ruff check src/ tests/  # clean
```

## Risk / Rollback
- Zero new LLM calls — purely deterministic graph traversal
- Additive change only — new context section in FILL prompt, no existing behavior modified
- If dramatic questions context is empty (no dilemma_impacts), the section renders as empty string — graceful degradation

Part 1 of #457

🤖 Generated with [Claude Code](https://claude.com/claude-code)