### PR TITLE
feat(grow): enrich gap beats with entity/location inheritance

### DIFF
--- a/docs/design/00-spec.md
+++ b/docs/design/00-spec.md
@@ -513,6 +513,11 @@ beat:
   relationships: relationship_id[]
   location: entity_id | null              # primary location (assigned in SEED)
   location_alternatives: entity_id[]      # other valid locations (enables intersection flexibility)
+  # Gap beat fields (only present on beats created by GROW Phase 4b/4c)
+  is_gap_beat: boolean                    # true for beats inserted to fill narrative/pacing gaps
+  transition_style: smooth | cut          # guidance for FILL on how to handle the transition
+  bridges_from: beat_id | null            # beat this gap follows (traceability)
+  bridges_to: beat_id | null              # beat this gap precedes (traceability)
 ```
 
 **Lifecycle:** Initial beats created in SEED, mutated and new beats added in GROW. Not exported.
@@ -528,6 +533,13 @@ beat:
 | `micro_beat` | Transition, time passage, minor moment | Brief, 1 paragraph |
 
 Scene type is assigned during GROW (Phase 4: Gap Detection) to ensure pacing variety across arcs. GROW may propose additional beats to address pacing gaps (e.g., "three scenes in a row with no sequel").
+
+**Gap beats:** Beats created by GROW Phase 4b/4c to fill narrative or pacing gaps. Gap beats inherit `entities` and `location` from adjacent beats to maintain context. The `transition_style` field guides FILL:
+
+| Style | When Used | FILL Guidance |
+|-------|-----------|---------------|
+| `smooth` | Same location, shared entities, scene continuity | Flow naturally, echo imagery |
+| `cut` | Location change, scene type change, time jump | Establish new context quickly |
 
 **Beat types by path membership:**
 - **Single-path:** Serves one path's progression

--- a/src/questfoundry/graph/grow_algorithms.py
+++ b/src/questfoundry/graph/grow_algorithms.py
@@ -18,7 +18,7 @@ import contextlib
 from collections import defaultdict, deque
 from dataclasses import dataclass, field
 from itertools import product
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Literal
 
 from questfoundry.graph.context import normalize_scoped_id
 from questfoundry.graph.mutations import GrowErrorCategory, GrowValidationError
@@ -1512,9 +1512,13 @@ def insert_gap_beat(
     # Inherit entities (union of both adjacent beats, deduplicated)
     entities: list[str] = []
     if after_node:
-        entities.extend(after_node.get("entities") or [])
+        after_ents = after_node.get("entities")
+        if isinstance(after_ents, list):
+            entities.extend(after_ents)
     if before_node:
-        entities.extend(before_node.get("entities") or [])
+        before_ents = before_node.get("entities")
+        if isinstance(before_ents, list):
+            entities.extend(before_ents)
     entities = list(dict.fromkeys(entities))  # Deduplicate preserving order
 
     # Inherit location (prefer shared location, fallback to either)
@@ -1562,7 +1566,7 @@ def insert_gap_beat(
 def _infer_transition_style(
     from_beat: dict[str, object] | None,
     to_beat: dict[str, object] | None,
-) -> str:
+) -> Literal["smooth", "cut"]:
     """Infer whether a gap transition should be smooth or a hard cut.
 
     Heuristics:

--- a/src/questfoundry/graph/grow_algorithms.py
+++ b/src/questfoundry/graph/grow_algorithms.py
@@ -1478,6 +1478,10 @@ def insert_gap_beat(
     Creates a new beat node and adjusts requires edges to maintain ordering.
     The new beat is assigned to the specified path.
 
+    Gap beats inherit entities (union) and location from adjacent beats to
+    provide context for FILL stage transitions. A transition_style field
+    indicates whether the gap should be a smooth continuation or a hard cut.
+
     Args:
         graph: Graph to mutate.
         path_id: Path this beat belongs to (prefixed ID).
@@ -1501,7 +1505,27 @@ def insert_gap_beat(
     raw_id = f"gap_{max_gap_index + 1}"
     beat_id = f"beat::{raw_id}"
 
-    # Create the beat node
+    # Get adjacent beat nodes for inheritance
+    after_node = graph.get_node(after_beat) if after_beat else None
+    before_node = graph.get_node(before_beat) if before_beat else None
+
+    # Inherit entities (union of both adjacent beats, deduplicated)
+    entities: list[str] = []
+    if after_node:
+        entities.extend(after_node.get("entities") or [])
+    if before_node:
+        entities.extend(before_node.get("entities") or [])
+    entities = list(dict.fromkeys(entities))  # Deduplicate preserving order
+
+    # Inherit location (prefer shared location, fallback to either)
+    after_loc = after_node.get("location") if after_node else None
+    before_loc = before_node.get("location") if before_node else None
+    location = after_loc if after_loc == before_loc else (after_loc or before_loc)
+
+    # Infer transition style based on context
+    transition_style = _infer_transition_style(after_node, before_node)
+
+    # Create the beat node with enriched context
     graph.create_node(
         beat_id,
         {
@@ -1511,6 +1535,12 @@ def insert_gap_beat(
             "scene_type": scene_type,
             "paths": [path_id.removeprefix("path::")],
             "is_gap_beat": True,
+            # Enrichment fields for transition handling
+            "entities": entities,
+            "location": location,
+            "transition_style": transition_style,
+            "bridges_from": after_beat,
+            "bridges_to": before_beat,
         },
     )
 
@@ -1527,6 +1557,50 @@ def insert_gap_beat(
         graph.add_edge("requires", before_beat, beat_id)
 
     return beat_id
+
+
+def _infer_transition_style(
+    from_beat: dict[str, object] | None,
+    to_beat: dict[str, object] | None,
+) -> str:
+    """Infer whether a gap transition should be smooth or a hard cut.
+
+    Heuristics:
+    - Same location + shared entities → smooth
+    - Different locations → cut
+    - Different scene types → cut
+    - No shared entities but same location → smooth
+
+    Args:
+        from_beat: The beat before the gap (or None).
+        to_beat: The beat after the gap (or None).
+
+    Returns:
+        "smooth" or "cut" based on context analysis.
+    """
+    if not from_beat or not to_beat:
+        return "smooth"  # Default when context is missing
+
+    from_loc = from_beat.get("location")
+    to_loc = to_beat.get("location")
+
+    # Different locations usually warrant a cut
+    if from_loc and to_loc and from_loc != to_loc:
+        return "cut"
+
+    # Scene type changes often need cuts
+    if from_beat.get("scene_type") != to_beat.get("scene_type"):
+        return "cut"
+
+    # Same location with any shared entities → smooth
+    from_ent_raw = from_beat.get("entities")
+    to_ent_raw = to_beat.get("entities")
+    from_entities: set[str] = set(from_ent_raw) if isinstance(from_ent_raw, list) else set()
+    to_entities: set[str] = set(to_ent_raw) if isinstance(to_ent_raw, list) else set()
+    if from_loc == to_loc and from_entities & to_entities:
+        return "smooth"
+
+    return "smooth"  # Default to smooth for continuity
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem
Gap beats created during GROW Phase 4b/4c lack context for FILL transitions.
Currently they have no entities or location, causing:
- Hard transition warnings (`shared_entities: 0`)
- No context for FILL to write smooth transitions
- Gaps ARE the transition — they shouldn't trigger warnings

Ref #634

## Changes
- `insert_gap_beat()` now inherits entities (union) and location from adjacent beats
- Added `transition_style` field ("smooth" | "cut") based on context heuristics
- Added `bridges_from` / `bridges_to` for traceability
- Added `_infer_transition_style()` helper function
- Updated ontology docs with new gap beat fields
- Added 8 new unit tests covering all enrichment scenarios

## Not Included / Future PRs
- Suppress gap warnings in FILL (Phase 2 of #634 plan)
- Passage collapse algorithm (Phase 3-4)
- FILL integration for merged passages (Phase 5-6)

## Test Plan
```bash
uv run pytest tests/unit/test_grow_algorithms.py::TestInsertGapBeat -v
# 13 passed
```

## Risk / Rollback
- Backwards compatible: existing gap beats work unchanged
- New fields are additive
- No changes to FILL consumption yet (that's Phase 2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)