### PR TITLE
fix(dress): allow illustration briefs to target non-passage nodes

### DIFF
--- a/tests/unit/test_dress_mutations.py
+++ b/tests/unit/test_dress_mutations.py
@@ -446,6 +446,35 @@ class TestApplyDressIllustration:
                 category="scene",
             )
 
+    def test_cover_brief_targets_vision(self, dress_graph: Graph) -> None:
+        """Cover brief targets vision::main, not a passage."""
+        from questfoundry.graph.dress_mutations import apply_dress_illustration
+
+        dress_graph.create_node("vision::main", {"type": "vision", "genre": "cyberpunk"})
+        dress_graph.create_node(
+            "illustration_brief::cover",
+            {"type": "illustration_brief", "subject": "Cover image"},
+        )
+        dress_graph.add_edge("targets", "illustration_brief::cover", "vision::main")
+
+        illust_id = apply_dress_illustration(
+            dress_graph,
+            brief_id="illustration_brief::cover",
+            asset_path="assets/cover.png",
+            caption="",
+            category="vista",
+        )
+
+        assert illust_id == "illustration::main"
+        node = dress_graph.get_node(illust_id)
+        assert node is not None
+        assert node["asset"] == "assets/cover.png"
+
+        # Depicts edge should point to vision::main
+        depicts = dress_graph.get_edges(from_id=illust_id, edge_type="Depicts")
+        assert len(depicts) == 1
+        assert depicts[0]["to"] == "vision::main"
+
 
 # ---------------------------------------------------------------------------
 # Validation


### PR DESCRIPTION
## Problem

`apply_dress_illustration` assumes all illustration briefs target passages, but the cover brief targets `vision::main`. Running `qf generate-images` fails with:

```
ValueError: Brief illustration_brief::cover has no targets edge to a passage
```

This regression was introduced when the cover illustration was anchored to `vision::main` instead of a synthetic `passage::cover` node.

## Changes

- **`dress_mutations.py`**: Generalise `apply_dress_illustration` to follow the brief's `targets` edge to any node type (passage, vision, etc.), not just passages. Variable names changed from `passage_id` to `target_id`.
- **`test_dress_mutations.py`**: Add `test_cover_brief_targets_vision` verifying the cover brief creates an illustration depicting `vision::main`.

## Not Included / Future PRs

- None — this is a targeted bug fix

## Test Plan

```
$ uv run pytest tests/unit/test_dress_mutations.py -x -q
23 passed in 0.04s

$ uv run pytest tests/unit/test_export_context.py tests/unit/test_ship_stage.py -x -q
24 passed in 0.29s
```

## Risk / Rollback

- Low risk — the only behavioral change is that `apply_dress_illustration` now follows `targets` edges to any node type instead of only passages. All existing passage-targeting briefs work identically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)