### PR TITLE
test: add test coverage for interactive mode callbacks

### DIFF
--- a/tests/unit/test_discuss_agent.py
+++ b/tests/unit/test_discuss_agent.py
@@ -327,51 +327,55 @@ class TestInteractiveMode:
         assert calls == 3  # One AIMessage per turn
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("exit_cmd", ["/done", "/quit", "/exit"])
     @patch("questfoundry.agents.discuss.create_discuss_agent")
-    async def test_interactive_exit_on_done_command(self, mock_create: MagicMock) -> None:
+    async def test_interactive_exit_on_done_command(
+        self, mock_create: MagicMock, exit_cmd: str
+    ) -> None:
         """Interactive mode exits on /done, /quit, /exit commands."""
-        for exit_cmd in ["/done", "/quit", "/exit"]:
-            mock_agent = AsyncMock()
-            mock_agent.ainvoke.return_value = {"messages": [AIMessage(content="Response")]}
-            mock_create.return_value = mock_agent
+        mock_agent = AsyncMock()
+        mock_agent.ainvoke.return_value = {"messages": [AIMessage(content="Response")]}
+        mock_create.return_value = mock_agent
 
-            user_input_fn = AsyncMock(return_value=exit_cmd)
-            on_assistant = MagicMock()
+        user_input_fn = AsyncMock(return_value=exit_cmd)
+        on_assistant = MagicMock()
 
-            await run_discuss_phase(
-                model=MagicMock(),
-                tools=[],
-                user_prompt="Test",
-                interactive=True,
-                user_input_fn=user_input_fn,
-                on_assistant_message=on_assistant,
-            )
+        await run_discuss_phase(
+            model=MagicMock(),
+            tools=[],
+            user_prompt="Test",
+            interactive=True,
+            user_input_fn=user_input_fn,
+            on_assistant_message=on_assistant,
+        )
 
-            # Only 1 turn (initial) — exit command prevents second invoke
-            assert mock_agent.ainvoke.call_count == 1, f"Failed for {exit_cmd}"
+        # Only 1 turn (initial) — exit command prevents second invoke
+        assert mock_agent.ainvoke.call_count == 1
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("empty_input", ["", "  ", None])
     @patch("questfoundry.agents.discuss.create_discuss_agent")
-    async def test_interactive_exit_on_empty_input(self, mock_create: MagicMock) -> None:
+    async def test_interactive_exit_on_empty_input(
+        self, mock_create: MagicMock, empty_input: str | None
+    ) -> None:
         """Interactive mode exits on empty input or None."""
-        for empty_input in ["", "  ", None]:
-            mock_agent = AsyncMock()
-            mock_agent.ainvoke.return_value = {"messages": [AIMessage(content="Response")]}
-            mock_create.return_value = mock_agent
+        mock_agent = AsyncMock()
+        mock_agent.ainvoke.return_value = {"messages": [AIMessage(content="Response")]}
+        mock_create.return_value = mock_agent
 
-            user_input_fn = AsyncMock(return_value=empty_input)
-            on_assistant = MagicMock()
+        user_input_fn = AsyncMock(return_value=empty_input)
+        on_assistant = MagicMock()
 
-            await run_discuss_phase(
-                model=MagicMock(),
-                tools=[],
-                user_prompt="Test",
-                interactive=True,
-                user_input_fn=user_input_fn,
-                on_assistant_message=on_assistant,
-            )
+        await run_discuss_phase(
+            model=MagicMock(),
+            tools=[],
+            user_prompt="Test",
+            interactive=True,
+            user_input_fn=user_input_fn,
+            on_assistant_message=on_assistant,
+        )
 
-            assert mock_agent.ainvoke.call_count == 1, f"Failed for {empty_input!r}"
+        assert mock_agent.ainvoke.call_count == 1
 
     @pytest.mark.asyncio
     async def test_interactive_without_input_fn_raises(self) -> None:


### PR DESCRIPTION
## Problem
Interactive mode in `DiscussAgent` (added in PR #90) has zero test coverage. The multi-turn conversation loop, exit commands, callback invocations, and metric aggregation are all untested.

## Changes
- Add `TestInteractiveMode` class with 7 test methods to `tests/unit/test_discuss_agent.py`:
  1. `test_interactive_multi_turn_conversation` — verifies agent processes 3 turns (initial + 2 follow-ups) before `/done`
  2. `test_interactive_exit_on_done_command` — tests all exit commands: `/done`, `/quit`, `/exit`
  3. `test_interactive_exit_on_empty_input` — tests exit on `""`, `"  "`, and `None`
  4. `test_interactive_without_input_fn_raises` — ValueError when `user_input_fn=None`
  5. `test_interactive_without_assistant_callback_raises` — ValueError when `on_assistant_message=None`
  6. `test_interactive_callbacks_invoked` — verifies `on_assistant_message`, `on_llm_start`, `on_llm_end` called correctly
  7. `test_interactive_metrics_across_turns` — verifies token counts (100 + 150 = 250) and call counts aggregate

## Not Included / Future PRs
- Message history accumulation test (complex due to agent mock setup returning full history)
- Integration tests with real agent execution

## Test Plan
```bash
uv run pytest tests/unit/test_discuss_agent.py -x -q  # 24 passed (7 new + 17 existing)
```

## Risk / Rollback
None — test-only change.

Closes #91

🤖 Generated with [Claude Code](https://claude.com/claude-code)