### PR TITLE
feat(a1111): wire LLM distiller into generate-images + prompt engineering

### DIFF
--- a/src/questfoundry/cli.py
+++ b/src/questfoundry/cli.py
@@ -1477,16 +1477,22 @@ def generate_images(
         )
         raise typer.Exit(1)
 
-    # Resolve LLM provider for prompt distillation (only needed for A1111,
-    # not placeholder): CLI flag → env var → project.yaml
+    # Resolve LLM provider for prompt distillation (only A1111 needs this
+    # for condensing prose briefs into SD tags): CLI flag → env var → project.yaml
     llm_provider_spec = provider or os.environ.get("QF_PROVIDER") or config.providers.default
 
     llm_model = None
-    if llm_provider_spec and resolved_provider != "placeholder":
+    if llm_provider_spec and resolved_provider.startswith("a1111"):
         from questfoundry.providers.factory import create_chat_model, get_default_model
 
         if "/" in llm_provider_spec:
             prov_name, model_name = llm_provider_spec.split("/", 1)
+            if not prov_name or not model_name:
+                console.print(
+                    f"[red]Error:[/red] Invalid provider spec: '{llm_provider_spec}'. "
+                    "Expected format 'provider/model'."
+                )
+                raise typer.Exit(1)
         else:
             prov_name = llm_provider_spec
             default_model = get_default_model(prov_name)

--- a/src/questfoundry/cli.py
+++ b/src/questfoundry/cli.py
@@ -1477,11 +1477,12 @@ def generate_images(
         )
         raise typer.Exit(1)
 
-    # Resolve LLM provider for prompt distillation: CLI flag → env var → project.yaml
+    # Resolve LLM provider for prompt distillation (only needed for A1111,
+    # not placeholder): CLI flag → env var → project.yaml
     llm_provider_spec = provider or os.environ.get("QF_PROVIDER") or config.providers.default
 
     llm_model = None
-    if llm_provider_spec:
+    if llm_provider_spec and resolved_provider != "placeholder":
         from questfoundry.providers.factory import create_chat_model, get_default_model
 
         if "/" in llm_provider_spec:

--- a/src/questfoundry/cli.py
+++ b/src/questfoundry/cli.py
@@ -1417,6 +1417,13 @@ def generate_images(
             help="Image provider (e.g., openai/gpt-image-1, placeholder).",
         ),
     ] = None,
+    provider: Annotated[
+        str | None,
+        typer.Option(
+            "--provider",
+            help="LLM provider for prompt distillation (e.g., openai/gpt-4o).",
+        ),
+    ] = None,
     image_budget: Annotated[
         int,
         typer.Option("--image-budget", help="Max images to generate (0=all selected briefs)."),
@@ -1436,9 +1443,12 @@ def generate_images(
     The image provider is resolved in order: --image-provider flag,
     QF_IMAGE_PROVIDER env var, providers.image in project.yaml.
 
+    The LLM provider (for prompt distillation) is resolved in order:
+    --provider flag, QF_PROVIDER env var, providers.default in project.yaml.
+
     Examples:
         qf generate-images --project my-story --image-provider placeholder
-        qf generate-images -p my-story --image-provider openai/gpt-image-1 --image-budget 3
+        qf generate-images -p my-story --image-provider a1111/sdxl_base --provider openai/gpt-4o
     """
     import os
 
@@ -1450,12 +1460,13 @@ def generate_images(
     _configure_project_logging(project_path)
 
     log = get_logger(__name__)
+    config = load_project_config(project_path)
 
     # Resolve image provider: CLI flag → env var → project.yaml
     resolved_provider = (
         image_provider
         or os.environ.get("QF_IMAGE_PROVIDER")
-        or load_project_config(project_path).providers.get_image_provider()
+        or config.providers.get_image_provider()
     )
 
     if not resolved_provider:
@@ -1466,10 +1477,34 @@ def generate_images(
         )
         raise typer.Exit(1)
 
+    # Resolve LLM provider for prompt distillation: CLI flag → env var → project.yaml
+    llm_provider_spec = provider or os.environ.get("QF_PROVIDER") or config.providers.default
+
+    llm_model = None
+    if llm_provider_spec:
+        from questfoundry.providers.factory import create_chat_model, get_default_model
+
+        if "/" in llm_provider_spec:
+            prov_name, model_name = llm_provider_spec.split("/", 1)
+        else:
+            prov_name = llm_provider_spec
+            default_model = get_default_model(prov_name)
+            if not default_model:
+                console.print(
+                    f"[red]Error:[/red] Provider '{prov_name}' requires an explicit model. "
+                    f"Use --provider {prov_name}/<model>."
+                )
+                raise typer.Exit(1)
+            model_name = default_model
+
+        llm_model = create_chat_model(prov_name, model_name)
+        log.info("distiller_llm_created", provider=prov_name, model=model_name)
+
     log.info(
         "generate_images_start",
         provider=resolved_provider,
         budget=image_budget,
+        distiller_llm=llm_provider_spec,
     )
 
     stage = DressStage(
@@ -1492,6 +1527,7 @@ def generate_images(
                 image_budget=image_budget,
                 force=force,
                 on_phase_progress=_on_phase_progress,
+                model=llm_model,
             )
         )
     except DressStageError as e:

--- a/src/questfoundry/pipeline/stages/dress.py
+++ b/src/questfoundry/pipeline/stages/dress.py
@@ -1017,8 +1017,9 @@ class DressStage:
             log.debug(
                 "image_prompt_distilled",
                 brief_id=brief_id,
-                positive_len=len(positive),
-                negative_len=len(negative or ""),
+                positive_prompt=positive,
+                negative_prompt=negative or "",
+                positive_words=len(positive.split()),
                 distilled=distiller is not None,
             )
             prepared.append((brief_id, positive, negative, brief_data))

--- a/src/questfoundry/pipeline/stages/dress.py
+++ b/src/questfoundry/pipeline/stages/dress.py
@@ -855,6 +855,7 @@ class DressStage:
         image_budget: int = 0,
         force: bool = False,
         on_phase_progress: PhaseProgressFn | None = None,
+        model: BaseChatModel | None = None,
     ) -> DressPhaseResult:
         """Run Phase 4 (image generation) only on an existing project.
 
@@ -866,6 +867,8 @@ class DressStage:
             image_budget: Maximum number of images to generate (0 = unlimited).
             force: If True, regenerate images even if illustrations already exist.
             on_phase_progress: Optional progress callback.
+            model: Optional LLM for prompt distillation. Required for A1111
+                provider; passed through to ``create_image_provider(llm=...)``.
 
         Returns:
             DressPhaseResult from Phase 4.
@@ -892,7 +895,7 @@ class DressStage:
         self._image_budget = image_budget
         self._force_regenerate = force
 
-        result = await self._phase_4_generate(graph)
+        result = await self._phase_4_generate(graph, model=model)
 
         if result.status != "failed":
             graph.save(project_path / "graph.json")

--- a/src/questfoundry/providers/image_a1111.py
+++ b/src/questfoundry/providers/image_a1111.py
@@ -84,17 +84,41 @@ _SDXL_PRESET = _A1111Preset(
     quality_tier="high",
 )
 
+_SDXL_LIGHTNING_PRESET = _A1111Preset(
+    sizes={
+        "1:1": (1024, 1024),
+        "16:9": (1344, 768),
+        "9:16": (768, 1344),
+        "3:2": (1216, 832),
+        "2:3": (832, 1216),
+    },
+    steps=6,
+    sampler="DPM++ SDE",
+    scheduler="karras",
+    cfg_scale=2.0,
+    quality_tier="high",
+)
+
 _XL_TAGS = ("sdxl", "xl_", "_xl", "-xl")
+_LIGHTNING_TAGS = ("lightning", "turbo")
 
 
 def _resolve_preset(model: str | None) -> _A1111Preset:
     """Choose generation preset based on checkpoint name.
 
-    Matches models containing "sdxl", "xl_", "_xl", or "-xl"
-    (case-insensitive). Examples: ``sdxl_base``, ``realvisxl_v40``,
-    ``dreamshaperXL``.
+    Detection order:
+    1. Lightning/Turbo SDXL — low steps, low CFG, DPM++ SDE
+    2. Standard SDXL — matches "sdxl", "xl_", "_xl", "-xl"
+    3. SD 1.5 — fallback default
     """
-    if model and any(tag in model.lower() for tag in _XL_TAGS):
+    if not model:
+        return _SD15_PRESET
+    lower = model.lower()
+    is_xl = any(tag in lower for tag in _XL_TAGS)
+    is_lightning = any(tag in lower for tag in _LIGHTNING_TAGS)
+    if is_xl and is_lightning:
+        return _SDXL_LIGHTNING_PRESET
+    if is_xl:
         return _SDXL_PRESET
     return _SD15_PRESET
 

--- a/src/questfoundry/providers/image_a1111.py
+++ b/src/questfoundry/providers/image_a1111.py
@@ -195,7 +195,7 @@ class A1111ImageProvider:
         across two chunks separated by BREAK).
         """
         assert self._llm is not None  # guaranteed by caller
-        is_xl = self._preset is _SDXL_PRESET
+        is_xl = self._preset in (_SDXL_PRESET, _SDXL_LIGHTNING_PRESET)
         entity_cap = 3 if is_xl else 2
         capped_entities = brief.entity_fragments[:entity_cap]
 
@@ -250,13 +250,23 @@ class A1111ImageProvider:
                 "blurry, text, watermark, deformed hands, extra fingers"
             )
 
+        checkpoint_hint = ""
+        if self._model:
+            checkpoint_hint = (
+                f"\nTARGET CHECKPOINT: {self._model}\n"
+                "Adapt your tag style to this checkpoint. For example, anime/"
+                "illustration models (Animagine, NovelAI, etc.) expect Danbooru-"
+                "style tags (1girl, blue_hair, masterpiece). Photorealistic "
+                "models prefer natural descriptive tags.\n"
+            )
+
         system_msg = (
             f"TAG BUDGET: {tag_limit} tags maximum. Target {tag_target} tags. "
             "Anything beyond the budget is silently discarded by SD CLIP.\n\n"
             "You are a Stable Diffusion prompt distiller. The brief below is "
             "REFERENCE MATERIAL, not a checklist. Extract the visually essential "
             "elements — enough to compose a clear scene, not just an abstract "
-            "impression.\n\n"
+            f"impression.\n{checkpoint_hint}\n"
             "PRIORITY TIERS (spend your tag budget here):\n"
             "1. Subject — what is in the image (5-8 tags)\n"
             "2. Key entities — most important 1-2 characters/objects, "

--- a/src/questfoundry/providers/image_a1111.py
+++ b/src/questfoundry/providers/image_a1111.py
@@ -194,19 +194,22 @@ class A1111ImageProvider:
             brief_text += f"Negative: {negative_raw}\n"
 
         tag_limit = 75 if is_xl else 40
+        tag_target = "25-35" if is_xl else "15-25"
         if is_xl:
             format_instruction = (
                 "FORMAT: <scene tags> BREAK <style tags>\n"
-                "Scene chunk: subject + key entities + one composition tag + mood.\n"
-                "Style chunk: art style, medium, palette, quality boosters.\n"
-                "Scene chunk: ~50 tags. Style chunk: ~20 tags."
+                "Scene chunk: subject + entities + composition + mood + lighting.\n"
+                "Style chunk: art style, medium, palette, quality boosters."
             )
             example = (
-                "EXAMPLE (13 tags total — this is the right length):\n"
-                "warrior on bridge, scarred face, jade pendant, wide shot, "
-                "golden hour, epic BREAK watercolor, traditional paper, "
-                "crimson gold palette, masterpiece, best quality\n"
-                "blurry, text, watermark, deformed hands"
+                "EXAMPLE (27 tags — this is the right length):\n"
+                "warrior on bridge, scarred face, jade pendant, leather armor, "
+                "two soldiers behind, wide shot, golden hour, mist rising, "
+                "epic tension, warm rimlight, torch glow BREAK watercolor, "
+                "traditional paper, bold ink outlines, crimson gold palette, "
+                "desaturated background, masterpiece, best quality, "
+                "highly detailed, sharp focus\n"
+                "blurry, text, watermark, deformed hands, extra fingers"
             )
         else:
             format_instruction = (
@@ -214,27 +217,33 @@ class A1111ImageProvider:
                 "Order: subject, entities, composition, style, mood, palette."
             )
             example = (
-                "EXAMPLE (8 tags total — this is the right length):\n"
-                "warrior on bridge, scarred face, wide shot, watercolor, "
-                "epic mood, crimson gold palette, masterpiece, best quality\n"
-                "blurry, text, watermark, deformed hands"
+                "EXAMPLE (18 tags — this is the right length):\n"
+                "warrior on bridge, scarred face, jade pendant, leather armor, "
+                "two soldiers behind, wide shot, golden hour, mist, epic tension, "
+                "warm rimlight, watercolor, ink outlines, crimson gold palette, "
+                "masterpiece, best quality, highly detailed, sharp focus, "
+                "dramatic lighting\n"
+                "blurry, text, watermark, deformed hands, extra fingers"
             )
 
         system_msg = (
-            f"TAG BUDGET: {tag_limit} tags. You MUST use FEWER than {tag_limit}. "
-            "Anything beyond this is silently discarded by SD CLIP.\n\n"
+            f"TAG BUDGET: {tag_limit} tags maximum. Target {tag_target} tags. "
+            "Anything beyond the budget is silently discarded by SD CLIP.\n\n"
             "You are a Stable Diffusion prompt distiller. The brief below is "
-            "REFERENCE MATERIAL, not a checklist. Most of it must be discarded. "
-            "Your job is to extract only the visually essential elements.\n\n"
+            "REFERENCE MATERIAL, not a checklist. Extract the visually essential "
+            "elements — enough to compose a clear scene, not just an abstract "
+            "impression.\n\n"
             "PRIORITY TIERS (spend your tag budget here):\n"
             "1. Subject — what is in the image (5-8 tags)\n"
-            "2. Key entities — most important 1-2 characters/objects (3-5 tags)\n"
-            "3. Composition — ONE camera/framing tag only (1 tag)\n"
-            "4. Style/medium — art style and medium (2-4 tags)\n"
-            "5. Mood/palette — only if budget remains (1-3 tags)\n"
-            "6. Quality boosters — masterpiece, best quality (1-2 tags)\n\n"
-            "DROP EVERYTHING ELSE. No backstory. No lighting details beyond one "
-            "word. No spatial relationships. No abstract concepts.\n\n"
+            "2. Key entities — most important 1-2 characters/objects, "
+            "include distinguishing visual details (4-6 tags)\n"
+            "3. Composition + camera — framing, angle, depth (2-3 tags)\n"
+            "4. Lighting + mood — key light, atmosphere (2-3 tags)\n"
+            "5. Style/medium — art style and medium (3-5 tags)\n"
+            "6. Palette — dominant colors (2-3 tags)\n"
+            "7. Quality boosters — masterpiece, best quality (2-3 tags)\n\n"
+            "DROP: backstory, abstract concepts, narrative, prose descriptions. "
+            "KEEP: concrete visual details that a painter would need.\n\n"
             "RULES:\n"
             "- Each tag is 1-4 words, comma-separated.\n"
             "- No prose, no articles, no prepositions, no sentences.\n"
@@ -242,8 +251,8 @@ class A1111ImageProvider:
             "- No labels, no explanation, no commentary.\n"
             f"- {format_instruction}\n\n"
             f"{example}\n\n"
-            f"REMINDER: {tag_limit} tag budget. Count before you answer. "
-            "Shorter is better. Aim for 60-70% of budget, not 100%."
+            f"REMINDER: Target {tag_target} tags. Do NOT go under 15 or over "
+            f"{tag_limit}."
         )
 
         from langchain_core.messages import HumanMessage, SystemMessage

--- a/src/questfoundry/providers/image_placeholder.py
+++ b/src/questfoundry/providers/image_placeholder.py
@@ -131,6 +131,6 @@ class PlaceholderImageProvider:
                 "quality": "placeholder",
                 "size": f"{width}x{height}",
                 "color": f"#{r:02x}{g:02x}{b:02x}",
-                "prompt_preview": prompt[:80],
+                "prompt": prompt,
             },
         )

--- a/tests/unit/test_image_a1111.py
+++ b/tests/unit/test_image_a1111.py
@@ -14,7 +14,6 @@ from questfoundry.providers.image_a1111 import (
     _SD15_PRESET,
     _SDXL_PRESET,
     A1111ImageProvider,
-    _condense_to_tags,
     _resolve_preset,
 )
 from questfoundry.providers.image_brief import ImageBrief
@@ -335,52 +334,6 @@ class TestA1111Presets:
         assert payload["cfg_scale"] == 7.0
 
 
-class TestCondenseToTags:
-    """Tests for prose-to-tag condensation helper."""
-
-    def test_strips_articles_prepositions(self) -> None:
-        text = "a tall warrior with a scarred face in the courtyard"
-        result = _condense_to_tags(text)
-        assert "a " not in f" {result} ".replace(",", " ")
-        assert "tall warrior" in result
-        assert "scarred face" in result
-        assert "courtyard" in result
-
-    def test_splits_on_semicolons(self) -> None:
-        text = "clean vector shapes; halftone textures; prismatic lens flares"
-        result = _condense_to_tags(text)
-        assert "clean vector shapes" in result
-        assert "halftone textures" in result
-        assert "prismatic lens flares" in result
-
-    def test_preserves_commas_as_tags(self) -> None:
-        text = "chrome highlights, neon bloom, light film grain"
-        result = _condense_to_tags(text)
-        assert "chrome highlights" in result
-        assert "neon bloom" in result
-        assert "light film grain" in result
-
-    def test_empty_input(self) -> None:
-        assert _condense_to_tags("") == ""
-        assert _condense_to_tags("   ") == ""
-
-    def test_prose_heavy_example(self) -> None:
-        text = (
-            "clean vector shapes with confident black linework, "
-            "chrome highlights, neon bloom, light film grain; "
-            "occasional halftone textures, speedlines, "
-            "and prismatic lens flares for mythic objects"
-        )
-        result = _condense_to_tags(text)
-        # Filler words stripped (case-insensitive check for all)
-        lower_tags = result.lower().split(", ")
-        assert "with" not in lower_tags
-        assert "occasional" not in lower_tags
-        # Content preserved
-        assert "clean vector shapes" in result
-        assert "chrome highlights" in result
-
-
 class TestA1111DistillPrompt:
     """Tests for PromptDistiller implementation."""
 
@@ -406,111 +359,12 @@ class TestA1111DistillPrompt:
         assert isinstance(provider, PromptDistiller)
 
     @pytest.mark.asyncio()
-    async def test_sd15_subject_first(self) -> None:
-        """Subject should come before style in SD 1.5 prompts."""
+    async def test_no_llm_raises(self) -> None:
+        """distill_prompt raises when no LLM is provided."""
         provider = A1111ImageProvider(host="http://localhost:7860")
         brief = self._make_brief()
-        positive, negative = await provider.distill_prompt(brief)
-
-        subject_pos = positive.find("Battle scene")
-        style_pos = positive.find("watercolor")
-        assert subject_pos < style_pos, "Subject should precede style"
-
-        assert negative is not None
-        assert "modern elements" in negative
-        assert "photorealism" in negative
-
-    @pytest.mark.asyncio()
-    async def test_sd15_entity_cap(self) -> None:
-        """SD 1.5 should include at most 2 entity fragments."""
-        provider = A1111ImageProvider(host="http://localhost:7860")
-        brief = self._make_brief(
-            entity_fragments=[
-                "tall warrior, scarred face",
-                "old mage, white beard",
-                "young thief, hooded cloak",
-            ]
-        )
-        positive, _ = await provider.distill_prompt(brief)
-
-        # Third entity should not appear
-        assert "hooded cloak" not in positive
-        # First two should be present (condensed)
-        assert "tall warrior" in positive
-        assert "old mage" in positive
-
-    @pytest.mark.asyncio()
-    async def test_sd15_truncation(self) -> None:
-        """SD 1.5 prompts should not exceed 60 words."""
-        long_composition = " ".join(f"word{i}" for i in range(80))
-        provider = A1111ImageProvider(host="http://localhost:7860")
-        brief = self._make_brief(composition=long_composition)
-        positive, _ = await provider.distill_prompt(brief)
-
-        word_count = len(positive.split())
-        assert word_count <= 60
-
-    @pytest.mark.asyncio()
-    async def test_sdxl_break_separated(self) -> None:
-        """SDXL prompts should use BREAK to separate scene from style."""
-        provider = A1111ImageProvider(model="sdxl_base", host="http://localhost:7860")
-        brief = self._make_brief()
-        positive, _ = await provider.distill_prompt(brief)
-
-        assert " BREAK " in positive
-        scene, style = positive.split(" BREAK ")
-        # Subject in scene chunk
-        assert "Battle scene" in scene
-        # Style in style chunk
-        assert "watercolor" in style
-
-    @pytest.mark.asyncio()
-    async def test_sdxl_entity_cap(self) -> None:
-        """SDXL should include at most 3 entity fragments."""
-        provider = A1111ImageProvider(model="sdxl_base", host="http://localhost:7860")
-        brief = self._make_brief(
-            entity_fragments=[
-                "tall warrior, scarred face",
-                "old mage, white beard",
-                "young thief, hooded cloak",
-                "dark knight, obsidian armor",
-            ]
-        )
-        positive, _ = await provider.distill_prompt(brief)
-
-        # Fourth entity should not appear
-        assert "obsidian armor" not in positive
-        # First three should be present
-        assert "tall warrior" in positive
-        assert "old mage" in positive
-        assert "hooded cloak" in positive
-
-    @pytest.mark.asyncio()
-    async def test_sdxl_quality_boosters(self) -> None:
-        """SDXL style chunk should include quality boosters."""
-        provider = A1111ImageProvider(model="sdxl_base", host="http://localhost:7860")
-        brief = self._make_brief()
-        positive, _ = await provider.distill_prompt(brief)
-
-        _, style = positive.split(" BREAK ")
-        assert "masterpiece" in style
-        assert "best quality" in style
-
-    @pytest.mark.asyncio()
-    async def test_rule_based_no_art_direction(self) -> None:
-        provider = A1111ImageProvider(host="http://localhost:7860")
-        brief = self._make_brief(art_style=None, art_medium=None, palette=[])
-        positive, _ = await provider.distill_prompt(brief)
-
-        assert "Battle scene" in positive
-        assert "watercolor" not in positive
-
-    @pytest.mark.asyncio()
-    async def test_rule_based_includes_style_overrides(self) -> None:
-        provider = A1111ImageProvider(host="http://localhost:7860")
-        brief = self._make_brief(style_overrides="darker palette")
-        positive, _ = await provider.distill_prompt(brief)
-        assert "darker palette" in positive
+        with pytest.raises(ImageProviderError, match="requires an LLM"):
+            await provider.distill_prompt(brief)
 
     @pytest.mark.asyncio()
     async def test_llm_system_prompt_subject_first(self) -> None:
@@ -582,16 +436,6 @@ class TestA1111DistillPrompt:
         # Negative still passed through directly
         assert negative is not None
         assert "modern elements" in negative
-
-    @pytest.mark.asyncio()
-    async def test_no_llm_falls_back_to_rule_based(self) -> None:
-        provider = A1111ImageProvider(host="http://localhost:7860")
-        assert provider._llm is None
-        brief = self._make_brief()
-        positive, _ = await provider.distill_prompt(brief)
-        # Should still produce valid output via rule-based path
-        assert "watercolor" in positive
-        assert "Battle scene" in positive
 
     def test_factory_passes_llm(self) -> None:
         from questfoundry.providers.image_factory import create_image_provider

--- a/tests/unit/test_image_a1111.py
+++ b/tests/unit/test_image_a1111.py
@@ -380,8 +380,8 @@ class TestA1111DistillPrompt:
 
         call_args = mock_llm.ainvoke.call_args[0][0]
         system_msg = call_args[0].content
-        assert "40 tags" in system_msg
-        assert "HARD LIMIT" in system_msg
+        assert "40" in system_msg
+        assert "TAG BUDGET" in system_msg
         assert "subject" in system_msg.lower()
 
     @pytest.mark.asyncio()

--- a/tests/unit/test_image_placeholder.py
+++ b/tests/unit/test_image_placeholder.py
@@ -96,7 +96,7 @@ class TestPlaceholderImageProvider:
         provider = PlaceholderImageProvider()
         result = await provider.generate("A long prompt about a watercolor landscape")
 
-        assert "watercolor" in result.provider_metadata["prompt_preview"]
+        assert "watercolor" in result.provider_metadata["prompt"]
 
 
 class TestFactoryPlaceholder:


### PR DESCRIPTION
## Summary

Wire the LLM prompt distiller into the `generate-images` CLI command so A1111 image generation uses GPT-4o (or any configured LLM) to compress prose-heavy briefs into SD-optimised tags. Removes the rule-based distiller which couldn't handle 500-800 word briefs. Adds architecture-aware presets for Lightning/Turbo SDXL models.

## Related Issues

Related to #501 (architecture-aware prompt distiller)

## Changes

- **CLI**: Add `--provider` flag to `generate-images` command; resolves LLM via CLI flag → env var → project config
- **Dress stage**: Pass LLM model through `run_generate_only(model=...)` to `_phase_4_generate`
- **A1111 distiller**: Remove entire rule-based distiller (~130 lines); rewrite LLM system prompt with budget framing, priority tiers, sandwich pattern, and calibrated examples targeting 25-35 tags (SDXL) / 15-25 tags (SD 1.5)
- **Safety net**: Add `_truncate_tags` hard-truncation for when LLMs still overshoot CLIP limits
- **Lightning preset**: Auto-detect "lightning"/"turbo" checkpoints → DPM++ SDE, 6 steps, CFG 2.0
- **Checkpoint hint**: Pass checkpoint name to LLM so it adapts tag style (e.g. Danbooru for anime models)
- **Logging**: Full prompts logged instead of 80-char truncated previews

## Not Included / Future PRs

- Checkpoint-specific prompt templates (e.g. hardcoded Danbooru tag format for Animagine)
- Multi-character scene improvements (fundamental SDXL limitation)
- Prompt template fixes for entity fragments (#503 — separate PR)

## Test Plan

- [x] Unit tests pass (`uv run pytest tests/unit/test_image_a1111.py` — 43 tests)
- [x] mypy clean, ruff clean
- [x] Manual testing with 4 SDXL checkpoints:
  - `sd_xl_base_1.0` — vanilla baseline
  - `dreamshaperXL_lightningDPMSDE` — Lightning preset verified (6 steps, CFG 2.0)
  - `juggernautXL_ragnarokBy` — standard SDXL settings
  - `animagine-xl` — best style match for cel-shaded art direction
- [x] Tag counts verified: previous runs 55-161 tags → now 17-34 tags (within 75-tag CLIP budget)

## Review Guide

Suggested file order:
1. `cli.py` — new `--provider` flag wiring
2. `dress.py` — model passthrough (small)
3. `image_a1111.py` — main changes: presets, distiller prompt, truncation
4. `test_image_a1111.py` — updated tests

## Checklist

- [x] Code follows project conventions
- [x] Tests added/updated for changes
- [x] No TODO stubs in committed code
- [x] Type hints added for new code