### PR TITLE
feat(fill): integrate entity arc context into prose generation

### DIFF
--- a/prompts/templates/fill_phase1_prose.yaml
+++ b/prompts/templates/fill_phase1_prose.yaml
@@ -55,6 +55,9 @@ system: |
   ## Entity States
   {entity_states}
 
+  ## Entity Arc Context
+  {entity_arc_context}
+
   ## Recent Passages (Sliding Window)
   {sliding_window}
 

--- a/prompts/templates/fill_phase1_prose_only.yaml
+++ b/prompts/templates/fill_phase1_prose_only.yaml
@@ -55,6 +55,9 @@ system: |
   ## Entity States
   {entity_states}
 
+  ## Entity Arc Context
+  {entity_arc_context}
+
   ## Recent Passages (Sliding Window)
   {sliding_window}
 

--- a/src/questfoundry/pipeline/stages/fill.py
+++ b/src/questfoundry/pipeline/stages/fill.py
@@ -27,6 +27,7 @@ from questfoundry.artifacts.validator import get_all_field_paths
 from questfoundry.export.i18n import get_output_language_instruction
 from questfoundry.graph.context import strip_scope_prefix
 from questfoundry.graph.fill_context import (
+    compute_arc_hints,
     compute_first_appearances,
     compute_is_ending,
     compute_lexical_diversity,
@@ -34,6 +35,7 @@ from questfoundry.graph.fill_context import (
     format_dramatic_questions,
     format_dream_vision,
     format_ending_guidance,
+    format_entity_arc_context,
     format_entity_states,
     format_entry_states,
     format_grow_summary,
@@ -896,13 +898,17 @@ class FillStage:
                 "atmospheric_detail": format_atmospheric_detail(graph, passage_id),
                 "entry_states": format_entry_states(graph, passage_id, arc_id),
                 "entity_states": format_entity_states(graph, passage_id),
+                "entity_arc_context": format_entity_arc_context(graph, passage_id, arc_id),
                 "sliding_window": format_sliding_window(graph, arc_id, current_idx, window_size),
                 "lookahead": format_lookahead_context(graph, passage_id, arc_id),
                 "shadow_states": format_shadow_states(graph, passage_id, arc_id),
                 "path_arcs": format_path_arc_context(graph, passage_id, arc_id),
                 "vocabulary_note": vocabulary_note,
                 "ending_guidance": format_ending_guidance(is_ending),
-                "introduction_guidance": format_introduction_guidance(first_names),
+                "introduction_guidance": format_introduction_guidance(
+                    first_names,
+                    arc_hints=compute_arc_hints(graph, first_eids, arc_id),
+                ),
                 "output_language_instruction": self._lang_instruction,
             }
 


### PR DESCRIPTION
## Problem
Entity arcs generated in GROW Phase 4f (PR #585) are stored on path nodes but not consumed by FILL. Without positional context, the LLM has no guidance on where an entity is in its arc trajectory — leading to flat character progression, especially at scale with weaker models.

## Changes
- **`format_entity_arc_context()`** in `fill_context.py` — computes positional context (pre-pivot / at-pivot / post-pivot) for entities with arcs on active paths. Only shows arcs for entities present in the current passage.
- **`compute_arc_hints()`** in `fill_context.py` — maps first-appearance entity IDs to arc_types from active paths, used for arc-aware introduction framing.
- **`format_introduction_guidance()`** — extended with optional `arc_hints` parameter. When an entity has an arc AND is being introduced, adds arc-specific framing (e.g., "establish the facade that will later be peeled back" for revelation arcs).
- **`_ARC_INTRODUCTION_HINTS`** — mapping from arc_type to introduction craft guidance.
- **FILL templates** — `{entity_arc_context}` added to both `fill_phase1_prose.yaml` and `fill_phase1_prose_only.yaml`, placed after `{entity_states}`.
- **`fill.py` wiring** — imports and context dict entries for `format_entity_arc_context` and `compute_arc_hints`.
- **22 new tests** across entity arc context, arc hints, and introduction guidance.

## Not Included / Future PRs
- No changes needed — this completes #564.

## Test Plan
```bash
uv run mypy src/questfoundry/graph/fill_context.py src/questfoundry/pipeline/stages/fill.py  # ✅ no issues
uv run ruff check src/  # ✅ all checks passed
uv run pytest tests/unit/test_fill_context.py -x -q  # ✅ 111 passed
```

## Risk / Rollback
- Graceful degradation: if no `entity_arcs` on path nodes (Phase 4f skipped/failed), `format_entity_arc_context` returns empty string — same as today
- Introduction guidance is backwards-compatible: `arc_hints=None` produces identical output to before
- No changes to FILL's core prose generation logic — only additional context

## Review Guide
Suggested review order:
1. `src/questfoundry/graph/fill_context.py` — new functions and `_ARC_INTRODUCTION_HINTS`
2. `prompts/templates/fill_phase1_prose.yaml` — template variable placement
3. `src/questfoundry/pipeline/stages/fill.py` — wiring (small diff)
4. `tests/unit/test_fill_context.py` — test coverage

Stacked on #585.

🤖 Generated with [Claude Code](https://claude.com/claude-code)