### PR TITLE
fix(tracing): pass stage name through serialize_to_artifact

### DIFF
--- a/src/questfoundry/pipeline/stages/brainstorm.py
+++ b/src/questfoundry/pipeline/stages/brainstorm.py
@@ -297,6 +297,7 @@ class BrainstormStage:
             callbacks=callbacks,
             semantic_validator=validate_brainstorm_mutations,
             semantic_error_class=BrainstormMutationError,
+            stage="brainstorm",
         )
         total_llm_calls += 1
         total_tokens += serialize_tokens

--- a/src/questfoundry/pipeline/stages/dream.py
+++ b/src/questfoundry/pipeline/stages/dream.py
@@ -173,6 +173,7 @@ class DreamStage:
             schema=DreamArtifact,
             provider_name=serialize_provider_name or provider_name,
             callbacks=callbacks,
+            stage="dream",
         )
         if on_phase_progress is not None:
             on_phase_progress("serialize", "completed", None)

--- a/src/questfoundry/pipeline/stages/dress.py
+++ b/src/questfoundry/pipeline/stages/dress.py
@@ -471,6 +471,7 @@ class DressStage:
             provider_name=self._serialize_provider_name or self._provider_name,
             system_prompt=serialize_prompt,
             callbacks=self._callbacks,
+            stage="dress",
         )
         total_llm_calls += 1
         total_tokens += serialize_tokens


### PR DESCRIPTION
## Problem
`serialize_to_artifact()` hardcodes `"dream"` in trace tags and metadata regardless of which stage calls it. LangSmith traces for SEED, BRAINSTORM, and DRESS serialization all appear as "dream" stage, making debugging harder.

## Changes
- Add `stage: str = "unknown"` parameter to `serialize_to_artifact()`
- Replace all 4 hardcoded `"dream"` occurrences with the `stage` parameter
- Update all 9 call sites:
  - `dream.py` → `stage="dream"`
  - `brainstorm.py` → `stage="brainstorm"`
  - `dress.py` → `stage="dress"`
  - 5 internal SEED callers in `serialize.py` → `stage="seed"`
- Default `"unknown"` (not `"dream"`) makes missed callers obvious

Closes #475

## Test Plan
- `uv run pytest tests/unit/test_serialize.py -x -q -k "StageParam"` — 2 passed
- `uv run mypy src/questfoundry/agents/serialize.py src/questfoundry/pipeline/stages/dream.py src/questfoundry/pipeline/stages/brainstorm.py src/questfoundry/pipeline/stages/dress.py` — clean

## Risk / Rollback
- Backward compatible: default parameter preserves existing behavior for any callers not updated
- Only affects tracing metadata, no functional changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)