### PR TITLE
feat(providers): implement PromptDistiller for A1111 and OpenAI

### DIFF
--- a/src/questfoundry/pipeline/stages/dress.py
+++ b/src/questfoundry/pipeline/stages/dress.py
@@ -971,8 +971,11 @@ class DressStage:
             )
             prepared.append((brief_id, positive, negative, brief_data))
 
-        # Free VRAM between LLM distillation and image generation
-        if distiller is not None and model is not None:
+        # Free VRAM between LLM distillation and image generation.
+        # Only unload when the provider actually used an LLM for distillation
+        # (e.g., A1111 with llm= set). Rule-based distillers don't load VRAM.
+        used_llm = getattr(provider, "_llm", None) is not None
+        if used_llm and model is not None:
             from questfoundry.providers.factory import unload_ollama_model
 
             await unload_ollama_model(model)

--- a/src/questfoundry/pipeline/stages/dress.py
+++ b/src/questfoundry/pipeline/stages/dress.py
@@ -886,7 +886,7 @@ class DressStage:
     async def _phase_4_generate(
         self,
         graph: Graph,
-        model: BaseChatModel | None = None,  # noqa: ARG002
+        model: BaseChatModel | None = None,
     ) -> DressPhaseResult:
         """Phase 4: Generate images for selected illustration briefs.
 
@@ -933,7 +933,7 @@ class DressStage:
         if self.project_path is None:
             raise DressStageError("project_path is required for image generation")
 
-        provider = create_image_provider(self._image_provider_spec)
+        provider = create_image_provider(self._image_provider_spec, llm=model)
         asset_mgr = AssetManager(self.project_path)
         art_dir = graph.get_node("art_direction::main") or {}
         aspect_ratio = art_dir.get("aspect_ratio", "16:9")
@@ -970,6 +970,12 @@ class DressStage:
                 distilled=distiller is not None,
             )
             prepared.append((brief_id, positive, negative, brief_data))
+
+        # Free VRAM between LLM distillation and image generation
+        if distiller is not None and model is not None:
+            from questfoundry.providers.factory import unload_ollama_model
+
+            await unload_ollama_model(model)
 
         # --- Pass 2: generate images (GPU-only, LLM no longer needed) -----
         for brief_id, positive, negative, brief_data in prepared:

--- a/src/questfoundry/providers/image_factory.py
+++ b/src/questfoundry/providers/image_factory.py
@@ -14,6 +14,8 @@ from questfoundry.providers.image import ImageProvider, ImageProviderError
 
 def create_image_provider(
     provider_spec: str,
+    *,
+    llm: Any | None = None,
     **kwargs: Any,
 ) -> ImageProvider:
     """Create an image provider from a spec string.
@@ -21,6 +23,8 @@ def create_image_provider(
     Args:
         provider_spec: Format ``provider/model`` (e.g., ``openai/gpt-image-1``).
             If no model is specified, a provider-specific default is used.
+        llm: Optional LLM model for providers that do prompt distillation
+            (currently A1111 only).
         **kwargs: Additional provider options forwarded to the constructor.
 
     Returns:
@@ -52,6 +56,6 @@ def create_image_provider(
     if provider_lower == "a1111":
         from questfoundry.providers.image_a1111 import A1111ImageProvider
 
-        return A1111ImageProvider(model=model, **kwargs)
+        return A1111ImageProvider(model=model, llm=llm, **kwargs)
 
     raise ImageProviderError(provider_lower, f"Unknown image provider: {provider_lower}")


### PR DESCRIPTION
## Problem

Image providers receive a pre-flattened comma-joined prompt string regardless of their capabilities. A1111/SD truncates at ~77 CLIP tokens, discarding most of the rich brief content. DALL-E handles prose but gets the same comma-joined format. Each provider should transform briefs in its own optimal way.

## Changes

**A1111 provider** (`image_a1111.py`):
- Accepts optional `llm` kwarg at construction for LLM-based distillation
- Implements `PromptDistiller.distill_prompt()` with two paths:
  - **Rule-based** (default): reorders fields by CLIP priority — style/medium first, then entities, subject, mood, composition last. Truncates to ~60 words (~75 CLIP tokens). No LLM needed.
  - **LLM-based** (when `llm` provided): single cheap LLM call to condense the full brief into SD-optimised comma-separated tags

**OpenAI provider** (`image_openai.py`):
- Implements `PromptDistiller.distill_prompt()` formatting briefs as natural-language prose paragraphs with labeled sections (Composition:, Mood:, Style:, etc.)
- Preserves full detail since DALL-E 3 / gpt-image-1 handle prose well

**Factory** (`image_factory.py`):
- `create_image_provider()` now accepts keyword-only `llm` parameter
- Passes `llm` to A1111 constructor; other providers ignore it

**Phase 4** (`dress.py`):
- Passes `llm=model` to `create_image_provider()` for distillation
- Adds VRAM unload between Pass 1 (prompt distillation) and Pass 2 (image generation) when using a distiller with an Ollama LLM

## Not Included / Future PRs

- `dress_distill.yaml` prompt template for fine-tuning LLM distillation output
- Checkpoint-aware token limits (SD 1.5 vs SDXL)
- Enhanced debug logging with full prompt previews in `debug.jsonl`

Closes #497

## Test Plan

```bash
uv run mypy src/questfoundry/providers/ src/questfoundry/pipeline/stages/dress.py  # ✅
uv run ruff check src/ tests/  # ✅
uv run pytest tests/unit/test_image_a1111.py tests/unit/test_image_provider.py tests/unit/test_dress_stage.py tests/unit/test_image_brief.py tests/unit/test_image_placeholder.py -x -q  # 137 passed ✅
```

New tests:
- A1111 rule-based tag order (style before subject)
- A1111 truncation at 60 words
- A1111 LLM distillation with mocked LLM
- A1111 fallback to rule-based without LLM
- A1111 style_overrides inclusion
- Factory LLM passthrough
- OpenAI prose formatting
- OpenAI style_overrides inclusion
- PromptDistiller protocol conformance for both providers

## Risk / Rollback

- A1111 rule-based distillation is the default (no LLM required) — existing setups work unchanged
- OpenAI formatting is a strict improvement over the flat comma-join
- VRAM unload only triggers when a distiller is present AND model is not None
- All 137 existing + new tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)