### PR TITLE
fix(prompts): constrain entity fragments to appearance only

### DIFF
--- a/prompts/templates/dress_discuss.yaml
+++ b/prompts/templates/dress_discuss.yaml
@@ -24,7 +24,7 @@ system: |
   - Consider how the medium affects mood (watercolor = dreamlike, ink = stark, etc.)
   - Entity visuals must be specific enough to maintain consistency across images
   - Include distinguishing features and color associations for each entity
-  - The reference_prompt_fragment for each entity should describe APPEARANCE ONLY (clothing, colors, build, distinguishing features — no camera angles, framing, or action poses)
+  - The reference_prompt_fragment for each entity should describe APPEARANCE ONLY (clothing, colors, build, distinguishing features — no camera angles, framing, poses, or actions)
   - Think about what should be AVOIDED globally (photorealism for a stylized story, etc.)
   {mode_section}
 

--- a/prompts/templates/dress_discuss.yaml
+++ b/prompts/templates/dress_discuss.yaml
@@ -24,7 +24,7 @@ system: |
   - Consider how the medium affects mood (watercolor = dreamlike, ink = stark, etc.)
   - Entity visuals must be specific enough to maintain consistency across images
   - Include distinguishing features and color associations for each entity
-  - The reference_prompt_fragment for each entity should be a concise image prompt snippet
+  - The reference_prompt_fragment for each entity should describe APPEARANCE ONLY (clothing, colors, build, distinguishing features — no camera angles, framing, or action poses)
   - Think about what should be AVOIDED globally (photorealism for a stylized story, etc.)
   {mode_section}
 

--- a/prompts/templates/dress_serialize.yaml
+++ b/prompts/templates/dress_serialize.yaml
@@ -26,7 +26,7 @@ system: |
   - description: Prose description of appearance
   - distinguishing_features: List of key visual identifiers
   - color_associations: Colors tied to this entity (can be empty)
-  - reference_prompt_fragment: Concise image prompt snippet for this entity
+  - reference_prompt_fragment: Visual appearance tags only (clothing, colors, build, distinguishing features — NO camera angles, framing, poses, or actions)
 
   ## Rules
   - Every entity_id MUST be from the valid entity IDs list — do not invent IDs

--- a/prompts/templates/dress_summarize.yaml
+++ b/prompts/templates/dress_summarize.yaml
@@ -15,7 +15,7 @@ system: |
     - Physical description
     - Distinguishing features
     - Color associations
-    - A concise reference prompt fragment for image generation (appearance only — no camera angles or action poses)
+    - A concise reference prompt fragment for image generation (appearance only — no camera angles, framing, poses, or actions)
 
   ## Guidelines
   - Extract concrete decisions, not vague ideas

--- a/prompts/templates/dress_summarize.yaml
+++ b/prompts/templates/dress_summarize.yaml
@@ -15,7 +15,7 @@ system: |
     - Physical description
     - Distinguishing features
     - Color associations
-    - A concise reference prompt fragment for image generation
+    - A concise reference prompt fragment for image generation (appearance only — no camera angles or action poses)
 
   ## Guidelines
   - Extract concrete decisions, not vague ideas


### PR DESCRIPTION
## Problem

Entity `reference_prompt_fragment` values generated by DRESS include camera directions ("low-angle dutch tilt", "symmetrical framing") and action poses ("flipping a glowing coin mid-arc") that conflict with per-brief composition settings in image generation.

Closes #503

## Changes

- **dress_serialize.yaml**: Changed fragment description from "Concise image prompt snippet" to "Visual appearance tags only (clothing, colors, build, distinguishing features — NO camera angles, framing, poses, or actions)"
- **dress_discuss.yaml**: Changed fragment guidance from "concise image prompt snippet" to "APPEARANCE ONLY (clothing, colors, build, distinguishing features — no camera angles, framing, or action poses)"
- **dress_summarize.yaml**: Added "(appearance only — no camera angles or action poses)" qualifier to fragment description

## Not Included / Future PRs

- Architecture-aware prompt distiller (#501) — separate PR with code changes

## Test Plan

- Prompt template changes only — no code to test
- Pre-commit hooks pass (YAML validation, trailing whitespace)
- Effect will be visible in next `qf dress` run: entity fragments should contain only appearance descriptors

## Risk / Rollback

- Zero risk to existing code — only affects LLM prompt instructions
- Existing projects keep their current entity fragments; only new DRESS runs will use the updated prompts

🤖 Generated with [Claude Code](https://claude.com/claude-code)