### PR TITLE
feat(ship): add ShipStage and CLI command (#397)

### DIFF
--- a/src/questfoundry/cli.py
+++ b/src/questfoundry/cli.py
@@ -89,7 +89,7 @@ DEFAULT_FILL_PROMPT = (
 DEFAULT_DRESS_PROMPT = "Establish art direction, generate illustration briefs and codex entries."
 
 # Pipeline stage order and configuration
-STAGE_ORDER = ["dream", "brainstorm", "seed", "grow", "fill", "dress"]
+STAGE_ORDER = ["dream", "brainstorm", "seed", "grow", "fill", "dress", "ship"]
 
 # Stage prompt configuration for the run command
 # Maps stage name to (default_interactive_prompt, default_noninteractive_prompt)
@@ -117,6 +117,10 @@ STAGE_PROMPTS: dict[str, tuple[str, str | None]] = {
     "dress": (
         DEFAULT_DRESS_PROMPT,
         DEFAULT_DRESS_PROMPT,  # Same for both modes
+    ),
+    "ship": (
+        "Export to playable format.",
+        "Export to playable format.",  # SHIP is deterministic, prompt unused
     ),
 }
 
@@ -1311,6 +1315,69 @@ def dress(
     )
 
 
+@app.command()
+def ship(
+    project: Annotated[
+        Path | None,
+        typer.Option(
+            "--project",
+            "-p",
+            help="Project directory. Can be a path or name (looks in --projects-dir).",
+        ),
+    ] = None,
+    export_format: Annotated[
+        str,
+        typer.Option(
+            "--format",
+            "-f",
+            help="Export format: json, twee, html.",
+        ),
+    ] = "twee",
+    output: Annotated[
+        Path | None,
+        typer.Option(
+            "--output",
+            "-o",
+            help="Custom output directory (default: {project}/exports/{format}/).",
+        ),
+    ] = None,
+) -> None:
+    """Run SHIP stage - export story to playable format.
+
+    Exports the completed story graph to a playable format.
+    SHIP is deterministic and does not use an LLM.
+
+    Supported formats:
+      - twee: SugarCube 2 Twee source (default)
+      - html: Standalone playable HTML file
+      - json: Structured JSON data
+
+    Requires FILL stage to have completed first (all passages need prose).
+    """
+    from questfoundry.pipeline.stages.ship import ShipStage, ShipStageError
+
+    project_path = _resolve_project_path(project)
+    _require_project(project_path)
+    _configure_project_logging(project_path)
+
+    log = get_logger(__name__)
+    log.info("ship_cli_start", format=export_format)
+
+    console.print()
+    console.print(f"[dim]Exporting story as {export_format}...[/dim]")
+
+    try:
+        stage = ShipStage(project_path)
+        output_file = stage.execute(export_format=export_format, output_dir=output)
+    except ShipStageError as e:
+        console.print(f"\n[red]Error:[/red] {e}")
+        raise typer.Exit(1) from None
+
+    console.print()
+    console.print(f"[green]✓[/green] SHIP stage completed ({export_format})")
+    console.print(f"  Output: [cyan]{output_file}[/cyan]")
+
+
 @app.command("generate-images")
 def generate_images(
     project: Annotated[
@@ -1567,6 +1634,26 @@ def run(
 
     # Run each stage
     for stage_name in stages_to_run:
+        # SHIP is deterministic (no LLM) — handle separately
+        if stage_name == "ship":
+            from questfoundry.pipeline.stages.ship import ShipStage, ShipStageError
+
+            console.print()
+            console.print("[dim]Exporting story as twee...[/dim]")
+            try:
+                ship_stage = ShipStage(project_path)
+                output_file = ship_stage.execute(export_format="twee")
+            except ShipStageError as e:
+                console.print(f"\n[red]Error:[/red] {e}")
+                console.print()
+                console.print("[red]Pipeline stopped at SHIP stage.[/red]")
+                raise typer.Exit(1) from None
+
+            console.print()
+            console.print("[green]✓[/green] SHIP stage completed (twee)")
+            console.print(f"  Output: [cyan]{output_file}[/cyan]")
+            continue
+
         default_interactive_prompt, default_noninteractive_prompt = STAGE_PROMPTS[stage_name]
 
         # Use provided prompt only for DREAM, defaults for others

--- a/src/questfoundry/pipeline/stages/__init__.py
+++ b/src/questfoundry/pipeline/stages/__init__.py
@@ -39,6 +39,7 @@ from questfoundry.pipeline.stages.seed import (
     create_seed_stage,
     seed_stage,
 )
+from questfoundry.pipeline.stages.ship import ShipStage, ShipStageError
 
 # Register built-in stages
 register_stage(dream_stage)
@@ -60,6 +61,8 @@ __all__ = [
     "GrowStageError",
     "SeedStage",
     "SeedStageError",
+    "ShipStage",
+    "ShipStageError",
     "Stage",
     "brainstorm_stage",
     "create_brainstorm_stage",

--- a/src/questfoundry/pipeline/stages/ship.py
+++ b/src/questfoundry/pipeline/stages/ship.py
@@ -1,0 +1,123 @@
+"""SHIP stage — export story graph to playable formats.
+
+SHIP is deterministic (no LLM). It reads the completed story graph,
+validates that all passages have prose, builds an ExportContext, and
+delegates to a format-specific exporter (JSON, Twee, HTML).
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from questfoundry.export import build_export_context, get_exporter
+from questfoundry.graph.graph import Graph
+from questfoundry.observability.logging import get_logger
+from questfoundry.pipeline.config import load_project_config
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+log = get_logger(__name__)
+
+
+class ShipStageError(ValueError):
+    """Error during SHIP stage execution."""
+
+
+class ShipStage:
+    """Export story graph to a playable format.
+
+    Unlike other stages, SHIP does not use an LLM. It reads the graph
+    directly and transforms it to the requested export format.
+
+    Args:
+        project_path: Path to the project directory.
+    """
+
+    def __init__(self, project_path: Path) -> None:
+        self._project_path = project_path
+
+    def execute(
+        self,
+        export_format: str = "twee",
+        output_dir: Path | None = None,
+    ) -> Path:
+        """Export the story graph to a playable format.
+
+        Args:
+            export_format: Export format name (json, twee, html).
+            output_dir: Custom output directory. Defaults to
+                ``{project}/exports/{format}/``.
+
+        Returns:
+            Path to the main output file.
+
+        Raises:
+            ShipStageError: If the graph is missing, has no passages,
+                or passages are missing prose.
+        """
+        log.info(
+            "ship_start",
+            project=str(self._project_path),
+            format=export_format,
+        )
+
+        # Load graph
+        graph_file = self._project_path / "graph.json"
+        if not graph_file.exists():
+            raise ShipStageError(
+                f"No graph.json found in {self._project_path}. "
+                "Run pipeline stages (dream → fill) first."
+            )
+        graph = Graph.load(self._project_path)
+
+        # Validate passages have prose
+        passages = graph.get_nodes_by_type("passage")
+        if not passages:
+            raise ShipStageError("Graph contains no passages — nothing to export.")
+
+        missing_prose = [pid for pid, data in passages.items() if not data.get("prose")]
+        if missing_prose:
+            raise ShipStageError(
+                f"{len(missing_prose)} passage(s) missing prose. "
+                f"Run FILL stage first. Examples: {missing_prose[:3]}"
+            )
+
+        # Get project name for title
+        try:
+            config = load_project_config(self._project_path)
+            project_name = config.name
+        except Exception:
+            project_name = self._project_path.name
+
+        # Build export context
+        context = build_export_context(graph, project_name)
+
+        log.info(
+            "ship_context_built",
+            passages=len(context.passages),
+            choices=len(context.choices),
+            entities=len(context.entities),
+            codewords=len(context.codewords),
+            illustrations=len(context.illustrations),
+            codex_entries=len(context.codex_entries),
+            has_art_direction=context.art_direction is not None,
+        )
+
+        # Get exporter
+        try:
+            exporter = get_exporter(export_format)
+        except ValueError as e:
+            raise ShipStageError(str(e)) from e
+
+        # Export
+        target_dir = output_dir or (self._project_path / "exports" / export_format)
+        output_file = exporter.export(context, target_dir)
+
+        log.info(
+            "ship_complete",
+            format=export_format,
+            output=str(output_file),
+        )
+
+        return output_file

--- a/tests/unit/test_ship_stage.py
+++ b/tests/unit/test_ship_stage.py
@@ -1,0 +1,170 @@
+"""Tests for SHIP stage (deterministic export)."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+from questfoundry.graph.graph import Graph
+from questfoundry.pipeline.stages.ship import ShipStage, ShipStageError
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _create_project_with_graph(project_path: Path, *, with_prose: bool = True) -> None:
+    """Create a minimal project with graph.json for SHIP testing."""
+    from ruamel.yaml import YAML
+
+    project_path.mkdir(parents=True, exist_ok=True)
+
+    # project.yaml
+    yaml_writer = YAML()
+    config = {"name": "test-story", "version": "1.0", "providers": {"default": "ollama/test"}}
+    with (project_path / "project.yaml").open("w") as f:
+        yaml_writer.dump(config, f)
+
+    # Build a graph with passages and choices
+    g = Graph()
+    g.create_node(
+        "passage::intro",
+        {
+            "type": "passage",
+            "raw_id": "intro",
+            "prose": "You stand at the gates." if with_prose else "",
+        },
+    )
+    g.create_node(
+        "passage::castle",
+        {
+            "type": "passage",
+            "raw_id": "castle",
+            "prose": "You enter the castle." if with_prose else "",
+            "is_ending": True,
+        },
+    )
+    g.create_node(
+        "choice::enter",
+        {
+            "type": "choice",
+            "from_passage": "passage::intro",
+            "to_passage": "passage::castle",
+            "label": "Enter the castle",
+        },
+    )
+    g.add_edge("choice_from", "choice::enter", "passage::intro")
+    g.add_edge("choice_to", "choice::enter", "passage::castle")
+
+    g.save(project_path / "graph.json")
+
+
+class TestShipStage:
+    def test_export_twee(self, tmp_path: Path) -> None:
+        project = tmp_path / "my-story"
+        _create_project_with_graph(project)
+
+        stage = ShipStage(project)
+        result = stage.execute(export_format="twee")
+
+        assert result.exists()
+        assert result.suffix == ".twee"
+        content = result.read_text()
+        assert ":: StoryTitle" in content
+
+    def test_export_json(self, tmp_path: Path) -> None:
+        project = tmp_path / "my-story"
+        _create_project_with_graph(project)
+
+        stage = ShipStage(project)
+        result = stage.execute(export_format="json")
+
+        assert result.exists()
+        assert result.suffix == ".json"
+
+    def test_export_html(self, tmp_path: Path) -> None:
+        project = tmp_path / "my-story"
+        _create_project_with_graph(project)
+
+        stage = ShipStage(project)
+        result = stage.execute(export_format="html")
+
+        assert result.exists()
+        assert result.name == "story.html"
+        content = result.read_text()
+        assert "<!DOCTYPE html>" in content
+
+    def test_custom_output_dir(self, tmp_path: Path) -> None:
+        project = tmp_path / "my-story"
+        _create_project_with_graph(project)
+        custom_dir = tmp_path / "custom-output"
+
+        stage = ShipStage(project)
+        result = stage.execute(export_format="json", output_dir=custom_dir)
+
+        assert result.parent == custom_dir
+
+    def test_default_output_dir(self, tmp_path: Path) -> None:
+        project = tmp_path / "my-story"
+        _create_project_with_graph(project)
+
+        stage = ShipStage(project)
+        result = stage.execute(export_format="twee")
+
+        assert "exports" in str(result)
+        assert "twee" in str(result)
+
+    def test_missing_graph_raises(self, tmp_path: Path) -> None:
+        project = tmp_path / "my-story"
+        project.mkdir(parents=True)
+
+        stage = ShipStage(project)
+        with pytest.raises(ShipStageError, match=r"No graph\.json found"):
+            stage.execute()
+
+    def test_missing_prose_raises(self, tmp_path: Path) -> None:
+        project = tmp_path / "my-story"
+        _create_project_with_graph(project, with_prose=False)
+
+        stage = ShipStage(project)
+        with pytest.raises(ShipStageError, match="missing prose"):
+            stage.execute()
+
+    def test_empty_graph_raises(self, tmp_path: Path) -> None:
+        from ruamel.yaml import YAML
+
+        project = tmp_path / "my-story"
+        project.mkdir(parents=True)
+
+        yaml_writer = YAML()
+        config = {"name": "test", "version": "1.0", "providers": {"default": "ollama/test"}}
+        with (project / "project.yaml").open("w") as f:
+            yaml_writer.dump(config, f)
+
+        # Graph with no passages
+        g = Graph()
+        g.save(project / "graph.json")
+
+        stage = ShipStage(project)
+        with pytest.raises(ShipStageError, match="no passages"):
+            stage.execute()
+
+    def test_unknown_format_raises(self, tmp_path: Path) -> None:
+        project = tmp_path / "my-story"
+        _create_project_with_graph(project)
+
+        stage = ShipStage(project)
+        with pytest.raises(ShipStageError, match="Unknown export format"):
+            stage.execute(export_format="pdf")
+
+    def test_project_name_from_config(self, tmp_path: Path) -> None:
+        project = tmp_path / "my-story"
+        _create_project_with_graph(project)
+
+        stage = ShipStage(project)
+        result = stage.execute(export_format="json")
+
+        import json
+
+        data = json.loads(result.read_text())
+        assert data["title"] == "test-story"


### PR DESCRIPTION
## Problem
The SHIP stage is the final pipeline stage, needed to export the completed story graph into playable formats. Without it, users have no way to get their story out of QuestFoundry into a playable form.

## Changes
- `src/questfoundry/pipeline/stages/ship.py`: New `ShipStage` class — validates graph has passages with prose, builds `ExportContext`, delegates to format-specific exporter
- `src/questfoundry/cli.py`: Added `qf ship` command with `--format` (twee/html/json) and `--output` options; added SHIP handling in `qf run` loop (deterministic, no LLM); updated `STAGE_ORDER` and `STAGE_PROMPTS`
- `src/questfoundry/pipeline/stages/__init__.py`: Registered `ShipStage` and `ShipStageError` exports
- `tests/unit/test_ship_stage.py`: 10 unit tests covering all formats, error cases, custom/default output dirs, project name extraction

## Not Included / Future PRs
- E2E testing with a real completed project (manual testing)
- Additional export formats beyond json/twee/html

## Test Plan
- `uv run pytest tests/unit/test_ship_stage.py -x -q` → 10 passed
- `uv run pytest tests/unit/test_html_exporter.py tests/unit/test_twee_exporter.py tests/unit/test_json_exporter.py tests/unit/test_export_context.py -x -q` → 39 passed
- `uv run ruff check` + `uv run mypy` → clean
- `qf ship --help` → shows correct usage

## Risk / Rollback
- Low risk: SHIP is additive (new command + new stage class)
- No changes to existing stage behavior
- ShipStage does NOT implement the Stage protocol (no LLM needed) — called directly from CLI

## Review Guide
1. `src/questfoundry/pipeline/stages/ship.py` — core stage logic
2. `src/questfoundry/cli.py` — CLI command + run loop integration
3. `tests/unit/test_ship_stage.py` — test coverage

**Stack: PR 4 of 4** (`feat/ship-stage` → `feat/ship-html` → `feat/ship-twee` → `feat/ship-export-base` → `main`)

Closes #397

🤖 Generated with [Claude Code](https://claude.com/claude-code)