### PR TITLE
fix(providers): use model_copy instead of bind for A1111 distillation (#648)

### DIFF
--- a/src/questfoundry/providers/image_a1111.py
+++ b/src/questfoundry/providers/image_a1111.py
@@ -192,35 +192,39 @@ class A1111ImageProvider:
         return await self._distill_with_llm(brief)
 
     def _bind_distill_limits(self, llm: Any, *, stop: list[str]) -> Any:
-        """Bind conservative generation limits for prompt distillation.
+        """Create a model copy with conservative generation limits for distillation.
+
+        Uses model_copy() instead of bind() because bind() kwargs are ignored
+        by some providers (Ollama reads from instance attributes, not invoke kwargs).
 
         We rely on provider-side caps to prevent pathological runs where the
         model ignores formatting instructions and generates extremely long output.
         """
-        if not hasattr(llm, "bind"):
+        # model_copy requires the model to be a Pydantic model
+        if not hasattr(llm, "model_copy"):
             return llm
 
-        bind_kwargs: dict[str, Any] = {}
+        updates: dict[str, Any] = {}
 
         # Ollama (langchain-ollama ChatOllama) uses num_predict.
         if hasattr(llm, "num_predict"):
-            bind_kwargs["num_predict"] = _DISTILL_MAX_OUTPUT_TOKENS
+            updates["num_predict"] = _DISTILL_MAX_OUTPUT_TOKENS
         # Most hosted providers use max_tokens.
         elif hasattr(llm, "max_tokens"):
-            bind_kwargs["max_tokens"] = _DISTILL_MAX_OUTPUT_TOKENS
+            updates["max_tokens"] = _DISTILL_MAX_OUTPUT_TOKENS
 
+        # Stop sequences - skip if model doesn't support
         if hasattr(llm, "stop"):
-            bind_kwargs["stop"] = stop
+            updates["stop"] = stop
 
-        # Keep distillation deterministic-ish; if a provider doesn't support it,
-        # the attribute check keeps this a no-op.
+        # Keep distillation deterministic-ish
         if hasattr(llm, "temperature"):
-            bind_kwargs["temperature"] = 0.2
+            updates["temperature"] = 0.2
 
-        if not bind_kwargs:
+        if not updates:
             return llm
 
-        return llm.bind(**bind_kwargs)
+        return llm.model_copy(update=updates)
 
     def _parse_distilled_output(self, raw: str) -> tuple[str, str | None]:
         """Parse the LLM's output into (positive, negative).

--- a/src/questfoundry/providers/image_a1111.py
+++ b/src/questfoundry/providers/image_a1111.py
@@ -191,7 +191,7 @@ class A1111ImageProvider:
             )
         return await self._distill_with_llm(brief)
 
-    def _bind_distill_limits(self, llm: Any, *, stop: list[str]) -> Any:
+    def _apply_distill_limits(self, llm: Any, *, stop: list[str]) -> Any:
         """Create a model copy with conservative generation limits for distillation.
 
         Uses model_copy() instead of bind() because bind() kwargs are ignored
@@ -368,7 +368,7 @@ class A1111ImageProvider:
 
         from langchain_core.messages import HumanMessage, SystemMessage
 
-        distill_llm = self._bind_distill_limits(self._llm, stop=[_DISTILL_STOP_MARKER])
+        distill_llm = self._apply_distill_limits(self._llm, stop=[_DISTILL_STOP_MARKER])
 
         last_error: str | None = None
         for attempt in range(1, _DISTILL_MAX_RETRIES + 1):

--- a/tests/unit/test_image_a1111.py
+++ b/tests/unit/test_image_a1111.py
@@ -396,7 +396,7 @@ class TestA1111DistillPrompt:
     async def test_llm_system_prompt_tag_limit(self) -> None:
         """SD 1.5 distiller should enforce 40-tag limit."""
         mock_llm = AsyncMock()
-        mock_llm.bind = Mock(return_value=mock_llm)
+        mock_llm.model_copy = Mock(return_value=mock_llm)
         mock_response = AsyncMock()
         mock_response.content = "warrior battle, courtyard, epic, watercolor"
         mock_llm.ainvoke = AsyncMock(return_value=mock_response)
@@ -413,14 +413,16 @@ class TestA1111DistillPrompt:
         assert "subject" in system_msg.lower()
         assert "CLIP encoder" in system_msg
         assert "ENTITY EXPANSION" in system_msg
-        assert mock_llm.bind.call_args.kwargs["num_predict"] > 0
-        assert mock_llm.bind.call_args.kwargs["stop"]
+        # model_copy is called with update={...} instead of bind(**kwargs)
+        update_dict = mock_llm.model_copy.call_args.kwargs["update"]
+        assert update_dict["num_predict"] > 0
+        assert update_dict["stop"]
 
     @pytest.mark.asyncio()
     async def test_llm_sdxl_break_instruction(self) -> None:
         """SDXL LLM distiller should mention BREAK and 75-tag limit."""
         mock_llm = AsyncMock()
-        mock_llm.bind = Mock(return_value=mock_llm)
+        mock_llm.model_copy = Mock(return_value=mock_llm)
         mock_response = AsyncMock()
         mock_response.content = "scene tags BREAK style tags"
         mock_llm.ainvoke = AsyncMock(return_value=mock_response)
@@ -439,7 +441,7 @@ class TestA1111DistillPrompt:
     async def test_llm_entity_cap(self) -> None:
         """LLM distiller should also cap entities."""
         mock_llm = AsyncMock()
-        mock_llm.bind = Mock(return_value=mock_llm)
+        mock_llm.model_copy = Mock(return_value=mock_llm)
         mock_response = AsyncMock()
         mock_response.content = "test prompt"
         mock_llm.ainvoke = AsyncMock(return_value=mock_response)
@@ -459,7 +461,7 @@ class TestA1111DistillPrompt:
     async def test_llm_distillation_two_line_output(self) -> None:
         """LLM returns positive on line 1, negative on line 2."""
         mock_llm = AsyncMock()
-        mock_llm.bind = Mock(return_value=mock_llm)
+        mock_llm.model_copy = Mock(return_value=mock_llm)
         mock_response = AsyncMock()
         mock_response.content = (
             "warrior battle, courtyard, epic, watercolor, golden hour\n"
@@ -480,7 +482,7 @@ class TestA1111DistillPrompt:
     async def test_llm_distillation_single_line_output(self) -> None:
         """LLM returns only positive — negative is None."""
         mock_llm = AsyncMock()
-        mock_llm.bind = Mock(return_value=mock_llm)
+        mock_llm.model_copy = Mock(return_value=mock_llm)
         mock_response = AsyncMock()
         mock_response.content = "warrior battle, courtyard, epic, watercolor"
         mock_llm.ainvoke = AsyncMock(return_value=mock_response)
@@ -496,7 +498,7 @@ class TestA1111DistillPrompt:
     async def test_llm_strips_labels(self) -> None:
         """LLM output with 'Positive:' / 'Negative:' labels gets stripped."""
         mock_llm = AsyncMock()
-        mock_llm.bind = Mock(return_value=mock_llm)
+        mock_llm.model_copy = Mock(return_value=mock_llm)
         mock_response = AsyncMock()
         mock_response.content = (
             "Positive: warrior, courtyard, watercolor\nNegative: photorealism, text"
@@ -514,7 +516,7 @@ class TestA1111DistillPrompt:
     async def test_llm_receives_negative_in_brief(self) -> None:
         """Negative prompt text is included in the brief sent to the LLM."""
         mock_llm = AsyncMock()
-        mock_llm.bind = Mock(return_value=mock_llm)
+        mock_llm.model_copy = Mock(return_value=mock_llm)
         mock_response = AsyncMock()
         mock_response.content = "tags\nbad things"
         mock_llm.ainvoke = AsyncMock(return_value=mock_response)


### PR DESCRIPTION
## Problem

`_bind_distill_limits()` uses `llm.bind(temperature=0.2)` which:
- Silently fails for Ollama (bind kwargs ignored)
- Fails at runtime for o1/o3 models (reject `stop`)

## Changes

- Replace `bind()` with `model_copy(update={...})` in `_apply_distill_limits()` (renamed from `_bind_distill_limits`)
- Update tests to mock `model_copy` instead of `bind`

## Why model_copy()

LangChain models are Pydantic models. `model_copy(update={...})` creates a new instance with updated attributes, which providers actually read. Unlike `bind()`, the updates go directly into instance attributes.

## Test Plan

```bash
uv run pytest tests/unit/test_image_a1111.py -x -q
# 43 passed
```

## Risk / Rollback

- Low risk: Same behavior for providers that supported bind correctly
- Rollback: Revert commit

Closes #648

🤖 Generated with [Claude Code](https://claude.com/claude-code)