### PR TITLE
feat(fill): add dialogue-tag and anti-telling rules, enhance vocabulary alerts

### DIFF
--- a/prompts/templates/fill_phase1_prose.yaml
+++ b/prompts/templates/fill_phase1_prose.yaml
@@ -91,6 +91,15 @@ system: |
   11. Every scene and sequel MUST contain at least one line of dialogue or one
       concrete physical action (a character doing something with their body, not
       just thinking or feeling).
+  12. Dialogue tags: prefer "said" or no tag. Use action beats instead of
+      adverb-laden tags or said-bookisms.
+      BAD: "she whispered softly", "he retorted angrily"
+      GOOD: She leaned closer. "..." / He slammed the glass down. "..."
+  13. NEVER name the theme, mood, or emotion directly in prose. Show it through
+      what characters do, notice, or fail to notice.
+      BAD: "A wave of grief washed over her." / "He felt angry."
+      GOOD: "She picked up his coffee mug, still warm, and held it with both hands."
+      GOOD: "His jaw tightened. He set down the glass without drinking."
 
   ## Poly-State Examples (CRITICAL for shared beats)
   GOOD: "The stranger's expression was unreadable" (works for trust or betrayal)

--- a/src/questfoundry/graph/fill_context.py
+++ b/src/questfoundry/graph/fill_context.py
@@ -6,6 +6,8 @@ arcs) as context strings for FILL's prose generation and review phases.
 
 from __future__ import annotations
 
+import re
+from collections import Counter
 from typing import TYPE_CHECKING
 
 import yaml
@@ -1013,11 +1015,11 @@ def _extract_top_bigrams(texts: list[str], n: int = 5, min_count: int = 2) -> li
         List of bigram strings (e.g. ["stale air", "whiskey burn"]),
         ordered by frequency descending.
     """
-    from collections import Counter
-
     bigrams: list[str] = []
     for text in texts:
-        words = text.lower().split()
+        words = re.sub(r"[^\w\s]", "", text.lower()).split()
+        if len(words) < 2:
+            continue
         bigrams.extend(f"{words[i]} {words[i + 1]}" for i in range(len(words) - 1))
     counts = Counter(bigrams)
     return [bigram for bigram, count in counts.most_common(n) if count >= min_count]

--- a/src/questfoundry/pipeline/stages/fill.py
+++ b/src/questfoundry/pipeline/stages/fill.py
@@ -751,8 +751,9 @@ class FillStage:
                 # Track prose for lexical diversity monitoring
                 recent_prose.append(passage_output.prose)
                 if len(recent_prose) % _DIVERSITY_CHECK_INTERVAL == 0:
-                    ratio = compute_lexical_diversity(recent_prose[-_DIVERSITY_CHECK_INTERVAL:])
-                    vocabulary_note = format_vocabulary_note(ratio)
+                    window = recent_prose[-_DIVERSITY_CHECK_INTERVAL:]
+                    ratio = compute_lexical_diversity(window)
+                    vocabulary_note = format_vocabulary_note(ratio, recent_prose=window)
                     if vocabulary_note:
                         log.info("lexical_diversity_low", ratio=f"{ratio:.2f}")
 


### PR DESCRIPTION
## Problem
FILL prose quality suffers from two universal issues across all providers (#549, #550):
1. Adverb-heavy dialogue tags and said-bookisms degrade prose voice
2. Generic vocabulary diversity warnings don't prevent specific phrase repetition (e.g., "stale air" appearing 3 times)

## Changes
- Add rules 12 (dialogue tags: prefer action beats) and 13 (anti-telling: never name emotions directly) to FILL Phase 1 prose template with concrete BAD/GOOD examples
- Enhance `format_vocabulary_note()` to extract top repeated bigrams from recent prose and list them as explicit "DO NOT USE" prohibitions instead of a generic warning
- Add `_extract_top_bigrams()` helper for bigram frequency analysis
- Pass recent prose window to vocabulary note formatting in `fill.py`

## Not Included / Future PRs
- Ending guidance threading (#550) — PR2 in stack
- Gemini-specific retry improvements (#549) — PR3 in stack
- Two-step FILL architecture — PR4 in stack
- Character introduction guidance — separate issue to be created

## Test Plan
- `uv run pytest tests/unit/test_fill_context.py::TestExtractTopBigrams tests/unit/test_fill_context.py::TestLexicalDiversity -x -q` — 15 tests pass
- `uv run mypy src/questfoundry/graph/fill_context.py src/questfoundry/pipeline/stages/fill.py` — clean
- `uv run ruff check src/` — clean
- Pre-commit passes on all changed files

## Risk / Rollback
- Prompt-only changes (rules 12/13) are additive and cannot break existing behavior
- Vocabulary note enhancement is backward-compatible (new `recent_prose` param defaults to `None`)
- No schema, model, or pipeline changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)