### PR TITLE
feat(providers): add Google Gemini provider support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,10 +52,14 @@ openai = [
 anthropic = [
     "langchain-anthropic>=0.3",
 ]
+google = [
+    "langchain-google-genai>=2.0",
+]
 all-providers = [
     "langchain-ollama>=0.3",
     "langchain-openai>=0.3",
     "langchain-anthropic>=0.3",
+    "langchain-google-genai>=2.0",
 ]
 tracing = [
     "langsmith>=0.2",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -152,6 +152,7 @@ module = [
     "langchain_ollama.*",
     "langchain_openai.*",
     "langchain_anthropic.*",
+    "langchain_google_genai.*",
     "ifcraftcorpus.*",
     "pvlwebtools.*",
 ]

--- a/src/questfoundry/cli.py
+++ b/src/questfoundry/cli.py
@@ -2006,7 +2006,7 @@ async def _check_google() -> bool:
 
     import httpx
 
-    api_key = os.getenv("GOOGLE_API_KEY")
+    api_key: str | None = os.getenv("GOOGLE_API_KEY")
     try:
         async with httpx.AsyncClient(timeout=10.0) as client:
             response = await client.get(

--- a/src/questfoundry/providers/factory.py
+++ b/src/questfoundry/providers/factory.py
@@ -484,7 +484,7 @@ def _create_google_base_model(model: str, **kwargs: Any) -> BaseChatModel:
             "langchain-google-genai not installed. Run: uv add langchain-google-genai",
         ) from e
 
-    api_key = kwargs.get("api_key") or os.getenv("GOOGLE_API_KEY")
+    api_key = kwargs.get("google_api_key") or kwargs.get("api_key") or os.getenv("GOOGLE_API_KEY")
     if not api_key:
         log.error("provider_config_error", provider="google", missing="GOOGLE_API_KEY")
         raise ProviderError(

--- a/src/questfoundry/providers/model_info.py
+++ b/src/questfoundry/providers/model_info.py
@@ -71,6 +71,11 @@ KNOWN_MODELS: dict[str, dict[str, ModelProperties]] = {
         "claude-3-opus-20240229": ModelProperties(context_window=200_000, supports_vision=True),
         "claude-3-haiku-20240307": ModelProperties(context_window=200_000, supports_vision=True),
     },
+    "google": {
+        "gemini-2.5-flash": ModelProperties(context_window=1_000_000, supports_vision=True),
+        "gemini-2.5-pro": ModelProperties(context_window=1_000_000, supports_vision=True),
+        "gemini-2.0-flash": ModelProperties(context_window=1_000_000, supports_vision=True),
+    },
 }
 
 # Default context window when model is not in known list.
@@ -85,6 +90,7 @@ _PROVIDER_MAX_CONCURRENCY: dict[str, int] = {
     "ollama": 2,
     "openai": 20,
     "anthropic": 10,
+    "google": 20,
 }
 
 

--- a/src/questfoundry/providers/settings.py
+++ b/src/questfoundry/providers/settings.py
@@ -53,6 +53,12 @@ TEMPERATURE_MAP: dict[str, dict[CreativityLevel, float]] = {
         CreativityLevel.BALANCED: 0.5,
         CreativityLevel.CREATIVE: 0.8,
     },
+    "google": {
+        CreativityLevel.DETERMINISTIC: 0.0,
+        CreativityLevel.FOCUSED: 0.3,
+        CreativityLevel.BALANCED: 0.7,
+        CreativityLevel.CREATIVE: 0.9,
+    },
 }
 
 # Role defaults (semantic level, not raw temperature)
@@ -101,6 +107,7 @@ def get_max_temperature(provider: str) -> float:
         "openai": 2.0,
         "anthropic": 1.0,
         "ollama": 2.0,  # Ollama allows > 1.0 though rarely useful
+        "google": 2.0,
     }
     return provider_limits.get(provider.lower(), 1.0)
 
@@ -154,12 +161,12 @@ class PhaseSettings:
             kwargs["top_p"] = self.top_p
 
         if self.seed is not None:
-            # Anthropic doesn't support seed - log warning and skip
-            if provider.lower() == "anthropic":
+            # Anthropic and Google don't support seed - log warning and skip
+            if provider.lower() in ("anthropic", "google"):
                 log.warning(
                     "seed_not_supported",
                     provider=provider,
-                    note="Anthropic does not support seed parameter, ignoring",
+                    note=f"{provider} does not support seed parameter, ignoring",
                 )
             else:
                 kwargs["seed"] = self.seed

--- a/src/questfoundry/providers/settings.py
+++ b/src/questfoundry/providers/settings.py
@@ -166,7 +166,7 @@ class PhaseSettings:
                 log.warning(
                     "seed_not_supported",
                     provider=provider,
-                    note=f"{provider} does not support seed parameter, ignoring",
+                    note=f"{provider.lower()} does not support seed parameter, ignoring",
                 )
             else:
                 kwargs["seed"] = self.seed

--- a/src/questfoundry/providers/structured_output.py
+++ b/src/questfoundry/providers/structured_output.py
@@ -56,6 +56,10 @@ def get_default_strategy(provider_name: str) -> StructuredOutputStrategy:
     if provider_lower.startswith("ollama"):
         return StructuredOutputStrategy.JSON_MODE
 
+    # Google: JSON_MODE (native JSON schema support)
+    if provider_lower.startswith("google") or provider_lower.startswith("gemini"):
+        return StructuredOutputStrategy.JSON_MODE
+
     # Anthropic and others: JSON_MODE
     return StructuredOutputStrategy.JSON_MODE
 

--- a/tests/unit/test_model_info.py
+++ b/tests/unit/test_model_info.py
@@ -25,6 +25,11 @@ class TestModelInfoDefaults:
         info = get_model_info("anthropic", "claude-sonnet-4-20250514")
         assert info.max_concurrency == 10
 
+    def test_google_concurrency(self) -> None:
+        """Google models get high concurrency (cloud API)."""
+        info = get_model_info("google", "gemini-2.5-flash")
+        assert info.max_concurrency == 20
+
     def test_unknown_provider_concurrency(self) -> None:
         """Unknown providers fall back to concurrency of 2."""
         info = get_model_info("unknown_provider", "some-model")

--- a/tests/unit/test_provider_factory.py
+++ b/tests/unit/test_provider_factory.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+import sys
 from dataclasses import FrozenInstanceError
+from types import ModuleType
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -11,6 +13,7 @@ from pydantic import BaseModel
 from questfoundry.providers.base import ProviderError
 from questfoundry.providers.factory import (
     PROVIDER_DEFAULTS,
+    _normalize_provider,
     _query_ollama_num_ctx,
     create_chat_model,
     create_model_for_structured_output,
@@ -43,6 +46,11 @@ def test_get_default_model_ollama_returns_none() -> None:
     assert get_default_model("ollama") is None
 
 
+def test_get_default_model_google() -> None:
+    """Google has a default model."""
+    assert get_default_model("google") == "gemini-2.5-flash"
+
+
 def test_get_default_model_unknown_provider() -> None:
     """Unknown providers return None."""
     assert get_default_model("unknown") is None
@@ -53,8 +61,27 @@ def test_provider_defaults_dict_structure() -> None:
     assert "ollama" in PROVIDER_DEFAULTS
     assert "openai" in PROVIDER_DEFAULTS
     assert "anthropic" in PROVIDER_DEFAULTS
+    assert "google" in PROVIDER_DEFAULTS
     # Ollama should require explicit model
     assert PROVIDER_DEFAULTS["ollama"] is None
+
+
+# --- Tests for _normalize_provider (alias resolution) ---
+
+
+def test_normalize_provider_gemini_alias() -> None:
+    """'gemini' resolves to 'google'."""
+    assert _normalize_provider("gemini") == "google"
+    assert _normalize_provider("Gemini") == "google"
+    assert _normalize_provider("GEMINI") == "google"
+
+
+def test_normalize_provider_passthrough() -> None:
+    """Other provider names pass through lowercased."""
+    assert _normalize_provider("openai") == "openai"
+    assert _normalize_provider("OPENAI") == "openai"
+    assert _normalize_provider("google") == "google"
+    assert _normalize_provider("ollama") == "ollama"
 
 
 # --- Tests for create_chat_model ---
@@ -229,6 +256,87 @@ def test_create_chat_model_anthropic_import_error() -> None:
         create_chat_model("anthropic", "model")
 
     assert "langchain-anthropic not installed" in str(exc_info.value)
+
+
+def test_create_chat_model_google_missing_key() -> None:
+    """Factory raises error when GOOGLE_API_KEY not set."""
+    with (
+        patch.dict("os.environ", {}, clear=True),
+        patch(
+            "questfoundry.providers.factory._create_google_base_model",
+            side_effect=ProviderError(
+                "google",
+                "API key required. Set GOOGLE_API_KEY environment variable.",
+            ),
+        ),
+        pytest.raises(ProviderError) as exc_info,
+    ):
+        create_chat_model("google", "gemini-2.5-flash")
+
+    assert "API key required" in str(exc_info.value)
+    assert exc_info.value.provider == "google"
+
+
+def _mock_google_module() -> tuple[ModuleType, MagicMock]:
+    """Create a mock langchain_google_genai module with ChatGoogleGenerativeAI."""
+    mock_module = ModuleType("langchain_google_genai")
+    mock_class = MagicMock()
+    mock_module.ChatGoogleGenerativeAI = mock_class  # type: ignore[attr-defined]
+    return mock_module, mock_class
+
+
+def test_create_chat_model_google_success() -> None:
+    """Factory creates Google Gemini chat model."""
+    mock_chat = MagicMock()
+    mock_module, mock_class = _mock_google_module()
+    mock_class.return_value = mock_chat
+
+    with (
+        patch.dict("os.environ", {"GOOGLE_API_KEY": "test-key"}),
+        patch.dict(sys.modules, {"langchain_google_genai": mock_module}),
+    ):
+        result = create_chat_model("google", "gemini-2.5-flash", temperature=0.7)
+
+    assert result is mock_chat
+    mock_class.assert_called_once_with(
+        model="gemini-2.5-flash",
+        google_api_key="test-key",
+        temperature=0.7,
+    )
+
+
+def test_create_chat_model_google_import_error() -> None:
+    """Factory raises error when langchain-google-genai not installed."""
+    with (
+        patch.dict("os.environ", {"GOOGLE_API_KEY": "test-key"}),
+        patch(
+            "questfoundry.providers.factory._create_google_base_model",
+            side_effect=ProviderError(
+                "google",
+                "langchain-google-genai not installed. Run: uv add langchain-google-genai",
+            ),
+        ),
+        pytest.raises(ProviderError) as exc_info,
+    ):
+        create_chat_model("google", "model")
+
+    assert "langchain-google-genai not installed" in str(exc_info.value)
+
+
+def test_create_chat_model_google_top_p() -> None:
+    """Factory passes top_p parameter for Google."""
+    mock_chat = MagicMock()
+    mock_module, mock_class = _mock_google_module()
+    mock_class.return_value = mock_chat
+
+    with (
+        patch.dict("os.environ", {"GOOGLE_API_KEY": "test-key"}),
+        patch.dict(sys.modules, {"langchain_google_genai": mock_module}),
+    ):
+        create_chat_model("google", "gemini-2.5-flash", temperature=0.5, top_p=0.9)
+
+    call_kwargs = mock_class.call_args[1]
+    assert call_kwargs["top_p"] == 0.9
 
 
 def test_create_chat_model_case_insensitive() -> None:
@@ -485,6 +593,62 @@ def test_create_model_structured_default_model_anthropic() -> None:
     assert call_kwargs["model"] == "claude-sonnet-4-20250514"  # Uses PROVIDER_DEFAULTS
 
 
+def test_create_model_structured_google_with_schema() -> None:
+    """Factory creates Google model with structured output using JSON_MODE."""
+    mock_chat = MagicMock()
+    mock_structured = MagicMock()
+    mock_chat.with_structured_output.return_value = mock_structured
+    mock_module, mock_class = _mock_google_module()
+    mock_class.return_value = mock_chat
+
+    with (
+        patch.dict("os.environ", {"GOOGLE_API_KEY": "test-key"}),
+        patch.dict(sys.modules, {"langchain_google_genai": mock_module}),
+    ):
+        result = create_model_for_structured_output(
+            "google",
+            model_name="gemini-2.5-flash",
+            schema=SampleSchema,
+        )
+
+    assert result is mock_structured
+    call_args = mock_chat.with_structured_output.call_args
+    assert call_args[0][0] is SampleSchema
+    assert call_args[1]["method"] == "json_schema"  # JSON_MODE for Google
+
+
+def test_create_model_structured_default_model_google() -> None:
+    """Factory uses default model name for Google when not provided."""
+    mock_chat = MagicMock()
+    mock_module, mock_class = _mock_google_module()
+    mock_class.return_value = mock_chat
+
+    with (
+        patch.dict("os.environ", {"GOOGLE_API_KEY": "test-key"}),
+        patch.dict(sys.modules, {"langchain_google_genai": mock_module}),
+    ):
+        create_model_for_structured_output("google")
+
+    call_kwargs = mock_class.call_args[1]
+    assert call_kwargs["model"] == "gemini-2.5-flash"  # Uses PROVIDER_DEFAULTS
+
+
+def test_create_model_structured_gemini_alias() -> None:
+    """Factory handles 'gemini' alias in structured output creation."""
+    mock_chat = MagicMock()
+    mock_module, mock_class = _mock_google_module()
+    mock_class.return_value = mock_chat
+
+    with (
+        patch.dict("os.environ", {"GOOGLE_API_KEY": "test-key"}),
+        patch.dict(sys.modules, {"langchain_google_genai": mock_module}),
+    ):
+        create_model_for_structured_output("gemini")
+
+    call_kwargs = mock_class.call_args[1]
+    assert call_kwargs["model"] == "gemini-2.5-flash"
+
+
 def test_create_model_structured_unknown_provider() -> None:
     """Factory raises error for unknown provider."""
     with pytest.raises(ProviderError) as exc_info:
@@ -533,6 +697,14 @@ def test_get_model_info_anthropic() -> None:
     info = get_model_info("anthropic", "claude-sonnet-4-20250514")
 
     assert info.context_window == 200_000
+    assert info.supports_vision is True
+
+
+def test_get_model_info_google() -> None:
+    """get_model_info works for Google Gemini models."""
+    info = get_model_info("google", "gemini-2.5-flash")
+
+    assert info.context_window == 1_000_000
     assert info.supports_vision is True
 
 

--- a/tests/unit/test_settings.py
+++ b/tests/unit/test_settings.py
@@ -34,6 +34,7 @@ class TestTemperatureMap:
         assert "openai" in TEMPERATURE_MAP
         assert "anthropic" in TEMPERATURE_MAP
         assert "ollama" in TEMPERATURE_MAP
+        assert "google" in TEMPERATURE_MAP
 
     def test_all_levels_mapped_for_each_provider(self) -> None:
         """Each provider has mappings for all creativity levels."""
@@ -84,6 +85,10 @@ class TestGetTemperatureForPhase:
             ("summarize", "openai", 0.7),
             ("summarize", "anthropic", 0.5),
             ("summarize", "ollama", 0.5),
+            # Google (same scale as OpenAI)
+            ("discuss", "google", 0.9),
+            ("summarize", "google", 0.7),
+            ("serialize", "google", 0.0),
             # Serialize phase (DETERMINISTIC)
             ("serialize", "openai", 0.0),
             ("serialize", "anthropic", 0.0),
@@ -124,6 +129,10 @@ class TestGetMaxTemperature:
     def test_ollama_max(self) -> None:
         """Ollama has max temperature of 2.0."""
         assert get_max_temperature("ollama") == 2.0
+
+    def test_google_max(self) -> None:
+        """Google has max temperature of 2.0."""
+        assert get_max_temperature("google") == 2.0
 
     def test_unknown_provider_defaults_to_1(self) -> None:
         """Unknown provider defaults to 1.0 max."""
@@ -257,6 +266,12 @@ class TestPhaseSettingsToModelKwargs:
         """Excludes seed from kwargs for Anthropic (not supported)."""
         settings = PhaseSettings(seed=42)
         kwargs = settings.to_model_kwargs("discuss", "anthropic")
+        assert "seed" not in kwargs
+
+    def test_excludes_seed_for_google(self) -> None:
+        """Excludes seed from kwargs for Google (not supported)."""
+        settings = PhaseSettings(seed=42)
+        kwargs = settings.to_model_kwargs("discuss", "google")
         assert "seed" not in kwargs
 
     def test_clamps_temperature_for_anthropic(self) -> None:


### PR DESCRIPTION
## Problem
Only three LLM providers supported (Ollama, OpenAI, Anthropic). Google Gemini offers competitive pricing and 1M token context windows, expanding provider options for users.

Closes #177

## Changes
- Add `_create_google_base_model()` factory function using `ChatGoogleGenerativeAI`
- Add `_normalize_provider()` to resolve "gemini" alias to "google"
- Add Google to `PROVIDER_DEFAULTS` with `gemini-2.5-flash` default
- Add Google → `JSON_MODE` structured output strategy
- Add 3 Gemini models to `KNOWN_MODELS` registry (1M context, vision support)
- Add Google temperature mapping and max temperature (2.0)
- Filter `seed` parameter for Google (not supported)
- Add `_check_google()` connectivity check to `qf doctor`
- Add `langchain-google-genai>=2.0` optional dependency

## Not Included / Future PRs
- Model list display in `qf doctor` (#525)
- FILL phase research tools (#452)

## Test Plan
- `uv run pytest tests/unit/test_provider_factory.py tests/unit/test_model_info.py tests/unit/test_settings.py -x -q` — 146 passed
- Tests cover: default model, alias normalization, model creation (success/missing key/import error/top_p), structured output (JSON_MODE), temperature mapping, model info, concurrency, seed exclusion

## Risk / Rollback
- Low risk: new provider is additive, no changes to existing providers
- Google package is optional (`pip install questfoundry[google]`)
- No breaking changes to existing API

🤖 Generated with [Claude Code](https://claude.com/claude-code)