### PR TITLE
fix(inspect): emit valid JSON and correct start detection

### DIFF
--- a/src/questfoundry/cli.py
+++ b/src/questfoundry/cli.py
@@ -2556,7 +2556,14 @@ def inspect(
         import dataclasses
         import json
 
-        console.print(json.dumps(dataclasses.asdict(report), indent=2))
+        # Emit machine-readable JSON. Rich will otherwise wrap long lines at the
+        # terminal width (80), which can split string values and break JSON.
+        console.print(
+            json.dumps(dataclasses.asdict(report), indent=2),
+            soft_wrap=True,
+            markup=False,
+            highlight=False,
+        )
         return
 
     _render_inspection_report(report)

--- a/src/questfoundry/export/context.py
+++ b/src/questfoundry/export/context.py
@@ -100,7 +100,10 @@ def _mark_start_and_endings(
     has_outgoing: set[str] = set()
 
     for choice in choices:
-        has_incoming.add(choice.to_passage)
+        # Return links (spoke→hub) should not prevent hubs from being recognised
+        # as the unique start passage.
+        if not choice.is_return:
+            has_incoming.add(choice.to_passage)
         has_outgoing.add(choice.from_passage)
 
     for passage in passages:

--- a/src/questfoundry/inspection.py
+++ b/src/questfoundry/inspection.py
@@ -255,15 +255,14 @@ def _branching_stats(graph: Graph) -> BranchingStats | None:
     # Exclude hub-spoke return links (spoke→hub with is_return=True), otherwise
     # hubs can incorrectly appear to have incoming edges and start_count becomes 0.
     choice_nodes = graph.get_nodes_by_type("choice")
-    has_incoming: set[str] = set()
-    has_outgoing: set[str] = set()
-    for choice_data in choice_nodes.values():
-        from_passage = choice_data.get("from_passage")
-        to_passage = choice_data.get("to_passage")
-        if from_passage:
-            has_outgoing.add(from_passage)
-        if to_passage and not choice_data.get("is_return"):
-            has_incoming.add(to_passage)
+    has_incoming: set[str] = {
+        data["to_passage"]
+        for data in choice_nodes.values()
+        if data.get("to_passage") and not data.get("is_return")
+    }
+    # For outgoing, it's more direct to use the `choice_from` edges.
+    choice_from_edges = graph.get_edges(edge_type="choice_from")
+    has_outgoing = {e["to"] for e in choice_from_edges}
 
     start_count = sum(1 for pid in passages if pid not in has_incoming)
     ending_count = sum(1 for pid in passages if pid not in has_outgoing)


### PR DESCRIPTION
## Problem
`qf inspect --json` is not machine-readable because Rich wraps long lines at terminal width, splitting string values and producing invalid JSON. Also, start passage counting in both `qf inspect` and exports incorrectly treats hub-spoke return links (`is_return=True`) as incoming, leading to `start_passages: 0` and potentially wrong start passage selection.

## Changes
- Emit JSON with Rich `soft_wrap=True` to prevent line-wrapping inside string values.
- Exclude `is_return` choices from incoming-edge accounting when marking start passages in export context.
- Exclude `is_return` choices from incoming-edge accounting for `qf inspect` branching stats.
- Add unit tests covering valid JSON output and return-link start detection.

## Not Included / Future PRs
- No changes to GROW choice `requires/grants` semantics or linear-stretch collapsing (tracked separately).

## Test Plan
- `uv run ruff check src/questfoundry/cli.py src/questfoundry/export/context.py src/questfoundry/inspection.py tests/unit/test_cli.py tests/unit/test_export_context.py tests/unit/test_inspection.py`
- `uv run pytest tests/unit/test_cli.py -x -q`
- `uv run pytest tests/unit/test_export_context.py -x -q`
- `uv run pytest tests/unit/test_inspection.py -x -q`

## Risk / Rollback
- Low risk: changes are isolated to CLI output and start/ending detection logic.
- Rollback: revert this PR to restore previous behavior (JSON output + start counting).