### PR TITLE
feat(providers): add A1111 image provider for local Stable Diffusion

### DIFF
--- a/src/questfoundry/providers/image_a1111.py
+++ b/src/questfoundry/providers/image_a1111.py
@@ -1,0 +1,151 @@
+"""Automatic1111 (Stable Diffusion WebUI) image provider.
+
+Generates images via the A1111 REST API (``/sdapi/v1/txt2img``).
+Requires ``A1111_HOST`` environment variable pointing to a running
+WebUI instance (e.g., ``http://athena:7860``).
+
+The provider spec string selects the SD checkpoint::
+
+    a1111                   # Use whatever checkpoint is loaded
+    a1111/dreamshaper_8     # Override to dreamshaper_8
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from typing import Any
+
+import httpx
+
+from questfoundry.providers.image import (
+    ImageProviderConnectionError,
+    ImageProviderError,
+    ImageResult,
+)
+
+# SD-friendly pixel dimensions (multiples of 8).
+_ASPECT_RATIO_TO_SIZE: dict[str, tuple[int, int]] = {
+    "1:1": (512, 512),
+    "16:9": (768, 432),
+    "9:16": (432, 768),
+    "3:2": (768, 512),
+    "2:3": (512, 768),
+}
+
+_DEFAULT_TIMEOUT = 120.0  # Image generation can be slow on consumer GPUs
+
+
+class A1111ImageProvider:
+    """Image provider using Automatic1111 Stable Diffusion WebUI.
+
+    Args:
+        model: Optional SD checkpoint name (e.g., ``dreamshaper_8``).
+            When set, the request includes ``override_settings.sd_model_checkpoint``.
+        host: WebUI base URL. Falls back to ``A1111_HOST`` env var.
+    """
+
+    def __init__(
+        self,
+        model: str | None = None,
+        host: str | None = None,
+    ) -> None:
+        self._host = host or os.environ.get("A1111_HOST")
+        if not self._host:
+            raise ImageProviderError(
+                "a1111",
+                "A1111_HOST environment variable is required. "
+                "Set it to the WebUI URL (e.g., http://localhost:7860).",
+            )
+        # Strip trailing slash for consistent URL construction
+        self._host = self._host.rstrip("/")
+        self._model = model
+        self._client = httpx.AsyncClient(timeout=_DEFAULT_TIMEOUT)
+
+    async def generate(
+        self,
+        prompt: str,
+        *,
+        negative_prompt: str | None = None,
+        aspect_ratio: str = "1:1",
+        quality: str = "standard",  # noqa: ARG002
+    ) -> ImageResult:
+        """Generate an image via A1111 txt2img API.
+
+        Args:
+            prompt: Positive text prompt.
+            negative_prompt: Negative prompt (natively supported by SD).
+            aspect_ratio: Desired aspect ratio (e.g., "16:9").
+            quality: Ignored — SD quality is controlled by steps/cfg.
+
+        Returns:
+            ImageResult with PNG data and provider metadata.
+
+        Raises:
+            ImageProviderConnectionError: If A1111 is unreachable.
+            ImageProviderError: On API errors or unexpected responses.
+        """
+        width, height = _ASPECT_RATIO_TO_SIZE.get(aspect_ratio, (512, 512))
+
+        payload: dict[str, Any] = {
+            "prompt": prompt,
+            "negative_prompt": negative_prompt or "",
+            "width": width,
+            "height": height,
+            "steps": 25,
+            "cfg_scale": 7.0,
+            "sampler_name": "Euler a",
+        }
+
+        if self._model:
+            payload["override_settings"] = {"sd_model_checkpoint": self._model}
+
+        url = f"{self._host}/sdapi/v1/txt2img"
+
+        try:
+            response = await self._client.post(url, json=payload)
+        except httpx.ConnectError as e:
+            raise ImageProviderConnectionError(
+                "a1111", f"Cannot connect to A1111 at {self._host}: {e}"
+            ) from e
+        except httpx.TimeoutException as e:
+            raise ImageProviderConnectionError(
+                "a1111", f"Request to A1111 timed out ({_DEFAULT_TIMEOUT}s): {e}"
+            ) from e
+
+        if response.status_code != 200:
+            body_preview = response.text[:200]
+            raise ImageProviderError(
+                "a1111",
+                f"A1111 returned HTTP {response.status_code}: {body_preview}",
+            )
+
+        data = response.json()
+        images = data.get("images")
+        if not images:
+            raise ImageProviderError("a1111", "A1111 response missing 'images' field")
+
+        # Extract seed from response info if available
+        seed = None
+        info_str = data.get("info")
+        if info_str:
+            try:
+                info = json.loads(info_str) if isinstance(info_str, str) else info_str
+                seed = info.get("seed")
+            except (json.JSONDecodeError, TypeError):
+                pass
+
+        metadata: dict[str, Any] = {
+            "quality": "low",
+            "model": self._model,
+            "size": f"{width}x{height}",
+            "steps": 25,
+        }
+        if seed is not None:
+            metadata["seed"] = seed
+
+        return ImageResult.from_base64(
+            images[0],
+            content_type="image/png",
+            **metadata,
+        )

--- a/src/questfoundry/providers/image_factory.py
+++ b/src/questfoundry/providers/image_factory.py
@@ -49,4 +49,9 @@ def create_image_provider(
             return OpenAIImageProvider(model=model, **kwargs)
         return OpenAIImageProvider(**kwargs)
 
+    if provider_lower == "a1111":
+        from questfoundry.providers.image_a1111 import A1111ImageProvider
+
+        return A1111ImageProvider(model=model, **kwargs)
+
     raise ImageProviderError(provider_lower, f"Unknown image provider: {provider_lower}")

--- a/tests/unit/test_image_a1111.py
+++ b/tests/unit/test_image_a1111.py
@@ -1,0 +1,210 @@
+"""Tests for A1111 (Automatic1111) image provider."""
+
+from __future__ import annotations
+
+import base64
+import json
+from unittest.mock import AsyncMock, patch
+
+import httpx
+import pytest
+
+from questfoundry.providers.image import ImageProviderConnectionError, ImageProviderError
+from questfoundry.providers.image_a1111 import _ASPECT_RATIO_TO_SIZE, A1111ImageProvider
+
+
+def _fake_response(
+    image_b64: str = "",
+    seed: int = 42,
+    status_code: int = 200,
+) -> httpx.Response:
+    """Build a fake httpx.Response mimicking A1111 txt2img output."""
+    if not image_b64:
+        image_b64 = base64.b64encode(b"fake_png_data").decode()
+    body = {
+        "images": [image_b64],
+        "info": json.dumps({"seed": seed}),
+    }
+    return httpx.Response(status_code, json=body)
+
+
+class TestA1111Provider:
+    @pytest.mark.asyncio()
+    async def test_generate_returns_image(self) -> None:
+        provider = A1111ImageProvider(host="http://localhost:7860")
+        mock_response = _fake_response()
+
+        with patch.object(
+            provider._client, "post", new_callable=AsyncMock, return_value=mock_response
+        ):
+            result = await provider.generate("a cat sitting on a roof")
+
+        assert result.image_data == b"fake_png_data"
+        assert result.content_type == "image/png"
+        assert result.provider_metadata["quality"] == "low"
+
+    @pytest.mark.asyncio()
+    async def test_checkpoint_override(self) -> None:
+        provider = A1111ImageProvider(model="dreamshaper_8", host="http://localhost:7860")
+        mock_post = AsyncMock(return_value=_fake_response())
+
+        with patch.object(provider._client, "post", mock_post):
+            await provider.generate("test prompt")
+
+        call_kwargs = mock_post.call_args
+        payload = call_kwargs.kwargs.get("json") or call_kwargs[1].get("json")
+        assert payload["override_settings"]["sd_model_checkpoint"] == "dreamshaper_8"
+
+    @pytest.mark.asyncio()
+    async def test_no_checkpoint_when_unset(self) -> None:
+        provider = A1111ImageProvider(host="http://localhost:7860")
+        mock_post = AsyncMock(return_value=_fake_response())
+
+        with patch.object(provider._client, "post", mock_post):
+            await provider.generate("test prompt")
+
+        call_kwargs = mock_post.call_args
+        payload = call_kwargs.kwargs.get("json") or call_kwargs[1].get("json")
+        assert "override_settings" not in payload
+
+    @pytest.mark.asyncio()
+    async def test_negative_prompt_passed(self) -> None:
+        provider = A1111ImageProvider(host="http://localhost:7860")
+        mock_post = AsyncMock(return_value=_fake_response())
+
+        with patch.object(provider._client, "post", mock_post):
+            await provider.generate("a castle", negative_prompt="blurry, low quality")
+
+        call_kwargs = mock_post.call_args
+        payload = call_kwargs.kwargs.get("json") or call_kwargs[1].get("json")
+        assert payload["negative_prompt"] == "blurry, low quality"
+
+    @pytest.mark.asyncio()
+    async def test_aspect_ratio_mapping(self) -> None:
+        provider = A1111ImageProvider(host="http://localhost:7860")
+
+        for ratio, (expected_w, expected_h) in _ASPECT_RATIO_TO_SIZE.items():
+            mock_post = AsyncMock(return_value=_fake_response())
+            with patch.object(provider._client, "post", mock_post):
+                await provider.generate("test", aspect_ratio=ratio)
+
+            call_kwargs = mock_post.call_args
+            payload = call_kwargs.kwargs.get("json") or call_kwargs[1].get("json")
+            assert payload["width"] == expected_w, f"Wrong width for {ratio}"
+            assert payload["height"] == expected_h, f"Wrong height for {ratio}"
+
+    @pytest.mark.asyncio()
+    async def test_unknown_ratio_defaults_512(self) -> None:
+        provider = A1111ImageProvider(host="http://localhost:7860")
+        mock_post = AsyncMock(return_value=_fake_response())
+
+        with patch.object(provider._client, "post", mock_post):
+            await provider.generate("test", aspect_ratio="4:3")
+
+        payload = mock_post.call_args.kwargs.get("json") or mock_post.call_args[1].get("json")
+        assert payload["width"] == 512
+        assert payload["height"] == 512
+
+    @pytest.mark.asyncio()
+    async def test_connection_error(self) -> None:
+        provider = A1111ImageProvider(host="http://localhost:7860")
+
+        with (
+            patch.object(
+                provider._client,
+                "post",
+                new_callable=AsyncMock,
+                side_effect=httpx.ConnectError("refused"),
+            ),
+            pytest.raises(ImageProviderConnectionError, match="Cannot connect"),
+        ):
+            await provider.generate("test")
+
+    @pytest.mark.asyncio()
+    async def test_timeout_error(self) -> None:
+        provider = A1111ImageProvider(host="http://localhost:7860")
+
+        with (
+            patch.object(
+                provider._client,
+                "post",
+                new_callable=AsyncMock,
+                side_effect=httpx.ReadTimeout("timeout"),
+            ),
+            pytest.raises(ImageProviderConnectionError, match="timed out"),
+        ):
+            await provider.generate("test")
+
+    @pytest.mark.asyncio()
+    async def test_http_error(self) -> None:
+        provider = A1111ImageProvider(host="http://localhost:7860")
+        error_response = httpx.Response(500, text="Internal Server Error")
+
+        with (
+            patch.object(
+                provider._client, "post", new_callable=AsyncMock, return_value=error_response
+            ),
+            pytest.raises(ImageProviderError, match="HTTP 500"),
+        ):
+            await provider.generate("test")
+
+    @pytest.mark.asyncio()
+    async def test_missing_images_field(self) -> None:
+        provider = A1111ImageProvider(host="http://localhost:7860")
+        bad_response = httpx.Response(200, json={"parameters": {}})
+
+        with (
+            patch.object(
+                provider._client, "post", new_callable=AsyncMock, return_value=bad_response
+            ),
+            pytest.raises(ImageProviderError, match="missing 'images'"),
+        ):
+            await provider.generate("test")
+
+    def test_missing_host_raises(self) -> None:
+        with (
+            patch.dict("os.environ", {}, clear=True),
+            pytest.raises(ImageProviderError, match="A1111_HOST"),
+        ):
+            A1111ImageProvider()
+
+    @pytest.mark.asyncio()
+    async def test_quality_metadata(self) -> None:
+        provider = A1111ImageProvider(host="http://localhost:7860")
+
+        with patch.object(
+            provider._client, "post", new_callable=AsyncMock, return_value=_fake_response()
+        ):
+            result = await provider.generate("test")
+
+        assert result.provider_metadata["quality"] == "low"
+
+    @pytest.mark.asyncio()
+    async def test_seed_in_metadata(self) -> None:
+        provider = A1111ImageProvider(host="http://localhost:7860")
+
+        with patch.object(
+            provider._client,
+            "post",
+            new_callable=AsyncMock,
+            return_value=_fake_response(seed=12345),
+        ):
+            result = await provider.generate("test")
+
+        assert result.provider_metadata["seed"] == 12345
+
+
+class TestA1111FactoryRouting:
+    def test_factory_creates_a1111_provider(self) -> None:
+        from questfoundry.providers.image_factory import create_image_provider
+
+        provider = create_image_provider("a1111/dreamshaper_8", host="http://localhost:7860")
+        assert isinstance(provider, A1111ImageProvider)
+        assert provider._model == "dreamshaper_8"
+
+    def test_factory_a1111_without_model(self) -> None:
+        from questfoundry.providers.image_factory import create_image_provider
+
+        provider = create_image_provider("a1111", host="http://localhost:7860")
+        assert isinstance(provider, A1111ImageProvider)
+        assert provider._model is None


### PR DESCRIPTION
## Problem

No way to generate images locally using Stable Diffusion. Users with a GPU (e.g., RTX 4060) should be able to use their local A1111 WebUI instance for cheap, fast image generation.

## Changes

- Add `A1111ImageProvider` in `src/questfoundry/providers/image_a1111.py`:
  - POST to `{A1111_HOST}/sdapi/v1/txt2img`
  - Spec string selects checkpoint: `a1111/dreamshaper_8`
  - Native negative prompt support
  - SD-friendly aspect ratio mapping (512x512, 768x432, etc.)
  - Returns `quality="low"` in provider metadata
  - Proper error handling: connection errors, timeouts, HTTP errors
- Add `"a1111"` routing to `image_factory.py`
- 15 tests covering: generation, checkpoint override, negative prompts, aspect ratios, all error paths, factory routing

## Not Included / Future PRs

- SDXL-specific dimension presets (could add `a1111xl` spec later)
- ControlNet / img2img support
- Sampling parameter configurability (steps, cfg_scale, sampler)

## Test Plan

```bash
uv run pytest tests/unit/test_image_a1111.py -x -q  # 15 tests pass
uv run ruff check src/questfoundry/providers/image_a1111.py
uv run mypy src/questfoundry/providers/image_a1111.py
```

Live smoke test:
```bash
A1111_HOST=http://athena:7860 qf generate-images --project test-20260201T0715 --image-provider a1111/dreamshaper_8 --image-budget 1
```

## Risk / Rollback

- Additive change only — no existing behavior modified
- A1111 is optional — only loaded when `a1111` spec is used
- Uses httpx (already a base dependency)

🤖 Generated with [Claude Code](https://claude.com/claude-code)