### PR TITLE
feat(fill): enable two-step by default with CLI opt-out, add SEED tension guidance

### DIFF
--- a/prompts/templates/serialize_seed_sections.yaml
+++ b/prompts/templates/serialize_seed_sections.yaml
@@ -90,6 +90,30 @@ dilemmas_prompt: |
   WRONG: `explored: ["opt_a"]` but path uses `answer_id: "opt_b"`
   RIGHT: `explored: ["opt_a", "opt_b"]` and paths use those exact IDs
 
+  ## Tension Balance: How Many Answers to Explore
+
+  Exploring more answers creates more paths, more branching, and a larger story.
+  Leaving answers unexplored creates dramatic shadows — tensions that are felt
+  but never resolved, adding subtext and replayability.
+
+  GOOD tension balance:
+  - Dilemma with 2 answers: explore BOTH (2 paths). This is the default —
+    binary dilemmas are designed to create two-path branching.
+  - Dilemma with 3+ answers: explore 2, leave 1 unexplored. The unexplored
+    answer becomes an intriguing "road not taken" that enriches the narrative.
+
+  BAD tension balance:
+  - Exploring ALL answers of every dilemma: creates too many paths, dilutes
+    each path's narrative weight. The story becomes wide but shallow.
+  - Exploring only 1 answer per dilemma: eliminates meaningful branching.
+    Players have no real choice, defeating the purpose of the dilemma.
+  - Leaving ALL answers unexplored: no paths are created. The dilemma has
+    no gameplay impact.
+
+  GUIDELINE: Aim for 2-4 total paths. For a vignette scope, 2 paths is
+  ideal. For a full story, 3-4 paths provide rich branching without
+  overwhelming the GROW stage.
+
   ## What NOT to Do
   - Do NOT skip dilemmas because they aren't mentioned in the brief
   - Do NOT invent dilemmas not in the manifest

--- a/src/questfoundry/pipeline/orchestrator.py
+++ b/src/questfoundry/pipeline/orchestrator.py
@@ -598,6 +598,8 @@ class PipelineOrchestrator:
             image_budget = context.get("image_budget", 0)
             if image_budget > 0:
                 stage_kwargs["image_budget"] = image_budget
+            if "two_step" in context:
+                stage_kwargs["two_step"] = context["two_step"]
 
             # Resolve size profile from DREAM vision node (for post-DREAM stages)
             if stage_name != "dream":

--- a/src/questfoundry/pipeline/stages/fill.py
+++ b/src/questfoundry/pipeline/stages/fill.py
@@ -301,7 +301,7 @@ class FillStage:
         self._size_profile = kwargs.get("size_profile")
         self._max_concurrency = kwargs.get("max_concurrency", 2)
         self._lang_instruction = get_output_language_instruction(kwargs.get("language", "en"))
-        self._two_step = kwargs.get("two_step", False)
+        self._two_step = kwargs.get("two_step", True)
         log.info("stage_start", stage="fill")
 
         phases = self._phase_order()


### PR DESCRIPTION
## Problem
Two-step FILL prose generation (PR #557) was behind a `two_step=False` default, requiring programmatic activation. Users had no CLI access. Additionally, SEED prompts lacked guidance on how many dilemma answers to explore vs leave unexplored.

## Changes
- **Default two-step=True**: Two-step is now on by default — prose quality improves by removing JSON constraints from creative output. The only cost is one extra small LLM call per passage.
- **CLI flag**: `--two-step/--no-two-step` on `qf fill` and `qf run` commands. Users who want single-call for cost savings can opt out with `--no-two-step`.
- **SEED tension guidance**: Added BAD/GOOD examples to dilemma decisions prompt showing proper tension balance — when to explore vs leave answers unexplored, target of 2-4 total paths.

Closes #558
Closes #303

## Not Included / Future PRs
- project.yaml `fill.two_step` config support (config concern, separate PR)

## Test Plan
- `uv run mypy src/questfoundry/cli.py src/questfoundry/pipeline/stages/fill.py` — clean
- `uv run ruff check src/` — clean
- Pre-commit hooks pass

## Risk / Rollback
- Default change: existing users get two-step automatically. If issues arise, `--no-two-step` provides immediate escape hatch.
- SEED prompt change: additive guidance only, no schema changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)