### PR TITLE
chore: extend strip_scope_prefix usage to remaining files

### DIFF
--- a/src/questfoundry/artifacts/enrichment.py
+++ b/src/questfoundry/artifacts/enrichment.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
+from questfoundry.graph.context import strip_scope_prefix
 from questfoundry.observability.logging import get_logger
 
 if TYPE_CHECKING:
@@ -92,7 +93,7 @@ def _enrich_entities(graph: Graph, entity_decisions: list[dict[str, Any]]) -> li
     for decision in entity_decisions:
         entity_id = decision.get("entity_id", "")
         # Strip prefix if present (e.g., "entity::the_detective" -> "the_detective")
-        lookup_id = entity_id.split("::")[-1]
+        lookup_id = strip_scope_prefix(entity_id)
         node = entity_data.get(lookup_id, {}) if lookup_id else {}
 
         # Build enriched entity in consistent field order
@@ -138,7 +139,7 @@ def _enrich_dilemmas(graph: Graph, dilemma_decisions: list[dict[str, Any]]) -> l
     for decision in dilemma_decisions:
         dilemma_id = decision.get("dilemma_id", "")
         # Strip prefix if present (e.g., "dilemma::host_motivation" -> "host_motivation")
-        lookup_id = dilemma_id.split("::")[-1]
+        lookup_id = strip_scope_prefix(dilemma_id)
         node = dilemma_data.get(lookup_id, {}) if lookup_id else {}
 
         # Build enriched dilemma in consistent field order
@@ -153,7 +154,7 @@ def _enrich_dilemmas(graph: Graph, dilemma_decisions: list[dict[str, Any]]) -> l
 
         # Handle central_entity_ids with prefix stripping for readability
         if value := node.get("central_entity_ids"):
-            enriched["central_entity_ids"] = [eid.split("::")[-1] for eid in value]
+            enriched["central_entity_ids"] = [strip_scope_prefix(eid) for eid in value]
 
         # Add SEED decision fields (supports old 'considered' and 'implicit' field names)
         enriched["explored"] = decision.get("explored", decision.get("considered", []))

--- a/src/questfoundry/graph/errors.py
+++ b/src/questfoundry/graph/errors.py
@@ -13,6 +13,8 @@ from dataclasses import dataclass, field
 from difflib import get_close_matches
 from typing import Any
 
+from questfoundry.graph.context import parse_scoped_id, strip_scope_prefix
+
 
 class GraphIntegrityError(Exception):
     """Base class for graph integrity violations.
@@ -60,12 +62,12 @@ class NodeNotFoundError(GraphIntegrityError):
     def _get_suggestions(self) -> list[str]:
         """Find similar IDs that might be typos."""
         # Extract raw_id from prefixed ID (e.g., "entity::kay" -> "kay")
-        raw_id = self.node_id.split("::")[-1] if "::" in self.node_id else self.node_id
-        raw_available = [a.split("::")[-1] for a in self.available]
+        raw_id = strip_scope_prefix(self.node_id)
+        raw_available = [strip_scope_prefix(a) for a in self.available]
         matches = get_close_matches(raw_id, raw_available, n=3, cutoff=0.6)
 
         # Reconstruct full IDs with prefix
-        prefix = self.node_id.split("::")[0] if "::" in self.node_id else ""
+        prefix, _ = parse_scoped_id(self.node_id)
         if prefix:
             return [f"{prefix}::{m}" for m in matches]
         return matches

--- a/src/questfoundry/pipeline/stages/grow.py
+++ b/src/questfoundry/pipeline/stages/grow.py
@@ -30,7 +30,7 @@ from pydantic import BaseModel, ValidationError
 from questfoundry.agents.serialize import extract_tokens
 from questfoundry.artifacts.validator import get_all_field_paths
 from questfoundry.export.i18n import get_output_language_instruction
-from questfoundry.graph.context import normalize_scoped_id
+from questfoundry.graph.context import normalize_scoped_id, strip_scope_prefix
 from questfoundry.graph.graph import Graph
 from questfoundry.graph.mutations import GrowMutationError, GrowValidationError
 from questfoundry.models.grow import GrowPhaseResult, GrowResult
@@ -1607,9 +1607,7 @@ class GrowStage:
 
         passage_count = 0
         for beat_id, beat_data in sorted(beat_nodes.items()):
-            raw_id = beat_data.get(
-                "raw_id", beat_id.split("::")[-1] if "::" in beat_id else beat_id
-            )
+            raw_id = beat_data.get("raw_id", strip_scope_prefix(beat_id))
             passage_id = f"passage::{raw_id}"
 
             graph.create_node(
@@ -1675,9 +1673,7 @@ class GrowStage:
 
         codeword_count = 0
         for cons_id, cons_data in sorted(consequence_nodes.items()):
-            cons_raw = cons_data.get(
-                "raw_id", cons_id.split("::")[-1] if "::" in cons_id else cons_id
-            )
+            cons_raw = cons_data.get("raw_id", strip_scope_prefix(cons_id))
             codeword_id = f"codeword::{cons_raw}_committed"
 
             graph.create_node(

--- a/src/questfoundry/pipeline/stages/seed.py
+++ b/src/questfoundry/pipeline/stages/seed.py
@@ -28,7 +28,11 @@ from questfoundry.agents import (
     summarize_discussion,
 )
 from questfoundry.graph import Graph
-from questfoundry.graph.context import format_summarize_manifest, get_expected_counts
+from questfoundry.graph.context import (
+    format_summarize_manifest,
+    get_expected_counts,
+    strip_scope_prefix,
+)
 from questfoundry.graph.mutations import format_semantic_errors_as_content
 from questfoundry.graph.seed_pruning import compute_arc_count, prune_to_arc_limit
 from questfoundry.observability.logging import get_logger
@@ -106,7 +110,7 @@ def _format_dilemma(dilemma_id: str, dilemma_data: dict[str, Any], graph: Graph)
             entities_display.append(ref[8:])  # Skip "entity::" prefix
         elif "::" in ref:
             # Fallback for other prefixed formats
-            entities_display.append(ref.split("::")[-1])
+            entities_display.append(strip_scope_prefix(ref))
         else:
             entities_display.append(ref)
 


### PR DESCRIPTION
## Problem
Several files use inline `split("::")[-1]` patterns instead of the canonical `strip_scope_prefix()` function from `graph.context`. This inconsistency was identified in #332 and tracked as follow-up work.

## Changes
- `graph/errors.py`: Replace 3× `split("::")` with `strip_scope_prefix()` and `parse_scoped_id()`
- `artifacts/enrichment.py`: Replace 3× `split("::")[-1]` with `strip_scope_prefix()`
- `pipeline/stages/grow.py`: Replace 2× `split("::")[-1]` with `strip_scope_prefix()`
- `pipeline/stages/seed.py`: Replace 1× `split("::")[-1]` with `strip_scope_prefix()`

## Not Included / Future PRs
- `graph/graph.py` line 348: Uses `split("::")[0]` to get the *prefix* (node type inference) — different intent, not a candidate for `strip_scope_prefix`
- `graph/grow_algorithms.py` lines 842, 851: Uses `rsplit("::", 1)` for variant ID construction — different splitting semantics
- `graph/context.py` internal uses: These define the canonical functions themselves

## Test Plan
```bash
uv run ruff check src/ && uv run mypy src/  # All pass
uv run pytest tests/unit/test_graph_context.py tests/unit/test_mutations.py tests/unit/test_enrichment.py -x -q  # 254 passed
```

## Risk / Rollback
Low — mechanical replacement, no behavior change. `strip_scope_prefix()` uses `split("::", 1)` internally which is equivalent to `split("::")[-1]` for standard single-prefix IDs.

Closes #336

🤖 Generated with [Claude Code](https://claude.com/claude-code)