### PR TITLE
feat(grow): Phase 9c hub-and-spoke exploration nodes

### DIFF
--- a/prompts/templates/grow_phase9c_hub_spokes.yaml
+++ b/prompts/templates/grow_phase9c_hub_spokes.yaml
@@ -29,7 +29,7 @@ system: |
   4. Maximum 3 hubs per story
 
   ## Spoke Design Rules
-  1. Each spoke is 2-4 sentences of flavor/atmosphere, NOT plot-critical content
+  1. Each spoke is 1-2 sentences of flavor/atmosphere, NOT plot-critical content
   2. Spokes should reveal character, setting, or world detail
   3. 2-4 spokes per hub
   4. Spoke labels: 3-6 words, action phrases in imperative form

--- a/prompts/templates/grow_phase9c_hub_spokes.yaml
+++ b/prompts/templates/grow_phase9c_hub_spokes.yaml
@@ -1,0 +1,62 @@
+name: grow_phase9c_hub_spokes
+description: Identify hub passages and propose optional exploration spokes
+
+system: |
+  You are adding optional exploration nodes to an interactive story. Some
+  passages are natural "hub" locations where the player arrives and could
+  explore before continuing the main story.
+
+  ## What is a Hub-and-Spoke Pattern?
+  A hub is a passage where the player can optionally explore side content
+  (spokes) before choosing to continue the main story. Spokes are short,
+  flavor-only passages that return to the hub.
+
+  Example:
+  - Hub: "You arrive at the bustling marketplace"
+  - Spoke 1: "Examine the merchant's exotic wares" → return to hub
+  - Spoke 2: "Listen to the street musician" → return to hub
+  - Forward: "Head toward the palace gates" → next story passage
+
+  ## Passages to Consider
+  {passage_context}
+
+  {output_language_instruction}
+
+  ## Hub Selection Criteria
+  1. Good hubs are ARRIVAL passages — entering a location or meeting a group
+  2. Good hubs have environmental detail worth exploring
+  3. Bad hubs are action scenes, chases, or emotionally intense moments
+  4. Maximum 3 hubs per story
+
+  ## Spoke Design Rules
+  1. Each spoke is 2-4 sentences of flavor/atmosphere, NOT plot-critical content
+  2. Spokes should reveal character, setting, or world detail
+  3. 2-4 spokes per hub
+  4. Spoke labels: 3-6 words, action phrases in imperative form
+  5. Forward label: describes continuing the main story
+
+  ## What NOT to Do
+  - Do NOT use passage IDs not listed in the Valid IDs section
+  - Do NOT make spokes plot-critical (they are OPTIONAL)
+  - Do NOT add explanatory prose before or after the JSON output
+  - Do NOT propose hubs at ending passages (no outgoing choices)
+  - It is VALID to return 0 hubs if no passage is suitable
+
+  ## Valid IDs
+  Valid passage IDs: {valid_passage_ids}
+
+  ## Output Format
+  Return a JSON object with a "hubs" array. Each hub has:
+  - passage_id: the passage that becomes a hub
+  - spokes: array of 2-4 spokes, each with:
+    - summary: 1-2 sentence description of what the player finds
+    - label: choice label to enter the spoke (3-6 words)
+  - forward_label: choice label for continuing the story (3-6 words)
+
+user: |
+  Identify 0-3 passages suitable as exploration hubs and propose spokes.
+  Return 0 hubs if no passage is suitable for exploration.
+
+  REMINDER: Return ONLY a valid JSON object. Use ONLY passage IDs from the Valid IDs section. Do NOT add prose before or after the JSON.
+
+components: []

--- a/src/questfoundry/export/base.py
+++ b/src/questfoundry/export/base.py
@@ -32,6 +32,7 @@ class ExportChoice:
     label: str
     requires: list[str] = field(default_factory=list)
     grants: list[str] = field(default_factory=list)
+    is_return: bool = False
 
 
 @dataclass

--- a/src/questfoundry/export/context.py
+++ b/src/questfoundry/export/context.py
@@ -85,6 +85,7 @@ def _extract_choices(graph: Graph) -> list[ExportChoice]:
             label=data.get("label", "continue"),
             requires=data.get("requires", []),
             grants=data.get("grants", []),
+            is_return=data.get("is_return", False),
         )
         for _node_id, data in sorted(nodes.items())
     ]

--- a/src/questfoundry/graph/grow_validation.py
+++ b/src/questfoundry/graph/grow_validation.py
@@ -388,6 +388,9 @@ def check_passage_dag_cycles(graph: Graph) -> ValidationCheck:
     successors: dict[str, list[str]] = {pid: [] for pid in passage_nodes}
 
     for choice_data in choice_nodes.values():
+        # Skip is_return edges (spoke→hub back-links) — they are intentional cycles
+        if choice_data.get("is_return"):
+            continue
         from_p = choice_data.get("from_passage")
         to_p = choice_data.get("to_passage")
         if from_p and to_p and from_p in passage_nodes and to_p in passage_nodes:

--- a/src/questfoundry/graph/grow_validators.py
+++ b/src/questfoundry/graph/grow_validators.py
@@ -236,7 +236,8 @@ def validate_phase9c_output(
     """Validate Phase 9c hub-spoke proposals.
 
     Checks:
-    - passage_id exists in valid passage IDs
+    - passage_id exists in valid passage IDs (which excludes ending passages,
+      ensuring hubs have outgoing choices)
     """
     errors: list[GrowValidationError] = []
     for i, hub in enumerate(result.hubs):

--- a/src/questfoundry/graph/grow_validators.py
+++ b/src/questfoundry/graph/grow_validators.py
@@ -22,6 +22,7 @@ if TYPE_CHECKING:
         Phase4fOutput,
         Phase8cOutput,
         Phase9bOutput,
+        Phase9cOutput,
         Phase9Output,
     )
 
@@ -228,6 +229,29 @@ def validate_phase9b_output(
     return errors
 
 
+def validate_phase9c_output(
+    result: Phase9cOutput,
+    valid_passage_ids: set[str],
+) -> list[GrowValidationError]:
+    """Validate Phase 9c hub-spoke proposals.
+
+    Checks:
+    - passage_id exists in valid passage IDs
+    """
+    errors: list[GrowValidationError] = []
+    for i, hub in enumerate(result.hubs):
+        if hub.passage_id not in valid_passage_ids:
+            errors.append(
+                GrowValidationError(
+                    field_path=f"hubs.{i}.passage_id",
+                    issue=f"Passage ID not found: {hub.passage_id}",
+                    provided=hub.passage_id,
+                    available=sorted(valid_passage_ids)[:10],
+                )
+            )
+    return errors
+
+
 def format_semantic_errors(errors: list[GrowValidationError]) -> str:
     """Format semantic validation errors as LLM feedback.
 
@@ -296,6 +320,7 @@ def count_entries(result: object) -> int:
         "labels",
         "arcs",
         "proposals",
+        "hubs",
     ):
         entries = getattr(result, attr, None)
         if entries is not None:

--- a/src/questfoundry/models/__init__.py
+++ b/src/questfoundry/models/__init__.py
@@ -66,6 +66,7 @@ from questfoundry.models.grow import (
     GapProposal,
     GrowPhaseResult,
     GrowResult,
+    HubProposal,
     IntersectionProposal,
     OverlayProposal,
     Passage,
@@ -80,8 +81,10 @@ from questfoundry.models.grow import (
     Phase4fOutput,
     Phase8cOutput,
     Phase9bOutput,
+    Phase9cOutput,
     Phase9Output,
     SceneTypeTag,
+    SpokeProposal,
 )
 from questfoundry.models.pipeline import PhaseResult
 from questfoundry.models.seed import (
@@ -143,6 +146,7 @@ __all__ = [
     "GapProposal",
     "GrowPhaseResult",
     "GrowResult",
+    "HubProposal",
     "Illustration",
     "IllustrationBrief",
     "IllustrationCategory",
@@ -164,10 +168,12 @@ __all__ = [
     "Phase8cOutput",
     "Phase9Output",
     "Phase9bOutput",
+    "Phase9cOutput",
     "PhaseResult",
     "ReviewFlag",
     "SceneTypeTag",
     "Scope",
     "SeedOutput",
+    "SpokeProposal",
     "VoiceDocument",
 ]

--- a/src/questfoundry/models/grow.py
+++ b/src/questfoundry/models/grow.py
@@ -80,6 +80,7 @@ class Choice(BaseModel):
     label: str = Field(min_length=1)
     requires: list[str] = Field(default_factory=list)
     grants: list[str] = Field(default_factory=list)
+    is_return: bool = Field(default=False, description="True for spoke→hub return links")
 
 
 class EntityOverlay(BaseModel):
@@ -325,6 +326,27 @@ class Phase9bOutput(BaseModel):
     """Wrapper for Phase 9b structured output (fork proposals)."""
 
     proposals: list[ForkProposal] = Field(default_factory=list)
+
+
+class SpokeProposal(BaseModel):
+    """A single spoke in a hub-and-spoke exploration node."""
+
+    summary: str = Field(min_length=1, description="Summary of the spoke passage")
+    label: str = Field(min_length=1, description="Choice label to enter the spoke")
+
+
+class HubProposal(BaseModel):
+    """Phase 9c: A hub passage with optional exploration spokes."""
+
+    passage_id: str = Field(min_length=1, description="Which passage becomes a hub")
+    spokes: list[SpokeProposal] = Field(min_length=2, max_length=4)
+    forward_label: str = Field(min_length=1, description="Label for the 'continue story' choice")
+
+
+class Phase9cOutput(BaseModel):
+    """Wrapper for Phase 9c structured output (hub proposals)."""
+
+    hubs: list[HubProposal] = Field(default_factory=list)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/integration/test_grow_e2e.py
+++ b/tests/integration/test_grow_e2e.py
@@ -155,9 +155,9 @@ class TestGrowFullPipeline:
     """E2E tests running all 18 GROW phases on the fixture graph."""
 
     def test_all_phases_complete(self, pipeline_result: dict[str, Any]) -> None:
-        """Verify all 19 phases complete with no failures."""
+        """Verify all 20 phases complete with no failures."""
         phases = pipeline_result["result_dict"]["phases_completed"]
-        assert len(phases) == 19
+        assert len(phases) == 20
         for phase in phases:
             assert phase["status"] in ("completed", "skipped"), (
                 f"Phase {phase['phase']} has unexpected status: {phase['status']}"

--- a/tests/unit/test_grow_algorithms.py
+++ b/tests/unit/test_grow_algorithms.py
@@ -1617,9 +1617,9 @@ class TestPhaseIntegrationEndToEnd:
         mock_model = _make_grow_mock_model(graph)
         result_dict, _llm_calls, _tokens = await stage.execute(model=mock_model, user_prompt="")
 
-        # All 19 phases should run (completed or skipped)
+        # All 20 phases should run (completed or skipped)
         phases = result_dict["phases_completed"]
-        assert len(phases) == 19
+        assert len(phases) == 20
         for phase in phases:
             assert phase["status"] in ("completed", "skipped")
 


### PR DESCRIPTION
## Problem
Players have no opportunity for optional exploration. The story is strictly linear with only forward-facing choices, missing the environmental discovery that makes interactive fiction engaging.

## Changes
- **Models**: Add `is_return` field to `Choice`, plus `SpokeProposal`, `HubProposal`, `Phase9cOutput`
- **Prompt**: Add `grow_phase9c_hub_spokes.yaml` template
- **Phase 9c**: New `_phase_9c_hub_spokes()` between fork_beats and validation
  - LLM identifies 0-3 hub candidates from non-ending passages
  - Creates spoke passages (synthetic, flavor-only) with return links
  - Relabels existing forward choice with contextual label
  - Capped at 3 hubs per story
- **DAG cycles**: `check_passage_dag_cycles()` excludes `is_return` choices from Kahn's algorithm
- **Export**: `ExportChoice.is_return` field, passed through from graph
- **Validator**: `validate_phase9c_output()` checks hub passage IDs exist

## Not Included / Future PRs
All 5 suggestions from #598 are now implemented across PRs 1-5.

## Test Plan
- `test_hub_creates_spokes_and_return_links`: 2 spokes + return links created, forward relabeled
- `test_return_links_excluded_from_cycle_check`: is_return edges don't trigger cycle failure
- `test_empty_hubs_noop`: 0 hubs from LLM → noop
- Export tests pass with new is_return field

```
uv run pytest tests/unit/test_grow_stage.py tests/unit/test_grow_validation.py tests/unit/test_twee_exporter.py tests/unit/test_html_exporter.py -x -q  # 177 passed
uv run mypy src/questfoundry/  # Success
```

## Risk / Rollback
High. Spoke→hub return links create intentional cycles excluded via `is_return` flag. If the flag is lost or mishandled, cycle detection will fail. Export renderers handle back-links natively (Twee `[[Return->hub]]`, HTML JS state machine).

## Review Guide
Suggested review order:
1. `models/grow.py` — is_return on Choice + new models
2. `grow_validation.py` — is_return exclusion in cycle check (3 lines, critical)
3. `grow_phase9c_hub_spokes.yaml` — prompt template
4. `grow.py` — Phase 9c implementation + phase order
5. `export/base.py` + `export/context.py` — is_return passthrough
6. Tests

Closes #598

🤖 Generated with [Claude Code](https://claude.com/claude-code)