### PR TITLE
fix(fill): store story_title on voice node, remove phantom vision::main

### DIFF
--- a/docs/design/00-spec.md
+++ b/docs/design/00-spec.md
@@ -111,7 +111,7 @@ This is not a pipeline of files where each stage produces a new artifact. Rather
 | BRAINSTORM | Entity, Dilemma, Answer | — | Vision |
 | SEED | Path, Consequence, Beat | Entity (curate), Dilemma (explore) | Entity, Dilemma |
 | GROW | Arc, Passage, Choice, Codeword; new Beats | Beat (scene_type, intersection) | Path, Beat, Entity |
-| FILL | — | Passage (prose), Entity (details) | Passage, Entity, Path |
+| FILL | Voice | Passage (prose), Entity (details) | Passage, Entity, Path |
 | DRESS | ArtDirection, EntityVisual, IllustrationBrief, Illustration, CodexEntry | — | Passage, Entity, Vision, Codeword |
 | SHIP | — (export only) | — | Persistent nodes |
 
@@ -887,6 +887,9 @@ Before prose generation, establish the voice document. This synthesizes DREAM's 
 **Voice document schema:**
 ```yaml
 voice:
+  # Identity
+  story_title: string                # generated title for the story
+
   # Structural choices
   pov: first | second | third_limited | third_omniscient
   pov_character: entity_id | null    # whose perspective (for limited POVs)

--- a/src/questfoundry/pipeline/stages/dress.py
+++ b/src/questfoundry/pipeline/stages/dress.py
@@ -1104,8 +1104,9 @@ def _create_cover_brief(graph: Graph) -> bool:
     tone_str = ", ".join(tone) if isinstance(tone, list) else str(tone)
     themes_str = ", ".join(themes) if isinstance(themes, list) else str(themes)
 
-    # Build subject from non-empty parts
-    story_title = vision.get("story_title") or ""
+    # Build subject from non-empty parts — title lives on voice node (FILL)
+    voice_node = graph.get_node("voice::voice")
+    story_title = (voice_node or {}).get("story_title") or ""
     title_desc = f'"{story_title}", ' if story_title else ""
     parts = [f"Cover image for {title_desc}a {genre} story"]
     if tone_str:

--- a/src/questfoundry/pipeline/stages/fill.py
+++ b/src/questfoundry/pipeline/stages/fill.py
@@ -493,16 +493,14 @@ class FillStage:
             FillPhase0Output,
         )
 
-        # Store the voice document as a graph node
+        # Store the voice document as a graph node (includes story_title)
         voice_data: dict[str, Any] = {
             "type": "voice",
             "raw_id": "voice",
+            "story_title": output.story_title,
             **output.voice.model_dump(),
         }
         graph.create_node("voice::voice", voice_data)
-
-        # Store generated title on the vision node (story-level identity metadata)
-        graph.upsert_node("vision::main", {"story_title": output.story_title})
 
         log.info(
             "voice_document_created",

--- a/src/questfoundry/pipeline/stages/ship.py
+++ b/src/questfoundry/pipeline/stages/ship.py
@@ -88,9 +88,9 @@ class ShipStage:
                 f"Run FILL stage first. Examples: {missing_prose[:3]}"
             )
 
-        # Get story title: graph (from FILL) → project config → directory name
-        vision = graph.get_node("vision::main")
-        story_title = (vision or {}).get("story_title") or ""
+        # Get story title: voice node (from FILL) → project config → directory name
+        voice = graph.get_node("voice::voice")
+        story_title = (voice or {}).get("story_title") or ""
         if not story_title:
             try:
                 config = load_project_config(self._project_path)

--- a/tests/unit/test_dress_stage.py
+++ b/tests/unit/test_dress_stage.py
@@ -1225,6 +1225,19 @@ class TestCreateCoverBrief:
         assert brief is not None
         assert "thriller" in brief["subject"]
 
+    def test_reads_story_title_from_voice_node(self) -> None:
+        g = Graph()
+        g.create_node("vision", {"type": "vision", "genre": "fantasy", "tone": ["epic"]})
+        g.create_node(
+            "voice::voice", {"type": "voice", "raw_id": "voice", "story_title": "The Hollow Crown"}
+        )
+
+        _create_cover_brief(g)
+
+        brief = g.get_node("illustration_brief::cover")
+        assert brief is not None
+        assert "The Hollow Crown" in brief["subject"]
+
 
 # ---------------------------------------------------------------------------
 # Standalone generate-images (run_generate_only)

--- a/tests/unit/test_fill_stage.py
+++ b/tests/unit/test_fill_stage.py
@@ -344,12 +344,16 @@ class TestPhase0Voice:
         assert result.llm_calls == 1
         assert result.tokens_used == 500
 
-        # Voice node should be created in graph
+        # Voice node should be created in graph with story_title
         voice_node = graph.get_node("voice::voice")
         assert voice_node is not None
         assert voice_node["pov"] == "third_limited"
         assert voice_node["tense"] == "past"
         assert voice_node["voice_register"] == "literary"
+        assert voice_node["story_title"] == "The Hollow Crown"
+
+        # No phantom vision::main node should exist
+        assert graph.get_node("vision::main") is None
 
     @pytest.mark.asyncio
     async def test_passes_context_to_llm(self) -> None:

--- a/tests/unit/test_ship_stage.py
+++ b/tests/unit/test_ship_stage.py
@@ -207,15 +207,15 @@ class TestShipStage:
         assert data["title"] == "my-fallback-story"
 
     def test_graph_title_takes_priority(self, tmp_path: Path) -> None:
-        """Story title from graph (FILL) takes priority over project config name."""
+        """Story title from voice node (FILL) takes priority over project config name."""
         project = tmp_path / "my-story"
         _create_project_with_graph(project)
 
-        # Add a vision node with a generated story title
+        # Add a voice node with a generated story title
         g = Graph.load(project)
         g.create_node(
-            "vision::main",
-            {"type": "vision", "genre": "fantasy", "story_title": "The Hollow Crown"},
+            "voice::voice",
+            {"type": "voice", "raw_id": "voice", "story_title": "The Hollow Crown"},
         )
         g.save(project / "graph.json")
 
@@ -228,13 +228,13 @@ class TestShipStage:
         assert data["title"] == "The Hollow Crown"
 
     def test_graph_title_fallback_to_config(self, tmp_path: Path) -> None:
-        """Falls back to config name when vision node has no story_title."""
+        """Falls back to config name when voice node has no story_title."""
         project = tmp_path / "my-story"
         _create_project_with_graph(project)
 
-        # Vision node exists but without story_title
+        # Voice node exists but without story_title
         g = Graph.load(project)
-        g.create_node("vision::main", {"type": "vision", "genre": "fantasy"})
+        g.create_node("voice::voice", {"type": "voice", "raw_id": "voice"})
         g.save(project / "graph.json")
 
         stage = ShipStage(project)
@@ -251,7 +251,7 @@ class TestShipStage:
         _create_project_with_graph(project)
 
         g = Graph.load(project)
-        g.create_node("vision::main", {"type": "vision", "genre": "fantasy", "story_title": None})
+        g.create_node("voice::voice", {"type": "voice", "raw_id": "voice", "story_title": None})
         g.save(project / "graph.json")
 
         stage = ShipStage(project)


### PR DESCRIPTION
## Problem

PR #506 stored `story_title` by upserting `vision::main` — a phantom second vision node. This has three problems:

1. **No-backflow violation**: FILL writes to a vision-typed node, but vision is owned by DREAM
2. **Data fragmentation**: DREAM creates `"vision"` (non-prefixed), FILL creates `"vision::main"` — `get_nodes_by_type("vision")` returns both nondeterministically
3. **Missing from ontology**: `story_title` was never added to the spec

## Changes

- **Spec** (`docs/design/00-spec.md`): Add `story_title` to Voice schema, update FILL Creates column to "Voice"
- **FILL** (`fill.py`): Store `story_title` on `voice::voice` node instead of upserting `vision::main`
- **SHIP** (`ship.py`): Read title from `voice::voice` instead of `vision::main`
- **DRESS** (`dress.py`): Read title from `voice::voice` in `_create_cover_brief()`
- **Tests**: Update 3 SHIP title tests to use `voice::voice`, add `story_title` assertion to FILL test, add voice-node cover brief test to DRESS, assert `vision::main` is not created

## Not Included / Future PRs

- Standalone cover illustration (#512) — will be PR 2, stacked on this branch

## Test Plan

```
uv run pytest tests/unit/test_fill_stage.py tests/unit/test_ship_stage.py tests/unit/test_dress_stage.py -x -q
# 121 passed
uv run mypy src/questfoundry/pipeline/stages/fill.py src/questfoundry/pipeline/stages/ship.py src/questfoundry/pipeline/stages/dress.py
# Success: no issues found in 3 source files
```

## Risk / Rollback

- Any existing `graph.json` with `story_title` on `vision::main` will lose the title (falls back to project config name). This is acceptable since `vision::main` was a bug.
- No feature flags needed — this is a correctness fix.

Closes #515

🤖 Generated with [Claude Code](https://claude.com/claude-code)