### PR TITLE
feat(fill): add character introduction guidance for first appearances

### DIFF
--- a/prompts/templates/fill_phase1_prose.yaml
+++ b/prompts/templates/fill_phase1_prose.yaml
@@ -103,6 +103,8 @@ system: |
 
   {ending_guidance}
 
+  {introduction_guidance}
+
   ## Poly-State Examples (CRITICAL for shared beats)
   GOOD: "The stranger's expression was unreadable" (works for trust or betrayal)
   GOOD: "Something had shifted between them" (ambiguous emotional change)

--- a/prompts/templates/fill_phase1_prose_only.yaml
+++ b/prompts/templates/fill_phase1_prose_only.yaml
@@ -103,6 +103,8 @@ system: |
 
   {ending_guidance}
 
+  {introduction_guidance}
+
   ## Poly-State Examples (CRITICAL for shared beats)
   GOOD: "The stranger's expression was unreadable" (works for trust or betrayal)
   GOOD: "Something had shifted between them" (ambiguous emotional change)

--- a/src/questfoundry/graph/fill_context.py
+++ b/src/questfoundry/graph/fill_context.py
@@ -1040,6 +1040,80 @@ def format_ending_guidance(is_ending: bool) -> str:
     )
 
 
+def compute_first_appearances(
+    graph: Graph, passage_id: str, arc_passage_ids: list[str]
+) -> list[str]:
+    """Find entity IDs appearing in this passage for the first time in the arc.
+
+    Iterates arc passages up to the current one, collecting entity IDs
+    referenced in each passage. Returns entities present in the current
+    passage but absent from all earlier arc passages.
+
+    Args:
+        graph: Graph containing passage and entity nodes.
+        passage_id: The passage being generated.
+        arc_passage_ids: Ordered list of passage IDs in the arc.
+
+    Returns:
+        List of entity IDs appearing for the first time.
+    """
+    # Find this passage's index in the arc
+    try:
+        current_idx = arc_passage_ids.index(passage_id)
+    except ValueError:
+        return []
+
+    passage = graph.get_node(passage_id)
+    if not passage:
+        return []
+    current_entities = set(passage.get("entities", []))
+    if not current_entities:
+        return []
+
+    # Collect entities seen in earlier passages
+    seen_entities: set[str] = set()
+    for prior_id in arc_passage_ids[:current_idx]:
+        prior = graph.get_node(prior_id)
+        if prior:
+            seen_entities.update(prior.get("entities", []))
+
+    return sorted(current_entities - seen_entities)
+
+
+def format_introduction_guidance(entity_names: list[str]) -> str:
+    """Format craft guidance for passages introducing characters for the first time.
+
+    When a passage contains entities not seen in any earlier arc passage,
+    returns prose guidance for introducing them effectively. Returns empty
+    string when no new entities are introduced.
+
+    Args:
+        entity_names: Display names of entities being introduced.
+
+    Returns:
+        Introduction guidance string, or empty string.
+    """
+    if not entity_names:
+        return ""
+    names_list = ", ".join(f"**{name}**" for name in entity_names)
+    return (
+        f"## Character Introduction — First Appearance\n\n"
+        f"This passage introduces {names_list} for the first time. "
+        f"The reader has never encountered them before.\n\n"
+        "- **Ground in concrete sensory detail.** Give the reader something "
+        "physical to anchor: a gesture, a texture, a sound. "
+        "Avoid abstract descriptions of personality.\n"
+        "- **Reveal through action, not exposition.** Show the character doing "
+        "something that implies who they are. Don't summarise their backstory.\n"
+        "- **Establish one distinctive trait immediately.** A verbal tic, a "
+        "physical feature, a habit — something the reader can attach identity to.\n"
+        "- **Earn the name.** Introduce the character in context before naming them. "
+        "Let the reader see them first, then learn what to call them.\n\n"
+        'BAD: "Marcus was a tall, brooding man who had spent years in the military."\n'
+        "GOOD: A hand — scarred, steady — turned the glass without drinking."
+    )
+
+
 def compute_lexical_diversity(prose_texts: list[str]) -> float:
     """Compute type-token ratio across recent prose passages.
 

--- a/src/questfoundry/graph/fill_context.py
+++ b/src/questfoundry/graph/fill_context.py
@@ -1095,7 +1095,13 @@ def format_introduction_guidance(entity_names: list[str]) -> str:
     """
     if not entity_names:
         return ""
-    names_list = ", ".join(f"**{name}**" for name in entity_names)
+    bold_names = [f"**{name}**" for name in entity_names]
+    if len(bold_names) == 1:
+        names_list = bold_names[0]
+    elif len(bold_names) == 2:
+        names_list = f"{bold_names[0]} and {bold_names[1]}"
+    else:
+        names_list = ", ".join(bold_names[:-1]) + f", and {bold_names[-1]}"
     return (
         f"## Character Introduction — First Appearance\n\n"
         f"This passage introduces {names_list} for the first time. "

--- a/src/questfoundry/pipeline/stages/fill.py
+++ b/src/questfoundry/pipeline/stages/fill.py
@@ -25,6 +25,7 @@ from pydantic import BaseModel, ValidationError
 from questfoundry.agents.serialize import extract_tokens
 from questfoundry.artifacts.validator import get_all_field_paths
 from questfoundry.export.i18n import get_output_language_instruction
+from questfoundry.graph.context import strip_scope_prefix
 from questfoundry.graph.fill_context import (
     compute_first_appearances,
     compute_is_ending,
@@ -880,7 +881,10 @@ class FillStage:
             # Compute first-appearance entity names for introduction guidance
             arc_order = arc_passage_orders.get(arc_id, [])
             first_eids = compute_first_appearances(graph, passage_id, arc_order)
-            first_names = [(graph.get_node(eid) or {}).get("raw_id", eid) for eid in first_eids]
+            first_names = [
+                (graph.get_node(eid) or {}).get("raw_id", strip_scope_prefix(eid))
+                for eid in first_eids
+            ]
             context = {
                 "voice_document": voice_context,
                 "story_identity": story_identity_context,

--- a/tests/unit/test_fill_context.py
+++ b/tests/unit/test_fill_context.py
@@ -1217,7 +1217,10 @@ class TestIntroductionGuidance:
         assert "**butler**" in result
         assert "sensory detail" in result
 
-    def test_multiple_names_listed(self) -> None:
+    def test_two_names_uses_and(self) -> None:
         result = format_introduction_guidance(["butler", "detective"])
-        assert "**butler**" in result
-        assert "**detective**" in result
+        assert "**butler** and **detective**" in result
+
+    def test_three_names_uses_oxford_comma(self) -> None:
+        result = format_introduction_guidance(["butler", "detective", "maid"])
+        assert "**butler**, **detective**, and **maid**" in result

--- a/tests/unit/test_fill_context.py
+++ b/tests/unit/test_fill_context.py
@@ -6,6 +6,7 @@ import pytest
 
 from questfoundry.graph.fill_context import (
     _extract_top_bigrams,
+    compute_first_appearances,
     compute_is_ending,
     compute_lexical_diversity,
     compute_open_questions,
@@ -17,6 +18,7 @@ from questfoundry.graph.fill_context import (
     format_entity_states,
     format_entry_states,
     format_grow_summary,
+    format_introduction_guidance,
     format_lookahead_context,
     format_narrative_context,
     format_passage_context,
@@ -1160,3 +1162,62 @@ class TestEchoPrompt:
 
         result = format_lookahead_context(g, "passage::p2", "arc::spine")
         assert "Thematic Echo" not in result
+
+
+class TestFirstAppearances:
+    """Tests for compute_first_appearances."""
+
+    def test_first_passage_all_new(self) -> None:
+        """All entities in the first passage are first appearances."""
+        g = Graph.empty()
+        g.create_node("passage::p1", {"type": "passage", "entities": ["entity::a", "entity::b"]})
+        g.create_node("passage::p2", {"type": "passage", "entities": ["entity::c"]})
+        result = compute_first_appearances(g, "passage::p1", ["passage::p1", "passage::p2"])
+        assert result == ["entity::a", "entity::b"]
+
+    def test_already_seen_excluded(self) -> None:
+        """Entities seen in earlier passages are not first appearances."""
+        g = Graph.empty()
+        g.create_node("passage::p1", {"type": "passage", "entities": ["entity::a", "entity::b"]})
+        g.create_node("passage::p2", {"type": "passage", "entities": ["entity::a", "entity::c"]})
+        result = compute_first_appearances(g, "passage::p2", ["passage::p1", "passage::p2"])
+        assert result == ["entity::c"]
+
+    def test_no_entities_returns_empty(self) -> None:
+        """Passage with no entities returns empty list."""
+        g = Graph.empty()
+        g.create_node("passage::p1", {"type": "passage", "entities": []})
+        result = compute_first_appearances(g, "passage::p1", ["passage::p1"])
+        assert result == []
+
+    def test_passage_not_in_arc_returns_empty(self) -> None:
+        """Passage not in the arc list returns empty."""
+        g = Graph.empty()
+        g.create_node("passage::p1", {"type": "passage", "entities": ["entity::a"]})
+        result = compute_first_appearances(g, "passage::p1", ["passage::other"])
+        assert result == []
+
+    def test_missing_passage_node_returns_empty(self) -> None:
+        """Non-existent passage returns empty."""
+        g = Graph.empty()
+        result = compute_first_appearances(g, "passage::missing", ["passage::missing"])
+        assert result == []
+
+
+class TestIntroductionGuidance:
+    """Tests for format_introduction_guidance."""
+
+    def test_empty_names_returns_empty(self) -> None:
+        result = format_introduction_guidance([])
+        assert result == ""
+
+    def test_single_name_returns_guidance(self) -> None:
+        result = format_introduction_guidance(["butler"])
+        assert "Character Introduction" in result
+        assert "**butler**" in result
+        assert "sensory detail" in result
+
+    def test_multiple_names_listed(self) -> None:
+        result = format_introduction_guidance(["butler", "detective"])
+        assert "**butler**" in result
+        assert "**detective**" in result


### PR DESCRIPTION
## Problem
When a passage introduces a character for the first time, the LLM has no craft guidance for grounding them. Characters appear without distinctive physical detail or anchoring action, especially on smaller models.

## Changes
- `compute_first_appearances(graph, passage_id, arc_passage_ids)` — detects entities in the current passage not seen in any earlier arc passage
- `format_introduction_guidance(entity_names)` — returns craft guidance (sensory detail, reveal through action, establish distinctive trait) with BAD/GOOD examples
- Wired into `_phase_1_generate()` context assembly
- `{introduction_guidance}` placeholder added to both prose templates

Closes #559

## Not Included / Future PRs
- Introduction guidance for entities re-appearing after long absence (could be tracked separately)

## Test Plan
- `uv run pytest tests/unit/test_fill_context.py -x -q -k "FirstAppearances or IntroductionGuidance"` — 8 passed
- `uv run mypy src/questfoundry/graph/fill_context.py src/questfoundry/pipeline/stages/fill.py` — clean

## Risk / Rollback
- Additive only — empty string when no new entities, so existing passages unchanged
- No schema changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)