### PR TITLE
feat(config): add image provider config precedence

### DIFF
--- a/src/questfoundry/cli.py
+++ b/src/questfoundry/cli.py
@@ -289,6 +289,7 @@ def _get_orchestrator(
     provider_discuss_override: str | None = None,
     provider_summarize_override: str | None = None,
     provider_serialize_override: str | None = None,
+    image_provider_override: str | None = None,
 ) -> PipelineOrchestrator:
     """Get a pipeline orchestrator for the project.
 
@@ -298,6 +299,8 @@ def _get_orchestrator(
         provider_discuss_override: Optional provider override for discuss phase.
         provider_summarize_override: Optional provider override for summarize phase.
         provider_serialize_override: Optional provider override for serialize phase.
+        image_provider_override: Optional image provider override
+            (e.g., "openai/gpt-image-1", "placeholder").
 
     Returns:
         Configured PipelineOrchestrator.
@@ -310,6 +313,7 @@ def _get_orchestrator(
         provider_discuss_override=provider_discuss_override,
         provider_summarize_override=provider_summarize_override,
         provider_serialize_override=provider_serialize_override,
+        image_provider_override=image_provider_override,
         enable_llm_logging=_log_enabled,
     )
 
@@ -403,6 +407,7 @@ async def _run_stage_async(
     provider_discuss: str | None = None,
     provider_summarize: str | None = None,
     provider_serialize: str | None = None,
+    image_provider: str | None = None,
 ) -> StageResult:
     """Run a stage asynchronously and close orchestrator.
 
@@ -414,6 +419,7 @@ async def _run_stage_async(
         provider_discuss: Optional provider override for discuss phase.
         provider_summarize: Optional provider override for summarize phase.
         provider_serialize: Optional provider override for serialize phase.
+        image_provider: Optional image provider override for DRESS stage.
 
     Returns:
         StageResult from the stage execution.
@@ -425,6 +431,7 @@ async def _run_stage_async(
         provider_discuss_override=provider_discuss,
         provider_summarize_override=provider_summarize,
         provider_serialize_override=provider_serialize,
+        image_provider_override=image_provider,
     )
     log.debug("provider_configured", provider=f"{orchestrator.config.provider.name}")
     try:
@@ -550,6 +557,7 @@ def _run_stage_command(
                 provider_discuss,
                 provider_summarize,
                 provider_serialize,
+                image_provider,
             )
         )
     else:

--- a/src/questfoundry/pipeline/config.py
+++ b/src/questfoundry/pipeline/config.py
@@ -48,6 +48,7 @@ class ProvidersConfig:
     discuss: str | None = None
     summarize: str | None = None
     serialize: str | None = None
+    image: str | None = None
     settings: dict[str, PhaseSettings] = field(default_factory=dict)
 
     def get_phase_settings(self, phase: str) -> PhaseSettings:
@@ -90,6 +91,15 @@ class ProvidersConfig:
         """
         return self.serialize or self.default
 
+    def get_image_provider(self) -> str | None:
+        """Get the config-level image provider.
+
+        Returns image provider string if set, otherwise None.
+        Image generation is opt-in — there is no default.
+        Environment variables are resolved by the orchestrator.
+        """
+        return self.image
+
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> ProvidersConfig:
         """Create config from dictionary.
@@ -120,6 +130,7 @@ class ProvidersConfig:
             discuss=data.get("discuss"),
             summarize=data.get("summarize"),
             serialize=data.get("serialize"),
+            image=data.get("image"),
             settings=settings,
         )
 

--- a/src/questfoundry/pipeline/orchestrator.py
+++ b/src/questfoundry/pipeline/orchestrator.py
@@ -564,7 +564,7 @@ class PipelineOrchestrator:
                 stage_kwargs["on_phase_progress"] = on_phase_progress
 
             # Stage-specific options
-            image_provider = context.get("image_provider") or self._get_resolved_image_provider()
+            image_provider = self._get_resolved_image_provider()
             if image_provider:
                 stage_kwargs["image_provider"] = image_provider
 

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -133,6 +133,34 @@ class TestProvidersConfig:
         with patch.dict("os.environ", {"QF_PROVIDER_SERIALIZE": "openai/o3-mini"}):
             assert config.get_serialize_provider() == "openai/o1-mini"
 
+    def test_from_dict_with_image_provider(self) -> None:
+        """Parse config with image provider set."""
+        data = {
+            "default": "ollama/qwen3:4b-instruct-32k",
+            "image": "openai/gpt-image-1",
+        }
+        config = ProvidersConfig.from_dict(data)
+
+        assert config.image == "openai/gpt-image-1"
+        assert config.get_image_provider() == "openai/gpt-image-1"
+
+    def test_from_dict_without_image_provider(self) -> None:
+        """Image provider defaults to None (opt-in)."""
+        config = ProvidersConfig.from_dict({"default": "ollama/qwen3:4b-instruct-32k"})
+
+        assert config.image is None
+        assert config.get_image_provider() is None
+
+    def test_get_image_provider_ignores_env(self) -> None:
+        """ProvidersConfig returns config value, not env var (SRP: orchestrator handles env)."""
+        config = ProvidersConfig(
+            default="ollama/qwen3:4b-instruct-32k",
+            image="openai/gpt-image-1",
+        )
+
+        with patch.dict("os.environ", {"QF_IMAGE_PROVIDER": "placeholder"}):
+            assert config.get_image_provider() == "openai/gpt-image-1"
+
 
 # --- Tests for ProjectConfig with hybrid providers ---
 


### PR DESCRIPTION
## Problem
Image provider can only be configured via `--image-provider` CLI flag. No support for environment variables or project.yaml config, unlike LLM providers which have a 6-level precedence chain.

## Changes
- Add `image: str | None` field to `ProvidersConfig` with `get_image_provider()` accessor
- Add `_get_resolved_image_provider()` to `PipelineOrchestrator` with 3-level precedence: CLI flag → `QF_IMAGE_PROVIDER` env → `providers.image` config
- Wire `image_provider_override` through `_get_orchestrator()` and `_run_stage_async()`
- Orchestrator now resolves image provider through precedence chain instead of raw context passthrough

## Not Included / Future PRs
- Image factory extraction (PR 2)
- Placeholder / A1111 providers (PR 3, PR 8)
- Quality tracking, budget control, cover images (PRs 4-6)
- Standalone `qf generate-images` command (PR 7)

## Test Plan
- `uv run pytest tests/unit/test_config.py tests/unit/test_orchestrator.py -x -q` — 65 tests pass
- Tests cover: config parsing with/without image field, precedence chain (CLI > env > config > None)

## Risk / Rollback
- Backward compatible — existing projects without `providers.image` continue to work (returns None)
- No behavior change for projects not using image generation

🤖 Generated with [Claude Code](https://claude.com/claude-code)