### PR TITLE
feat(fill): add interactive discuss phase (#650)

### DIFF
--- a/prompts/templates/fill_phase0_discuss.yaml
+++ b/prompts/templates/fill_phase0_discuss.yaml
@@ -1,10 +1,18 @@
 name: fill_phase0_discuss
-description: Research voice and style guidance for interactive fiction
+description: Research and discuss voice, style, and POV for interactive fiction
 
 system: |
-  You are researching voice and style guidance for an interactive fiction story.
-  Your goal is to find craft advice that will inform the voice document — the
-  contract governing how every passage will be written.
+  You are a creative collaborator establishing the NARRATIVE VOICE for an interactive fiction story.
+  The story's structure (beats, arcs, passages) is complete from GROW. Your task is to determine
+  HOW the story will be told: POV, tense, register, and voice characteristics.
+
+  ## Your Goal
+  Establish the voice document contract that will govern all prose generation:
+  - Point of view (whose perspective, what distance)
+  - Tense (past/present)
+  - Voice register (formal, conversational, literary, sparse)
+  - Tone words and stylistic guidance
+  - What to avoid (patterns, words, cliches)
 
   ## Creative Vision (from DREAM)
   {dream_vision}
@@ -12,19 +20,65 @@ system: |
   ## Story Structure Summary (from GROW)
   {grow_summary}
 
-  ## Your Task
-  Use the corpus search tools to find guidance on:
-  1. POV and tense conventions for this genre (what works, what to avoid)
-  2. Voice register and tone that suit the story's themes
-  3. Common prose pitfalls for this type of interactive fiction
+  ## Valid Characters for POV (CRITICAL)
+  These are the ONLY characters that exist in this story. Do NOT invent new characters.
+  {valid_characters}
 
-  Make 2-3 targeted searches. Summarize what you find into actionable
-  guidance for writing the voice document. If no relevant guidance is found,
-  say so and move on — do not invent references.
+  ## POV Hints (from DREAM/BRAINSTORM)
+  {pov_context}
 
+  ## Guidelines
+
+  ### POV Character Selection (CRITICAL)
+  - For first-person or third-limited POV, the POV character MUST be one of the valid characters listed above
+  - Do NOT invent characters like "Mila", "the reader", or other names not in the valid characters list
+  - If DREAM specified a protagonist, confirm it matches an actual character entity
+  - If no protagonist is defined, discuss options with the user (interactive) or choose the most prominent character (autonomous)
+
+  ### POV Character Naming (CRITICAL)
+  GOOD: Use a character from the valid characters list: "Kay", "Marcus", "the protagonist"
+  BAD: Invent a new character: "Mila", "the reader as Alex", "your character named Sam"
+
+  ### Voice Decisions to Make
+  1. **POV**: first, second, third_limited, or third_omniscient?
+     - If first/third_limited: which character from the valid list?
+  2. **Tense**: past or present?
+  3. **Register**: formal, conversational, literary, or sparse?
+  4. **Tone**: What 3-5 adjectives capture the voice? (derived from DREAM themes)
+  5. **Avoid patterns**: What genre-specific pitfalls to watch for?
+
+  ### Using the Corpus Tools
+  Search for craft guidance on:
+  - POV/tense conventions for this genre
+  - Voice register that suits the themes
+  - Common prose pitfalls for this type of interactive fiction
+  {mode_section}
+
+  ## FILL Stage Scope (CRITICAL)
+  FILL establishes VOICE only. Do NOT modify the story's structure.
+
+  **What the discuss phase captures:**
+  - POV choice and rationale
+  - Tense choice and rationale
+  - Voice register and tone decisions
+  - Research findings from corpus
+
+  **What NOT to discuss:**
+  - Plot changes, beat modifications, or new characters
+  - Mechanical or gameplay changes
+  - Art direction (that's DRESS stage)
+
+non_interactive_section: |
   ## Mode: Autonomous
-  You are running without user interaction. Search the corpus, read relevant
-  documents, and synthesize your findings into concise recommendations.
-  Do NOT ask clarifying questions.
+  You are running without user interaction. Make confident voice decisions
+  based on the story's genre, tone, and themes. Do NOT ask clarifying questions.
+
+  For POV character selection:
+  - If DREAM specified a protagonist, use that character
+  - Otherwise, choose the most prominent character from the valid characters list
+  - NEVER invent a new character name
+
+  Search the corpus for genre-appropriate voice guidance, then synthesize
+  your findings into actionable decisions.
 
 components: []

--- a/prompts/templates/fill_phase0_discuss.yaml
+++ b/prompts/templates/fill_phase0_discuss.yaml
@@ -36,7 +36,7 @@ system: |
   - If no protagonist is defined, discuss options with the user (interactive) or choose the most prominent character (autonomous)
 
   ### POV Character Naming (CRITICAL)
-  GOOD: Use a character from the valid characters list: "Kay", "Marcus", "the protagonist"
+  GOOD: Use an exact character name from the valid characters list: "Kay", "Marcus"
   BAD: Invent a new character: "Mila", "the reader as Alex", "your character named Sam"
 
   ### Voice Decisions to Make

--- a/src/questfoundry/pipeline/stages/fill.py
+++ b/src/questfoundry/pipeline/stages/fill.py
@@ -50,6 +50,7 @@ from questfoundry.graph.fill_context import (
     format_shadow_states,
     format_sliding_window,
     format_story_identity,
+    format_valid_characters,
     format_vocabulary_note,
     format_voice_context,
     get_arc_passage_order,
@@ -266,6 +267,12 @@ class FillStage:
         self._max_concurrency: int = 2
         self._lang_instruction: str = ""
         self._two_step: bool = False
+        # Interactive mode attributes (set in execute(), defaults for direct calls)
+        self._interactive: bool = False
+        self._user_input_fn: UserInputFn | None = None
+        self._on_assistant_message: AssistantMessageFn | None = None
+        self._on_llm_start: LLMCallbackFn | None = None
+        self._on_llm_end: LLMCallbackFn | None = None
 
     CHECKPOINT_DIR = "snapshots"
 
@@ -318,11 +325,11 @@ class FillStage:
         user_prompt: str,  # noqa: ARG002
         provider_name: str | None = None,
         *,
-        interactive: bool = False,  # noqa: ARG002
-        user_input_fn: UserInputFn | None = None,  # noqa: ARG002
-        on_assistant_message: AssistantMessageFn | None = None,  # noqa: ARG002
-        on_llm_start: LLMCallbackFn | None = None,  # noqa: ARG002
-        on_llm_end: LLMCallbackFn | None = None,  # noqa: ARG002
+        interactive: bool = False,
+        user_input_fn: UserInputFn | None = None,
+        on_assistant_message: AssistantMessageFn | None = None,
+        on_llm_start: LLMCallbackFn | None = None,
+        on_llm_end: LLMCallbackFn | None = None,
         project_path: Path | None = None,
         callbacks: list[BaseCallbackHandler] | None = None,
         summarize_model: BaseChatModel | None = None,  # noqa: ARG002
@@ -342,11 +349,11 @@ class FillStage:
             model: LangChain chat model for prose generation.
             user_prompt: User guidance (unused in FILL).
             provider_name: Provider name for structured output strategy.
-            interactive: Interactive mode flag (unused).
-            user_input_fn: User input function (unused).
-            on_assistant_message: Assistant message callback (unused).
-            on_llm_start: LLM start callback (unused).
-            on_llm_end: LLM end callback (unused).
+            interactive: Enable interactive discuss phase for voice determination.
+            user_input_fn: Function for interactive user input.
+            on_assistant_message: Callback for assistant messages in interactive mode.
+            on_llm_start: LLM start callback for progress tracking.
+            on_llm_end: LLM end callback for progress tracking.
             project_path: Override for project path.
             callbacks: LangChain callback handlers.
             summarize_model: Summarize model (unused).
@@ -374,11 +381,16 @@ class FillStage:
         self._provider_name = provider_name
         self._serialize_model = serialize_model
         self._serialize_provider_name = serialize_provider_name
+        self._interactive = interactive
+        self._user_input_fn = user_input_fn
+        self._on_assistant_message = on_assistant_message
+        self._on_llm_start = on_llm_start
+        self._on_llm_end = on_llm_end
         self._size_profile = kwargs.get("size_profile")
         self._max_concurrency = kwargs.get("max_concurrency", 2)
         self._lang_instruction = get_output_language_instruction(kwargs.get("language", "en"))
         self._two_step = kwargs.get("two_step", True)
-        log.info("stage_start", stage="fill")
+        log.info("stage_start", stage="fill", interactive=interactive)
 
         phases = self._phase_order()
         phase_map = {name: i for i, (_, name) in enumerate(phases)}
@@ -731,29 +743,46 @@ class FillStage:
         graph: Graph,
         model: BaseChatModel,
     ) -> tuple[str, int, int]:
-        """Phase 0a: Research voice guidance using corpus tools.
+        """Phase 0a: Research voice guidance using discuss phase.
 
-        Runs a non-interactive discuss phase with corpus-only tools to
-        gather craft advice on POV, tense, register, and genre pitfalls.
-        Results are summarized for injection into the voice template.
+        Runs a discuss phase (interactive or autonomous) to explore voice
+        decisions including POV character selection. Prevents phantom character
+        invention by providing explicit valid character list.
 
         Returns:
             Tuple of (research_summary, llm_calls, tokens_used).
         """
         from questfoundry.agents import run_discuss_phase, summarize_discussion
         from questfoundry.prompts.loader import PromptLoader
-        from questfoundry.tools.langchain_tools import get_corpus_tools
+        from questfoundry.tools.langchain_tools import (
+            get_corpus_tools,
+            get_interactive_tools,
+        )
 
         loader = PromptLoader(_get_prompts_path())
         template = loader.load("fill_phase0_discuss")
 
+        # Build mode section based on interactive flag
+        if self._interactive:
+            mode_section = ""
+        else:
+            mode_section = getattr(template, "non_interactive_section", None) or (
+                "## Mode: Autonomous\nMake confident voice decisions based on genre and tone."
+            )
+
         system_prompt = template.system.format(
             dream_vision=format_dream_vision(graph),
             grow_summary=format_grow_summary(graph),
+            valid_characters=format_valid_characters(graph),
+            pov_context=format_pov_context(graph),
+            mode_section=mode_section,
         )
 
         tools = get_corpus_tools()
-        if not tools:
+        if self._interactive:
+            tools = [*tools, *get_interactive_tools()]
+
+        if not tools and not self._interactive:
             log.info("voice_research_skipped", reason="no corpus tools available")
             return "", 0, 0
 
@@ -762,7 +791,9 @@ class FillStage:
             tools=tools,
             user_prompt="Research voice and style guidance for this story.",
             max_iterations=25,
-            interactive=False,
+            interactive=self._interactive,
+            user_input_fn=self._user_input_fn,
+            on_assistant_message=self._on_assistant_message,
             system_prompt=system_prompt,
             stage_name="fill",
             callbacks=self._callbacks,
@@ -781,6 +812,7 @@ class FillStage:
             llm_calls=discuss_calls + 1,
             tokens=total_tokens,
             brief_length=len(brief),
+            interactive=self._interactive,
         )
 
         return brief, discuss_calls + 1, total_tokens


### PR DESCRIPTION
## Problem

FILL stage jumps straight to voice determination without human review, causing:
- POV character choice made without validation against actual entities
- Phantom character invention ("Mila" bug)
- No human gate before expensive prose generation

## Changes

- Add `format_valid_characters()` to `fill_context.py` for POV character validation
  - Lists all character entities with raw_ids
  - Marks protagonist with `(PROTAGONIST)` indicator
  - Prevents LLM from inventing characters not in the graph

- Update `fill_phase0_discuss.yaml` template:
  - Add `{valid_characters}` placeholder for character list injection
  - Add `{mode_section}` for interactive vs autonomous mode switching
  - Add `non_interactive_section` key with autonomous instructions
  - Add defensive prompt patterns (good/bad examples for POV naming)

- Wire interactive mode through `_phase_0a_voice_research()`:
  - Inject valid_characters and mode_section into system prompt
  - Add interactive tools when `interactive=True`
  - Pass interactive flag and callbacks to `run_discuss_phase()`

- Initialize interactive mode attributes in `FillStage.__init__()`:
  - Fixes AttributeError when tests call phase methods directly

## Not Included / Future PRs

- Voice document schema validation (existing implementation)
- End-to-end interactive testing (requires manual verification)

## Test Plan

```bash
# Type check
uv run mypy src/questfoundry/pipeline/stages/fill.py src/questfoundry/graph/fill_context.py
# Success: no issues found in 2 source files

# Unit tests
uv run pytest tests/unit/test_fill_stage.py tests/unit/test_fill_context.py -x -q
# 194 passed
```

## Risk / Rollback

- Low risk: Adds optional interactive mode, default behavior unchanged (non-interactive)
- Rollback: Revert this commit; autonomous mode continues to work

🤖 Generated with [Claude Code](https://claude.com/claude-code)