### PR TITLE
feat(grow): collapse linear beat runs before passages

### DIFF
--- a/src/questfoundry/pipeline/stages/grow.py
+++ b/src/questfoundry/pipeline/stages/grow.py
@@ -178,6 +178,7 @@ class GrowStage:
             (self._phase_5_enumerate_arcs, "enumerate_arcs"),
             (self._phase_6_divergence, "divergence"),
             (self._phase_7_convergence, "convergence"),
+            (self._phase_7b_collapse_linear_beats, "collapse_linear_beats"),
             (self._phase_8a_passages, "passages"),
             (self._phase_8b_codewords, "codewords"),
             (self._phase_8c_overlays, "overlays"),
@@ -1822,6 +1823,30 @@ class GrowStage:
             phase="convergence",
             status="completed",
             detail=f"Found {convergence_count} convergence points",
+        )
+
+    async def _phase_7b_collapse_linear_beats(
+        self,
+        graph: Graph,
+        model: BaseChatModel,  # noqa: ARG002
+    ) -> GrowPhaseResult:
+        """Phase 7b: Collapse mandatory linear beat runs before passage creation."""
+        from questfoundry.graph.grow_algorithms import collapse_linear_beats
+
+        result = collapse_linear_beats(graph, min_run_length=2)
+        if result.beats_removed == 0:
+            return GrowPhaseResult(
+                phase="collapse_linear_beats",
+                status="completed",
+                detail="No linear beat runs to collapse",
+            )
+
+        return GrowPhaseResult(
+            phase="collapse_linear_beats",
+            status="completed",
+            detail=(
+                f"Collapsed {result.beats_removed} beats across {result.runs_collapsed} run(s)"
+            ),
         )
 
     async def _phase_8a_passages(self, graph: Graph, model: BaseChatModel) -> GrowPhaseResult:  # noqa: ARG002

--- a/tests/integration/test_grow_e2e.py
+++ b/tests/integration/test_grow_e2e.py
@@ -152,12 +152,12 @@ def pipeline_result(tmp_path_factory: pytest.TempPathFactory) -> dict[str, Any]:
 
 
 class TestGrowFullPipeline:
-    """E2E tests running all 18 GROW phases on the fixture graph."""
+    """E2E tests running all 21 GROW phases on the fixture graph."""
 
     def test_all_phases_complete(self, pipeline_result: dict[str, Any]) -> None:
-        """Verify all 20 phases complete with no failures."""
+        """Verify all 21 phases complete with no failures."""
         phases = pipeline_result["result_dict"]["phases_completed"]
-        assert len(phases) == 20
+        assert len(phases) == 21
         for phase in phases:
             assert phase["status"] in ("completed", "skipped"), (
                 f"Phase {phase['phase']} has unexpected status: {phase['status']}"

--- a/tests/unit/test_grow_stage.py
+++ b/tests/unit/test_grow_stage.py
@@ -57,7 +57,7 @@ class TestGrowStageExecute:
         assert tokens == 0
         # All phases run to completion (empty graph = no work to do)
         phases = result_dict["phases_completed"]
-        assert len(phases) == 20
+        assert len(phases) == 21
         for phase in phases:
             assert phase["status"] == "completed"
 
@@ -185,10 +185,10 @@ class TestGrowStageExecute:
 
 
 class TestGrowStagePhaseOrder:
-    def test_phase_order_returns_eighteen_phases(self) -> None:
+    def test_phase_order_returns_twenty_one_phases(self) -> None:
         stage = GrowStage()
         phases = stage._phase_order()
-        assert len(phases) == 20
+        assert len(phases) == 21
 
     def test_phase_order_names(self) -> None:
         stage = GrowStage()
@@ -206,6 +206,7 @@ class TestGrowStagePhaseOrder:
             "enumerate_arcs",
             "divergence",
             "convergence",
+            "collapse_linear_beats",
             "passages",
             "codewords",
             "overlays",


### PR DESCRIPTION
## Problem
GROW can produce long mandatory linear runs (single-in/out beats), leading to click fatigue.

## Changes
- add deterministic linear-beat collapse step before passage creation
- merge summaries/entities/impacts onto the kept beat and rewire requires/grants/belongs_to
- update arc sequences after collapse
- add unit tests for collapsing, exemptions, and hub boundaries
- update phase-order tests for the new phase

## Not Included / Future PRs
- None

## Test Plan
- `uv run ruff check src/questfoundry/graph/grow_algorithms.py src/questfoundry/pipeline/stages/grow.py tests/unit/test_grow_algorithms.py tests/unit/test_grow_stage.py`
- `uv run pytest tests/unit/test_grow_algorithms.py tests/unit/test_grow_stage.py -x -q`

## Risk / Rollback
- Medium; structural mutation in GROW before passages
- Revert this PR to disable collapsing

Closes #615