### PR TITLE
fix(grow): start prune BFS from synthetic prologue when it exists

### DIFF
--- a/src/questfoundry/pipeline/stages/grow.py
+++ b/src/questfoundry/pipeline/stages/grow.py
@@ -117,6 +117,7 @@ class GrowStage:
         self._lang_instruction: str = ""
 
     CHECKPOINT_DIR = "snapshots"
+    PROLOGUE_ID = "passage::prologue"
 
     # Type for async phase functions: (Graph, BaseChatModel) -> GrowPhaseResult
     PhaseFunc = Callable[["Graph", "BaseChatModel"], Awaitable[GrowPhaseResult]]
@@ -2231,7 +2232,7 @@ class GrowStage:
                 orphan_count=len(orphan_starts),
                 orphans=orphan_starts[:5],
             )
-            prologue_id = "passage::prologue"
+            prologue_id = self.PROLOGUE_ID
             graph.create_node(
                 prologue_id,
                 {
@@ -2954,10 +2955,9 @@ class GrowStage:
         starts from there. Otherwise, falls back to the first spine passage.
         """
         # If synthetic prologue exists, it is the real start
-        prologue_id = "passage::prologue"
-        if prologue_id in passage_nodes:
-            start_passage = prologue_id
-            log.debug("prune_start_from_prologue", start=prologue_id)
+        if self.PROLOGUE_ID in passage_nodes:
+            start_passage = self.PROLOGUE_ID
+            log.debug("prune_start_from_prologue", start=self.PROLOGUE_ID)
         else:
             # Find spine arc's first passage
             arc_nodes = graph.get_nodes_by_type("arc")

--- a/src/questfoundry/pipeline/stages/grow.py
+++ b/src/questfoundry/pipeline/stages/grow.py
@@ -2948,22 +2948,32 @@ class GrowStage:
     def _reachable_via_choices(
         self, graph: Graph, passage_nodes: dict[str, dict[str, Any]]
     ) -> set[str]:
-        """BFS from first spine passage via choice_to edges."""
-        # Find spine arc's first passage
-        arc_nodes = graph.get_nodes_by_type("arc")
-        start_passage: str | None = None
+        """BFS from story start via choice_to edges.
 
-        for _arc_id, arc_data in arc_nodes.items():
-            if arc_data.get("arc_type") == "spine":
-                sequence = arc_data.get("sequence", [])
-                if sequence:
-                    # First beat → its passage
-                    first_beat = sequence[0]
-                    for p_id, p_data in passage_nodes.items():
-                        if p_data.get("from_beat") == first_beat:
-                            start_passage = p_id
-                            break
-                break
+        If a synthetic prologue exists, it is the real story start and BFS
+        starts from there. Otherwise, falls back to the first spine passage.
+        """
+        # If synthetic prologue exists, it is the real start
+        prologue_id = "passage::prologue"
+        if prologue_id in passage_nodes:
+            start_passage = prologue_id
+            log.debug("prune_start_from_prologue", start=prologue_id)
+        else:
+            # Find spine arc's first passage
+            arc_nodes = graph.get_nodes_by_type("arc")
+            start_passage = None
+
+            for _arc_id, arc_data in arc_nodes.items():
+                if arc_data.get("arc_type") == "spine":
+                    sequence = arc_data.get("sequence", [])
+                    if sequence:
+                        # First beat → its passage
+                        first_beat = sequence[0]
+                        for p_id, p_data in passage_nodes.items():
+                            if p_data.get("from_beat") == first_beat:
+                                start_passage = p_id
+                                break
+                    break
 
         if not start_passage:
             log.warning("phase9_no_spine_arc", detail="Cannot BFS without spine; all passages kept")

--- a/tests/unit/test_grow_algorithms.py
+++ b/tests/unit/test_grow_algorithms.py
@@ -1344,6 +1344,9 @@ class TestPhase11Integration:
                 "grants": [],
             },
         )
+        graph.add_edge("choice_from", "choice::prologue_to_spine", "passage::prologue")
+        graph.add_edge("choice_to", "choice::prologue_to_spine", "passage::spine_1")
+
         graph.create_node(
             "choice::prologue_to_branch",
             {
@@ -1355,6 +1358,8 @@ class TestPhase11Integration:
                 "grants": [],
             },
         )
+        graph.add_edge("choice_from", "choice::prologue_to_branch", "passage::prologue")
+        graph.add_edge("choice_to", "choice::prologue_to_branch", "passage::branch_1")
 
         # Create choice: spine_1 → spine_2
         graph.create_node(
@@ -1368,6 +1373,8 @@ class TestPhase11Integration:
                 "grants": [],
             },
         )
+        graph.add_edge("choice_from", "choice::spine_continue", "passage::spine_1")
+        graph.add_edge("choice_to", "choice::spine_continue", "passage::spine_2")
 
         stage = GrowStage()
         mock_model = MagicMock()

--- a/tests/unit/test_grow_algorithms.py
+++ b/tests/unit/test_grow_algorithms.py
@@ -1251,6 +1251,140 @@ class TestPhase11Integration:
         assert "passage::a" in passage_nodes
         assert "passage::b" in passage_nodes
 
+    @pytest.mark.asyncio
+    async def test_prune_starts_from_prologue_when_exists(self) -> None:
+        """Prune uses prologue as BFS start when it exists (issue #627).
+
+        When Phase 9 creates a synthetic prologue to unify multiple orphan
+        starts, Phase 11 prune must start BFS from the prologue, not from the
+        first spine passage. Otherwise, the prologue and sibling branch paths
+        can be incorrectly pruned.
+        """
+        from questfoundry.pipeline.stages.grow import GrowStage
+
+        graph = Graph.empty()
+
+        # Create spine arc with 2 beats
+        graph.create_node(
+            "arc::spine",
+            {
+                "type": "arc",
+                "raw_id": "spine",
+                "arc_type": "spine",
+                "paths": ["path_a"],
+                "sequence": ["beat::spine_1", "beat::spine_2"],
+            },
+        )
+        graph.create_node("beat::spine_1", {"type": "beat", "raw_id": "spine_1"})
+        graph.create_node("beat::spine_2", {"type": "beat", "raw_id": "spine_2"})
+
+        # Create a sibling branch arc (different starting point)
+        graph.create_node(
+            "arc::branch",
+            {
+                "type": "arc",
+                "raw_id": "branch",
+                "arc_type": "branch",
+                "paths": ["path_b"],
+                "sequence": ["beat::branch_1"],
+            },
+        )
+        graph.create_node("beat::branch_1", {"type": "beat", "raw_id": "branch_1"})
+
+        # Create passages for beats
+        graph.create_node(
+            "passage::spine_1",
+            {
+                "type": "passage",
+                "raw_id": "spine_1",
+                "from_beat": "beat::spine_1",
+                "summary": "Spine start",
+            },
+        )
+        graph.create_node(
+            "passage::spine_2",
+            {
+                "type": "passage",
+                "raw_id": "spine_2",
+                "from_beat": "beat::spine_2",
+                "summary": "Spine end",
+            },
+        )
+        graph.create_node(
+            "passage::branch_1",
+            {
+                "type": "passage",
+                "raw_id": "branch_1",
+                "from_beat": "beat::branch_1",
+                "summary": "Branch start",
+            },
+        )
+
+        # Create synthetic prologue (as Phase 9 would when there are multiple orphan starts)
+        graph.create_node(
+            "passage::prologue",
+            {
+                "type": "passage",
+                "raw_id": "prologue",
+                "from_beat": None,
+                "summary": "The story begins...",
+                "is_synthetic": True,
+            },
+        )
+
+        # Create choices: prologue → both starting passages
+        graph.create_node(
+            "choice::prologue_to_spine",
+            {
+                "type": "choice",
+                "from_passage": "passage::prologue",
+                "to_passage": "passage::spine_1",
+                "label": "Take the spine path",
+                "requires": [],
+                "grants": [],
+            },
+        )
+        graph.create_node(
+            "choice::prologue_to_branch",
+            {
+                "type": "choice",
+                "from_passage": "passage::prologue",
+                "to_passage": "passage::branch_1",
+                "label": "Take the branch path",
+                "requires": [],
+                "grants": [],
+            },
+        )
+
+        # Create choice: spine_1 → spine_2
+        graph.create_node(
+            "choice::spine_continue",
+            {
+                "type": "choice",
+                "from_passage": "passage::spine_1",
+                "to_passage": "passage::spine_2",
+                "label": "Continue",
+                "requires": [],
+                "grants": [],
+            },
+        )
+
+        stage = GrowStage()
+        mock_model = MagicMock()
+        result = await stage._phase_11_prune(graph, mock_model)
+
+        assert result.status == "completed"
+        assert "All passages reachable" in result.detail
+
+        # All passages should be preserved including prologue and branch
+        passage_nodes = graph.get_nodes_by_type("passage")
+        assert "passage::prologue" in passage_nodes, "Prologue should NOT be pruned"
+        assert "passage::spine_1" in passage_nodes
+        assert "passage::spine_2" in passage_nodes
+        assert "passage::branch_1" in passage_nodes, (
+            "Branch should NOT be pruned (reachable via prologue)"
+        )
+
 
 # ---------------------------------------------------------------------------
 # Phase 3: Intersection Algorithms


### PR DESCRIPTION
## Problem
When GROW Phase 9 creates a synthetic `passage::prologue` (because there are multiple orphan starts), Phase 11 prune still computes reachability starting from the first spine passage. This incorrectly prunes the prologue itself and any paths only reachable via the prologue.

Closes #627

## Changes
- Modified `_reachable_via_choices` in `grow.py` to check for `passage::prologue` first
- If prologue exists, use it as BFS start (it's the real story start)
- Otherwise, fall back to existing spine passage logic
- Added test `test_prune_starts_from_prologue_when_exists` covering the scenario

## Not Included / Future PRs
- None

## Test Plan
```bash
uv run pytest tests/unit/test_grow_algorithms.py::TestPhase11Integration -xvs
# 6 passed
```

All existing Phase 11 tests still pass, plus the new test verifies the fix.

## Risk / Rollback
- Low risk: only changes BFS start selection logic
- Backward compatible: existing behavior unchanged when no prologue exists
- Rollback: revert this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)