### PR TITLE
feat(i18n): inject language instruction into SEED stage

### DIFF
--- a/prompts/templates/discuss_seed.yaml
+++ b/prompts/templates/discuss_seed.yaml
@@ -159,6 +159,7 @@ system: |
   - Do NOT invent locations not in BRAINSTORM
   - Do NOT use objects as locations (objects are NOT places)
   - Do NOT ask clarifying questions in non-interactive mode
+  {output_language_instruction}
   {research_tools_section}
   {mode_section}
 

--- a/prompts/templates/serialize_seed.yaml
+++ b/prompts/templates/serialize_seed.yaml
@@ -118,7 +118,6 @@ system: |
   - path_importance must be exactly "major" or "minor" (lowercase)
   - effect must be exactly "advances", "reveals", "commits", or "complicates"
   - disposition must be exactly "retained" or "cut"
-  {output_language_instruction}
 
   ## Output
 

--- a/prompts/templates/serialize_seed.yaml
+++ b/prompts/templates/serialize_seed.yaml
@@ -118,6 +118,7 @@ system: |
   - path_importance must be exactly "major" or "minor" (lowercase)
   - effect must be exactly "advances", "reveals", "commits", or "complicates"
   - disposition must be exactly "retained" or "cut"
+  {output_language_instruction}
 
   ## Output
 

--- a/prompts/templates/summarize_seed.yaml
+++ b/prompts/templates/summarize_seed.yaml
@@ -101,6 +101,7 @@ system: |
 
   If your story needs a scene in a character's personal space, use a retained
   location and put details in the beat summary.
+  {output_language_instruction}
 
   ## Output Format
 

--- a/src/questfoundry/agents/prompts.py
+++ b/src/questfoundry/agents/prompts.py
@@ -212,6 +212,7 @@ def get_seed_discuss_prompt(
     research_tools_available: bool = True,
     interactive: bool = True,
     size_profile: SizeProfile | None = None,
+    output_language_instruction: str = "",
 ) -> str:
     """Build the SEED discuss prompt with brainstorm context.
 
@@ -221,6 +222,7 @@ def get_seed_discuss_prompt(
         interactive: Whether running in interactive mode. When False,
             includes instructions for autonomous decision-making.
         size_profile: Size profile for parameterizing count guidance.
+        output_language_instruction: Language instruction for non-English output.
 
     Returns:
         System prompt string for the SEED discuss agent.
@@ -230,6 +232,7 @@ def get_seed_discuss_prompt(
         research_tools_available=research_tools_available,
         interactive=interactive,
         brainstorm_context=brainstorm_context,
+        output_language_instruction=output_language_instruction,
         **size_template_vars(size_profile),
     )
 
@@ -241,6 +244,7 @@ def get_seed_summarize_prompt(
     entity_manifest: str = "",
     dilemma_manifest: str = "",
     size_profile: SizeProfile | None = None,
+    output_language_instruction: str = "",
 ) -> str:
     """Build the SEED summarize prompt with manifest awareness.
 
@@ -255,6 +259,7 @@ def get_seed_summarize_prompt(
         entity_manifest: Formatted list of entity IDs for manifest.
         dilemma_manifest: Formatted list of dilemma IDs for manifest.
         size_profile: Size profile for parameterizing count guidance.
+        output_language_instruction: Language instruction for non-English output.
 
     Returns:
         System prompt string for the SEED summarize call.
@@ -270,6 +275,7 @@ def get_seed_summarize_prompt(
         dilemma_count=dilemma_count,
         entity_manifest=entity_manifest or "(No entities)",
         dilemma_manifest=dilemma_manifest or "(No dilemmas)",
+        output_language_instruction=output_language_instruction,
         **size_template_vars(size_profile),
     )
 

--- a/src/questfoundry/pipeline/stages/seed.py
+++ b/src/questfoundry/pipeline/stages/seed.py
@@ -27,6 +27,7 @@ from questfoundry.agents import (
     serialize_seed_as_function,
     summarize_discussion,
 )
+from questfoundry.export.i18n import get_output_language_instruction
 from questfoundry.graph import Graph
 from questfoundry.graph.context import (
     format_summarize_manifest,
@@ -302,6 +303,9 @@ class SeedStage:
         brainstorm_context = self._get_brainstorm_context(resolved_path)
         log.debug("seed_brainstorm_loaded", context_length=len(brainstorm_context))
 
+        # Get language instruction (empty string for English)
+        lang_instruction = get_output_language_instruction(kwargs.get("language", "en"))
+
         # Get research tools (and interactive tools when in interactive mode)
         tools = get_all_research_tools()
         if interactive:
@@ -314,6 +318,7 @@ class SeedStage:
             research_tools_available=bool(tools),
             interactive=interactive,
             size_profile=size_profile,
+            output_language_instruction=lang_instruction,
         )
 
         # Phase 1: Discuss
@@ -357,6 +362,7 @@ class SeedStage:
             entity_manifest=manifests["entity_manifest"],
             dilemma_manifest=manifests["dilemma_manifest"],
             size_profile=size_profile,
+            output_language_instruction=lang_instruction,
         )
 
         # Outer loop: conversation-level retry for semantic errors


### PR DESCRIPTION
## Problem
The `--language` flag was not being respected in SEED stage, causing path names,
descriptions, beat summaries, and consequences to be generated in English even
when Dutch or other languages were specified.

## Changes
- Added `{output_language_instruction}` placeholder to SEED prompt templates:
  - discuss_seed.yaml
  - summarize_seed.yaml
  - serialize_seed.yaml
- Updated `get_seed_discuss_prompt()` and `get_seed_summarize_prompt()` in agents/prompts.py
- Updated seed.py stage to get language from kwargs and pass to prompts

## Not Included / Future PRs
- serialize_seed_sections.yaml prompts are not updated (heavily structural, narrative
  content comes from summarize brief which is now in target language)
- Additional GROW phases that may need language injection (PR 3)

## Test Plan
- `uv run pytest tests/unit/test_seed*.py -x -q` - all 35 tests pass
- Manual verification that prompts include language instruction when passed

## Risk / Rollback
- Low risk: empty string for English means no change to default behavior
- Feature-flagged by `--language` CLI flag

## Stack
This PR depends on: #629 (feat/i18n-brainstorm)

🤖 Generated with [Claude Code](https://claude.com/claude-code)