### PR TITLE
feat(providers): add placeholder image provider

### DIFF
--- a/src/questfoundry/providers/image_factory.py
+++ b/src/questfoundry/providers/image_factory.py
@@ -37,6 +37,11 @@ def create_image_provider(
 
     provider_lower = provider.lower()
 
+    if provider_lower == "placeholder":
+        from questfoundry.providers.image_placeholder import PlaceholderImageProvider
+
+        return PlaceholderImageProvider(**kwargs)
+
     if provider_lower == "openai":
         from questfoundry.providers.image_openai import OpenAIImageProvider
 

--- a/src/questfoundry/providers/image_placeholder.py
+++ b/src/questfoundry/providers/image_placeholder.py
@@ -1,0 +1,132 @@
+"""Placeholder image provider for testing.
+
+Generates minimal solid-color PNG images with no external dependencies.
+Zero cost, instant generation — ideal for development and CI.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import struct
+import zlib
+
+from questfoundry.providers.image import ImageResult
+
+# Aspect ratio → (width, height) for placeholder images.
+# Kept small to minimize memory/disk usage during testing.
+_ASPECT_RATIO_TO_SIZE: dict[str, tuple[int, int]] = {
+    "1:1": (256, 256),
+    "16:9": (640, 360),
+    "9:16": (360, 640),
+    "3:2": (480, 320),
+    "2:3": (320, 480),
+}
+
+# Rotate through muted colors for visual distinction between placeholders.
+_PALETTE: list[tuple[int, int, int]] = [
+    (88, 101, 130),  # slate blue
+    (130, 88, 101),  # dusty rose
+    (101, 130, 88),  # sage green
+    (130, 118, 88),  # warm sand
+    (88, 130, 125),  # teal
+    (118, 88, 130),  # muted purple
+]
+
+
+def _make_png(width: int, height: int, r: int, g: int, b: int) -> bytes:
+    """Generate a minimal solid-color PNG in pure Python.
+
+    Creates an uncompressed RGB PNG with no filtering.
+    Not optimized for size — these are throwaway test images.
+
+    Args:
+        width: Image width in pixels.
+        height: Image height in pixels.
+        r: Red channel (0-255).
+        g: Green channel (0-255).
+        b: Blue channel (0-255).
+
+    Returns:
+        Raw PNG bytes.
+    """
+
+    def _chunk(chunk_type: bytes, data: bytes) -> bytes:
+        """Build a PNG chunk with CRC."""
+        payload = chunk_type + data
+        crc = struct.pack(">I", zlib.crc32(payload) & 0xFFFFFFFF)
+        return struct.pack(">I", len(data)) + payload + crc
+
+    # PNG signature
+    sig = b"\x89PNG\r\n\x1a\n"
+
+    # IHDR: width, height, 8-bit depth, RGB (color type 2)
+    ihdr_data = struct.pack(">IIBBBBB", width, height, 8, 2, 0, 0, 0)
+    ihdr = _chunk(b"IHDR", ihdr_data)
+
+    # IDAT: raw pixel data (filter byte 0 + RGB triplets per row)
+    row = bytes([0]) + bytes([r, g, b]) * width  # filter=None + pixels
+    raw_data = row * height
+    compressed = zlib.compress(raw_data)
+    idat = _chunk(b"IDAT", compressed)
+
+    # IEND
+    iend = _chunk(b"IEND", b"")
+
+    return sig + ihdr + idat + iend
+
+
+class PlaceholderImageProvider:
+    """Zero-cost image provider that generates solid-color PNGs.
+
+    Each call produces a minimal PNG with a color selected from a
+    rotating palette (based on prompt hash). The ``quality`` metadata
+    is always ``"placeholder"``.
+
+    Useful for:
+    - Testing the image generation pipeline without API costs
+    - CI/CD runs where real images are unnecessary
+    - Validating asset storage and graph mutations
+    """
+
+    async def generate(
+        self,
+        prompt: str,
+        *,
+        negative_prompt: str | None = None,  # noqa: ARG002
+        aspect_ratio: str = "1:1",
+        quality: str = "standard",  # noqa: ARG002
+    ) -> ImageResult:
+        """Generate a placeholder PNG.
+
+        The color is deterministically chosen from the prompt hash,
+        so the same prompt always produces the same color.
+
+        Args:
+            prompt: Text prompt (used only for color selection).
+            negative_prompt: Ignored.
+            aspect_ratio: Determines image dimensions.
+            quality: Ignored (always produces minimal quality).
+
+        Returns:
+            ImageResult with a solid-color PNG and ``quality="placeholder"``
+            in provider_metadata.
+        """
+        size = _ASPECT_RATIO_TO_SIZE.get(aspect_ratio, _ASPECT_RATIO_TO_SIZE["1:1"])
+        width, height = size
+
+        # Deterministic color from prompt hash
+        idx = int(hashlib.md5(prompt.encode()).hexdigest(), 16) % len(_PALETTE)
+        r, g, b = _PALETTE[idx]
+
+        image_data = _make_png(width, height, r, g, b)
+
+        return ImageResult(
+            image_data=image_data,
+            content_type="image/png",
+            provider_metadata={
+                "quality": "placeholder",
+                "size": f"{width}x{height}",
+                "color": f"#{r:02x}{g:02x}{b:02x}",
+                "prompt_preview": prompt[:80],
+            },
+        )

--- a/tests/unit/test_image_placeholder.py
+++ b/tests/unit/test_image_placeholder.py
@@ -1,0 +1,116 @@
+"""Tests for PlaceholderImageProvider."""
+
+from __future__ import annotations
+
+import pytest
+
+from questfoundry.providers.image import ImageProvider
+from questfoundry.providers.image_placeholder import PlaceholderImageProvider, _make_png
+
+
+class TestMakePng:
+    """Test the pure-Python PNG generator."""
+
+    def test_produces_valid_png_signature(self) -> None:
+        data = _make_png(2, 2, 128, 128, 128)
+        assert data[:8] == b"\x89PNG\r\n\x1a\n"
+
+    def test_different_sizes_produce_different_lengths(self) -> None:
+        small = _make_png(1, 1, 0, 0, 0)
+        large = _make_png(100, 100, 0, 0, 0)
+        assert len(large) > len(small)
+
+    def test_different_colors_produce_different_data(self) -> None:
+        red = _make_png(4, 4, 255, 0, 0)
+        blue = _make_png(4, 4, 0, 0, 255)
+        assert red != blue
+
+
+class TestPlaceholderImageProvider:
+    """Test the placeholder provider."""
+
+    def test_conforms_to_protocol(self) -> None:
+        provider = PlaceholderImageProvider()
+        assert isinstance(provider, ImageProvider)
+
+    @pytest.mark.asyncio()
+    async def test_generate_returns_image_result(self) -> None:
+        provider = PlaceholderImageProvider()
+        result = await provider.generate("test prompt")
+
+        assert result.image_data[:8] == b"\x89PNG\r\n\x1a\n"
+        assert result.content_type == "image/png"
+        assert result.size_bytes > 0
+
+    @pytest.mark.asyncio()
+    async def test_quality_metadata(self) -> None:
+        provider = PlaceholderImageProvider()
+        result = await provider.generate("test prompt")
+
+        assert result.provider_metadata["quality"] == "placeholder"
+
+    @pytest.mark.asyncio()
+    async def test_size_metadata_default_aspect(self) -> None:
+        provider = PlaceholderImageProvider()
+        result = await provider.generate("test", aspect_ratio="1:1")
+
+        assert result.provider_metadata["size"] == "256x256"
+
+    @pytest.mark.asyncio()
+    async def test_16_9_aspect_ratio(self) -> None:
+        provider = PlaceholderImageProvider()
+        result = await provider.generate("test", aspect_ratio="16:9")
+
+        assert result.provider_metadata["size"] == "640x360"
+
+    @pytest.mark.asyncio()
+    async def test_unknown_aspect_ratio_falls_back(self) -> None:
+        """Unknown aspect ratios fall back to 1:1 instead of erroring."""
+        provider = PlaceholderImageProvider()
+        result = await provider.generate("test", aspect_ratio="4:3")
+
+        assert result.provider_metadata["size"] == "256x256"
+
+    @pytest.mark.asyncio()
+    async def test_deterministic_color(self) -> None:
+        """Same prompt always produces the same color."""
+        provider = PlaceholderImageProvider()
+        r1 = await provider.generate("hello world")
+        r2 = await provider.generate("hello world")
+
+        assert r1.provider_metadata["color"] == r2.provider_metadata["color"]
+
+    @pytest.mark.asyncio()
+    async def test_different_prompts_may_differ(self) -> None:
+        """Different prompts can produce different colors."""
+        provider = PlaceholderImageProvider()
+        r1 = await provider.generate("alpha")
+        r2 = await provider.generate("beta")
+
+        # Not guaranteed different, but with 6 palette colors
+        # these specific prompts happen to differ
+        assert r1.provider_metadata["color"] != r2.provider_metadata["color"]
+
+    @pytest.mark.asyncio()
+    async def test_prompt_preview_in_metadata(self) -> None:
+        provider = PlaceholderImageProvider()
+        result = await provider.generate("A long prompt about a watercolor landscape")
+
+        assert "watercolor" in result.provider_metadata["prompt_preview"]
+
+
+class TestFactoryPlaceholder:
+    """Test factory routing for placeholder provider."""
+
+    def test_factory_creates_placeholder(self) -> None:
+        from questfoundry.providers.image_factory import create_image_provider
+
+        provider = create_image_provider("placeholder")
+        assert isinstance(provider, PlaceholderImageProvider)
+
+    def test_factory_ignores_model_for_placeholder(self) -> None:
+        from questfoundry.providers.image_factory import create_image_provider
+
+        # placeholder/anything should still work
+        provider = create_image_provider("placeholder/ignored")
+        assert isinstance(provider, PlaceholderImageProvider)


### PR DESCRIPTION
## Problem
Testing the image generation pipeline requires real API calls (OpenAI), which are slow and expensive. No zero-cost alternative exists for development and CI.

## Changes
- Add `PlaceholderImageProvider` — generates solid-color PNGs in pure Python (no Pillow dependency)
- Colors deterministically selected from a 6-color muted palette based on prompt hash
- Returns `quality="placeholder"` in provider_metadata
- Add `"placeholder"` routing to `image_factory.py`
- 14 new tests covering protocol conformance, aspect ratios, determinism, metadata

## Not Included / Future PRs
- A1111 provider (PR 8)
- Quality tracking on Illustration nodes (PR 4)
- Budget control (PR 5)

## Test Plan
- `uv run pytest tests/unit/test_image_placeholder.py tests/unit/test_image_provider.py -x -q` — 35 tests pass

## Risk / Rollback
- Additive only — no existing behavior changes
- Zero external dependencies

🤖 Generated with [Claude Code](https://claude.com/claude-code)