### PR TITLE
feat(fill): generate spoke labels alongside prose for hub passages

### DIFF
--- a/prompts/templates/fill_phase1_prose.yaml
+++ b/prompts/templates/fill_phase1_prose.yaml
@@ -117,6 +117,8 @@ system: |
   voice), list them in entity_updates so they persist for later passages.
   Only update EXISTING entities — do not create new ones.
 
+  {spoke_context}
+
   ## Output Format
   Return a JSON object with a "passage" field containing:
   - passage_id: the passage ID
@@ -124,6 +126,7 @@ system: |
   - flag: "ok" or "incompatible_states"
   - flag_reason: explanation if flagged (empty otherwise)
   - entity_updates: list of {{entity_id, field, value}} (may be empty)
+  - spoke_labels: list of {{choice_id, label}} for any hub-to-spoke choices (may be empty)
 
 user: |
   Write the prose for passage {passage_id} following the voice document and

--- a/prompts/templates/fill_phase1_prose.yaml
+++ b/prompts/templates/fill_phase1_prose.yaml
@@ -125,8 +125,10 @@ system: |
   - prose: the generated text
   - flag: "ok" or "incompatible_states"
   - flag_reason: explanation if flagged (empty otherwise)
-  - entity_updates: list of {{entity_id, field, value}} (may be empty)
-  - spoke_labels: list of {{choice_id, label}} for any hub-to-spoke choices (may be empty)
+  - entity_updates: array of objects with entity_id, field, value (may be empty)
+  - spoke_labels: array of spoke label objects (may be empty), each with:
+    - choice_id: the choice node ID (may omit "choice::" prefix)
+    - label: the final label text (3-60 characters)
 
 user: |
   Write the prose for passage {passage_id} following the voice document and

--- a/prompts/templates/fill_phase1_prose_only.yaml
+++ b/prompts/templates/fill_phase1_prose_only.yaml
@@ -76,6 +76,8 @@ system: |
   ## Vocabulary Note
   {vocabulary_note}
 
+  {spoke_context}
+
   {output_language_instruction}
 
   ## Rules

--- a/prompts/templates/grow_phase9c_hub_spokes.yaml
+++ b/prompts/templates/grow_phase9c_hub_spokes.yaml
@@ -32,8 +32,10 @@ system: |
   1. Each spoke is 1-2 sentences of flavor/atmosphere, NOT plot-critical content
   2. Spokes should reveal character, setting, or world detail
   3. 2-4 spokes per hub
-  4. Spoke labels: 3-6 words, action phrases in imperative form
-  5. Forward label: describes continuing the main story
+  4. Spoke labels are OPTIONAL — if omitted, FILL stage will generate them
+     based on the prose it writes. This ensures labels match actual content.
+  5. If you DO provide labels: 3-6 words, action phrases in imperative form
+  6. Forward label: describes continuing the main story (required)
 
   ## What NOT to Do
   - Do NOT use passage IDs not listed in the Valid IDs section
@@ -50,7 +52,8 @@ system: |
   - passage_id: the passage that becomes a hub
   - spokes: array of 2-4 spokes, each with:
     - summary: 1-2 sentence description of what the player finds
-    - label: choice label to enter the spoke (3-6 words)
+    - label: (optional) choice label to enter the spoke (3-6 words)
+    - label_style: (optional) "functional", "evocative", or "character_voice"
   - forward_label: choice label for continuing the story (3-6 words)
 
 user: |

--- a/prompts/templates/grow_phase9c_hub_spokes.yaml
+++ b/prompts/templates/grow_phase9c_hub_spokes.yaml
@@ -53,7 +53,11 @@ system: |
   - spokes: array of 2-4 spokes, each with:
     - summary: 1-2 sentence description of what the player finds
     - label: (optional) choice label to enter the spoke (3-6 words)
-    - label_style: (optional) "functional", "evocative", or "character_voice"
+    - label_style: (optional) style hint for FILL-generated labels:
+      - "functional": Clear action verbs (default) — "Examine the clock", "Read the letter"
+      - "evocative": Atmospheric — "Trace the faded ink", "Listen to the silence"
+      - "character_voice": Internal thought — "That clock... why did it stop?"
+      If omitted, defaults to "functional"
   - forward_label: choice label for continuing the story (3-6 words)
 
 user: |

--- a/src/questfoundry/graph/fill_context.py
+++ b/src/questfoundry/graph/fill_context.py
@@ -218,8 +218,8 @@ def get_pending_spoke_labels(graph: Graph, hub_passage_id: str) -> list[dict[str
         if not choice_data:
             continue
 
-        # Check if label is missing or empty
-        current_label = choice_data.get("label", "")
+        # Check if label is missing or empty (both None and "" are falsy)
+        current_label = choice_data.get("label")
         if current_label:
             continue  # Already has a label
 

--- a/src/questfoundry/models/__init__.py
+++ b/src/questfoundry/models/__init__.py
@@ -50,6 +50,7 @@ from questfoundry.models.fill import (
     FillPhaseResult,
     FillResult,
     ReviewFlag,
+    SpokeLabelUpdate,
     VoiceDocument,
 )
 from questfoundry.models.grow import (
@@ -84,6 +85,7 @@ from questfoundry.models.grow import (
     Phase9cOutput,
     Phase9Output,
     SceneTypeTag,
+    SpokeLabelStyle,
     SpokeProposal,
 )
 from questfoundry.models.pipeline import PhaseResult
@@ -174,6 +176,8 @@ __all__ = [
     "SceneTypeTag",
     "Scope",
     "SeedOutput",
+    "SpokeLabelStyle",
+    "SpokeLabelUpdate",
     "SpokeProposal",
     "VoiceDocument",
 ]

--- a/src/questfoundry/models/fill.py
+++ b/src/questfoundry/models/fill.py
@@ -78,6 +78,21 @@ class EntityUpdate(BaseModel):
     value: str = Field(min_length=1, description="New detail to add")
 
 
+class SpokeLabelUpdate(BaseModel):
+    """Final label for a hub-to-spoke choice.
+
+    When GROW creates spokes with label=None, FILL generates labels
+    alongside prose to ensure the choice text matches passage content.
+    """
+
+    choice_id: str = Field(min_length=1, description="ID of the hub-to-spoke choice")
+    label: str = Field(
+        min_length=1,
+        max_length=60,
+        description="Final choice label (e.g., 'Examine the sketch')",
+    )
+
+
 class FillPassageOutput(BaseModel):
     """LLM output for a single passage prose generation.
 
@@ -98,6 +113,10 @@ class FillPassageOutput(BaseModel):
     entity_updates: list[EntityUpdate] = Field(
         default_factory=list,
         description="Micro-details discovered during generation",
+    )
+    spoke_labels: list[SpokeLabelUpdate] = Field(
+        default_factory=list,
+        description="Labels for hub-to-spoke choices (when hub passage generates prose)",
     )
 
 

--- a/src/questfoundry/models/fill.py
+++ b/src/questfoundry/models/fill.py
@@ -88,8 +88,8 @@ class SpokeLabelUpdate(BaseModel):
     choice_id: str = Field(min_length=1, description="ID of the hub-to-spoke choice")
     label: str = Field(
         min_length=1,
-        max_length=60,
-        description="Final choice label (e.g., 'Examine the sketch')",
+        max_length=80,  # Allows some flexibility for verbose styles and translations
+        description="Final choice label, 3-60 chars (e.g., 'Examine the sketch')",
     )
 
 

--- a/src/questfoundry/models/grow.py
+++ b/src/questfoundry/models/grow.py
@@ -328,11 +328,26 @@ class Phase9bOutput(BaseModel):
     proposals: list[ForkProposal] = Field(default_factory=list)
 
 
+SpokeLabelStyle = Literal["functional", "evocative", "character_voice"]
+
+
 class SpokeProposal(BaseModel):
-    """A single spoke in a hub-and-spoke exploration node."""
+    """A single spoke in a hub-and-spoke exploration node.
+
+    The label field is optional: if None, FILL will generate the label
+    alongside prose to ensure coherence between passage content and
+    choice text.
+    """
 
     summary: str = Field(min_length=1, description="Summary of the spoke passage")
-    label: str = Field(min_length=1, description="Choice label to enter the spoke")
+    label: str | None = Field(
+        default=None,
+        description="Choice label to enter the spoke (None = FILL generates)",
+    )
+    label_style: SpokeLabelStyle = Field(
+        default="functional",
+        description="Style hint for FILL-generated labels",
+    )
 
 
 class HubProposal(BaseModel):

--- a/src/questfoundry/pipeline/stages/grow.py
+++ b/src/questfoundry/pipeline/stages/grow.py
@@ -2845,18 +2845,19 @@ class GrowStage:
                 )
 
                 # Choice: hub → spoke
+                # If label is None, FILL will generate it alongside prose
                 to_spoke_cid = f"choice::{raw_id}__spoke_{i}"
-                graph.create_node(
-                    to_spoke_cid,
-                    {
-                        "type": "choice",
-                        "from_passage": hub_id,
-                        "to_passage": spoke_pid,
-                        "label": spoke.label,
-                        "requires": [],
-                        "grants": [],
-                    },
-                )
+                choice_data: dict[str, object] = {
+                    "type": "choice",
+                    "from_passage": hub_id,
+                    "to_passage": spoke_pid,
+                    "requires": [],
+                    "grants": [],
+                    "label_style": spoke.label_style,
+                }
+                if spoke.label:
+                    choice_data["label"] = spoke.label
+                graph.create_node(to_spoke_cid, choice_data)
                 graph.add_edge("choice_from", to_spoke_cid, hub_id)
                 graph.add_edge("choice_to", to_spoke_cid, spoke_pid)
 


### PR DESCRIPTION
## Problem

Spoke choices (environmental exploration options) have labels that reference objects not present in the passage prose. For example, "Look at the Photo" leads to a passage describing a "sketch", or "Check the Letters" when prose mentions "notes".

Root cause: Spoke labels are created during GROW (Phase 9c) as structural placeholders, but FILL generates prose without knowledge of these labels. The labels are frozen before prose exists.

## Solution

Make spoke labels optional in GROW, letting FILL generate them alongside prose. This ensures coherence between what the prose describes and what the choice labels reference.

**Key insight from IF expert analysis**: "Labels are narrative content (FILL's domain), not graph structure (GROW's domain). GROW defines topology; FILL writes words."

## Changes

### Model changes
- `SpokeProposal.label` is now optional (`None` = FILL generates)
- Add `SpokeProposal.label_style` for style hints (`functional`, `evocative`, `character_voice`)
- Add `SpokeLabelUpdate` model for FILL output
- Add `spoke_labels` field to `FillPassageOutput`

### Stage changes
- GROW: Store `label_style` on choice nodes, omit label if `None`
- FILL: Inject spoke context for hub passages via `format_spoke_context()`
- FILL: Process `spoke_labels` from output, update choice nodes

### Prompt changes
- `grow_phase9c`: Labels are now optional, `label_style` documented
- `fill_phase1_prose`: Added `{spoke_context}` section and `spoke_labels` in output format
- `fill_phase1_prose_only`: Added `{spoke_context}` for prose guidance (no label output)

### Tests
- Added `TestGetPendingSpokeLabels` (4 tests)
- Added `TestFormatSpokeContext` (2 tests)

## Not Included / Future PRs
- Two-step mode spoke label extraction (would need separate LLM call like entity extraction)
- Spoke label validation in export (ensuring all spokes have labels)

## Test Plan
```bash
uv run pytest tests/unit/test_fill_context.py -x -q  # 149 passed
uv run pytest tests/unit/test_mutations.py -x -q     # 164 passed
uv run ruff check src/                               # All checks passed
```

## Risk / Rollback
- **Backward compatible**: Existing graphs with spoke labels continue to work unchanged
- **Forward compatible**: New spokes can have labels (GROW) or not (FILL generates)
- Low risk: Only affects new hub-and-spoke generation

Closes #640

🤖 Generated with [Claude Code](https://claude.com/claude-code)