### PR TITLE
feat(export): Exporter protocol, ExportContext, and JSON exporter

### DIFF
--- a/src/questfoundry/export/__init__.py
+++ b/src/questfoundry/export/__init__.py
@@ -15,12 +15,12 @@ from questfoundry.export.base import (
 from questfoundry.export.context import build_export_context
 from questfoundry.export.json_exporter import JsonExporter
 
-_EXPORTERS: dict[str, type[JsonExporter]] = {
+_EXPORTERS: dict[str, type[Exporter]] = {
     "json": JsonExporter,
 }
 
 
-def get_exporter(format_name: str) -> JsonExporter:
+def get_exporter(format_name: str) -> Exporter:
     """Get an exporter instance by format name.
 
     Args:

--- a/src/questfoundry/export/__init__.py
+++ b/src/questfoundry/export/__init__.py
@@ -1,1 +1,55 @@
 """Export format handlers (Twee, HTML, JSON)."""
+
+from __future__ import annotations
+
+from questfoundry.export.base import (
+    ExportChoice,
+    ExportCodeword,
+    ExportCodexEntry,
+    ExportContext,
+    ExportEntity,
+    Exporter,
+    ExportIllustration,
+    ExportPassage,
+)
+from questfoundry.export.context import build_export_context
+from questfoundry.export.json_exporter import JsonExporter
+
+_EXPORTERS: dict[str, type[JsonExporter]] = {
+    "json": JsonExporter,
+}
+
+
+def get_exporter(format_name: str) -> JsonExporter:
+    """Get an exporter instance by format name.
+
+    Args:
+        format_name: Export format (e.g., "json", "twee", "html").
+
+    Returns:
+        Exporter instance.
+
+    Raises:
+        ValueError: If the format is not supported.
+    """
+    cls = _EXPORTERS.get(format_name)
+    if cls is None:
+        supported = ", ".join(sorted(_EXPORTERS))
+        msg = f"Unknown export format '{format_name}'. Supported: {supported}"
+        raise ValueError(msg)
+    return cls()
+
+
+__all__ = [
+    "ExportChoice",
+    "ExportCodeword",
+    "ExportCodexEntry",
+    "ExportContext",
+    "ExportEntity",
+    "ExportIllustration",
+    "ExportPassage",
+    "Exporter",
+    "JsonExporter",
+    "build_export_context",
+    "get_exporter",
+]

--- a/src/questfoundry/export/base.py
+++ b/src/questfoundry/export/base.py
@@ -1,0 +1,109 @@
+"""Export data models and Exporter protocol.
+
+Defines the intermediate representation (ExportContext) that all exporters
+consume, plus the Exporter protocol they must implement.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any, Protocol
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+@dataclass
+class ExportPassage:
+    """A player-facing passage with prose."""
+
+    id: str
+    prose: str
+    is_start: bool = False
+    is_ending: bool = False
+
+
+@dataclass
+class ExportChoice:
+    """A navigable link between two passages."""
+
+    from_passage: str
+    to_passage: str
+    label: str
+    requires: list[str] = field(default_factory=list)
+    grants: list[str] = field(default_factory=list)
+
+
+@dataclass
+class ExportEntity:
+    """A story entity (character, location, object, faction)."""
+
+    id: str
+    entity_type: str
+    concept: str
+    overlays: list[dict[str, Any]] = field(default_factory=list)
+
+
+@dataclass
+class ExportCodeword:
+    """A state-tracking codeword."""
+
+    id: str
+    codeword_type: str
+    tracks: str | None = None
+
+
+@dataclass
+class ExportIllustration:
+    """An illustration asset linked to a passage."""
+
+    passage_id: str
+    asset_path: str
+    caption: str
+    category: str
+
+
+@dataclass
+class ExportCodexEntry:
+    """A codex encyclopedia entry for an entity."""
+
+    entity_id: str
+    rank: int
+    visible_when: list[str] = field(default_factory=list)
+    content: str = ""
+
+
+@dataclass
+class ExportContext:
+    """All data needed by exporters, extracted from the story graph.
+
+    This is the intermediate representation between the internal graph
+    format and the various export formats (Twee, HTML, JSON).
+    """
+
+    title: str
+    passages: list[ExportPassage]
+    choices: list[ExportChoice]
+    entities: list[ExportEntity] = field(default_factory=list)
+    codewords: list[ExportCodeword] = field(default_factory=list)
+    illustrations: list[ExportIllustration] = field(default_factory=list)
+    codex_entries: list[ExportCodexEntry] = field(default_factory=list)
+    art_direction: dict[str, Any] | None = None
+
+
+class Exporter(Protocol):
+    """Protocol for story export format handlers."""
+
+    format_name: str
+
+    def export(self, context: ExportContext, output_dir: Path) -> Path:
+        """Export the story to the given output directory.
+
+        Args:
+            context: Extracted story data.
+            output_dir: Directory to write output files.
+
+        Returns:
+            Path to the main output file.
+        """
+        ...

--- a/src/questfoundry/export/context.py
+++ b/src/questfoundry/export/context.py
@@ -1,0 +1,192 @@
+"""Build ExportContext from a story graph.
+
+Extracts all player-facing nodes and edges from the graph, ignoring
+working nodes (dilemmas, paths, beats, arcs, etc.) and internal edges.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from questfoundry.export.base import (
+    ExportChoice,
+    ExportCodeword,
+    ExportCodexEntry,
+    ExportContext,
+    ExportEntity,
+    ExportIllustration,
+    ExportPassage,
+)
+
+if TYPE_CHECKING:
+    from questfoundry.graph.graph import Graph
+
+
+def build_export_context(graph: Graph, project_name: str) -> ExportContext:
+    """Extract player-facing data from the story graph.
+
+    Args:
+        graph: Loaded story graph.
+        project_name: Project name used as story title.
+
+    Returns:
+        ExportContext containing all data needed by exporters.
+
+    Raises:
+        ValueError: If no passages exist in the graph.
+    """
+    passages = _extract_passages(graph)
+    if not passages:
+        msg = "Graph contains no passages — nothing to export"
+        raise ValueError(msg)
+
+    choices = _extract_choices(graph)
+    _mark_start_and_endings(passages, choices)
+
+    return ExportContext(
+        title=project_name,
+        passages=passages,
+        choices=choices,
+        entities=_extract_entities(graph),
+        codewords=_extract_codewords(graph),
+        illustrations=_extract_illustrations(graph),
+        codex_entries=_extract_codex_entries(graph),
+        art_direction=_extract_art_direction(graph),
+    )
+
+
+def _extract_passages(graph: Graph) -> list[ExportPassage]:
+    """Extract passage nodes with prose."""
+    nodes = graph.get_nodes_by_type("passage")
+    return [
+        ExportPassage(
+            id=node_id,
+            prose=data.get("prose", ""),
+        )
+        for node_id, data in sorted(nodes.items())
+    ]
+
+
+def _extract_choices(graph: Graph) -> list[ExportChoice]:
+    """Extract choice nodes (navigation links between passages)."""
+    nodes = graph.get_nodes_by_type("choice")
+    return [
+        ExportChoice(
+            from_passage=data["from_passage"],
+            to_passage=data["to_passage"],
+            label=data.get("label", "continue"),
+            requires=data.get("requires", []),
+            grants=data.get("grants", []),
+        )
+        for _node_id, data in sorted(nodes.items())
+    ]
+
+
+def _mark_start_and_endings(
+    passages: list[ExportPassage],
+    choices: list[ExportChoice],
+) -> None:
+    """Determine start passage (no incoming choices) and endings (no outgoing)."""
+    has_incoming: set[str] = set()
+    has_outgoing: set[str] = set()
+
+    for choice in choices:
+        has_incoming.add(choice.to_passage)
+        has_outgoing.add(choice.from_passage)
+
+    for passage in passages:
+        if passage.id not in has_incoming:
+            passage.is_start = True
+        if passage.id not in has_outgoing:
+            passage.is_ending = True
+
+
+def _extract_entities(graph: Graph) -> list[ExportEntity]:
+    """Extract entity nodes."""
+    nodes = graph.get_nodes_by_type("entity")
+    return [
+        ExportEntity(
+            id=node_id,
+            entity_type=data.get("entity_type", "unknown"),
+            concept=data.get("concept", ""),
+            overlays=data.get("overlays", []),
+        )
+        for node_id, data in sorted(nodes.items())
+    ]
+
+
+def _extract_codewords(graph: Graph) -> list[ExportCodeword]:
+    """Extract codeword nodes."""
+    nodes = graph.get_nodes_by_type("codeword")
+    return [
+        ExportCodeword(
+            id=node_id,
+            codeword_type=data.get("codeword_type", "granted"),
+            tracks=data.get("tracks"),
+        )
+        for node_id, data in sorted(nodes.items())
+    ]
+
+
+def _extract_illustrations(graph: Graph) -> list[ExportIllustration]:
+    """Extract illustrations linked to passages via Depicts edges."""
+    illustration_nodes = graph.get_nodes_by_type("illustration")
+    if not illustration_nodes:
+        return []
+
+    # Build illustration→passage mapping from Depicts edges
+    depicts_edges = graph.get_edges(edge_type="Depicts")
+    illust_to_passage: dict[str, str] = {}
+    for edge in depicts_edges:
+        illust_to_passage[edge["from"]] = edge["to"]
+
+    result: list[ExportIllustration] = []
+    for node_id, data in sorted(illustration_nodes.items()):
+        passage_id = illust_to_passage.get(node_id)
+        if passage_id:
+            result.append(
+                ExportIllustration(
+                    passage_id=passage_id,
+                    asset_path=data.get("asset", ""),
+                    caption=data.get("caption", ""),
+                    category=data.get("category", "scene"),
+                )
+            )
+    return result
+
+
+def _extract_codex_entries(graph: Graph) -> list[ExportCodexEntry]:
+    """Extract codex entries linked to entities via HasEntry edges."""
+    codex_nodes = graph.get_nodes_by_type("codex_entry")
+    if not codex_nodes:
+        return []
+
+    # Build codex→entity mapping from HasEntry edges
+    has_entry_edges = graph.get_edges(edge_type="HasEntry")
+    codex_to_entity: dict[str, str] = {}
+    for edge in has_entry_edges:
+        codex_to_entity[edge["from"]] = edge["to"]
+
+    result: list[ExportCodexEntry] = []
+    for node_id, data in sorted(codex_nodes.items()):
+        entity_id = codex_to_entity.get(node_id)
+        if entity_id:
+            result.append(
+                ExportCodexEntry(
+                    entity_id=entity_id,
+                    rank=data.get("rank", 0),
+                    visible_when=data.get("visible_when", []),
+                    content=data.get("content", ""),
+                )
+            )
+    return result
+
+
+def _extract_art_direction(graph: Graph) -> dict[str, Any] | None:
+    """Extract art direction node if DRESS stage was run."""
+    nodes = graph.get_nodes_by_type("art_direction")
+    if not nodes:
+        return None
+    # There's typically one art_direction::main node
+    _node_id, data = next(iter(nodes.items()))
+    return {k: v for k, v in data.items() if k not in ("type", "raw_id")}

--- a/src/questfoundry/export/context.py
+++ b/src/questfoundry/export/context.py
@@ -17,9 +17,12 @@ from questfoundry.export.base import (
     ExportIllustration,
     ExportPassage,
 )
+from questfoundry.observability.logging import get_logger
 
 if TYPE_CHECKING:
     from questfoundry.graph.graph import Graph
+
+log = get_logger(__name__)
 
 
 def build_export_context(graph: Graph, project_name: str) -> ExportContext:
@@ -35,6 +38,8 @@ def build_export_context(graph: Graph, project_name: str) -> ExportContext:
     Raises:
         ValueError: If no passages exist in the graph.
     """
+    log.info("export_context_start", project=project_name)
+
     passages = _extract_passages(graph)
     if not passages:
         msg = "Graph contains no passages — nothing to export"
@@ -43,43 +48,71 @@ def build_export_context(graph: Graph, project_name: str) -> ExportContext:
     choices = _extract_choices(graph)
     _mark_start_and_endings(passages, choices)
 
+    entities = _extract_entities(graph)
+    codewords = _extract_codewords(graph)
+    illustrations = _extract_illustrations(graph)
+    codex_entries = _extract_codex_entries(graph)
+    art_direction = _extract_art_direction(graph)
+
+    log.info(
+        "export_context_complete",
+        passages=len(passages),
+        choices=len(choices),
+        entities=len(entities),
+        codewords=len(codewords),
+        illustrations=len(illustrations),
+        codex_entries=len(codex_entries),
+        has_art_direction=art_direction is not None,
+    )
+
     return ExportContext(
         title=project_name,
         passages=passages,
         choices=choices,
-        entities=_extract_entities(graph),
-        codewords=_extract_codewords(graph),
-        illustrations=_extract_illustrations(graph),
-        codex_entries=_extract_codex_entries(graph),
-        art_direction=_extract_art_direction(graph),
+        entities=entities,
+        codewords=codewords,
+        illustrations=illustrations,
+        codex_entries=codex_entries,
+        art_direction=art_direction,
     )
 
 
 def _extract_passages(graph: Graph) -> list[ExportPassage]:
     """Extract passage nodes with prose."""
     nodes = graph.get_nodes_by_type("passage")
-    return [
-        ExportPassage(
-            id=node_id,
-            prose=data.get("prose", ""),
-        )
-        for node_id, data in sorted(nodes.items())
-    ]
+    passages: list[ExportPassage] = []
+    for node_id, data in sorted(nodes.items()):
+        prose = data.get("prose", "")
+        if not prose:
+            log.warning("passage_missing_prose", passage_id=node_id)
+        passages.append(ExportPassage(id=node_id, prose=prose))
+    return passages
 
 
 def _extract_choices(graph: Graph) -> list[ExportChoice]:
-    """Extract choice nodes (navigation links between passages)."""
+    """Extract choice nodes (navigation links between passages).
+
+    Raises:
+        ValueError: If a choice node is missing required from_passage or to_passage.
+    """
     nodes = graph.get_nodes_by_type("choice")
-    return [
-        ExportChoice(
-            from_passage=data["from_passage"],
-            to_passage=data["to_passage"],
-            label=data.get("label", "continue"),
-            requires=data.get("requires", []),
-            grants=data.get("grants", []),
+    choices: list[ExportChoice] = []
+    for node_id, data in sorted(nodes.items()):
+        from_passage = data.get("from_passage")
+        to_passage = data.get("to_passage")
+        if not from_passage or not to_passage:
+            msg = f"Choice node '{node_id}' missing required 'from_passage' or 'to_passage'"
+            raise ValueError(msg)
+        choices.append(
+            ExportChoice(
+                from_passage=from_passage,
+                to_passage=to_passage,
+                label=data.get("label", "continue"),
+                requires=data.get("requires") or [],
+                grants=data.get("grants") or [],
+            )
         )
-        for _node_id, data in sorted(nodes.items())
-    ]
+    return choices
 
 
 def _mark_start_and_endings(
@@ -104,28 +137,40 @@ def _mark_start_and_endings(
 def _extract_entities(graph: Graph) -> list[ExportEntity]:
     """Extract entity nodes."""
     nodes = graph.get_nodes_by_type("entity")
-    return [
-        ExportEntity(
-            id=node_id,
-            entity_type=data.get("entity_type", "unknown"),
-            concept=data.get("concept", ""),
-            overlays=data.get("overlays", []),
+    entities: list[ExportEntity] = []
+    for node_id, data in sorted(nodes.items()):
+        entity_type = data.get("entity_type")
+        if not entity_type:
+            log.warning("entity_missing_type", entity_id=node_id)
+            entity_type = "unknown"
+        entities.append(
+            ExportEntity(
+                id=node_id,
+                entity_type=entity_type,
+                concept=data.get("concept", ""),
+                overlays=data.get("overlays") or [],
+            )
         )
-        for node_id, data in sorted(nodes.items())
-    ]
+    return entities
 
 
 def _extract_codewords(graph: Graph) -> list[ExportCodeword]:
     """Extract codeword nodes."""
     nodes = graph.get_nodes_by_type("codeword")
-    return [
-        ExportCodeword(
-            id=node_id,
-            codeword_type=data.get("codeword_type", "granted"),
-            tracks=data.get("tracks"),
+    codewords: list[ExportCodeword] = []
+    for node_id, data in sorted(nodes.items()):
+        cw_type = data.get("codeword_type")
+        if not cw_type:
+            log.warning("codeword_missing_type", codeword_id=node_id)
+            cw_type = "granted"
+        codewords.append(
+            ExportCodeword(
+                id=node_id,
+                codeword_type=cw_type,
+                tracks=data.get("tracks"),
+            )
         )
-        for node_id, data in sorted(nodes.items())
-    ]
+    return codewords
 
 
 def _extract_illustrations(graph: Graph) -> list[ExportIllustration]:

--- a/src/questfoundry/export/json_exporter.py
+++ b/src/questfoundry/export/json_exporter.py
@@ -1,0 +1,40 @@
+"""JSON export format.
+
+Serializes the ExportContext to a structured JSON file suitable
+for external tools, custom game engines, or programmatic analysis.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import asdict
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from questfoundry.export.base import ExportContext
+
+
+class JsonExporter:
+    """Export story as structured JSON."""
+
+    format_name = "json"
+
+    def export(self, context: ExportContext, output_dir: Path) -> Path:
+        """Write story data as formatted JSON.
+
+        Args:
+            context: Extracted story data.
+            output_dir: Directory to write output files.
+
+        Returns:
+            Path to the generated story.json file.
+        """
+        output_dir.mkdir(parents=True, exist_ok=True)
+        output_file = output_dir / "story.json"
+
+        data = asdict(context)
+        output_file.write_text(json.dumps(data, indent=2, ensure_ascii=False))
+
+        return output_file

--- a/tests/unit/test_export_context.py
+++ b/tests/unit/test_export_context.py
@@ -1,0 +1,215 @@
+"""Tests for ExportContext builder."""
+
+from __future__ import annotations
+
+import pytest
+
+from questfoundry.export.context import build_export_context
+from questfoundry.graph.graph import Graph
+
+
+def _minimal_graph() -> Graph:
+    """Build a minimal graph with passages and choices."""
+    g = Graph()
+    g.create_node(
+        "passage::intro",
+        {
+            "type": "passage",
+            "raw_id": "intro",
+            "prose": "You stand at the gates.",
+        },
+    )
+    g.create_node(
+        "passage::choice_a",
+        {
+            "type": "passage",
+            "raw_id": "choice_a",
+            "prose": "You enter the castle.",
+        },
+    )
+    g.create_node(
+        "passage::choice_b",
+        {
+            "type": "passage",
+            "raw_id": "choice_b",
+            "prose": "You flee into the forest.",
+        },
+    )
+    g.create_node(
+        "choice::intro_to_a",
+        {
+            "type": "choice",
+            "from_passage": "passage::intro",
+            "to_passage": "passage::choice_a",
+            "label": "Enter the castle",
+            "requires": [],
+            "grants": ["codeword::entered_castle"],
+        },
+    )
+    g.create_node(
+        "choice::intro_to_b",
+        {
+            "type": "choice",
+            "from_passage": "passage::intro",
+            "to_passage": "passage::choice_b",
+            "label": "Flee to the forest",
+            "requires": [],
+            "grants": [],
+        },
+    )
+    # Edges for choice connectivity
+    g.add_edge("choice_from", "choice::intro_to_a", "passage::intro")
+    g.add_edge("choice_to", "choice::intro_to_a", "passage::choice_a")
+    g.add_edge("choice_from", "choice::intro_to_b", "passage::intro")
+    g.add_edge("choice_to", "choice::intro_to_b", "passage::choice_b")
+    return g
+
+
+def _graph_with_entities(g: Graph) -> Graph:
+    """Add entity and codeword nodes to a graph."""
+    g.create_node(
+        "entity::hero",
+        {
+            "type": "entity",
+            "raw_id": "hero",
+            "entity_type": "character",
+            "concept": "The protagonist",
+            "overlays": [{"when": ["codeword::entered_castle"], "details": {"mood": "brave"}}],
+        },
+    )
+    g.create_node(
+        "codeword::entered_castle",
+        {
+            "type": "codeword",
+            "raw_id": "entered_castle",
+            "codeword_type": "granted",
+            "tracks": "consequence::entered",
+        },
+    )
+    return g
+
+
+def _graph_with_dress(g: Graph) -> Graph:
+    """Add DRESS stage nodes to a graph."""
+    g.create_node(
+        "art_direction::main",
+        {
+            "type": "art_direction",
+            "style": "watercolor",
+            "medium": "digital painting",
+            "palette": ["blue", "gold"],
+        },
+    )
+    g.create_node(
+        "illustration::intro_scene",
+        {
+            "type": "illustration",
+            "asset": "assets/abc123.png",
+            "caption": "The gates loom before you.",
+            "category": "scene",
+        },
+    )
+    g.add_edge("Depicts", "illustration::intro_scene", "passage::intro")
+    g.create_node(
+        "codex::hero_rank1",
+        {
+            "type": "codex_entry",
+            "rank": 1,
+            "visible_when": [],
+            "content": "A brave adventurer.",
+        },
+    )
+    g.create_node(
+        "entity::hero",
+        {
+            "type": "entity",
+            "raw_id": "hero",
+            "entity_type": "character",
+            "concept": "The protagonist",
+        },
+    )
+    g.add_edge("HasEntry", "codex::hero_rank1", "entity::hero")
+    return g
+
+
+class TestBuildExportContext:
+    def test_minimal_graph(self) -> None:
+        g = _minimal_graph()
+        ctx = build_export_context(g, "test-story")
+
+        assert ctx.title == "test-story"
+        assert len(ctx.passages) == 3
+        assert len(ctx.choices) == 2
+
+    def test_start_passage_detected(self) -> None:
+        g = _minimal_graph()
+        ctx = build_export_context(g, "test")
+
+        start_passages = [p for p in ctx.passages if p.is_start]
+        assert len(start_passages) == 1
+        assert start_passages[0].id == "passage::intro"
+
+    def test_ending_passages_detected(self) -> None:
+        g = _minimal_graph()
+        ctx = build_export_context(g, "test")
+
+        endings = [p for p in ctx.passages if p.is_ending]
+        assert len(endings) == 2
+        ending_ids = {p.id for p in endings}
+        assert ending_ids == {"passage::choice_a", "passage::choice_b"}
+
+    def test_choice_data(self) -> None:
+        g = _minimal_graph()
+        ctx = build_export_context(g, "test")
+
+        castle_choice = next(c for c in ctx.choices if c.label == "Enter the castle")
+        assert castle_choice.from_passage == "passage::intro"
+        assert castle_choice.to_passage == "passage::choice_a"
+        assert castle_choice.grants == ["codeword::entered_castle"]
+
+    def test_entities_and_codewords(self) -> None:
+        g = _graph_with_entities(_minimal_graph())
+        ctx = build_export_context(g, "test")
+
+        assert len(ctx.entities) == 1
+        assert ctx.entities[0].id == "entity::hero"
+        assert ctx.entities[0].entity_type == "character"
+
+        assert len(ctx.codewords) == 1
+        assert ctx.codewords[0].id == "codeword::entered_castle"
+        assert ctx.codewords[0].tracks == "consequence::entered"
+
+    def test_dress_nodes_present(self) -> None:
+        g = _graph_with_dress(_minimal_graph())
+        ctx = build_export_context(g, "test")
+
+        assert ctx.art_direction is not None
+        assert ctx.art_direction["style"] == "watercolor"
+
+        assert len(ctx.illustrations) == 1
+        assert ctx.illustrations[0].passage_id == "passage::intro"
+        assert ctx.illustrations[0].asset_path == "assets/abc123.png"
+
+        assert len(ctx.codex_entries) == 1
+        assert ctx.codex_entries[0].entity_id == "entity::hero"
+        assert ctx.codex_entries[0].rank == 1
+
+    def test_no_dress_nodes(self) -> None:
+        g = _minimal_graph()
+        ctx = build_export_context(g, "test")
+
+        assert ctx.art_direction is None
+        assert ctx.illustrations == []
+        assert ctx.codex_entries == []
+
+    def test_empty_graph_raises(self) -> None:
+        g = Graph()
+        with pytest.raises(ValueError, match="no passages"):
+            build_export_context(g, "test")
+
+    def test_passage_prose_preserved(self) -> None:
+        g = _minimal_graph()
+        ctx = build_export_context(g, "test")
+
+        intro = next(p for p in ctx.passages if p.id == "passage::intro")
+        assert intro.prose == "You stand at the gates."

--- a/tests/unit/test_json_exporter.py
+++ b/tests/unit/test_json_exporter.py
@@ -1,0 +1,82 @@
+"""Tests for JSON exporter."""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+
+from questfoundry.export.base import ExportChoice, ExportContext, ExportPassage
+from questfoundry.export.json_exporter import JsonExporter
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _simple_context() -> ExportContext:
+    """Build a minimal ExportContext for testing."""
+    return ExportContext(
+        title="Test Story",
+        passages=[
+            ExportPassage(id="p1", prose="Opening scene.", is_start=True),
+            ExportPassage(id="p2", prose="The end.", is_ending=True),
+        ],
+        choices=[
+            ExportChoice(
+                from_passage="p1",
+                to_passage="p2",
+                label="Continue",
+                requires=[],
+                grants=["codeword::done"],
+            ),
+        ],
+    )
+
+
+class TestJsonExporter:
+    def test_creates_output_file(self, tmp_path: Path) -> None:
+        exporter = JsonExporter()
+        result = exporter.export(_simple_context(), tmp_path / "out")
+
+        assert result.exists()
+        assert result.name == "story.json"
+
+    def test_output_is_valid_json(self, tmp_path: Path) -> None:
+        exporter = JsonExporter()
+        result = exporter.export(_simple_context(), tmp_path / "out")
+
+        data = json.loads(result.read_text())
+        assert isinstance(data, dict)
+
+    def test_structure(self, tmp_path: Path) -> None:
+        exporter = JsonExporter()
+        result = exporter.export(_simple_context(), tmp_path / "out")
+
+        data = json.loads(result.read_text())
+        assert data["title"] == "Test Story"
+        assert len(data["passages"]) == 2
+        assert len(data["choices"]) == 1
+        assert data["passages"][0]["prose"] == "Opening scene."
+        assert data["passages"][0]["is_start"] is True
+        assert data["choices"][0]["grants"] == ["codeword::done"]
+
+    def test_creates_output_directory(self, tmp_path: Path) -> None:
+        exporter = JsonExporter()
+        nested = tmp_path / "deep" / "nested" / "dir"
+        result = exporter.export(_simple_context(), nested)
+
+        assert result.exists()
+        assert nested.exists()
+
+    def test_roundtrip(self, tmp_path: Path) -> None:
+        exporter = JsonExporter()
+        ctx = _simple_context()
+        result = exporter.export(ctx, tmp_path / "out")
+
+        data = json.loads(result.read_text())
+        # Verify key fields survive serialization
+        assert data["passages"][1]["is_ending"] is True
+        assert data["art_direction"] is None
+        assert data["illustrations"] == []
+
+    def test_format_name(self) -> None:
+        assert JsonExporter.format_name == "json"


### PR DESCRIPTION
## Problem
The SHIP stage needs infrastructure to export story graphs to playable formats. Currently `src/questfoundry/export/` is empty.

## Changes
- `export/base.py`: ExportContext dataclass (intermediate representation) with typed dataclasses for passages, choices, entities, codewords, illustrations, codex entries. Exporter protocol.
- `export/context.py`: `build_export_context()` extracts player-facing data from the graph, ignoring working nodes. Derives start/ending passages from choice edges. Handles optional DRESS nodes gracefully.
- `export/json_exporter.py`: First concrete exporter — serializes ExportContext to formatted JSON.
- `export/__init__.py`: Exporter registry with `get_exporter()` lookup.
- Tests: 15 tests covering context building, start/ending detection, DRESS node extraction, JSON roundtrip.

## Not Included / Future PRs
- Twee exporter (#395)
- HTML exporter (#396)
- ShipStage + CLI command (#397)

## Test Plan
```
uv run pytest tests/unit/test_export_context.py tests/unit/test_json_exporter.py -x -q
# 15 passed
```

## Risk / Rollback
No impact on existing functionality — all new files.

Closes #394
Parent: #393

🤖 Generated with [Claude Code](https://claude.com/claude-code)