### PR TITLE
feat(providers): role-based provider selection with global user config

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -641,17 +641,23 @@ Configuration follows a strict precedence order (highest to lowest):
 3. **Project config** - `project.yaml` providers.default
 4. **Defaults** - `ollama/qwen3:4b-instruct-32k`
 
-### Hybrid Provider Configuration (Phase-Specific)
+### Hybrid Provider Configuration (Role-Based)
 
-Different providers can be used for each pipeline phase (discuss, summarize, serialize). This allows using creative models for discussion and reasoning models for serialization.
+Different providers can be used for each LLM role (creative, balanced, structured). This allows using creative models for prose generation and reasoning models for structured output. Legacy phase names (discuss, summarize, serialize) are accepted as aliases.
 
-**6-level precedence chain** (per phase):
-1. Phase-specific CLI flag (`--provider-discuss`, `--provider-summarize`, `--provider-serialize`)
+**Roles**: `creative` (discuss), `balanced` (summarize), `structured` (serialize)
+
+**8-level precedence chain** (per role):
+1. Role-specific CLI flag (`--provider-creative`, `--provider-balanced`, `--provider-structured`)
 2. General CLI flag (`--provider`)
-3. Phase-specific env var (`QF_PROVIDER_DISCUSS`, `QF_PROVIDER_SUMMARIZE`, `QF_PROVIDER_SERIALIZE`)
+3. Role-specific env var (`QF_PROVIDER_CREATIVE`, `QF_PROVIDER_BALANCED`, `QF_PROVIDER_STRUCTURED`)
 4. General env var (`QF_PROVIDER`)
-5. Phase-specific config (`providers.discuss`, `providers.summarize`, `providers.serialize`)
-6. Default config (`providers.default`)
+5. Role-specific project config (`providers.creative`, `providers.balanced`, `providers.structured`)
+6. Role-specific user config (`~/.config/questfoundry/config.yaml`)
+7. Default project config (`providers.default`)
+8. Default user config
+
+Legacy CLI flags (`--provider-discuss`, etc.) and env vars (`QF_PROVIDER_DISCUSS`, etc.) are accepted as aliases.
 
 **Example project.yaml with hybrid providers:**
 ```yaml

--- a/src/questfoundry/cli.py
+++ b/src/questfoundry/cli.py
@@ -300,9 +300,9 @@ def _get_orchestrator(
     Args:
         project_path: Path to the project directory.
         provider_override: Optional provider string (e.g., "openai/gpt-5-mini") to override config.
-        provider_discuss_override: Optional provider override for discuss phase.
-        provider_summarize_override: Optional provider override for summarize phase.
-        provider_serialize_override: Optional provider override for serialize phase.
+        provider_discuss_override: Optional provider override for discuss/creative phase.
+        provider_summarize_override: Optional provider override for summarize/balanced phase.
+        provider_serialize_override: Optional provider override for serialize/structured phase.
         image_provider_override: Optional image provider override
             (e.g., "openai/gpt-image-1", "placeholder").
 
@@ -311,6 +311,7 @@ def _get_orchestrator(
     """
     from questfoundry.pipeline import PipelineOrchestrator
 
+    # Pass legacy phase names — orchestrator maps them to role names internally
     return PipelineOrchestrator(
         project_path,
         provider_override=provider_override,

--- a/src/questfoundry/pipeline/config.py
+++ b/src/questfoundry/pipeline/config.py
@@ -16,6 +16,14 @@ DEFAULT_PROVIDER = "ollama"
 DEFAULT_MODEL = "qwen3:4b-instruct-32k"
 DEFAULT_STAGES = ["dream", "brainstorm", "seed", "grow", "fill", "ship"]
 
+# Role-based provider names and their legacy aliases.
+# Maps legacy phase names to canonical role names.
+ROLE_ALIASES: dict[str, str] = {
+    "discuss": "creative",
+    "summarize": "balanced",
+    "serialize": "structured",
+}
+
 
 @dataclass
 class ProviderConfig:
@@ -27,69 +35,113 @@ class ProviderConfig:
 
 @dataclass
 class ProvidersConfig:
-    """Configuration for LLM providers with phase-specific overrides.
+    """Configuration for LLM providers with role-based overrides.
 
-    Supports hybrid model configurations where different phases use different
-    LLM providers. Each phase (discuss, summarize, serialize) can optionally
+    Supports hybrid model configurations where different roles use different
+    LLM providers. Each role (creative, balanced, structured) can optionally
     override the default provider.
+
+    Role-based names map to work types:
+    - creative: exploration, prose generation (high temperature)
+    - balanced: summarization, narrative refinement (medium temperature)
+    - structured: JSON/YAML serialization, briefs (deterministic)
+
+    Legacy phase names (discuss, summarize, serialize) are accepted as aliases.
 
     This class resolves only from project config. Environment variables and
     CLI flags are handled by the orchestrator's full precedence chain.
 
     Attributes:
         default: Default provider string (e.g., "ollama/qwen3:4b-instruct-32k"). Required.
-        discuss: Optional provider override for the discuss phase.
-        summarize: Optional provider override for the summarize phase.
-        serialize: Optional provider override for the serialize phase.
-        settings: Phase-specific model settings (temperature, top_p, seed).
+        creative: Optional provider override for creative role (alias: discuss).
+        balanced: Optional provider override for balanced role (alias: summarize).
+        structured: Optional provider override for structured role (alias: serialize).
+        image: Optional image generation provider (opt-in, no default).
+        settings: Role/phase-specific model settings (temperature, top_p, seed).
     """
 
     default: str
-    discuss: str | None = None
-    summarize: str | None = None
-    serialize: str | None = None
+    creative: str | None = None
+    balanced: str | None = None
+    structured: str | None = None
     image: str | None = None
     settings: dict[str, PhaseSettings] = field(default_factory=dict)
 
+    # Legacy aliases — read-only properties for backwards compatibility
+    @property
+    def discuss(self) -> str | None:
+        """Legacy alias for creative."""
+        return self.creative
+
+    @property
+    def summarize(self) -> str | None:
+        """Legacy alias for balanced."""
+        return self.balanced
+
+    @property
+    def serialize(self) -> str | None:
+        """Legacy alias for structured."""
+        return self.structured
+
     def get_phase_settings(self, phase: str) -> PhaseSettings:
-        """Get settings for a phase, with defaults.
+        """Get settings for a role or phase, with defaults.
+
+        Accepts both role names (creative, balanced, structured) and
+        legacy phase names (discuss, summarize, serialize).
 
         Args:
-            phase: Pipeline phase (discuss, summarize, serialize).
+            phase: Role or phase name.
 
         Returns:
-            PhaseSettings for the phase. Returns configured settings if present,
-            otherwise returns default (empty) PhaseSettings. Note that actual
-            temperature values are computed dynamically in to_model_kwargs()
-            based on the phase and provider when not explicitly configured.
+            PhaseSettings for the role/phase. Returns configured settings if
+            present, otherwise returns default (empty) PhaseSettings.
         """
         from questfoundry.providers.settings import get_default_phase_settings
 
-        return self.settings.get(phase) or get_default_phase_settings(phase)
+        # Try exact name first, then try canonical role name
+        canonical = ROLE_ALIASES.get(phase, phase)
+        return (
+            self.settings.get(phase)
+            or self.settings.get(canonical)
+            or get_default_phase_settings(phase)
+        )
 
-    def get_discuss_provider(self) -> str:
-        """Get the config-level provider for the discuss phase.
+    def get_creative_provider(self) -> str:
+        """Get the config-level provider for the creative role.
 
-        Returns phase-specific config if set, otherwise default.
+        Returns role-specific config if set, otherwise default.
         Environment variables are resolved by the orchestrator.
         """
-        return self.discuss or self.default
+        return self.creative or self.default
+
+    def get_balanced_provider(self) -> str:
+        """Get the config-level provider for the balanced role.
+
+        Returns role-specific config if set, otherwise default.
+        Environment variables are resolved by the orchestrator.
+        """
+        return self.balanced or self.default
+
+    def get_structured_provider(self) -> str:
+        """Get the config-level provider for the structured role.
+
+        Returns role-specific config if set, otherwise default.
+        Environment variables are resolved by the orchestrator.
+        """
+        return self.structured or self.default
+
+    # Legacy aliases for backwards compatibility
+    def get_discuss_provider(self) -> str:
+        """Legacy alias for get_creative_provider."""
+        return self.get_creative_provider()
 
     def get_summarize_provider(self) -> str:
-        """Get the config-level provider for the summarize phase.
-
-        Returns phase-specific config if set, otherwise default.
-        Environment variables are resolved by the orchestrator.
-        """
-        return self.summarize or self.default
+        """Legacy alias for get_balanced_provider."""
+        return self.get_balanced_provider()
 
     def get_serialize_provider(self) -> str:
-        """Get the config-level provider for the serialize phase.
-
-        Returns phase-specific config if set, otherwise default.
-        Environment variables are resolved by the orchestrator.
-        """
-        return self.serialize or self.default
+        """Legacy alias for get_structured_provider."""
+        return self.get_structured_provider()
 
     def get_image_provider(self) -> str | None:
         """Get the config-level image provider.
@@ -104,13 +156,18 @@ class ProvidersConfig:
     def from_dict(cls, data: dict[str, Any]) -> ProvidersConfig:
         """Create config from dictionary.
 
+        Accepts both role names (creative, balanced, structured) and
+        legacy phase names (discuss, summarize, serialize). Role names
+        take precedence if both are specified.
+
         Args:
             data: Dictionary with provider configuration. Can have:
                 - default: Required default provider string
-                - discuss: Optional discuss phase provider
-                - summarize: Optional summarize phase provider
-                - serialize: Optional serialize phase provider
-                - settings: Optional dict of phase -> settings
+                - creative/discuss: Optional creative role provider
+                - balanced/summarize: Optional balanced role provider
+                - structured/serialize: Optional structured role provider
+                - image: Optional image provider
+                - settings: Optional dict of role/phase -> settings
 
         Returns:
             ProvidersConfig instance.
@@ -119,17 +176,22 @@ class ProvidersConfig:
 
         default = data.get("default", f"{DEFAULT_PROVIDER}/{DEFAULT_MODEL}")
 
-        # Parse phase-specific settings
+        # Parse role-specific settings
         settings_data = data.get("settings", {})
         settings: dict[str, PhaseSettings] = {}
         for phase_name, phase_settings_data in settings_data.items():
             settings[phase_name] = PhaseSettings.from_dict(phase_settings_data)
 
+        # Accept both role names and legacy phase names (role names take precedence)
+        creative = data.get("creative") or data.get("discuss")
+        balanced = data.get("balanced") or data.get("summarize")
+        structured = data.get("structured") or data.get("serialize")
+
         return cls(
             default=default,
-            discuss=data.get("discuss"),
-            summarize=data.get("summarize"),
-            serialize=data.get("serialize"),
+            creative=creative,
+            balanced=balanced,
+            structured=structured,
             image=data.get("image"),
             settings=settings,
         )

--- a/src/questfoundry/pipeline/config.py
+++ b/src/questfoundry/pipeline/config.py
@@ -83,7 +83,7 @@ class ProvidersConfig:
         """Legacy alias for structured."""
         return self.structured
 
-    def get_phase_settings(self, phase: str) -> PhaseSettings:
+    def get_role_settings(self, phase: str) -> PhaseSettings:
         """Get settings for a role or phase, with defaults.
 
         Accepts both role names (creative, balanced, structured) and

--- a/src/questfoundry/pipeline/orchestrator.py
+++ b/src/questfoundry/pipeline/orchestrator.py
@@ -115,6 +115,9 @@ class PipelineOrchestrator:
         provider_discuss_override: str | None = None,
         provider_summarize_override: str | None = None,
         provider_serialize_override: str | None = None,
+        provider_creative_override: str | None = None,
+        provider_balanced_override: str | None = None,
+        provider_structured_override: str | None = None,
         image_provider_override: str | None = None,
         enable_llm_logging: bool = False,
     ) -> None:
@@ -125,10 +128,13 @@ class PipelineOrchestrator:
             gate: Optional gate hook for stage transitions.
                 Defaults to AutoApproveGate.
             provider_override: Optional provider string (e.g., "openai/gpt-5-mini")
-                to override the project config for all phases.
-            provider_discuss_override: Optional provider override for discuss phase.
-            provider_summarize_override: Optional provider override for summarize phase.
-            provider_serialize_override: Optional provider override for serialize phase.
+                to override the project config for all roles.
+            provider_discuss_override: Legacy alias for provider_creative_override.
+            provider_summarize_override: Legacy alias for provider_balanced_override.
+            provider_serialize_override: Legacy alias for provider_structured_override.
+            provider_creative_override: Optional provider override for creative role.
+            provider_balanced_override: Optional provider override for balanced role.
+            provider_structured_override: Optional provider override for structured role.
             image_provider_override: Optional image provider override
                 (e.g., "openai/gpt-image-1", "placeholder").
             enable_llm_logging: If True, log LLM calls to logs/llm_calls.jsonl.
@@ -137,14 +143,16 @@ class PipelineOrchestrator:
             ProjectConfigError: If project.yaml cannot be loaded.
 
         Note:
-            Phase-specific overrides take precedence over provider_override.
-            Resolution order for each phase:
-            1. Phase-specific CLI flag (e.g., --provider-discuss)
+            Role-specific overrides take precedence over provider_override.
+            Resolution order for each role (8-level chain):
+            1. Role-specific CLI flag (e.g., --provider-creative)
             2. General CLI flag (--provider)
-            3. Phase-specific env var (e.g., QF_PROVIDER_DISCUSS)
+            3. Role-specific env var (e.g., QF_PROVIDER_CREATIVE)
             4. General env var (QF_PROVIDER)
-            5. Phase-specific config (e.g., providers.discuss)
-            6. Default config (providers.default)
+            5. Role-specific project config (e.g., providers.creative)
+            6. Default project config (providers.default)
+            7. Role-specific user config (~/.config/questfoundry/config.yaml)
+            8. Default user config
 
             Image provider resolution (opt-in, no default):
             1. --image-provider CLI flag
@@ -154,9 +162,12 @@ class PipelineOrchestrator:
         self.project_path = project_path
         self._gate = gate or AutoApproveGate()
         self._provider_override = provider_override
-        self._provider_discuss_override = provider_discuss_override
-        self._provider_summarize_override = provider_summarize_override
-        self._provider_serialize_override = provider_serialize_override
+        # Role-based overrides (merge legacy + new, role names take precedence)
+        self._provider_creative_override = provider_creative_override or provider_discuss_override
+        self._provider_balanced_override = provider_balanced_override or provider_summarize_override
+        self._provider_structured_override = (
+            provider_structured_override or provider_serialize_override
+        )
         self._image_provider_override = image_provider_override
         self._enable_llm_logging = enable_llm_logging
 
@@ -169,23 +180,28 @@ class PipelineOrchestrator:
 
             self.config = create_default_config("unnamed")
 
+        # Load global user config (lowest priority)
+        from questfoundry.pipeline.user_config import load_user_config
+
+        self._user_config = load_user_config()
+
         # Initialize components
         self._reader = ArtifactReader(project_path)
         self._writer = ArtifactWriter(project_path)
         self._validator = ArtifactValidator()
 
-        # Chat models will be lazily initialized (one per phase for hybrid support)
-        self._chat_model: BaseChatModel | None = None  # Default/discuss model
-        self._summarize_model: BaseChatModel | None = None
-        self._serialize_model: BaseChatModel | None = None
+        # Chat models will be lazily initialized (one per role for hybrid support)
+        self._creative_model: BaseChatModel | None = None
+        self._balanced_model: BaseChatModel | None = None
+        self._structured_model: BaseChatModel | None = None
 
-        # Provider/model names for each phase
-        self._provider_name: str | None = None  # Discuss phase provider
-        self._model_name: str | None = None  # Discuss phase model
-        self._summarize_provider_name: str | None = None
-        self._summarize_model_name: str | None = None
-        self._serialize_provider_name: str | None = None
-        self._serialize_model_name: str | None = None
+        # Provider/model names for each role
+        self._provider_name: str | None = None  # Creative role provider
+        self._model_name: str | None = None  # Creative role model
+        self._balanced_provider_name: str | None = None
+        self._balanced_model_name: str | None = None
+        self._structured_provider_name: str | None = None
+        self._structured_model_name: str | None = None
 
         # Model info (set when model is created)
         self._model_info: ModelInfo | None = None
@@ -272,91 +288,110 @@ class PipelineOrchestrator:
 
             self._callbacks = create_logging_callbacks(self._llm_logger)
 
-    def _get_resolved_discuss_provider(self) -> str:
-        """Get the final resolved provider string for discuss phase.
+    def _get_resolved_role_provider(self, role: str) -> str:
+        """Get the final resolved provider string for a role.
 
-        Applies full precedence chain:
-        1. --provider-discuss CLI flag
-        2. --provider CLI flag
-        3. QF_PROVIDER_DISCUSS env var
-        4. QF_PROVIDER env var
-        5. providers.discuss config
-        6. providers.default config
+        Applies full 8-level precedence chain:
+        1. Role-specific CLI flag (e.g., --provider-creative)
+        2. General CLI flag (--provider)
+        3. Role-specific env var (e.g., QF_PROVIDER_CREATIVE)
+        4. General env var (QF_PROVIDER)
+        5. Role-specific project config (e.g., providers.creative)
+        6. Default project config (providers.default)
+        7. Role-specific user config
+        8. Default user config
+
+        Also checks legacy env vars (QF_PROVIDER_DISCUSS, etc.) for
+        backwards compatibility.
+
+        Args:
+            role: Provider role ("creative", "balanced", "structured").
 
         Returns:
             The resolved provider string (e.g., "ollama/qwen3:4b-instruct-32k").
         """
-        return (
-            self._provider_discuss_override
-            or self._provider_override
-            or os.environ.get("QF_PROVIDER_DISCUSS")
-            or os.environ.get("QF_PROVIDER")
-            or self.config.providers.get_discuss_provider()
-        )
+        # Map roles to their CLI overrides and config methods
+        role_map = {
+            "creative": (
+                self._provider_creative_override,
+                self.config.providers.get_creative_provider,
+                "QF_PROVIDER_CREATIVE",
+                "QF_PROVIDER_DISCUSS",  # Legacy env var
+            ),
+            "balanced": (
+                self._provider_balanced_override,
+                self.config.providers.get_balanced_provider,
+                "QF_PROVIDER_BALANCED",
+                "QF_PROVIDER_SUMMARIZE",  # Legacy env var
+            ),
+            "structured": (
+                self._provider_structured_override,
+                self.config.providers.get_structured_provider,
+                "QF_PROVIDER_STRUCTURED",
+                "QF_PROVIDER_SERIALIZE",  # Legacy env var
+            ),
+        }
 
-    def _get_chat_model(self) -> BaseChatModel:
-        """Get or create the LangChain chat model for discuss phase.
+        cli_override, config_getter, env_var, legacy_env_var = role_map[role]
 
-        Uses `_get_resolved_discuss_provider()` for provider resolution.
-        See that method for the full 6-level precedence chain.
-
-        Returns:
-            Configured BaseChatModel.
-        """
-        if self._chat_model is not None:
-            return self._chat_model
-
-        self._ensure_callbacks_initialized()
-
-        provider_string = self._get_resolved_discuss_provider()
-        chat_model, provider_name, model = self._create_model_for_provider(
-            provider_string, phase="discuss"
-        )
-
-        self._provider_name = provider_name
-        self._model_name = model
-
-        # Store model info for context budget awareness (discuss phase only)
-        # Note: summarize/serialize phases use fixed-size inputs where context
-        # budgeting is less critical
-        self._model_info = get_model_info(provider_name, model)
-
-        self._chat_model = chat_model
-        return self._chat_model
-
-    def _get_resolved_phase_provider(self, phase: Literal["summarize", "serialize"]) -> str:
-        """Get the final resolved provider string for a specific phase.
-
-        Applies full precedence chain:
-        1. Phase-specific CLI flag (e.g., --provider-summarize)
-        2. General CLI flag (--provider)
-        3. Phase-specific env var (e.g., QF_PROVIDER_SUMMARIZE)
-        4. General env var (QF_PROVIDER)
-        5. Phase-specific config (e.g., providers.summarize)
-        6. Default config (providers.default)
-
-        Args:
-            phase: The pipeline phase ("summarize" or "serialize").
-
-        Returns:
-            The resolved provider string (e.g., "openai/gpt-5-mini").
-        """
-        if phase == "summarize":
-            cli_override = self._provider_summarize_override
-            config_provider = self.config.providers.get_summarize_provider()
-            env_var = "QF_PROVIDER_SUMMARIZE"
-        else:  # serialize
-            cli_override = self._provider_serialize_override
-            config_provider = self.config.providers.get_serialize_provider()
-            env_var = "QF_PROVIDER_SERIALIZE"
+        # User config fallback (levels 7-8)
+        user_default = None
+        user_role = None
+        if self._user_config:
+            user_default = self._user_config.default
+            user_role_getter = getattr(self._user_config, f"get_{role}_provider", None)
+            if user_role_getter:
+                user_role_value = user_role_getter()
+                # Only use if different from user default (means it was explicitly set)
+                if user_role_value != self._user_config.default:
+                    user_role = user_role_value
 
         return (
             cli_override
             or self._provider_override
             or os.environ.get(env_var)
+            or os.environ.get(legacy_env_var)
             or os.environ.get("QF_PROVIDER")
-            or config_provider
+            or config_getter()  # Levels 5-6 (role config → default config)
+            or user_role  # Level 7
+            or user_default  # Level 8
+            or self.config.providers.default  # Final fallback
         )
+
+    # Legacy aliases
+    def _get_resolved_discuss_provider(self) -> str:
+        """Legacy alias for _get_resolved_role_provider('creative')."""
+        return self._get_resolved_role_provider("creative")
+
+    def _get_resolved_phase_provider(self, phase: Literal["summarize", "serialize"]) -> str:
+        """Legacy alias for role-based resolution."""
+        role = "balanced" if phase == "summarize" else "structured"
+        return self._get_resolved_role_provider(role)
+
+    def _get_chat_model(self) -> BaseChatModel:
+        """Get or create the LangChain chat model for creative role (discuss phase).
+
+        Returns:
+            Configured BaseChatModel.
+        """
+        if self._creative_model is not None:
+            return self._creative_model
+
+        self._ensure_callbacks_initialized()
+
+        provider_string = self._get_resolved_role_provider("creative")
+        chat_model, provider_name, model = self._create_model_for_provider(
+            provider_string, phase="creative"
+        )
+
+        self._provider_name = provider_name
+        self._model_name = model
+
+        # Store model info for context budget awareness
+        self._model_info = get_model_info(provider_name, model)
+
+        self._creative_model = chat_model
+        return self._creative_model
 
     def _get_resolved_image_provider(self) -> str | None:
         """Get the final resolved image provider string.
@@ -378,72 +413,65 @@ class PipelineOrchestrator:
             or self.config.providers.get_image_provider()
         )
 
-    def _get_phase_model(
+    def _get_role_model(
         self,
-        phase: Literal["summarize", "serialize"],
+        role: Literal["balanced", "structured"],
     ) -> BaseChatModel:
-        """Get or create the LangChain chat model for a specific phase.
+        """Get or create the LangChain chat model for a specific role.
 
-        Always creates a separate model instance for each phase since
-        model settings (temperature, top_p, seed) differ per phase.
-        Models are lazily created and cached per phase.
+        Always creates a separate model instance for each role since
+        model settings (temperature, top_p, seed) differ per role.
+        Models are lazily created and cached per role.
 
         Args:
-            phase: The pipeline phase ("summarize" or "serialize").
+            role: The provider role ("balanced" or "structured").
 
         Returns:
-            Configured BaseChatModel for the specified phase.
+            Configured BaseChatModel for the specified role.
         """
         # Check cached model first
-        cached_model = self._summarize_model if phase == "summarize" else self._serialize_model
+        cached_model = self._balanced_model if role == "balanced" else self._structured_model
 
         # Return cached model if available
         if cached_model is not None:
             return cached_model
 
-        # Get provider for this phase
-        phase_provider = self._get_resolved_phase_provider(phase)
+        # Get provider for this role
+        role_provider = self._get_resolved_role_provider(role)
 
-        # Create new model with phase-specific settings
-        # (always separate from discuss model since settings differ)
+        # Create new model with role-specific settings
         self._ensure_callbacks_initialized()
         chat_model, provider_name, model = self._create_model_for_provider(
-            phase_provider, phase=phase
+            role_provider, phase=role
         )
 
         # Cache the model and metadata
-        if phase == "summarize":
-            self._summarize_provider_name = provider_name
-            self._summarize_model_name = model
-            self._summarize_model = chat_model
-        else:  # serialize
-            self._serialize_provider_name = provider_name
-            self._serialize_model_name = model
-            self._serialize_model = chat_model
+        if role == "balanced":
+            self._balanced_provider_name = provider_name
+            self._balanced_model_name = model
+            self._balanced_model = chat_model
+        else:  # structured
+            self._structured_provider_name = provider_name
+            self._structured_model_name = model
+            self._structured_model = chat_model
 
         return chat_model
 
     def _get_summarize_model(self) -> BaseChatModel:
-        """Get or create the LangChain chat model for summarize phase.
-
-        Uses the summarize-specific provider if configured, otherwise falls
-        back to the discuss model.
+        """Get or create the LangChain chat model for balanced role (summarize phase).
 
         Returns:
-            Configured BaseChatModel for summarize phase.
+            Configured BaseChatModel for balanced role.
         """
-        return self._get_phase_model("summarize")
+        return self._get_role_model("balanced")
 
     def _get_serialize_model(self) -> BaseChatModel:
-        """Get or create the LangChain chat model for serialize phase.
-
-        Uses the serialize-specific provider if configured, otherwise falls
-        back to the discuss model.
+        """Get or create the LangChain chat model for structured role (serialize phase).
 
         Returns:
-            Configured BaseChatModel for serialize phase.
+            Configured BaseChatModel for structured role.
         """
-        return self._get_phase_model("serialize")
+        return self._get_role_model("structured")
 
     @property
     def model_info(self) -> ModelInfo | None:
@@ -522,9 +550,9 @@ class PipelineOrchestrator:
             # Build Ollama model-eviction hooks for phase transitions.
             # When switching from one Ollama model to a different one,
             # send keep_alive=0 to free VRAM before the new model loads.
-            discuss_provider = self._get_resolved_discuss_provider()
-            summarize_provider = self._get_resolved_phase_provider("summarize")
-            serialize_provider = self._get_resolved_phase_provider("serialize")
+            discuss_provider = self._get_resolved_role_provider("creative")
+            summarize_provider = self._get_resolved_role_provider("balanced")
+            serialize_provider = self._get_resolved_role_provider("structured")
 
             async def _noop() -> None:
                 pass
@@ -591,11 +619,11 @@ class PipelineOrchestrator:
                 on_llm_end=on_llm_end,
                 project_path=self.project_path,
                 callbacks=self._callbacks,
-                # Hybrid model support: pass phase-specific models
+                # Hybrid model support: pass role-specific models
                 summarize_model=summarize_model,
                 serialize_model=serialize_model,
-                summarize_provider_name=self._summarize_provider_name,
-                serialize_provider_name=self._serialize_provider_name,
+                summarize_provider_name=self._balanced_provider_name,
+                serialize_provider_name=self._structured_provider_name,
                 # Ollama model-eviction hooks (no-ops when same model across phases)
                 unload_after_discuss=unload_after_discuss,
                 unload_after_summarize=unload_after_summarize,
@@ -764,12 +792,12 @@ class PipelineOrchestrator:
 
     async def close(self) -> None:
         """Close the orchestrator and release resources."""
-        if self._chat_model is not None:
+        if self._creative_model is not None:
             # Some chat models may have async close methods
-            if hasattr(self._chat_model, "close"):
-                close_method = self._chat_model.close
+            if hasattr(self._creative_model, "close"):
+                close_method = self._creative_model.close
                 if callable(close_method):
                     result = close_method()
                     if hasattr(result, "__await__"):
                         await result
-            self._chat_model = None
+            self._creative_model = None

--- a/src/questfoundry/pipeline/stages/fill.py
+++ b/src/questfoundry/pipeline/stages/fill.py
@@ -380,9 +380,9 @@ class FillStage:
         user_text = template.user.format(**context) if template.user else None
 
         if creative:
-            # Use discuss-phase model for creative output (prose generation).
-            # The serialize model has DETERMINISTIC temperature (0.0) which
-            # causes severe self-plagiarism and lexical collapse in prose.
+            # Use creative-role model for prose generation.
+            # The structured-role model has DETERMINISTIC temperature (0.0)
+            # which causes severe self-plagiarism and lexical collapse.
             effective_model = model
             effective_provider = self._provider_name
         else:

--- a/src/questfoundry/pipeline/user_config.py
+++ b/src/questfoundry/pipeline/user_config.py
@@ -1,0 +1,61 @@
+"""Global user configuration loading.
+
+Reads user-level provider defaults from ~/.config/questfoundry/config.yaml.
+This is the lowest-priority source in the provider resolution chain, below
+CLI flags, environment variables, and project config.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from questfoundry.observability.logging import get_logger
+
+if TYPE_CHECKING:
+    from questfoundry.pipeline.config import ProvidersConfig
+
+log = get_logger(__name__)
+
+# XDG-compliant default config directory
+_DEFAULT_CONFIG_DIR = Path.home() / ".config" / "questfoundry"
+
+
+def load_user_config(config_dir: Path | None = None) -> ProvidersConfig | None:
+    """Load global user provider configuration.
+
+    Args:
+        config_dir: Override config directory (for testing).
+            Defaults to ~/.config/questfoundry/.
+
+    Returns:
+        ProvidersConfig from user config, or None if file doesn't exist.
+    """
+    config_dir = config_dir or _DEFAULT_CONFIG_DIR
+    config_path = config_dir / "config.yaml"
+
+    if not config_path.exists():
+        return None
+
+    from ruamel.yaml import YAML
+
+    from questfoundry.pipeline.config import ProvidersConfig
+
+    yaml = YAML()
+    try:
+        with config_path.open("r", encoding="utf-8") as f:
+            data = yaml.load(f)
+
+        if data is None:
+            return None
+
+        providers_data = dict(data).get("providers", {})
+        if not providers_data:
+            return None
+
+        config = ProvidersConfig.from_dict(providers_data)
+        log.debug("user_config_loaded", path=str(config_path))
+        return config
+    except Exception as e:
+        log.warning("user_config_load_failed", path=str(config_path), error=str(e))
+        return None

--- a/src/questfoundry/pipeline/user_config.py
+++ b/src/questfoundry/pipeline/user_config.py
@@ -56,6 +56,6 @@ def load_user_config(config_dir: Path | None = None) -> ProvidersConfig | None:
         config = ProvidersConfig.from_dict(providers_data)
         log.debug("user_config_loaded", path=str(config_path))
         return config
-    except Exception as e:
+    except (OSError, ValueError) as e:
         log.warning("user_config_load_failed", path=str(config_path), error=str(e))
         return None

--- a/src/questfoundry/providers/settings.py
+++ b/src/questfoundry/providers/settings.py
@@ -55,12 +55,17 @@ TEMPERATURE_MAP: dict[str, dict[CreativityLevel, float]] = {
     },
 }
 
-# Phase defaults (semantic level, not raw temperature)
+# Role defaults (semantic level, not raw temperature)
 # Based on agent prompt engineering best practices:
-# - discuss: high creativity for exploration
-# - summarize: balanced for coherent narratives
-# - serialize: deterministic for structured output
+# - creative: high creativity for exploration and prose generation
+# - balanced: balanced for coherent narratives and summarization
+# - structured: deterministic for structured output and serialization
 PHASE_CREATIVITY: dict[str, CreativityLevel] = {
+    # Role-based names (primary)
+    "creative": CreativityLevel.CREATIVE,
+    "balanced": CreativityLevel.BALANCED,
+    "structured": CreativityLevel.DETERMINISTIC,
+    # Legacy phase names (aliases)
     "discuss": CreativityLevel.CREATIVE,
     "summarize": CreativityLevel.BALANCED,
     "serialize": CreativityLevel.DETERMINISTIC,

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -392,8 +392,8 @@ class TestProvidersConfigSettings:
 
         assert config.settings == {}
 
-    def test_get_phase_settings_returns_configured(self) -> None:
-        """get_phase_settings returns configured settings."""
+    def test_get_role_settings_returns_configured(self) -> None:
+        """get_role_settings returns configured settings."""
         from questfoundry.providers.settings import PhaseSettings
 
         config = ProvidersConfig(
@@ -401,19 +401,19 @@ class TestProvidersConfigSettings:
             settings={"discuss": PhaseSettings(temperature=0.95)},
         )
 
-        settings = config.get_phase_settings("discuss")
+        settings = config.get_role_settings("discuss")
         assert settings.temperature == 0.95
 
-    def test_get_phase_settings_returns_defaults_when_not_configured(self) -> None:
-        """get_phase_settings returns defaults when phase not in settings."""
+    def test_get_role_settings_returns_defaults_when_not_configured(self) -> None:
+        """get_role_settings returns defaults when phase not in settings."""
         config = ProvidersConfig(default="ollama/qwen3:4b-instruct-32k")
 
-        settings = config.get_phase_settings("discuss")
+        settings = config.get_role_settings("discuss")
         # Default settings have no explicit temperature (uses phase/provider default)
         assert settings.temperature is None
 
-    def test_get_phase_settings_merges_with_defaults(self) -> None:
-        """get_phase_settings merges configured with defaults."""
+    def test_get_role_settings_merges_with_defaults(self) -> None:
+        """get_role_settings merges configured with defaults."""
         from questfoundry.providers.settings import PhaseSettings
 
         # Configure only temperature, leave top_p as default
@@ -422,12 +422,12 @@ class TestProvidersConfigSettings:
             settings={"discuss": PhaseSettings(temperature=0.95)},
         )
 
-        settings = config.get_phase_settings("discuss")
+        settings = config.get_role_settings("discuss")
         assert settings.temperature == 0.95
         assert settings.top_p is None  # Not configured, uses default
 
-    def test_get_phase_settings_resolves_role_aliases(self) -> None:
-        """get_phase_settings resolves legacy phase names to role names in settings."""
+    def test_get_role_settings_resolves_role_aliases(self) -> None:
+        """get_role_settings resolves legacy phase names to role names in settings."""
         from questfoundry.providers.settings import PhaseSettings
 
         config = ProvidersConfig(
@@ -436,7 +436,7 @@ class TestProvidersConfigSettings:
         )
 
         # Looking up "discuss" should find "creative" settings via alias
-        settings = config.get_phase_settings("discuss")
+        settings = config.get_role_settings("discuss")
         assert settings.temperature == 0.95
 
 

--- a/tests/unit/test_orchestrator.py
+++ b/tests/unit/test_orchestrator.py
@@ -36,27 +36,27 @@ def mock_provider() -> MagicMock:
 
 
 def _inject_mock_models(orchestrator: PipelineOrchestrator) -> MagicMock:
-    """Inject mock models for all phases (discuss, summarize, serialize).
+    """Inject mock models for all roles (creative, balanced, structured).
 
-    This helper sets up mocks for the chat model and phase-specific models
+    This helper sets up mocks for the chat model and role-specific models
     that would otherwise require provider configuration (e.g., OLLAMA_HOST).
 
     Returns:
-        The mock model instance used for all phases.
+        The mock model instance used for all roles.
     """
     mock_model = MagicMock()
-    # Discuss phase model
-    orchestrator._chat_model = mock_model
+    # Creative role model
+    orchestrator._creative_model = mock_model
     orchestrator._provider_name = "mock"
     orchestrator._model_name = "mock-model"
-    # Summarize phase model
-    orchestrator._summarize_model = mock_model
-    orchestrator._summarize_provider_name = "mock"
-    orchestrator._summarize_model_name = "mock-model"
-    # Serialize phase model
-    orchestrator._serialize_model = mock_model
-    orchestrator._serialize_provider_name = "mock"
-    orchestrator._serialize_model_name = "mock-model"
+    # Balanced role model
+    orchestrator._balanced_model = mock_model
+    orchestrator._balanced_provider_name = "mock"
+    orchestrator._balanced_model_name = "mock-model"
+    # Structured role model
+    orchestrator._structured_model = mock_model
+    orchestrator._structured_provider_name = "mock"
+    orchestrator._structured_model_name = "mock-model"
     return mock_model
 
 
@@ -241,7 +241,7 @@ def test_orchestrator_model_info_after_model_creation(tmp_path: Path) -> None:
     orchestrator = PipelineOrchestrator(tmp_path)
     # Inject mock chat model and model info directly
     mock_model = MagicMock()
-    orchestrator._chat_model = mock_model
+    orchestrator._creative_model = mock_model
     orchestrator._provider_name = "openai"
     orchestrator._model_name = "gpt-5-mini"
 
@@ -375,12 +375,12 @@ async def test_orchestrator_close_sync(tmp_path: Path) -> None:
     # Inject mock chat model directly
     mock_model = MagicMock()
     mock_model.close = MagicMock(return_value=None)  # Sync close
-    orchestrator._chat_model = mock_model
+    orchestrator._creative_model = mock_model
 
     # Close orchestrator
     await orchestrator.close()
 
-    assert orchestrator._chat_model is None
+    assert orchestrator._creative_model is None
     mock_model.close.assert_called_once()
 
 
@@ -391,12 +391,12 @@ async def test_orchestrator_close_async(tmp_path: Path) -> None:
     # Inject mock chat model with async close
     mock_model = MagicMock()
     mock_model.close = AsyncMock(return_value=None)  # Async close
-    orchestrator._chat_model = mock_model
+    orchestrator._creative_model = mock_model
 
     # Close orchestrator
     await orchestrator.close()
 
-    assert orchestrator._chat_model is None
+    assert orchestrator._creative_model is None
     mock_model.close.assert_awaited_once()
 
 
@@ -606,9 +606,10 @@ def test_orchestrator_stores_phase_overrides(tmp_path: Path) -> None:
     )
 
     assert orchestrator._provider_override == "ollama/default"
-    assert orchestrator._provider_discuss_override == "ollama/discuss"
-    assert orchestrator._provider_summarize_override == "openai/gpt-5-mini"
-    assert orchestrator._provider_serialize_override == "openai/o1-mini"
+    # Legacy params are mapped to role-based attributes
+    assert orchestrator._provider_creative_override == "ollama/discuss"
+    assert orchestrator._provider_balanced_override == "openai/gpt-5-mini"
+    assert orchestrator._provider_structured_override == "openai/o1-mini"
 
 
 def test_orchestrator_discuss_override_precedence(tmp_path: Path) -> None:


### PR DESCRIPTION
## Problem

Phase-based provider selection (discuss/summarize/serialize) doesn't map to all LLM work types. The FILL stage uses a `creative=True` workaround, and there's no global user config for provider defaults.

Closes #521

## Changes

- **`providers/settings.py`**: Add `creative`, `balanced`, `structured` as primary keys in `PHASE_CREATIVITY` mapping (legacy phase names kept as aliases)
- **`pipeline/config.py`**: Replace `discuss`/`summarize`/`serialize` fields with `creative`/`balanced`/`structured` in `ProvidersConfig`. Legacy names become `@property` aliases. `from_dict()` accepts both naming schemes. Add role-based resolver methods.
- **`pipeline/user_config.py`** (new): Global user config loader reading `~/.config/questfoundry/config.yaml`
- **`pipeline/orchestrator.py`**: Extend 6-level precedence chain to 8-level: role CLI → general CLI → role env → legacy env → general env → project config → user config → user default. Rename internal caches from phase to role names. Legacy methods delegate to role-based resolution.
- **`cli.py`**, **`stages/fill.py`**: Update docs/comments for role-based terminology

## Not Included / Future PRs

- New `--provider-creative`/`--provider-balanced`/`--provider-structured` CLI flags (existing `--provider-discuss` etc. work through legacy mapping)
- `image` role provider resolution (#519)
- LLM batching (#518) and multi-language (#496) are separate PRs

## Test Plan

```
uv run pytest tests/unit/test_config.py tests/unit/test_orchestrator.py tests/unit/test_cli.py -x -q
# 150 passed
uv run mypy src/questfoundry/pipeline/config.py src/questfoundry/pipeline/orchestrator.py src/questfoundry/pipeline/user_config.py src/questfoundry/providers/settings.py
# Success: no issues found
uv run ruff check src/questfoundry/pipeline/ src/questfoundry/providers/ src/questfoundry/cli.py
# All checks passed
```

## Risk / Rollback

- Fully backwards compatible: existing project configs, CLI flags, and env vars continue to work unchanged
- Role-based names take precedence when both old and new names are specified in config
- No runtime behavior changes for existing users

## Review Guide

Suggested review order:
1. `src/questfoundry/providers/settings.py` — small, sets context
2. `src/questfoundry/pipeline/config.py` — core abstraction changes
3. `src/questfoundry/pipeline/user_config.py` — new file, standalone
4. `src/questfoundry/pipeline/orchestrator.py` — main integration
5. `tests/` — validation

🤖 Generated with [Claude Code](https://claude.com/claude-code)