### PR TITLE
feat(cli): role-based provider flags, init display, JSON_MODE docs

### DIFF
--- a/src/questfoundry/cli.py
+++ b/src/questfoundry/cli.py
@@ -901,6 +901,7 @@ def init(
 
     console.print(f"[green]✓[/green] Created project: [bold]{name}[/bold]")
     console.print(f"  Location: {project_path.absolute()}")
+    console.print(f"  Provider: {provider or 'default'}")
     console.print()
     console.print("Next steps:")
     console.print(f"  cd {name}")
@@ -924,17 +925,35 @@ def dream(
             "--provider", help="LLM provider for all phases (e.g., ollama/qwen3:4b-instruct-32k)"
         ),
     ] = None,
+    provider_creative: Annotated[
+        str | None,
+        typer.Option("--provider-creative", help="LLM provider for creative/discuss role"),
+    ] = None,
+    provider_balanced: Annotated[
+        str | None,
+        typer.Option("--provider-balanced", help="LLM provider for balanced/summarize role"),
+    ] = None,
+    provider_structured: Annotated[
+        str | None,
+        typer.Option("--provider-structured", help="LLM provider for structured/serialize role"),
+    ] = None,
     provider_discuss: Annotated[
         str | None,
-        typer.Option("--provider-discuss", help="LLM provider for discuss phase"),
+        typer.Option(
+            "--provider-discuss", help="LLM provider for discuss phase (legacy)", hidden=True
+        ),
     ] = None,
     provider_summarize: Annotated[
         str | None,
-        typer.Option("--provider-summarize", help="LLM provider for summarize phase"),
+        typer.Option(
+            "--provider-summarize", help="LLM provider for summarize phase (legacy)", hidden=True
+        ),
     ] = None,
     provider_serialize: Annotated[
         str | None,
-        typer.Option("--provider-serialize", help="LLM provider for serialize phase"),
+        typer.Option(
+            "--provider-serialize", help="LLM provider for serialize phase (legacy)", hidden=True
+        ),
     ] = None,
     interactive: Annotated[
         bool | None,
@@ -968,9 +987,9 @@ def dream(
         default_noninteractive_prompt=None,  # DREAM requires explicit prompt
         preview_fn=_preview_dream_artifact,
         next_step_hint="qf brainstorm",
-        provider_discuss=provider_discuss,
-        provider_summarize=provider_summarize,
-        provider_serialize=provider_serialize,
+        provider_discuss=provider_creative or provider_discuss,
+        provider_summarize=provider_balanced or provider_summarize,
+        provider_serialize=provider_structured or provider_serialize,
     )
 
 
@@ -991,17 +1010,35 @@ def brainstorm(
             "--provider", help="LLM provider for all phases (e.g., ollama/qwen3:4b-instruct-32k)"
         ),
     ] = None,
+    provider_creative: Annotated[
+        str | None,
+        typer.Option("--provider-creative", help="LLM provider for creative/discuss role"),
+    ] = None,
+    provider_balanced: Annotated[
+        str | None,
+        typer.Option("--provider-balanced", help="LLM provider for balanced/summarize role"),
+    ] = None,
+    provider_structured: Annotated[
+        str | None,
+        typer.Option("--provider-structured", help="LLM provider for structured/serialize role"),
+    ] = None,
     provider_discuss: Annotated[
         str | None,
-        typer.Option("--provider-discuss", help="LLM provider for discuss phase"),
+        typer.Option(
+            "--provider-discuss", help="LLM provider for discuss phase (legacy)", hidden=True
+        ),
     ] = None,
     provider_summarize: Annotated[
         str | None,
-        typer.Option("--provider-summarize", help="LLM provider for summarize phase"),
+        typer.Option(
+            "--provider-summarize", help="LLM provider for summarize phase (legacy)", hidden=True
+        ),
     ] = None,
     provider_serialize: Annotated[
         str | None,
-        typer.Option("--provider-serialize", help="LLM provider for serialize phase"),
+        typer.Option(
+            "--provider-serialize", help="LLM provider for serialize phase (legacy)", hidden=True
+        ),
     ] = None,
     interactive: Annotated[
         bool | None,
@@ -1038,9 +1075,9 @@ def brainstorm(
         default_noninteractive_prompt=DEFAULT_NONINTERACTIVE_BRAINSTORM_PROMPT,
         preview_fn=_preview_brainstorm_artifact,
         next_step_hint="qf seed",
-        provider_discuss=provider_discuss,
-        provider_summarize=provider_summarize,
-        provider_serialize=provider_serialize,
+        provider_discuss=provider_creative or provider_discuss,
+        provider_summarize=provider_balanced or provider_summarize,
+        provider_serialize=provider_structured or provider_serialize,
     )
 
 
@@ -1061,17 +1098,35 @@ def seed(
             "--provider", help="LLM provider for all phases (e.g., ollama/qwen3:4b-instruct-32k)"
         ),
     ] = None,
+    provider_creative: Annotated[
+        str | None,
+        typer.Option("--provider-creative", help="LLM provider for creative/discuss role"),
+    ] = None,
+    provider_balanced: Annotated[
+        str | None,
+        typer.Option("--provider-balanced", help="LLM provider for balanced/summarize role"),
+    ] = None,
+    provider_structured: Annotated[
+        str | None,
+        typer.Option("--provider-structured", help="LLM provider for structured/serialize role"),
+    ] = None,
     provider_discuss: Annotated[
         str | None,
-        typer.Option("--provider-discuss", help="LLM provider for discuss phase"),
+        typer.Option(
+            "--provider-discuss", help="LLM provider for discuss phase (legacy)", hidden=True
+        ),
     ] = None,
     provider_summarize: Annotated[
         str | None,
-        typer.Option("--provider-summarize", help="LLM provider for summarize phase"),
+        typer.Option(
+            "--provider-summarize", help="LLM provider for summarize phase (legacy)", hidden=True
+        ),
     ] = None,
     provider_serialize: Annotated[
         str | None,
-        typer.Option("--provider-serialize", help="LLM provider for serialize phase"),
+        typer.Option(
+            "--provider-serialize", help="LLM provider for serialize phase (legacy)", hidden=True
+        ),
     ] = None,
     interactive: Annotated[
         bool | None,
@@ -1109,9 +1164,9 @@ def seed(
         default_interactive_prompt=DEFAULT_INTERACTIVE_SEED_PROMPT,
         default_noninteractive_prompt=DEFAULT_NONINTERACTIVE_SEED_PROMPT,
         preview_fn=_preview_seed_artifact,
-        provider_discuss=provider_discuss,
-        provider_summarize=provider_summarize,
-        provider_serialize=provider_serialize,
+        provider_discuss=provider_creative or provider_discuss,
+        provider_summarize=provider_balanced or provider_summarize,
+        provider_serialize=provider_structured or provider_serialize,
     )
 
     # SEED-specific message about path freeze
@@ -1134,17 +1189,35 @@ def grow(
             "--provider", help="LLM provider for all phases (e.g., ollama/qwen3:4b-instruct-32k)"
         ),
     ] = None,
+    provider_creative: Annotated[
+        str | None,
+        typer.Option("--provider-creative", help="LLM provider for creative/discuss role"),
+    ] = None,
+    provider_balanced: Annotated[
+        str | None,
+        typer.Option("--provider-balanced", help="LLM provider for balanced/summarize role"),
+    ] = None,
+    provider_structured: Annotated[
+        str | None,
+        typer.Option("--provider-structured", help="LLM provider for structured/serialize role"),
+    ] = None,
     provider_discuss: Annotated[
         str | None,
-        typer.Option("--provider-discuss", help="LLM provider for discuss phase"),
+        typer.Option(
+            "--provider-discuss", help="LLM provider for discuss phase (legacy)", hidden=True
+        ),
     ] = None,
     provider_summarize: Annotated[
         str | None,
-        typer.Option("--provider-summarize", help="LLM provider for summarize phase"),
+        typer.Option(
+            "--provider-summarize", help="LLM provider for summarize phase (legacy)", hidden=True
+        ),
     ] = None,
     provider_serialize: Annotated[
         str | None,
-        typer.Option("--provider-serialize", help="LLM provider for serialize phase"),
+        typer.Option(
+            "--provider-serialize", help="LLM provider for serialize phase (legacy)", hidden=True
+        ),
     ] = None,
     resume_from: Annotated[
         str | None,
@@ -1176,9 +1249,9 @@ def grow(
         default_noninteractive_prompt=DEFAULT_GROW_PROMPT,
         preview_fn=_preview_grow_artifact,
         next_step_hint="qf fill",
-        provider_discuss=provider_discuss,
-        provider_summarize=provider_summarize,
-        provider_serialize=provider_serialize,
+        provider_discuss=provider_creative or provider_discuss,
+        provider_summarize=provider_balanced or provider_summarize,
+        provider_serialize=provider_structured or provider_serialize,
         resume_from=resume_from,
     )
 
@@ -1199,17 +1272,35 @@ def fill(
             "--provider", help="LLM provider for all phases (e.g., ollama/qwen3:4b-instruct-32k)"
         ),
     ] = None,
+    provider_creative: Annotated[
+        str | None,
+        typer.Option("--provider-creative", help="LLM provider for creative/discuss role"),
+    ] = None,
+    provider_balanced: Annotated[
+        str | None,
+        typer.Option("--provider-balanced", help="LLM provider for balanced/summarize role"),
+    ] = None,
+    provider_structured: Annotated[
+        str | None,
+        typer.Option("--provider-structured", help="LLM provider for structured/serialize role"),
+    ] = None,
     provider_discuss: Annotated[
         str | None,
-        typer.Option("--provider-discuss", help="LLM provider for discuss phase"),
+        typer.Option(
+            "--provider-discuss", help="LLM provider for discuss phase (legacy)", hidden=True
+        ),
     ] = None,
     provider_summarize: Annotated[
         str | None,
-        typer.Option("--provider-summarize", help="LLM provider for summarize phase"),
+        typer.Option(
+            "--provider-summarize", help="LLM provider for summarize phase (legacy)", hidden=True
+        ),
     ] = None,
     provider_serialize: Annotated[
         str | None,
-        typer.Option("--provider-serialize", help="LLM provider for serialize phase"),
+        typer.Option(
+            "--provider-serialize", help="LLM provider for serialize phase (legacy)", hidden=True
+        ),
     ] = None,
     resume_from: Annotated[
         str | None,
@@ -1249,9 +1340,9 @@ def fill(
         default_noninteractive_prompt=DEFAULT_FILL_PROMPT,
         preview_fn=_preview_fill_artifact,
         next_step_hint="qf dress",
-        provider_discuss=provider_discuss,
-        provider_summarize=provider_summarize,
-        provider_serialize=provider_serialize,
+        provider_discuss=provider_creative or provider_discuss,
+        provider_summarize=provider_balanced or provider_summarize,
+        provider_serialize=provider_structured or provider_serialize,
         resume_from=resume_from,
         two_step=two_step,
     )
@@ -1273,17 +1364,35 @@ def dress(
             "--provider", help="LLM provider for all phases (e.g., ollama/qwen3:4b-instruct-32k)"
         ),
     ] = None,
+    provider_creative: Annotated[
+        str | None,
+        typer.Option("--provider-creative", help="LLM provider for creative/discuss role"),
+    ] = None,
+    provider_balanced: Annotated[
+        str | None,
+        typer.Option("--provider-balanced", help="LLM provider for balanced/summarize role"),
+    ] = None,
+    provider_structured: Annotated[
+        str | None,
+        typer.Option("--provider-structured", help="LLM provider for structured/serialize role"),
+    ] = None,
     provider_discuss: Annotated[
         str | None,
-        typer.Option("--provider-discuss", help="LLM provider for discuss phase"),
+        typer.Option(
+            "--provider-discuss", help="LLM provider for discuss phase (legacy)", hidden=True
+        ),
     ] = None,
     provider_summarize: Annotated[
         str | None,
-        typer.Option("--provider-summarize", help="LLM provider for summarize phase"),
+        typer.Option(
+            "--provider-summarize", help="LLM provider for summarize phase (legacy)", hidden=True
+        ),
     ] = None,
     provider_serialize: Annotated[
         str | None,
-        typer.Option("--provider-serialize", help="LLM provider for serialize phase"),
+        typer.Option(
+            "--provider-serialize", help="LLM provider for serialize phase (legacy)", hidden=True
+        ),
     ] = None,
     image_provider: Annotated[
         str | None,
@@ -1320,9 +1429,9 @@ def dress(
         default_noninteractive_prompt=DEFAULT_DRESS_PROMPT,
         preview_fn=_preview_dress_artifact,
         next_step_hint="qf ship",
-        provider_discuss=provider_discuss,
-        provider_summarize=provider_summarize,
-        provider_serialize=provider_serialize,
+        provider_discuss=provider_creative or provider_discuss,
+        provider_summarize=provider_balanced or provider_summarize,
+        provider_serialize=provider_structured or provider_serialize,
         resume_from=resume_from,
         image_provider=image_provider,
         image_budget=image_budget,
@@ -1604,17 +1713,35 @@ def run(
             "--provider", help="LLM provider for all phases (e.g., ollama/qwen3:4b-instruct-32k)"
         ),
     ] = None,
+    provider_creative: Annotated[
+        str | None,
+        typer.Option("--provider-creative", help="LLM provider for creative/discuss role"),
+    ] = None,
+    provider_balanced: Annotated[
+        str | None,
+        typer.Option("--provider-balanced", help="LLM provider for balanced/summarize role"),
+    ] = None,
+    provider_structured: Annotated[
+        str | None,
+        typer.Option("--provider-structured", help="LLM provider for structured/serialize role"),
+    ] = None,
     provider_discuss: Annotated[
         str | None,
-        typer.Option("--provider-discuss", help="LLM provider for discuss phase"),
+        typer.Option(
+            "--provider-discuss", help="LLM provider for discuss phase (legacy)", hidden=True
+        ),
     ] = None,
     provider_summarize: Annotated[
         str | None,
-        typer.Option("--provider-summarize", help="LLM provider for summarize phase"),
+        typer.Option(
+            "--provider-summarize", help="LLM provider for summarize phase (legacy)", hidden=True
+        ),
     ] = None,
     provider_serialize: Annotated[
         str | None,
-        typer.Option("--provider-serialize", help="LLM provider for serialize phase"),
+        typer.Option(
+            "--provider-serialize", help="LLM provider for serialize phase (legacy)", hidden=True
+        ),
     ] = None,
     interactive: Annotated[
         bool | None,
@@ -1760,9 +1887,9 @@ def run(
                 default_noninteractive_prompt=default_noninteractive_prompt,
                 preview_fn=STAGE_PREVIEW_FNS.get(stage_name),
                 next_step_hint=next_step_hint,
-                provider_discuss=provider_discuss,
-                provider_summarize=provider_summarize,
-                provider_serialize=provider_serialize,
+                provider_discuss=provider_creative or provider_discuss,
+                provider_summarize=provider_balanced or provider_summarize,
+                provider_serialize=provider_structured or provider_serialize,
                 image_provider=image_provider,
                 image_budget=image_budget,
                 two_step=two_step,

--- a/src/questfoundry/providers/structured_output.py
+++ b/src/questfoundry/providers/structured_output.py
@@ -1,4 +1,29 @@
-"""Structured output strategies for different providers."""
+"""Structured output strategies for different providers.
+
+Strategy Selection History and Rationale
+-----------------------------------------
+All providers now use per-provider defaults selected by ``get_default_strategy()``:
+
+- **OpenAI**: ``TOOL`` (function_calling) — OpenAI's ``json_schema`` strict mode
+  requires all properties in ``required``, which breaks schemas with optional
+  fields (e.g., ``Field(default_factory=dict)``).
+- **Ollama**: ``JSON_MODE`` (json_schema) — the ``TOOL`` strategy returns ``None``
+  for complex nested schemas like ``BrainstormOutput`` and ``SeedOutput``.
+- **Anthropic / Google / others**: ``JSON_MODE`` (json_schema) — native JSON mode
+  works reliably for complex schemas.
+
+The two available strategies:
+
+- ``method="json_schema"`` (``JSON_MODE``): Uses the provider's native JSON mode
+  to constrain output to the schema. Efficient and consistent.
+- ``method="function_calling"`` (``TOOL``): Creates a synthetic tool whose
+  parameters match the schema, then forces the model to call it. Useful when
+  native JSON mode has compatibility issues (e.g., OpenAI strict mode).
+
+Earlier iterations tried a single global strategy for all providers, but
+provider-specific quirks made per-provider defaults necessary. See PR #480
+and PR #494 for the investigation history.
+"""
 
 from __future__ import annotations
 

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -1177,27 +1177,31 @@ def _strip_ansi(text: str) -> str:
     return re.sub(r"\x1b\[[0-9;]*m", "", text)
 
 
-def test_dream_help_shows_phase_provider_flags() -> None:
-    """Test dream --help shows all phase-specific provider flags."""
+def test_dream_help_shows_role_provider_flags() -> None:
+    """Test dream --help shows role-based provider flags (not legacy)."""
     result = runner.invoke(app, ["dream", "--help"])
     output = _strip_ansi(result.stdout)
 
     assert result.exit_code == 0
-    assert "--provider-discuss" in output
-    assert "--provider-summarize" in output
-    assert "--provider-serialize" in output
+    assert "--provider-creative" in output
+    assert "--provider-balanced" in output
+    assert "--provider-structured" in output
+    # Legacy flags should be hidden
+    assert "--provider-discuss" not in output
 
 
-def test_run_help_shows_phase_provider_flags() -> None:
-    """Test run --help shows all phase-specific provider flags."""
+def test_run_help_shows_role_provider_flags() -> None:
+    """Test run --help shows role-based provider flags (not legacy)."""
     result = runner.invoke(app, ["run", "--help"])
     output = _strip_ansi(result.stdout)
 
     assert result.exit_code == 0
-    assert "--provider-discuss" in output
-    # Rich may truncate long option names with ellipsis depending on column width
-    assert "--provider-summar" in output
-    assert "--provider-serial" in output
+    # Rich may truncate long option names with ellipsis (Unicode …) depending on column width
+    assert "--provider-creat" in output
+    assert "--provider-balan" in output
+    assert "--provider-struc" in output
+    # Legacy flags should be hidden
+    assert "--provider-discuss" not in output
 
 
 # --- Run --init Tests ---


### PR DESCRIPTION
## Problem

CLI users must use internal phase names (discuss/summarize/serialize) for provider flags, which don't map to the user-visible roles (creative/balanced/structured). The `init` command doesn't show which provider was configured. The structured output strategy rationale is undocumented.

## Changes

- Add `--provider-creative`, `--provider-balanced`, `--provider-structured` flags to all stage commands (dream, brainstorm, seed, grow, fill, dress, run)
- Mark legacy `--provider-discuss`/`-summarize`/`-serialize` as hidden (still functional for backward compatibility)
- Role-based flags take precedence over legacy flags
- Show provider in `qf init` output
- Document JSON_MODE strategy selection rationale in `structured_output.py`
- Update CLI tests to verify role-based flags appear in help and legacy are hidden

Closes #537, Closes #180, Closes #479

## Not Included / Future PRs

- #538 (image provider resolution) — verified already implemented in orchestrator + `ProvidersConfig.image`. Will close separately.

## Test Plan

```
uv run mypy src/questfoundry/cli.py src/questfoundry/providers/structured_output.py  # Pass
uv run ruff check src/questfoundry/cli.py src/questfoundry/providers/structured_output.py  # Pass
uv run pytest tests/unit/test_cli.py -x -q  # 78 passed
```

## Risk / Rollback

Low risk. Legacy flags remain functional (hidden but accepted). No behavior changes for users who don't use the new flags.