### PR TITLE
feat(dress): add image budget control

### DIFF
--- a/src/questfoundry/cli.py
+++ b/src/questfoundry/cli.py
@@ -455,6 +455,7 @@ def _run_stage_command(
     provider_serialize: str | None = None,
     resume_from: str | None = None,
     image_provider: str | None = None,
+    image_budget: int = 0,
 ) -> None:
     """Common logic for running a stage command.
 
@@ -504,6 +505,8 @@ def _run_stage_command(
         context["resume_from"] = resume_from
     if image_provider:
         context["image_provider"] = image_provider
+    if image_budget > 0:
+        context["image_budget"] = image_budget
 
     # Add phase progress callback (used by GROW, and optionally by other stages)
     def _on_phase_progress(phase: str, status: str, detail: str | None) -> None:
@@ -1268,6 +1271,10 @@ def dress(
         str | None,
         typer.Option("--image-provider", help="Image provider (e.g., openai/gpt-image-1)"),
     ] = None,
+    image_budget: Annotated[
+        int,
+        typer.Option("--image-budget", help="Max images to generate (0=all selected briefs)"),
+    ] = 0,
     resume_from: Annotated[
         str | None,
         typer.Option("--resume-from", help="Resume from named phase (skips earlier phases)"),
@@ -1300,6 +1307,7 @@ def dress(
         provider_serialize=provider_serialize,
         resume_from=resume_from,
         image_provider=image_provider,
+        image_budget=image_budget,
     )
 
 

--- a/src/questfoundry/pipeline/orchestrator.py
+++ b/src/questfoundry/pipeline/orchestrator.py
@@ -567,6 +567,9 @@ class PipelineOrchestrator:
             image_provider = self._get_resolved_image_provider()
             if image_provider:
                 stage_kwargs["image_provider"] = image_provider
+            image_budget = context.get("image_budget", 0)
+            if image_budget > 0:
+                stage_kwargs["image_budget"] = image_budget
 
             # Resolve size profile from DREAM vision node (for post-DREAM stages)
             if stage_name != "dream":


### PR DESCRIPTION
## Problem
No way to limit the number of images generated during DRESS Phase 4. Running with an expensive provider (OpenAI) generates all selected briefs, which can be 40+ images at ~$0.10 each.

## Changes
- Add `--image-budget N` CLI flag to `qf dress` (default 0 = all)
- Add `_apply_image_budget()` helper that sorts briefs by priority (1 first) and slices to budget
- Budget is applied after Phase 3 selection, further constraining which briefs are rendered
- Stable ID-based tiebreaking for same-priority briefs
- Pass budget through context → orchestrator → DressStage

## Not Included / Future PRs
- Cover image (PR 6)
- Standalone command (PR 7)
- A1111 provider (PR 8)

## Test Plan
- `uv run pytest tests/unit/test_dress_stage.py::TestApplyImageBudget tests/unit/test_dress_stage.py::TestPhase4Generate -x -q` — 9 tests pass
- Tests cover: highest priority selection, mixed priorities, budget > total, stable ordering, missing briefs

## Risk / Rollback
- Default budget=0 preserves current behavior (generate all)
- Budget only applied when explicitly set via CLI flag

🤖 Generated with [Claude Code](https://claude.com/claude-code)