### PR TITLE
feat(grow): add Phase 4d atmospheric detail and entry states (#462)

### DIFF
--- a/prompts/templates/fill_phase1_prose.yaml
+++ b/prompts/templates/fill_phase1_prose.yaml
@@ -39,6 +39,12 @@ system: |
   - **resolve**: Settle a thread. Provide earned clarity — not easy answers.
     The resolution should feel inevitable in hindsight.
 
+  ## Atmospheric Detail
+  {atmospheric_detail}
+
+  ## Entry States
+  {entry_states}
+
   ## Entity States
   {entity_states}
 

--- a/prompts/templates/grow_phase4d_atmospheric.yaml
+++ b/prompts/templates/grow_phase4d_atmospheric.yaml
@@ -1,0 +1,62 @@
+name: grow_phase4d_atmospheric
+description: Generate atmospheric details and entry states for beats
+
+system: |
+  You are adding sensory atmosphere to story beats.
+
+  ## Atmospheric Detail
+  For EACH beat, write a single recurring sensory detail that anchors the
+  setting — what the protagonist sees, hears, smells, or feels physically.
+  This detail will be woven into the prose as a sensory anchor.
+
+  Examples:
+  - "Lamp oil smoke curling beneath low stone ceilings"
+  - "The persistent drone of cicadas in the humid air"
+  - "Cold steel handrails vibrating faintly underfoot"
+
+  Write ENVIRONMENT, not character emotion. Not "a sense of dread" but
+  "the smell of wet earth and rust."
+
+  ## Entry States (shared beats only)
+  Some beats are shared between paths — players arrive from different
+  emotional contexts. For EACH shared beat, describe the emotional quality
+  a reader carries FROM each path.
+
+  Shared beats: {shared_beats}
+
+  Examples:
+  - path_trust: "cautious warmth" (built trust with mentor)
+  - path_betray: "defensive guilt" (chose self-preservation)
+
+  Write 2-3 word emotional descriptors, not sentences.
+
+  ## Beats to Annotate
+  {beat_summaries}
+
+  ## Path Information
+  {path_info}
+
+  ## What NOT to Do
+  - Do NOT use IDs not listed in the Valid IDs section
+  - Do NOT write character emotions as atmospheric detail
+  - Do NOT write full sentences as entry moods
+  - Do NOT provide entry_states for non-shared beats
+
+  ## Valid IDs
+  Valid beat_ids (use ONLY these): {valid_beat_ids}
+  Valid path_ids (use ONLY these): {valid_path_ids}
+  Total beats: {beat_count}
+
+  ## Output Format
+  Return a JSON object with:
+  - details: array of {{beat_id, atmospheric_detail}} for ALL beats
+  - entry_states: array of {{beat_id, moods: [{{path_id, mood}}]}} for shared beats ONLY
+
+user: |
+  Generate atmospheric details for all beats, and entry states for shared beats.
+
+  REMINDER: Return ONLY a valid JSON object. Use ONLY IDs from the Valid IDs
+  section. Every beat needs an atmospheric_detail. Only shared beats get entry_states.
+  Do NOT add prose before or after the JSON.
+
+components: []

--- a/src/questfoundry/graph/fill_context.py
+++ b/src/questfoundry/graph/fill_context.py
@@ -755,6 +755,90 @@ def format_narrative_context(graph: Graph, passage_id: str) -> str:
     return "\n".join(lines)
 
 
+# ---------------------------------------------------------------------------
+# Atmospheric detail and entry states
+# ---------------------------------------------------------------------------
+
+
+def format_atmospheric_detail(graph: Graph, passage_id: str) -> str:
+    """Format atmospheric detail for a passage's beat.
+
+    Args:
+        graph: Graph containing passage and beat nodes.
+        passage_id: The passage being generated.
+
+    Returns:
+        Formatted atmospheric detail, or empty string if not set.
+    """
+    passage = graph.get_node(passage_id)
+    if not passage:
+        return ""
+
+    beat_id = passage.get("from_beat", "")
+    beat = graph.get_node(beat_id) if beat_id else None
+    if not beat:
+        return ""
+
+    detail = beat.get("atmospheric_detail", "")
+    if not detail:
+        return ""
+
+    return (
+        f"**Atmospheric Detail:** {detail}\n\n"
+        "Weave this sensory detail into the prose as a recurring anchor. "
+        "Do not state it as a list — embed it naturally."
+    )
+
+
+def format_entry_states(graph: Graph, passage_id: str, arc_id: str) -> str:
+    """Format entry state context for shared beats.
+
+    For poly-state beats, shows how readers arrive from different paths.
+
+    Args:
+        graph: Graph containing passage, beat, and arc nodes.
+        passage_id: The passage being generated.
+        arc_id: The arc being traversed.
+
+    Returns:
+        Formatted entry states, or empty string if not a shared beat.
+    """
+    passage = graph.get_node(passage_id)
+    if not passage:
+        return ""
+
+    beat_id = passage.get("from_beat", "")
+    beat = graph.get_node(beat_id) if beat_id else None
+    if not beat:
+        return ""
+
+    entry_states = beat.get("entry_states", [])
+    if not entry_states:
+        return ""
+
+    # Identify active paths from the arc
+    arc_node = graph.get_node(arc_id)
+    active_paths: set[str] = set()
+    if arc_node:
+        active_paths = set(arc_node.get("paths", []))
+
+    lines = [
+        "**Entry States** (how readers arrive at this shared beat):",
+        "",
+    ]
+
+    for entry in entry_states:
+        path_id = entry.get("path_id", "")
+        mood = entry.get("mood", "")
+        indicator = " <- ACTIVE" if path_id in active_paths else ""
+        lines.append(f"- {path_id}: {mood}{indicator}")
+
+    lines.append("")
+    lines.append("Write prose that accommodates ALL entry moods.")
+
+    return "\n".join(lines)
+
+
 def format_passages_batch(
     graph: Graph,
     passage_ids: list[str],

--- a/src/questfoundry/pipeline/stages/fill.py
+++ b/src/questfoundry/pipeline/stages/fill.py
@@ -25,9 +25,11 @@ from pydantic import BaseModel, ValidationError
 from questfoundry.agents.serialize import extract_tokens
 from questfoundry.artifacts.validator import get_all_field_paths
 from questfoundry.graph.fill_context import (
+    format_atmospheric_detail,
     format_dramatic_questions,
     format_dream_vision,
     format_entity_states,
+    format_entry_states,
     format_grow_summary,
     format_lookahead_context,
     format_narrative_context,
@@ -569,6 +571,8 @@ class FillStage:
                 "scene_type": scene_type,
                 "dramatic_questions": format_dramatic_questions(graph, arc_id, beat_id),
                 "narrative_context": format_narrative_context(graph, passage_id),
+                "atmospheric_detail": format_atmospheric_detail(graph, passage_id),
+                "entry_states": format_entry_states(graph, passage_id, arc_id),
                 "entity_states": format_entity_states(graph, passage_id),
                 "sliding_window": format_sliding_window(graph, arc_id, current_idx),
                 "lookahead": format_lookahead_context(graph, passage_id, arc_id),

--- a/src/questfoundry/pipeline/stages/grow.py
+++ b/src/questfoundry/pipeline/stages/grow.py
@@ -149,11 +149,13 @@ class GrowStage:
             All phases are async and accept (graph, model) parameters.
             Deterministic phases ignore the model parameter.
         """
-        # Gap detection (4a/4b/4c) runs BEFORE intersections (3) so that
-        # each path is fully elaborated before cross-path weaving.  This
-        # prevents "conditional prerequisites" — a shared beat depending on
-        # a path-specific gap beat — which would cause silent `requires`
-        # edge drops during arc enumeration and passage DAG cycles.
+        # Phases 4a-4d run BEFORE intersections (3) so that each path is
+        # fully elaborated before cross-path weaving.  Gap detection
+        # (4a/4b/4c) prevents "conditional prerequisites" — a shared beat
+        # depending on a path-specific gap beat — which would cause silent
+        # `requires` edge drops during arc enumeration and passage DAG
+        # cycles.  Phase 4d (atmospheric) annotates beats with sensory
+        # detail and entry states that intersections need for shared beats.
         # See: check_intersection_compatibility() invariant, #357/#358/#359.
         return [
             (self._phase_1_validate_dag, "validate_dag"),

--- a/tests/unit/test_fill_context.py
+++ b/tests/unit/test_fill_context.py
@@ -850,9 +850,8 @@ class TestFormatEntryStates:
             {"type": "arc", "paths": ["path::trust", "path::betray"]},
         )
         result = format_entry_states(g, "passage::p1", "arc::a1")
-        assert "cautious warmth" in result
-        assert "defensive guilt" in result
-        assert "ACTIVE" in result
+        assert "path::trust: cautious warmth <- ACTIVE" in result
+        assert "path::betray: defensive guilt <- ACTIVE" in result
 
     def test_marks_active_paths(self) -> None:
         g = Graph.empty()
@@ -879,6 +878,5 @@ class TestFormatEntryStates:
         result = format_entry_states(g, "passage::p1", "arc::a1")
         assert "path::trust: cautious warmth <- ACTIVE" in result
         # betray is NOT active in this arc
-        assert (
-            "path::betray: defensive guilt\n" in result or "path::betray: defensive guilt" in result
-        )
+        assert "path::betray: defensive guilt" in result
+        assert "path::betray: defensive guilt <- ACTIVE" not in result

--- a/tests/unit/test_fill_context.py
+++ b/tests/unit/test_fill_context.py
@@ -7,9 +7,11 @@ import pytest
 from questfoundry.graph.fill_context import (
     compute_open_questions,
     derive_pacing,
+    format_atmospheric_detail,
     format_dramatic_questions,
     format_dream_vision,
     format_entity_states,
+    format_entry_states,
     format_grow_summary,
     format_lookahead_context,
     format_narrative_context,
@@ -764,3 +766,119 @@ class TestFormatNarrativeContext:
         result = format_narrative_context(g, "passage::p1")
         assert "develop" in result
         assert "Exit Mood" not in result
+
+
+# ---------------------------------------------------------------------------
+# Atmospheric Detail and Entry States Tests
+# ---------------------------------------------------------------------------
+
+
+class TestFormatAtmosphericDetail:
+    """Tests for format_atmospheric_detail."""
+
+    def test_returns_empty_for_missing_passage(self) -> None:
+        g = Graph.empty()
+        assert format_atmospheric_detail(g, "passage::nope") == ""
+
+    def test_returns_empty_when_no_detail(self, fill_graph: Graph) -> None:
+        """Beats without atmospheric_detail get empty context."""
+        result = format_atmospheric_detail(fill_graph, "passage::p_opening")
+        assert result == ""
+
+    def test_formats_atmospheric_detail(self) -> None:
+        g = Graph.empty()
+        g.create_node(
+            "beat::b1",
+            {
+                "type": "beat",
+                "raw_id": "b1",
+                "atmospheric_detail": "Cold stone walls slick with condensation",
+            },
+        )
+        g.create_node(
+            "passage::p1",
+            {"type": "passage", "raw_id": "p1", "from_beat": "beat::b1"},
+        )
+        result = format_atmospheric_detail(g, "passage::p1")
+        assert "Cold stone walls" in result
+        assert "sensory" in result.lower()
+
+    def test_returns_empty_when_beat_missing(self) -> None:
+        g = Graph.empty()
+        g.create_node(
+            "passage::p1",
+            {"type": "passage", "raw_id": "p1", "from_beat": "beat::missing"},
+        )
+        assert format_atmospheric_detail(g, "passage::p1") == ""
+
+
+class TestFormatEntryStates:
+    """Tests for format_entry_states."""
+
+    def test_returns_empty_for_missing_passage(self) -> None:
+        g = Graph.empty()
+        assert format_entry_states(g, "passage::nope", "arc::a1") == ""
+
+    def test_returns_empty_when_no_entry_states(self) -> None:
+        g = Graph.empty()
+        g.create_node("beat::b1", {"type": "beat", "raw_id": "b1"})
+        g.create_node(
+            "passage::p1",
+            {"type": "passage", "raw_id": "p1", "from_beat": "beat::b1"},
+        )
+        assert format_entry_states(g, "passage::p1", "arc::a1") == ""
+
+    def test_formats_entry_states(self) -> None:
+        g = Graph.empty()
+        g.create_node(
+            "beat::shared",
+            {
+                "type": "beat",
+                "raw_id": "shared",
+                "entry_states": [
+                    {"path_id": "path::trust", "mood": "cautious warmth"},
+                    {"path_id": "path::betray", "mood": "defensive guilt"},
+                ],
+            },
+        )
+        g.create_node(
+            "passage::p1",
+            {"type": "passage", "raw_id": "p1", "from_beat": "beat::shared"},
+        )
+        g.create_node(
+            "arc::a1",
+            {"type": "arc", "paths": ["path::trust", "path::betray"]},
+        )
+        result = format_entry_states(g, "passage::p1", "arc::a1")
+        assert "cautious warmth" in result
+        assert "defensive guilt" in result
+        assert "ACTIVE" in result
+
+    def test_marks_active_paths(self) -> None:
+        g = Graph.empty()
+        g.create_node(
+            "beat::shared",
+            {
+                "type": "beat",
+                "raw_id": "shared",
+                "entry_states": [
+                    {"path_id": "path::trust", "mood": "cautious warmth"},
+                    {"path_id": "path::betray", "mood": "defensive guilt"},
+                ],
+            },
+        )
+        g.create_node(
+            "passage::p1",
+            {"type": "passage", "raw_id": "p1", "from_beat": "beat::shared"},
+        )
+        # Arc only includes trust path
+        g.create_node(
+            "arc::a1",
+            {"type": "arc", "paths": ["path::trust"]},
+        )
+        result = format_entry_states(g, "passage::p1", "arc::a1")
+        assert "path::trust: cautious warmth <- ACTIVE" in result
+        # betray is NOT active in this arc
+        assert (
+            "path::betray: defensive guilt\n" in result or "path::betray: defensive guilt" in result
+        )

--- a/tests/unit/test_grow_stage.py
+++ b/tests/unit/test_grow_stage.py
@@ -57,7 +57,7 @@ class TestGrowStageExecute:
         assert tokens == 0
         # All phases run to completion (empty graph = no work to do)
         phases = result_dict["phases_completed"]
-        assert len(phases) == 15
+        assert len(phases) == 16
         for phase in phases:
             assert phase["status"] == "completed"
 
@@ -123,10 +123,10 @@ class TestGrowStageExecute:
 
 
 class TestGrowStagePhaseOrder:
-    def test_phase_order_returns_fifteen_phases(self) -> None:
+    def test_phase_order_returns_sixteen_phases(self) -> None:
         stage = GrowStage()
         phases = stage._phase_order()
-        assert len(phases) == 15
+        assert len(phases) == 16
 
     def test_phase_order_names(self) -> None:
         stage = GrowStage()
@@ -137,6 +137,7 @@ class TestGrowStagePhaseOrder:
             "scene_types",
             "narrative_gaps",
             "pacing_gaps",
+            "atmospheric",
             "intersections",
             "enumerate_arcs",
             "divergence",


### PR DESCRIPTION
## Problem
The FILL stage prose generation lacks sensory environment context and per-path emotional entry points, making generated prose less grounded and less responsive to branching narrative paths.

## Changes
- Add `_phase_4d_atmospheric()` method to GROW stage (runs after Phase 4c pacing gaps)
- Add `grow_phase4d_atmospheric.yaml` prompt template for batch LLM call
- Add `format_atmospheric_detail()` and `format_entry_states()` formatters in fill_context.py
- Wire new formatters into FILL Phase 1 prose generation context
- Update `fill_phase1_prose.yaml` template with atmospheric detail and entry states sections

## Not Included / Future PRs
- Phase 4e per-path mini-arcs (#463) — next PR in stack
- Post-FILL arc validation (#464)

## Test Plan
- 8 new tests for formatters (missing passage, absent data, formatting, active path marking)
- `uv run mypy src/` — clean
- `uv run pytest tests/unit/test_fill_context.py -x -q` — 61 passed

## Risk / Rollback
- Additive only — new GROW phase and FILL context fields
- Graceful degradation: formatters return empty string if data absent

## Review Guide
1. `prompts/templates/grow_phase4d_atmospheric.yaml` — prompt design
2. `src/questfoundry/pipeline/stages/grow.py` — Phase 4d method
3. `src/questfoundry/graph/fill_context.py` — formatters
4. `src/questfoundry/pipeline/stages/fill.py` — wiring
5. `tests/unit/test_fill_context.py` — new tests