### PR TITLE
fix(dress): entity name dereference and distiller CLIP context

### DIFF
--- a/src/questfoundry/pipeline/stages/dress.py
+++ b/src/questfoundry/pipeline/stages/dress.py
@@ -1364,7 +1364,7 @@ def build_image_brief(graph: Graph, brief: dict[str, Any]) -> ImageBrief:
         if ev:
             frag = ev.get("reference_prompt_fragment", "")
             if frag:
-                entity_fragments.append(frag)
+                entity_fragments.append(f"{raw_eid}: {frag}")
 
     return ImageBrief(
         subject=brief.get("subject", ""),

--- a/src/questfoundry/providers/image_a1111.py
+++ b/src/questfoundry/providers/image_a1111.py
@@ -261,8 +261,10 @@ class A1111ImageProvider:
             )
 
         system_msg = (
-            f"TAG BUDGET: {tag_limit} tags maximum. Target {tag_target} tags. "
-            "Anything beyond the budget is silently discarded by SD CLIP.\n\n"
+            "CONTEXT: Stable Diffusion's CLIP encoder has a hard token window. "
+            "Anything beyond it is silently ignored. Your job is to distill a "
+            "prose brief into compact, comma-separated visual tags that fit.\n\n"
+            f"TAG BUDGET: {tag_limit} tags maximum. Target {tag_target} tags.\n\n"
             "You are a Stable Diffusion prompt distiller. The brief below is "
             "REFERENCE MATERIAL, not a checklist. Extract the visually essential "
             "elements — enough to compose a clear scene, not just an abstract "
@@ -279,6 +281,10 @@ class A1111ImageProvider:
             "DROP: backstory, abstract concepts, narrative, prose descriptions. "
             "KEEP: concrete visual details that a painter would need.\n\n"
             "RULES:\n"
+            "- ENTITY EXPANSION: SD does not know character names. Replace names "
+            '(e.g., "Eleanor") with their visual descriptions from the Entities '
+            'field (e.g., "elara: tall woman, dark coat" → use '
+            '"tall woman, dark coat").\n'
             "- Each tag is 1-4 words, comma-separated.\n"
             "- No prose, no articles, no prepositions, no sentences.\n"
             "- Output EXACTLY two lines. Line 1: positive. Line 2: negative.\n"

--- a/src/questfoundry/providers/image_a1111.py
+++ b/src/questfoundry/providers/image_a1111.py
@@ -283,7 +283,7 @@ class A1111ImageProvider:
             "RULES:\n"
             "- ENTITY EXPANSION: SD does not know character names. Replace names "
             '(e.g., "Eleanor") with their visual descriptions from the Entities '
-            'field (e.g., "elara: tall woman, dark coat" → use '
+            'field (e.g., "eleanor: tall woman, dark coat" → use '
             '"tall woman, dark coat").\n'
             "- Each tag is 1-4 words, comma-separated.\n"
             "- No prose, no articles, no prepositions, no sentences.\n"

--- a/tests/unit/test_image_a1111.py
+++ b/tests/unit/test_image_a1111.py
@@ -409,6 +409,8 @@ class TestA1111DistillPrompt:
         assert "40" in system_msg
         assert "TAG BUDGET" in system_msg
         assert "subject" in system_msg.lower()
+        assert "CLIP encoder" in system_msg
+        assert "ENTITY EXPANSION" in system_msg
 
     @pytest.mark.asyncio()
     async def test_llm_sdxl_break_instruction(self) -> None:

--- a/tests/unit/test_image_brief.py
+++ b/tests/unit/test_image_brief.py
@@ -147,7 +147,7 @@ class TestBuildImageBrief:
 
         assert isinstance(result, ImageBrief)
         assert result.subject == "Battle scene"
-        assert result.entity_fragments == ["tall warrior, scarred face"]
+        assert result.entity_fragments == ["hero: tall warrior, scarred face"]
         assert result.art_style == "watercolor"
         assert result.palette == ["deep indigo", "gold"]
         assert result.negative_defaults == "photorealism"
@@ -179,7 +179,7 @@ class TestBuildImageBrief:
         brief_data = {"subject": "Fight", "entities": ["entity::hero"]}
         result = build_image_brief(g, brief_data)
 
-        assert result.entity_fragments == ["tall warrior"]
+        assert result.entity_fragments == ["hero: tall warrior"]
 
     def test_empty_strings_become_none(self) -> None:
         g = Graph()


### PR DESCRIPTION
## Problem
1. **Entity names not dereferenced**: `build_image_brief()` passes anonymous visual descriptions (e.g., "tall woman in dark coat") without entity names. The distiller LLM sees character names in the `subject` field (e.g., "Eleanor") but has no way to map them to descriptions. SD has no concept of character names.

2. **Missing CLIP context**: The system prompt doesn't explain *why* distillation happens — no mention of CLIP token limits or that excess tokens are silently dropped.

## Changes
- `build_image_brief()`: entity fragments now include entity ID prefix — `"elara: tall woman, dark coat"` instead of just `"tall woman, dark coat"`
- A1111 system prompt: added CONTEXT paragraph explaining CLIP token window and silent truncation
- A1111 system prompt: added ENTITY EXPANSION rule instructing the LLM to replace character names with visual descriptions from the Entities field

## Not Included / Future PRs
- Cover brief reanchoring (#512)
- Progress feedback (#513)

## Test Plan
- `uv run pytest tests/unit/test_image_a1111.py tests/unit/test_image_brief.py -x -q` — 58 tests pass
- Updated assertions verify entity fragments include name prefix and system prompt includes CLIP/entity content

## Risk / Rollback
- Entity fragment format change is additive — existing code that consumes fragments will see richer context
- System prompt changes may slightly alter distilled output quality (intended improvement)

🤖 Generated with [Claude Code](https://claude.com/claude-code)