### PR TITLE
fix(dress): enforce short descriptive captions instead of prose excerpts

### DIFF
--- a/prompts/templates/dress_brief.yaml
+++ b/prompts/templates/dress_brief.yaml
@@ -42,7 +42,7 @@ system: |
   - category: One of "scene", "portrait", "vista", "item_detail"
   - subject: What the image depicts (concise description)
   - entities: List of entity IDs present in the image (raw IDs, no scope prefix)
-  - caption: Proposed diegetic caption in the story's voice
+  - caption: Short descriptive caption (10-50 chars). Format: "[Subject] [action/state]"
   - mood: Emotional tone of the image
   - composition: Framing and camera notes (2-4 sentences)
   - style_overrides: Deviations from global art direction (usually empty string)
@@ -60,7 +60,9 @@ system: |
   ## Guidelines
   - Match the global art direction style and palette
   - Use entity visual references for consistent depiction
-  - The caption should be diegetic — written in the story's voice, not meta-commentary
+  - CAPTION FORMAT: Short, descriptive alt-text (10-50 chars). NOT prose excerpts.
+    GOOD: "Kay reading the letter", "The manor at dusk", "Dr. Aris pouring tea"
+    BAD: "I remember the first time I saw a garden bloom..." (too long, too narrative)
   - Consider what makes a compelling still image from the scene
   - COMPOSITION VARIETY: Do NOT use the same camera angle and framing for every
     brief. The art direction composition_notes are defaults, not mandates. Vary
@@ -71,8 +73,8 @@ system: |
     Consider: wonder, dread, fury, tenderness, humor, triumph, melancholy, awe,
     confusion, serenity, panic, relief. Match the mood to what actually happens
     in the passage.
-  - CAPTION UNIQUENESS: Each caption must use different imagery and phrasing.
-    Never reuse metaphors or sentence patterns across briefs.
+  - CAPTION LENGTH: Captions MUST be under 60 characters. They are for alt-text
+    and figure labels, not narrative prose. If your caption exceeds 60 chars, shorten it.
   - NEGATIVE FIELD: Only list negatives SPECIFIC to this brief that go beyond
     the global negative_defaults. If no brief-specific negatives apply, use an
     empty string.

--- a/src/questfoundry/models/dress.py
+++ b/src/questfoundry/models/dress.py
@@ -62,7 +62,11 @@ class Illustration(BaseModel):
     """
 
     asset: str = Field(min_length=1, description="Path to image file (e.g. assets/<hash>.png)")
-    caption: str = Field(min_length=1, description="Diegetic caption — in-world voice")
+    caption: str = Field(
+        min_length=1,
+        max_length=100,
+        description="Short descriptive caption for alt-text (10-60 chars ideal)",
+    )
     category: IllustrationCategory = Field(
         description="Image category",
     )
@@ -147,7 +151,11 @@ class IllustrationBrief(BaseModel):
     entities: list[str] = Field(
         description="Entity IDs present in scene",
     )
-    caption: str = Field(min_length=1, description="Proposed diegetic caption")
+    caption: str = Field(
+        min_length=1,
+        max_length=100,
+        description="Short descriptive caption for alt-text (10-60 chars ideal)",
+    )
     mood: str = Field(min_length=1, description="Emotional tone")
     composition: str = Field(min_length=1, description="Framing / camera notes")
     style_overrides: str = Field(

--- a/src/questfoundry/models/dress.py
+++ b/src/questfoundry/models/dress.py
@@ -55,7 +55,7 @@ class ArtDirection(BaseModel):
 
 
 class Illustration(BaseModel):
-    """Art asset with diegetic caption.
+    """Art asset with descriptive caption for accessibility.
 
     Generated from an IllustrationBrief and linked to a passage
     via a Depicts edge.
@@ -64,7 +64,7 @@ class Illustration(BaseModel):
     asset: str = Field(min_length=1, description="Path to image file (e.g. assets/<hash>.png)")
     caption: str = Field(
         min_length=1,
-        max_length=100,
+        max_length=100,  # Defensive max; prompt targets 10-60 chars
         description="Short descriptive caption for alt-text (10-60 chars ideal)",
     )
     category: IllustrationCategory = Field(
@@ -153,7 +153,7 @@ class IllustrationBrief(BaseModel):
     )
     caption: str = Field(
         min_length=1,
-        max_length=100,
+        max_length=100,  # Defensive max; prompt targets 10-60 chars
         description="Short descriptive caption for alt-text (10-60 chars ideal)",
     )
     mood: str = Field(min_length=1, description="Emotional tone")


### PR DESCRIPTION
## Problem
DRESS stage generates narrative prose excerpts as captions (e.g., "I remember the first time I saw a garden bloom...") instead of short descriptive alt-text. This produces captions that are too long and don't serve their purpose as figure labels and accessibility text.

## Changes
- Add `max_length=100` constraint to caption fields in `Illustration` and `IllustrationBrief` models
- Update `dress_brief.yaml` prompt to request short descriptive captions (10-50 chars)
- Add explicit good/bad examples: "Kay reading the letter" (good) vs "I remember the first time..." (bad)
- Replace "diegetic caption" language with "short descriptive caption" throughout

## Not Included / Future PRs
- Validation of existing captions (would require migration)

## Test Plan
```bash
uv run pytest tests/unit/test_dress*.py -x -q  # 150 passed
uv run ruff check src/questfoundry/models/dress.py  # All checks passed
```

## Risk / Rollback
- Low risk: Only affects new brief generation, not existing data
- Prompt changes guide LLM behavior but don't break existing flows

Closes #641

🤖 Generated with [Claude Code](https://claude.com/claude-code)