### PR TITLE
feat(dress): standalone cover illustration, no synthetic passage

### DIFF
--- a/docs/design/00-spec.md
+++ b/docs/design/00-spec.md
@@ -579,7 +579,7 @@ Structured image prompt with priority scoring. One brief is generated per passag
 illustration_brief:
   id: string
   priority: integer                     # 1=must-have, 2=important, 3=nice-to-have
-  category: string                      # scene | portrait | vista | item_detail
+  category: string                      # scene | portrait | vista | item_detail | cover
   subject: string                       # what the image depicts
   entities: string[]                    # entity IDs present in scene
   composition: string                   # framing / camera notes

--- a/src/questfoundry/export/base.py
+++ b/src/questfoundry/export/base.py
@@ -87,6 +87,7 @@ class ExportContext:
     entities: list[ExportEntity] = field(default_factory=list)
     codewords: list[ExportCodeword] = field(default_factory=list)
     illustrations: list[ExportIllustration] = field(default_factory=list)
+    cover: ExportIllustration | None = None
     codex_entries: list[ExportCodexEntry] = field(default_factory=list)
     art_direction: dict[str, Any] | None = None
 

--- a/src/questfoundry/export/context.py
+++ b/src/questfoundry/export/context.py
@@ -17,9 +17,12 @@ from questfoundry.export.base import (
     ExportIllustration,
     ExportPassage,
 )
+from questfoundry.observability.logging import get_logger
 
 if TYPE_CHECKING:
     from questfoundry.graph.graph import Graph
+
+log = get_logger(__name__)
 
 
 def build_export_context(graph: Graph, project_name: str) -> ExportContext:
@@ -155,7 +158,13 @@ def _extract_illustrations(
     for node_id, data in sorted(illustration_nodes.items()):
         category = data.get("category", "scene")
         passage_id = illust_to_passage.get(node_id)
-        if category == "cover" and not passage_id:
+        if category == "cover":
+            if passage_id:
+                log.warning(
+                    "cover_has_depicts_edge",
+                    illustration_id=node_id,
+                    passage_id=passage_id,
+                )
             cover = ExportIllustration(
                 passage_id="",
                 asset_path=data.get("asset", ""),

--- a/src/questfoundry/export/html_exporter.py
+++ b/src/questfoundry/export/html_exporter.py
@@ -76,6 +76,13 @@ class HtmlExporter:
         if context.art_direction:
             art_direction_meta = f'<meta name="art-direction" content="{html.escape(json.dumps(context.art_direction))}">'
 
+        # Build cover HTML
+        cover_html = ""
+        if context.cover and context.cover.asset_path:
+            cap = html.escape(context.cover.caption) if context.cover.caption else ""
+            caption_tag = f"\n  <figcaption>{cap}</figcaption>" if cap else ""
+            cover_html = f'<figure class="cover">\n  <img src="{html.escape(context.cover.asset_path)}" alt="Cover illustration">{caption_tag}\n</figure>'
+
         # Build the complete HTML document
         content = _build_html_document(
             title=context.title,
@@ -83,6 +90,7 @@ class HtmlExporter:
             start_id=_safe_id(start_id),
             codex_html=codex_html,
             art_direction_meta=art_direction_meta,
+            cover_html=cover_html,
         )
 
         output_file.write_text(content, encoding="utf-8")
@@ -177,6 +185,7 @@ def _build_html_document(
     start_id: str,
     codex_html: str = "",
     art_direction_meta: str = "",
+    cover_html: str = "",
 ) -> str:
     """Build the complete HTML document."""
     extra_meta = f"\n{art_direction_meta}" if art_direction_meta else ""
@@ -308,6 +317,7 @@ h1 {{
 </head>
 <body>
 <h1>{html.escape(title)}</h1>
+{cover_html}
 {codex_button}
 {passages_html}
 

--- a/src/questfoundry/export/twee_exporter.py
+++ b/src/questfoundry/export/twee_exporter.py
@@ -47,7 +47,7 @@ class TweeExporter:
         output_file = output_dir / "story.twee"
 
         lines: list[str] = []
-        lines.extend(_story_header(context.title))
+        lines.extend(_story_header(context.title, context.cover))
         lines.append("")
 
         # Build lookup structures
@@ -108,14 +108,18 @@ class TweeExporter:
         return output_file
 
 
-def _story_header(title: str) -> list[str]:
+def _story_header(title: str, cover: ExportIllustration | None = None) -> list[str]:
     """Generate Twee 3 story header passages."""
     ifid = str(uuid.uuid4()).upper()
-    return [
+    header = [
         f":: StoryTitle\n{title}",
         "",
         f':: StoryData\n{{"ifid": "{ifid}", "format": "SugarCube", "format-version": "2.37.3"}}',
     ]
+    if cover and cover.asset_path:
+        header.append("")
+        header.append(f":: StoryInit\n[img[{cover.asset_path}]]")
+    return header
 
 
 def _passage_name(passage_id: str) -> str:

--- a/src/questfoundry/models/dress.py
+++ b/src/questfoundry/models/dress.py
@@ -19,7 +19,7 @@ from pydantic import BaseModel, Field
 
 from questfoundry.models.pipeline import PhaseResult
 
-IllustrationCategory = Literal["scene", "portrait", "vista", "item_detail"]
+IllustrationCategory = Literal["scene", "portrait", "vista", "item_detail", "cover"]
 
 # ---------------------------------------------------------------------------
 # Persistent nodes (exported by SHIP)

--- a/src/questfoundry/pipeline/stages/dress.py
+++ b/src/questfoundry/pipeline/stages/dress.py
@@ -1095,11 +1095,13 @@ class DressStage:
 
 
 def _create_cover_brief(graph: Graph) -> bool:
-    """Create a cover illustration brief from vision and art direction.
+    """Create a standalone cover illustration brief from vision and art direction.
 
     Synthesizes a cover image brief from the story's genre, tone,
     themes, and art direction. The cover gets priority 1 (must-have)
-    and category "vista".
+    and category "cover". Unlike passage briefs, the cover brief is
+    standalone — no targets edge, no synthetic passage node, no Depicts
+    edge when rendered.
 
     Args:
         graph: Story graph with vision and art_direction nodes.
@@ -1157,19 +1159,17 @@ def _create_cover_brief(graph: Graph) -> bool:
             style_overrides = ". ".join(style_parts) + "."
 
     brief_data = {
-        "category": "vista",
+        "type": "illustration_brief",
+        "category": "cover",
         "subject": subject,
         "composition": composition,
         "mood": mood,
         "caption": "",
         "style_overrides": style_overrides,
+        "priority": 1,
     }
 
-    # Ensure passage::cover exists as a synthetic anchor for the cover brief
-    if not graph.has_node("passage::cover"):
-        graph.create_node("passage::cover", {"type": "passage", "synthetic": True})
-
-    apply_dress_brief(graph, "cover", brief_data, priority=1)
+    graph.upsert_node("illustration_brief::cover", brief_data)
     log.info("cover_brief_created")
     return True
 

--- a/tests/unit/test_dress_stage.py
+++ b/tests/unit/test_dress_stage.py
@@ -1184,29 +1184,36 @@ class TestCreateCoverBrief:
         brief = g.get_node("illustration_brief::cover")
         assert brief is not None
         assert brief["priority"] == 1
-        assert brief["category"] == "vista"
+        assert brief["category"] == "cover"
         assert "space opera" in brief["subject"]
         assert "fate" in brief["subject"]
 
-    def test_creates_synthetic_passage_node(self) -> None:
+    def test_no_synthetic_passage_node(self) -> None:
         g = Graph()
         g.create_node("vision", {"type": "vision", "genre": "mystery"})
 
         _create_cover_brief(g)
 
-        passage = g.get_node("passage::cover")
-        assert passage is not None
-        assert passage.get("synthetic") is True
+        assert g.get_node("passage::cover") is None
 
-    def test_targets_edge_to_passage_cover(self) -> None:
+    def test_no_targets_edge(self) -> None:
         g = Graph()
         g.create_node("vision", {"type": "vision", "genre": "fantasy"})
 
         _create_cover_brief(g)
 
         edges = g.get_edges(from_id="illustration_brief::cover", edge_type="targets")
-        assert len(edges) == 1
-        assert edges[0]["to"] == "passage::cover"
+        assert len(edges) == 0
+
+    def test_cover_category(self) -> None:
+        g = Graph()
+        g.create_node("vision", {"type": "vision", "genre": "fantasy"})
+
+        _create_cover_brief(g)
+
+        brief = g.get_node("illustration_brief::cover")
+        assert brief is not None
+        assert brief["category"] == "cover"
 
     def test_returns_false_without_vision(self) -> None:
         g = Graph()

--- a/tests/unit/test_export_context.py
+++ b/tests/unit/test_export_context.py
@@ -213,3 +213,29 @@ class TestBuildExportContext:
 
         intro = next(p for p in ctx.passages if p.id == "passage::intro")
         assert intro.prose == "You stand at the gates."
+
+    def test_cover_illustration_separated(self) -> None:
+        g = _graph_with_dress(_minimal_graph())
+        # Add a standalone cover illustration (no Depicts edge)
+        g.create_node(
+            "illustration::cover",
+            {
+                "type": "illustration",
+                "asset": "assets/cover.png",
+                "caption": "Cover art",
+                "category": "cover",
+            },
+        )
+        ctx = build_export_context(g, "test")
+
+        assert ctx.cover is not None
+        assert ctx.cover.asset_path == "assets/cover.png"
+        assert ctx.cover.category == "cover"
+        # Cover should NOT appear in passage illustrations
+        assert all(ill.category != "cover" for ill in ctx.illustrations)
+
+    def test_no_cover_when_absent(self) -> None:
+        g = _minimal_graph()
+        ctx = build_export_context(g, "test")
+
+        assert ctx.cover is None

--- a/tests/unit/test_html_exporter.py
+++ b/tests/unit/test_html_exporter.py
@@ -249,3 +249,26 @@ class TestHtmlExporter:
         content = result.read_text()
 
         assert "art-direction" not in content
+
+    def test_cover_rendered_when_present(self, tmp_path: Path) -> None:
+        ctx = _simple_context()
+        ctx.cover = ExportIllustration(
+            passage_id="",
+            asset_path="assets/cover.png",
+            caption="Cover art",
+            category="cover",
+        )
+        exporter = HtmlExporter()
+        result = exporter.export(ctx, tmp_path / "out")
+        content = result.read_text()
+
+        assert '<figure class="cover">' in content
+        assert "assets/cover.png" in content
+        assert "Cover art" in content
+
+    def test_no_cover_when_absent(self, tmp_path: Path) -> None:
+        exporter = HtmlExporter()
+        result = exporter.export(_simple_context(), tmp_path / "out")
+        content = result.read_text()
+
+        assert '<figure class="cover">' not in content

--- a/tests/unit/test_twee_exporter.py
+++ b/tests/unit/test_twee_exporter.py
@@ -300,3 +300,25 @@ class TestTweeExporter:
         content = result.read_text()
 
         assert "StoryArtDirection" not in content
+
+    def test_cover_rendered_in_story_init(self, tmp_path: Path) -> None:
+        ctx = _simple_context()
+        ctx.cover = ExportIllustration(
+            passage_id="",
+            asset_path="assets/cover.png",
+            caption="",
+            category="cover",
+        )
+        exporter = TweeExporter()
+        result = exporter.export(ctx, tmp_path / "out")
+        content = result.read_text()
+
+        assert ":: StoryInit" in content
+        assert "[img[assets/cover.png]]" in content
+
+    def test_no_story_init_without_cover(self, tmp_path: Path) -> None:
+        exporter = TweeExporter()
+        result = exporter.export(_simple_context(), tmp_path / "out")
+        content = result.read_text()
+
+        assert ":: StoryInit" not in content


### PR DESCRIPTION
## Problem

Cover art is bibliographic metadata, not a narrative unit. The previous design created a synthetic `passage::cover` node and targeted it with a `Depicts` edge, which broke SHIP validation ("passage missing prose"). Every IF system (Twine, Inform, ink, ChoiceScript) treats cover as metadata outside the story graph.

## Changes

- **Spec** (`00-spec.md`): Add `cover` to IllustrationBrief category enum
- **Model** (`models/dress.py`): Add `"cover"` to `IllustrationCategory` literal
- **DRESS** (`dress.py`): `_create_cover_brief()` writes brief directly to graph — no synthetic passage, no targets edge
- **Mutations** (`dress_mutations.py`): `apply_dress_illustration()` handles briefs without targets edges (standalone cover) — derives illustration ID from brief ID, skips Depicts edge
- **Export base** (`base.py`): Add `cover: ExportIllustration | None` to `ExportContext`
- **Export context** (`context.py`): `_extract_illustrations()` separates cover (category="cover", no Depicts) from passage illustrations
- **HTML exporter**: Renders cover `<figure>` after `<h1>` title
- **Twee exporter**: Renders cover `[img[...]]` in StoryInit passage

## Not Included / Future PRs

- Cover rendering in JSON exporter (if needed)

## Test Plan

```
uv run pytest tests/unit/test_dress_stage.py tests/unit/test_dress_mutations.py tests/unit/test_ship_stage.py tests/unit/test_export_context.py -x -q
# 113 passed
uv run mypy src/questfoundry/models/dress.py src/questfoundry/graph/dress_mutations.py src/questfoundry/pipeline/stages/dress.py src/questfoundry/export/
# Success: no issues found in 7 source files
```

## Risk / Rollback

- Existing graphs with `passage::cover` and a targets edge to it will have their cover illustration exported to `ExportContext.cover` instead of the passage illustrations list (graceful degradation — the cover still renders).
- No feature flags needed.

**Stacked on #516** — merge #516 first, then retarget this to main.

Closes #512

🤖 Generated with [Claude Code](https://claude.com/claude-code)