### PR TITLE
feat(grow): contextual labels for single-successor passages

### DIFF
--- a/prompts/templates/grow_phase9_continue_labels.yaml
+++ b/prompts/templates/grow_phase9_continue_labels.yaml
@@ -1,0 +1,60 @@
+name: grow_phase9_continue_labels
+description: Generate diegetic transition labels for single-successor passages
+
+system: |
+  You are creating transition labels for an interactive story. When a passage
+  has only one way forward, the link still needs a diegetic label that
+  describes what the player DOES next — not a meta-game "continue" button.
+
+  ## What is a Diegetic Transition Label?
+  A short action phrase describing the protagonist's next move, written from
+  within the story world.
+
+  GOOD labels:
+  - "Search the room"
+  - "Follow the trail"
+  - "Confront the captain"
+  - "Step through the doorway"
+  - "Wait for nightfall"
+  - "Open the letter"
+
+  BAD labels (too generic or meta):
+  - "Continue"
+  - "Next"
+  - "Go on"
+  - "Proceed"
+  - "Read more"
+
+  ## Transitions to Label
+  {transition_context}
+
+  {output_language_instruction}
+
+  ## Label Design Rules
+  1. Each label should be 3-6 words, written as an action phrase
+  2. Labels must reflect what happens in the target passage
+  3. Never use generic labels like "Continue", "Go on", "Next", "Proceed"
+  4. Write in second person imperative or infinitive form
+  5. Vary the verb — don't start every label with the same word
+
+  ## What NOT to Do
+  - Do NOT use IDs not listed in the Valid IDs section
+  - Do NOT produce labels longer than 8 words
+  - Do NOT add explanatory prose before or after the JSON output
+
+  ## Valid IDs
+  Valid from_passage IDs: {valid_from_ids}
+  Valid to_passage IDs: {valid_to_ids}
+
+  ## Output Format
+  Return a JSON object with a "labels" array. Each label has:
+  - from_passage: the passage where the transition occurs
+  - to_passage: the passage the transition leads to
+  - label: the diegetic action label (3-6 words)
+
+user: |
+  Write diegetic transition labels for each single-successor passage above.
+
+  REMINDER: Return ONLY a valid JSON object. Use ONLY IDs from the Valid IDs section. Do NOT add prose before or after the JSON.
+
+components: []

--- a/prompts/templates/grow_phase9_continue_labels.yaml
+++ b/prompts/templates/grow_phase9_continue_labels.yaml
@@ -39,7 +39,7 @@ system: |
 
   ## What NOT to Do
   - Do NOT use IDs not listed in the Valid IDs section
-  - Do NOT produce labels longer than 8 words
+  - Do NOT produce labels longer than 6 words
   - Do NOT add explanatory prose before or after the JSON output
 
   ## Valid IDs

--- a/src/questfoundry/cli.py
+++ b/src/questfoundry/cli.py
@@ -2607,7 +2607,8 @@ def _render_inspection_report(report: InspectionReport) -> None:
         console.print("[bold]Branching Structure[/bold]")
         console.print(
             f"  Choices: [bold]{b.total_choices}[/bold] "
-            f"({b.meaningful_choices} meaningful, {b.continue_choices} continue)"
+            f"({b.meaningful_choices} meaningful, {b.contextual_choices} contextual, "
+            f"{b.continue_choices} continue)"
         )
         console.print(
             f"  Dilemmas: [bold]{b.total_dilemmas}[/bold] "

--- a/src/questfoundry/inspection.py
+++ b/src/questfoundry/inspection.py
@@ -193,7 +193,8 @@ def _branching_stats(graph: Graph) -> BranchingStats | None:
 
     choices = graph.get_nodes_by_type("choice")
 
-    # Classify by graph structure: count outgoing choices per source passage
+    # Classify by graph structure: count outgoing choices per source passage.
+    # choice_from edges point choice→source_passage, so e["to"] = source passage.
     choice_from_edges_all = graph.get_edges(edge_type="choice_from")
     outgoing_per_passage: dict[str, int] = Counter(e["to"] for e in choice_from_edges_all)
 

--- a/src/questfoundry/pipeline/stages/grow.py
+++ b/src/questfoundry/pipeline/stages/grow.py
@@ -2140,6 +2140,12 @@ class GrowStage:
                     single_label_lookup[(label_item.from_passage, label_item.to_passage)] = (
                         label_item.label
                     )
+                if len(single_label_lookup) < len(single_successors):
+                    log.warning(
+                        "phase9_incomplete_labels",
+                        returned=len(single_label_lookup),
+                        expected=len(single_successors),
+                    )
             except GrowStageError:
                 log.warning("phase9_continue_labels_failed", fallback="continue")
 


### PR DESCRIPTION
## Problem
Single-successor passages get hardcoded `label="continue"` in GROW Phase 9, creating a passive reading experience with generic transition buttons instead of diegetic action phrases.

## Changes
- Add `grow_phase9_continue_labels.yaml` prompt template for generating 3-6 word transition labels
- Replace the hardcoded "continue" loop in Phase 9 with a batched LLM call using the new template
- Fall back to "continue" on LLM failure (graceful degradation)
- Add `contextual_choices` field to `BranchingStats` in inspection
- Reclassify choices by graph structure: meaningful (2+ outgoing), contextual (1 outgoing, non-continue label), continue (fallback)
- Update CLI display to show 3-way classification

## Not Included / Future PRs
- Max consecutive linear validation (PR 2)
- Dilemma prose coverage (PR 3)
- Fork-beats (PR 4)
- Hub-and-spoke exploration (PR 5)

## Test Plan
- `test_phase_9_single_successor_generates_contextual_labels`: verifies LLM-generated labels replace "continue"
- `test_phase_9_single_successor_falls_back_to_continue`: verifies graceful fallback on LLM failure
- `test_structural_classification`: verifies 2+ outgoing choices classified as meaningful
- `test_three_way_classification`: verifies contextual vs continue classification for single-outgoing

```
uv run pytest tests/unit/test_grow_stage.py tests/unit/test_inspection.py -x -q  # 105 passed
uv run mypy src/questfoundry/  # Success
uv run ruff check src/  # All checks passed
```

## Risk / Rollback
Low. One extra batched LLM call per story. Falls back to "continue" on any failure. No graph structure changes.

Closes #598 (partial — contextual labels)

🤖 Generated with [Claude Code](https://claude.com/claude-code)