### PR TITLE
fix(stages): replace str.format() with brace-safe template substitution

### DIFF
--- a/src/questfoundry/pipeline/stages/dress.py
+++ b/src/questfoundry/pipeline/stages/dress.py
@@ -62,6 +62,7 @@ from questfoundry.observability.logging import get_logger
 from questfoundry.observability.tracing import traceable
 from questfoundry.pipeline.batching import batch_llm_calls
 from questfoundry.pipeline.gates import AutoApprovePhaseGate
+from questfoundry.prompts.compiler import safe_format
 from questfoundry.providers.image import PromptDistiller
 from questfoundry.providers.image_brief import ImageBrief, flatten_brief_to_prompt
 from questfoundry.providers.image_factory import create_image_provider
@@ -534,8 +535,6 @@ class DressStage:
 
         loader = PromptLoader(_get_prompts_path())
         template = loader.load(template_name)
-
-        from questfoundry.prompts.compiler import safe_format
 
         system_text = safe_format(template.system, context) if context else template.system
         user_text = (

--- a/src/questfoundry/pipeline/stages/dress.py
+++ b/src/questfoundry/pipeline/stages/dress.py
@@ -535,8 +535,12 @@ class DressStage:
         loader = PromptLoader(_get_prompts_path())
         template = loader.load(template_name)
 
-        system_text = template.system.format(**context) if context else template.system
-        user_text = template.user.format(**context) if template.user else None
+        from questfoundry.prompts.compiler import safe_format
+
+        system_text = safe_format(template.system, context) if context else template.system
+        user_text = (
+            safe_format(template.user, context) if template.user and context else template.user
+        )
 
         if creative:
             # Use discuss-phase model for creative output (briefs, captions).

--- a/src/questfoundry/pipeline/stages/fill.py
+++ b/src/questfoundry/pipeline/stages/fill.py
@@ -57,6 +57,7 @@ from questfoundry.observability.logging import get_logger
 from questfoundry.observability.tracing import traceable
 from questfoundry.pipeline.batching import batch_llm_calls
 from questfoundry.pipeline.gates import AutoApprovePhaseGate
+from questfoundry.prompts.compiler import safe_format
 from questfoundry.providers.structured_output import (
     unwrap_structured_result,
     with_structured_output,
@@ -381,8 +382,6 @@ class FillStage:
 
         loader = PromptLoader(_get_prompts_path())
         template = loader.load(template_name)
-
-        from questfoundry.prompts.compiler import safe_format
 
         system_text = safe_format(template.system, context) if context else template.system
         user_text = (

--- a/src/questfoundry/pipeline/stages/fill.py
+++ b/src/questfoundry/pipeline/stages/fill.py
@@ -382,8 +382,12 @@ class FillStage:
         loader = PromptLoader(_get_prompts_path())
         template = loader.load(template_name)
 
-        system_text = template.system.format(**context) if context else template.system
-        user_text = template.user.format(**context) if template.user else None
+        from questfoundry.prompts.compiler import safe_format
+
+        system_text = safe_format(template.system, context) if context else template.system
+        user_text = (
+            safe_format(template.user, context) if template.user and context else template.user
+        )
 
         if creative:
             # Use creative-role model for prose generation.

--- a/src/questfoundry/pipeline/stages/grow.py
+++ b/src/questfoundry/pipeline/stages/grow.py
@@ -38,6 +38,7 @@ from questfoundry.observability.logging import get_logger
 from questfoundry.observability.tracing import traceable
 from questfoundry.pipeline.batching import batch_llm_calls
 from questfoundry.pipeline.gates import AutoApprovePhaseGate
+from questfoundry.prompts.compiler import safe_format
 from questfoundry.providers.structured_output import (
     unwrap_structured_result,
     with_structured_output,
@@ -408,8 +409,6 @@ class GrowStage:
 
         loader = PromptLoader(_get_prompts_path())
         template = loader.load(template_name)
-
-        from questfoundry.prompts.compiler import safe_format
 
         # Build system message from template with context injection
         system_text = safe_format(template.system, context) if context else template.system

--- a/src/questfoundry/pipeline/stages/grow.py
+++ b/src/questfoundry/pipeline/stages/grow.py
@@ -409,9 +409,13 @@ class GrowStage:
         loader = PromptLoader(_get_prompts_path())
         template = loader.load(template_name)
 
+        from questfoundry.prompts.compiler import safe_format
+
         # Build system message from template with context injection
-        system_text = template.system.format(**context) if context else template.system
-        user_text = template.user.format(**context) if template.user else None
+        system_text = safe_format(template.system, context) if context else template.system
+        user_text = (
+            safe_format(template.user, context) if template.user and context else template.user
+        )
 
         effective_model = self._serialize_model or model
         effective_provider = self._serialize_provider_name or self._provider_name

--- a/src/questfoundry/prompts/__init__.py
+++ b/src/questfoundry/prompts/__init__.py
@@ -5,6 +5,7 @@ from questfoundry.prompts.compiler import (
     CompiledPrompt,
     PromptCompileError,
     PromptCompiler,
+    safe_format,
 )
 from questfoundry.prompts.loader import (
     PromptLoader,
@@ -22,4 +23,5 @@ __all__ = [
     "PromptTemplate",
     "TemplateNotFoundError",
     "TemplateParseError",
+    "safe_format",
 ]


### PR DESCRIPTION
## Problem
`_fill_llm_call` (and equivalent in dress.py, grow.py) uses `str.format(**context)` for template substitution. If any context value contains curly braces — common in LLM-generated content like research notes, JSON, or code examples — `str.format()` raises `KeyError` or `IndexError`.

This was observed as a `KeyError: 'research_notes'` crash in FILL Phase 0, and the underlying vulnerability affects all three stages.

Closes #545

## Changes
1. **`prompts/compiler.py`**: Add `safe_format()` function using regex substitution — replaces only known `{variable}` placeholders, ignores all other braces in substituted values
2. **`fill.py`, `dress.py`, `grow.py`**: Replace `template.system.format(**context)` with `safe_format(template.system, context)`
3. **Tests**: 7 test cases covering basic substitution, unmatched placeholders, braces in values, nested braces, empty inputs

## Not Included
- Migration to `ChatPromptTemplate` (larger refactor, tracked separately)
- Template syntax change to `{{ variable }}` (would break all templates)

## Test Plan
- `uv run pytest tests/unit/test_prompt_compiler.py -x -q` — 25 passed
- `uv run pytest tests/unit/test_fill_stage.py tests/unit/test_grow_stage.py -x -q` — 128 passed
- mypy + ruff clean

## Risk / Rollback
- Low risk. `safe_format()` is a strict superset of `str.format()` for the `{variable}` pattern — all existing templates work identically. The only behavioral change is that braces in values no longer crash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)