### PR TITLE
fix: address unresolved review findings from PR #510-#528 sweep

### DIFF
--- a/src/questfoundry/export/html_exporter.py
+++ b/src/questfoundry/export/html_exporter.py
@@ -84,7 +84,9 @@ class HtmlExporter:
         if context.cover and context.cover.asset_path:
             cap = html.escape(context.cover.caption) if context.cover.caption else ""
             caption_tag = f"\n  <figcaption>{cap}</figcaption>" if cap else ""
-            cover_html = f'<figure class="cover">\n  <img src="{html.escape(context.cover.asset_path)}" alt="{html.escape(ui["cover_alt"])}">{caption_tag}\n</figure>'
+            # When figcaption is present, use empty alt to avoid screen reader redundancy
+            alt_attr = "" if cap else html.escape(ui["cover_alt"])
+            cover_html = f'<figure class="cover">\n  <img src="{html.escape(context.cover.asset_path)}" alt="{alt_attr}">{caption_tag}\n</figure>'
 
         # Build the complete HTML document
         content = _build_html_document(

--- a/src/questfoundry/export/twee_exporter.py
+++ b/src/questfoundry/export/twee_exporter.py
@@ -120,7 +120,8 @@ def _story_header(title: str, cover: ExportIllustration | None = None) -> list[s
     ]
     if cover and cover.asset_path:
         header.append("")
-        header.append(f":: StoryInit\n[img[{cover.asset_path}]]")
+        alt = cover.caption or "Cover illustration"
+        header.append(f":: StoryInit\n[img[{alt}|{cover.asset_path}]]")
     return header
 
 

--- a/src/questfoundry/export/twee_exporter.py
+++ b/src/questfoundry/export/twee_exporter.py
@@ -48,7 +48,7 @@ class TweeExporter:
         output_file = output_dir / "story.twee"
 
         lines: list[str] = []
-        lines.extend(_story_header(context.title, context.cover))
+        lines.extend(_story_header(context.title, context.cover, context.language))
         lines.append("")
 
         # Build lookup structures
@@ -110,7 +110,11 @@ class TweeExporter:
         return output_file
 
 
-def _story_header(title: str, cover: ExportIllustration | None = None) -> list[str]:
+def _story_header(
+    title: str,
+    cover: ExportIllustration | None = None,
+    language: str = "en",
+) -> list[str]:
     """Generate Twee 3 story header passages."""
     ifid = str(uuid.uuid4()).upper()
     header = [
@@ -120,7 +124,8 @@ def _story_header(title: str, cover: ExportIllustration | None = None) -> list[s
     ]
     if cover and cover.asset_path:
         header.append("")
-        alt = cover.caption or "Cover illustration"
+        ui = get_ui_strings(language)
+        alt = cover.caption or ui["cover_alt"]
         header.append(f":: StoryInit\n[img[{alt}|{cover.asset_path}]]")
     return header
 

--- a/src/questfoundry/pipeline/stages/dress.py
+++ b/src/questfoundry/pipeline/stages/dress.py
@@ -1040,8 +1040,8 @@ class DressStage:
                 bid, bdata = item
                 ib = build_image_brief(graph, bdata)
                 pos, neg = await distiller.distill_prompt(ib)
-                # Distiller makes 1 LLM call per brief; token count not tracked
-                # by the distiller API (returns text only, not metrics).
+                # A1111 distiller uses 1 LLM call; OpenAI distiller is pure
+                # formatting. Token count not available from distiller API.
                 return (bid, pos, neg, bdata), 1, 0
 
             results, _, _, _errs = await batch_llm_calls(

--- a/tests/unit/test_orchestrator.py
+++ b/tests/unit/test_orchestrator.py
@@ -803,6 +803,31 @@ providers:
     assert resolved == "ollama/proj-creative"
 
 
+def test_orchestrator_user_role_beats_project_default(tmp_path: Path) -> None:
+    """User role-specific config takes precedence over project default (no project role)."""
+    config_file = tmp_path / "project.yaml"
+    config_file.write_text(
+        """
+name: precedence_test
+providers:
+  default: ollama/proj-default
+"""
+    )
+
+    orchestrator = PipelineOrchestrator(tmp_path)
+
+    from questfoundry.pipeline.config import ProvidersConfig
+
+    orchestrator._user_config = ProvidersConfig(
+        default="openai/user-default",
+        creative="openai/user-creative",
+    )
+
+    # User role-specific (level 6) should beat project default (level 7)
+    resolved = orchestrator._get_resolved_role_provider("creative")
+    assert resolved == "openai/user-creative"
+
+
 # --- Tests for image provider precedence ---
 
 

--- a/tests/unit/test_twee_exporter.py
+++ b/tests/unit/test_twee_exporter.py
@@ -314,7 +314,7 @@ class TestTweeExporter:
         content = result.read_text()
 
         assert ":: StoryInit" in content
-        assert "[img[assets/cover.png]]" in content
+        assert "[img[Cover illustration|assets/cover.png]]" in content
 
     def test_no_story_init_without_cover(self, tmp_path: Path) -> None:
         exporter = TweeExporter()


### PR DESCRIPTION
## Problem
Comprehensive review of all PRs #510-#528 identified several unaddressed findings: accessibility bugs, overly-broad exception handling, misleading comments, and a missing regression test.

## Changes

1. **fix(a11y): cover image alt text** (#529)
   - Twee: use `[img[alt|src]]` format with caption or fallback
   - HTML: use empty `alt=""` when `<figcaption>` is present to avoid screen reader redundancy

2. **fix(config): user_config exception handling** (#530)
   - Separate file errors (OSError) and parse errors (YAMLError) from validation errors
   - Let ValueError/ValidationError propagate instead of silently falling back to None

3. **fix(docs): dress distiller comment** (#532)
   - Clarify that A1111 distiller makes LLM calls but OpenAI distiller is pure formatting

4. **test: provider precedence regression test** (#531)
   - Add test: user role-specific config beats project default (the gap that caused "critical bug" confusion in PR #522 review)

## Not Included / Future PRs
- #533 i18n enhancements (feature work)
- #534 fill.py pre-compute pattern (refactor)
- #537 role-based CLI flags (feature)
- #538 image role provider (feature)
- #539 checkpoint-specific templates (feature)
- #540 multi-character scenes (feature)
- #541 story_title model alignment (refactor)
- #542 JSON cover export (feature)
- #543 structlog migration (refactor)

## Test Plan
- `uv run pytest tests/unit/test_twee_exporter.py tests/unit/test_html_exporter.py -x -q` - 44 passed
- `uv run pytest tests/unit/test_orchestrator.py -x -q` - 40 passed
- mypy + ruff clean on all changed files

## Risk / Rollback
- Low risk. Accessibility fix, exception handling fix, comment fix, and test addition.
- user_config change: invalid configs that previously silently fell back will now raise — this is intentional (per CLAUDE.md "silent fallbacks are bugs").

🤖 Generated with [Claude Code](https://claude.com/claude-code)