### PR TITLE
fix(dream): make scope and story_size required fields

### DIFF
--- a/prompts/templates/serialize.yaml
+++ b/prompts/templates/serialize.yaml
@@ -20,19 +20,28 @@ system: |
   - Output ONLY the structured JSON
   - Follow the schema exactly
 
+  ## scope field (REQUIRED — validation will reject output without it)
+  The "scope" object is REQUIRED. You MUST include it with a "story_size" value.
+  Pick one of: "vignette", "short", "standard", "long".
+
+  Example: "scope": {"story_size": "vignette"}
+
+  If the brief says "vignette-length" or "vignette" → use "vignette".
+  If the brief says "short" → use "short".
+  If the brief says "long" → use "long".
+  If no size is mentioned → use "standard".
+
   ## Scope Boundary (for DREAM artifacts)
   DREAM artifacts capture HIGH-LEVEL VISION only. Even if the brief contains
   detailed content, include ONLY:
   - genre, subgenre, tone, audience, themes (high-level descriptors)
   - style_notes (prose guidance, 50-200 chars, NOT plot summaries)
-  - scope: ALWAYS include. Set story_size to one of: "vignette", "short", "standard", "long".
-    If the brief mentions "vignette" → {"story_size": "vignette"}
-    If the brief mentions "short" → {"story_size": "short"}
-    If the brief mentions "long" → {"story_size": "long"}
-    If no size is mentioned → {"story_size": "standard"}
+  - scope (REQUIRED — see above)
   - content_notes (warnings/guidance, NOT specific scenes or character arcs)
 
   Do NOT serialize specific characters, scenes, endings, or mechanics into
   DREAM fields. Those belong in BRAINSTORM/SEED stages.
+
+  REMINDER: "scope" is required. Do not omit it.
 
 components: []

--- a/prompts/templates/summarize.yaml
+++ b/prompts/templates/summarize.yaml
@@ -11,7 +11,7 @@ system: |
   - Target audience
   - Core themes to explore
   - Style guidance for writing
-  - Scope constraints (word count range, passage count, branching complexity)
+  - Story size: one of "vignette", "short", "standard", or "long" (preserve the exact keyword from the discussion)
   - Content notes (what to include/exclude)
 
   ## Guidelines
@@ -34,7 +34,7 @@ system: |
 
   **Keep only:**
   - Genre, tone, themes (high-level)
-  - Audience and scope constraints
+  - Audience and story size (exact keyword: vignette/short/standard/long)
   - Style guidance
   - Content warnings/notes (general, not specific scenes)
 

--- a/src/questfoundry/models/dream.py
+++ b/src/questfoundry/models/dream.py
@@ -32,7 +32,6 @@ class Scope(BaseModel):
     """
 
     story_size: Literal["vignette", "short", "standard", "long"] = Field(
-        default="standard",
         description='Story size preset: "vignette", "short", "standard", or "long"',
     )
 
@@ -47,7 +46,7 @@ class DreamArtifact(BaseModel):
         default=None, description="Content advisory notes for inclusions and exclusions"
     )
     genre: str = Field(description="Primary genre", min_length=1)
-    scope: Scope = Field(default_factory=Scope)
+    scope: Scope = Field(description="Story scope with size preset")
     style_notes: str | None = Field(default=None, description="Style guidance", min_length=1)
     subgenre: str | None = Field(
         default=None, description="Optional genre refinement", min_length=1

--- a/tests/unit/test_artifacts.py
+++ b/tests/unit/test_artifacts.py
@@ -417,9 +417,7 @@ def test_roundtrip_preserves_data(tmp_path: Path) -> None:
 
 def test_scope_requires_story_size() -> None:
     """Scope model requires story_size (no default)."""
-    import pytest
-
-    with pytest.raises(Exception):  # noqa: B017
+    with pytest.raises(ValidationError):
         Scope()  # type: ignore[call-arg]
 
     scope = Scope(story_size="vignette")
@@ -431,9 +429,7 @@ def test_scope_requires_story_size() -> None:
 
 def test_scope_required_on_dream_artifact() -> None:
     """DreamArtifact requires scope (no default)."""
-    import pytest
-
-    with pytest.raises(Exception):  # noqa: B017
+    with pytest.raises(ValidationError):
         DreamArtifact(
             genre="mystery",
             tone=["dark"],

--- a/tests/unit/test_artifacts.py
+++ b/tests/unit/test_artifacts.py
@@ -25,6 +25,7 @@ def test_dream_artifact_valid_minimal() -> None:
         tone=["dark"],
         audience="adult",
         themes=["betrayal"],
+        scope=Scope(story_size="standard"),
     )
     assert artifact.type == "dream"
     assert artifact.version == 1
@@ -57,6 +58,7 @@ def test_dream_artifact_invalid_empty_genre() -> None:
             tone=["dark"],
             audience="adult",
             themes=["betrayal"],
+            scope=Scope(story_size="standard"),
         )
     assert "genre" in str(exc_info.value)
 
@@ -69,6 +71,7 @@ def test_dream_artifact_invalid_empty_tone() -> None:
             tone=[],
             audience="adult",
             themes=["betrayal"],
+            scope=Scope(story_size="standard"),
         )
     assert "tone" in str(exc_info.value)
 
@@ -81,6 +84,7 @@ def test_dream_artifact_invalid_audience() -> None:
             tone=["dark"],
             audience="",  # Empty string not allowed
             themes=["betrayal"],
+            scope=Scope(story_size="standard"),
         )
     assert "audience" in str(exc_info.value)
 
@@ -93,6 +97,7 @@ def test_dream_artifact_invalid_empty_themes() -> None:
             tone=["dark"],
             audience="adult",
             themes=[],
+            scope=Scope(story_size="standard"),
         )
     assert "themes" in str(exc_info.value)
 
@@ -111,6 +116,7 @@ def test_dream_artifact_accepts_flexible_audience() -> None:
         tone=["dark"],
         audience="adults",  # Not strictly "adult" but valid
         themes=["betrayal"],
+        scope=Scope(story_size="standard"),
     )
     assert artifact.audience == "adults"
 
@@ -126,6 +132,7 @@ def test_writer_creates_artifact_file(tmp_path: Path) -> None:
         tone=["dark"],
         audience="adult",
         themes=["betrayal"],
+        scope=Scope(story_size="standard"),
     )
 
     path = writer.write(artifact, "dream")
@@ -142,6 +149,7 @@ def test_writer_creates_artifacts_directory(tmp_path: Path) -> None:
         tone=["dark"],
         audience="adult",
         themes=["betrayal"],
+        scope=Scope(story_size="standard"),
     )
 
     writer.write(artifact, "dream")
@@ -159,6 +167,7 @@ def test_writer_writes_dict(tmp_path: Path) -> None:
         "tone": ["dark"],
         "audience": "adult",
         "themes": ["betrayal"],
+        "scope": {"story_size": "standard"},
     }
 
     path = writer.write(data, "dream")
@@ -175,6 +184,7 @@ def test_writer_excludes_none_values(tmp_path: Path) -> None:
         audience="adult",
         themes=["betrayal"],
         subgenre=None,  # Should not appear in output
+        scope=Scope(story_size="standard"),
     )
 
     path = writer.write(artifact, "dream")
@@ -195,6 +205,7 @@ def test_reader_reads_artifact(tmp_path: Path) -> None:
         tone=["dark"],
         audience="adult",
         themes=["betrayal"],
+        scope=Scope(story_size="standard"),
     )
     writer.write(artifact, "dream")
 
@@ -216,6 +227,7 @@ def test_reader_read_validated(tmp_path: Path) -> None:
         tone=["dark", "atmospheric"],
         audience="adult",
         themes=["betrayal"],
+        scope=Scope(story_size="standard"),
     )
     writer.write(artifact, "dream")
 
@@ -246,6 +258,7 @@ def test_reader_exists(tmp_path: Path) -> None:
         tone=["dark"],
         audience="adult",
         themes=["betrayal"],
+        scope=Scope(story_size="standard"),
     )
     writer.write(artifact, "dream")
 
@@ -268,6 +281,7 @@ def test_validator_valid_data() -> None:
         "tone": ["dark"],
         "audience": "adult",
         "themes": ["betrayal"],
+        "scope": {"story_size": "standard"},
     }
 
     errors = validator.validate(data, "dream")
@@ -285,6 +299,7 @@ def test_validator_is_valid() -> None:
         "tone": ["dark"],
         "audience": "adult",
         "themes": ["betrayal"],
+        "scope": {"story_size": "standard"},
     }
     invalid_data = {
         "type": "dream",
@@ -293,6 +308,7 @@ def test_validator_is_valid() -> None:
         "tone": [],  # Invalid: empty
         "audience": "adult",
         "themes": ["betrayal"],
+        "scope": {"story_size": "standard"},
     }
 
     assert validator.is_valid(valid_data, "dream")
@@ -309,6 +325,7 @@ def test_validator_invalid_data_pydantic() -> None:
         "tone": [],  # Invalid: must have at least 1
         "audience": "adult",
         "themes": ["betrayal"],
+        "scope": {"story_size": "standard"},
     }
 
     errors = validator.validate(data, "dream")
@@ -327,6 +344,7 @@ def test_validator_invalid_data_schema() -> None:
         "tone": ["dark"],
         "audience": "",  # Empty string not allowed (minLength=1)
         "themes": ["betrayal"],
+        "scope": {"story_size": "standard"},
     }
 
     errors = validator.validate(data, "dream")
@@ -344,6 +362,7 @@ def test_validator_raise_on_error() -> None:
         "tone": [],
         "audience": "adult",
         "themes": ["betrayal"],
+        "scope": {"story_size": "standard"},
     }
 
     with pytest.raises(ArtifactValidationError) as exc_info:
@@ -396,27 +415,38 @@ def test_roundtrip_preserves_data(tmp_path: Path) -> None:
     assert loaded.scope.story_size == original.scope.story_size
 
 
-def test_scope_defaults_to_standard() -> None:
-    """Scope model defaults to standard when no story_size given."""
-    scope = Scope()
-    assert scope.story_size == "standard"
+def test_scope_requires_story_size() -> None:
+    """Scope model requires story_size (no default)."""
+    import pytest
 
-    # Explicit value overrides default
+    with pytest.raises(Exception):  # noqa: B017
+        Scope()  # type: ignore[call-arg]
+
     scope = Scope(story_size="vignette")
     assert scope.story_size == "vignette"
 
+    scope = Scope(story_size="standard")
+    assert scope.story_size == "standard"
 
-def test_scope_defaults_when_omitted() -> None:
-    """DreamArtifact.scope defaults to standard preset when omitted.
 
-    The scope field uses default_factory=Scope, so it's always present
-    with standard preset values even when not explicitly provided.
-    """
+def test_scope_required_on_dream_artifact() -> None:
+    """DreamArtifact requires scope (no default)."""
+    import pytest
+
+    with pytest.raises(Exception):  # noqa: B017
+        DreamArtifact(
+            genre="mystery",
+            tone=["dark"],
+            audience="adult",
+            themes=["betrayal"],
+            # scope not provided — should fail
+        )
+
     artifact = DreamArtifact(
         genre="mystery",
         tone=["dark"],
         audience="adult",
         themes=["betrayal"],
-        # scope not provided — gets default Scope with standard values
+        scope=Scope(story_size="vignette"),
     )
-    assert artifact.scope.story_size == "standard"
+    assert artifact.scope.story_size == "vignette"

--- a/tests/unit/test_dream_stage.py
+++ b/tests/unit/test_dream_stage.py
@@ -7,7 +7,7 @@ from unittest.mock import MagicMock, call, patch
 import pytest
 from langchain_core.messages import AIMessage, HumanMessage
 
-from questfoundry.artifacts import DreamArtifact
+from questfoundry.artifacts import DreamArtifact, Scope
 from questfoundry.pipeline.stages import DreamStage, get_stage
 
 # --- Stage Registration Tests ---
@@ -56,6 +56,7 @@ async def test_execute_calls_all_three_phases() -> None:
             tone=["epic"],
             audience="adult",
             themes=["heroism"],
+            scope=Scope(story_size="standard"),
         )
         mock_serialize.return_value = (mock_artifact, 200)
 
@@ -102,6 +103,7 @@ async def test_execute_emits_phase_progress() -> None:
             tone=["epic"],
             audience="adult",
             themes=["heroism"],
+            scope=Scope(story_size="standard"),
         )
         mock_serialize.return_value = (mock_artifact, 200)
 
@@ -139,6 +141,7 @@ async def test_execute_passes_model_to_all_phases() -> None:
             tone=["dark"],
             audience="adult",
             themes=["justice"],
+            scope=Scope(story_size="standard"),
         )
         mock_serialize.return_value = (mock_artifact, 100)
 
@@ -169,6 +172,7 @@ async def test_execute_passes_user_prompt_to_discuss() -> None:
             tone=["epic"],
             audience="adult",
             themes=["exploration"],
+            scope=Scope(story_size="standard"),
         )
         mock_serialize.return_value = (mock_artifact, 100)
 
@@ -201,6 +205,7 @@ async def test_execute_passes_messages_to_summarize() -> None:
             tone=["epic"],
             audience="adult",
             themes=["magic"],
+            scope=Scope(story_size="standard"),
         )
         mock_serialize.return_value = (mock_artifact, 100)
 
@@ -228,6 +233,7 @@ async def test_execute_passes_brief_to_serialize() -> None:
             tone=["epic"],
             audience="adult",
             themes=["adventure"],
+            scope=Scope(story_size="standard"),
         )
         mock_serialize.return_value = (mock_artifact, 100)
 
@@ -255,6 +261,7 @@ async def test_execute_passes_provider_name_to_serialize() -> None:
             tone=["dark"],
             audience="adult",
             themes=["fear"],
+            scope=Scope(story_size="standard"),
         )
         mock_serialize.return_value = (mock_artifact, 100)
 
@@ -286,6 +293,7 @@ async def test_execute_passes_dream_artifact_schema() -> None:
             tone=["sweet"],
             audience="adult",
             themes=["love"],
+            scope=Scope(story_size="standard"),
         )
         mock_serialize.return_value = (mock_artifact, 100)
 
@@ -314,6 +322,7 @@ async def test_execute_returns_artifact_as_dict() -> None:
             tone=["tense", "dark"],
             audience="adult",
             themes=["paranoia"],
+            scope=Scope(story_size="standard"),
         )
         mock_serialize.return_value = (mock_artifact, 100)
 
@@ -346,6 +355,7 @@ async def test_execute_uses_research_tools() -> None:
             tone=["suspenseful"],
             audience="adult",
             themes=["secrets"],
+            scope=Scope(story_size="standard"),
         )
         mock_serialize.return_value = (mock_artifact, 100)
 

--- a/tests/unit/test_size.py
+++ b/tests/unit/test_size.py
@@ -190,9 +190,11 @@ class TestResolveSizeFromGraph:
 class TestScopeStorySize:
     """Tests for story_size field on the DREAM Scope model."""
 
-    def test_default_story_size_is_standard(self) -> None:
-        scope = Scope(estimated_passages=30, target_word_count=15000)
-        assert scope.story_size == "standard"
+    def test_story_size_is_required(self) -> None:
+        from pydantic import ValidationError
+
+        with pytest.raises(ValidationError):
+            Scope()  # type: ignore[call-arg]
 
     def test_explicit_story_size(self) -> None:
         scope = Scope(story_size="vignette", estimated_passages=10, target_word_count=3000)
@@ -213,10 +215,12 @@ class TestScopeStorySize:
         )
         assert scope.story_size == "long"
 
-    def test_story_size_absent_defaults_to_standard(self) -> None:
-        """Backward compatibility: old artifacts without story_size still validate."""
-        scope = Scope.model_validate({"estimated_passages": 30, "target_word_count": 15000})
-        assert scope.story_size == "standard"
+    def test_story_size_absent_raises_error(self) -> None:
+        """story_size is required — omitting it raises a validation error."""
+        from pydantic import ValidationError
+
+        with pytest.raises(ValidationError):
+            Scope.model_validate({"estimated_passages": 30, "target_word_count": 15000})
 
 
 class TestSizeTemplateVars:


### PR DESCRIPTION
## Problem

The LLM silently omits `scope` during DREAM serialization because `default_factory=Scope` makes it optional in the JSON schema generated by `with_structured_output()`. Pydantic then defaults to `story_size: "standard"`, hiding the omission. A user prompt like "vignette-length pulp space opera" produces `story_size: standard` instead of `vignette`.

## Changes

- Remove default from `Scope.story_size` — now a required `Literal` enum field
- Remove `default_factory` from `DreamArtifact.scope` — now required in the schema
- Add sandwich-pattern scope instructions in `serialize.yaml` (top + bottom reminder)
- Preserve exact story_size keyword through `summarize.yaml` prompt
- Update all test constructors to provide explicit `scope=Scope(story_size=...)`
- Add tests for required-field validation (missing scope and story_size both rejected)

## Not Included / Future PRs

- Other stages that consume `scope` don't need changes (they read from the artifact, not construct it)
- No changes to the validation/repair loop itself — it already handles required-field errors

## Test Plan

```
uv run mypy src/questfoundry/models/dream.py  # clean
uv run ruff check src/ tests/                  # clean
uv run pytest tests/unit/test_artifacts.py tests/unit/test_dream_stage.py -x -q  # 37 passed
```

## Risk / Rollback

- **Breaking change for existing artifacts**: Existing `dream.yaml` files that lack `scope` will fail `read_validated()`. This is intentional — the old default was silently wrong.
- **LLM retry cost**: If the model omits scope, it now triggers a validation retry (max 3). This is the correct behavior — one retry is cheaper than generating a full story with wrong scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)