### PR TITLE
refactor(providers): extract image factory to image_factory.py

### DIFF
--- a/src/questfoundry/pipeline/stages/dress.py
+++ b/src/questfoundry/pipeline/stages/dress.py
@@ -60,7 +60,7 @@ from questfoundry.models.dress import (
 from questfoundry.observability.logging import get_logger
 from questfoundry.observability.tracing import traceable
 from questfoundry.pipeline.gates import AutoApprovePhaseGate
-from questfoundry.providers.image_openai import create_image_provider
+from questfoundry.providers.image_factory import create_image_provider
 from questfoundry.providers.structured_output import (
     StructuredOutputStrategy,
     with_structured_output,

--- a/src/questfoundry/providers/__init__.py
+++ b/src/questfoundry/providers/__init__.py
@@ -17,10 +17,8 @@ from questfoundry.providers.image import (
     ImageProviderError,
     ImageResult,
 )
-from questfoundry.providers.image_openai import (
-    OpenAIImageProvider,
-    create_image_provider,
-)
+from questfoundry.providers.image_factory import create_image_provider
+from questfoundry.providers.image_openai import OpenAIImageProvider
 from questfoundry.providers.model_info import (
     ModelInfo,
     get_model_info,

--- a/src/questfoundry/providers/image_factory.py
+++ b/src/questfoundry/providers/image_factory.py
@@ -40,6 +40,8 @@ def create_image_provider(
     if provider_lower == "openai":
         from questfoundry.providers.image_openai import OpenAIImageProvider
 
-        return OpenAIImageProvider(model=model or "gpt-image-1", **kwargs)
+        if model:
+            return OpenAIImageProvider(model=model, **kwargs)
+        return OpenAIImageProvider(**kwargs)
 
     raise ImageProviderError(provider_lower, f"Unknown image provider: {provider_lower}")

--- a/src/questfoundry/providers/image_factory.py
+++ b/src/questfoundry/providers/image_factory.py
@@ -1,0 +1,45 @@
+"""Image provider factory.
+
+Creates image provider instances from spec strings (e.g., ``openai/gpt-image-1``).
+Provider implementations are lazily imported to avoid pulling in optional
+dependencies until actually needed.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from questfoundry.providers.image import ImageProvider, ImageProviderError
+
+
+def create_image_provider(
+    provider_spec: str,
+    **kwargs: Any,
+) -> ImageProvider:
+    """Create an image provider from a spec string.
+
+    Args:
+        provider_spec: Format ``provider/model`` (e.g., ``openai/gpt-image-1``).
+            If no model is specified, a provider-specific default is used.
+        **kwargs: Additional provider options forwarded to the constructor.
+
+    Returns:
+        Configured image provider.
+
+    Raises:
+        ImageProviderError: If provider is unknown.
+    """
+    if "/" in provider_spec:
+        provider, model = provider_spec.split("/", 1)
+    else:
+        provider = provider_spec
+        model = None
+
+    provider_lower = provider.lower()
+
+    if provider_lower == "openai":
+        from questfoundry.providers.image_openai import OpenAIImageProvider
+
+        return OpenAIImageProvider(model=model or "gpt-image-1", **kwargs)
+
+    raise ImageProviderError(provider_lower, f"Unknown image provider: {provider_lower}")

--- a/src/questfoundry/providers/image_openai.py
+++ b/src/questfoundry/providers/image_openai.py
@@ -204,33 +204,3 @@ class OpenAIImageProvider:
             raise ImageProviderError("openai", f"API error (HTTP {status}): {error}") from error
 
         raise ImageProviderError("openai", f"Image generation failed: {error}") from error
-
-
-def create_image_provider(
-    provider_spec: str,
-    **kwargs: Any,
-) -> OpenAIImageProvider:
-    """Factory: create an image provider from a spec string.
-
-    Args:
-        provider_spec: Format ``provider/model`` (e.g., ``openai/gpt-image-1``).
-        **kwargs: Additional provider options.
-
-    Returns:
-        Configured image provider.
-
-    Raises:
-        ImageProviderError: If provider is unknown.
-    """
-    if "/" in provider_spec:
-        provider, model = provider_spec.split("/", 1)
-    else:
-        provider = provider_spec
-        model = "gpt-image-1"
-
-    provider_lower = provider.lower()
-
-    if provider_lower == "openai":
-        return OpenAIImageProvider(model=model, **kwargs)
-
-    raise ImageProviderError(provider_lower, f"Unknown image provider: {provider_lower}")

--- a/tests/unit/test_image_provider.py
+++ b/tests/unit/test_image_provider.py
@@ -236,7 +236,7 @@ class TestOpenAIImageProvider:
 
 class TestCreateImageProvider:
     def test_openai_with_model(self) -> None:
-        from questfoundry.providers.image_openai import create_image_provider
+        from questfoundry.providers.image_factory import create_image_provider
 
         with patch.dict("os.environ", {"OPENAI_API_KEY": "sk-test"}):
             provider = create_image_provider("openai/gpt-image-1")
@@ -245,7 +245,7 @@ class TestCreateImageProvider:
         assert provider._model == "gpt-image-1"
 
     def test_openai_default_model(self) -> None:
-        from questfoundry.providers.image_openai import create_image_provider
+        from questfoundry.providers.image_factory import create_image_provider
 
         with patch.dict("os.environ", {"OPENAI_API_KEY": "sk-test"}):
             provider = create_image_provider("openai")
@@ -253,7 +253,7 @@ class TestCreateImageProvider:
         assert provider._model == "gpt-image-1"
 
     def test_unknown_provider_raises(self) -> None:
-        from questfoundry.providers.image_openai import create_image_provider
+        from questfoundry.providers.image_factory import create_image_provider
 
         with pytest.raises(ImageProviderError, match="Unknown image provider"):
             create_image_provider("midjourney/v6")


### PR DESCRIPTION
## Problem
`create_image_provider()` lives in `image_openai.py`, coupling all provider routing to the OpenAI module. Adding placeholder and A1111 providers would require importing them in the OpenAI module.

## Changes
- Extract `create_image_provider()` to new `image_factory.py` with lazy imports
- Remove factory from `image_openai.py`
- Update `providers/__init__.py` re-export
- Update imports in `dress.py` and tests

## Not Included / Future PRs
- Placeholder provider (PR 3)
- A1111 provider (PR 8)

## Test Plan
- `uv run pytest tests/unit/test_image_provider.py -x -q` — 21 tests pass
- All existing factory tests pass with new import path

## Risk / Rollback
- Pure mechanical refactor — no behavior change
- All imports updated; `__init__.py` re-export maintained

🤖 Generated with [Claude Code](https://claude.com/claude-code)