### PR TITLE
feat(fill): add research tools to FILL Phase 0 voice

### DIFF
--- a/prompts/templates/fill_phase0_discuss.yaml
+++ b/prompts/templates/fill_phase0_discuss.yaml
@@ -1,0 +1,30 @@
+name: fill_phase0_discuss
+description: Research voice and style guidance for interactive fiction
+
+system: |
+  You are researching voice and style guidance for an interactive fiction story.
+  Your goal is to find craft advice that will inform the voice document — the
+  contract governing how every passage will be written.
+
+  ## Creative Vision (from DREAM)
+  {dream_vision}
+
+  ## Story Structure Summary (from GROW)
+  {grow_summary}
+
+  ## Your Task
+  Use the corpus search tools to find guidance on:
+  1. POV and tense conventions for this genre (what works, what to avoid)
+  2. Voice register and tone that suit the story's themes
+  3. Common prose pitfalls for this type of interactive fiction
+
+  Make 2-3 targeted searches. Summarize what you find into actionable
+  guidance for writing the voice document. If no relevant guidance is found,
+  say so and move on — do not invent references.
+
+  ## Mode: Autonomous
+  You are running without user interaction. Search the corpus, read relevant
+  documents, and synthesize your findings into concise recommendations.
+  Do NOT ask clarifying questions.
+
+components: []

--- a/prompts/templates/fill_phase0_voice.yaml
+++ b/prompts/templates/fill_phase0_voice.yaml
@@ -15,6 +15,9 @@ system: |
   ## Scene Type Distribution
   {scene_types_summary}
 
+  ## Research Notes
+  {research_notes}
+
   ## Voice Document Fields
 
   Create a voice document with these fields:


### PR DESCRIPTION
## Problem
FILL Phase 0 (voice document) asks the LLM to match POV/tense to "genre conventions" but provides no reference material. The corpus tools could ground voice decisions in curated craft guidance.

Closes #452

## Changes
- Add `fill_phase0_discuss.yaml` template for corpus-based voice research
- Add `_phase_0a_voice_research()` method that runs discuss + summarize sub-phase with corpus tools
- Inject `{research_notes}` section into `fill_phase0_voice.yaml` template
- Modify `_phase_0_voice()` to call research before the voice LLM call
- Graceful degradation: continues without notes if corpus tools unavailable or research fails
- Research metrics (LLM calls, tokens) included in phase totals

## Not Included / Future PRs
- Google Gemini provider (#177 / PR #526)
- Doctor models display (#525 / PR #527)

## Test Plan
- `uv run pytest tests/unit/test_fill_stage.py -x -q` - 44 passed
- `uv run pytest tests/unit/test_fill_stage.py -x -q -k voice` - 7 passed
- `uv run mypy src/questfoundry/pipeline/stages/fill.py` - no issues
- `uv run ruff check src/questfoundry/pipeline/stages/fill.py` - all checks passed

## Risk / Rollback
- Low risk: research sub-phase is additive and fails gracefully
- No corpus tools installed = empty research notes, same behavior as before
- Research failure caught by try/except, voice continues with "No research notes available."

🤖 Generated with [Claude Code](https://claude.com/claude-code)