### PR TITLE
feat(validation): max consecutive linear passages check

### DIFF
--- a/src/questfoundry/graph/grow_validation.py
+++ b/src/questfoundry/graph/grow_validation.py
@@ -578,6 +578,152 @@ def check_spine_arc_exists(graph: Graph) -> ValidationCheck:
     )
 
 
+def build_passage_adjacency(graph: Graph) -> dict[str, list[str]]:
+    """Build passage → successor passages adjacency list from choice nodes.
+
+    Args:
+        graph: The story graph.
+
+    Returns:
+        Dict mapping each passage ID to a list of successor passage IDs.
+    """
+    choices = graph.get_nodes_by_type("choice")
+    adjacency: dict[str, list[str]] = {}
+    for _cid, cdata in choices.items():
+        from_p = cdata.get("from_passage", "")
+        to_p = cdata.get("to_passage", "")
+        if from_p and to_p:
+            adjacency.setdefault(from_p, []).append(to_p)
+    return adjacency
+
+
+def build_outgoing_count(graph: Graph) -> dict[str, int]:
+    """Count outgoing choices per passage from choice_from edges.
+
+    Args:
+        graph: The story graph.
+
+    Returns:
+        Dict mapping passage ID to number of outgoing choices.
+    """
+    # choice_from edges point choice → source_passage, so e["to"] = source passage.
+    choice_from_edges = graph.get_edges(edge_type="choice_from")
+    outgoing_count: dict[str, int] = {}
+    for edge in choice_from_edges:
+        source = edge["to"]
+        outgoing_count[source] = outgoing_count.get(source, 0) + 1
+    return outgoing_count
+
+
+def find_max_consecutive_linear(graph: Graph) -> int:
+    """Compute the longest consecutive single-outgoing passage stretch.
+
+    Uses BFS from start passages, tracking per-path run lengths.
+    Passages whose beat has ``narrative_function`` in {"confront", "resolve"}
+    are exempt (linearity is narratively appropriate at climax/resolution).
+
+    Args:
+        graph: The story graph.
+
+    Returns:
+        Length of the longest linear stretch (0 if no passages or no linear runs).
+    """
+    passages = graph.get_nodes_by_type("passage")
+    if not passages:
+        return 0
+
+    outgoing_count = build_outgoing_count(graph)
+    adjacency = build_passage_adjacency(graph)
+    exempt_passages = _build_exempt_passages(graph, passages)
+    starts = _find_start_passages(graph, passages)
+
+    max_len = 0
+    for _violation in _walk_linear_stretches(
+        starts, adjacency, outgoing_count, exempt_passages, threshold=0
+    ):
+        max_len = max(max_len, len(_violation))
+    return max_len
+
+
+def _build_exempt_passages(graph: Graph, passages: dict[str, dict[str, object]]) -> set[str]:
+    """Build set of passages exempt from linearity checks (confront/resolve beats)."""
+    beats = graph.get_nodes_by_type("beat")
+    exempt_beats: set[str] = set()
+    for bid, bdata in beats.items():
+        if bdata.get("narrative_function") in {"confront", "resolve"}:
+            exempt_beats.add(bid)
+
+    exempt: set[str] = set()
+    for pid, pdata in passages.items():
+        if pdata.get("from_beat") in exempt_beats:
+            exempt.add(pid)
+    return exempt
+
+
+def _find_start_passages(graph: Graph, passages: dict[str, dict[str, object]]) -> list[str]:
+    """Find passages with no incoming choice edges."""
+    choice_to_edges = graph.get_edges(edge_type="choice_to")
+    has_incoming = {e["to"] for e in choice_to_edges}
+    return [pid for pid in passages if pid not in has_incoming]
+
+
+def _walk_linear_stretches(
+    starts: list[str],
+    adjacency: dict[str, list[str]],
+    outgoing_count: dict[str, int],
+    exempt_passages: set[str],
+    threshold: int,
+) -> list[list[str]]:
+    """BFS walk to find linear stretches exceeding threshold.
+
+    Tracks per-path run context so convergence points are evaluated
+    correctly from each incoming path.
+
+    Args:
+        starts: Start passage IDs for BFS.
+        adjacency: Passage → successors mapping.
+        outgoing_count: Passage → outgoing choice count.
+        exempt_passages: Passages exempt from linearity (confront/resolve).
+        threshold: Minimum run length to report. 0 = report all runs.
+
+    Returns:
+        List of passage ID lists, one per linear stretch exceeding threshold.
+    """
+    stretches: list[list[str]] = []
+    # Track best known run reaching each node to prune redundant BFS paths
+    best_run_at: dict[str, int] = {}
+
+    for start in starts:
+        queue: deque[tuple[str, list[str]]] = deque()
+        is_linear = outgoing_count.get(start, 0) == 1 and start not in exempt_passages
+        initial_run = [start] if is_linear else []
+        queue.append((start, initial_run))
+
+        while queue:
+            current, run = queue.popleft()
+
+            for successor in adjacency.get(current, []):
+                is_succ_linear = (
+                    outgoing_count.get(successor, 0) == 1 and successor not in exempt_passages
+                )
+                if is_succ_linear:
+                    new_run = [*run, successor]
+                    # Only continue if this path offers a longer run than previously seen
+                    if len(new_run) <= best_run_at.get(successor, 0):
+                        continue
+                    best_run_at[successor] = len(new_run)
+                    if (threshold > 0 and len(new_run) > threshold) or threshold == 0:
+                        stretches.append(new_run)
+                    queue.append((successor, new_run))
+                else:
+                    # Reset run at branching/exempt nodes; only visit if not yet seen
+                    if successor not in best_run_at:
+                        best_run_at[successor] = 0
+                        queue.append((successor, []))
+
+    return stretches
+
+
 def check_max_consecutive_linear(graph: Graph, max_run: int = 2) -> ValidationCheck:
     """Warn when too many consecutive single-outgoing passages form a linear stretch.
 
@@ -603,67 +749,12 @@ def check_max_consecutive_linear(graph: Graph, max_run: int = 2) -> ValidationCh
             message="No passages to check",
         )
 
-    # Build outgoing count per passage from choice edges
-    choice_from_edges = graph.get_edges(edge_type="choice_from")
-    outgoing_count: dict[str, int] = {}
-    for edge in choice_from_edges:
-        source = edge["to"]  # choice_from: choice → source passage
-        outgoing_count[source] = outgoing_count.get(source, 0) + 1
+    outgoing_count = build_outgoing_count(graph)
+    adjacency = build_passage_adjacency(graph)
+    exempt_passages = _build_exempt_passages(graph, passages)
+    starts = _find_start_passages(graph, passages)
 
-    # Build adjacency: passage → list of successor passages via choices
-    choices = graph.get_nodes_by_type("choice")
-    adjacency: dict[str, list[str]] = {}
-    for _cid, cdata in choices.items():
-        from_p = cdata.get("from_passage", "")
-        to_p = cdata.get("to_passage", "")
-        if from_p and to_p:
-            adjacency.setdefault(from_p, []).append(to_p)
-
-    # Build exempt set: passages from confront/resolve beats
-    beats = graph.get_nodes_by_type("beat")
-    exempt_beats: set[str] = set()
-    for bid, bdata in beats.items():
-        if bdata.get("narrative_function") in {"confront", "resolve"}:
-            exempt_beats.add(bid)
-
-    exempt_passages: set[str] = set()
-    for pid, pdata in passages.items():
-        if pdata.get("from_beat") in exempt_beats:
-            exempt_passages.add(pid)
-
-    # Find start passages (no incoming choice edges)
-    choice_to_edges = graph.get_edges(edge_type="choice_to")
-    has_incoming = {e["to"] for e in choice_to_edges}
-    starts = [pid for pid in passages if pid not in has_incoming]
-
-    # BFS: track consecutive single-outgoing count per path
-    violations: list[list[str]] = []
-    visited: set[str] = set()
-
-    for start in starts:
-        queue: deque[tuple[str, list[str]]] = deque()
-        # Initialize run: if start is single-outgoing and not exempt, start a run
-        is_linear = outgoing_count.get(start, 0) == 1 and start not in exempt_passages
-        initial_run = [start] if is_linear else []
-        queue.append((start, initial_run))
-
-        while queue:
-            current, run = queue.popleft()
-            if current in visited:
-                continue
-            visited.add(current)
-
-            for successor in adjacency.get(current, []):
-                is_succ_linear = (
-                    outgoing_count.get(successor, 0) == 1 and successor not in exempt_passages
-                )
-                if is_succ_linear:
-                    new_run = [*run, successor]
-                    if len(new_run) > max_run:
-                        violations.append(new_run)
-                    queue.append((successor, new_run))
-                else:
-                    queue.append((successor, []))
+    violations = _walk_linear_stretches(starts, adjacency, outgoing_count, exempt_passages, max_run)
 
     if violations:
         longest = max(violations, key=len)

--- a/tests/unit/test_grow_validation.py
+++ b/tests/unit/test_grow_validation.py
@@ -15,6 +15,7 @@ from questfoundry.graph.grow_validation import (
     check_commits_timing,
     check_dilemmas_resolved,
     check_gate_satisfiability,
+    check_max_consecutive_linear,
     check_passage_dag_cycles,
     check_single_start,
     check_spine_arc_exists,
@@ -755,3 +756,109 @@ class TestPhase10Integration:
         # Should pass but with warnings
         assert result.status == "completed"
         assert "warnings" in result.detail
+
+
+def _make_chain_graph(passage_ids: list[str], beat_data: dict[str, dict] | None = None) -> Graph:
+    """Build a linear chain of passages connected by single-outgoing choices."""
+    graph = Graph.empty()
+    for pid in passage_ids:
+        pdata: dict = {
+            "type": "passage",
+            "raw_id": pid,
+            "from_beat": f"beat::{pid}",
+            "summary": f"Passage {pid}",
+        }
+        graph.create_node(f"passage::{pid}", pdata)
+        bdata: dict = {"type": "beat", "raw_id": pid, "summary": f"Beat {pid}"}
+        if beat_data and pid in beat_data:
+            bdata.update(beat_data[pid])
+        graph.create_node(f"beat::{pid}", bdata)
+
+    for i in range(len(passage_ids) - 1):
+        from_p = passage_ids[i]
+        to_p = passage_ids[i + 1]
+        cid = f"choice::{from_p}__{to_p}"
+        graph.create_node(
+            cid,
+            {
+                "type": "choice",
+                "from_passage": f"passage::{from_p}",
+                "to_passage": f"passage::{to_p}",
+                "label": "continue",
+                "requires": [],
+                "grants": [],
+            },
+        )
+        graph.add_edge("choice_from", cid, f"passage::{from_p}")
+        graph.add_edge("choice_to", cid, f"passage::{to_p}")
+
+    return graph
+
+
+class TestMaxConsecutiveLinear:
+    def test_three_consecutive_warns(self) -> None:
+        """3+ consecutive single-outgoing passages trigger a warning."""
+        graph = _make_chain_graph(["a", "b", "c", "d"])
+        # a→b→c→d: 3 single-outgoing (a, b, c) — d has 0 outgoing
+        result = check_max_consecutive_linear(graph, max_run=2)
+        assert result.severity == "warn"
+        assert "linear stretch" in result.message
+
+    def test_two_consecutive_passes(self) -> None:
+        """2 consecutive single-outgoing passages are within the limit."""
+        graph = _make_chain_graph(["a", "b", "c"])
+        # a→b→c: 2 single-outgoing (a, b) — within max_run=2
+        result = check_max_consecutive_linear(graph, max_run=2)
+        assert result.severity == "pass"
+
+    def test_multi_outgoing_resets_counter(self) -> None:
+        """A multi-outgoing passage resets the consecutive counter."""
+        graph = _make_chain_graph(["a", "b", "c", "d", "e"])
+        # Add a second choice from passage::b to make it multi-outgoing
+        graph.create_node(
+            "passage::alt",
+            {"type": "passage", "raw_id": "alt", "from_beat": "beat::alt", "summary": "Alt"},
+        )
+        graph.create_node(
+            "choice::b__alt",
+            {
+                "type": "choice",
+                "from_passage": "passage::b",
+                "to_passage": "passage::alt",
+                "label": "Take alternative",
+                "requires": [],
+                "grants": [],
+            },
+        )
+        graph.add_edge("choice_from", "choice::b__alt", "passage::b")
+        graph.add_edge("choice_to", "choice::b__alt", "passage::alt")
+
+        # Now: a(1)→b(2)→c(1)→d(1)→e(0)
+        # b has 2 outgoing so it's not linear — resets counter
+        # Runs: [a] (len 1), [c, d] (len 2) — both ≤2
+        result = check_max_consecutive_linear(graph, max_run=2)
+        assert result.severity == "pass"
+
+    def test_confront_beat_exempt(self) -> None:
+        """Passages from confront/resolve beats are exempt from linearity check."""
+        beat_data = {
+            "b": {"narrative_function": "confront"},
+            "c": {"narrative_function": "resolve"},
+        }
+        graph = _make_chain_graph(["a", "b", "c", "d"], beat_data=beat_data)
+        # a→b→c→d: b and c are exempt, so runs are [a] (len 1) only
+        result = check_max_consecutive_linear(graph, max_run=2)
+        assert result.severity == "pass"
+
+    def test_no_passages(self) -> None:
+        """Empty graph passes."""
+        graph = Graph.empty()
+        result = check_max_consecutive_linear(graph)
+        assert result.severity == "pass"
+
+    def test_included_in_run_all_checks(self) -> None:
+        """check_max_consecutive_linear is included in run_all_checks."""
+        graph = _make_linear_passage_graph()
+        report = run_all_checks(graph)
+        check_names = [c.name for c in report.checks]
+        assert "max_consecutive_linear" in check_names


### PR DESCRIPTION
## Problem
Long stretches of single-outgoing passages create a passive reading experience with no player agency.

## Changes
- Add `check_max_consecutive_linear()` validation check in `grow_validation.py`
- BFS-based algorithm that walks the passage graph and flags runs of 3+ consecutive single-outgoing passages
- Passages from beats with `narrative_function` in {"confront", "resolve"} are exempt (linearity appropriate for climax)
- Severity: warn (never blocks)
- Add to `run_all_checks()` so it runs in Phase 10 validation
- Add `max_consecutive_linear` metric to `BranchingStats` in inspection

## Not Included / Future PRs
- Dilemma prose coverage (PR 3)
- Fork-beats to break up linear stretches (PR 4)
- Hub-and-spoke exploration (PR 5)

## Test Plan
- `test_three_consecutive_warns`: 4-passage chain (3 single-outgoing) triggers warn
- `test_two_consecutive_passes`: 3-passage chain (2 single-outgoing) passes
- `test_multi_outgoing_resets_counter`: multi-choice passage breaks the run
- `test_confront_beat_exempt`: confront/resolve beats excluded
- `test_included_in_run_all_checks`: check appears in validation report

```
uv run pytest tests/unit/test_grow_validation.py tests/unit/test_inspection.py -x -q  # 62 passed
uv run mypy src/questfoundry/  # Success
```

## Risk / Rollback
Very low. Pure additive, warn-only validation check. No graph modifications.

Closes #598 (partial — max consecutive linear)

🤖 Generated with [Claude Code](https://claude.com/claude-code)