### PR TITLE
feat(grow): add Phase 4e per-path mini-arcs (#463)

### DIFF
--- a/prompts/templates/fill_phase1_prose.yaml
+++ b/prompts/templates/fill_phase1_prose.yaml
@@ -57,6 +57,9 @@ system: |
   ## Shadow States (Poly-State Context)
   {shadow_states}
 
+  ## Path Arcs
+  {path_arcs}
+
   ## Rules
 
   1. Follow the voice document for POV, tense, register, rhythm, and tone

--- a/prompts/templates/grow_phase4e_path_arcs.yaml
+++ b/prompts/templates/grow_phase4e_path_arcs.yaml
@@ -1,0 +1,47 @@
+name: grow_phase4e_path_arcs
+description: Generate thematic arc context for a single narrative path
+
+system: |
+  You are a narrative architect analyzing a single path through a branching
+  interactive fiction story. Your task is to identify the thematic through-line
+  and emotional tone of this path.
+
+  ## Path Information
+  **Path ID:** {path_id}
+  **Dilemma:** {dilemma_question}
+
+  ## Beat Sequence (in order)
+  {beat_sequence}
+
+  ## Rules
+
+  1. **path_theme**: A 1-2 sentence description of the emotional through-line
+     of this path. What is the reader's journey? What transformation or
+     realization does this path lead toward? (10-200 characters)
+
+  2. **path_mood**: A concise tone descriptor for the overall mood of this
+     path (e.g., "bittersweet resolve", "creeping dread", "fragile hope").
+     (2-50 characters)
+
+  3. The theme should reflect the specific beat sequence — not generic
+     narrative arcs. Reference the actual content of the beats.
+
+  4. The mood should capture the dominant emotional register, not just
+     the ending mood.
+
+  ## Output Format
+  Return a JSON object with:
+  - path_id: "{path_id}"
+  - path_theme: the emotional through-line (10-200 chars)
+  - path_mood: the tone descriptor (2-50 chars)
+
+user: |
+  Analyze the beat sequence for path {path_id} and generate its thematic
+  arc context.
+
+  CRITICAL REMINDERS:
+  - path_theme must reflect THIS path's specific beat content
+  - path_mood must be a concise tone descriptor, not a sentence
+  - Return ONLY a valid JSON object. Do NOT add prose before or after the JSON.
+
+components: []

--- a/src/questfoundry/graph/fill_context.py
+++ b/src/questfoundry/graph/fill_context.py
@@ -839,6 +839,64 @@ def format_entry_states(graph: Graph, passage_id: str, arc_id: str) -> str:
     return "\n".join(lines)
 
 
+# ---------------------------------------------------------------------------
+# Path arc context
+# ---------------------------------------------------------------------------
+
+
+def format_path_arc_context(graph: Graph, passage_id: str, arc_id: str) -> str:
+    """Format path arc context for a passage.
+
+    Shows the thematic through-line and mood of active paths in the arc
+    being generated, giving the prose writer emotional direction.
+
+    Args:
+        graph: Graph containing passage, arc, and path nodes.
+        passage_id: The passage being generated.
+        arc_id: The arc being traversed.
+
+    Returns:
+        Formatted path arc context, or empty string if no path arcs set.
+    """
+    passage = graph.get_node(passage_id)
+    if not passage:
+        return ""
+
+    arc_node = graph.get_node(arc_id)
+    if not arc_node:
+        return ""
+
+    arc_paths = arc_node.get("paths", [])
+    if not arc_paths:
+        return ""
+
+    lines: list[str] = []
+    for path_id in sorted(arc_paths):
+        path_node = graph.get_node(path_id)
+        if not path_node:
+            continue
+        theme = path_node.get("path_theme", "")
+        mood = path_node.get("path_mood", "")
+        if not theme and not mood:
+            continue
+        raw_id = path_node.get("raw_id", path_id)
+        parts = [f"**{raw_id}**"]
+        if mood:
+            parts.append(f"Mood: {mood}")
+        if theme:
+            parts.append(f"Theme: {theme}")
+        lines.append("- " + " | ".join(parts))
+
+    if not lines:
+        return ""
+
+    return (
+        "**Path Arcs** (thematic context for active paths):\n\n"
+        + "\n".join(lines)
+        + "\n\nLet the path mood and theme subtly inform tone and imagery."
+    )
+
+
 def format_passages_batch(
     graph: Graph,
     passage_ids: list[str],

--- a/src/questfoundry/pipeline/stages/fill.py
+++ b/src/questfoundry/pipeline/stages/fill.py
@@ -34,6 +34,7 @@ from questfoundry.graph.fill_context import (
     format_lookahead_context,
     format_narrative_context,
     format_passages_batch,
+    format_path_arc_context,
     format_scene_types_summary,
     format_shadow_states,
     format_sliding_window,
@@ -577,6 +578,7 @@ class FillStage:
                 "sliding_window": format_sliding_window(graph, arc_id, current_idx),
                 "lookahead": format_lookahead_context(graph, passage_id, arc_id),
                 "shadow_states": format_shadow_states(graph, passage_id, arc_id),
+                "path_arcs": format_path_arc_context(graph, passage_id, arc_id),
             }
 
             output, llm_calls, tokens = await self._fill_llm_call(

--- a/tests/integration/test_grow_e2e.py
+++ b/tests/integration/test_grow_e2e.py
@@ -152,12 +152,12 @@ def pipeline_result(tmp_path_factory: pytest.TempPathFactory) -> dict[str, Any]:
 
 
 class TestGrowFullPipeline:
-    """E2E tests running all 16 GROW phases on the fixture graph."""
+    """E2E tests running all 17 GROW phases on the fixture graph."""
 
     def test_all_phases_complete(self, pipeline_result: dict[str, Any]) -> None:
-        """Verify all 16 phases complete with no failures."""
+        """Verify all 17 phases complete with no failures."""
         phases = pipeline_result["result_dict"]["phases_completed"]
-        assert len(phases) == 16
+        assert len(phases) == 17
         for phase in phases:
             assert phase["status"] in ("completed", "skipped"), (
                 f"Phase {phase['phase']} has unexpected status: {phase['status']}"

--- a/tests/unit/test_grow_algorithms.py
+++ b/tests/unit/test_grow_algorithms.py
@@ -1612,9 +1612,9 @@ class TestPhaseIntegrationEndToEnd:
         mock_model = _make_grow_mock_model(graph)
         result_dict, _llm_calls, _tokens = await stage.execute(model=mock_model, user_prompt="")
 
-        # All 16 phases should run (completed or skipped)
+        # All 17 phases should run (completed or skipped)
         phases = result_dict["phases_completed"]
-        assert len(phases) == 16
+        assert len(phases) == 17
         for phase in phases:
             assert phase["status"] in ("completed", "skipped")
 

--- a/tests/unit/test_grow_stage.py
+++ b/tests/unit/test_grow_stage.py
@@ -57,7 +57,7 @@ class TestGrowStageExecute:
         assert tokens == 0
         # All phases run to completion (empty graph = no work to do)
         phases = result_dict["phases_completed"]
-        assert len(phases) == 16
+        assert len(phases) == 17
         for phase in phases:
             assert phase["status"] == "completed"
 
@@ -123,10 +123,10 @@ class TestGrowStageExecute:
 
 
 class TestGrowStagePhaseOrder:
-    def test_phase_order_returns_sixteen_phases(self) -> None:
+    def test_phase_order_returns_seventeen_phases(self) -> None:
         stage = GrowStage()
         phases = stage._phase_order()
-        assert len(phases) == 16
+        assert len(phases) == 17
 
     def test_phase_order_names(self) -> None:
         stage = GrowStage()
@@ -138,6 +138,7 @@ class TestGrowStagePhaseOrder:
             "narrative_gaps",
             "pacing_gaps",
             "atmospheric",
+            "path_arcs",
             "intersections",
             "enumerate_arcs",
             "divergence",


### PR DESCRIPTION
## Problem
FILL stage prose generation lacks awareness of the thematic through-line and emotional tone of the path being traversed, leading to prose that doesn't build toward the path's narrative arc.

## Changes
- Add `_phase_4e_path_arcs()` method to GROW stage (one LLM call per path, after Phase 4d)
- Add `grow_phase4e_path_arcs.yaml` prompt template
- Add `format_path_arc_context()` formatter in fill_context.py
- Wire path arc context into FILL Phase 1 prose generation
- Update `fill_phase1_prose.yaml` template with path arcs section

## Not Included / Future PRs
- Post-FILL arc validation (#464) — next PR in stack

## Test Plan
- 5 new tests for formatter (missing passage, missing arc, no arcs set, full formatting, skip paths without data)
- `uv run mypy src/` — clean
- `uv run pytest tests/unit/test_fill_context.py -x -q` — 66 passed

## Risk / Rollback
- Additive only — new GROW phase and FILL context field
- Graceful degradation: formatter returns empty string if path arcs absent
- Phase 4e skips paths with cycles or no beats (logged as warnings)