### PR TITLE
feat(export): add standalone HTML exporter

### DIFF
--- a/src/questfoundry/export/__init__.py
+++ b/src/questfoundry/export/__init__.py
@@ -13,16 +13,18 @@ from questfoundry.export.base import (
     ExportPassage,
 )
 from questfoundry.export.context import build_export_context
+from questfoundry.export.html_exporter import HtmlExporter
 from questfoundry.export.json_exporter import JsonExporter
 from questfoundry.export.twee_exporter import TweeExporter
 
-_EXPORTERS: dict[str, type[JsonExporter | TweeExporter]] = {
+_EXPORTERS: dict[str, type[JsonExporter | TweeExporter | HtmlExporter]] = {
     "json": JsonExporter,
     "twee": TweeExporter,
+    "html": HtmlExporter,
 }
 
 
-def get_exporter(format_name: str) -> JsonExporter | TweeExporter:
+def get_exporter(format_name: str) -> JsonExporter | TweeExporter | HtmlExporter:
     """Get an exporter instance by format name.
 
     Args:
@@ -51,6 +53,7 @@ __all__ = [
     "ExportIllustration",
     "ExportPassage",
     "Exporter",
+    "HtmlExporter",
     "JsonExporter",
     "TweeExporter",
     "build_export_context",

--- a/src/questfoundry/export/html_exporter.py
+++ b/src/questfoundry/export/html_exporter.py
@@ -1,0 +1,264 @@
+"""Standalone HTML export format.
+
+Generates a single self-contained HTML file with embedded CSS and
+JavaScript. The story is playable in any modern browser with no
+external dependencies.
+"""
+
+from __future__ import annotations
+
+import html
+import json
+from typing import TYPE_CHECKING
+
+from questfoundry.observability.logging import get_logger
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from questfoundry.export.base import ExportChoice, ExportContext, ExportPassage
+
+log = get_logger(__name__)
+
+
+class HtmlExporter:
+    """Export story as a standalone HTML file."""
+
+    format_name = "html"
+
+    def export(self, context: ExportContext, output_dir: Path) -> Path:
+        """Write story as a single playable HTML file.
+
+        Args:
+            context: Extracted story data.
+            output_dir: Directory to write output files.
+
+        Returns:
+            Path to the generated HTML file.
+        """
+        output_dir.mkdir(parents=True, exist_ok=True)
+        output_file = output_dir / "story.html"
+
+        # Find start passage
+        start_id = next(
+            (p.id for p in context.passages if p.is_start),
+            context.passages[0].id if context.passages else "",
+        )
+
+        # Build data structures for JavaScript
+        choices_by_passage: dict[str, list[ExportChoice]] = {}
+        for choice in context.choices:
+            choices_by_passage.setdefault(choice.from_passage, []).append(choice)
+
+        illustrations_by_passage = {ill.passage_id: ill for ill in context.illustrations}
+
+        passages_html = []
+        for passage in context.passages:
+            choices = choices_by_passage.get(passage.id, [])
+            illustration = illustrations_by_passage.get(passage.id)
+            passages_html.append(_render_passage_div(passage, choices, illustration))
+
+        # Build the complete HTML document
+        content = _build_html_document(
+            title=context.title,
+            passages_html="\n".join(passages_html),
+            start_id=_safe_id(start_id),
+        )
+
+        output_file.write_text(content, encoding="utf-8")
+
+        log.info(
+            "html_export_complete",
+            passages=len(context.passages),
+            choices=len(context.choices),
+            output=str(output_file),
+        )
+
+        return output_file
+
+
+def _safe_id(passage_id: str) -> str:
+    """Convert a passage ID to a safe HTML id attribute."""
+    return passage_id.replace("::", "--").replace(" ", "_")
+
+
+def _render_passage_div(
+    passage: ExportPassage,
+    choices: list[ExportChoice],
+    illustration: object | None = None,
+) -> str:
+    """Render a passage as an HTML div element."""
+    pid = _safe_id(passage.id)
+    prose_escaped = html.escape(passage.prose).replace("\n", "<br>\n")
+
+    parts = [f'<div class="passage" id="{pid}">']
+
+    # Illustration
+    if illustration is not None:
+        from questfoundry.export.base import ExportIllustration
+
+        if isinstance(illustration, ExportIllustration):
+            parts.append(
+                f'  <figure><img src="{html.escape(illustration.asset_path)}" alt="{html.escape(illustration.caption)}">'
+            )
+            parts.append(f"  <figcaption>{html.escape(illustration.caption)}</figcaption></figure>")
+
+    # Prose
+    parts.append(f'  <div class="prose">{prose_escaped}</div>')
+
+    # Choices
+    if choices:
+        parts.append('  <div class="choices">')
+        for choice in choices:
+            target = _safe_id(choice.to_passage)
+            label = html.escape(choice.label)
+            requires_attr = ""
+            grants_attr = ""
+            if choice.requires:
+                requires_attr = f' data-requires="{html.escape(json.dumps(choice.requires))}"'
+            if choice.grants:
+                grants_attr = f' data-grants="{html.escape(json.dumps(choice.grants))}"'
+            parts.append(
+                f'    <a class="choice" href="#" data-target="{target}"{requires_attr}{grants_attr}>{label}</a>'
+            )
+        parts.append("  </div>")
+
+    # Ending marker
+    if passage.is_ending:
+        parts.append('  <div class="ending">The End</div>')
+
+    parts.append("</div>")
+    return "\n".join(parts)
+
+
+def _build_html_document(
+    title: str,
+    passages_html: str,
+    start_id: str,
+) -> str:
+    """Build the complete HTML document."""
+    return f"""<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>{html.escape(title)}</title>
+<style>
+body {{
+  font-family: Georgia, 'Times New Roman', serif;
+  max-width: 700px;
+  margin: 2em auto;
+  padding: 0 1em;
+  background: #1a1a2e;
+  color: #e0e0e0;
+  line-height: 1.7;
+}}
+.passage {{
+  display: none;
+}}
+.passage.active {{
+  display: block;
+  animation: fadeIn 0.3s ease-in;
+}}
+@keyframes fadeIn {{
+  from {{ opacity: 0; }}
+  to {{ opacity: 1; }}
+}}
+.prose {{
+  margin-bottom: 1.5em;
+}}
+.choices {{
+  display: flex;
+  flex-direction: column;
+  gap: 0.5em;
+}}
+.choice {{
+  display: block;
+  padding: 0.7em 1em;
+  background: #16213e;
+  color: #a8d8ea;
+  text-decoration: none;
+  border-radius: 4px;
+  border: 1px solid #0f3460;
+  cursor: pointer;
+  transition: background 0.2s;
+}}
+.choice:hover {{
+  background: #0f3460;
+}}
+.choice.hidden {{
+  display: none;
+}}
+.ending {{
+  text-align: center;
+  font-style: italic;
+  margin-top: 2em;
+  color: #888;
+}}
+figure {{
+  margin: 1em 0;
+  text-align: center;
+}}
+figure img {{
+  max-width: 100%;
+  border-radius: 4px;
+}}
+figcaption {{
+  font-style: italic;
+  color: #888;
+  margin-top: 0.5em;
+}}
+h1 {{
+  text-align: center;
+  color: #a8d8ea;
+}}
+</style>
+</head>
+<body>
+<h1>{html.escape(title)}</h1>
+
+{passages_html}
+
+<script>
+(function() {{
+  const codewords = new Set();
+  const startId = "{start_id}";
+
+  function showPassage(id) {{
+    document.querySelectorAll('.passage').forEach(p => p.classList.remove('active'));
+    const el = document.getElementById(id);
+    if (el) {{
+      el.classList.add('active');
+      updateChoiceVisibility(el);
+      window.scrollTo(0, 0);
+    }}
+  }}
+
+  function updateChoiceVisibility(passageEl) {{
+    passageEl.querySelectorAll('.choice').forEach(link => {{
+      const requires = link.dataset.requires;
+      if (requires) {{
+        const needed = JSON.parse(requires);
+        const visible = needed.every(cw => codewords.has(cw));
+        link.classList.toggle('hidden', !visible);
+      }}
+    }});
+  }}
+
+  document.addEventListener('click', function(e) {{
+    const link = e.target.closest('.choice');
+    if (!link) return;
+    e.preventDefault();
+    const grants = link.dataset.grants;
+    if (grants) {{
+      JSON.parse(grants).forEach(cw => codewords.add(cw));
+    }}
+    const target = link.dataset.target;
+    if (target) showPassage(target);
+  }});
+
+  showPassage(startId);
+}})();
+</script>
+</body>
+</html>"""

--- a/tests/unit/test_html_exporter.py
+++ b/tests/unit/test_html_exporter.py
@@ -1,0 +1,174 @@
+"""Tests for standalone HTML exporter."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from questfoundry.export.base import (
+    ExportChoice,
+    ExportContext,
+    ExportIllustration,
+    ExportPassage,
+)
+from questfoundry.export.html_exporter import HtmlExporter
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _simple_context() -> ExportContext:
+    """Build a minimal ExportContext for testing."""
+    return ExportContext(
+        title="Test Story",
+        passages=[
+            ExportPassage(id="passage::intro", prose="You stand at the gates.", is_start=True),
+            ExportPassage(id="passage::castle", prose="You enter the castle.", is_ending=True),
+        ],
+        choices=[
+            ExportChoice(
+                from_passage="passage::intro",
+                to_passage="passage::castle",
+                label="Enter the castle",
+            ),
+        ],
+    )
+
+
+class TestHtmlExporter:
+    def test_creates_output_file(self, tmp_path: Path) -> None:
+        exporter = HtmlExporter()
+        result = exporter.export(_simple_context(), tmp_path / "out")
+
+        assert result.exists()
+        assert result.name == "story.html"
+
+    def test_html_structure(self, tmp_path: Path) -> None:
+        exporter = HtmlExporter()
+        result = exporter.export(_simple_context(), tmp_path / "out")
+        content = result.read_text()
+
+        assert "<!DOCTYPE html>" in content
+        assert "<title>Test Story</title>" in content
+        assert "</html>" in content
+
+    def test_passages_present(self, tmp_path: Path) -> None:
+        exporter = HtmlExporter()
+        result = exporter.export(_simple_context(), tmp_path / "out")
+        content = result.read_text()
+
+        assert 'class="passage"' in content
+        assert "You stand at the gates." in content
+        assert "You enter the castle." in content
+
+    def test_choices_present(self, tmp_path: Path) -> None:
+        exporter = HtmlExporter()
+        result = exporter.export(_simple_context(), tmp_path / "out")
+        content = result.read_text()
+
+        assert 'class="choice"' in content
+        assert "Enter the castle" in content
+        assert 'data-target="passage--castle"' in content
+
+    def test_start_passage_id(self, tmp_path: Path) -> None:
+        exporter = HtmlExporter()
+        result = exporter.export(_simple_context(), tmp_path / "out")
+        content = result.read_text()
+
+        assert 'const startId = "passage--intro"' in content
+
+    def test_codeword_requires(self, tmp_path: Path) -> None:
+        ctx = ExportContext(
+            title="Test",
+            passages=[
+                ExportPassage(id="p1", prose="Start.", is_start=True),
+                ExportPassage(id="p2", prose="Secret.", is_ending=True),
+            ],
+            choices=[
+                ExportChoice(
+                    from_passage="p1",
+                    to_passage="p2",
+                    label="Enter",
+                    requires=["codeword::has_key"],
+                ),
+            ],
+        )
+        exporter = HtmlExporter()
+        result = exporter.export(ctx, tmp_path / "out")
+        content = result.read_text()
+
+        assert "data-requires=" in content
+        assert "codeword::has_key" in content
+
+    def test_codeword_grants(self, tmp_path: Path) -> None:
+        ctx = ExportContext(
+            title="Test",
+            passages=[
+                ExportPassage(id="p1", prose="Start.", is_start=True),
+                ExportPassage(id="p2", prose="End.", is_ending=True),
+            ],
+            choices=[
+                ExportChoice(
+                    from_passage="p1",
+                    to_passage="p2",
+                    label="Go",
+                    grants=["codeword::visited"],
+                ),
+            ],
+        )
+        exporter = HtmlExporter()
+        result = exporter.export(ctx, tmp_path / "out")
+        content = result.read_text()
+
+        assert "data-grants=" in content
+        assert "codeword::visited" in content
+
+    def test_ending_marker(self, tmp_path: Path) -> None:
+        exporter = HtmlExporter()
+        result = exporter.export(_simple_context(), tmp_path / "out")
+        content = result.read_text()
+
+        assert 'class="ending"' in content
+        assert "The End" in content
+
+    def test_illustration(self, tmp_path: Path) -> None:
+        ctx = ExportContext(
+            title="Test",
+            passages=[
+                ExportPassage(id="p1", prose="Start.", is_start=True),
+            ],
+            choices=[],
+            illustrations=[
+                ExportIllustration(
+                    passage_id="p1",
+                    asset_path="assets/abc.png",
+                    caption="A gate.",
+                    category="scene",
+                ),
+            ],
+        )
+        exporter = HtmlExporter()
+        result = exporter.export(ctx, tmp_path / "out")
+        content = result.read_text()
+
+        assert '<img src="assets/abc.png"' in content
+        assert "A gate." in content
+
+    def test_javascript_engine(self, tmp_path: Path) -> None:
+        exporter = HtmlExporter()
+        result = exporter.export(_simple_context(), tmp_path / "out")
+        content = result.read_text()
+
+        assert "const codewords = new Set()" in content
+        assert "function showPassage" in content
+        assert "showPassage(startId)" in content
+
+    def test_format_name(self) -> None:
+        assert HtmlExporter.format_name == "html"
+
+    def test_creates_output_directory(self, tmp_path: Path) -> None:
+        exporter = HtmlExporter()
+        nested = tmp_path / "deep" / "nested"
+        result = exporter.export(_simple_context(), nested)
+
+        assert result.exists()
+        assert nested.exists()


### PR DESCRIPTION
## Problem
Need a standalone HTML export so stories can be played in any browser without external tools.

## Changes
- `export/html_exporter.py`: Single-file HTML with embedded CSS/JS
  - Dark theme with serif typography
  - Passages as hidden divs, shown/hidden via JS
  - Choice links with `data-target`, `data-requires`, `data-grants` attributes
  - JavaScript codeword engine using `Set` for conditional choice visibility
  - Illustrations as `<figure>` with `<figcaption>`
  - "The End" marker on ending passages
  - Fade-in animation on transitions
- Updated `export/__init__.py` to register HtmlExporter
- 12 tests covering structure, choices, codewords, illustrations

## Not Included / Future PRs
- ShipStage + CLI command (#397)

## Test Plan
```
uv run pytest tests/unit/test_html_exporter.py -x -q
# 12 passed
```

## Risk / Rollback
No impact on existing functionality — all new code.

Closes #396
Parent: #393

🤖 Generated with [Claude Code](https://claude.com/claude-code)