### PR TITLE
feat(seed): add beat uniqueness validation and low-count advisory

### DIFF
--- a/src/questfoundry/models/seed.py
+++ b/src/questfoundry/models/seed.py
@@ -342,6 +342,19 @@ class PathBeatsSection(BaseModel):
         description="2-4 initial beats for this specific path",
     )
 
+    @model_validator(mode="after")
+    def _check_beat_ids_unique(self) -> PathBeatsSection:
+        """Validate that beat IDs are unique within this path's beats."""
+        ids = [b.beat_id for b in self.initial_beats]
+        dupes = [bid for bid in ids if ids.count(bid) > 1]
+        if dupes:
+            msg = (
+                f"Duplicate beat IDs found: {sorted(set(dupes))}. "
+                f"Each beat must have a unique beat_id."
+            )
+            raise ValueError(msg)
+        return self
+
 
 class ConvergenceSection(BaseModel):
     """Wrapper for serializing convergence sketch separately."""

--- a/src/questfoundry/models/seed.py
+++ b/src/questfoundry/models/seed.py
@@ -345,12 +345,13 @@ class PathBeatsSection(BaseModel):
     @model_validator(mode="after")
     def _check_beat_ids_unique(self) -> PathBeatsSection:
         """Validate that beat IDs are unique within this path's beats."""
+        from collections import Counter
+
         ids = [b.beat_id for b in self.initial_beats]
-        dupes = [bid for bid in ids if ids.count(bid) > 1]
+        dupes = [bid for bid, count in Counter(ids).items() if count > 1]
         if dupes:
             msg = (
-                f"Duplicate beat IDs found: {sorted(set(dupes))}. "
-                f"Each beat must have a unique beat_id."
+                f"Duplicate beat IDs found: {sorted(dupes)}. Each beat must have a unique beat_id."
             )
             raise ValueError(msg)
         return self

--- a/src/questfoundry/pipeline/stages/seed.py
+++ b/src/questfoundry/pipeline/stages/seed.py
@@ -468,6 +468,21 @@ class SeedStage:
         path_count = len(artifact_data.get("paths", []))
         beat_count = len(artifact_data.get("initial_beats", []))
 
+        # Advisory warning: check beats-per-path ratio
+        if path_count > 0:
+            avg_beats = beat_count / path_count
+            if avg_beats < 3:
+                log.warning(
+                    "seed_low_beat_count",
+                    total_beats=beat_count,
+                    paths=path_count,
+                    avg_per_path=round(avg_beats, 1),
+                    message=(
+                        f"Average {avg_beats:.1f} beats/path (expected ~4). "
+                        f"Some models under-produce beats due to brevity optimization."
+                    ),
+                )
+
         # Warn if arc count is too low (linear story instead of IF)
         # This indicates the LLM didn't generate enough branching content
         min_arcs_warning = max(2, max_arcs // 4)


### PR DESCRIPTION
## Problem
The SEED stage lacks validation for duplicate beat IDs within a path's beats, which could cause graph conflicts in GROW. Additionally, some models (notably GPT-4o) under-produce beats due to brevity optimization, producing 6 beats instead of the expected 16 (4 per path × 4 paths). There's no advisory feedback when this happens.

## Changes
- **`models/seed.py`**: Add `model_validator` to `PathBeatsSection` that rejects duplicate beat IDs with a descriptive error message
- **`pipeline/stages/seed.py`**: Add advisory warning when average beats/path < 3 (expected ~4), logged as `seed_low_beat_count` event
- **`tests/unit/test_seed_stage.py`**: Add `TestPathBeatsSectionValidation` class with 5 tests:
  - `test_valid_four_beats` — 4 unique beats passes
  - `test_valid_two_beats` — 2 beats (minimum) passes
  - `test_one_beat_rejected` — fewer than 2 rejected by min_length
  - `test_five_beats_rejected` — more than 4 rejected by max_length
  - `test_duplicate_beat_ids_rejected` — duplicate IDs rejected by model_validator

## Not Included / Future PRs
- Configurable expected beats per path (currently hardcoded thresholds)
- Beat count as a repair loop trigger (currently advisory only)

## Test Plan
```bash
uv run ruff check src/ && uv run mypy src/questfoundry/models/seed.py src/questfoundry/pipeline/stages/seed.py  # Pass
uv run pytest tests/unit/test_seed_stage.py -x -q  # 26 passed (5 new)
```

## Risk / Rollback
Low. The duplicate ID validator is a new constraint but existing SEED output from healthy models always produces unique beat IDs. The advisory warning is log-only, no behavior change.

Closes #178

🤖 Generated with [Claude Code](https://claude.com/claude-code)