### PR TITLE
fix(tokens): extract token usage from structured output responses

### DIFF
--- a/src/questfoundry/agents/serialize.py
+++ b/src/questfoundry/agents/serialize.py
@@ -40,6 +40,7 @@ from questfoundry.observability.tracing import (
 )
 from questfoundry.providers.structured_output import (
     StructuredOutputStrategy,
+    unwrap_structured_result,
     with_structured_output,
 )
 
@@ -283,12 +284,7 @@ async def serialize_to_artifact(
                 tokens = extract_tokens(raw_result)
                 total_tokens += tokens
 
-                # Unwrap parsed value from include_raw=True dict
-                result = (
-                    raw_result["parsed"]
-                    if isinstance(raw_result, dict) and "parsed" in raw_result
-                    else raw_result
-                )
+                result = unwrap_structured_result(raw_result)
 
                 # If result is already a Pydantic model, validate succeeded
                 if isinstance(result, schema):

--- a/src/questfoundry/agents/serialize.py
+++ b/src/questfoundry/agents/serialize.py
@@ -277,11 +277,18 @@ async def serialize_to_artifact(
                 )
 
                 # Invoke structured output
-                result = await structured_model.ainvoke(messages, config=config)
+                raw_result = await structured_model.ainvoke(messages, config=config)
 
                 # Extract token usage from response if available
-                tokens = extract_tokens(result)
+                tokens = extract_tokens(raw_result)
                 total_tokens += tokens
+
+                # Unwrap parsed value from include_raw=True dict
+                result = (
+                    raw_result["parsed"]
+                    if isinstance(raw_result, dict) and "parsed" in raw_result
+                    else raw_result
+                )
 
                 # If result is already a Pydantic model, validate succeeded
                 if isinstance(result, schema):
@@ -405,12 +412,21 @@ def extract_tokens(result: object) -> int:
     - OpenAI: response_metadata["token_usage"]
     - Ollama: usage_metadata attribute on AIMessage
 
+    When ``include_raw=True`` is used with ``with_structured_output``,
+    the result is a dict ``{"raw": AIMessage, "parsed": ..., ...}``.
+    This function unwraps the raw AIMessage to access token metadata.
+
     Args:
-        result: Response from model invocation.
+        result: Response from model invocation (AIMessage, Pydantic model,
+            or raw dict from ``include_raw=True``).
 
     Returns:
         Total tokens used, or 0 if not available.
     """
+    # Unwrap raw dict from include_raw=True
+    if isinstance(result, dict) and "raw" in result:
+        result = result["raw"]
+
     # First check usage_metadata attribute (Ollama, newer providers)
     if hasattr(result, "usage_metadata"):
         usage = getattr(result, "usage_metadata", None)

--- a/src/questfoundry/pipeline/stages/dress.py
+++ b/src/questfoundry/pipeline/stages/dress.py
@@ -65,6 +65,7 @@ from questfoundry.providers.image_brief import ImageBrief, flatten_brief_to_prom
 from questfoundry.providers.image_factory import create_image_provider
 from questfoundry.providers.structured_output import (
     StructuredOutputStrategy,
+    unwrap_structured_result,
     with_structured_output,
 )
 from questfoundry.tools.langchain_tools import (
@@ -571,11 +572,7 @@ class DressStage:
                 llm_calls += 1
                 total_tokens += extract_tokens(raw_result)
 
-                result = (
-                    raw_result["parsed"]
-                    if isinstance(raw_result, dict) and "parsed" in raw_result
-                    else raw_result
-                )
+                result = unwrap_structured_result(raw_result)
                 validated = (
                     result
                     if isinstance(result, output_schema)

--- a/src/questfoundry/pipeline/stages/dress.py
+++ b/src/questfoundry/pipeline/stages/dress.py
@@ -567,13 +567,15 @@ class DressStage:
             )
 
             try:
-                result = await structured_model.ainvoke(messages, config=config)
+                raw_result = await structured_model.ainvoke(messages, config=config)
                 llm_calls += 1
-                # Note: extract_tokens returns 0 for Pydantic model results
-                # from with_structured_output. Token counts for structured
-                # output calls are not tracked. This matches FILL stage behavior.
-                total_tokens += extract_tokens(result)
+                total_tokens += extract_tokens(raw_result)
 
+                result = (
+                    raw_result["parsed"]
+                    if isinstance(raw_result, dict) and "parsed" in raw_result
+                    else raw_result
+                )
                 validated = (
                     result
                     if isinstance(result, output_schema)

--- a/src/questfoundry/pipeline/stages/fill.py
+++ b/src/questfoundry/pipeline/stages/fill.py
@@ -55,7 +55,10 @@ from questfoundry.models.fill import (
 from questfoundry.observability.logging import get_logger
 from questfoundry.observability.tracing import traceable
 from questfoundry.pipeline.gates import AutoApprovePhaseGate
-from questfoundry.providers.structured_output import with_structured_output
+from questfoundry.providers.structured_output import (
+    unwrap_structured_result,
+    with_structured_output,
+)
 
 if TYPE_CHECKING:
     from langchain_core.callbacks import BaseCallbackHandler
@@ -416,11 +419,7 @@ class FillStage:
                 llm_calls += 1
                 total_tokens += extract_tokens(raw_result)
 
-                result = (
-                    raw_result["parsed"]
-                    if isinstance(raw_result, dict) and "parsed" in raw_result
-                    else raw_result
-                )
+                result = unwrap_structured_result(raw_result)
                 validated = (
                     result
                     if isinstance(result, output_schema)

--- a/src/questfoundry/pipeline/stages/fill.py
+++ b/src/questfoundry/pipeline/stages/fill.py
@@ -412,10 +412,15 @@ class FillStage:
             )
 
             try:
-                result = await structured_model.ainvoke(messages, config=config)
+                raw_result = await structured_model.ainvoke(messages, config=config)
                 llm_calls += 1
-                total_tokens += extract_tokens(result)
+                total_tokens += extract_tokens(raw_result)
 
+                result = (
+                    raw_result["parsed"]
+                    if isinstance(raw_result, dict) and "parsed" in raw_result
+                    else raw_result
+                )
                 validated = (
                     result
                     if isinstance(result, output_schema)

--- a/src/questfoundry/pipeline/stages/grow.py
+++ b/src/questfoundry/pipeline/stages/grow.py
@@ -434,11 +434,16 @@ class GrowStage:
             )
 
             try:
-                result = await structured_model.ainvoke(messages, config=config)
+                raw_result = await structured_model.ainvoke(messages, config=config)
                 llm_calls += 1
-                total_tokens += extract_tokens(result)
+                total_tokens += extract_tokens(raw_result)
 
-                # with_structured_output returns validated Pydantic instance directly.
+                # Unwrap parsed value from include_raw=True dict
+                result = (
+                    raw_result["parsed"]
+                    if isinstance(raw_result, dict) and "parsed" in raw_result
+                    else raw_result
+                )
                 # Defensive fallback for providers that return dicts instead.
                 validated = (
                     result

--- a/src/questfoundry/pipeline/stages/grow.py
+++ b/src/questfoundry/pipeline/stages/grow.py
@@ -36,7 +36,10 @@ from questfoundry.models.grow import GrowPhaseResult, GrowResult
 from questfoundry.observability.logging import get_logger
 from questfoundry.observability.tracing import traceable
 from questfoundry.pipeline.gates import AutoApprovePhaseGate
-from questfoundry.providers.structured_output import with_structured_output
+from questfoundry.providers.structured_output import (
+    unwrap_structured_result,
+    with_structured_output,
+)
 
 if TYPE_CHECKING:
     from langchain_core.callbacks import BaseCallbackHandler
@@ -438,12 +441,7 @@ class GrowStage:
                 llm_calls += 1
                 total_tokens += extract_tokens(raw_result)
 
-                # Unwrap parsed value from include_raw=True dict
-                result = (
-                    raw_result["parsed"]
-                    if isinstance(raw_result, dict) and "parsed" in raw_result
-                    else raw_result
-                )
+                result = unwrap_structured_result(raw_result)
                 # Defensive fallback for providers that return dicts instead.
                 validated = (
                     result

--- a/src/questfoundry/providers/structured_output.py
+++ b/src/questfoundry/providers/structured_output.py
@@ -94,3 +94,16 @@ def with_structured_output(
 
     method = "function_calling" if strategy == StructuredOutputStrategy.TOOL else "json_schema"
     return model.with_structured_output(schema, method=method, include_raw=True)
+
+
+def unwrap_structured_result(raw_result: Any) -> Any:
+    """Unwrap parsed value from ``include_raw=True`` dict.
+
+    When ``with_structured_output(include_raw=True)`` is used, ``ainvoke()``
+    returns ``{"raw": AIMessage, "parsed": PydanticModel, "parsing_error": ...}``.
+    This extracts the ``parsed`` value, falling back to the raw result for
+    backward compatibility with mocks or providers that return models directly.
+    """
+    if isinstance(raw_result, dict) and "parsed" in raw_result:
+        return raw_result["parsed"]
+    return raw_result

--- a/src/questfoundry/providers/structured_output.py
+++ b/src/questfoundry/providers/structured_output.py
@@ -93,4 +93,4 @@ def with_structured_output(
             strategy = get_default_strategy(provider_name)
 
     method = "function_calling" if strategy == StructuredOutputStrategy.TOOL else "json_schema"
-    return model.with_structured_output(schema, method=method)
+    return model.with_structured_output(schema, method=method, include_raw=True)

--- a/tests/integration/test_structured_output.py
+++ b/tests/integration/test_structured_output.py
@@ -64,8 +64,11 @@ class TestStructuredOutputBasic:
             provider_name="ollama",
         )
 
-        result = await structured_model.ainvoke("Generate a title and count for a book")
+        raw_result = await structured_model.ainvoke("Generate a title and count for a book")
 
+        assert isinstance(raw_result, dict)
+        assert "parsed" in raw_result
+        result = raw_result["parsed"]
         assert isinstance(result, SimpleSchema)
         assert len(result.title) > 0
         assert result.count >= 1
@@ -86,8 +89,10 @@ class TestStructuredOutputBasic:
             provider_name="openai",
         )
 
-        result = await structured_model.ainvoke("Generate a title and count for a book")
+        raw_result = await structured_model.ainvoke("Generate a title and count for a book")
 
+        assert isinstance(raw_result, dict)
+        result = raw_result["parsed"]
         assert isinstance(result, SimpleSchema)
         assert len(result.title) > 0
         assert result.count >= 1
@@ -103,8 +108,10 @@ class TestStructuredOutputBasic:
             provider_name="test",
         )
 
-        result = await structured_model.ainvoke("Generate a title and count for an article")
+        raw_result = await structured_model.ainvoke("Generate a title and count for an article")
 
+        assert isinstance(raw_result, dict)
+        result = raw_result["parsed"]
         assert isinstance(result, SimpleSchema)
         assert len(result.title) > 0
         assert result.count >= 1
@@ -126,10 +133,11 @@ class TestStructuredOutputNested:
             provider_name="ollama",
         )
 
-        result = await structured_model.ainvoke(
+        raw_result = await structured_model.ainvoke(
             "Generate a shopping list with outer_name 'Groceries' and at least 2 items"
         )
 
+        result = raw_result["parsed"]
         assert isinstance(result, NestedSchema)
         assert len(result.outer_name) > 0
         assert len(result.items) >= 1
@@ -153,10 +161,11 @@ class TestStructuredOutputNested:
             provider_name="openai",
         )
 
-        result = await structured_model.ainvoke(
+        raw_result = await structured_model.ainvoke(
             "Generate a task list with outer_name 'Project Tasks' and 2-3 items"
         )
 
+        result = raw_result["parsed"]
         assert isinstance(result, NestedSchema)
         assert len(result.outer_name) > 0
         assert len(result.items) >= 1
@@ -178,10 +187,11 @@ class TestStructuredOutputOptionals:
             provider_name="ollama",
         )
 
-        result = await structured_model.ainvoke(
+        raw_result = await structured_model.ainvoke(
             "Generate an entry with required_field='test' and provide all optional fields too"
         )
 
+        result = raw_result["parsed"]
         assert isinstance(result, OptionalFieldsSchema)
         assert len(result.required_field) > 0
 
@@ -197,10 +207,11 @@ class TestStructuredOutputOptionals:
             provider_name="ollama",
         )
 
-        result = await structured_model.ainvoke(
+        raw_result = await structured_model.ainvoke(
             "Generate a minimal entry with only the required field set"
         )
 
+        result = raw_result["parsed"]
         assert isinstance(result, OptionalFieldsSchema)
         assert len(result.required_field) > 0
         # Optional fields may or may not be present
@@ -227,7 +238,7 @@ class TestStructuredOutputDreamArtifact:
             provider_name="ollama",
         )
 
-        result = await structured_model.ainvoke(
+        raw_result = await structured_model.ainvoke(
             """Create a DreamArtifact for a cozy mystery story:
             - Genre: Cozy Mystery
             - Audience: Adults
@@ -235,6 +246,7 @@ class TestStructuredOutputDreamArtifact:
             - Tone: Warm, witty"""
         )
 
+        result = raw_result["parsed"]
         assert isinstance(result, DreamArtifact)
         assert result.type == "dream"
         assert len(result.genre) > 0
@@ -258,7 +270,7 @@ class TestStructuredOutputDreamArtifact:
             provider_name="openai",
         )
 
-        result = await structured_model.ainvoke(
+        raw_result = await structured_model.ainvoke(
             """Create a DreamArtifact for a sci-fi story:
             - Genre: Science Fiction
             - Audience: Young Adults
@@ -266,6 +278,7 @@ class TestStructuredOutputDreamArtifact:
             - Tone: Adventurous, hopeful"""
         )
 
+        result = raw_result["parsed"]
         assert isinstance(result, DreamArtifact)
         assert result.type == "dream"
 

--- a/tests/unit/test_serialize.py
+++ b/tests/unit/test_serialize.py
@@ -323,6 +323,21 @@ class TestHelperFunctions:
 
         assert extract_tokens(mock_result) == 0
 
+    def test_extract_tokens_unwraps_raw_dict(self) -> None:
+        """extract_tokens should unwrap include_raw=True dict to get AIMessage."""
+        mock_ai_message = MagicMock()
+        mock_ai_message.usage_metadata = {"total_tokens": 350}
+        raw_result = {"raw": mock_ai_message, "parsed": MagicMock(), "parsing_error": None}
+
+        assert extract_tokens(raw_result) == 350
+
+    def test_extract_tokens_raw_dict_no_metadata(self) -> None:
+        """extract_tokens returns 0 when raw AIMessage has no metadata."""
+        mock_ai_message = MagicMock(spec=[])
+        raw_result = {"raw": mock_ai_message, "parsed": MagicMock(), "parsing_error": None}
+
+        assert extract_tokens(raw_result) == 0
+
     def test_format_validation_errors_with_location(self) -> None:
         """_format_validation_errors should include field location."""
         try:

--- a/tests/unit/test_structured_output.py
+++ b/tests/unit/test_structured_output.py
@@ -80,6 +80,7 @@ class TestWithStructuredOutput:
         mock_model.with_structured_output.assert_called_once_with(
             SampleSchema,
             method="function_calling",
+            include_raw=True,
         )
         assert result is mock_model
 
@@ -97,6 +98,7 @@ class TestWithStructuredOutput:
         mock_model.with_structured_output.assert_called_once_with(
             SampleSchema,
             method="json_schema",
+            include_raw=True,
         )
         assert result is mock_model
 
@@ -115,6 +117,7 @@ class TestWithStructuredOutput:
         mock_model.with_structured_output.assert_called_with(
             SampleSchema,
             method="json_schema",
+            include_raw=True,
         )
 
         # Test OpenAI (TOOL - function_calling handles optional fields)
@@ -128,6 +131,7 @@ class TestWithStructuredOutput:
         mock_model.with_structured_output.assert_called_with(
             SampleSchema,
             method="function_calling",
+            include_raw=True,
         )
 
     def test_with_structured_output_none_strategy_defaults_to_tool(self) -> None:
@@ -145,6 +149,7 @@ class TestWithStructuredOutput:
         mock_model.with_structured_output.assert_called_once_with(
             SampleSchema,
             method="function_calling",
+            include_raw=True,
         )
 
     def test_with_structured_output_none_strategy_with_provider(self) -> None:
@@ -163,4 +168,5 @@ class TestWithStructuredOutput:
         mock_model.with_structured_output.assert_called_once_with(
             SampleSchema,
             method="json_schema",
+            include_raw=True,
         )


### PR DESCRIPTION
## Problem

`with_structured_output()` returns Pydantic models directly, stripping the `AIMessage` wrapper that contains token usage metadata. This causes `extract_tokens()` to always return 0 for structured output calls, resulting in `Tokens: 0` in CLI output for FILL, GROW, DRESS, and `serialize_to_artifact`.

## Changes

- Add `include_raw=True` to `with_structured_output()` in `structured_output.py` so `ainvoke()` returns `{"raw": AIMessage, "parsed": PydanticModel, "parsing_error": None}` instead of just the Pydantic model
- Update `extract_tokens()` to unwrap the raw dict and extract token metadata from the `AIMessage`
- Update all 4 callers (`serialize_to_artifact`, fill, grow, dress) to unwrap `["parsed"]` from the raw result before type-checking
- Remove stale comment in dress.py that documented this as a known limitation

## Not Included / Future PRs

- No changes to discuss/summarize phases (they already use `AIMessage` directly)

## Test Plan

- Added 2 unit tests for `extract_tokens()` with raw dict input (with and without metadata)
- All existing tests pass (379 unit tests) — mocks that return Pydantic models directly are handled by the defensive `isinstance(raw_result, dict)` guard
- Updated integration tests to unwrap `["parsed"]` from raw result

```bash
uv run pytest tests/unit/test_serialize.py tests/unit/test_grow_stage.py tests/unit/test_fill_stage.py tests/unit/test_dress_stage.py tests/unit/test_grow_algorithms.py -x -q
# 379 passed
```

## Risk / Rollback

- Low risk — backward compatible. If `ainvoke()` returns a non-dict (e.g., from a mock), the guard `isinstance(raw_result, dict) and "parsed" in raw_result` falls through to the old behavior.
- No feature flags needed.

Closes #410

🤖 Generated with [Claude Code](https://claude.com/claude-code)