### PR TITLE
fix(dress): persist image-generation progress

### DIFF
--- a/src/questfoundry/pipeline/orchestrator.py
+++ b/src/questfoundry/pipeline/orchestrator.py
@@ -598,6 +598,10 @@ class PipelineOrchestrator:
             image_budget = context.get("image_budget", 0)
             if image_budget > 0:
                 stage_kwargs["image_budget"] = image_budget
+            if stage_name == "dress":
+                min_priority = context.get("min_priority", 3)
+                if isinstance(min_priority, int) and min_priority < 3:
+                    stage_kwargs["min_priority"] = min_priority
             if stage_name == "fill":
                 stage_kwargs["two_step"] = context.get("two_step", self.config.fill.two_step)
 


### PR DESCRIPTION
## Problem
DRESS Phase 4 (`generate`) only persisted illustration nodes at the end of the run, which is risky for long image-generation sessions (A1111). If interrupted, generated assets could exist on disk while the graph remained unchanged.

Additionally, running DRESS via `qf run --to dress` could fail in Phase 4 with `project_path is required for image generation` because the singleton stage instance didn’t persist the resolved `project_path` passed to `execute()`.

## Changes
- Persist `project_path` inside `DressStage.execute()` so downstream phases (especially Phase 4) can rely on it.
- Save `graph.json` after each approved DRESS phase to preserve expensive progress (briefs/codex/review) even if later phases fail.
- Save `graph.json` after each generated illustration in Phase 4 for crash resilience/resumability and real-time visibility in `qf inspect`.
- Forward `min_priority` from pipeline context into DRESS execution (so `qf run --min-priority ...` affects Phase 4 filtering).

## Not Included / Future PRs
- Retroactive reconciliation of already-generated assets with missing illustration nodes (not needed once incremental saves are in place).

## Test Plan
- `uv run ruff check src/questfoundry/pipeline/orchestrator.py src/questfoundry/pipeline/stages/dress.py tests/unit/test_dress_stage.py`
- `uv run mypy src/questfoundry/pipeline/orchestrator.py src/questfoundry/pipeline/stages/dress.py`
- `uv run pytest tests/unit/test_dress_stage.py -x -q`

## Risk / Rollback
- Risk: more frequent graph writes during DRESS generate (should be low; `Graph.save()` is atomic).
- Rollback: revert this PR.

Closes #597
