### PR TITLE
feat(fill): add post-FILL arc validation (#464)

### DIFF
--- a/src/questfoundry/graph/fill_validation.py
+++ b/src/questfoundry/graph/fill_validation.py
@@ -53,7 +53,7 @@ def check_intensity_progression(graph: Graph, arc_id: str) -> ValidationCheck:
             message=f"Arc has {len(sequence)} beats (< 3), too short to check",
         )
 
-    # Split into thirds
+    # Split into approximate thirds (first N, middle, last N where N = len//3)
     third = len(sequence) // 3
     first_third = sequence[:third]
     final_third = sequence[-third:]
@@ -142,6 +142,7 @@ def check_dramatic_questions_closed(graph: Graph, arc_id: str) -> ValidationChec
             message="All dramatic questions are resolved by arc end",
         )
 
+    # str() needed: compute_open_questions returns dict[str, str | int]
     unclosed = [str(q.get("dilemma_id", "?")) for q in open_qs]
     return ValidationCheck(
         name="dramatic_questions_closed",

--- a/src/questfoundry/graph/fill_validation.py
+++ b/src/questfoundry/graph/fill_validation.py
@@ -1,0 +1,264 @@
+"""Arc-level validation checks for post-FILL quality assurance.
+
+Validates narrative arc integrity after prose generation. These are pure,
+deterministic functions operating on the graph -- no LLM calls.
+
+Validation checks:
+- Intensity progression: final third should have more high-intensity beats
+- Dramatic questions closed: every opened question should be committed before arc end
+- Narrative function variety: no 5+ consecutive identical functions, must include
+  at least one confront or resolve
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from questfoundry.graph.fill_context import compute_open_questions, derive_pacing
+from questfoundry.graph.grow_validation import ValidationCheck, ValidationReport
+
+if TYPE_CHECKING:
+    from questfoundry.graph.graph import Graph
+
+# Maximum allowed run of identical consecutive narrative_function values.
+MAX_CONSECUTIVE_SAME_FUNCTION = 4
+
+
+def check_intensity_progression(graph: Graph, arc_id: str) -> ValidationCheck:
+    """Check that the final third of an arc has more high-intensity beats than the first third.
+
+    Uses derive_pacing() to classify each beat's intensity from its
+    narrative_function and scene_type.
+
+    Args:
+        graph: Graph containing arc and beat nodes.
+        arc_id: The arc to validate.
+
+    Returns:
+        ValidationCheck with pass/warn/fail severity.
+    """
+    arc_node = graph.get_node(arc_id)
+    if not arc_node:
+        return ValidationCheck(
+            name="intensity_progression",
+            severity="pass",
+            message=f"Arc {arc_id} not found, skipping",
+        )
+
+    sequence = arc_node.get("sequence", [])
+    if len(sequence) < 3:
+        return ValidationCheck(
+            name="intensity_progression",
+            severity="pass",
+            message=f"Arc has {len(sequence)} beats (< 3), too short to check",
+        )
+
+    # Split into thirds
+    third = len(sequence) // 3
+    first_third = sequence[:third]
+    final_third = sequence[-third:]
+
+    def count_high(beat_ids: list[str]) -> int:
+        count = 0
+        for bid in beat_ids:
+            beat = graph.get_node(bid)
+            if not beat:
+                continue
+            nf = beat.get("narrative_function", "")
+            st = beat.get("scene_type", "")
+            if nf and st:
+                intensity, _ = derive_pacing(nf, st)
+                if intensity == "high":
+                    count += 1
+        return count
+
+    first_high = count_high(first_third)
+    final_high = count_high(final_third)
+
+    if final_high > first_high:
+        return ValidationCheck(
+            name="intensity_progression",
+            severity="pass",
+            message=f"Intensity rises: first third {first_high} high, final third {final_high} high",
+        )
+
+    if final_high == first_high:
+        return ValidationCheck(
+            name="intensity_progression",
+            severity="warn",
+            message=(
+                f"Flat intensity: first third {first_high} high, final third {final_high} high. "
+                "Consider escalating tension toward the end."
+            ),
+        )
+
+    return ValidationCheck(
+        name="intensity_progression",
+        severity="warn",
+        message=(
+            f"Intensity drops: first third {first_high} high, final third {final_high} high. "
+            "The arc may feel anticlimactic."
+        ),
+    )
+
+
+def check_dramatic_questions_closed(graph: Graph, arc_id: str) -> ValidationCheck:
+    """Check that every opened dramatic question has a commits before arc end.
+
+    Walks the full beat sequence and uses compute_open_questions() with
+    a sentinel beat ID to get questions still open at the end.
+
+    Args:
+        graph: Graph containing arc, beat, and dilemma nodes.
+        arc_id: The arc to validate.
+
+    Returns:
+        ValidationCheck with pass/warn severity.
+    """
+    arc_node = graph.get_node(arc_id)
+    if not arc_node:
+        return ValidationCheck(
+            name="dramatic_questions_closed",
+            severity="pass",
+            message=f"Arc {arc_id} not found, skipping",
+        )
+
+    sequence = arc_node.get("sequence", [])
+    if not sequence:
+        return ValidationCheck(
+            name="dramatic_questions_closed",
+            severity="pass",
+            message="Arc has no beats",
+        )
+
+    # Use a sentinel that won't match any beat to walk the full sequence
+    sentinel = "__sentinel_end__"
+    open_qs = compute_open_questions(graph, arc_id, sentinel)
+
+    if not open_qs:
+        return ValidationCheck(
+            name="dramatic_questions_closed",
+            severity="pass",
+            message="All dramatic questions are resolved by arc end",
+        )
+
+    unclosed = [str(q.get("dilemma_id", "?")) for q in open_qs]
+    return ValidationCheck(
+        name="dramatic_questions_closed",
+        severity="warn",
+        message=f"{len(unclosed)} unclosed dramatic question(s): {', '.join(unclosed)}",
+    )
+
+
+def check_narrative_function_variety(graph: Graph, arc_id: str) -> ValidationCheck:
+    """Check narrative function variety within an arc.
+
+    Two checks:
+    1. No run of 5+ consecutive identical narrative_function values
+    2. Arc must contain at least one 'confront' or 'resolve'
+
+    Args:
+        graph: Graph containing arc and beat nodes.
+        arc_id: The arc to validate.
+
+    Returns:
+        ValidationCheck with pass/warn severity.
+    """
+    arc_node = graph.get_node(arc_id)
+    if not arc_node:
+        return ValidationCheck(
+            name="narrative_function_variety",
+            severity="pass",
+            message=f"Arc {arc_id} not found, skipping",
+        )
+
+    sequence = arc_node.get("sequence", [])
+    if not sequence:
+        return ValidationCheck(
+            name="narrative_function_variety",
+            severity="pass",
+            message="Arc has no beats",
+        )
+
+    functions: list[str] = []
+    for bid in sequence:
+        beat = graph.get_node(bid)
+        if not beat:
+            continue
+        nf = beat.get("narrative_function", "")
+        if nf:
+            functions.append(nf)
+
+    if not functions:
+        return ValidationCheck(
+            name="narrative_function_variety",
+            severity="warn",
+            message="No beats have narrative_function set",
+        )
+
+    # Check for long runs
+    max_run = 1
+    run_fn = ""
+    current_run = 1
+    for i in range(1, len(functions)):
+        if functions[i] == functions[i - 1]:
+            current_run += 1
+            if current_run > max_run:
+                max_run = current_run
+                run_fn = functions[i]
+        else:
+            current_run = 1
+
+    issues: list[str] = []
+    if max_run > MAX_CONSECUTIVE_SAME_FUNCTION:
+        issues.append(
+            f"{max_run} consecutive '{run_fn}' beats (max {MAX_CONSECUTIVE_SAME_FUNCTION})"
+        )
+
+    # Check for climactic functions
+    has_climactic = any(f in ("confront", "resolve") for f in functions)
+    if not has_climactic:
+        issues.append("No 'confront' or 'resolve' beats in arc")
+
+    if issues:
+        return ValidationCheck(
+            name="narrative_function_variety",
+            severity="warn",
+            message="; ".join(issues),
+        )
+
+    return ValidationCheck(
+        name="narrative_function_variety",
+        severity="pass",
+        message=f"Good variety: {len(set(functions))} distinct functions, max run {max_run}",
+    )
+
+
+def run_arc_validation(graph: Graph) -> ValidationReport:
+    """Run all arc-level validation checks across all arcs.
+
+    Args:
+        graph: Graph containing arc and beat nodes.
+
+    Returns:
+        ValidationReport with all check results.
+    """
+    report = ValidationReport()
+    arcs = graph.get_nodes_by_type("arc")
+
+    if not arcs:
+        report.checks.append(
+            ValidationCheck(
+                name="arc_validation",
+                severity="pass",
+                message="No arcs found, skipping validation",
+            )
+        )
+        return report
+
+    for arc_id in sorted(arcs.keys()):
+        report.checks.append(check_intensity_progression(graph, arc_id))
+        report.checks.append(check_dramatic_questions_closed(graph, arc_id))
+        report.checks.append(check_narrative_function_variety(graph, arc_id))
+
+    return report

--- a/tests/unit/test_fill_stage.py
+++ b/tests/unit/test_fill_stage.py
@@ -255,7 +255,7 @@ class TestFillStageExecute:
         _mock_implemented_phases(stage)
         await stage.execute(mock_model, "", on_phase_progress=on_progress)
 
-        assert len(progress_calls) == 4
+        assert len(progress_calls) == 5
         assert progress_calls[0][0] == "voice"
 
     @pytest.mark.asyncio
@@ -273,15 +273,15 @@ class TestFillStageExecute:
 
 
 class TestPhaseOrder:
-    def test_four_phases(self) -> None:
+    def test_five_phases(self) -> None:
         stage = FillStage()
         phases = stage._phase_order()
-        assert len(phases) == 4
+        assert len(phases) == 5
 
     def test_phase_names(self) -> None:
         stage = FillStage()
         names = [name for _, name in stage._phase_order()]
-        assert names == ["voice", "generate", "review", "revision"]
+        assert names == ["voice", "generate", "review", "revision", "arc_validation"]
 
 
 class TestCheckpointing:

--- a/tests/unit/test_fill_validation.py
+++ b/tests/unit/test_fill_validation.py
@@ -1,0 +1,277 @@
+"""Tests for post-FILL arc-level validation checks."""
+
+from __future__ import annotations
+
+from questfoundry.graph.fill_validation import (
+    check_dramatic_questions_closed,
+    check_intensity_progression,
+    check_narrative_function_variety,
+    run_arc_validation,
+)
+from questfoundry.graph.graph import Graph
+
+
+class TestCheckIntensityProgression:
+    """Tests for check_intensity_progression."""
+
+    def test_missing_arc(self) -> None:
+        g = Graph.empty()
+        result = check_intensity_progression(g, "arc::nope")
+        assert result.severity == "pass"
+        assert "not found" in result.message
+
+    def test_short_arc(self) -> None:
+        g = Graph.empty()
+        g.create_node("arc::a1", {"type": "arc", "sequence": ["beat::b1", "beat::b2"]})
+        result = check_intensity_progression(g, "arc::a1")
+        assert result.severity == "pass"
+        assert "too short" in result.message
+
+    def test_rising_intensity(self) -> None:
+        """Final third has more high-intensity beats than first third."""
+        g = Graph.empty()
+        beats = []
+        # First third: introduce/scene = medium intensity
+        for i in range(3):
+            bid = f"beat::b{i}"
+            g.create_node(
+                bid,
+                {
+                    "type": "beat",
+                    "narrative_function": "introduce",
+                    "scene_type": "scene",
+                },
+            )
+            beats.append(bid)
+        # Middle third: develop/scene = medium
+        for i in range(3, 6):
+            bid = f"beat::b{i}"
+            g.create_node(
+                bid,
+                {
+                    "type": "beat",
+                    "narrative_function": "develop",
+                    "scene_type": "scene",
+                },
+            )
+            beats.append(bid)
+        # Final third: confront/scene = high intensity
+        for i in range(6, 9):
+            bid = f"beat::b{i}"
+            g.create_node(
+                bid,
+                {
+                    "type": "beat",
+                    "narrative_function": "confront",
+                    "scene_type": "scene",
+                },
+            )
+            beats.append(bid)
+        g.create_node("arc::a1", {"type": "arc", "sequence": beats})
+        result = check_intensity_progression(g, "arc::a1")
+        assert result.severity == "pass"
+        assert "rises" in result.message
+
+    def test_flat_intensity(self) -> None:
+        """Same intensity in first and final thirds."""
+        g = Graph.empty()
+        beats = []
+        for i in range(6):
+            bid = f"beat::b{i}"
+            g.create_node(
+                bid,
+                {
+                    "type": "beat",
+                    "narrative_function": "develop",
+                    "scene_type": "scene",
+                },
+            )
+            beats.append(bid)
+        g.create_node("arc::a1", {"type": "arc", "sequence": beats})
+        result = check_intensity_progression(g, "arc::a1")
+        assert result.severity == "warn"
+        assert "Flat" in result.message
+
+    def test_dropping_intensity(self) -> None:
+        """High intensity in first third, low in final third."""
+        g = Graph.empty()
+        beats = []
+        # First third: confront/scene = high
+        for i in range(3):
+            bid = f"beat::b{i}"
+            g.create_node(
+                bid,
+                {
+                    "type": "beat",
+                    "narrative_function": "confront",
+                    "scene_type": "scene",
+                },
+            )
+            beats.append(bid)
+        # Middle and final: introduce/sequel = low
+        for i in range(3, 9):
+            bid = f"beat::b{i}"
+            g.create_node(
+                bid,
+                {
+                    "type": "beat",
+                    "narrative_function": "introduce",
+                    "scene_type": "sequel",
+                },
+            )
+            beats.append(bid)
+        g.create_node("arc::a1", {"type": "arc", "sequence": beats})
+        result = check_intensity_progression(g, "arc::a1")
+        assert result.severity == "warn"
+        assert "drops" in result.message
+
+
+class TestCheckDramaticQuestionsClosed:
+    """Tests for check_dramatic_questions_closed."""
+
+    def test_missing_arc(self) -> None:
+        g = Graph.empty()
+        result = check_dramatic_questions_closed(g, "arc::nope")
+        assert result.severity == "pass"
+
+    def test_empty_arc(self) -> None:
+        g = Graph.empty()
+        g.create_node("arc::a1", {"type": "arc", "sequence": []})
+        result = check_dramatic_questions_closed(g, "arc::a1")
+        assert result.severity == "pass"
+
+    def test_all_questions_closed(self) -> None:
+        g = Graph.empty()
+        g.create_node(
+            "dilemma::d1",
+            {"type": "dilemma", "question": "Trust or betray?"},
+        )
+        g.create_node(
+            "beat::b1",
+            {
+                "type": "beat",
+                "dilemma_impacts": [{"dilemma_id": "dilemma::d1", "effect": "advances"}],
+            },
+        )
+        g.create_node(
+            "beat::b2",
+            {
+                "type": "beat",
+                "dilemma_impacts": [{"dilemma_id": "dilemma::d1", "effect": "commits"}],
+            },
+        )
+        g.create_node("arc::a1", {"type": "arc", "sequence": ["beat::b1", "beat::b2"]})
+        result = check_dramatic_questions_closed(g, "arc::a1")
+        assert result.severity == "pass"
+        assert "resolved" in result.message
+
+    def test_unclosed_question(self) -> None:
+        g = Graph.empty()
+        g.create_node(
+            "dilemma::d1",
+            {"type": "dilemma", "question": "Trust or betray?"},
+        )
+        g.create_node(
+            "beat::b1",
+            {
+                "type": "beat",
+                "dilemma_impacts": [{"dilemma_id": "dilemma::d1", "effect": "advances"}],
+            },
+        )
+        g.create_node("beat::b2", {"type": "beat"})
+        g.create_node("arc::a1", {"type": "arc", "sequence": ["beat::b1", "beat::b2"]})
+        result = check_dramatic_questions_closed(g, "arc::a1")
+        assert result.severity == "warn"
+        assert "unclosed" in result.message.lower()
+        assert "dilemma::d1" in result.message
+
+
+class TestCheckNarrativeFunctionVariety:
+    """Tests for check_narrative_function_variety."""
+
+    def test_missing_arc(self) -> None:
+        g = Graph.empty()
+        result = check_narrative_function_variety(g, "arc::nope")
+        assert result.severity == "pass"
+
+    def test_empty_arc(self) -> None:
+        g = Graph.empty()
+        g.create_node("arc::a1", {"type": "arc", "sequence": []})
+        result = check_narrative_function_variety(g, "arc::a1")
+        assert result.severity == "pass"
+
+    def test_good_variety(self) -> None:
+        g = Graph.empty()
+        functions = ["introduce", "develop", "complicate", "confront", "resolve"]
+        beats = []
+        for i, fn in enumerate(functions):
+            bid = f"beat::b{i}"
+            g.create_node(bid, {"type": "beat", "narrative_function": fn})
+            beats.append(bid)
+        g.create_node("arc::a1", {"type": "arc", "sequence": beats})
+        result = check_narrative_function_variety(g, "arc::a1")
+        assert result.severity == "pass"
+        assert "Good variety" in result.message
+
+    def test_too_many_consecutive(self) -> None:
+        g = Graph.empty()
+        beats = []
+        # 5 consecutive "develop" exceeds max of 4
+        for i in range(5):
+            bid = f"beat::b{i}"
+            g.create_node(bid, {"type": "beat", "narrative_function": "develop"})
+            beats.append(bid)
+        # Add a resolve to satisfy the climactic check
+        g.create_node("beat::b5", {"type": "beat", "narrative_function": "resolve"})
+        beats.append("beat::b5")
+        g.create_node("arc::a1", {"type": "arc", "sequence": beats})
+        result = check_narrative_function_variety(g, "arc::a1")
+        assert result.severity == "warn"
+        assert "consecutive" in result.message
+
+    def test_no_climactic_functions(self) -> None:
+        g = Graph.empty()
+        beats = []
+        for i, fn in enumerate(["introduce", "develop", "complicate"]):
+            bid = f"beat::b{i}"
+            g.create_node(bid, {"type": "beat", "narrative_function": fn})
+            beats.append(bid)
+        g.create_node("arc::a1", {"type": "arc", "sequence": beats})
+        result = check_narrative_function_variety(g, "arc::a1")
+        assert result.severity == "warn"
+        assert "confront" in result.message or "resolve" in result.message
+
+    def test_no_functions_set(self) -> None:
+        g = Graph.empty()
+        g.create_node("beat::b1", {"type": "beat"})
+        g.create_node("arc::a1", {"type": "arc", "sequence": ["beat::b1"]})
+        result = check_narrative_function_variety(g, "arc::a1")
+        assert result.severity == "warn"
+        assert "No beats have narrative_function" in result.message
+
+
+class TestRunArcValidation:
+    """Tests for run_arc_validation."""
+
+    def test_no_arcs(self) -> None:
+        g = Graph.empty()
+        report = run_arc_validation(g)
+        assert not report.has_failures
+        assert len(report.checks) == 1
+
+    def test_runs_all_checks_per_arc(self) -> None:
+        g = Graph.empty()
+        functions = ["introduce", "develop", "complicate", "confront", "resolve"]
+        beats = []
+        for i, fn in enumerate(functions):
+            bid = f"beat::b{i}"
+            g.create_node(bid, {"type": "beat", "narrative_function": fn, "scene_type": "scene"})
+            beats.append(bid)
+        g.create_node("arc::a1", {"type": "arc", "sequence": beats})
+        report = run_arc_validation(g)
+        # 3 checks per arc
+        assert len(report.checks) == 3
+        check_names = {c.name for c in report.checks}
+        assert "intensity_progression" in check_names
+        assert "dramatic_questions_closed" in check_names
+        assert "narrative_function_variety" in check_names


### PR DESCRIPTION
## Problem
After FILL generates prose, there's no automated check for arc-level narrative quality — intensity progression, dramatic question resolution, and narrative function variety are unchecked.

## Changes
- Add `fill_validation.py` with three deterministic validation checks:
  - `check_intensity_progression`: Final third of arc should have more high-intensity beats than first third
  - `check_dramatic_questions_closed`: Every opened dramatic question should have a `commits` before arc end
  - `check_narrative_function_variety`: No 5+ consecutive identical functions; arc must include confront or resolve
- Add `_phase_4_arc_validation()` to FILL stage (runs after revision, no LLM calls)
- Reuses `ValidationCheck` / `ValidationReport` from `grow_validation.py`

## Not Included / Future PRs
- This completes epic #457

## Test Plan
- 17 new tests covering all check variants (missing arc, edge cases, pass/warn scenarios)
- `uv run mypy src/` — clean
- `uv run pytest tests/unit/test_fill_validation.py -x -q` — 17 passed

## Risk / Rollback
- All checks produce warnings, not failures — no blocking behavior
- Deterministic only, zero LLM cost
- Additive: new phase at end of FILL pipeline