### PR TITLE
feat(i18n): add --language CLI flag and expand UI_STRINGS

### DIFF
--- a/src/questfoundry/cli.py
+++ b/src/questfoundry/cli.py
@@ -462,6 +462,7 @@ def _run_stage_command(
     image_provider: str | None = None,
     image_budget: int = 0,
     two_step: bool = True,
+    language: str | None = None,
 ) -> None:
     """Common logic for running a stage command.
 
@@ -485,6 +486,7 @@ def _run_stage_command(
         resume_from: Phase name to resume execution from.
         image_provider: Image provider spec for DRESS stage (e.g., ``openai/gpt-image-1``).
         two_step: Whether to use two-step prose generation in FILL stage.
+        language: ISO 639-1 language code override (e.g., "nl", "ja").
     """
     log = get_logger(__name__)
 
@@ -516,6 +518,8 @@ def _run_stage_command(
         context["image_budget"] = image_budget
     if stage_name == "fill":
         context["two_step"] = two_step
+    if language:
+        context["language"] = language
 
     # Add phase progress callback (used by GROW, and optionally by other stages)
     def _on_phase_progress(phase: str, status: str, detail: str | None) -> None:
@@ -963,6 +967,10 @@ def dream(
             help="Enable/disable interactive conversation mode. Defaults to auto-detect based on TTY.",
         ),
     ] = None,
+    language: Annotated[
+        str | None,
+        typer.Option("--language", "-l", help="Output language (ISO 639-1 code, e.g., nl, ja, de)"),
+    ] = None,
 ) -> None:
     """Run DREAM stage - establish creative vision.
 
@@ -990,6 +998,7 @@ def dream(
         provider_discuss=provider_creative or provider_discuss,
         provider_summarize=provider_balanced or provider_summarize,
         provider_serialize=provider_structured or provider_serialize,
+        language=language,
     )
 
 
@@ -1048,6 +1057,10 @@ def brainstorm(
             help="Enable/disable interactive conversation mode. Defaults to auto-detect based on TTY.",
         ),
     ] = None,
+    language: Annotated[
+        str | None,
+        typer.Option("--language", "-l", help="Output language (ISO 639-1 code, e.g., nl, ja, de)"),
+    ] = None,
 ) -> None:
     """Run BRAINSTORM stage - generate entities and dilemmas.
 
@@ -1078,6 +1091,7 @@ def brainstorm(
         provider_discuss=provider_creative or provider_discuss,
         provider_summarize=provider_balanced or provider_summarize,
         provider_serialize=provider_structured or provider_serialize,
+        language=language,
     )
 
 
@@ -1136,6 +1150,10 @@ def seed(
             help="Enable/disable interactive conversation mode. Defaults to auto-detect based on TTY.",
         ),
     ] = None,
+    language: Annotated[
+        str | None,
+        typer.Option("--language", "-l", help="Output language (ISO 639-1 code, e.g., nl, ja, de)"),
+    ] = None,
 ) -> None:
     """Run SEED stage - triage brainstorm into story structure.
 
@@ -1167,6 +1185,7 @@ def seed(
         provider_discuss=provider_creative or provider_discuss,
         provider_summarize=provider_balanced or provider_summarize,
         provider_serialize=provider_structured or provider_serialize,
+        language=language,
     )
 
     # SEED-specific message about path freeze
@@ -1223,6 +1242,10 @@ def grow(
         str | None,
         typer.Option("--resume-from", help="Resume from named phase (skips earlier phases)"),
     ] = None,
+    language: Annotated[
+        str | None,
+        typer.Option("--language", "-l", help="Output language (ISO 639-1 code, e.g., nl, ja, de)"),
+    ] = None,
 ) -> None:
     """Run GROW stage - build complete branching structure.
 
@@ -1253,6 +1276,7 @@ def grow(
         provider_summarize=provider_balanced or provider_summarize,
         provider_serialize=provider_structured or provider_serialize,
         resume_from=resume_from,
+        language=language,
     )
 
 
@@ -1314,6 +1338,10 @@ def fill(
             "Improves quality by removing JSON constraints from creative output.",
         ),
     ] = True,
+    language: Annotated[
+        str | None,
+        typer.Option("--language", "-l", help="Output language (ISO 639-1 code, e.g., nl, ja, de)"),
+    ] = None,
 ) -> None:
     """Run FILL stage - generate prose for all passages.
 
@@ -1345,6 +1373,7 @@ def fill(
         provider_serialize=provider_structured or provider_serialize,
         resume_from=resume_from,
         two_step=two_step,
+        language=language,
     )
 
 
@@ -1406,6 +1435,10 @@ def dress(
         str | None,
         typer.Option("--resume-from", help="Resume from named phase (skips earlier phases)"),
     ] = None,
+    language: Annotated[
+        str | None,
+        typer.Option("--language", "-l", help="Output language (ISO 639-1 code, e.g., nl, ja, de)"),
+    ] = None,
 ) -> None:
     """Run DRESS stage - art direction, illustrations, and codex.
 
@@ -1435,6 +1468,7 @@ def dress(
         resume_from=resume_from,
         image_provider=image_provider,
         image_budget=image_budget,
+        language=language,
     )
 
 
@@ -1780,6 +1814,10 @@ def run(
             help="Two-step FILL prose generation (default: enabled).",
         ),
     ] = True,
+    language: Annotated[
+        str | None,
+        typer.Option("--language", "-l", help="Output language (ISO 639-1 code, e.g., nl, ja, de)"),
+    ] = None,
 ) -> None:
     """Run multiple pipeline stages sequentially.
 
@@ -1893,6 +1931,7 @@ def run(
                 image_provider=image_provider,
                 image_budget=image_budget,
                 two_step=two_step,
+                language=language,
             )
 
             # SEED-specific message

--- a/src/questfoundry/export/i18n.py
+++ b/src/questfoundry/export/i18n.py
@@ -69,6 +69,54 @@ UI_STRINGS: dict[str, dict[str, str]] = {
         "cover_alt": "Ilustração de capa",
         "continue": "continuar",
     },
+    "ja": {
+        "the_end": "終わり",
+        "codex": "コデックス",
+        "cover_alt": "表紙イラスト",
+        "continue": "続ける",
+    },
+    "ko": {
+        "the_end": "끝",
+        "codex": "코덱스",
+        "cover_alt": "표지 삽화",
+        "continue": "계속",
+    },
+    "zh": {
+        "the_end": "终",
+        "codex": "法典",
+        "cover_alt": "封面插图",
+        "continue": "继续",
+    },
+    "ru": {
+        "the_end": "Конец",
+        "codex": "Кодекс",
+        "cover_alt": "Обложка",
+        "continue": "продолжить",
+    },
+    "pl": {
+        "the_end": "Koniec",
+        "codex": "Kodeks",
+        "cover_alt": "Ilustracja okładki",
+        "continue": "kontynuuj",
+    },
+    "sv": {
+        "the_end": "Slut",
+        "codex": "Kodex",
+        "cover_alt": "Omslagsbild",
+        "continue": "fortsätt",
+    },
+    "da": {
+        "the_end": "Slut",
+        "codex": "Kodeks",
+        "cover_alt": "Forsideillustration",
+        "continue": "fortsæt",
+    },
+    "no": {
+        "the_end": "Slutt",
+        "codex": "Kodeks",
+        "cover_alt": "Forsideillustrasjon",
+        "continue": "fortsett",
+    },
 }
 
 

--- a/src/questfoundry/pipeline/orchestrator.py
+++ b/src/questfoundry/pipeline/orchestrator.py
@@ -585,7 +585,7 @@ class PipelineOrchestrator:
             stage_kwargs: dict[str, Any] = {}
             if self._model_info is not None:
                 stage_kwargs["max_concurrency"] = self._model_info.max_concurrency
-            stage_kwargs["language"] = self.config.language
+            stage_kwargs["language"] = context.get("language") or self.config.language
             if resume_from:
                 stage_kwargs["resume_from"] = resume_from
             if on_phase_progress:


### PR DESCRIPTION
## Problem
Users cannot override the project language from the CLI, making it cumbersome to test or generate stories in different languages without editing `project.yaml`. Additionally, several languages supported by `LANGUAGE_NAMES` were missing from `UI_STRINGS`.

## Changes
- Add `--language/-l` option to all 7 stage commands (`dream`, `brainstorm`, `seed`, `grow`, `fill`, `dress`, `run`)
- Wire language override through `_run_stage_command()` → context dict → orchestrator
- Orchestrator now reads `context.get("language") or self.config.language` for CLI precedence
- Expand `UI_STRINGS` in `i18n.py` with 8 new languages: Japanese, Korean, Chinese, Russian, Polish, Swedish, Danish, Norwegian

## Not Included / Future PRs
- Item 2 from #533: Language-specific voice document defaults — requires research into how IF conventions differ by language

## Test Plan
```
uv run ruff check src/questfoundry/cli.py src/questfoundry/export/i18n.py src/questfoundry/pipeline/orchestrator.py  # All checks passed
uv run mypy src/questfoundry/cli.py src/questfoundry/export/i18n.py src/questfoundry/pipeline/orchestrator.py  # no issues
uv run pytest tests/unit/test_cli.py -x -q  # 78 passed
uv run pytest tests/unit/ -x -q -k "i18n"  # 14 passed
```

## Risk / Rollback
- Low risk — additive CLI option with no change to default behavior
- When `--language` is not provided, behavior is identical to before

Partially closes #533

🤖 Generated with [Claude Code](https://claude.com/claude-code)