### PR TITLE
fix(providers): guardrail A1111 prompt distillation

### DIFF
--- a/src/questfoundry/artifacts/enrichment.py
+++ b/src/questfoundry/artifacts/enrichment.py
@@ -253,7 +253,7 @@ def _extract_arcs(graph: Graph) -> list[dict[str, Any]]:
         entry: dict[str, Any] = {
             "arc_id": arc_id,
             "arc_type": data.get("arc_type", "branch"),
-            "paths": data.get("paths", []),
+            "paths": sorted(data.get("paths", []) or []),
             "sequence": beat_sequence,
         }
         arcs.append(entry)
@@ -279,11 +279,11 @@ def _extract_beats(graph: Graph) -> list[dict[str, Any]]:
         if location := data.get("location"):
             entry["location"] = location
         if intersection_group := data.get("intersection_group"):
-            entry["intersection_group"] = intersection_group
+            entry["intersection_group"] = sorted(intersection_group)
         if belongs_to:
             entry["belongs_to"] = belongs_to
         if entities := data.get("entities"):
-            entry["entities"] = entities
+            entry["entities"] = sorted(entities)
         beats.append(entry)
     return beats
 
@@ -302,7 +302,7 @@ def _extract_passages(graph: Graph) -> list[dict[str, Any]]:
         if data.get("is_synthetic") is True:
             entry["is_synthetic"] = True
         if entities := data.get("entities"):
-            entry["entities"] = entities
+            entry["entities"] = sorted(entities)
         passages.append(entry)
     return passages
 
@@ -340,9 +340,9 @@ def _extract_choices(graph: Graph) -> list[dict[str, Any]]:
         if to_passage:
             entry["to_passage"] = to_passage
         if requires := data.get("requires"):
-            entry["requires"] = list(requires)
+            entry["requires"] = sorted(requires)
         if grants := data.get("grants"):
-            entry["grants"] = list(grants)
+            entry["grants"] = sorted(grants)
         if data.get("is_return") is True:
             entry["is_return"] = True
         choices.append(entry)
@@ -377,6 +377,6 @@ def _extract_codewords(graph: Graph) -> list[dict[str, Any]]:
             if grants_edges:
                 granted_by = sorted(e["from"] for e in grants_edges)
         if granted_by:
-            entry["granted_by"] = list(granted_by)
+            entry["granted_by"] = sorted(granted_by)
         codewords.append(entry)
     return codewords

--- a/src/questfoundry/pipeline/stages/grow.py
+++ b/src/questfoundry/pipeline/stages/grow.py
@@ -236,7 +236,7 @@ class GrowStage:
             **kwargs: Additional keyword arguments (ignored).
 
         Returns:
-            Tuple of (GrowResult dict, total_llm_calls, total_tokens).
+            Tuple of (GROW artifact dict, total_llm_calls, total_tokens).
 
         Raises:
             GrowStageError: If project_path is not provided.
@@ -382,12 +382,11 @@ class GrowStage:
             spine_arc_id=spine_arc_id,
         )
 
-        # Write human-readable artifact (story data extracted from graph)
+        # Artifact is derived from the graph (beats/arcs/passages/choices/codewords).
+        # The orchestrator is responsible for writing artifacts to disk.
         from questfoundry.artifacts.enrichment import extract_grow_artifact
-        from questfoundry.artifacts.writer import ArtifactWriter
 
         artifact_data = extract_grow_artifact(graph)
-        ArtifactWriter(resolved_path).write(artifact_data, "grow")
 
         log.info(
             "stage_complete",
@@ -397,7 +396,7 @@ class GrowStage:
             codewords=grow_result.codeword_count,
         )
 
-        return grow_result.model_dump(), total_llm_calls, total_tokens
+        return artifact_data, total_llm_calls, total_tokens
 
     # -------------------------------------------------------------------------
     # LLM helper

--- a/tests/unit/test_grow_algorithms.py
+++ b/tests/unit/test_grow_algorithms.py
@@ -1708,24 +1708,20 @@ class TestPhaseIntegrationEndToEnd:
         mock_model = _make_grow_mock_model(graph)
         result_dict, _llm_calls, _tokens = await stage.execute(model=mock_model, user_prompt="")
 
-        # All 21 phases should run (completed or skipped)
-        phases = result_dict["phases_completed"]
-        assert len(phases) == 21
-        for phase in phases:
-            assert phase["status"] in ("completed", "skipped")
+        assert set(result_dict.keys()) == {"arcs", "beats", "passages", "choices", "codewords"}
 
         # Should have created arcs
-        assert result_dict["arc_count"] == 4  # 2x2 = 4 arcs
-        assert result_dict["spine_arc_id"] is not None
+        assert len(result_dict["arcs"]) == 4  # 2x2 = 4 arcs
+        assert any(a.get("arc_type") == "spine" for a in result_dict["arcs"])
 
         # Should have passages (one per beat)
-        assert result_dict["passage_count"] == 8  # 8 beats in two-dilemma graph
+        assert len(result_dict["passages"]) == 8  # 8 beats in two-dilemma graph
 
         # Should have codewords (one per consequence)
-        assert result_dict["codeword_count"] == 4  # 4 consequences
+        assert len(result_dict["codewords"]) == 4  # 4 consequences
 
         # Should have choices (from Phase 9)
-        assert result_dict["choice_count"] > 0
+        assert len(result_dict["choices"]) > 0
 
     @pytest.mark.asyncio
     async def test_single_dilemma_full_run(self, tmp_path: Path) -> None:
@@ -1738,13 +1734,11 @@ class TestPhaseIntegrationEndToEnd:
         mock_model = _make_grow_mock_model(graph)
         result_dict, _llm_calls, _tokens = await stage.execute(model=mock_model, user_prompt="")
 
-        # All phases run (completed or skipped)
-        phases = result_dict["phases_completed"]
-        assert all(p["status"] in ("completed", "skipped") for p in phases)
+        assert set(result_dict.keys()) == {"arcs", "beats", "passages", "choices", "codewords"}
 
-        assert result_dict["arc_count"] == 2  # 1 dilemma x 2 paths = 2 arcs
-        assert result_dict["passage_count"] == 4  # 4 beats
-        assert result_dict["codeword_count"] == 2  # 2 consequences
+        assert len(result_dict["arcs"]) == 2  # 1 dilemma x 2 paths = 2 arcs
+        assert len(result_dict["passages"]) == 4  # 4 beats
+        assert len(result_dict["codewords"]) == 2  # 2 consequences
 
     @pytest.mark.asyncio
     async def test_final_graph_has_expected_nodes(self, tmp_path: Path) -> None:

--- a/tests/unit/test_grow_enrichment.py
+++ b/tests/unit/test_grow_enrichment.py
@@ -27,6 +27,35 @@ def test_extract_grow_artifact_uses_arc_sequence_order() -> None:
     assert artifact["arcs"][0]["sequence"] == ["beat::b", "beat::a"]
 
 
+def test_extract_grow_artifact_sorts_arc_paths() -> None:
+    graph = Graph.empty()
+    graph.create_node("beat::a", {"type": "beat", "summary": "A"})
+    graph.create_node(
+        "arc::branch",
+        {
+            "type": "arc",
+            "arc_type": "branch",
+            "paths": ["path::b", "path::a"],
+            "sequence": ["beat::a"],
+        },
+    )
+    artifact = extract_grow_artifact(graph)
+    assert artifact["arcs"][0]["paths"] == ["path::a", "path::b"]
+
+
+def test_extract_grow_artifact_arc_falls_back_to_arc_contains_edges() -> None:
+    graph = Graph.empty()
+    graph.create_node("beat::a", {"type": "beat", "summary": "A"})
+    graph.create_node("beat::b", {"type": "beat", "summary": "B"})
+    graph.create_node("arc::x", {"type": "arc", "arc_type": "branch", "paths": []})
+    graph.add_edge("arc_contains", "arc::x", "beat::b")
+    graph.add_edge("arc_contains", "arc::x", "beat::a")
+
+    artifact = extract_grow_artifact(graph)
+    assert len(artifact["arcs"]) == 1
+    assert set(artifact["arcs"][0]["sequence"]) == {"beat::a", "beat::b"}
+
+
 def test_extract_grow_artifact_includes_choice_requires_and_grants() -> None:
     graph = Graph.empty()
     graph.create_node("passage::p1", {"type": "passage", "summary": "One"})
@@ -50,3 +79,53 @@ def test_extract_grow_artifact_includes_choice_requires_and_grants() -> None:
     assert choice["to_passage"] == "passage::p2"
     assert choice["requires"] == ["codeword::cw1"]
     assert choice["grants"] == ["codeword::cw2"]
+
+
+def test_extract_grow_artifact_sorts_beat_entities_and_intersection_group() -> None:
+    graph = Graph.empty()
+    graph.create_node(
+        "beat::b1",
+        {
+            "type": "beat",
+            "summary": "X",
+            "entities": ["entity::b", "entity::a"],
+            "intersection_group": ["beat::z", "beat::y"],
+        },
+    )
+    artifact = extract_grow_artifact(graph)
+    assert len(artifact["beats"]) == 1
+    assert artifact["beats"][0]["entities"] == ["entity::a", "entity::b"]
+    assert artifact["beats"][0]["intersection_group"] == ["beat::y", "beat::z"]
+
+
+def test_extract_grow_artifact_sorts_passage_entities_and_includes_is_synthetic() -> None:
+    graph = Graph.empty()
+    graph.create_node(
+        "passage::p",
+        {
+            "type": "passage",
+            "summary": "P",
+            "from_beat": "beat::b",
+            "entities": ["entity::b", "entity::a"],
+            "is_synthetic": True,
+        },
+    )
+    artifact = extract_grow_artifact(graph)
+    assert len(artifact["passages"]) == 1
+    assert artifact["passages"][0]["entities"] == ["entity::a", "entity::b"]
+    assert artifact["passages"][0]["is_synthetic"] is True
+
+
+def test_extract_grow_artifact_codeword_falls_back_to_edges() -> None:
+    graph = Graph.empty()
+    graph.create_node("codeword::cw", {"type": "codeword", "raw_id": "cw"})
+    graph.create_node("consequence::c1", {"type": "consequence"})
+    graph.create_node("beat::b", {"type": "beat", "summary": "B"})
+    graph.add_edge("tracks", "codeword::cw", "consequence::c1")
+    graph.add_edge("grants", "beat::b", "codeword::cw")
+
+    artifact = extract_grow_artifact(graph)
+    assert len(artifact["codewords"]) == 1
+    cw = artifact["codewords"][0]
+    assert cw["tracks"] == "consequence::c1"
+    assert cw["granted_by"] == ["beat::b"]

--- a/tests/unit/test_grow_enrichment.py
+++ b/tests/unit/test_grow_enrichment.py
@@ -1,0 +1,52 @@
+"""Tests for GROW artifact extraction."""
+
+from __future__ import annotations
+
+from questfoundry.artifacts.enrichment import extract_grow_artifact
+from questfoundry.graph.graph import Graph
+
+
+def test_extract_grow_artifact_uses_arc_sequence_order() -> None:
+    graph = Graph.empty()
+
+    graph.create_node("beat::a", {"type": "beat", "summary": "A"})
+    graph.create_node("beat::b", {"type": "beat", "summary": "B"})
+
+    graph.create_node(
+        "arc::spine",
+        {
+            "type": "arc",
+            "arc_type": "spine",
+            "paths": ["path::p1"],
+            "sequence": ["beat::b", "beat::a"],
+        },
+    )
+
+    artifact = extract_grow_artifact(graph)
+    assert len(artifact["arcs"]) == 1
+    assert artifact["arcs"][0]["sequence"] == ["beat::b", "beat::a"]
+
+
+def test_extract_grow_artifact_includes_choice_requires_and_grants() -> None:
+    graph = Graph.empty()
+    graph.create_node("passage::p1", {"type": "passage", "summary": "One"})
+    graph.create_node("passage::p2", {"type": "passage", "summary": "Two"})
+    graph.create_node(
+        "choice::p1__p2",
+        {
+            "type": "choice",
+            "from_passage": "passage::p1",
+            "to_passage": "passage::p2",
+            "label": "Go",
+            "requires": ["codeword::cw1"],
+            "grants": ["codeword::cw2"],
+        },
+    )
+
+    artifact = extract_grow_artifact(graph)
+    assert len(artifact["choices"]) == 1
+    choice = artifact["choices"][0]
+    assert choice["from_passage"] == "passage::p1"
+    assert choice["to_passage"] == "passage::p2"
+    assert choice["requires"] == ["codeword::cw1"]
+    assert choice["grants"] == ["codeword::cw2"]


### PR DESCRIPTION
## Problem
A1111 prompt distillation can trigger pathological Ollama generations (e.g. `projects/test-20260204T0732` had a ~20m `/api/chat` call producing ~48k output tokens), destabilizing the server.

## Changes
- Bind conservative generation limits for distillation calls (Ollama `num_predict`, `stop`, plus low temperature when supported).
- Add bounded retry with backoff and clear error wrapping.
- Ensure distiller LLM calls carry runnable metadata so `llm_calls.jsonl` records `stage="dress"` (fixes tracking for #624).
- Add/adjust unit tests for binding + metadata.

## Not Included / Future PRs
- Provider factory defaults for `num_predict`/`stop` globally (kept scoped to distillation only).

## Test Plan
- `uv run ruff check src/questfoundry/providers/image_a1111.py tests/unit/test_image_a1111.py`
- `uv run mypy src/questfoundry/providers/image_a1111.py`
- `uv run pytest tests/unit/test_image_a1111.py -x -q`

## Risk / Rollback
- Risk: Distillation output may be shorter due to caps; mitigated by local truncation + retry.
- Rollback: Revert this PR to restore previous behavior.

Closes #625
Refs #624