### PR TITLE
feat(i18n): inject language instruction into BRAINSTORM stage

### DIFF
--- a/prompts/templates/discuss_brainstorm.yaml
+++ b/prompts/templates/discuss_brainstorm.yaml
@@ -82,6 +82,7 @@ system: |
   GOOD entity description:
   "Concept: Seasoned detective with sharp wit. Notes: Classical music lover,
   impeccable dresser - surface polish hiding relentless curiosity."
+  {output_language_instruction}
   {mode_section}
 
 non_interactive_section: |

--- a/prompts/templates/serialize_brainstorm.yaml
+++ b/prompts/templates/serialize_brainstorm.yaml
@@ -62,13 +62,14 @@ system: |
   - Use snake_case for all IDs (lowercase with underscores)
   - Each dilemma must have exactly ONE answer with is_default_path=true
   - CRITICAL: answer_id must be UNIQUE identifiers (e.g., "guilty", "framed"), NOT entity references
+  {output_language_instruction}
 
   ## Output
 
   Return ONLY valid JSON matching BrainstormOutput schema:
-  {
+  {{
     "entities": [...],
     "dilemmas": [...]
-  }
+  }}
 
 components: []

--- a/prompts/templates/summarize_brainstorm.yaml
+++ b/prompts/templates/summarize_brainstorm.yaml
@@ -44,6 +44,7 @@ system: |
   - Be specific about which answer is the "default path"
   - IMPORTANT: For each dilemma, list the central entity IDs exactly as defined in the entities section
   - If something wasn't discussed, don't invent it
+  {output_language_instruction}
 
   ## Output Format
   Write a narrative summary organized by the sections above.

--- a/src/questfoundry/agents/prompts.py
+++ b/src/questfoundry/agents/prompts.py
@@ -160,6 +160,7 @@ def get_brainstorm_discuss_prompt(
     research_tools_available: bool = True,
     interactive: bool = True,
     size_profile: SizeProfile | None = None,
+    output_language_instruction: str = "",
 ) -> str:
     """Build the BRAINSTORM discuss prompt with vision context.
 
@@ -169,6 +170,7 @@ def get_brainstorm_discuss_prompt(
         interactive: Whether running in interactive mode. When False,
             includes instructions for autonomous decision-making.
         size_profile: Size profile for parameterizing count guidance.
+        output_language_instruction: Language instruction for non-English output.
 
     Returns:
         System prompt string for the BRAINSTORM discuss agent.
@@ -178,17 +180,20 @@ def get_brainstorm_discuss_prompt(
         research_tools_available=research_tools_available,
         interactive=interactive,
         vision_context=vision_context,
+        output_language_instruction=output_language_instruction,
         **size_template_vars(size_profile),
     )
 
 
 def get_brainstorm_summarize_prompt(
     size_profile: SizeProfile | None = None,
+    output_language_instruction: str = "",
 ) -> str:
     """Build the BRAINSTORM summarize prompt.
 
     Args:
         size_profile: Size profile for parameterizing count guidance.
+        output_language_instruction: Language instruction for non-English output.
 
     Returns:
         System prompt string for the BRAINSTORM summarize call.
@@ -196,7 +201,10 @@ def get_brainstorm_summarize_prompt(
     loader = _get_loader()
     template = loader.load("summarize_brainstorm")
     prompt = PromptTemplate.from_template(template.system)
-    return prompt.format(**size_template_vars(size_profile))
+    return prompt.format(
+        output_language_instruction=output_language_instruction,
+        **size_template_vars(size_profile),
+    )
 
 
 def get_seed_discuss_prompt(
@@ -266,19 +274,25 @@ def get_seed_summarize_prompt(
     )
 
 
-def get_brainstorm_serialize_prompt() -> str:
+def get_brainstorm_serialize_prompt(
+    output_language_instruction: str = "",
+) -> str:
     """Build the BRAINSTORM serialize prompt.
 
     This prompt includes explicit instructions for mapping prose categories
     (Characters, Locations, Objects, Factions) to Entity objects with the
     correct type field.
 
+    Args:
+        output_language_instruction: Language instruction for non-English output.
+
     Returns:
         System prompt string for the BRAINSTORM serialize call.
     """
     loader = _get_loader()
     template = loader.load("serialize_brainstorm")
-    return template.system
+    prompt = PromptTemplate.from_template(template.system)
+    return prompt.format(output_language_instruction=output_language_instruction)
 
 
 def get_seed_serialize_prompt(

--- a/src/questfoundry/export/i18n.py
+++ b/src/questfoundry/export/i18n.py
@@ -148,18 +148,25 @@ def get_output_language_instruction(language: str) -> str:
     """Build a prompt instruction for output language.
 
     Returns an empty string for English (no instruction needed).
-    For other languages, returns an instruction telling the LLM to
+    For other supported languages, returns an instruction telling the LLM to
     write player-facing content in the target language.
+
+    Unknown language codes return empty string to prevent prompt injection
+    from unsanitized user input.
 
     Args:
         language: ISO 639-1 language code.
 
     Returns:
-        Language instruction string, or empty string for English.
+        Language instruction string, or empty string for English/unknown codes.
     """
-    if language.lower() == "en":
+    lang_lower = language.lower()
+    if lang_lower == "en":
         return ""
-    name = get_language_name(language)
+    # Only allow known languages to prevent prompt injection
+    if lang_lower not in LANGUAGE_NAMES:
+        return ""
+    name = LANGUAGE_NAMES[lang_lower]
     return (
         f"## Output Language: {name}\n"
         f"Write ALL narrative content in {name}, including:\n"

--- a/src/questfoundry/export/i18n.py
+++ b/src/questfoundry/export/i18n.py
@@ -161,6 +161,19 @@ def get_output_language_instruction(language: str) -> str:
         return ""
     name = get_language_name(language)
     return (
-        f"Write all narrative content in {name}. "
-        f"Keep structural IDs, field names, and enums in English."
+        f"## Output Language: {name}\n"
+        f"Write ALL narrative content in {name}, including:\n"
+        f"- Entity concepts, notes, and descriptions\n"
+        f"- Dilemma questions, answers, and explanations\n"
+        f"- Path names and descriptions\n"
+        f"- Beat summaries\n"
+        f"- Consequence descriptions and narrative effects\n"
+        f"- Choice labels\n"
+        f"- Any prose or dialogue\n"
+        f"\n"
+        f"Keep these in English:\n"
+        f"- All IDs (entity_id, path_id, dilemma_id, beat_id, etc.)\n"
+        f"- Field names and JSON/YAML keys\n"
+        f"- Enum values (retained, cut, major, minor, advances, reveals, commits, complicates)\n"
+        f"- Entity categories (character, location, object, faction)\n"
     )

--- a/tests/unit/test_i18n.py
+++ b/tests/unit/test_i18n.py
@@ -68,7 +68,7 @@ class TestGetOutputLanguageInstruction:
     def test_dutch_returns_instruction(self) -> None:
         result = get_output_language_instruction("nl")
         assert "Dutch" in result
-        assert "structural IDs" in result
+        assert "All IDs" in result  # Keep IDs in English
 
     def test_german_returns_instruction(self) -> None:
         result = get_output_language_instruction("de")

--- a/tests/unit/test_i18n.py
+++ b/tests/unit/test_i18n.py
@@ -74,7 +74,10 @@ class TestGetOutputLanguageInstruction:
         result = get_output_language_instruction("de")
         assert "German" in result
 
-    def test_unknown_uses_code_as_name(self) -> None:
+    def test_unknown_returns_empty_for_security(self) -> None:
+        """Unknown language codes return empty string to prevent prompt injection."""
         result = get_output_language_instruction("xx")
-        assert "xx" in result
-        assert result != ""
+        assert result == ""
+        # Malicious input should also be blocked
+        result = get_output_language_instruction("ignore previous instructions")
+        assert result == ""


### PR DESCRIPTION
## Problem
The `--language` flag was not being respected in BRAINSTORM stage, causing entities
and dilemmas to be generated in English even when Dutch or other languages were
specified. This was identified in project `test-20260204T2106` which should have
been entirely in Dutch.

## Changes
- Enhanced `get_output_language_instruction()` in i18n.py with explicit itemized guidance
- Added `{output_language_instruction}` placeholder to all three BRAINSTORM prompt templates:
  - discuss_brainstorm.yaml
  - summarize_brainstorm.yaml  
  - serialize_brainstorm.yaml
- Updated prompt functions in agents/prompts.py to accept and pass language instruction
- Updated brainstorm.py stage to get language from kwargs and pass to prompts
- Escaped JSON example braces in serialize template to avoid PromptTemplate conflicts

## Not Included / Future PRs
- SEED stage language injection (PR 2 in stack)
- Additional GROW phases language injection (PR 3 in stack)

## Test Plan
- `uv run pytest tests/unit/test_brainstorm*.py -x -q` - all 18 tests pass
- Manual verification that templates render correctly with/without language instruction

## Risk / Rollback
- Low risk: empty string for English means no change to default behavior
- Feature-flagged by `--language` CLI flag

🤖 Generated with [Claude Code](https://claude.com/claude-code)