### PR TITLE
feat(validation): dilemma prose coverage check

### DIFF
--- a/src/questfoundry/graph/fill_validation.py
+++ b/src/questfoundry/graph/fill_validation.py
@@ -248,8 +248,8 @@ def path_has_prose(graph: Graph, path_id: str) -> bool:
     Returns:
         True if at least one passage in the path has prose.
     """
-    belongs_to_edges = graph.get_edges(edge_type="belongs_to")
-    beat_ids = {e["from"] for e in belongs_to_edges if e["to"] == path_id}
+    belongs_to_edges = graph.get_edges(edge_type="belongs_to", to_id=path_id)
+    beat_ids = {e["from"] for e in belongs_to_edges}
 
     if not beat_ids:
         return False

--- a/tests/unit/test_fill_validation.py
+++ b/tests/unit/test_fill_validation.py
@@ -336,6 +336,12 @@ class TestDilemmaProseCoverage:
         assert checks[0].severity == "warn"
         assert "path::p2" in checks[0].message
 
+    def test_both_paths_missing_prose(self) -> None:
+        graph = _make_dilemma_graph(path_a_prose=False, path_b_prose=False)
+        checks = check_dilemma_prose_coverage(graph)
+        assert len(checks) == 1
+        assert checks[0].severity == "warn"
+
     def test_no_dilemmas(self) -> None:
         graph = Graph.empty()
         checks = check_dilemma_prose_coverage(graph)


### PR DESCRIPTION
## Problem
Not all dilemma paths get prose content. When only one answer path has prose, branching is wasted — the player sees a choice but one option leads nowhere.

## Changes
- Extract `path_has_prose()` from `inspection.py` into `fill_validation.py` as a shared public function
- Add `check_dilemma_prose_coverage()` that warns when dilemma answer paths are missing prose
- Add to `run_arc_validation()` so it runs during post-FILL validation
- Update `inspection.py` to use the shared function (removes duplicate code)

## Not Included / Future PRs
- Fork-beats to break up linear stretches (PR 4)
- Hub-and-spoke exploration (PR 5)

## Test Plan
- `test_both_paths_have_prose`: both paths have prose → no warnings
- `test_one_path_missing_prose`: one path missing → warn with path ID
- `test_no_dilemmas`: empty graph → no warnings
- `test_included_in_run_arc_validation`: check appears in validation report
- `test_path_with_prose` / `test_path_without_prose` / `test_nonexistent_path`: shared helper tests

```
uv run pytest tests/unit/test_fill_validation.py tests/unit/test_inspection.py -x -q  # 44 passed
uv run mypy src/questfoundry/  # Success
```

## Risk / Rollback
Low. Additive validation + small refactor of shared helper. No graph modifications.

Closes #598 (partial — dilemma prose coverage)

🤖 Generated with [Claude Code](https://claude.com/claude-code)