### PR TITLE
feat(fill): suppress hard transition warnings for gap beats

### DIFF
--- a/src/questfoundry/graph/fill_context.py
+++ b/src/questfoundry/graph/fill_context.py
@@ -319,6 +319,11 @@ def format_continuity_warning(
     if (cur_beat or {}).get("scene_type") == "micro_beat":
         return ""
 
+    # Gap beats ARE the transition — they have inherited context and shouldn't
+    # trigger hard transition warnings. Their transition_style already guides FILL.
+    if (cur_beat or {}).get("is_gap_beat"):
+        return ""
+
     prev_entities = _entities_for(prev_passage_id)
     cur_entities = _entities_for(cur_passage_id)
     ent_overlap = _jaccard(prev_entities, cur_entities)

--- a/tests/unit/test_fill_continuity_warning.py
+++ b/tests/unit/test_fill_continuity_warning.py
@@ -90,3 +90,11 @@ def test_continuity_warning_suppressed_for_synthetic_passage() -> None:
     graph, arc_id = _make_two_passages_graph(shared_entity=False)
     graph.update_node("passage::b", is_synthetic=True)
     assert format_continuity_warning(graph, arc_id, 1) == ""
+
+
+def test_continuity_warning_suppressed_for_gap_beat() -> None:
+    """Gap beats ARE the transition — they shouldn't trigger hard transition warnings."""
+    graph, arc_id = _make_two_passages_graph(shared_entity=False)
+    # Mark beat::b as a gap beat (created by GROW Phase 4b/4c)
+    graph.update_node("beat::b", is_gap_beat=True, transition_style="smooth")
+    assert format_continuity_warning(graph, arc_id, 1) == ""


### PR DESCRIPTION
## Problem
Gap beats from GROW already have transition style guidance (smooth/cut) and inherited context. The FILL phase's continuity warnings were incorrectly flagging these as "hard transitions" when they're intentional transitions.

## Changes
- Add early return in `_intersection_hint()` to skip gap beats
- Add test coverage for gap beat warning suppression

## Test Plan
- `uv run pytest tests/unit/test_fill_continuity_warning.py -v`

## Risk / Rollback
- Safe change - only suppresses warnings, doesn't change generation behavior
- Can be reverted without affecting any persisted data

---
Closes #644 (recreating due to base branch deletion)

🤖 Generated with [Claude Code](https://claude.com/claude-code)