### PR TITLE
fix: Ollama concurrency control and smart model eviction

### DIFF
--- a/src/questfoundry/pipeline/stages/base.py
+++ b/src/questfoundry/pipeline/stages/base.py
@@ -14,6 +14,8 @@ AssistantMessageFn = Callable[[str], None]
 LLMCallbackFn = Callable[[str], None]
 # Phase progress callback: (phase_name, status, detail) -> None
 PhaseProgressFn = Callable[[str, str, str | None], None]
+# Async hook called between pipeline phases to unload Ollama models from VRAM
+UnloadHookFn = Callable[[], Awaitable[None]]
 
 
 class Stage(Protocol):

--- a/src/questfoundry/pipeline/stages/brainstorm.py
+++ b/src/questfoundry/pipeline/stages/brainstorm.py
@@ -260,6 +260,11 @@ class BrainstormStage:
         total_llm_calls += discuss_calls
         total_tokens += discuss_tokens
 
+        # Unload discuss model from VRAM if switching to a different Ollama model
+        unload_after_discuss = kwargs.get("unload_after_discuss")
+        if unload_after_discuss is not None:
+            await unload_after_discuss()
+
         # Phase 2: Summarize (use summarize_model if provided)
         log.debug("brainstorm_phase", phase="summarize")
         summarize_prompt = get_brainstorm_summarize_prompt(size_profile=size_profile)
@@ -274,6 +279,11 @@ class BrainstormStage:
             on_phase_progress("summarize", "completed", None)
         total_llm_calls += 1
         total_tokens += summarize_tokens
+
+        # Unload summarize model from VRAM if switching to a different Ollama model
+        unload_after_summarize = kwargs.get("unload_after_summarize")
+        if unload_after_summarize is not None:
+            await unload_after_summarize()
 
         # Phase 3: Serialize (use serialize_model if provided)
         log.debug("brainstorm_phase", phase="serialize")


### PR DESCRIPTION
## Problem

Three issues when running QuestFoundry with Ollama:

1. **Server overload**: `_serialize_beats_per_path()` fires `asyncio.create_task()` for all paths simultaneously with no concurrency limit. With 6+ paths, this floods Ollama with concurrent GPU inference requests, overwhelming the server and causing hangs/crashes.

2. **VRAM exhaustion**: When different Ollama models are used for discuss/summarize/serialize phases (hybrid provider configuration), the outgoing model stays loaded in VRAM for 5 minutes (Ollama's default `keep_alive`). Both models compete for GPU memory.

3. **Hardcoded num_ctx**: Context window is hardcoded to 32768 regardless of model capability. Models with different configured context windows get the wrong value. (#130)

## Changes

### Fix 1: Concurrency limiter
- Add `asyncio.Semaphore(max_concurrency=2)` to `_serialize_beats_per_path()` in `serialize.py`
- All paths still get tasks created, but only `max_concurrency` run simultaneously
- Default of 2 allows pipelining without flooding Ollama (whose `OLLAMA_NUM_PARALLEL` defaults to 1)

### Fix 2: Smart model eviction
- Add `unload_ollama_model()` utility that sends `POST /api/generate` with `keep_alive=0` to immediately unload a model from VRAM
- Orchestrator compares resolved provider strings across discuss/summarize/serialize phases
- When models differ, builds async unload hooks; when same model, hooks are no-ops
- Stages (Dream, Brainstorm, Seed, Dress) call hooks between phase transitions
- GROW/FILL stages unaffected (single-model, no three-phase pattern)

### Fix 3: Dynamic num_ctx from Ollama
- Add `_query_ollama_num_ctx()` that queries Ollama's `/api/show` endpoint at model creation time
- Extracts `num_ctx` from the model's Modelfile `parameters` field (the configured value)
- Falls back to architecture `context_length` from `model_info` if parameters lacks num_ctx
- Falls back to 32768 if query fails (Ollama unreachable, model not found)
- Explicit `num_ctx` kwarg still takes precedence over the query

### Edge cases handled
- Same model all phases: no unload calls (no-op hooks)
- Ollama→OpenAI switch: unloads the Ollama model
- OpenAI→Ollama: no unload needed
- Non-Ollama providers: utility silently returns
- Unload failure: logged as warning, non-fatal
- Ollama unreachable for /api/show: falls back to 32768

## Not Included / Future PRs
- Server-side `OLLAMA_NUM_PARALLEL` configuration guidance (docs)
- Making `max_concurrency` configurable via project.yaml

## Test Plan
- `uv run pytest tests/unit/test_provider_factory.py -x -q` — 71 tests pass (includes 4 unload tests + 5 num_ctx query tests)
- `uv run pytest tests/unit/test_serialize.py::TestSerializeBeatsPerPathConcurrency -x -q` — 1 test passes
- `uv run mypy src/` and `uv run ruff check src/` clean

## Risk / Rollback
- Semaphore default of 2 is conservative; can be increased if needed
- Unload hooks are no-ops when all phases use the same provider (most common case)
- Unload failures are non-fatal (warning logged, pipeline continues)
- num_ctx query adds one sync HTTP call at model creation; 10s timeout with graceful fallback

🤖 Generated with [Claude Code](https://claude.com/claude-code)