### PR TITLE
feat(cli): add `qf inspect` command for project quality analysis

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -595,6 +595,8 @@ uv run pytest --cov                                # With coverage (USES LLM - e
 qf dream                       # Run DREAM stage
 qf run --to seed              # Run up to SEED
 qf status                     # Show pipeline state
+qf inspect -p <project>       # Inspect project quality (no LLM calls)
+qf inspect -p <project> --json # Machine-readable JSON output
 ```
 
 ## Key Files to Reference

--- a/src/questfoundry/cli.py
+++ b/src/questfoundry/cli.py
@@ -34,6 +34,7 @@ load_dotenv()
 if TYPE_CHECKING:
     from prompt_toolkit.key_binding.key_processor import KeyPressEvent
 
+    from questfoundry.inspection import InspectionReport
     from questfoundry.pipeline import PipelineOrchestrator, StageResult
 
 # Type alias for artifact preview functions
@@ -2561,7 +2562,7 @@ def inspect(
     _render_inspection_report(report)
 
 
-def _render_inspection_report(report: Any) -> None:
+def _render_inspection_report(report: InspectionReport) -> None:
     """Render an InspectionReport using Rich tables and panels."""
     s = report.summary
     console.print()

--- a/src/questfoundry/inspection.py
+++ b/src/questfoundry/inspection.py
@@ -286,7 +286,7 @@ def _coverage_stats(graph: Graph, project_path: Path) -> CoverageStats:
 
     codex_entries = graph.get_nodes_by_type("codex_entry")
     has_entry_edges = graph.get_edges(edge_type="HasEntry")
-    entities_with_codex = len({e["from"] for e in has_entry_edges})
+    entities_with_codex = len({e["to"] for e in has_entry_edges})
 
     briefs = graph.get_nodes_by_type("illustration_brief")
     illustrations = graph.get_nodes_by_type("illustration")

--- a/src/questfoundry/inspection.py
+++ b/src/questfoundry/inspection.py
@@ -1,0 +1,320 @@
+"""Project inspection and quality analysis.
+
+Automates the manual quality review checks performed on completed projects.
+Pure graph analysis — no LLM calls.
+"""
+
+from __future__ import annotations
+
+from collections import Counter
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+from questfoundry.graph.fill_context import compute_lexical_diversity
+from questfoundry.graph.graph import Graph
+from questfoundry.graph.grow_validation import run_all_checks
+from questfoundry.observability.logging import get_logger
+from questfoundry.pipeline.config import ProjectConfigError, load_project_config
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+log = get_logger(__name__)
+
+
+@dataclass
+class GraphSummary:
+    """High-level graph statistics."""
+
+    project_name: str
+    last_stage: str | None
+    total_nodes: int
+    total_edges: int
+    node_counts: dict[str, int] = field(default_factory=dict)
+
+
+@dataclass
+class ProseStats:
+    """Prose quality metrics across all passages."""
+
+    total_passages: int
+    passages_with_prose: int
+    flagged_passages: list[dict[str, str]] = field(default_factory=list)
+    total_words: int = 0
+    avg_words: float = 0.0
+    min_words: int = 0
+    max_words: int = 0
+    lexical_diversity: float | None = None
+
+
+@dataclass
+class BranchingStats:
+    """Branching structure metrics."""
+
+    total_choices: int = 0
+    meaningful_choices: int = 0
+    continue_choices: int = 0
+    total_dilemmas: int = 0
+    fully_explored: int = 0
+    partially_explored: int = 0
+    start_passages: int = 0
+    ending_passages: int = 0
+
+
+@dataclass
+class CoverageStats:
+    """Entity, codex, and illustration coverage."""
+
+    entity_count: int = 0
+    entity_types: dict[str, int] = field(default_factory=dict)
+    codex_entries: int = 0
+    entities_with_codex: int = 0
+    illustration_briefs: int = 0
+    illustration_nodes: int = 0
+    asset_files: int = 0
+
+
+@dataclass
+class InspectionReport:
+    """Complete project inspection report."""
+
+    summary: GraphSummary
+    prose: ProseStats | None = None
+    branching: BranchingStats | None = None
+    coverage: CoverageStats = field(default_factory=CoverageStats)
+    validation_checks: list[dict[str, str]] = field(default_factory=list)
+
+
+def inspect_project(project_path: Path) -> InspectionReport:
+    """Run all inspection checks on a project.
+
+    Args:
+        project_path: Path to the project root directory.
+
+    Returns:
+        InspectionReport with all analysis results.
+    """
+    graph = Graph.load(project_path)
+
+    summary = _graph_summary(graph, project_path)
+    prose = _prose_stats(graph)
+    branching = _branching_stats(graph)
+    coverage = _coverage_stats(graph, project_path)
+    validation = _run_validation(graph)
+
+    log.info(
+        "inspection_complete",
+        project=summary.project_name,
+        nodes=summary.total_nodes,
+        edges=summary.total_edges,
+    )
+
+    return InspectionReport(
+        summary=summary,
+        prose=prose,
+        branching=branching,
+        coverage=coverage,
+        validation_checks=validation,
+    )
+
+
+def _graph_summary(graph: Graph, project_path: Path) -> GraphSummary:
+    """Extract high-level graph statistics."""
+    data = graph.to_dict()
+    nodes = data.get("nodes", {})
+    edges = data.get("edges", [])
+
+    node_counts: dict[str, int] = Counter(n.get("type", "unknown") for n in nodes.values())
+
+    project_name = graph.get_project_name() or ""
+    if not project_name:
+        try:
+            config = load_project_config(project_path)
+            project_name = config.name
+        except (ProjectConfigError, FileNotFoundError):
+            project_name = project_path.name
+
+    return GraphSummary(
+        project_name=project_name,
+        last_stage=graph.get_last_stage(),
+        total_nodes=len(nodes),
+        total_edges=len(edges),
+        node_counts=dict(sorted(node_counts.items(), key=lambda x: -x[1])),
+    )
+
+
+def _prose_stats(graph: Graph) -> ProseStats | None:
+    """Analyze prose quality across all passages."""
+    passages = graph.get_nodes_by_type("passage")
+    if not passages:
+        return None
+
+    word_counts: list[int] = []
+    prose_texts: list[str] = []
+    flagged: list[dict[str, str]] = []
+
+    for pid, data in passages.items():
+        prose = data.get("prose")
+        if not prose or not str(prose).strip():
+            entry: dict[str, str] = {"id": pid}
+            if data.get("flag"):
+                entry["flag"] = data["flag"]
+            if data.get("flag_reason"):
+                entry["flag_reason"] = data["flag_reason"]
+            flagged.append(entry)
+        else:
+            text = str(prose)
+            wc = len(text.split())
+            word_counts.append(wc)
+            prose_texts.append(text)
+
+    diversity = None
+    if len(prose_texts) >= 2:
+        diversity = round(compute_lexical_diversity(prose_texts), 3)
+
+    return ProseStats(
+        total_passages=len(passages),
+        passages_with_prose=len(word_counts),
+        flagged_passages=flagged,
+        total_words=sum(word_counts),
+        avg_words=round(sum(word_counts) / len(word_counts), 1) if word_counts else 0.0,
+        min_words=min(word_counts) if word_counts else 0,
+        max_words=max(word_counts) if word_counts else 0,
+        lexical_diversity=diversity,
+    )
+
+
+def _branching_stats(graph: Graph) -> BranchingStats | None:
+    """Analyze branching structure."""
+    passages = graph.get_nodes_by_type("passage")
+    if not passages:
+        return None
+
+    choices = graph.get_nodes_by_type("choice")
+    meaningful = 0
+    continue_count = 0
+    for _cid, cdata in choices.items():
+        label = cdata.get("label", "continue")
+        if label == "continue":
+            continue_count += 1
+        else:
+            meaningful += 1
+
+    # Dilemma exploration: check if both answers have prose passages
+    dilemmas = graph.get_nodes_by_type("dilemma")
+    has_answer_edges = graph.get_edges(edge_type="has_answer")
+    answers_by_dilemma: dict[str, list[str]] = {}
+    for edge in has_answer_edges:
+        answers_by_dilemma.setdefault(edge["from"], []).append(edge["to"])
+
+    # Build answer→path mapping via explores edges (path explores answer)
+    explores_edges = graph.get_edges(edge_type="explores")
+    answer_to_path: dict[str, str] = {}
+    for edge in explores_edges:
+        answer_to_path[edge["to"]] = edge["from"]
+
+    # Build path→has_prose lookup
+    paths = graph.get_nodes_by_type("path")
+    path_has_prose: dict[str, bool] = {}
+    for path_id in paths:
+        path_has_prose[path_id] = _path_has_prose(graph, path_id)
+
+    fully_explored = 0
+    partially_explored = 0
+    for did in dilemmas:
+        answer_ids = answers_by_dilemma.get(did, [])
+        answer_results: list[bool] = []
+        for aid in answer_ids:
+            answer_path = answer_to_path.get(aid)
+            if answer_path:
+                answer_results.append(path_has_prose.get(answer_path, False))
+
+        if len(answer_results) >= 2 and all(answer_results):
+            fully_explored += 1
+        elif any(answer_results):
+            partially_explored += 1
+
+    # Start and ending passages
+    # choice_to edges: choice → destination passage (incoming)
+    # choice_from edges: choice → source passage (outgoing)
+    choice_to_edges = graph.get_edges(edge_type="choice_to")
+    has_incoming = {e["to"] for e in choice_to_edges}
+    choice_from_edges = graph.get_edges(edge_type="choice_from")
+    has_outgoing = {e["to"] for e in choice_from_edges}
+
+    start_count = sum(1 for pid in passages if pid not in has_incoming)
+    ending_count = sum(1 for pid in passages if pid not in has_outgoing)
+
+    return BranchingStats(
+        total_choices=len(choices),
+        meaningful_choices=meaningful,
+        continue_choices=continue_count,
+        total_dilemmas=len(dilemmas),
+        fully_explored=fully_explored,
+        partially_explored=partially_explored,
+        start_passages=start_count,
+        ending_passages=ending_count,
+    )
+
+
+def _path_has_prose(graph: Graph, path_id: str) -> bool:
+    """Check if a path has any passages with prose content."""
+    # Beats belong directly to paths via belongs_to edges (beat → path)
+    belongs_to_edges = graph.get_edges(edge_type="belongs_to")
+    beat_ids = {e["from"] for e in belongs_to_edges if e["to"] == path_id}
+
+    if not beat_ids:
+        return False
+
+    # Find passages generated from those beats
+    passages = graph.get_nodes_by_type("passage")
+    for _pid, pdata in passages.items():
+        from_beat = pdata.get("from_beat", "")
+        if from_beat in beat_ids:
+            prose = pdata.get("prose")
+            if prose and str(prose).strip():
+                return True
+    return False
+
+
+def _coverage_stats(graph: Graph, project_path: Path) -> CoverageStats:
+    """Analyze entity, codex, and illustration coverage."""
+    entities = graph.get_nodes_by_type("entity")
+    entity_types: dict[str, int] = Counter(
+        d.get("entity_type", "unknown") for d in entities.values()
+    )
+
+    codex_entries = graph.get_nodes_by_type("codex_entry")
+    has_entry_edges = graph.get_edges(edge_type="HasEntry")
+    entities_with_codex = len({e["from"] for e in has_entry_edges})
+
+    briefs = graph.get_nodes_by_type("illustration_brief")
+    illustrations = graph.get_nodes_by_type("illustration")
+
+    assets_dir = project_path / "assets"
+    asset_count = len(list(assets_dir.glob("*.png"))) if assets_dir.exists() else 0
+
+    return CoverageStats(
+        entity_count=len(entities),
+        entity_types=dict(sorted(entity_types.items(), key=lambda x: -x[1])),
+        codex_entries=len(codex_entries),
+        entities_with_codex=entities_with_codex,
+        illustration_briefs=len(briefs),
+        illustration_nodes=len(illustrations),
+        asset_files=asset_count,
+    )
+
+
+def _run_validation(graph: Graph) -> list[dict[str, str]]:
+    """Run structural validation checks."""
+    passages = graph.get_nodes_by_type("passage")
+    if not passages:
+        return []
+
+    try:
+        report = run_all_checks(graph)
+    except Exception as exc:
+        log.warning("validation_skipped", reason=str(exc))
+        return [{"name": "validation", "severity": "warn", "message": f"Skipped: {exc}"}]
+
+    return [{"name": c.name, "severity": c.severity, "message": c.message} for c in report.checks]

--- a/tests/unit/test_inspection.py
+++ b/tests/unit/test_inspection.py
@@ -1,0 +1,266 @@
+"""Tests for project inspection module."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from questfoundry.graph.graph import Graph
+
+if TYPE_CHECKING:
+    from pathlib import Path
+from questfoundry.inspection import (
+    InspectionReport,
+    _branching_stats,
+    _coverage_stats,
+    _graph_summary,
+    _prose_stats,
+    inspect_project,
+)
+
+
+def _make_graph_with_passages(prose_texts: list[str | None]) -> Graph:
+    """Build a graph with passages having given prose values."""
+    graph = Graph.empty()
+    for i, prose in enumerate(prose_texts):
+        data: dict = {
+            "type": "passage",
+            "raw_id": f"p{i}",
+            "from_beat": f"beat::p{i}",
+            "summary": f"passage {i}",
+        }
+        if prose is not None:
+            data["prose"] = prose
+        else:
+            data["prose"] = None
+            data["flag"] = "incompatible_states"
+            data["flag_reason"] = "test reason"
+        graph.create_node(f"passage::p{i}", data)
+    return graph
+
+
+def _make_full_graph() -> Graph:
+    """Build a graph with passages, choices, entities, codex, and briefs."""
+    graph = _make_graph_with_passages(
+        ["The hero stood tall in the morning light.", "She ran through the dark forest quickly."]
+    )
+
+    # Add choices
+    graph.create_node(
+        "choice::p0__p1",
+        {
+            "type": "choice",
+            "from_passage": "passage::p0",
+            "to_passage": "passage::p1",
+            "label": "Enter the forest",
+            "requires": [],
+            "grants": [],
+        },
+    )
+    graph.create_node(
+        "choice::p0__p1_continue",
+        {
+            "type": "choice",
+            "from_passage": "passage::p0",
+            "to_passage": "passage::p1",
+            "label": "continue",
+            "requires": [],
+            "grants": [],
+        },
+    )
+    graph.add_edge("choice_from", "choice::p0__p1", "passage::p0")
+    graph.add_edge("choice_to", "choice::p0__p1", "passage::p1")
+    graph.add_edge("choice_from", "choice::p0__p1_continue", "passage::p0")
+    graph.add_edge("choice_to", "choice::p0__p1_continue", "passage::p1")
+
+    # Add entities
+    graph.create_node(
+        "entity::hero",
+        {"type": "entity", "entity_type": "character", "concept": "The Hero"},
+    )
+    graph.create_node(
+        "entity::forest",
+        {"type": "entity", "entity_type": "location", "concept": "Dark Forest"},
+    )
+
+    # Add codex entries with HasEntry edges
+    graph.create_node(
+        "codex_entry::hero_1",
+        {"type": "codex_entry", "title": "Hero", "rank": 1, "content": "A brave soul."},
+    )
+    graph.add_edge("HasEntry", "codex_entry::hero_1", "entity::hero")
+
+    # Add illustration briefs
+    graph.create_node(
+        "illustration_brief::ib1",
+        {"type": "illustration_brief", "subject": "hero", "priority": 1},
+    )
+
+    return graph
+
+
+class TestGraphSummary:
+    def test_counts_nodes_and_edges(self, tmp_path: Path) -> None:
+        graph = _make_full_graph()
+        summary = _graph_summary(graph, tmp_path)
+
+        assert summary.total_nodes > 0
+        assert summary.total_edges > 0
+        assert "passage" in summary.node_counts
+        assert "choice" in summary.node_counts
+
+    def test_node_counts_sorted_by_count(self, tmp_path: Path) -> None:
+        graph = _make_full_graph()
+        summary = _graph_summary(graph, tmp_path)
+
+        counts = list(summary.node_counts.values())
+        assert counts == sorted(counts, reverse=True)
+
+    def test_empty_graph(self, tmp_path: Path) -> None:
+        graph = Graph.empty()
+        summary = _graph_summary(graph, tmp_path)
+
+        assert summary.total_nodes == 0
+        assert summary.total_edges == 0
+
+
+class TestProseStats:
+    def test_word_counts(self) -> None:
+        graph = _make_graph_with_passages(["Hello world", "One two three four five"])
+        stats = _prose_stats(graph)
+
+        assert stats is not None
+        assert stats.total_passages == 2
+        assert stats.passages_with_prose == 2
+        assert stats.total_words == 7
+        assert stats.min_words == 2
+        assert stats.max_words == 5
+        assert stats.avg_words == 3.5
+
+    def test_flagged_passages_detected(self) -> None:
+        graph = _make_graph_with_passages(["Some prose here.", None])
+        stats = _prose_stats(graph)
+
+        assert stats is not None
+        assert stats.passages_with_prose == 1
+        assert len(stats.flagged_passages) == 1
+        assert stats.flagged_passages[0]["id"] == "passage::p1"
+        assert stats.flagged_passages[0]["flag"] == "incompatible_states"
+
+    def test_no_passages_returns_none(self) -> None:
+        graph = Graph.empty()
+        assert _prose_stats(graph) is None
+
+    def test_lexical_diversity(self) -> None:
+        graph = _make_graph_with_passages(["the the the the", "new new new new"])
+        stats = _prose_stats(graph)
+
+        assert stats is not None
+        assert stats.lexical_diversity is not None
+        assert 0.0 < stats.lexical_diversity < 1.0
+
+    def test_single_passage_no_diversity(self) -> None:
+        graph = _make_graph_with_passages(["Just one passage."])
+        stats = _prose_stats(graph)
+
+        assert stats is not None
+        assert stats.lexical_diversity is None
+
+
+class TestBranchingStats:
+    def test_meaningful_vs_continue(self) -> None:
+        graph = _make_full_graph()
+        stats = _branching_stats(graph)
+
+        assert stats is not None
+        assert stats.total_choices == 2
+        assert stats.meaningful_choices == 1
+        assert stats.continue_choices == 1
+
+    def test_no_passages_returns_none(self) -> None:
+        graph = Graph.empty()
+        assert _branching_stats(graph) is None
+
+    def test_start_and_ending_passages(self) -> None:
+        graph = _make_full_graph()
+        stats = _branching_stats(graph)
+
+        assert stats is not None
+        # p0 has no incoming → start, p1 has no outgoing → ending
+        assert stats.start_passages >= 1
+        assert stats.ending_passages >= 1
+
+
+class TestCoverageStats:
+    def test_entity_counts(self, tmp_path: Path) -> None:
+        graph = _make_full_graph()
+        stats = _coverage_stats(graph, tmp_path)
+
+        assert stats.entity_count == 2
+        assert stats.entity_types["character"] == 1
+        assert stats.entity_types["location"] == 1
+
+    def test_codex_entry_count(self, tmp_path: Path) -> None:
+        graph = _make_full_graph()
+        stats = _coverage_stats(graph, tmp_path)
+
+        assert stats.codex_entries == 1
+        assert stats.entities_with_codex == 1
+
+    def test_illustration_brief_count(self, tmp_path: Path) -> None:
+        graph = _make_full_graph()
+        stats = _coverage_stats(graph, tmp_path)
+
+        assert stats.illustration_briefs == 1
+        assert stats.illustration_nodes == 0
+
+    def test_asset_file_counting(self, tmp_path: Path) -> None:
+        graph = _make_full_graph()
+        assets = tmp_path / "assets"
+        assets.mkdir()
+        (assets / "img1.png").write_bytes(b"fake")
+        (assets / "img2.png").write_bytes(b"fake")
+
+        stats = _coverage_stats(graph, tmp_path)
+        assert stats.asset_files == 2
+
+    def test_no_assets_dir(self, tmp_path: Path) -> None:
+        graph = Graph.empty()
+        stats = _coverage_stats(graph, tmp_path)
+        assert stats.asset_files == 0
+
+
+class TestInspectProject:
+    def test_integration(self, tmp_path: Path) -> None:
+        """Full integration: write graph, run inspect."""
+        import json
+
+        graph = _make_full_graph()
+        graph_file = tmp_path / "graph.json"
+        graph_file.write_text(json.dumps(graph.to_dict()))
+
+        # Write a minimal project.yaml
+        (tmp_path / "project.yaml").write_text("name: test-project\nversion: 1\n")
+
+        report = inspect_project(tmp_path)
+
+        assert isinstance(report, InspectionReport)
+        assert report.summary.project_name == "test-project"
+        assert report.summary.total_nodes > 0
+        assert report.prose is not None
+        assert report.branching is not None
+        assert report.coverage.entity_count == 2
+
+    def test_json_serializable(self, tmp_path: Path) -> None:
+        """Report can be serialized to JSON."""
+        import dataclasses
+        import json
+
+        graph = _make_full_graph()
+        graph_file = tmp_path / "graph.json"
+        graph_file.write_text(json.dumps(graph.to_dict()))
+        (tmp_path / "project.yaml").write_text("name: test\nversion: 1\n")
+
+        report = inspect_project(tmp_path)
+        # Should not raise
+        result = json.dumps(dataclasses.asdict(report))
+        assert isinstance(result, str)

--- a/tests/unit/test_inspection.py
+++ b/tests/unit/test_inspection.py
@@ -206,6 +206,20 @@ class TestCoverageStats:
         assert stats.codex_entries == 1
         assert stats.entities_with_codex == 1
 
+    def test_entities_with_codex_counts_unique_entities(self, tmp_path: Path) -> None:
+        """Multiple codex entries per entity should count the entity once."""
+        graph = _make_full_graph()
+        # Add a second codex entry for the same entity (hero)
+        graph.create_node(
+            "codex_entry::hero_2",
+            {"type": "codex_entry", "title": "Hero Backstory", "rank": 2, "content": "More lore."},
+        )
+        graph.add_edge("HasEntry", "codex_entry::hero_2", "entity::hero")
+
+        stats = _coverage_stats(graph, tmp_path)
+        assert stats.codex_entries == 2  # Two entries total
+        assert stats.entities_with_codex == 1  # But only one unique entity
+
     def test_illustration_brief_count(self, tmp_path: Path) -> None:
         graph = _make_full_graph()
         stats = _coverage_stats(graph, tmp_path)


### PR DESCRIPTION
## Problem

Quality review of completed projects requires manually running dozens of graph queries to assess prose quality, branching structure, entity coverage, and structural integrity. This is tedious and error-prone.

Closes #552 (provides automated quality inspection tooling)

## Changes

- New `src/questfoundry/inspection.py` module with structured analysis functions:
  - `GraphSummary`: node/edge counts by type, last stage, project name
  - `ProseStats`: word counts (total/avg/min/max), lexical diversity, flagged passages
  - `BranchingStats`: choice analysis (meaningful vs "continue"), dilemma exploration coverage
  - `CoverageStats`: entity types, codex entries per entity, illustration briefs vs rendered
  - Reuses `grow_validation.run_all_checks()` for structural validation
- New `qf inspect` CLI command with Rich table output and `--json` flag
- 18 unit tests covering all analysis functions

## Not Included / Future PRs

- Per-arc narrative validation (fill_validation checks) — would add complexity, can be added later
- Opening pattern analysis (e.g., "54% of passages start with 'The'") — nice-to-have
- Comparison between projects — future feature

## Test Plan

- `uv run pytest tests/unit/test_inspection.py -x -q` — 18 tests pass
- `uv run mypy src/questfoundry/inspection.py src/questfoundry/cli.py` — clean
- Smoke tested on Axiom of Whispers project (578 nodes, 63 passages)
- JSON output mode verified

## Risk / Rollback

- Read-only command, no graph mutations
- No LLM calls — pure graph analysis
- Safe to remove without affecting any other functionality

🤖 Generated with [Claude Code](https://claude.com/claude-code)