### PR TITLE
feat(fill): generate story title during FILL Phase 0

### DIFF
--- a/prompts/templates/fill_phase0_voice.yaml
+++ b/prompts/templates/fill_phase0_voice.yaml
@@ -40,8 +40,18 @@ system: |
   - Consider the scene type distribution — a story heavy on micro_beats needs a
     register that works for brevity
 
+  ## Story Title
+
+  Also propose a **story_title** — a compelling title for this interactive fiction story.
+
+  - 2–8 words, evocative and genre-appropriate
+  - Reflect the central tension, setting, or theme — not generic
+  - Good: "The Hollow Crown", "Beneath the Crimson Tide", "Whispers at Dawnbreak"
+  - Bad: "Adventure Story", "The Quest", "A Dark Tale"
+
   ## Output Format
-  Return a JSON object with a "voice" field containing the voice document.
+  Return a JSON object with a "voice" field containing the voice document
+  and a "story_title" field with the title string.
 
 user: |
   Based on the creative vision and story structure above, propose a voice document.
@@ -52,6 +62,7 @@ user: |
   - tone_words must be distilled from DREAM themes, not generic filler
   - avoid_words and avoid_patterns should target the genre's common pitfalls
   - Consider scene type distribution — micro_beat-heavy stories need a register that works for brevity
+  - story_title must be evocative and genre-appropriate (2-8 words), NOT generic
   - Return ONLY a valid JSON object. Do NOT add prose before or after the JSON.
 
 components: []

--- a/src/questfoundry/models/fill.py
+++ b/src/questfoundry/models/fill.py
@@ -127,9 +127,13 @@ class ReviewFlag(BaseModel):
 
 
 class FillPhase0Output(BaseModel):
-    """Phase 0 structured output: voice determination."""
+    """Phase 0 structured output: voice determination and story title."""
 
     voice: VoiceDocument
+    story_title: str = Field(
+        min_length=1,
+        description="A compelling title for the story (2-8 words)",
+    )
 
 
 class FillPhase1Output(BaseModel):

--- a/src/questfoundry/models/fill.py
+++ b/src/questfoundry/models/fill.py
@@ -12,9 +12,9 @@ See docs/design/procedures/fill.md for algorithm details.
 
 from __future__ import annotations
 
-from typing import Literal
+from typing import Any, Literal
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
 
 from questfoundry.models.pipeline import PhaseResult
 
@@ -133,7 +133,16 @@ class FillPhase0Output(BaseModel):
     story_title: str = Field(
         min_length=1,
         description="A compelling title for the story (2-8 words)",
+        json_schema_extra={"strip_whitespace": True},
     )
+
+    @model_validator(mode="before")
+    @classmethod
+    def _strip_title_whitespace(cls, data: Any) -> Any:
+        """Strip whitespace from story_title before min_length check."""
+        if isinstance(data, dict) and isinstance(data.get("story_title"), str):
+            data["story_title"] = data["story_title"].strip()
+        return data
 
 
 class FillPhase1Output(BaseModel):

--- a/src/questfoundry/pipeline/stages/dress.py
+++ b/src/questfoundry/pipeline/stages/dress.py
@@ -1102,11 +1102,9 @@ def _create_cover_brief(graph: Graph) -> bool:
     themes_str = ", ".join(themes) if isinstance(themes, list) else str(themes)
 
     # Build subject from non-empty parts
-    story_title = vision.get("story_title", "")
-    if story_title:
-        parts = [f'Cover image for "{story_title}", a {genre} story']
-    else:
-        parts = [f"Cover image for a {genre} story"]
+    story_title = vision.get("story_title") or ""
+    title_desc = f'"{story_title}", ' if story_title else ""
+    parts = [f"Cover image for {title_desc}a {genre} story"]
     if tone_str:
         parts.append(f"Tone: {tone_str}")
     if themes_str:

--- a/src/questfoundry/pipeline/stages/dress.py
+++ b/src/questfoundry/pipeline/stages/dress.py
@@ -1102,7 +1102,11 @@ def _create_cover_brief(graph: Graph) -> bool:
     themes_str = ", ".join(themes) if isinstance(themes, list) else str(themes)
 
     # Build subject from non-empty parts
-    parts = [f"Cover image for a {genre} story"]
+    story_title = vision.get("story_title", "")
+    if story_title:
+        parts = [f'Cover image for "{story_title}", a {genre} story']
+    else:
+        parts = [f"Cover image for a {genre} story"]
     if tone_str:
         parts.append(f"Tone: {tone_str}")
     if themes_str:

--- a/src/questfoundry/pipeline/stages/fill.py
+++ b/src/questfoundry/pipeline/stages/fill.py
@@ -496,11 +496,16 @@ class FillStage:
             **output.voice.model_dump(),
         }
         graph.create_node("voice::voice", voice_data)
+
+        # Store generated title on the vision node (story-level identity metadata)
+        graph.upsert_node("vision::main", {"story_title": output.story_title})
+
         log.info(
             "voice_document_created",
             pov=output.voice.pov,
             tense=output.voice.tense,
             register=output.voice.voice_register,
+            story_title=output.story_title,
         )
 
         return FillPhaseResult(

--- a/src/questfoundry/pipeline/stages/ship.py
+++ b/src/questfoundry/pipeline/stages/ship.py
@@ -90,7 +90,7 @@ class ShipStage:
 
         # Get story title: graph (from FILL) → project config → directory name
         vision = graph.get_node("vision::main")
-        story_title = (vision or {}).get("story_title", "")
+        story_title = (vision or {}).get("story_title") or ""
         if not story_title:
             try:
                 config = load_project_config(self._project_path)

--- a/src/questfoundry/pipeline/stages/ship.py
+++ b/src/questfoundry/pipeline/stages/ship.py
@@ -88,15 +88,18 @@ class ShipStage:
                 f"Run FILL stage first. Examples: {missing_prose[:3]}"
             )
 
-        # Get project name for title
-        try:
-            config = load_project_config(self._project_path)
-            project_name = config.name
-        except (ProjectConfigError, FileNotFoundError, KeyError):
-            project_name = self._project_path.name
+        # Get story title: graph (from FILL) → project config → directory name
+        vision = graph.get_node("vision::main")
+        story_title = (vision or {}).get("story_title", "")
+        if not story_title:
+            try:
+                config = load_project_config(self._project_path)
+                story_title = config.name
+            except (ProjectConfigError, FileNotFoundError, KeyError):
+                story_title = self._project_path.name
 
         # Build export context
-        context = build_export_context(graph, project_name)
+        context = build_export_context(graph, story_title)
 
         log.info(
             "ship_context_built",

--- a/tests/unit/test_fill_models.py
+++ b/tests/unit/test_fill_models.py
@@ -277,6 +277,17 @@ class TestFillPhase0Output:
         with pytest.raises(ValidationError):
             FillPhase0Output(voice=voice, story_title="")
 
+    def test_whitespace_only_title_rejected(self) -> None:
+        voice = VoiceDocument(
+            pov="first",
+            tense="past",
+            voice_register="sparse",
+            sentence_rhythm="punchy",
+            tone_words=["terse"],
+        )
+        with pytest.raises(ValidationError):
+            FillPhase0Output(voice=voice, story_title="   ")
+
 
 class TestFillPhase1Output:
     def test_wraps_passage_output(self) -> None:

--- a/tests/unit/test_fill_models.py
+++ b/tests/unit/test_fill_models.py
@@ -262,8 +262,20 @@ class TestFillPhase0Output:
             sentence_rhythm="varied",
             tone_words=["atmospheric"],
         )
-        output = FillPhase0Output(voice=voice)
+        output = FillPhase0Output(voice=voice, story_title="The Hollow Crown")
         assert output.voice.pov == "third_limited"
+        assert output.story_title == "The Hollow Crown"
+
+    def test_empty_title_rejected(self) -> None:
+        voice = VoiceDocument(
+            pov="first",
+            tense="past",
+            voice_register="sparse",
+            sentence_rhythm="punchy",
+            tone_words=["terse"],
+        )
+        with pytest.raises(ValidationError):
+            FillPhase0Output(voice=voice, story_title="")
 
 
 class TestFillPhase1Output:

--- a/tests/unit/test_fill_stage.py
+++ b/tests/unit/test_fill_stage.py
@@ -316,7 +316,8 @@ def _make_voice_output() -> FillPhase0Output:
             tone_words=["atmospheric", "tense"],
             avoid_words=["suddenly"],
             avoid_patterns=["adverb-heavy dialogue tags"],
-        )
+        ),
+        story_title="The Hollow Crown",
     )
 
 

--- a/tests/unit/test_ship_stage.py
+++ b/tests/unit/test_ship_stage.py
@@ -244,3 +244,20 @@ class TestShipStage:
 
         data = json.loads(result.read_text())
         assert data["title"] == "test-story"
+
+    def test_graph_title_none_fallback_to_config(self, tmp_path: Path) -> None:
+        """Falls back to config name when story_title is explicitly None."""
+        project = tmp_path / "my-story"
+        _create_project_with_graph(project)
+
+        g = Graph.load(project)
+        g.create_node("vision::main", {"type": "vision", "genre": "fantasy", "story_title": None})
+        g.save(project / "graph.json")
+
+        stage = ShipStage(project)
+        result = stage.execute(export_format="json")
+
+        import json
+
+        data = json.loads(result.read_text())
+        assert data["title"] == "test-story"

--- a/tests/unit/test_ship_stage.py
+++ b/tests/unit/test_ship_stage.py
@@ -205,3 +205,42 @@ class TestShipStage:
 
         data = json.loads(result.read_text())
         assert data["title"] == "my-fallback-story"
+
+    def test_graph_title_takes_priority(self, tmp_path: Path) -> None:
+        """Story title from graph (FILL) takes priority over project config name."""
+        project = tmp_path / "my-story"
+        _create_project_with_graph(project)
+
+        # Add a vision node with a generated story title
+        g = Graph.load(project)
+        g.create_node(
+            "vision::main",
+            {"type": "vision", "genre": "fantasy", "story_title": "The Hollow Crown"},
+        )
+        g.save(project / "graph.json")
+
+        stage = ShipStage(project)
+        result = stage.execute(export_format="json")
+
+        import json
+
+        data = json.loads(result.read_text())
+        assert data["title"] == "The Hollow Crown"
+
+    def test_graph_title_fallback_to_config(self, tmp_path: Path) -> None:
+        """Falls back to config name when vision node has no story_title."""
+        project = tmp_path / "my-story"
+        _create_project_with_graph(project)
+
+        # Vision node exists but without story_title
+        g = Graph.load(project)
+        g.create_node("vision::main", {"type": "vision", "genre": "fantasy"})
+        g.save(project / "graph.json")
+
+        stage = ShipStage(project)
+        result = stage.execute(export_format="json")
+
+        import json
+
+        data = json.loads(result.read_text())
+        assert data["title"] == "test-story"


### PR DESCRIPTION
## Problem
The story has no generated title. SHIP uses the project directory name (e.g. `test-20260201T1237`) as the HTML `<title>` and cover page heading — not a real story title.

Closes #505.

## Changes
- Add `story_title` field (min_length=1) to `FillPhase0Output` — generated alongside the voice document in Phase 0, no extra LLM call
- Update `fill_phase0_voice.yaml` prompt with title guidelines (2-8 words, evocative, genre-appropriate)
- Store title on `vision::main` node in FILL Phase 0
- SHIP reads title with fallback chain: `vision::main.story_title` → `project.yaml` name → directory name
- DRESS cover brief includes title in subject when available (e.g. `Cover image for "The Hollow Crown", a fantasy story`)

## Not Included / Future PRs
- Subtitle / tagline generation
- Author attribution

## Test Plan
- `uv run pytest tests/unit/test_fill_models.py tests/unit/test_fill_stage.py tests/unit/test_ship_stage.py -x -q` — 85 passed
- `uv run mypy` + `uv run ruff check` — clean
- New tests: empty title validation, graph title priority over config, config fallback when no graph title

## Risk / Rollback
- Fully backwards compatible — old graphs without `story_title` fall back to existing behavior (project config name → directory name)
- `story_title` is required on `FillPhase0Output`, so re-running FILL will always produce a title going forward

🤖 Generated with [Claude Code](https://claude.com/claude-code)