### PR TITLE
fix(docs): correct provider precedence level numbers in orchestrator

### DIFF
--- a/src/questfoundry/pipeline/orchestrator.py
+++ b/src/questfoundry/pipeline/orchestrator.py
@@ -349,8 +349,8 @@ class PipelineOrchestrator:
             or os.environ.get(legacy_env_var)
             or os.environ.get("QF_PROVIDER")
             or getattr(self.config.providers, role, None)  # Level 5: role-specific project config
-            or user_role  # Level 7: role-specific user config
-            or self.config.providers.default  # Level 6: default project config
+            or user_role  # Level 6: role-specific user config
+            or self.config.providers.default  # Level 7: default project config
             or user_default  # Level 8: default user config
             or self.config.providers.default  # Guaranteed non-None fallback
         )

--- a/src/questfoundry/pipeline/orchestrator.py
+++ b/src/questfoundry/pipeline/orchestrator.py
@@ -150,8 +150,8 @@ class PipelineOrchestrator:
             3. Role-specific env var (e.g., QF_PROVIDER_CREATIVE)
             4. General env var (QF_PROVIDER)
             5. Role-specific project config (e.g., providers.creative)
-            6. Default project config (providers.default)
-            7. Role-specific user config (~/.config/questfoundry/config.yaml)
+            6. Role-specific user config (~/.config/questfoundry/config.yaml)
+            7. Default project config (providers.default)
             8. Default user config
 
             Image provider resolution (opt-in, no default):
@@ -297,8 +297,8 @@ class PipelineOrchestrator:
         3. Role-specific env var (e.g., QF_PROVIDER_CREATIVE)
         4. General env var (QF_PROVIDER)
         5. Role-specific project config (e.g., providers.creative)
-        6. Default project config (providers.default)
-        7. Role-specific user config
+        6. Role-specific user config
+        7. Default project config (providers.default)
         8. Default user config
 
         Also checks legacy env vars (QF_PROVIDER_DISCUSS, etc.) for


### PR DESCRIPTION
## Problem
The inline comments on the provider resolution chain in `orchestrator.py` had levels 6 and 7 swapped, contradicting CLAUDE.md documentation. The code itself was correct (user role-specific config correctly takes priority over project default), but the misleading comments caused significant review confusion in PR #522 where multiple reviewers flagged a "critical bug" that didn't actually exist.

## Changes
- Swap level numbers in comments on lines 352-353 to match CLAUDE.md

## Not Included / Future PRs
- Missing precedence test case tracked in #531
- Exception handling cleanup tracked in #530

## Test Plan
- Comment-only change, no behavior change
- mypy + ruff pass

## Risk / Rollback
- Zero risk, comment-only change

## Related
- Discovered during comprehensive PR review sweep of #510-#528
- Created follow-up issues: #529, #530, #531, #532, #533, #534

🤖 Generated with [Claude Code](https://claude.com/claude-code)