### PR TITLE
feat(i18n): multi-language interactive fiction generation (#496)

### DIFF
--- a/prompts/templates/dress_brief.yaml
+++ b/prompts/templates/dress_brief.yaml
@@ -55,6 +55,8 @@ system: |
     - -1: Less visually interesting than structure suggests
     - -2: Mostly dialogue/internal, poor illustration candidate
 
+  {output_language_instruction}
+
   ## Guidelines
   - Match the global art direction style and palette
   - Use entity visual references for consistent depiction

--- a/prompts/templates/dress_codex.yaml
+++ b/prompts/templates/dress_codex.yaml
@@ -23,6 +23,8 @@ system: |
   - visible_when: List of codeword IDs that must be unlocked to see this entry (empty for rank 1)
   - content: Diegetic text — written in the story's voice, not meta-commentary
 
+  {output_language_instruction}
+
   ## Rules
   - Rank 1 entry MUST have empty visible_when (always visible to player)
   - Higher rank entries should require relevant codewords

--- a/prompts/templates/fill_phase0_voice.yaml
+++ b/prompts/templates/fill_phase0_voice.yaml
@@ -49,6 +49,8 @@ system: |
   - Good: "The Hollow Crown", "Beneath the Crimson Tide", "Whispers at Dawnbreak"
   - Bad: "Adventure Story", "The Quest", "A Dark Tale"
 
+  {output_language_instruction}
+
   ## Output Format
   Return a JSON object with a "voice" field containing the voice document
   and a "story_title" field with the title string.

--- a/prompts/templates/fill_phase1_prose.yaml
+++ b/prompts/templates/fill_phase1_prose.yaml
@@ -70,6 +70,8 @@ system: |
   ## Vocabulary Note
   {vocabulary_note}
 
+  {output_language_instruction}
+
   ## Rules
 
   1. Follow the voice document for POV, tense, register, rhythm, and tone

--- a/prompts/templates/fill_phase3_revision.yaml
+++ b/prompts/templates/fill_phase3_revision.yaml
@@ -36,6 +36,8 @@ system: |
   - **flat_prose**: Add sensory detail, emotional interiority, and dilemma
     tension. Show, don't tell. Ground the reader in the moment.
 
+  {output_language_instruction}
+
   ## Rules
 
   1. Fix the flagged issue specifically — don't rewrite from scratch unless necessary

--- a/prompts/templates/grow_phase9_choices.yaml
+++ b/prompts/templates/grow_phase9_choices.yaml
@@ -27,6 +27,8 @@ system: |
   ## Divergence Points to Label
   {divergence_context}
 
+  {output_language_instruction}
+
   ## Label Design Rules
   1. Each label should be 3-8 words, written as an action phrase
   2. Labels at the same divergence point must be clearly distinct

--- a/src/questfoundry/export/base.py
+++ b/src/questfoundry/export/base.py
@@ -90,6 +90,7 @@ class ExportContext:
     cover: ExportIllustration | None = None
     codex_entries: list[ExportCodexEntry] = field(default_factory=list)
     art_direction: dict[str, Any] | None = None
+    language: str = "en"
 
 
 class Exporter(Protocol):

--- a/src/questfoundry/export/context.py
+++ b/src/questfoundry/export/context.py
@@ -25,12 +25,13 @@ if TYPE_CHECKING:
 log = get_logger(__name__)
 
 
-def build_export_context(graph: Graph, project_name: str) -> ExportContext:
+def build_export_context(graph: Graph, project_name: str, *, language: str = "en") -> ExportContext:
     """Extract player-facing data from the story graph.
 
     Args:
         graph: Loaded story graph.
         project_name: Project name used as story title.
+        language: ISO 639-1 language code for UI strings.
 
     Returns:
         ExportContext containing all data needed by exporters.
@@ -58,6 +59,7 @@ def build_export_context(graph: Graph, project_name: str) -> ExportContext:
         cover=cover,
         codex_entries=_extract_codex_entries(graph),
         art_direction=_extract_art_direction(graph),
+        language=language,
     )
 
 

--- a/src/questfoundry/export/i18n.py
+++ b/src/questfoundry/export/i18n.py
@@ -93,7 +93,7 @@ def get_ui_strings(language: str) -> dict[str, str]:
     Returns:
         Dictionary of UI string keys to localized values.
     """
-    return UI_STRINGS.get(language.lower(), UI_STRINGS["en"])
+    return {**UI_STRINGS["en"], **UI_STRINGS.get(language.lower(), {})}
 
 
 def get_output_language_instruction(language: str) -> str:

--- a/src/questfoundry/export/i18n.py
+++ b/src/questfoundry/export/i18n.py
@@ -1,0 +1,118 @@
+"""Internationalization for export UI strings.
+
+Maps ISO 639-1 language codes to player-facing UI strings used in
+exported HTML and Twee files. Falls back to English for unknown codes.
+"""
+
+from __future__ import annotations
+
+# ISO 639-1 code → full language name (for LLM prompt instructions).
+LANGUAGE_NAMES: dict[str, str] = {
+    "en": "English",
+    "nl": "Dutch",
+    "de": "German",
+    "fr": "French",
+    "es": "Spanish",
+    "it": "Italian",
+    "pt": "Portuguese",
+    "ja": "Japanese",
+    "ko": "Korean",
+    "zh": "Chinese",
+    "ru": "Russian",
+    "pl": "Polish",
+    "sv": "Swedish",
+    "da": "Danish",
+    "no": "Norwegian",
+}
+
+# UI strings per language for export chrome (buttons, labels, headings).
+UI_STRINGS: dict[str, dict[str, str]] = {
+    "en": {
+        "the_end": "The End",
+        "codex": "Codex",
+        "cover_alt": "Cover illustration",
+        "continue": "continue",
+    },
+    "nl": {
+        "the_end": "Einde",
+        "codex": "Codex",
+        "cover_alt": "Omslagillustratie",
+        "continue": "verder",
+    },
+    "de": {
+        "the_end": "Ende",
+        "codex": "Kodex",
+        "cover_alt": "Titelbild",
+        "continue": "weiter",
+    },
+    "fr": {
+        "the_end": "Fin",
+        "codex": "Codex",
+        "cover_alt": "Illustration de couverture",
+        "continue": "continuer",
+    },
+    "es": {
+        "the_end": "Fin",
+        "codex": "Códice",
+        "cover_alt": "Ilustración de portada",
+        "continue": "continuar",
+    },
+    "it": {
+        "the_end": "Fine",
+        "codex": "Codex",
+        "cover_alt": "Illustrazione di copertina",
+        "continue": "continua",
+    },
+    "pt": {
+        "the_end": "Fim",
+        "codex": "Códice",
+        "cover_alt": "Ilustração de capa",
+        "continue": "continuar",
+    },
+}
+
+
+def get_language_name(code: str) -> str:
+    """Get full language name from ISO 639-1 code.
+
+    Args:
+        code: ISO 639-1 language code (e.g., "en", "nl").
+
+    Returns:
+        Full language name, or the code itself if unknown.
+    """
+    return LANGUAGE_NAMES.get(code.lower(), code)
+
+
+def get_ui_strings(language: str) -> dict[str, str]:
+    """Get UI strings for a language, falling back to English.
+
+    Args:
+        language: ISO 639-1 language code.
+
+    Returns:
+        Dictionary of UI string keys to localized values.
+    """
+    return UI_STRINGS.get(language.lower(), UI_STRINGS["en"])
+
+
+def get_output_language_instruction(language: str) -> str:
+    """Build a prompt instruction for output language.
+
+    Returns an empty string for English (no instruction needed).
+    For other languages, returns an instruction telling the LLM to
+    write player-facing content in the target language.
+
+    Args:
+        language: ISO 639-1 language code.
+
+    Returns:
+        Language instruction string, or empty string for English.
+    """
+    if language.lower() == "en":
+        return ""
+    name = get_language_name(language)
+    return (
+        f"Write all narrative content in {name}. "
+        f"Keep structural IDs, field names, and enums in English."
+    )

--- a/src/questfoundry/export/twee_exporter.py
+++ b/src/questfoundry/export/twee_exporter.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import uuid
 from typing import TYPE_CHECKING, Any
 
+from questfoundry.export.i18n import get_ui_strings
 from questfoundry.observability.logging import get_logger
 
 if TYPE_CHECKING:
@@ -84,8 +85,9 @@ class TweeExporter:
             lines.append("")
 
         # Codex passage (if DRESS produced codex entries)
+        ui = get_ui_strings(context.language)
         if context.codex_entries:
-            lines.extend(_render_codex_passage(context.codex_entries))
+            lines.extend(_render_codex_passage(context.codex_entries, ui=ui))
             lines.append("")
 
         # Art direction metadata passage (if DRESS produced art direction)
@@ -205,13 +207,18 @@ def _render_choice(choice: ExportChoice) -> str:
     return link
 
 
-def _render_codex_passage(codex_entries: list[ExportCodexEntry]) -> list[str]:
+def _render_codex_passage(
+    codex_entries: list[ExportCodexEntry],
+    *,
+    ui: dict[str, str] | None = None,
+) -> list[str]:
     """Render a Codex passage with conditionally visible entries.
 
     Entries are sorted by rank. Each entry is wrapped in an ``<<if>>``
     block if it has ``visible_when`` codewords.
     """
-    lines = [":: Codex"]
+    codex_label = (ui or {}).get("codex", "Codex")
+    lines = [f":: {codex_label}"]
 
     sorted_entries = sorted(codex_entries, key=lambda e: e.rank)
     for entry in sorted_entries:

--- a/src/questfoundry/pipeline/config.py
+++ b/src/questfoundry/pipeline/config.py
@@ -259,6 +259,7 @@ class ProjectConfig:
     stages: list[str] = field(default_factory=lambda: list(DEFAULT_STAGES))
     gates: list[GateConfig] = field(default_factory=list)
     research_tools: ResearchToolsConfig = field(default_factory=ResearchToolsConfig)
+    language: str = "en"
 
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> ProjectConfig:
@@ -309,6 +310,7 @@ class ProjectConfig:
             stages=stages,
             gates=gates,
             research_tools=research_tools,
+            language=data.get("language", "en"),
         )
 
 

--- a/src/questfoundry/pipeline/orchestrator.py
+++ b/src/questfoundry/pipeline/orchestrator.py
@@ -585,6 +585,7 @@ class PipelineOrchestrator:
             stage_kwargs: dict[str, Any] = {}
             if self._model_info is not None:
                 stage_kwargs["max_concurrency"] = self._model_info.max_concurrency
+            stage_kwargs["language"] = self.config.language
             if resume_from:
                 stage_kwargs["resume_from"] = resume_from
             if on_phase_progress:

--- a/src/questfoundry/pipeline/stages/dress.py
+++ b/src/questfoundry/pipeline/stages/dress.py
@@ -35,6 +35,7 @@ from questfoundry.agents import (
 )
 from questfoundry.agents.serialize import extract_tokens
 from questfoundry.artifacts.validator import get_all_field_paths
+from questfoundry.export.i18n import get_output_language_instruction
 from questfoundry.graph.dress_context import (
     format_art_direction_context,
     format_entity_for_codex,
@@ -157,6 +158,7 @@ class DressStage:
         self._image_provider_spec: str | None = image_provider
         self._image_budget: int = 0
         self._max_concurrency: int = 2
+        self._lang_instruction: str = ""
 
     CHECKPOINT_DIR = "snapshots"
 
@@ -261,6 +263,7 @@ class DressStage:
             self._image_provider_spec = image_provider
         self._image_budget = kwargs.get("image_budget", 0)
         self._max_concurrency = kwargs.get("max_concurrency", 2)
+        self._lang_instruction = get_output_language_instruction(kwargs.get("language", "en"))
 
         log.info("stage_start", stage="dress")
 
@@ -663,6 +666,7 @@ class DressStage:
                 "entity_visuals": entity_visuals_ctx or "No entity visual profiles available.",
                 "priority_context": priority_ctx,
                 "composition_log": comp_log,
+                "output_language_instruction": self._lang_instruction,
             }
 
             output, llm_calls, tokens = await self._dress_llm_call(
@@ -759,6 +763,7 @@ class DressStage:
                 "vision_context": vision_ctx or "No creative vision available.",
                 "entity_details": entity_details_ctx,
                 "codewords": codeword_list or "No codewords defined.",
+                "output_language_instruction": self._lang_instruction,
             }
             output, llm_calls, tokens = await self._dress_llm_call(
                 model, "dress_codex", context, DressPhase2Output

--- a/src/questfoundry/pipeline/stages/grow.py
+++ b/src/questfoundry/pipeline/stages/grow.py
@@ -29,6 +29,7 @@ from pydantic import BaseModel, ValidationError
 
 from questfoundry.agents.serialize import extract_tokens
 from questfoundry.artifacts.validator import get_all_field_paths
+from questfoundry.export.i18n import get_output_language_instruction
 from questfoundry.graph.context import normalize_scoped_id
 from questfoundry.graph.graph import Graph
 from questfoundry.graph.mutations import GrowMutationError, GrowValidationError
@@ -111,6 +112,7 @@ class GrowStage:
         self._serialize_provider_name: str | None = None
         self._size_profile: SizeProfile | None = None
         self._max_concurrency: int = 2
+        self._lang_instruction: str = ""
 
     CHECKPOINT_DIR = "snapshots"
 
@@ -248,6 +250,7 @@ class GrowStage:
         self._serialize_provider_name = serialize_provider_name
         self._size_profile = kwargs.get("size_profile")
         self._max_concurrency = kwargs.get("max_concurrency", 2)
+        self._lang_instruction = get_output_language_instruction(kwargs.get("language", "en"))
         log.info("stage_start", stage="grow")
 
         phases = self._phase_order()
@@ -1969,6 +1972,7 @@ class GrowStage:
                 "divergence_context": "\n".join(divergence_lines),
                 "valid_from_ids": ", ".join(valid_from_ids),
                 "valid_to_ids": ", ".join(valid_to_ids),
+                "output_language_instruction": self._lang_instruction,
             }
 
             from questfoundry.graph.grow_validators import validate_phase9_output

--- a/src/questfoundry/pipeline/stages/ship.py
+++ b/src/questfoundry/pipeline/stages/ship.py
@@ -88,18 +88,21 @@ class ShipStage:
                 f"Run FILL stage first. Examples: {missing_prose[:3]}"
             )
 
-        # Get story title: voice node (from FILL) → project config → directory name
+        # Get story title and language from config
         voice = graph.get_node("voice::voice")
         story_title = (voice or {}).get("story_title") or ""
-        if not story_title:
-            try:
-                config = load_project_config(self._project_path)
+        language = "en"
+        try:
+            config = load_project_config(self._project_path)
+            if not story_title:
                 story_title = config.name
-            except (ProjectConfigError, FileNotFoundError, KeyError):
+            language = config.language
+        except (ProjectConfigError, FileNotFoundError, KeyError):
+            if not story_title:
                 story_title = self._project_path.name
 
         # Build export context
-        context = build_export_context(graph, story_title)
+        context = build_export_context(graph, story_title, language=language)
 
         log.info(
             "ship_context_built",

--- a/src/questfoundry/pipeline/stages/ship.py
+++ b/src/questfoundry/pipeline/stages/ship.py
@@ -92,14 +92,21 @@ class ShipStage:
         voice = graph.get_node("voice::voice")
         story_title = (voice or {}).get("story_title") or ""
         language = "en"
+        config_name: str | None = None
+
         try:
             config = load_project_config(self._project_path)
-            if not story_title:
-                story_title = config.name
             language = config.language
+            config_name = config.name
         except (ProjectConfigError, FileNotFoundError, KeyError):
-            if not story_title:
-                story_title = self._project_path.name
+            log.warning(
+                "project_config_load_failed",
+                path=str(self._project_path),
+                detail="Falling back to defaults for title and language.",
+            )
+
+        if not story_title:
+            story_title = config_name or self._project_path.name
 
         # Build export context
         context = build_export_context(graph, story_title, language=language)

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -532,3 +532,33 @@ class TestUserConfig:
 
         result = load_user_config(config_dir=config_dir)
         assert result is None
+
+
+class TestProjectConfigLanguage:
+    """Tests for ProjectConfig language field."""
+
+    def test_default_language_is_english(self) -> None:
+        data = {
+            "name": "test",
+            "providers": {"default": "ollama/qwen3:4b-instruct-32k"},
+        }
+        config = ProjectConfig.from_dict(data)
+        assert config.language == "en"
+
+    def test_language_from_dict(self) -> None:
+        data = {
+            "name": "test",
+            "language": "nl",
+            "providers": {"default": "ollama/qwen3:4b-instruct-32k"},
+        }
+        config = ProjectConfig.from_dict(data)
+        assert config.language == "nl"
+
+    def test_language_german(self) -> None:
+        data = {
+            "name": "test",
+            "language": "de",
+            "providers": {"default": "ollama/qwen3:4b-instruct-32k"},
+        }
+        config = ProjectConfig.from_dict(data)
+        assert config.language == "de"

--- a/tests/unit/test_export_context.py
+++ b/tests/unit/test_export_context.py
@@ -239,3 +239,15 @@ class TestBuildExportContext:
         ctx = build_export_context(g, "test")
 
         assert ctx.cover is None
+
+    def test_language_default_english(self) -> None:
+        g = _minimal_graph()
+        ctx = build_export_context(g, "test")
+
+        assert ctx.language == "en"
+
+    def test_language_passthrough(self) -> None:
+        g = _minimal_graph()
+        ctx = build_export_context(g, "test", language="nl")
+
+        assert ctx.language == "nl"

--- a/tests/unit/test_html_exporter.py
+++ b/tests/unit/test_html_exporter.py
@@ -272,3 +272,49 @@ class TestHtmlExporter:
         content = result.read_text()
 
         assert '<figure class="cover">' not in content
+
+    def test_dutch_language_export(self, tmp_path: Path) -> None:
+        ctx = ExportContext(
+            title="Mijn Verhaal",
+            language="nl",
+            passages=[
+                ExportPassage(id="p1", prose="Je staat bij de poort.", is_start=True),
+                ExportPassage(id="p2", prose="Je betreedt het kasteel.", is_ending=True),
+            ],
+            choices=[
+                ExportChoice(from_passage="p1", to_passage="p2", label="Betreed het kasteel"),
+            ],
+            codex_entries=[
+                ExportCodexEntry(entity_id="Zwaard", rank=1, content="Een legendarisch zwaard."),
+            ],
+        )
+        exporter = HtmlExporter()
+        result = exporter.export(ctx, tmp_path / "out")
+        content = result.read_text()
+
+        assert 'lang="nl"' in content
+        assert "Einde" in content  # Dutch "The End"
+        assert "Codex" in content  # Same in Dutch
+
+    def test_german_language_ending(self, tmp_path: Path) -> None:
+        ctx = ExportContext(
+            title="Test",
+            language="de",
+            passages=[
+                ExportPassage(id="p1", prose="Start.", is_start=True, is_ending=True),
+            ],
+            choices=[],
+        )
+        exporter = HtmlExporter()
+        result = exporter.export(ctx, tmp_path / "out")
+        content = result.read_text()
+
+        assert 'lang="de"' in content
+        assert "Ende" in content  # German "The End"
+
+    def test_default_language_is_english(self, tmp_path: Path) -> None:
+        exporter = HtmlExporter()
+        result = exporter.export(_simple_context(), tmp_path / "out")
+        content = result.read_text()
+
+        assert 'lang="en"' in content

--- a/tests/unit/test_i18n.py
+++ b/tests/unit/test_i18n.py
@@ -1,0 +1,80 @@
+"""Tests for export internationalization module."""
+
+from __future__ import annotations
+
+from questfoundry.export.i18n import (
+    get_language_name,
+    get_output_language_instruction,
+    get_ui_strings,
+)
+
+
+class TestGetLanguageName:
+    def test_known_language(self) -> None:
+        assert get_language_name("en") == "English"
+        assert get_language_name("nl") == "Dutch"
+        assert get_language_name("de") == "German"
+
+    def test_case_insensitive(self) -> None:
+        assert get_language_name("EN") == "English"
+        assert get_language_name("Nl") == "Dutch"
+
+    def test_unknown_returns_code(self) -> None:
+        assert get_language_name("xx") == "xx"
+        assert get_language_name("tlh") == "tlh"
+
+
+class TestGetUiStrings:
+    def test_english_strings(self) -> None:
+        ui = get_ui_strings("en")
+        assert ui["the_end"] == "The End"
+        assert ui["codex"] == "Codex"
+        assert ui["cover_alt"] == "Cover illustration"
+        assert ui["continue"] == "continue"
+
+    def test_dutch_strings(self) -> None:
+        ui = get_ui_strings("nl")
+        assert ui["the_end"] == "Einde"
+        assert ui["codex"] == "Codex"
+        assert ui["cover_alt"] == "Omslagillustratie"
+        assert ui["continue"] == "verder"
+
+    def test_german_strings(self) -> None:
+        ui = get_ui_strings("de")
+        assert ui["the_end"] == "Ende"
+        assert ui["codex"] == "Kodex"
+
+    def test_french_strings(self) -> None:
+        ui = get_ui_strings("fr")
+        assert ui["the_end"] == "Fin"
+
+    def test_case_insensitive(self) -> None:
+        ui = get_ui_strings("NL")
+        assert ui["the_end"] == "Einde"
+
+    def test_unknown_falls_back_to_english(self) -> None:
+        ui = get_ui_strings("xx")
+        assert ui["the_end"] == "The End"
+        assert ui["codex"] == "Codex"
+
+
+class TestGetOutputLanguageInstruction:
+    def test_english_returns_empty(self) -> None:
+        assert get_output_language_instruction("en") == ""
+
+    def test_english_case_insensitive(self) -> None:
+        assert get_output_language_instruction("EN") == ""
+
+    def test_dutch_returns_instruction(self) -> None:
+        result = get_output_language_instruction("nl")
+        assert "Dutch" in result
+        assert "structural IDs" in result
+
+    def test_german_returns_instruction(self) -> None:
+        result = get_output_language_instruction("de")
+        assert "German" in result
+
+    def test_unknown_uses_code_as_name(self) -> None:
+        result = get_output_language_instruction("xx")
+        assert "xx" in result
+        assert result != ""

--- a/tests/unit/test_twee_exporter.py
+++ b/tests/unit/test_twee_exporter.py
@@ -322,3 +322,41 @@ class TestTweeExporter:
         content = result.read_text()
 
         assert ":: StoryInit" not in content
+
+    def test_dutch_codex_passage_name(self, tmp_path: Path) -> None:
+        ctx = ExportContext(
+            title="Test",
+            language="nl",
+            passages=[
+                ExportPassage(id="p1", prose="Start.", is_start=True),
+            ],
+            choices=[],
+            codex_entries=[
+                ExportCodexEntry(entity_id="Held", rank=1, content="De held."),
+            ],
+        )
+        exporter = TweeExporter()
+        result = exporter.export(ctx, tmp_path / "out")
+        content = result.read_text()
+
+        # Dutch uses "Codex" (same as English for nl)
+        assert ":: Codex" in content
+
+    def test_german_codex_passage_name(self, tmp_path: Path) -> None:
+        ctx = ExportContext(
+            title="Test",
+            language="de",
+            passages=[
+                ExportPassage(id="p1", prose="Start.", is_start=True),
+            ],
+            choices=[],
+            codex_entries=[
+                ExportCodexEntry(entity_id="Held", rank=1, content="Der Held."),
+            ],
+        )
+        exporter = TweeExporter()
+        result = exporter.export(ctx, tmp_path / "out")
+        content = result.read_text()
+
+        # German uses "Kodex"
+        assert ":: Kodex" in content


### PR DESCRIPTION
## Problem
All player-facing output is English-only. No language configuration exists, and UI strings in exporters are hardcoded. Users cannot generate interactive fiction in other languages.

## Changes
- Add `language: str` field to `ProjectConfig` (ISO 639-1, default `"en"`)
- Create `export/i18n.py` module with UI strings for 7 languages (en, nl, de, fr, es, it, pt), language name lookup, and output language instruction builder
- Pass language through orchestrator → stage kwargs → ExportContext
- Localize HTML exporter: `lang` attribute, "The End", "Codex", "Cover illustration" use i18n lookups
- Localize Twee exporter: codex passage name uses i18n lookup
- Inject `{output_language_instruction}` into 6 prompt templates (FILL voice/prose/revision, GROW choices, DRESS briefs/codex) — empty for English, instructs LLM to write narrative in target language for others
- Add `_lang_instruction` field to FILL, GROW, and DRESS stages

## Not Included / Future PRs
- Adding more languages to UI_STRINGS (only need dict entries)
- CLI `--language` flag override
- Language-specific voice document defaults
- Translation of non-player-facing content (IDs, field names stay English by design)

## Test Plan
- `uv run pytest tests/unit/test_i18n.py tests/unit/test_html_exporter.py tests/unit/test_twee_exporter.py tests/unit/test_export_context.py tests/unit/test_config.py -x -q` — 103 tests pass
- `uv run mypy` on all changed source files — no issues
- `uv run ruff check` on all changed files — clean

## Review Guide
Suggested review order:
1. `src/questfoundry/export/i18n.py` — new i18n module (core of the feature)
2. `src/questfoundry/pipeline/config.py` — language field addition
3. `src/questfoundry/export/html_exporter.py` + `twee_exporter.py` — localized output
4. `src/questfoundry/pipeline/stages/{fill,grow,dress}.py` — prompt injection plumbing
5. `prompts/templates/*.yaml` — template placeholders
6. Tests

## Risk / Rollback
- Default language is English — zero behavioral change for existing projects
- Unknown language codes fall back to English UI strings gracefully
- Prompt instruction is empty string for English — no prompt change for default case

Closes #496

🤖 Generated with [Claude Code](https://claude.com/claude-code)