### PR TITLE
feat(doctor): show available models in qf doctor

### DIFF
--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -299,7 +299,7 @@ def test_doctor_shows_configuration() -> None:
     """Test qf doctor shows configuration section."""
     with (
         patch.dict("os.environ", {"OLLAMA_HOST": "http://test:11434"}, clear=False),
-        patch("questfoundry.cli._check_providers", return_value=True),
+        patch("questfoundry.cli._check_providers", return_value=(True, {})),
     ):
         result = runner.invoke(app, ["doctor"])
 
@@ -310,7 +310,7 @@ def test_doctor_checks_ollama_host() -> None:
     """Test qf doctor checks OLLAMA_HOST."""
     with (
         patch.dict("os.environ", {"OLLAMA_HOST": "http://test:11434"}, clear=False),
-        patch("questfoundry.cli._check_providers", return_value=True),
+        patch("questfoundry.cli._check_providers", return_value=(True, {})),
     ):
         result = runner.invoke(app, ["doctor"])
 
@@ -326,7 +326,7 @@ def test_doctor_masks_api_keys() -> None:
             {"OPENAI_API_KEY": "sk-1234567890abcdef"},
             clear=False,
         ),
-        patch("questfoundry.cli._check_providers", return_value=True),
+        patch("questfoundry.cli._check_providers", return_value=(True, {})),
     ):
         result = runner.invoke(app, ["doctor"])
 
@@ -341,7 +341,7 @@ def test_doctor_shows_unconfigured() -> None:
     """Test qf doctor shows unconfigured providers."""
     with (
         patch.dict("os.environ", {}, clear=True),
-        patch("questfoundry.cli._check_providers", return_value=False),
+        patch("questfoundry.cli._check_providers", return_value=(False, {})),
     ):
         result = runner.invoke(app, ["doctor"])
 
@@ -356,7 +356,7 @@ def test_doctor_checks_project_when_present(tmp_path: Path) -> None:
 
     with (
         patch.dict("os.environ", {"OLLAMA_HOST": "http://test:11434"}),
-        patch("questfoundry.cli._check_providers", return_value=True),
+        patch("questfoundry.cli._check_providers", return_value=(True, {})),
     ):
         result = runner.invoke(app, ["doctor", "--project", str(project_path)])
 
@@ -368,7 +368,7 @@ def test_doctor_exit_code_on_failure() -> None:
     """Test qf doctor exits with code 1 on failure."""
     with (
         patch.dict("os.environ", {}, clear=True),
-        patch("questfoundry.cli._check_providers", return_value=False),
+        patch("questfoundry.cli._check_providers", return_value=(False, {})),
     ):
         result = runner.invoke(app, ["doctor"])
 


### PR DESCRIPTION
## Problem
`qf doctor` checks provider connectivity but doesn't show which models are available. Users configuring hybrid providers need to know what models they can use and their capabilities.

Closes #525

## Changes
- Refactor `_check_ollama()`, `_check_openai()`, `_check_anthropic()` to return `tuple[bool, list[str]]` with discovered model names
- OpenAI now filters `/v1/models` response to chat models (gpt-*, o1*, o3*, o4*) and shows count
- Anthropic returns `KNOWN_MODELS` registry entries (no public list API)
- Add `_show_available_models()`: Rich table with Provider, Model, Context, Vision, Tools columns
- Cross-reference discovered models with `KNOWN_MODELS` for capabilities (unknown models show `?`)
- Add `_format_context_window()` helper (32768 -> "32K", 1000000 -> "1M")
- Update test mocks for new return type

## Not Included / Future PRs
- Google Gemini provider (#177 / PR #526)
- FILL phase research tools (#452)

## Test Plan
- `uv run pytest tests/unit/test_cli.py -x -q` - 75 passed
- `uv run mypy src/questfoundry/cli.py` - no issues
- `uv run ruff check src/questfoundry/cli.py` - all checks passed

## Risk / Rollback
- Low risk: additive feature, no changes to provider behavior
- Table display only shows when providers are connected
- Existing doctor checks work identically

🤖 Generated with [Claude Code](https://claude.com/claude-code)