### PR TITLE
feat(dress): add --min-priority flag for image generation

### DIFF
--- a/prompts/templates/dress_codex.yaml
+++ b/prompts/templates/dress_codex.yaml
@@ -19,6 +19,7 @@ system: |
   Return a JSON object with:
 
   **entries** (list of objects):
+  - title: Short display title for this entry (e.g., character name, location name, faction name)
   - rank: Display order (1 = base knowledge, higher = deeper revelation)
   - visible_when: List of codeword IDs that must be unlocked to see this entry (empty for rank 1)
   - content: Diegetic text — written in the story's voice, not meta-commentary

--- a/src/questfoundry/cli.py
+++ b/src/questfoundry/cli.py
@@ -1693,7 +1693,12 @@ def generate_images(
 
     def _on_phase_progress(phase: str, status: str, detail: str | None) -> None:
         detail_str = f" ({detail})" if detail else ""
-        status_icon = "[green]✓[/green]" if status == "completed" else "[red]✗[/red]"
+        if status == "completed":
+            status_icon = "[green]✓[/green]"
+        elif status == "failed":
+            status_icon = "[red]✗[/red]"
+        else:
+            status_icon = "[yellow]○[/yellow]"
         console.print(f"  {status_icon} {phase}{detail_str}")
 
     console.print()

--- a/src/questfoundry/cli.py
+++ b/src/questfoundry/cli.py
@@ -39,6 +39,17 @@ if TYPE_CHECKING:
 # Type alias for artifact preview functions
 PreviewFn = Callable[[dict[str, Any]], None]
 
+# Shared CLI option types (used across multiple commands)
+MinPriorityOption = Annotated[
+    int,
+    typer.Option(
+        "--min-priority",
+        min=1,
+        max=3,
+        help="Only generate images with this priority or higher (1=must-have, 2=important, 3=all).",
+    ),
+]
+
 app = typer.Typer(
     name="qf",
     help="QuestFoundry: Pipeline-driven interactive fiction generation.",
@@ -1590,15 +1601,7 @@ def generate_images(
         int,
         typer.Option("--image-budget", help="Max images to generate (0=all selected briefs)."),
     ] = 0,
-    min_priority: Annotated[
-        int,
-        typer.Option(
-            "--min-priority",
-            min=1,
-            max=3,
-            help="Only generate images with this priority or higher (1=must-have, 2=important, 3=all).",
-        ),
-    ] = 3,
+    min_priority: MinPriorityOption = 3,
     force: Annotated[
         bool,
         typer.Option("--force", help="Regenerate images even if illustrations already exist."),
@@ -1828,15 +1831,7 @@ def run(
             help="Max images to generate in DRESS stage (0=all selected briefs).",
         ),
     ] = 0,
-    min_priority: Annotated[
-        int,
-        typer.Option(
-            "--min-priority",
-            min=1,
-            max=3,
-            help="Only generate images with this priority or higher (1=must-have, 2=important, 3=all).",
-        ),
-    ] = 3,
+    min_priority: MinPriorityOption = 3,
     two_step: Annotated[
         bool | None,
         typer.Option(

--- a/src/questfoundry/export/base.py
+++ b/src/questfoundry/export/base.py
@@ -68,6 +68,7 @@ class ExportCodexEntry:
     """A codex encyclopedia entry for an entity."""
 
     entity_id: str
+    title: str
     rank: int
     visible_when: list[str] = field(default_factory=list)
     content: str = ""

--- a/src/questfoundry/export/context.py
+++ b/src/questfoundry/export/context.py
@@ -201,9 +201,22 @@ def _extract_codex_entries(graph: Graph) -> list[ExportCodexEntry]:
     for node_id, data in sorted(codex_nodes.items()):
         entity_id = codex_to_entity.get(node_id)
         if entity_id:
+            title = data.get("title", "")
+            if not title:
+                # Fallback: derive from entity concept ("Name — description")
+                entity_node = graph.get_node(entity_id)
+                if entity_node:
+                    concept = entity_node.get("concept", "")
+                    for sep in (" \u2014 ", " - ", " \u2013 "):
+                        if sep in concept:
+                            title = concept.split(sep, 1)[0].strip()
+                            break
+                if not title:
+                    title = entity_id
             result.append(
                 ExportCodexEntry(
                     entity_id=entity_id,
+                    title=title,
                     rank=data.get("rank", 0),
                     visible_when=data.get("visible_when", []),
                     content=data.get("content", ""),

--- a/src/questfoundry/export/html_exporter.py
+++ b/src/questfoundry/export/html_exporter.py
@@ -187,7 +187,7 @@ def _render_codex_panel(
         if entry.visible_when:
             visible_attr = f' data-visible-when="{html.escape(json.dumps(entry.visible_when))}"'
         parts.append(f'  <div class="codex-entry"{visible_attr}>')
-        parts.append(f"    <h3>{html.escape(entry.entity_id)}</h3>")
+        parts.append(f"    <h3>{html.escape(entry.title)}</h3>")
         parts.append(f"    <p>{html.escape(entry.content)}</p>")
         parts.append("  </div>")
     parts.append("</div>")

--- a/src/questfoundry/export/twee_exporter.py
+++ b/src/questfoundry/export/twee_exporter.py
@@ -228,7 +228,7 @@ def _render_codex_passage(
 
     sorted_entries = sorted(codex_entries, key=lambda e: e.rank)
     for entry in sorted_entries:
-        entry_lines = [f"!! {entry.entity_id}", entry.content, ""]
+        entry_lines = [f"!! {entry.title}", entry.content, ""]
         if entry.visible_when:
             conditions = " and ".join(_codeword_var(cw) for cw in entry.visible_when)
             lines.append(f"<<if {conditions}>>")

--- a/src/questfoundry/models/dress.py
+++ b/src/questfoundry/models/dress.py
@@ -79,6 +79,10 @@ class CodexEntry(BaseModel):
     more as they unlock codewords. Linked to entity via HasEntry edge.
     """
 
+    title: str = Field(
+        min_length=1,
+        description="Short display title for this entry (e.g., character name, location name)",
+    )
     rank: int = Field(ge=1, description="Display order (1 = base knowledge, higher = deeper)")
     visible_when: list[str] = Field(
         default_factory=list,

--- a/src/questfoundry/pipeline/stages/dress.py
+++ b/src/questfoundry/pipeline/stages/dress.py
@@ -1465,7 +1465,19 @@ def build_image_brief(graph: Graph, brief: dict[str, Any]) -> ImageBrief:
         if ev:
             frag = ev.get("reference_prompt_fragment", "")
             if frag:
-                entity_fragments.append(f"{raw_eid}: {frag}")
+                # Include the display name so the distiller can match
+                # "Bailey" in the subject to "Bailey (ch_bailey): ..."
+                entity_node = graph.get_node(f"entity::{raw_eid}")
+                name = ""
+                if entity_node:
+                    concept = entity_node.get("concept", "")
+                    # Name is the first part before " —" or " -"
+                    for sep in (" \u2014 ", " - ", " \u2013 "):
+                        if sep in concept:
+                            name = concept.split(sep, 1)[0].strip()
+                            break
+                label = f"{name} ({raw_eid})" if name else raw_eid
+                entity_fragments.append(f"{label}: {frag}")
 
     return ImageBrief(
         subject=brief.get("subject", ""),

--- a/src/questfoundry/pipeline/stages/dress.py
+++ b/src/questfoundry/pipeline/stages/dress.py
@@ -1476,7 +1476,7 @@ def build_image_brief(graph: Graph, brief: dict[str, Any]) -> ImageBrief:
                         if sep in concept:
                             name = concept.split(sep, 1)[0].strip()
                             break
-                label = f"{name} ({raw_eid})" if name else raw_eid
+                label = name if name else raw_eid
                 entity_fragments.append(f"{label}: {frag}")
 
     return ImageBrief(

--- a/src/questfoundry/pipeline/stages/dress.py
+++ b/src/questfoundry/pipeline/stages/dress.py
@@ -1241,23 +1241,34 @@ def _create_cover_brief(graph: Graph) -> bool:
 def _filter_by_priority(
     graph: Graph,
     brief_ids: list[str],
-    max_priority: int,
+    priority_threshold: int,
 ) -> list[str]:
-    """Keep only briefs with priority <= max_priority.
+    """Keep only briefs with priority <= priority_threshold.
 
-    Lower priority numbers are more important (1=must-have, 3=nice-to-have).
+    Priority uses an inverted scale: lower numbers are more important
+    (1=must-have, 2=important, 3=nice-to-have). A threshold of 2 keeps
+    priority 1 and 2, excluding 3.
+
     Briefs missing from the graph default to priority 3.
 
     Args:
         graph: Story graph containing brief nodes.
         brief_ids: All selected brief IDs.
-        max_priority: Maximum priority value to include (1-3).
+        priority_threshold: Maximum priority value to include (1-3).
 
     Returns:
         Filtered list of brief IDs.
+
+    Raises:
+        ValueError: If priority_threshold is not in [1, 3].
     """
+    if not 1 <= priority_threshold <= 3:
+        msg = f"priority_threshold must be 1-3, got {priority_threshold}"
+        raise ValueError(msg)
     return [
-        bid for bid in brief_ids if (graph.get_node(bid) or {}).get("priority", 3) <= max_priority
+        bid
+        for bid in brief_ids
+        if (graph.get_node(bid) or {}).get("priority", 3) <= priority_threshold
     ]
 
 

--- a/src/questfoundry/pipeline/stages/fill.py
+++ b/src/questfoundry/pipeline/stages/fill.py
@@ -690,7 +690,7 @@ class FillStage:
             model=model,
             tools=tools,
             user_prompt="Research voice and style guidance for this story.",
-            max_iterations=8,
+            max_iterations=25,
             interactive=False,
             system_prompt=system_prompt,
             stage_name="fill",

--- a/src/questfoundry/providers/image_a1111.py
+++ b/src/questfoundry/providers/image_a1111.py
@@ -282,9 +282,12 @@ class A1111ImageProvider:
             "KEEP: concrete visual details that a painter would need.\n\n"
             "RULES:\n"
             "- ENTITY EXPANSION: SD does not know character names. Replace names "
-            '(e.g., "Eleanor") with their visual descriptions from the Entities '
-            'field (e.g., "eleanor: tall woman, dark coat" → use '
-            '"tall woman, dark coat").\n'
+            "in the Subject with their visual descriptions from the Entities "
+            'field. Each entity is listed as "Name (id): visual description". '
+            "Match names in the Subject to entity names, then use the visual "
+            'tags (e.g., "Bailey slides..." + "Bailey (ch_bailey): club owner, '
+            'gray pinstripe suit" → "club owner, gray pinstripe suit, '
+            'sliding tab").\n'
             "- Each tag is 1-4 words, comma-separated.\n"
             "- No prose, no articles, no prepositions, no sentences.\n"
             "- Output EXACTLY two lines. Line 1: positive. Line 2: negative.\n"

--- a/src/questfoundry/providers/image_a1111.py
+++ b/src/questfoundry/providers/image_a1111.py
@@ -283,9 +283,9 @@ class A1111ImageProvider:
             "RULES:\n"
             "- ENTITY EXPANSION: SD does not know character names. Replace names "
             "in the Subject with their visual descriptions from the Entities "
-            'field. Each entity is listed as "Name (id): visual description". '
+            'field. Each entity is listed as "Name: visual description". '
             "Match names in the Subject to entity names, then use the visual "
-            'tags (e.g., "Bailey slides..." + "Bailey (ch_bailey): club owner, '
+            'tags (e.g., "Bailey slides..." + "Bailey: club owner, '
             'gray pinstripe suit" → "club owner, gray pinstripe suit, '
             'sliding tab").\n'
             "- Each tag is 1-4 words, comma-separated.\n"

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -1190,8 +1190,10 @@ def test_dream_help_shows_role_provider_flags() -> None:
     assert "--provider-discuss" not in output
 
 
-def test_run_help_shows_role_provider_flags() -> None:
+def test_run_help_shows_role_provider_flags(monkeypatch: pytest.MonkeyPatch) -> None:
     """Test run --help shows role-based provider flags (not legacy)."""
+    # Run command has many options; Rich truncates help at narrow widths
+    monkeypatch.setenv("COLUMNS", "200")
     result = runner.invoke(app, ["run", "--help"])
     output = _strip_ansi(result.stdout)
 

--- a/tests/unit/test_dress_models.py
+++ b/tests/unit/test_dress_models.py
@@ -110,12 +110,14 @@ class TestIllustration:
 
 class TestCodexEntry:
     def test_valid_base_entry(self) -> None:
-        entry = CodexEntry(rank=1, content="A traveling scholar.")
+        entry = CodexEntry(title="Aldric", rank=1, content="A traveling scholar.")
         assert entry.visible_when == []
         assert entry.rank == 1
+        assert entry.title == "Aldric"
 
     def test_gated_entry(self) -> None:
         entry = CodexEntry(
+            title="Aldric",
             rank=2,
             visible_when=["met_aldric"],
             content="Claims to be a former court advisor.",
@@ -124,15 +126,15 @@ class TestCodexEntry:
 
     def test_rank_zero_rejected(self) -> None:
         with pytest.raises(ValidationError):
-            CodexEntry(rank=0, content="content")
+            CodexEntry(title="Test", rank=0, content="content")
 
     def test_negative_rank_rejected(self) -> None:
         with pytest.raises(ValidationError):
-            CodexEntry(rank=-1, content="content")
+            CodexEntry(title="Test", rank=-1, content="content")
 
     def test_empty_content_rejected(self) -> None:
         with pytest.raises(ValidationError):
-            CodexEntry(rank=1, content="")
+            CodexEntry(title="Test", rank=1, content="")
 
 
 # ---------------------------------------------------------------------------
@@ -369,8 +371,13 @@ class TestDressPhase2Output:
     def test_valid_phase2(self) -> None:
         output = DressPhase2Output(
             entries=[
-                CodexEntry(rank=1, content="A traveling scholar."),
-                CodexEntry(rank=2, visible_when=["met_aldric"], content="Former court advisor."),
+                CodexEntry(title="Aldric", rank=1, content="A traveling scholar."),
+                CodexEntry(
+                    title="Aldric's Past",
+                    rank=2,
+                    visible_when=["met_aldric"],
+                    content="Former court advisor.",
+                ),
             ],
         )
         assert len(output.entries) == 2
@@ -430,7 +437,9 @@ class TestRoundtrip:
         assert restored == ad
 
     def test_codex_entry_roundtrip(self) -> None:
-        entry = CodexEntry(rank=2, visible_when=["met_aldric"], content="Former court advisor.")
+        entry = CodexEntry(
+            title="Aldric", rank=2, visible_when=["met_aldric"], content="Former court advisor."
+        )
         data = entry.model_dump()
         restored = CodexEntry.model_validate(data)
         assert restored == entry

--- a/tests/unit/test_dress_stage.py
+++ b/tests/unit/test_dress_stage.py
@@ -207,7 +207,9 @@ class TestPhase0ArtDirection:
             llm_adjustment=0,
         )
         mock_codex_out = DressPhase2Output(
-            entries=[CodexEntry(rank=1, visible_when=[], content="Base knowledge.")]
+            entries=[
+                CodexEntry(title="Test Entity", rank=1, visible_when=[], content="Base knowledge.")
+            ]
         )
 
         with (
@@ -905,8 +907,14 @@ class TestPhase1Briefs:
 def mock_codex_output() -> DressPhase2Output:
     return DressPhase2Output(
         entries=[
-            CodexEntry(rank=1, visible_when=[], content="A young scholar of the old academy."),
             CodexEntry(
+                title="Aldric",
+                rank=1,
+                visible_when=[],
+                content="A young scholar of the old academy.",
+            ),
+            CodexEntry(
+                title="Aldric's Secret",
                 rank=2,
                 visible_when=["met_aldric"],
                 content="The scholar secretly studies forbidden texts.",

--- a/tests/unit/test_dress_stage.py
+++ b/tests/unit/test_dress_stage.py
@@ -1181,7 +1181,7 @@ class TestFilterByPriority:
         return g
 
     def test_keeps_high_priority(self) -> None:
-        """min_priority=2 keeps priority 1 and 2, excludes 3."""
+        """priority_threshold=2 keeps priority 1 and 2, excludes 3."""
         g = self._make_graph_with_briefs(
             {
                 "illustration_brief::a": 1,
@@ -1192,12 +1192,12 @@ class TestFilterByPriority:
         result = _filter_by_priority(
             g,
             ["illustration_brief::a", "illustration_brief::b", "illustration_brief::c"],
-            max_priority=2,
+            priority_threshold=2,
         )
         assert result == ["illustration_brief::a", "illustration_brief::b"]
 
     def test_must_have_only(self) -> None:
-        """min_priority=1 keeps only priority 1."""
+        """priority_threshold=1 keeps only priority 1."""
         g = self._make_graph_with_briefs(
             {
                 "illustration_brief::a": 1,
@@ -1208,12 +1208,12 @@ class TestFilterByPriority:
         result = _filter_by_priority(
             g,
             ["illustration_brief::a", "illustration_brief::b", "illustration_brief::c"],
-            max_priority=1,
+            priority_threshold=1,
         )
         assert result == ["illustration_brief::a", "illustration_brief::c"]
 
     def test_all_priorities(self) -> None:
-        """min_priority=3 keeps everything (no filtering)."""
+        """priority_threshold=3 keeps everything (no filtering)."""
         g = self._make_graph_with_briefs(
             {
                 "illustration_brief::a": 1,
@@ -1221,11 +1221,11 @@ class TestFilterByPriority:
             }
         )
         all_ids = ["illustration_brief::a", "illustration_brief::b"]
-        result = _filter_by_priority(g, all_ids, max_priority=3)
+        result = _filter_by_priority(g, all_ids, priority_threshold=3)
         assert result == all_ids
 
     def test_missing_node_defaults_to_low_priority(self) -> None:
-        """Briefs not in graph default to priority 3 (excluded at min_priority=2)."""
+        """Briefs not in graph default to priority 3 (excluded at priority_threshold=2)."""
         g = self._make_graph_with_briefs(
             {
                 "illustration_brief::real": 1,
@@ -1234,7 +1234,7 @@ class TestFilterByPriority:
         result = _filter_by_priority(
             g,
             ["illustration_brief::real", "illustration_brief::missing"],
-            max_priority=2,
+            priority_threshold=2,
         )
         assert result == ["illustration_brief::real"]
 
@@ -1250,7 +1250,7 @@ class TestFilterByPriority:
         result = _filter_by_priority(
             g,
             ["illustration_brief::z", "illustration_brief::a", "illustration_brief::m"],
-            max_priority=1,
+            priority_threshold=1,
         )
         assert result == ["illustration_brief::z", "illustration_brief::m"]
 

--- a/tests/unit/test_html_exporter.py
+++ b/tests/unit/test_html_exporter.py
@@ -184,6 +184,7 @@ class TestHtmlExporter:
             codex_entries=[
                 ExportCodexEntry(
                     entity_id="Ancient Sword",
+                    title="Ancient Sword",
                     rank=1,
                     visible_when=["codeword::sword_found"],
                     content="A legendary blade.",
@@ -209,7 +210,7 @@ class TestHtmlExporter:
             ],
             choices=[],
             codex_entries=[
-                ExportCodexEntry(entity_id="Lore", rank=1, content="Some lore."),
+                ExportCodexEntry(entity_id="Lore", title="Lore", rank=1, content="Some lore."),
             ],
         )
         exporter = HtmlExporter()
@@ -285,7 +286,9 @@ class TestHtmlExporter:
                 ExportChoice(from_passage="p1", to_passage="p2", label="Betreed het kasteel"),
             ],
             codex_entries=[
-                ExportCodexEntry(entity_id="Zwaard", rank=1, content="Een legendarisch zwaard."),
+                ExportCodexEntry(
+                    entity_id="Zwaard", title="Zwaard", rank=1, content="Een legendarisch zwaard."
+                ),
             ],
         )
         exporter = HtmlExporter()

--- a/tests/unit/test_twee_exporter.py
+++ b/tests/unit/test_twee_exporter.py
@@ -206,6 +206,7 @@ class TestTweeExporter:
             codex_entries=[
                 ExportCodexEntry(
                     entity_id="Ancient Sword",
+                    title="Ancient Sword",
                     rank=1,
                     visible_when=["codeword::sword_found"],
                     content="A legendary blade.",
@@ -239,6 +240,7 @@ class TestTweeExporter:
             codex_entries=[
                 ExportCodexEntry(
                     entity_id="World Lore",
+                    title="World Lore",
                     rank=1,
                     visible_when=[],
                     content="Always visible lore.",
@@ -262,9 +264,9 @@ class TestTweeExporter:
             ],
             choices=[],
             codex_entries=[
-                ExportCodexEntry(entity_id="Zeta", rank=3, content="Third."),
-                ExportCodexEntry(entity_id="Alpha", rank=1, content="First."),
-                ExportCodexEntry(entity_id="Beta", rank=2, content="Second."),
+                ExportCodexEntry(entity_id="Zeta", title="Zeta", rank=3, content="Third."),
+                ExportCodexEntry(entity_id="Alpha", title="Alpha", rank=1, content="First."),
+                ExportCodexEntry(entity_id="Beta", title="Beta", rank=2, content="Second."),
             ],
         )
         exporter = TweeExporter()
@@ -332,7 +334,7 @@ class TestTweeExporter:
             ],
             choices=[],
             codex_entries=[
-                ExportCodexEntry(entity_id="Held", rank=1, content="De held."),
+                ExportCodexEntry(entity_id="Held", title="Held", rank=1, content="De held."),
             ],
         )
         exporter = TweeExporter()
@@ -351,7 +353,7 @@ class TestTweeExporter:
             ],
             choices=[],
             codex_entries=[
-                ExportCodexEntry(entity_id="Held", rank=1, content="Der Held."),
+                ExportCodexEntry(entity_id="Held", title="Held", rank=1, content="Der Held."),
             ],
         )
         exporter = TweeExporter()


### PR DESCRIPTION
## Problem

This PR bundles several improvements to the DRESS stage and related fixes:

1. `qf generate-images` had no way to filter by priority level — only `--image-budget N` existed
2. Codex entries used raw entity IDs as display headers instead of human-readable titles
3. Progress display showed ✗ for in-progress image generation steps
4. FILL stage voice research hit GraphRecursionError with Gemini (limit too low)
5. Image distiller entity fragments didn't include human-readable names

## Changes

**Priority filter (Closes #593)**
- Add `_filter_by_priority()` helper in `dress.py` that filters briefs by priority threshold
- Add `--min-priority` CLI flag (1-3) to `qf generate-images` and `qf run`
- Priority filter runs **before** budget truncation, so both compose
- Default is 3 (no filtering), preserving existing behavior
- 5 unit tests for the filter helper

**Codex titles (Closes #587)**
- Add `title` field to `CodexEntry` model
- Update prompt template to request titles from LLM
- Export layer uses title for display, with fallback to entity concept name
- Update Twee and HTML exporters to render `entry.title` instead of `entry.entity_id`

**Bug fixes**
- Fix progress icon: in-progress steps now show ○ instead of ✗
- Bump FILL voice research recursion limit from 8 to 25 for Gemini compatibility
- Entity fragments now include human-readable names (extracted from entity concept) instead of raw IDs

## Not Included / Future PRs

- No changes to `qf dress` standalone command for priority filtering

## Test Plan

```bash
uv run pytest tests/unit/test_dress_stage.py tests/unit/test_twee_exporter.py tests/unit/test_html_exporter.py -x -q
# 117 passed
uv run mypy src/
# Success
```

## Risk / Rollback

Low risk — default values preserve existing behavior. Codex title has a fallback chain (LLM title → entity concept name → entity ID) for backward compatibility with existing graphs.

Closes #593
Closes #587

🤖 Generated with [Claude Code](https://claude.com/claude-code)