### PR TITLE
feat(cli): add standalone generate-images command

### DIFF
--- a/src/questfoundry/cli.py
+++ b/src/questfoundry/cli.py
@@ -1382,7 +1382,6 @@ def generate_images(
         project_path=project_path,
         image_provider=resolved_provider,
     )
-    stage._image_budget = image_budget
 
     def _on_phase_progress(phase: str, status: str, detail: str | None) -> None:
         detail_str = f" ({detail})" if detail else ""
@@ -1396,6 +1395,7 @@ def generate_images(
         result = asyncio.run(
             stage.run_generate_only(
                 project_path,
+                image_budget=image_budget,
                 on_phase_progress=_on_phase_progress,
             )
         )

--- a/src/questfoundry/cli.py
+++ b/src/questfoundry/cli.py
@@ -1311,6 +1311,108 @@ def dress(
     )
 
 
+@app.command("generate-images")
+def generate_images(
+    project: Annotated[
+        Path | None,
+        typer.Option(
+            "--project",
+            "-p",
+            help="Project directory. Can be a path or name (looks in --projects-dir).",
+        ),
+    ] = None,
+    image_provider: Annotated[
+        str | None,
+        typer.Option(
+            "--image-provider",
+            help="Image provider (e.g., openai/gpt-image-1, placeholder).",
+        ),
+    ] = None,
+    image_budget: Annotated[
+        int,
+        typer.Option("--image-budget", help="Max images to generate (0=all selected briefs)."),
+    ] = 0,
+) -> None:
+    """Generate images for an existing DRESS project.
+
+    Runs only the image generation phase (Phase 4) of the DRESS stage.
+    Requires that 'qf dress' has already been run to create briefs
+    and selections.
+
+    The image provider is resolved in order: --image-provider flag,
+    QF_IMAGE_PROVIDER env var, providers.image in project.yaml.
+
+    Examples:
+        qf generate-images --project my-story --image-provider placeholder
+        qf generate-images -p my-story --image-provider openai/gpt-image-1 --image-budget 3
+    """
+    import os
+
+    from questfoundry.pipeline.config import load_project_config
+    from questfoundry.pipeline.stages.dress import DressStage, DressStageError
+
+    project_path = _resolve_project_path(project)
+    _require_project(project_path)
+    _configure_project_logging(project_path)
+
+    log = get_logger(__name__)
+
+    # Resolve image provider: CLI flag → env var → project.yaml
+    resolved_provider = (
+        image_provider
+        or os.environ.get("QF_IMAGE_PROVIDER")
+        or load_project_config(project_path).providers.get_image_provider()
+    )
+
+    if not resolved_provider:
+        console.print(
+            "[red]Error:[/red] No image provider specified. "
+            "Use --image-provider, set QF_IMAGE_PROVIDER, "
+            "or add providers.image to project.yaml."
+        )
+        raise typer.Exit(1)
+
+    log.info(
+        "generate_images_start",
+        provider=resolved_provider,
+        budget=image_budget,
+    )
+
+    stage = DressStage(
+        project_path=project_path,
+        image_provider=resolved_provider,
+    )
+    stage._image_budget = image_budget
+
+    def _on_phase_progress(phase: str, status: str, detail: str | None) -> None:
+        detail_str = f" ({detail})" if detail else ""
+        status_icon = "[green]✓[/green]" if status == "completed" else "[red]✗[/red]"
+        console.print(f"  {status_icon} {phase}{detail_str}")
+
+    console.print()
+    console.print(f"[dim]Generating images with {resolved_provider}...[/dim]")
+
+    try:
+        result = asyncio.run(
+            stage.run_generate_only(
+                project_path,
+                on_phase_progress=_on_phase_progress,
+            )
+        )
+    except DressStageError as e:
+        console.print(f"\n[red]Error:[/red] {e}")
+        raise typer.Exit(1) from None
+
+    console.print()
+    if result.status == "failed":
+        console.print(f"[red]✗[/red] Image generation failed: {result.detail}")
+        raise typer.Exit(1)
+
+    console.print(f"[green]✓[/green] Image generation complete: {result.detail}")
+    if _log_enabled:
+        console.print(f"  Logs: [dim]{project_path / 'logs'}[/dim]")
+
+
 @app.command()
 def run(
     to_stage: Annotated[

--- a/tests/unit/test_dress_stage.py
+++ b/tests/unit/test_dress_stage.py
@@ -1192,13 +1192,12 @@ class TestRunGenerateOnly:
         mock_provider.generate = AsyncMock(return_value=mock_result)
 
         stage = DressStage(image_provider="placeholder")
-        stage._image_budget = 1
 
         with patch(
             "questfoundry.pipeline.stages.dress.create_image_provider",
             return_value=mock_provider,
         ):
-            result = await stage.run_generate_only(tmp_path)
+            result = await stage.run_generate_only(tmp_path, image_budget=1)
 
         assert "1 images generated" in result.detail
 


### PR DESCRIPTION
## Problem

There's no way to generate images independently after running `qf dress`. Users must re-run the entire DRESS stage to generate images, which is wasteful when they only want to change the image provider or budget.

## Changes

- Add `qf generate-images` CLI command that runs only DRESS Phase 4 (image generation)
  - `--project/-p`: Project directory
  - `--image-provider`: Image provider spec (e.g., `openai/gpt-image-1`, `placeholder`)
  - `--image-budget`: Max images to generate (0=all selected briefs)
- Provider resolves via: CLI flag → `QF_IMAGE_PROVIDER` env → `providers.image` config
- Add public `DressStage.run_generate_only()` method for programmatic access
- Fails with clear error if `qf dress` hasn't been run yet (no brief selection)

## Not Included / Future PRs

- A1111 provider (planned as PR 8, branches from PR 4)
- Interactive brief selection in Phase 3

## Test Plan

```bash
uv run pytest tests/unit/test_dress_stage.py::TestRunGenerateOnly -x -q  # 4 tests
uv run pytest tests/unit/test_cli.py::test_generate_images_no_project_fails -x -q
uv run pytest tests/unit/test_cli.py::test_generate_images_no_provider_fails -x -q
uv run pytest tests/unit/test_cli.py::test_generate_images_no_selection_fails -x -q
uv run pytest tests/unit/test_cli.py::test_generate_images_success -x -q
```

All 8 new tests pass. Pre-commit hooks (ruff, mypy, format) all green.

## Risk / Rollback

- No changes to existing command behavior
- New command only, additive change
- `run_generate_only()` is a thin wrapper around existing `_phase_4_generate()`

🤖 Generated with [Claude Code](https://claude.com/claude-code)