### PR TITLE
feat(dress): track image quality tier on Illustration nodes

### DIFF
--- a/src/questfoundry/graph/dress_mutations.py
+++ b/src/questfoundry/graph/dress_mutations.py
@@ -160,6 +160,7 @@ def apply_dress_illustration(
     asset_path: str,
     caption: str,
     category: str,
+    quality: str = "high",
 ) -> str:
     """Create an Illustration node with Depicts and from_brief edges.
 
@@ -169,6 +170,7 @@ def apply_dress_illustration(
         asset_path: Relative path to the image file.
         caption: Diegetic caption from the brief.
         category: Image category (scene, portrait, vista, item_detail).
+        quality: Image quality tier (placeholder, low, high).
 
     Returns:
         The created illustration node ID.
@@ -191,6 +193,7 @@ def apply_dress_illustration(
         "asset": asset_path,
         "caption": caption,
         "category": category,
+        "quality": quality,
     }
     graph.upsert_node(node_id, illust_data)
 

--- a/src/questfoundry/models/dress.py
+++ b/src/questfoundry/models/dress.py
@@ -66,7 +66,7 @@ class Illustration(BaseModel):
     category: IllustrationCategory = Field(
         description="Image category",
     )
-    quality: str = Field(
+    quality: Literal["placeholder", "low", "high"] = Field(
         default="high",
         description="Image quality tier: placeholder, low, or high",
     )

--- a/src/questfoundry/models/dress.py
+++ b/src/questfoundry/models/dress.py
@@ -66,6 +66,10 @@ class Illustration(BaseModel):
     category: IllustrationCategory = Field(
         description="Image category",
     )
+    quality: str = Field(
+        default="high",
+        description="Image quality tier: placeholder, low, or high",
+    )
 
 
 class CodexEntry(BaseModel):

--- a/src/questfoundry/pipeline/stages/dress.py
+++ b/src/questfoundry/pipeline/stages/dress.py
@@ -884,12 +884,14 @@ class DressStage:
                 )
                 asset_path = asset_mgr.store(result.image_data, result.content_type)
 
+                quality = result.provider_metadata.get("quality", "high")
                 apply_dress_illustration(
                     graph,
                     brief_id=brief_id,
                     asset_path=asset_path,
                     caption=brief_data.get("caption", ""),
                     category=brief_data.get("category", "scene"),
+                    quality=quality,
                 )
                 generated += 1
 

--- a/src/questfoundry/providers/image_openai.py
+++ b/src/questfoundry/providers/image_openai.py
@@ -162,7 +162,8 @@ class OpenAIImageProvider:
         metadata: dict[str, Any] = {
             "model": self._model,
             "size": size,
-            "quality": quality,
+            "quality": "high",
+            "api_quality": quality,
         }
         revised_prompt = getattr(image_item, "revised_prompt", None)
         if revised_prompt:

--- a/tests/unit/test_dress_mutations.py
+++ b/tests/unit/test_dress_mutations.py
@@ -380,6 +380,59 @@ class TestApplyDressIllustration:
         assert len(from_brief) == 1
         assert from_brief[0]["to"] == brief_id
 
+    def test_quality_defaults_to_high(self, dress_graph: Graph) -> None:
+        from questfoundry.graph.dress_mutations import apply_dress_brief, apply_dress_illustration
+
+        brief_id = apply_dress_brief(
+            dress_graph,
+            passage_id="opening",
+            brief={
+                "category": "scene",
+                "subject": "s",
+                "composition": "c",
+                "mood": "m",
+                "caption": "c",
+            },
+            priority=1,
+        )
+        illust_id = apply_dress_illustration(
+            dress_graph,
+            brief_id=brief_id,
+            asset_path="assets/abc.png",
+            caption="cap",
+            category="scene",
+        )
+        node = dress_graph.get_node(illust_id)
+        assert node is not None
+        assert node["quality"] == "high"
+
+    def test_quality_placeholder(self, dress_graph: Graph) -> None:
+        from questfoundry.graph.dress_mutations import apply_dress_brief, apply_dress_illustration
+
+        brief_id = apply_dress_brief(
+            dress_graph,
+            passage_id="opening",
+            brief={
+                "category": "scene",
+                "subject": "s",
+                "composition": "c",
+                "mood": "m",
+                "caption": "c",
+            },
+            priority=1,
+        )
+        illust_id = apply_dress_illustration(
+            dress_graph,
+            brief_id=brief_id,
+            asset_path="assets/abc.png",
+            caption="cap",
+            category="scene",
+            quality="placeholder",
+        )
+        node = dress_graph.get_node(illust_id)
+        assert node is not None
+        assert node["quality"] == "placeholder"
+
     def test_brief_without_targets_raises(self, dress_graph: Graph) -> None:
         from questfoundry.graph.dress_mutations import apply_dress_illustration
 


### PR DESCRIPTION
## Problem
Generated images have no metadata indicating whether they are placeholders, low-quality local renders, or high-quality API images. This prevents re-generation at higher quality and quality-based filtering.

## Changes
- Add `quality: str` field to `Illustration` model (default `"high"`)
- Add `quality` parameter to `apply_dress_illustration()` mutation
- Phase 4 extracts `quality` from `ImageResult.provider_metadata` and passes to mutation
- OpenAI provider sets `quality="high"`, placeholder sets `quality="placeholder"`
- Renamed OpenAI's API quality param to `api_quality` in metadata to avoid collision

## Not Included / Future PRs
- Budget control (PR 5)
- Cover image (PR 6)
- A1111 provider with `quality="low"` (PR 8)
- Re-generation at higher quality (`qf regenerate-images`)

## Test Plan
- `uv run pytest tests/unit/test_dress_mutations.py tests/unit/test_image_provider.py -x -q` — 43 tests pass
- New tests: quality defaults to "high", quality="placeholder" stored correctly

## Risk / Rollback
- Backward compatible — `quality` defaults to "high" on existing Illustration nodes
- No migration needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)