### PR TITLE
feat(pov): establish POV architecture from DREAM through FILL

### DIFF
--- a/prompts/templates/dream.yaml
+++ b/prompts/templates/dream.yaml
@@ -15,6 +15,24 @@ system: |
   - Style guidance for writing
   - Scope constraints (word count, passages, branching complexity)
   - Content notes (what to include/exclude)
+  - POV preference (optional hint for prose generation)
+  - Whether a defined protagonist exists
+
+  ## Narrative Perspective (Optional)
+
+  You may specify a preferred point of view style:
+  - **first**: Intimate, subjective ("I opened the door")
+  - **second**: Immersive, direct address ("You open the door")
+  - **third_limited**: Close but separate ("Kay opened the door")
+  - **third_omniscient**: All-knowing narrator
+
+  Genre conventions:
+  - Fantasy often uses third_limited past
+  - Horror can use second present for immediacy
+  - Mystery often uses first past
+
+  If you have a clear preference, specify `pov_style`. If unsure, leave it null for FILL to decide.
+  Also indicate `protagonist_defined: true` if the story has a clear main character.
 
   Be specific and evocative. The DREAM artifact guides all subsequent stages.
 

--- a/prompts/templates/fill_phase0_voice.yaml
+++ b/prompts/templates/fill_phase0_voice.yaml
@@ -18,6 +18,9 @@ system: |
   ## Research Notes
   {research_notes}
 
+  ## POV Hints (from DREAM/BRAINSTORM)
+  {pov_context}
+
   ## Voice Document Fields
 
   Create a voice document with these fields:

--- a/prompts/templates/serialize_brainstorm.yaml
+++ b/prompts/templates/serialize_brainstorm.yaml
@@ -20,6 +20,7 @@ system: |
   - `entity_category`: One of "character", "location", "object", "faction"
   - `concept`: One-line essence from the brief
   - `notes`: Optional additional context from the brief
+  - `is_protagonist`: true for ONE character if story has defined protagonist (default: false)
 
   ## Dilemma Structure
 

--- a/src/questfoundry/graph/mutations.py
+++ b/src/questfoundry/graph/mutations.py
@@ -1087,6 +1087,23 @@ def validate_seed_mutations(graph: Graph, output: dict[str, Any]) -> list[SeedVa
                         category=SeedErrorCategory.SEMANTIC,
                     )
                 )
+            else:
+                # Validate pov_character is a character entity (not location/object/faction)
+                pov_entity_type = entity_types.get(normalized_pov, "")
+                if pov_entity_type != "character":
+                    # Get list of character entities for helpful error message
+                    character_ids = sorted(
+                        eid for eid, etype in entity_types.items() if etype == "character"
+                    )
+                    errors.append(
+                        SeedValidationError(
+                            field_path=f"paths.{i}.pov_character",
+                            issue=f"POV character must be a character entity, not '{pov_entity_type}'",
+                            available=character_ids,
+                            provided=pov_char,
+                            category=SeedErrorCategory.SEMANTIC,
+                        )
+                    )
 
     # 5-8. Validate beats (single pass over initial_beats)
     # Build cut-entity set for disposition checks

--- a/src/questfoundry/graph/mutations.py
+++ b/src/questfoundry/graph/mutations.py
@@ -555,6 +555,9 @@ def apply_dream_mutations(graph: Graph, output: dict[str, Any]) -> None:
         "style_notes": output.get("style_notes"),
         "scope": output.get("scope"),
         "content_notes": output.get("content_notes"),
+        # POV hints (optional, may be None)
+        "pov_style": output.get("pov_style"),
+        "protagonist_defined": output.get("protagonist_defined", False),
     }
 
     # Remove None values for cleaner storage
@@ -649,6 +652,36 @@ def validate_brainstorm_mutations(output: dict[str, Any]) -> list[BrainstormVali
                     provided=f"found {default_count} defaults",
                 )
             )
+
+    # 4. Validate is_protagonist constraints
+    protagonist_count = 0
+    protagonist_indices: list[int] = []
+    for i, entity in enumerate(entities):
+        if entity.get("is_protagonist"):
+            protagonist_count += 1
+            protagonist_indices.append(i)
+            # is_protagonist only valid for character entities
+            entity_category = entity.get("entity_category", "")
+            if entity_category != "character":
+                errors.append(
+                    BrainstormValidationError(
+                        field_path=f"entities.{i}.is_protagonist",
+                        issue=f"is_protagonist=true only valid for character entities, not '{entity_category}'",
+                        available=["character"],
+                        provided=entity_category,
+                    )
+                )
+
+    # At most one protagonist allowed
+    if protagonist_count > 1:
+        errors.append(
+            BrainstormValidationError(
+                field_path="entities",
+                issue=f"Multiple protagonists defined ({protagonist_count} at indices {protagonist_indices}). Only one character can be the protagonist.",
+                available=[],
+                provided=str(protagonist_count),
+            )
+        )
 
     return errors
 
@@ -1029,6 +1062,31 @@ def validate_seed_mutations(graph: Graph, output: dict[str, Any]) -> list[SeedVa
                             category=SeedErrorCategory.SEMANTIC,
                         )
                     )
+
+        # 4b. Validate pov_character references a valid retained entity
+        pov_char = path.get("pov_character")
+        if pov_char:
+            normalized_pov, scope_error = _normalize_id(pov_char, "entity")
+            if scope_error:
+                errors.append(
+                    SeedValidationError(
+                        field_path=f"paths.{i}.pov_character",
+                        issue=scope_error,
+                        available=sorted_entity_ids,
+                        provided=pov_char,
+                        category=SeedErrorCategory.INNER,
+                    )
+                )
+            elif normalized_pov not in valid_entity_ids:
+                errors.append(
+                    SeedValidationError(
+                        field_path=f"paths.{i}.pov_character",
+                        issue=f"POV character '{normalized_pov}' not found in entities",
+                        available=sorted_entity_ids,
+                        provided=pov_char,
+                        category=SeedErrorCategory.SEMANTIC,
+                    )
+                )
 
     # 5-8. Validate beats (single pass over initial_beats)
     # Build cut-entity set for disposition checks

--- a/src/questfoundry/models/brainstorm.py
+++ b/src/questfoundry/models/brainstorm.py
@@ -42,6 +42,10 @@ class Entity(BaseModel):
     )
     concept: str = Field(min_length=1, description="One-line essence of the entity")
     notes: str | None = Field(default=None, description="Freeform notes from discussion")
+    is_protagonist: bool = Field(
+        default=False,
+        description="True if this character is the primary POV character (only valid for characters)",
+    )
 
 
 class Answer(BaseModel):

--- a/src/questfoundry/models/dream.py
+++ b/src/questfoundry/models/dream.py
@@ -59,3 +59,12 @@ class DreamArtifact(BaseModel):
     )
     type: Literal["dream"] = "dream"
     version: int = Field(default=1, description="Schema version number", ge=1)
+    # POV hints for downstream stages (optional)
+    pov_style: Literal["first", "second", "third_limited", "third_omniscient"] | None = Field(
+        default=None,
+        description="Preferred narrative POV (hint for FILL, not mandate)",
+    )
+    protagonist_defined: bool = Field(
+        default=False,
+        description="True if the story has a defined protagonist character",
+    )

--- a/src/questfoundry/models/seed.py
+++ b/src/questfoundry/models/seed.py
@@ -157,6 +157,10 @@ class Path(BaseModel):
         default_factory=list,
         description="Consequence IDs for this path (references consequence_id)",
     )
+    pov_character: str | None = Field(
+        default=None,
+        description="Entity ID of the POV character for this path (overrides global protagonist)",
+    )
 
 
 class DilemmaImpact(BaseModel):

--- a/src/questfoundry/pipeline/stages/fill.py
+++ b/src/questfoundry/pipeline/stages/fill.py
@@ -45,6 +45,7 @@ from questfoundry.graph.fill_context import (
     format_narrative_context,
     format_passages_batch,
     format_path_arc_context,
+    format_pov_context,
     format_scene_types_summary,
     format_shadow_states,
     format_sliding_window,
@@ -782,6 +783,7 @@ class FillStage:
             "grow_summary": format_grow_summary(graph),
             "scene_types_summary": format_scene_types_summary(graph),
             "research_notes": research_notes or "No research notes available.",
+            "pov_context": format_pov_context(graph),
             "output_language_instruction": self._lang_instruction,
             **size_template_vars(self._size_profile),
         }


### PR DESCRIPTION
## Problem
Currently POV (Point of View) is only defined in FILL Phase 0's VoiceDocument. This means earlier stages (DREAM, BRAINSTORM, SEED) have no way to express or validate POV intent, leading to potential inconsistencies.

## Changes
- **DREAM**: Add optional `pov_style` hint and `protagonist_defined` flag to DreamArtifact
- **BRAINSTORM**: Add `is_protagonist` field to Entity model with validation
  - Only one character can be protagonist
  - Only characters can have `is_protagonist=True`
- **SEED**: Add `pov_character` field to Path model for per-path POV override
  - Validates that referenced entity exists
- **FILL**: 
  - Add `format_pov_context()` to inject POV hints into Phase 0 voice determination
  - Add `get_path_pov_character()` for resolving POV character (path override -> global protagonist)
- **Prompt templates**: Updated dream.yaml, serialize_brainstorm.yaml, fill_phase0_voice.yaml

## Not Included / Future PRs
- Using POV character in prose generation context (FILL Phase 1+)
- Validating that pov_character is present in beat entities

## Test Plan
- Added unit tests for protagonist validation in brainstorm mutations
- Added unit tests for POV field handling in dream mutations  
- Added unit tests for pov_character validation in seed mutations
- Added unit tests for format_pov_context() and get_path_pov_character()
- All 2346 unit tests pass

## Risk / Rollback
- All new fields are optional with sensible defaults (None/False)
- Fully backwards compatible - existing projects work unchanged

Closes #633

🤖 Generated with [Claude Code](https://claude.com/claude-code)