### PR TITLE
feat(export): add Twee/SugarCube exporter

### DIFF
--- a/src/questfoundry/export/__init__.py
+++ b/src/questfoundry/export/__init__.py
@@ -14,13 +14,15 @@ from questfoundry.export.base import (
 )
 from questfoundry.export.context import build_export_context
 from questfoundry.export.json_exporter import JsonExporter
+from questfoundry.export.twee_exporter import TweeExporter
 
-_EXPORTERS: dict[str, type[JsonExporter]] = {
+_EXPORTERS: dict[str, type[JsonExporter | TweeExporter]] = {
     "json": JsonExporter,
+    "twee": TweeExporter,
 }
 
 
-def get_exporter(format_name: str) -> JsonExporter:
+def get_exporter(format_name: str) -> JsonExporter | TweeExporter:
     """Get an exporter instance by format name.
 
     Args:
@@ -50,6 +52,7 @@ __all__ = [
     "ExportPassage",
     "Exporter",
     "JsonExporter",
+    "TweeExporter",
     "build_export_context",
     "get_exporter",
 ]

--- a/src/questfoundry/export/__init__.py
+++ b/src/questfoundry/export/__init__.py
@@ -15,12 +15,12 @@ from questfoundry.export.base import (
 from questfoundry.export.context import build_export_context
 from questfoundry.export.json_exporter import JsonExporter
 
-_EXPORTERS: dict[str, type[Exporter]] = {
+_EXPORTERS: dict[str, type[JsonExporter]] = {
     "json": JsonExporter,
 }
 
 
-def get_exporter(format_name: str) -> Exporter:
+def get_exporter(format_name: str) -> JsonExporter:
     """Get an exporter instance by format name.
 
     Args:

--- a/src/questfoundry/export/twee_exporter.py
+++ b/src/questfoundry/export/twee_exporter.py
@@ -1,0 +1,188 @@
+"""Twee/SugarCube export format.
+
+Generates a Twee 3 file compatible with SugarCube 2. The output can be
+imported into Twine or compiled directly with Tweego.
+
+Format reference: https://twinery.org/cookbook/terms/terms_twee.html
+SugarCube: https://www.motoslave.net/sugarcube/2/docs/
+"""
+
+from __future__ import annotations
+
+import uuid
+from typing import TYPE_CHECKING
+
+from questfoundry.observability.logging import get_logger
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from questfoundry.export.base import (
+        ExportChoice,
+        ExportContext,
+        ExportIllustration,
+        ExportPassage,
+    )
+
+log = get_logger(__name__)
+
+
+class TweeExporter:
+    """Export story as Twee 3 / SugarCube 2 format."""
+
+    format_name = "twee"
+
+    def export(self, context: ExportContext, output_dir: Path) -> Path:
+        """Write story as a .twee file.
+
+        Args:
+            context: Extracted story data.
+            output_dir: Directory to write output files.
+
+        Returns:
+            Path to the generated .twee file.
+        """
+        output_dir.mkdir(parents=True, exist_ok=True)
+        output_file = output_dir / "story.twee"
+
+        lines: list[str] = []
+        lines.extend(_story_header(context.title))
+        lines.append("")
+
+        # Build lookup structures
+        choices_by_passage = _group_choices_by_passage(context.choices)
+        illustrations_by_passage: dict[str, ExportIllustration] = {
+            ill.passage_id: ill for ill in context.illustrations
+        }
+
+        # Find start passage
+        start_passage = next((p for p in context.passages if p.is_start), context.passages[0])
+
+        # Emit start passage first
+        lines.extend(
+            _render_passage(
+                start_passage,
+                choices_by_passage.get(start_passage.id, []),
+                illustrations_by_passage.get(start_passage.id),
+                is_start=True,
+            )
+        )
+        lines.append("")
+
+        # Emit remaining passages
+        for passage in context.passages:
+            if passage.id == start_passage.id:
+                continue
+            lines.extend(
+                _render_passage(
+                    passage,
+                    choices_by_passage.get(passage.id, []),
+                    illustrations_by_passage.get(passage.id),
+                )
+            )
+            lines.append("")
+
+        content = "\n".join(lines)
+        output_file.write_text(content, encoding="utf-8")
+
+        log.info(
+            "twee_export_complete",
+            passages=len(context.passages),
+            choices=len(context.choices),
+            output=str(output_file),
+        )
+
+        return output_file
+
+
+def _story_header(title: str) -> list[str]:
+    """Generate Twee 3 story header passages."""
+    ifid = str(uuid.uuid4()).upper()
+    return [
+        f":: StoryTitle\n{title}",
+        "",
+        f':: StoryData\n{{"ifid": "{ifid}", "format": "SugarCube", "format-version": "2.37.3"}}',
+    ]
+
+
+def _passage_name(passage_id: str) -> str:
+    """Convert a passage ID to a Twee passage name.
+
+    Strips the ``passage::`` prefix for cleaner output.
+    """
+    if passage_id.startswith("passage::"):
+        return passage_id[len("passage::") :]
+    return passage_id
+
+
+def _codeword_var(codeword_id: str) -> str:
+    """Convert a codeword ID to a SugarCube variable name.
+
+    Strips the ``codeword::`` prefix and uses ``$`` notation.
+    """
+    name = codeword_id
+    if name.startswith("codeword::"):
+        name = name[len("codeword::") :]
+    return f"${name}"
+
+
+def _group_choices_by_passage(
+    choices: list[ExportChoice],
+) -> dict[str, list[ExportChoice]]:
+    """Group choices by their source passage."""
+    result: dict[str, list[ExportChoice]] = {}
+    for choice in choices:
+        result.setdefault(choice.from_passage, []).append(choice)
+    return result
+
+
+def _render_passage(
+    passage: ExportPassage,
+    choices: list[ExportChoice],
+    illustration: ExportIllustration | None = None,
+    *,
+    is_start: bool = False,
+) -> list[str]:
+    """Render a single passage as Twee markup."""
+    name = "Start" if is_start else _passage_name(passage.id)
+    tags = " [start]" if is_start else ""
+    lines = [f":: {name}{tags}"]
+
+    # Illustration
+    if illustration is not None:
+        lines.append(f"[img[{illustration.asset_path}]]")
+        if illustration.caption:
+            lines.append(f"//{illustration.caption}//")
+
+    # Prose
+    lines.append(passage.prose)
+
+    # Choices
+    for choice in choices:
+        lines.append(_render_choice(choice))
+
+    return lines
+
+
+def _render_choice(choice: ExportChoice) -> str:
+    """Render a single choice as SugarCube markup.
+
+    If the choice has grants, uses ``<<link>>`` with ``<<set>>`` to
+    assign codewords before navigating. If it also has requires, wraps
+    the link in an ``<<if>>`` conditional.
+
+    If no grants, uses simple ``[[label->target]]`` syntax.
+    """
+    target = _passage_name(choice.to_passage)
+
+    if choice.grants:
+        # Use <<link>> macro to set codewords before navigating
+        sets = "".join(f"<<set {_codeword_var(cw)} to true>>" for cw in choice.grants)
+        link = f'<<link "{choice.label}">>{sets}<<goto "{target}">><</link>>'
+    else:
+        link = f"[[{choice.label}->{target}]]"
+
+    if choice.requires:
+        conditions = " and ".join(_codeword_var(cw) for cw in choice.requires)
+        return f"<<if {conditions}>>{link}<</if>>"
+    return link

--- a/tests/unit/test_twee_exporter.py
+++ b/tests/unit/test_twee_exporter.py
@@ -1,0 +1,196 @@
+"""Tests for Twee/SugarCube exporter."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from questfoundry.export.base import (
+    ExportChoice,
+    ExportContext,
+    ExportIllustration,
+    ExportPassage,
+)
+from questfoundry.export.twee_exporter import TweeExporter
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _simple_context() -> ExportContext:
+    """Build a minimal ExportContext for testing."""
+    return ExportContext(
+        title="Test Story",
+        passages=[
+            ExportPassage(id="passage::intro", prose="You stand at the gates.", is_start=True),
+            ExportPassage(id="passage::castle", prose="You enter the castle.", is_ending=True),
+            ExportPassage(id="passage::forest", prose="You flee into the forest.", is_ending=True),
+        ],
+        choices=[
+            ExportChoice(
+                from_passage="passage::intro",
+                to_passage="passage::castle",
+                label="Enter the castle",
+            ),
+            ExportChoice(
+                from_passage="passage::intro",
+                to_passage="passage::forest",
+                label="Flee to the forest",
+            ),
+        ],
+    )
+
+
+class TestTweeExporter:
+    def test_creates_output_file(self, tmp_path: Path) -> None:
+        exporter = TweeExporter()
+        result = exporter.export(_simple_context(), tmp_path / "out")
+
+        assert result.exists()
+        assert result.name == "story.twee"
+
+    def test_story_title(self, tmp_path: Path) -> None:
+        exporter = TweeExporter()
+        result = exporter.export(_simple_context(), tmp_path / "out")
+        content = result.read_text()
+
+        assert ":: StoryTitle\nTest Story" in content
+
+    def test_story_data_header(self, tmp_path: Path) -> None:
+        exporter = TweeExporter()
+        result = exporter.export(_simple_context(), tmp_path / "out")
+        content = result.read_text()
+
+        assert ":: StoryData" in content
+        assert '"format": "SugarCube"' in content
+
+    def test_start_passage(self, tmp_path: Path) -> None:
+        exporter = TweeExporter()
+        result = exporter.export(_simple_context(), tmp_path / "out")
+        content = result.read_text()
+
+        assert ":: Start [start]" in content
+        assert "You stand at the gates." in content
+
+    def test_passage_names_stripped(self, tmp_path: Path) -> None:
+        exporter = TweeExporter()
+        result = exporter.export(_simple_context(), tmp_path / "out")
+        content = result.read_text()
+
+        # passage:: prefix should be stripped
+        assert ":: castle" in content
+        assert ":: forest" in content
+        assert "passage::" not in content.split(":: StoryData")[1]  # Not in passage names
+
+    def test_simple_choices(self, tmp_path: Path) -> None:
+        exporter = TweeExporter()
+        result = exporter.export(_simple_context(), tmp_path / "out")
+        content = result.read_text()
+
+        assert "[[Enter the castle->castle]]" in content
+        assert "[[Flee to the forest->forest]]" in content
+
+    def test_conditional_choice(self, tmp_path: Path) -> None:
+        ctx = ExportContext(
+            title="Test",
+            passages=[
+                ExportPassage(id="p1", prose="Start.", is_start=True),
+                ExportPassage(id="p2", prose="Secret room.", is_ending=True),
+            ],
+            choices=[
+                ExportChoice(
+                    from_passage="p1",
+                    to_passage="p2",
+                    label="Enter secret room",
+                    requires=["codeword::has_key"],
+                ),
+            ],
+        )
+        exporter = TweeExporter()
+        result = exporter.export(ctx, tmp_path / "out")
+        content = result.read_text()
+
+        assert "<<if $has_key>>[[Enter secret room->p2]]<</if>>" in content
+
+    def test_choice_with_grants(self, tmp_path: Path) -> None:
+        ctx = ExportContext(
+            title="Test",
+            passages=[
+                ExportPassage(id="p1", prose="Start.", is_start=True),
+                ExportPassage(id="p2", prose="Castle.", is_ending=True),
+            ],
+            choices=[
+                ExportChoice(
+                    from_passage="p1",
+                    to_passage="p2",
+                    label="Take the sword",
+                    grants=["codeword::has_sword"],
+                ),
+            ],
+        )
+        exporter = TweeExporter()
+        result = exporter.export(ctx, tmp_path / "out")
+        content = result.read_text()
+
+        # Should use <<link>> macro with <<set>> and <<goto>>
+        assert (
+            '<<link "Take the sword">><<set $has_sword to true>><<goto "p2">><</link>>' in content
+        )
+
+    def test_choice_with_requires_and_grants(self, tmp_path: Path) -> None:
+        ctx = ExportContext(
+            title="Test",
+            passages=[
+                ExportPassage(id="p1", prose="Start.", is_start=True),
+                ExportPassage(id="p2", prose="End.", is_ending=True),
+            ],
+            choices=[
+                ExportChoice(
+                    from_passage="p1",
+                    to_passage="p2",
+                    label="Use key",
+                    requires=["codeword::has_key"],
+                    grants=["codeword::door_opened"],
+                ),
+            ],
+        )
+        exporter = TweeExporter()
+        result = exporter.export(ctx, tmp_path / "out")
+        content = result.read_text()
+
+        assert "<<if $has_key>>" in content
+        assert '<<link "Use key">><<set $door_opened to true>><<goto "p2">><</link>>' in content
+        assert "<</if>>" in content
+
+    def test_illustration(self, tmp_path: Path) -> None:
+        ctx = ExportContext(
+            title="Test",
+            passages=[
+                ExportPassage(id="passage::intro", prose="Start.", is_start=True),
+            ],
+            choices=[],
+            illustrations=[
+                ExportIllustration(
+                    passage_id="passage::intro",
+                    asset_path="assets/abc123.png",
+                    caption="A dark gate.",
+                    category="scene",
+                ),
+            ],
+        )
+        exporter = TweeExporter()
+        result = exporter.export(ctx, tmp_path / "out")
+        content = result.read_text()
+
+        assert "[img[assets/abc123.png]]" in content
+        assert "//A dark gate.//" in content
+
+    def test_format_name(self) -> None:
+        assert TweeExporter.format_name == "twee"
+
+    def test_creates_output_directory(self, tmp_path: Path) -> None:
+        exporter = TweeExporter()
+        nested = tmp_path / "deep" / "nested"
+        result = exporter.export(_simple_context(), nested)
+
+        assert result.exists()
+        assert nested.exists()


### PR DESCRIPTION
## Problem
Need Twee/SugarCube format export so stories can be imported into Twine or compiled with Tweego.

## Changes
- `export/twee_exporter.py`: TweeExporter generating Twee 3 / SugarCube 2 format
  - StoryTitle + StoryData headers with generated IFID
  - `[[label->target]]` for simple choices, `<<link>>` with `<<set>>`+`<<goto>>` for choices with grants
  - `<<if>>` conditionals for codeword-gated choices
  - `[img[path]]` for illustrations with italic captions
  - Start passage tagged with `[start]`
- Updated `export/__init__.py` to register TweeExporter
- 12 tests covering all choice/grant/require combinations

## Not Included / Future PRs
- HTML exporter (#396)
- ShipStage + CLI (#397)

## Test Plan
```
uv run pytest tests/unit/test_twee_exporter.py -x -q
# 12 passed
```

## Risk / Rollback
No impact on existing functionality — all new code.

Closes #395
Parent: #393

🤖 Generated with [Claude Code](https://claude.com/claude-code)