### PR TITLE
fix(grow): prevent intersections collapsing branching

### DIFF
--- a/prompts/templates/grow_phase3_intersections.yaml
+++ b/prompts/templates/grow_phase3_intersections.yaml
@@ -13,6 +13,7 @@ system: |
 
   ## Clustering Rules
   1. Each intersection must contain beats from at least 2 DIFFERENT dilemmas
+  1b. Keep intersections SMALL: prefer 2 beats; 3 beats maximum
   2. Beats in an intersection should share a plausible location or moment
   3. Prefer location overlap as the strongest signal for clustering
   4. Entity overlap (same character in both beats) is a secondary signal
@@ -21,13 +22,17 @@ system: |
 
   ## Dilemma Matching (CRITICAL)
   Each beat below is tagged with `[dilemma: ...]`. Use this tag to ensure
-  every intersection mixes beats from DIFFERENT dilemmas:
+  every intersection mixes beats from DIFFERENT dilemmas. This also means:
+  - An intersection may include at most ONE beat per dilemma (all dilemma tags must be distinct)
 
   GOOD: beat from [dilemma: dilemma::A] + beat from [dilemma: dilemma::B] = valid (2 different dilemmas)
   BAD:  beat from [dilemma: dilemma::A] + beat from [dilemma: dilemma::A] = INVALID (same dilemma)
+  BAD:  beat from [dilemma: dilemma::A] + another beat from [dilemma: dilemma::A] + beat from [dilemma: dilemma::B]
+        = INVALID (multiple beats from the same dilemma)
 
   ## What NOT to Do
   - Do NOT group beats that share the same [dilemma: ...] tag
+  - Do NOT propose intersections with 4+ beats (max is 3)
   - Do NOT propose intersections with only 1 beat
   - Do NOT use beat IDs not listed in the Valid IDs section
   - Do NOT force intersections where there is no natural scene overlap

--- a/tests/unit/test_grow_algorithms.py
+++ b/tests/unit/test_grow_algorithms.py
@@ -1318,6 +1318,60 @@ class TestCheckKnotCompatibility:
         )
         assert errors == []
 
+    def test_rejects_intersection_larger_than_cap(self) -> None:
+        """Intersections are capped to prevent path-infection clusters."""
+        from questfoundry.graph.grow_algorithms import check_intersection_compatibility
+        from tests.fixtures.grow_fixtures import make_two_dilemma_graph
+
+        graph = make_two_dilemma_graph()
+        errors = check_intersection_compatibility(
+            graph,
+            [
+                "beat::mentor_meet",
+                "beat::artifact_discover",
+                "beat::mentor_commits_canonical",
+                "beat::artifact_commits_canonical",
+            ],
+            max_intersection_size=3,
+        )
+        assert len(errors) == 1
+        assert "maximum allowed is 3" in errors[0].issue
+
+    def test_rejects_multiple_beats_from_same_dilemma(self) -> None:
+        """Intersections must include at most 1 beat per dilemma."""
+        from questfoundry.graph.grow_algorithms import check_intersection_compatibility
+
+        graph = Graph.empty()
+        graph.create_node("dilemma::a", {"type": "dilemma", "raw_id": "a"})
+        graph.create_node("dilemma::b", {"type": "dilemma", "raw_id": "b"})
+        graph.create_node(
+            "path::a1",
+            {
+                "type": "path",
+                "raw_id": "a1",
+                "dilemma_id": "dilemma::a",
+                "is_canonical": True,
+            },
+        )
+        graph.create_node(
+            "path::b1",
+            {
+                "type": "path",
+                "raw_id": "b1",
+                "dilemma_id": "dilemma::b",
+                "is_canonical": True,
+            },
+        )
+        graph.create_node("beat::a_1", {"type": "beat", "raw_id": "a_1"})
+        graph.create_node("beat::a_2", {"type": "beat", "raw_id": "a_2"})
+        graph.create_node("beat::b_1", {"type": "beat", "raw_id": "b_1"})
+        graph.add_edge("belongs_to", "beat::a_1", "path::a1")
+        graph.add_edge("belongs_to", "beat::a_2", "path::a1")
+        graph.add_edge("belongs_to", "beat::b_1", "path::b1")
+
+        errors = check_intersection_compatibility(graph, ["beat::a_1", "beat::a_2", "beat::b_1"])
+        assert any("multiple beats from the same dilemma" in e.issue for e in errors)
+
     def test_incompatible_same_dilemma(self) -> None:
         """Beats from same dilemma are incompatible."""
         from questfoundry.graph.grow_algorithms import check_intersection_compatibility
@@ -1333,9 +1387,18 @@ class TestCheckKnotCompatibility:
         """Beats with requires edge are incompatible."""
         from questfoundry.graph.grow_algorithms import check_intersection_compatibility
 
-        graph = make_two_dilemma_graph()
-        # mentor_meet requires opening, and both are in the graph
-        errors = check_intersection_compatibility(graph, ["beat::opening", "beat::mentor_meet"])
+        graph = Graph.empty()
+        graph.create_node("dilemma::a", {"type": "dilemma", "raw_id": "a"})
+        graph.create_node("dilemma::b", {"type": "dilemma", "raw_id": "b"})
+        graph.create_node("path::a1", {"type": "path", "raw_id": "a1", "dilemma_id": "dilemma::a"})
+        graph.create_node("path::b1", {"type": "path", "raw_id": "b1", "dilemma_id": "dilemma::b"})
+        graph.create_node("beat::a", {"type": "beat", "raw_id": "a"})
+        graph.create_node("beat::b", {"type": "beat", "raw_id": "b"})
+        graph.add_edge("belongs_to", "beat::a", "path::a1")
+        graph.add_edge("belongs_to", "beat::b", "path::b1")
+        graph.add_edge("requires", "beat::a", "beat::b")
+
+        errors = check_intersection_compatibility(graph, ["beat::a", "beat::b"])
         assert len(errors) > 0
         assert any("requires" in e.issue for e in errors)
 
@@ -2186,10 +2249,27 @@ class TestConditionalPrerequisiteInvariant:
 
     When a proposed intersection beat has a ``requires`` edge to a beat
     outside the intersection whose paths do NOT cover the full union of
-    intersection beat paths, ``check_intersection_compatibility`` attempts
-    recovery via lift (widen prerequisite) or split (create path-specific
-    variant) before rejecting. See GitHub #360 and #361.
+    intersection beat paths, ``check_intersection_compatibility`` rejects the
+    intersection by default. Optional recovery via lift (widen prerequisite)
+    and split (create path-specific variant) can be enabled explicitly.
     """
+
+    def test_rejects_conditional_prerequisite_by_default(self) -> None:
+        """Conditional prerequisites are rejected unless recovery is enabled."""
+        from questfoundry.graph.grow_algorithms import check_intersection_compatibility
+        from tests.fixtures.grow_fixtures import make_conditional_prerequisite_graph
+
+        graph = make_conditional_prerequisite_graph()
+        errors = check_intersection_compatibility(
+            graph, ["beat::mentor_meet", "beat::artifact_discover"]
+        )
+        assert len(errors) > 0
+        assert any("Conditional prerequisites are not allowed" in e.issue for e in errors)
+
+        # Ensure the default path does not mutate the graph.
+        gap_edges = graph.get_edges(from_id="beat::gap_1", to_id=None, edge_type="belongs_to")
+        gap_paths = {e["to"] for e in gap_edges}
+        assert gap_paths == {"path::mentor_trust_canonical"}
 
     def test_lifts_conditional_prerequisite(self) -> None:
         """Prerequisite spanning fewer paths is lifted to cover intersection."""
@@ -2198,7 +2278,9 @@ class TestConditionalPrerequisiteInvariant:
 
         graph = make_conditional_prerequisite_graph()
         errors = check_intersection_compatibility(
-            graph, ["beat::mentor_meet", "beat::artifact_discover"]
+            graph,
+            ["beat::mentor_meet", "beat::artifact_discover"],
+            allow_prerequisite_recovery=True,
         )
         # Lift succeeds — gap_1 gets widened to all 4 paths
         assert errors == []
@@ -2266,7 +2348,9 @@ class TestConditionalPrerequisiteInvariant:
         graph.add_edge("requires", "beat::mentor_meet", "beat::orphan_prereq")
 
         errors = check_intersection_compatibility(
-            graph, ["beat::mentor_meet", "beat::artifact_discover"]
+            graph,
+            ["beat::mentor_meet", "beat::artifact_discover"],
+            allow_prerequisite_recovery=True,
         )
         # Lift succeeds — orphan gets widened to all paths
         assert errors == []
@@ -2297,7 +2381,9 @@ class TestConditionalPrerequisiteInvariant:
         graph.add_edge("requires", "beat::artifact_discover", "beat::gap_2")
 
         errors = check_intersection_compatibility(
-            graph, ["beat::mentor_meet", "beat::artifact_discover"]
+            graph,
+            ["beat::mentor_meet", "beat::artifact_discover"],
+            allow_prerequisite_recovery=True,
         )
         # Both lifts succeed
         assert errors == []
@@ -2317,7 +2403,9 @@ class TestConditionalPrerequisiteInvariant:
         graph.add_edge("requires", "beat::gap_1", "beat::gap_0")
 
         errors = check_intersection_compatibility(
-            graph, ["beat::mentor_meet", "beat::artifact_discover"]
+            graph,
+            ["beat::mentor_meet", "beat::artifact_discover"],
+            allow_prerequisite_recovery=True,
         )
         # Both gap_0 and gap_1 lifted transitively
         assert errors == []
@@ -2359,7 +2447,9 @@ class TestConditionalPrerequisiteInvariant:
         )
 
         errors = check_intersection_compatibility(
-            graph, ["beat::mentor_meet", "beat::artifact_discover"]
+            graph,
+            ["beat::mentor_meet", "beat::artifact_discover"],
+            allow_prerequisite_recovery=True,
         )
         assert len(errors) > 0
         assert any("conditional_prerequisite" in e.field_path for e in errors)
@@ -2387,7 +2477,9 @@ class TestConditionalPrerequisiteInvariant:
             prev = deep_id
 
         errors = check_intersection_compatibility(
-            graph, ["beat::mentor_meet", "beat::artifact_discover"]
+            graph,
+            ["beat::mentor_meet", "beat::artifact_discover"],
+            allow_prerequisite_recovery=True,
         )
         # Lift fails but split succeeds — no errors
         assert errors == []

--- a/tests/unit/test_grow_validators.py
+++ b/tests/unit/test_grow_validators.py
@@ -112,6 +112,23 @@ class TestValidatePhase3Output:
         )
         assert errors == []
 
+    def test_rejects_oversized_intersection(self) -> None:
+        result = Phase3Output(
+            intersections=[
+                IntersectionProposal(
+                    beat_ids=["beat::b1", "beat::b2", "beat::b3", "beat::b4"],
+                    rationale="too big",
+                )
+            ]
+        )
+        errors = validate_phase3_output(
+            result,
+            valid_beat_ids={"beat::b1", "beat::b2", "beat::b3", "beat::b4"},
+            max_intersection_size=3,
+        )
+        assert len(errors) == 1
+        assert "maximum allowed is 3" in errors[0].issue
+
     def test_invalid_beat_id(self) -> None:
         result = Phase3Output(
             intersections=[


### PR DESCRIPTION
## Problem
GROW Phase 3 intersections could collapse macro-branching: intersections + conditional prerequisite lift/split would over-share beats across paths ("path infection"), making arcs near-identical and yielding very few true divergence points.

## Changes
- Hardened Phase 3 intersection compatibility: cap intersection size, require exactly one beat per dilemma, and reject conditional prerequisites by default.
- Validated intersection proposals against a pre-intersections snapshot and applied accepted intersections in a batch to prevent cascade effects.
- Tightened `grow_phase3_intersections` prompt constraints and added a semantic validator cap for oversized intersections.
- Updated unit tests for the new rules and opt-in prerequisite recovery.

## Not Included / Future PRs
- #609 (add explicit arc-collapse / over-sharing divergence validation)
- #610 (Phase 9 requires/grants semantics)

## Test Plan
- `uv run ruff check src/questfoundry/graph/grow_algorithms.py src/questfoundry/graph/grow_validators.py src/questfoundry/pipeline/stages/grow.py tests/unit/test_grow_algorithms.py tests/unit/test_grow_validators.py`
- `uv run mypy src/questfoundry/graph/grow_algorithms.py src/questfoundry/graph/grow_validators.py src/questfoundry/pipeline/stages/grow.py`
- `uv run pytest tests/unit/test_grow_algorithms.py -x -q`
- `uv run pytest tests/unit/test_grow_validators.py -x -q`
- `uv run pytest tests/unit/test_grow_stage.py -x -q`
- Manual: reran GROW on a copy of `projects/test-20260204T0732` reset to `snapshots/grow-pre-validate_dag.json`; resulting run reported `Created 52 choices (14 divergence points)`.

## Risk / Rollback
- Risk: fewer intersections will be accepted (especially if prerequisites are path-specific); this is intentional to preserve branching and avoid invalid DAGs.
- Rollback: revert this PR and re-run GROW from the SEED snapshot.

Closes #606
Closes #607
Closes #608
Relates-to #605
