### PR TITLE
feat(ship): export DRESS data in Twee/HTML formats

### DIFF
--- a/src/questfoundry/export/assets.py
+++ b/src/questfoundry/export/assets.py
@@ -1,0 +1,52 @@
+"""Asset bundling for SHIP exports.
+
+Copies illustration image files from the project directory to the
+export output directory so that relative paths in the exported
+formats (Twee, HTML) resolve correctly.
+"""
+
+from __future__ import annotations
+
+import shutil
+from typing import TYPE_CHECKING
+
+from questfoundry.observability.logging import get_logger
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from questfoundry.export.base import ExportIllustration
+
+log = get_logger(__name__)
+
+
+def bundle_assets(
+    illustrations: list[ExportIllustration],
+    project_path: Path,
+    output_dir: Path,
+) -> int:
+    """Copy illustration assets from project to export directory.
+
+    Args:
+        illustrations: Illustrations with relative asset paths.
+        project_path: Root project directory containing source assets.
+        output_dir: Export output directory to copy assets into.
+
+    Returns:
+        Number of assets successfully copied.
+    """
+    copied = 0
+    for ill in illustrations:
+        src = project_path / ill.asset_path
+        if not src.exists():
+            log.warning("asset_missing", path=str(src), passage=ill.passage_id)
+            continue
+        dest = output_dir / ill.asset_path
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(src, dest)
+        copied += 1
+
+    if copied:
+        log.info("assets_bundled", count=copied, output_dir=str(output_dir))
+
+    return copied

--- a/src/questfoundry/export/assets.py
+++ b/src/questfoundry/export/assets.py
@@ -36,14 +36,19 @@ def bundle_assets(
         Number of assets successfully copied.
     """
     copied = 0
+    project_resolved = project_path.resolve()
     for ill in illustrations:
         src = project_path / ill.asset_path
-        if not src.exists():
+        src_resolved = src.resolve()
+        if not src_resolved.is_relative_to(project_resolved):
+            log.warning("asset_outside_project", path=str(src), passage=ill.passage_id)
+            continue
+        if not src_resolved.exists():
             log.warning("asset_missing", path=str(src), passage=ill.passage_id)
             continue
         dest = output_dir / ill.asset_path
         dest.parent.mkdir(parents=True, exist_ok=True)
-        shutil.copy2(src, dest)
+        shutil.copy2(src_resolved, dest)
         copied += 1
 
     if copied:

--- a/src/questfoundry/export/html_exporter.py
+++ b/src/questfoundry/export/html_exporter.py
@@ -69,7 +69,9 @@ class HtmlExporter:
         if context.codex_entries:
             codex_html = _render_codex_panel(context.codex_entries)
 
-        # Build art direction meta tag
+        # Build art direction meta tag.
+        # json.dumps() serializes to JSON, then html.escape() escapes any
+        # HTML-special chars (<, >, &, ", ') for safe embedding in an attribute.
         art_direction_meta = ""
         if context.art_direction:
             art_direction_meta = f'<meta name="art-direction" content="{html.escape(json.dumps(context.art_direction))}">'
@@ -115,10 +117,12 @@ def _render_passage_div(
 
     # Illustration
     if illustration is not None:
+        parts.append("  <figure>")
         parts.append(
-            f'  <figure><img src="{html.escape(illustration.asset_path)}" alt="{html.escape(illustration.caption)}" />'
+            f'    <img src="{html.escape(illustration.asset_path)}" alt="{html.escape(illustration.caption)}" />'
         )
-        parts.append(f"  <figcaption>{html.escape(illustration.caption)}</figcaption></figure>")
+        parts.append(f"    <figcaption>{html.escape(illustration.caption)}</figcaption>")
+        parts.append("  </figure>")
 
     # Prose
     parts.append(f'  <div class="prose">{prose_escaped}</div>')
@@ -154,6 +158,8 @@ def _render_codex_panel(codex_entries: list[ExportCodexEntry]) -> str:
     parts = ['<div id="codex" class="codex-panel">']
     parts.append("  <h2>Codex</h2>")
     for entry in sorted_entries:
+        # json.dumps() handles quoting/escaping of codeword values,
+        # html.escape() makes the JSON safe inside an HTML attribute.
         visible_attr = ""
         if entry.visible_when:
             visible_attr = f' data-visible-when="{html.escape(json.dumps(entry.visible_when))}"'

--- a/src/questfoundry/export/html_exporter.py
+++ b/src/questfoundry/export/html_exporter.py
@@ -16,7 +16,13 @@ from questfoundry.observability.logging import get_logger
 if TYPE_CHECKING:
     from pathlib import Path
 
-    from questfoundry.export.base import ExportChoice, ExportContext, ExportPassage
+    from questfoundry.export.base import (
+        ExportChoice,
+        ExportCodexEntry,
+        ExportContext,
+        ExportIllustration,
+        ExportPassage,
+    )
 
 log = get_logger(__name__)
 
@@ -58,11 +64,23 @@ class HtmlExporter:
             illustration = illustrations_by_passage.get(passage.id)
             passages_html.append(_render_passage_div(passage, choices, illustration))
 
+        # Build codex HTML
+        codex_html = ""
+        if context.codex_entries:
+            codex_html = _render_codex_panel(context.codex_entries)
+
+        # Build art direction meta tag
+        art_direction_meta = ""
+        if context.art_direction:
+            art_direction_meta = f'<meta name="art-direction" content="{html.escape(json.dumps(context.art_direction))}">'
+
         # Build the complete HTML document
         content = _build_html_document(
             title=context.title,
             passages_html="\n".join(passages_html),
             start_id=_safe_id(start_id),
+            codex_html=codex_html,
+            art_direction_meta=art_direction_meta,
         )
 
         output_file.write_text(content, encoding="utf-8")
@@ -71,6 +89,8 @@ class HtmlExporter:
             "html_export_complete",
             passages=len(context.passages),
             choices=len(context.choices),
+            codex_entries=len(context.codex_entries),
+            has_art_direction=context.art_direction is not None,
             output=str(output_file),
         )
 
@@ -85,7 +105,7 @@ def _safe_id(passage_id: str) -> str:
 def _render_passage_div(
     passage: ExportPassage,
     choices: list[ExportChoice],
-    illustration: object | None = None,
+    illustration: ExportIllustration | None = None,
 ) -> str:
     """Render a passage as an HTML div element."""
     pid = _safe_id(passage.id)
@@ -95,13 +115,10 @@ def _render_passage_div(
 
     # Illustration
     if illustration is not None:
-        from questfoundry.export.base import ExportIllustration
-
-        if isinstance(illustration, ExportIllustration):
-            parts.append(
-                f'  <figure><img src="{html.escape(illustration.asset_path)}" alt="{html.escape(illustration.caption)}">'
-            )
-            parts.append(f"  <figcaption>{html.escape(illustration.caption)}</figcaption></figure>")
+        parts.append(
+            f'  <figure><img src="{html.escape(illustration.asset_path)}" alt="{html.escape(illustration.caption)}" />'
+        )
+        parts.append(f"  <figcaption>{html.escape(illustration.caption)}</figcaption></figure>")
 
     # Prose
     parts.append(f'  <div class="prose">{prose_escaped}</div>')
@@ -131,17 +148,40 @@ def _render_passage_div(
     return "\n".join(parts)
 
 
+def _render_codex_panel(codex_entries: list[ExportCodexEntry]) -> str:
+    """Render a toggleable codex panel with conditionally visible entries."""
+    sorted_entries = sorted(codex_entries, key=lambda e: e.rank)
+    parts = ['<div id="codex" class="codex-panel">']
+    parts.append("  <h2>Codex</h2>")
+    for entry in sorted_entries:
+        visible_attr = ""
+        if entry.visible_when:
+            visible_attr = f' data-visible-when="{html.escape(json.dumps(entry.visible_when))}"'
+        parts.append(f'  <div class="codex-entry"{visible_attr}>')
+        parts.append(f"    <h3>{html.escape(entry.entity_id)}</h3>")
+        parts.append(f"    <p>{html.escape(entry.content)}</p>")
+        parts.append("  </div>")
+    parts.append("</div>")
+    return "\n".join(parts)
+
+
 def _build_html_document(
     title: str,
     passages_html: str,
     start_id: str,
+    codex_html: str = "",
+    art_direction_meta: str = "",
 ) -> str:
     """Build the complete HTML document."""
+    extra_meta = f"\n{art_direction_meta}" if art_direction_meta else ""
+    codex_button = (
+        '<button class="codex-toggle" id="codex-toggle">Codex</button>' if codex_html else ""
+    )
     return f"""<!DOCTYPE html>
 <html lang="en">
 <head>
 <meta charset="UTF-8">
-<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">{extra_meta}
 <title>{html.escape(title)}</title>
 <style>
 body {{
@@ -212,12 +252,60 @@ h1 {{
   text-align: center;
   color: #a8d8ea;
 }}
+.codex-toggle {{
+  position: fixed;
+  top: 1em;
+  right: 1em;
+  padding: 0.5em 1em;
+  background: #16213e;
+  color: #a8d8ea;
+  border: 1px solid #0f3460;
+  border-radius: 4px;
+  cursor: pointer;
+  z-index: 10;
+}}
+.codex-toggle:hover {{
+  background: #0f3460;
+}}
+.codex-panel {{
+  display: none;
+  position: fixed;
+  top: 4em;
+  right: 1em;
+  width: 300px;
+  max-height: 80vh;
+  overflow-y: auto;
+  background: #16213e;
+  border: 1px solid #0f3460;
+  border-radius: 4px;
+  padding: 1em;
+  z-index: 10;
+}}
+.codex-panel.visible {{
+  display: block;
+}}
+.codex-panel h2 {{
+  margin-top: 0;
+  color: #a8d8ea;
+}}
+.codex-entry {{
+  margin-bottom: 1em;
+}}
+.codex-entry.hidden {{
+  display: none;
+}}
+.codex-entry h3 {{
+  color: #a8d8ea;
+  margin-bottom: 0.3em;
+}}
 </style>
 </head>
 <body>
 <h1>{html.escape(title)}</h1>
-
+{codex_button}
 {passages_html}
+
+{codex_html}
 
 <script>
 (function() {{
@@ -253,9 +341,32 @@ h1 {{
     if (grants) {{
       JSON.parse(grants).forEach(cw => codewords.add(cw));
     }}
+    updateCodexVisibility();
     const target = link.dataset.target;
     if (target) showPassage(target);
   }});
+
+  function updateCodexVisibility() {{
+    document.querySelectorAll('.codex-entry').forEach(entry => {{
+      const visibleWhen = entry.dataset.visibleWhen;
+      if (visibleWhen) {{
+        const needed = JSON.parse(visibleWhen);
+        const visible = needed.every(cw => codewords.has(cw));
+        entry.classList.toggle('hidden', !visible);
+      }}
+    }});
+  }}
+
+  const codexToggle = document.getElementById('codex-toggle');
+  if (codexToggle) {{
+    codexToggle.addEventListener('click', function() {{
+      const panel = document.getElementById('codex');
+      if (panel) {{
+        panel.classList.toggle('visible');
+        updateCodexVisibility();
+      }}
+    }});
+  }}
 
   showPassage(startId);
 }})();

--- a/src/questfoundry/export/twee_exporter.py
+++ b/src/questfoundry/export/twee_exporter.py
@@ -223,6 +223,11 @@ def _render_codex_passage(codex_entries: list[ExportCodexEntry]) -> list[str]:
     return lines
 
 
+def _escape_sugarcube(text: str) -> str:
+    """Escape SugarCube macro delimiters to prevent unintended execution."""
+    return text.replace("<<", "&lt;&lt;").replace(">>", "&gt;&gt;")
+
+
 def _render_art_direction_passage(art_direction: dict[str, Any]) -> list[str]:
     """Render art direction as a metadata-only passage.
 
@@ -231,5 +236,7 @@ def _render_art_direction_passage(art_direction: dict[str, Any]) -> list[str]:
     """
     lines = [':: StoryArtDirection {"position":"0,0","size":"100,100"}']
     for key, value in sorted(art_direction.items()):
-        lines.append(f"{key}: {value}")
+        safe_key = _escape_sugarcube(str(key))
+        safe_value = _escape_sugarcube(str(value))
+        lines.append(f"{safe_key}: {safe_value}")
     return lines

--- a/src/questfoundry/pipeline/stages/ship.py
+++ b/src/questfoundry/pipeline/stages/ship.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from questfoundry.export import build_export_context, get_exporter
+from questfoundry.export.assets import bundle_assets
 from questfoundry.graph.graph import Graph
 from questfoundry.observability.logging import get_logger
 from questfoundry.pipeline.config import ProjectConfigError, load_project_config
@@ -117,6 +118,10 @@ class ShipStage:
         # Export
         target_dir = output_dir or (self._project_path / "exports" / export_format)
         output_file = exporter.export(context, target_dir)
+
+        # Bundle illustration assets
+        if context.illustrations:
+            bundle_assets(context.illustrations, self._project_path, target_dir)
 
         log.info(
             "ship_complete",

--- a/src/questfoundry/pipeline/stages/ship.py
+++ b/src/questfoundry/pipeline/stages/ship.py
@@ -119,9 +119,12 @@ class ShipStage:
         target_dir = output_dir or (self._project_path / "exports" / export_format)
         output_file = exporter.export(context, target_dir)
 
-        # Bundle illustration assets
+        # Bundle illustration assets (non-fatal — export is valid without them)
         if context.illustrations:
-            bundle_assets(context.illustrations, self._project_path, target_dir)
+            try:
+                bundle_assets(context.illustrations, self._project_path, target_dir)
+            except OSError as e:
+                log.warning("asset_bundling_failed", error=str(e))
 
         log.info(
             "ship_complete",

--- a/tests/unit/test_asset_bundling.py
+++ b/tests/unit/test_asset_bundling.py
@@ -1,0 +1,105 @@
+"""Tests for asset bundling during SHIP export."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from questfoundry.export.assets import bundle_assets
+from questfoundry.export.base import ExportIllustration
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _make_illustration(
+    passage_id: str = "p1", asset_path: str = "assets/img.png"
+) -> ExportIllustration:
+    return ExportIllustration(
+        passage_id=passage_id,
+        asset_path=asset_path,
+        caption="Test image",
+        category="scene",
+    )
+
+
+class TestBundleAssets:
+    def test_copies_existing_asset(self, tmp_path: Path) -> None:
+        project = tmp_path / "project"
+        project.mkdir()
+        assets_dir = project / "assets"
+        assets_dir.mkdir()
+        (assets_dir / "img.png").write_bytes(b"fake-png-data")
+
+        output = tmp_path / "output"
+        ill = _make_illustration()
+        copied = bundle_assets([ill], project, output)
+
+        assert copied == 1
+        assert (output / "assets" / "img.png").exists()
+        assert (output / "assets" / "img.png").read_bytes() == b"fake-png-data"
+
+    def test_skips_missing_asset(self, tmp_path: Path) -> None:
+        project = tmp_path / "project"
+        project.mkdir()
+
+        output = tmp_path / "output"
+        ill = _make_illustration()
+        copied = bundle_assets([ill], project, output)
+
+        assert copied == 0
+        assert not (output / "assets" / "img.png").exists()
+
+    def test_empty_illustrations_list(self, tmp_path: Path) -> None:
+        project = tmp_path / "project"
+        project.mkdir()
+        output = tmp_path / "output"
+
+        copied = bundle_assets([], project, output)
+
+        assert copied == 0
+
+    def test_nested_asset_path(self, tmp_path: Path) -> None:
+        project = tmp_path / "project"
+        (project / "assets" / "scenes").mkdir(parents=True)
+        (project / "assets" / "scenes" / "castle.png").write_bytes(b"castle")
+
+        output = tmp_path / "output"
+        ill = _make_illustration(asset_path="assets/scenes/castle.png")
+        copied = bundle_assets([ill], project, output)
+
+        assert copied == 1
+        assert (output / "assets" / "scenes" / "castle.png").exists()
+
+    def test_multiple_assets(self, tmp_path: Path) -> None:
+        project = tmp_path / "project"
+        (project / "assets").mkdir(parents=True)
+        (project / "assets" / "a.png").write_bytes(b"aaa")
+        (project / "assets" / "b.png").write_bytes(b"bbb")
+
+        output = tmp_path / "output"
+        ills = [
+            _make_illustration(passage_id="p1", asset_path="assets/a.png"),
+            _make_illustration(passage_id="p2", asset_path="assets/b.png"),
+        ]
+        copied = bundle_assets(ills, project, output)
+
+        assert copied == 2
+        assert (output / "assets" / "a.png").read_bytes() == b"aaa"
+        assert (output / "assets" / "b.png").read_bytes() == b"bbb"
+
+    def test_partial_missing(self, tmp_path: Path) -> None:
+        """When some assets exist and some don't, copies what it can."""
+        project = tmp_path / "project"
+        (project / "assets").mkdir(parents=True)
+        (project / "assets" / "exists.png").write_bytes(b"data")
+
+        output = tmp_path / "output"
+        ills = [
+            _make_illustration(passage_id="p1", asset_path="assets/exists.png"),
+            _make_illustration(passage_id="p2", asset_path="assets/missing.png"),
+        ]
+        copied = bundle_assets(ills, project, output)
+
+        assert copied == 1
+        assert (output / "assets" / "exists.png").exists()
+        assert not (output / "assets" / "missing.png").exists()

--- a/tests/unit/test_asset_bundling.py
+++ b/tests/unit/test_asset_bundling.py
@@ -87,6 +87,21 @@ class TestBundleAssets:
         assert (output / "assets" / "a.png").read_bytes() == b"aaa"
         assert (output / "assets" / "b.png").read_bytes() == b"bbb"
 
+    def test_path_traversal_rejected(self, tmp_path: Path) -> None:
+        """Asset paths that resolve outside the project are skipped."""
+        project = tmp_path / "project"
+        project.mkdir()
+        outside = tmp_path / "secret"
+        outside.mkdir()
+        (outside / "passwd.txt").write_bytes(b"secret")
+
+        output = tmp_path / "output"
+        ill = _make_illustration(asset_path="../secret/passwd.txt")
+        copied = bundle_assets([ill], project, output)
+
+        assert copied == 0
+        assert not (output / ".." / "secret" / "passwd.txt").exists()
+
     def test_partial_missing(self, tmp_path: Path) -> None:
         """When some assets exist and some don't, copies what it can."""
         project = tmp_path / "project"


### PR DESCRIPTION
## Problem
Issue #432: SHIP exports reference DRESS-stage data (codex entries, illustrations, art direction) but Twee and HTML exporters don't render codex entries or art direction, and illustration assets aren't copied to the export directory.

## Changes
- **Codex entries in Twee**: New `:: Codex` passage with entries sorted by rank, wrapped in `<<if>>` conditionals for `visible_when` codewords
- **Codex entries in HTML**: Toggleable codex panel with `data-visible-when` attributes and JS visibility updates tied to the existing codeword `Set`
- **Asset bundling**: New `export/assets.py` module with `bundle_assets()` that copies illustration files from project to export directory; called from `ShipStage.execute()` after export
- **Art direction in Twee**: `:: StoryArtDirection` metadata passage (unlinked, safe for SugarCube)
- **Art direction in HTML**: `<meta name="art-direction">` tag in `<head>`
- **Cleanup**: Fixed illustration type (`ExportIllustration | None` instead of `object | None`), self-closing `<img />` tag

## Not Included / Future PRs
- Entity visuals in exports (these are working nodes, excluded by design)
- Base64-embedding illustrations in HTML (current approach uses file references + bundling)
- Auto-linking Codex passage from story passages (left to authors)

## Test Plan
```bash
uv run ruff check src/questfoundry/export/ src/questfoundry/pipeline/stages/ship.py  # ✓
uv run mypy src/questfoundry/export/ src/questfoundry/pipeline/stages/ship.py  # ✓
uv run pytest tests/unit/test_twee_exporter.py tests/unit/test_html_exporter.py tests/unit/test_asset_bundling.py tests/unit/test_ship_stage.py -x -q  # 53 passed ✓
```

New tests:
- `test_asset_bundling.py`: 6 tests (copy, skip missing, empty list, nested paths, multiple, partial)
- `test_twee_exporter.py`: +7 tests (codex rendered/empty/no-visible-when/sorted, art direction rendered/absent)
- `test_html_exporter.py`: +6 tests (codex panel/toggle/empty, art direction meta/absent)

## Risk / Rollback
- Backward compatible: existing exports without DRESS data are unchanged (codex/art direction sections only render when data is present)
- Asset bundling logs warnings for missing files instead of failing

Closes #432

🤖 Generated with [Claude Code](https://claude.com/claude-code)