### PR TITLE
feat(fill): two-step prose generation with analytical entity extraction

### DIFF
--- a/prompts/templates/fill_phase1_extract.yaml
+++ b/prompts/templates/fill_phase1_extract.yaml
@@ -9,8 +9,11 @@ system: |
   ## Entity Reference
   {entity_states}
 
+  ### Valid Entity IDs
+  {valid_entity_ids}
+
   ## Rules
-  - Only reference EXISTING entity IDs from the list above
+  - Only use entity IDs from the Valid Entity IDs list above — do NOT invent new IDs
   - Only extract details that are NEW — not restating what is already known
   - Focus on concrete, observable details: physical appearance, habits, voice
     qualities, distinctive objects, sensory markers

--- a/prompts/templates/fill_phase1_extract.yaml
+++ b/prompts/templates/fill_phase1_extract.yaml
@@ -1,0 +1,32 @@
+name: fill_phase1_extract
+description: Extract entity micro-details from generated prose
+
+system: |
+  You are an analyst reviewing prose written for an interactive fiction passage.
+  Your task is to extract entity micro-details (appearance, mannerisms, voice)
+  that were introduced in the prose and should persist for future passages.
+
+  ## Entity Reference
+  {entity_states}
+
+  ## Rules
+  - Only reference EXISTING entity IDs from the list above
+  - Only extract details that are NEW — not restating what is already known
+  - Focus on concrete, observable details: physical appearance, habits, voice
+    qualities, distinctive objects, sensory markers
+  - Do NOT extract emotional states, plot developments, or abstract qualities
+  - If no new entity details were introduced, return an empty list
+
+user: |
+  Here is the prose for passage {passage_id}:
+
+  ---
+  {prose_text}
+  ---
+
+  Extract any new entity micro-details introduced in this prose.
+  Return a JSON object with an "entity_updates" array.
+  Each update should have: entity_id, field (e.g. "appearance", "mannerism",
+  "voice"), and value (the specific detail).
+
+components: []

--- a/prompts/templates/fill_phase1_prose_only.yaml
+++ b/prompts/templates/fill_phase1_prose_only.yaml
@@ -1,0 +1,135 @@
+name: fill_phase1_prose_only
+description: Generate prose for a single passage (plain text, no JSON)
+
+system: |
+  You are writing prose for an interactive fiction passage. Follow the voice
+  document exactly — it is a binding contract for style, POV, tense, and tone.
+
+  ## Voice Document
+  {voice_document}
+
+  ## Story Identity
+  {story_identity}
+
+  This is the genre and thematic compass. Let it influence word choice, imagery
+  selection, and emotional register without overriding the voice document's specifics.
+
+  ## Current Passage
+  **Passage ID:** {passage_id}
+  **Beat Summary:** {beat_summary}
+  **Scene Type:** {scene_type}
+
+  ## Open Dramatic Questions
+  {dramatic_questions}
+
+  ## Narrative Pacing
+  {narrative_context}
+
+  ## Scene Type Guidance
+  - **scene**: Full dramatic structure (goal, obstacle, outcome). 3+ paragraphs.
+    Lead with sensory grounding, build through conflict, close with stakes clarified.
+    Include at least one line of dialogue or direct action per paragraph.
+  - **sequel**: Reactive processing (reaction, dilemma, decision). 2-3 paragraphs.
+    Breathing room after intensity. Ground reactions in physical sensation or gesture.
+  - **micro_beat**: Brief transition. 1 paragraph. Functional prose that moves
+    the story forward without dwelling. Prefer a single concrete action or image.
+
+  ## Narrative Function Guidance
+  - **introduce**: Ground the reader. Establish new elements through sensory detail
+    and action, not exposition. End with a hook or question.
+  - **develop**: Deepen what is already known. Layer in contradiction, nuance, or
+    intimacy. Show character through choice, not description.
+  - **complicate**: Raise stakes or introduce obstacles. The reader should feel
+    the ground shift. End with the situation worse or more uncertain.
+  - **confront**: Direct engagement with tension. Strip away ambiguity. Force
+    characters (and reader) to face what they have been avoiding.
+  - **resolve**: Settle a thread. Provide earned clarity — not easy answers.
+    The resolution should feel inevitable in hindsight.
+
+  ## Atmospheric Detail
+  {atmospheric_detail}
+
+  ## Entry States
+  {entry_states}
+
+  ## Entity States
+  {entity_states}
+
+  ## Recent Passages (Sliding Window)
+  {sliding_window}
+
+  ## Lookahead
+  {lookahead}
+
+  ## Shadow States (Poly-State Context)
+  {shadow_states}
+
+  ## Path Arcs
+  {path_arcs}
+
+  ## Vocabulary Note
+  {vocabulary_note}
+
+  {output_language_instruction}
+
+  ## Rules
+
+  1. Follow the voice document for POV, tense, register, rhythm, and tone
+  2. Match the scene type guidance for length and structure
+  3. Match the narrative function guidance for dramatic purpose
+  4. Match the target length — do not over-write micro_beats or under-write confrontations
+  5. Cover the beat summary content — do not invent major plot points
+  6. Maintain continuity with the sliding window passages
+  7. Let open dramatic questions create subtext — do not resolve them unless
+     this beat commits to an answer
+  8. Build toward the exit mood through imagery and rhythm — do not state it directly
+  9. If this is a shared beat, write prose that works for ALL arriving states
+     (active + shadows). Use ambiguous phrasing when states diverge.
+  10. DO NOT repeat phrases, metaphors, or sentence structures from the sliding
+      window. Each passage must use fresh imagery and vocabulary. If the previous
+      passages used a metaphor (e.g., "like a wound"), find a different one.
+  11. Every scene and sequel MUST contain at least one line of dialogue or one
+      concrete physical action (a character doing something with their body, not
+      just thinking or feeling).
+  12. Dialogue tags: prefer "said" or no tag. Use action beats instead of
+      adverb-laden tags or said-bookisms.
+      BAD: "she whispered softly", "he retorted angrily"
+      GOOD: She leaned closer. "..." / He slammed the glass down. "..."
+  13. NEVER name the theme, mood, or emotion directly in prose. Show it through
+      what characters do, notice, or fail to notice.
+      BAD: "A wave of grief washed over her." / "He felt angry."
+      GOOD: "She picked up his coffee mug, still warm, and held it with both hands."
+      GOOD: "His jaw tightened. He set down the glass without drinking."
+
+  {ending_guidance}
+
+  ## Poly-State Examples (CRITICAL for shared beats)
+  GOOD: "The stranger's expression was unreadable" (works for trust or betrayal)
+  GOOD: "Something had shifted between them" (ambiguous emotional change)
+  BAD: "Kay trusted the mentor completely" (only works for one path state)
+  BAD: "The betrayal still burned in Kay's mind" (reveals path-specific knowledge)
+
+  ## Poly-State Failure
+
+  If you CANNOT write prose compatible with all shadow states because:
+  - Internal monologue requires contradictory knowledge
+  - Body language only makes sense for one state
+  - Dialogue would reveal path-specific information
+  - Emotional register is fundamentally different (rage vs warmth)
+
+  Then output EXACTLY the following line and nothing else:
+  INCOMPATIBLE_STATES: <your explanation of why states are incompatible>
+  Do NOT attempt to write prose. Just output that line.
+
+user: |
+  Write the prose for passage {passage_id} following the voice document and
+  scene type guidance above.
+
+  CRITICAL REMINDERS:
+  - Follow the voice document EXACTLY — POV, tense, register, rhythm, tone
+  - Match scene type guidance for structure and length
+  - Cover beat summary content — do NOT invent major plot points
+  - For shared beats, prose must work for ALL arriving states (active + shadows)
+  - Return ONLY the prose text. No JSON, no commentary, no preamble.
+
+components: []

--- a/src/questfoundry/models/__init__.py
+++ b/src/questfoundry/models/__init__.py
@@ -42,6 +42,7 @@ from questfoundry.models.dress import (
 )
 from questfoundry.models.fill import (
     EntityUpdate,
+    FillExtractOutput,
     FillPassageOutput,
     FillPhase0Output,
     FillPhase1Output,
@@ -126,6 +127,7 @@ __all__ = [
     "EntityVisualWithId",
     "EntryMood",
     "EntryStateBeat",
+    "FillExtractOutput",
     "FillPassageOutput",
     "FillPhase0Output",
     "FillPhase1Output",

--- a/src/questfoundry/models/fill.py
+++ b/src/questfoundry/models/fill.py
@@ -101,6 +101,21 @@ class FillPassageOutput(BaseModel):
     )
 
 
+class FillExtractOutput(BaseModel):
+    """Analytical extraction of entity updates from generated prose.
+
+    Used in two-step FILL mode: after prose is generated as plain text,
+    a separate low-temperature call extracts entity micro-details. The
+    prose itself is already stored on the passage node; this schema
+    captures only the structured metadata.
+    """
+
+    entity_updates: list[EntityUpdate] = Field(
+        default_factory=list,
+        description="Micro-details discovered in the prose",
+    )
+
+
 # ---------------------------------------------------------------------------
 # Review
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_fill_models.py
+++ b/tests/unit/test_fill_models.py
@@ -7,6 +7,7 @@ from pydantic import ValidationError
 
 from questfoundry.models.fill import (
     EntityUpdate,
+    FillExtractOutput,
     FillPassageOutput,
     FillPhase0Output,
     FillPhase1Output,
@@ -340,6 +341,29 @@ class TestFillPhaseResult:
         )
         assert result.llm_calls == 45
         assert result.tokens_used == 90000
+
+
+class TestFillExtractOutput:
+    def test_empty_entity_updates(self) -> None:
+        output = FillExtractOutput()
+        assert output.entity_updates == []
+
+    def test_with_entity_updates(self) -> None:
+        output = FillExtractOutput(
+            entity_updates=[
+                EntityUpdate(entity_id="kay", field="appearance", value="scarred hands"),
+                EntityUpdate(entity_id="mentor", field="voice", value="raspy baritone"),
+            ]
+        )
+        assert len(output.entity_updates) == 2
+        assert output.entity_updates[0].entity_id == "kay"
+        assert output.entity_updates[1].field == "voice"
+
+    def test_invalid_entity_update_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            FillExtractOutput(
+                entity_updates=[{"entity_id": "", "field": "appearance", "value": "tall"}]
+            )
 
 
 class TestFillResult:


### PR DESCRIPTION
## Problem

The single-call FILL approach forces the LLM to simultaneously write creative prose AND produce valid JSON with entity_updates. This dual constraint causes:
- Gemini 2.5 Pro: 11 retries (vs GPT-5's 2) because JSON formatting interferes with prose quality
- All providers: lower prose quality when the model must "think about" JSON structure while writing creatively

## Changes

- Add `FillExtractOutput` model for entity extraction (decoupled from prose)
- Add `fill_phase1_prose_only.yaml` template — plain text output, no JSON
- Add `fill_phase1_extract.yaml` template — analytical entity extraction
- Implement `_fill_prose_call()` — plain text LLM call with INCOMPATIBLE_STATES sentinel detection
- Implement `_fill_extract_call()` — structured call with FillExtractOutput schema
- Modify `_phase_1_generate` to conditionally use two-step path when `two_step=True`
- Feature-flagged via `two_step` kwarg on `execute()` (default: False, preserves existing behavior)

### Design decisions

- **Step 1 (prose)**: High temperature, plain text, no `with_structured_output`. Poly-state failures detected via `INCOMPATIBLE_STATES:` sentinel prefix.
- **Step 2 (extract)**: Low temperature, structured output with `FillExtractOutput`. Skipped for `micro_beat` passages (no entity details expected).
- **Graceful degradation**: If extraction fails, prose is preserved — entity updates are optional metadata.

## Not Included / Future PRs

- CLI `--two-step` flag wiring (can be added when ready to test end-to-end)
- Character introduction guidance (#550b — separate issue to be created)

## Test Plan

```bash
uv run pytest tests/unit/test_fill_stage.py tests/unit/test_fill_models.py -x -q  # 91 passed
uv run mypy src/questfoundry/pipeline/stages/fill.py src/questfoundry/models/fill.py  # Success
uv run ruff check src/  # All checks passed
```

Tests cover:
- Prose call returns plain text
- Sentinel detection for INCOMPATIBLE_STATES
- Extract call returns structured entity updates
- Full two-step pipeline (prose + extract)
- micro_beat extraction skip
- Feature flag fallback to single-call
- Extract failure preserves prose

## Risk / Rollback

- Feature-flagged: `two_step=False` by default, zero behavior change until explicitly enabled
- No changes to existing single-call path
- Stack PR 4/4 — depends on feat/fill-retry-diag

🤖 Generated with [Claude Code](https://claude.com/claude-code)