### PR TITLE
prompt: harden templates for LLM structured output reliability

### DIFF
--- a/prompts/templates/dress_brief.yaml
+++ b/prompts/templates/dress_brief.yaml
@@ -42,7 +42,7 @@ system: |
   - category: One of "scene", "portrait", "vista", "item_detail"
   - subject: What the image depicts (concise description)
   - entities: List of entity IDs present in the image (raw IDs, no scope prefix)
-  - caption: Short descriptive caption (10-50 chars). Format: "[Subject] [action/state]"
+  - caption: Short descriptive caption (10-60 chars). Format: "[Subject] [action/state]"
   - mood: Emotional tone of the image
   - composition: Framing and camera notes (2-4 sentences)
   - style_overrides: Deviations from global art direction (usually empty string)
@@ -69,7 +69,7 @@ system: |
   RIGHT: "The manor at dusk" (17 chars)
   RIGHT: "Dr. Aris pouring tea" (20 chars)
 
-  Format: "[Subject] [action/state]" — descriptive alt-text, NOT prose excerpts.
+  - Format: "[Subject] [action/state]" — descriptive alt-text, NOT prose excerpts.
   - Consider what makes a compelling still image from the scene
   - COMPOSITION VARIETY: Do NOT use the same camera angle and framing for every
     brief. The art direction composition_notes are defaults, not mandates. Vary

--- a/prompts/templates/dress_brief.yaml
+++ b/prompts/templates/dress_brief.yaml
@@ -60,9 +60,16 @@ system: |
   ## Guidelines
   - Match the global art direction style and palette
   - Use entity visual references for consistent depiction
-  - CAPTION FORMAT: Short, descriptive alt-text (10-50 chars). NOT prose excerpts.
-    GOOD: "Kay reading the letter", "The manor at dusk", "Dr. Aris pouring tea"
-    BAD: "I remember the first time I saw a garden bloom..." (too long, too narrative)
+
+  ## Caption Length (STRICT)
+  Captions MUST be 10-60 characters. Count your characters.
+  WRONG: "A scene" (8 chars — too short)
+  WRONG: "I remember the first time I saw a garden bloom in the spring light..." (70 chars — too long, too narrative)
+  RIGHT: "Kay reading the letter" (22 chars)
+  RIGHT: "The manor at dusk" (17 chars)
+  RIGHT: "Dr. Aris pouring tea" (20 chars)
+
+  Format: "[Subject] [action/state]" — descriptive alt-text, NOT prose excerpts.
   - Consider what makes a compelling still image from the scene
   - COMPOSITION VARIETY: Do NOT use the same camera angle and framing for every
     brief. The art direction composition_notes are defaults, not mandates. Vary

--- a/prompts/templates/dress_summarize.yaml
+++ b/prompts/templates/dress_summarize.yaml
@@ -17,6 +17,17 @@ system: |
     - Color associations
     - A concise reference prompt fragment for image generation (appearance only — no camera angles, framing, poses, or actions)
 
+  ## NO DELEGATION (CRITICAL)
+  You are GENERATING the visual brief, not suggesting how to generate it.
+
+  DO NOT write:
+  - "The art style could be..."
+  - "Consider using a palette of..."
+  - "You might want to describe the character as..."
+
+  DO write the actual style decisions, color palettes, and visual profiles directly.
+  Your output IS the result.
+
   ## Guidelines
   - Extract concrete decisions, not vague ideas
   - Preserve specific details like color names, style descriptors, distinguishing features

--- a/prompts/templates/fill_phase0_voice.yaml
+++ b/prompts/templates/fill_phase0_voice.yaml
@@ -50,10 +50,20 @@ system: |
 
   Also propose a **story_title** — a compelling title for this interactive fiction story.
 
-  - 2–8 words, evocative and genre-appropriate
+  ## Length Requirements (STRICT)
+  - **story_title**: 2-8 words. Count your words.
+    WRONG: "A" (1 word — too short)
+    WRONG: "The Long and Winding Road Through the Mountains of Despair" (11 words — too long)
+    RIGHT: "The Hollow Crown" (3 words)
+    RIGHT: "Beneath the Crimson Tide" (4 words)
+    RIGHT: "Whispers at Dawnbreak" (3 words)
+
+  - **tone_words**: At least 1 adjective required (typically 3-5).
+    WRONG: [] (empty — validation will fail)
+    RIGHT: ["terse", "wry", "melancholic"]
+
   - Reflect the central tension, setting, or theme — not generic
-  - Good: "The Hollow Crown", "Beneath the Crimson Tide", "Whispers at Dawnbreak"
-  - Bad: "Adventure Story", "The Quest", "A Dark Tale"
+  - Bad: "Adventure Story", "The Quest", "A Dark Tale" (too generic)
 
   {output_language_instruction}
 

--- a/prompts/templates/grow_phase4a_scene_types.yaml
+++ b/prompts/templates/grow_phase4a_scene_types.yaml
@@ -28,9 +28,9 @@ system: |
   "reluctant hope", "cold clarity", "breathless tension", "numb acceptance",
   "fierce defiance", "bitter calm", "fragile trust"
 
-  Write a SHORT emotional phrase (2-3 words). Not a sentence.
-  GOOD: "bitter resolve"
-  BAD: "The reader feels a sense of growing unease about what comes next"
+  Write a SHORT emotional phrase (2-3 words, 2-40 characters). Not a sentence.
+  GOOD: "bitter resolve" (14 chars)
+  BAD: "The reader feels a sense of growing unease about what comes next" (too long)
 
   ## Classification Guidelines
   1. Beats with dilemma_impacts (commits/escalates) are scenes — they drive conflict forward

--- a/prompts/templates/grow_phase4d_atmospheric.yaml
+++ b/prompts/templates/grow_phase4d_atmospheric.yaml
@@ -4,31 +4,31 @@ description: Generate atmospheric details and entry states for beats
 system: |
   You are adding sensory atmosphere to story beats.
 
-  ## Atmospheric Detail
+  ## Atmospheric Detail (10-200 characters)
   For EACH beat, write a single recurring sensory detail that anchors the
   setting — what the protagonist sees, hears, smells, or feels physically.
   This detail will be woven into the prose as a sensory anchor.
 
-  Examples:
-  - "Lamp oil smoke curling beneath low stone ceilings"
-  - "The persistent drone of cicadas in the humid air"
-  - "Cold steel handrails vibrating faintly underfoot"
+  Examples (with character counts):
+  - "Lamp oil smoke curling beneath low stone ceilings" (49 chars)
+  - "The persistent drone of cicadas in the humid air" (49 chars)
+  - "Cold steel handrails vibrating faintly underfoot" (49 chars)
 
   Write ENVIRONMENT, not character emotion. Not "a sense of dread" but
   "the smell of wet earth and rust."
 
-  ## Entry States (shared beats only)
+  ## Entry States (shared beats only, 2-50 characters per mood)
   Some beats are shared between paths — players arrive from different
   emotional contexts. For EACH shared beat, describe the emotional quality
   a reader carries FROM each path.
 
   Shared beats: {shared_beats}
 
-  Examples:
-  - path_trust: "cautious warmth" (built trust with mentor)
-  - path_betray: "defensive guilt" (chose self-preservation)
+  Examples (with character counts):
+  - path_trust: "cautious warmth" (15 chars) — built trust with mentor
+  - path_betray: "defensive guilt" (15 chars) — chose self-preservation
 
-  Write 2-3 word emotional descriptors, not sentences.
+  Write 2-3 word emotional descriptors (2-50 chars). Not sentences.
 
   ## Beats to Annotate
   {beat_summaries}

--- a/prompts/templates/grow_phase4e_path_arcs.yaml
+++ b/prompts/templates/grow_phase4e_path_arcs.yaml
@@ -17,17 +17,26 @@ system: |
 
   1. **path_theme**: A 1-2 sentence description of the emotional through-line
      of this path. What is the reader's journey? What transformation or
-     realization does this path lead toward? (10-200 characters)
+     realization does this path lead toward?
 
   2. **path_mood**: A concise tone descriptor for the overall mood of this
      path (e.g., "bittersweet resolve", "creeping dread", "fragile hope").
-     (2-50 characters)
 
   3. The theme should reflect the specific beat sequence — not generic
      narrative arcs. Reference the actual content of the beats.
 
   4. The mood should capture the dominant emotional register, not just
      the ending mood.
+
+  ## Length Requirements (STRICT)
+  - **path_theme**: 10-200 characters MAXIMUM. Count your characters.
+    WRONG: "This path explores how the protagonist navigates the complex..." (verbose, will exceed 200)
+    RIGHT: "Discovery gives way to dread as truth surfaces" (47 chars)
+  - **path_mood**: 2-50 characters. A phrase, not a sentence.
+    WRONG: "The reader experiences a growing sense of unease as..." (too long)
+    RIGHT: "creeping unease" (15 chars)
+
+  CRITICAL: Some models ignore schema maxLength constraints. Count characters manually.
 
   ## Output Format
   Return a JSON object with:

--- a/prompts/templates/grow_phase4f_entity_arcs.yaml
+++ b/prompts/templates/grow_phase4f_entity_arcs.yaml
@@ -21,12 +21,19 @@ system: |
   Write a concise trajectory showing how the entity changes across this path's
   beats. Use 2-4 steps separated by arrows.
 
-  GOOD: "trusted ally → doubts surface → revealed as spy"
-  GOOD: "mundane letter → imbued with dread → proof of betrayal"
-  GOOD: "safe harbor → tension creeps in → site of confrontation"
+  GOOD: "trusted ally → doubts surface → revealed as spy" (47 chars)
+  GOOD: "mundane letter → imbued with dread → proof of betrayal" (55 chars)
+  GOOD: "safe harbor → tension creeps in → site of confrontation" (56 chars)
   BAD: "the character undergoes a transformation" (too abstract)
   BAD: "start → middle → end" (generic, not specific to this entity)
   BAD: "A complex journey of self-discovery and growth" (prose, not trajectory)
+
+  ## Length Requirements (STRICT)
+  - **arc_line**: 10-200 characters MAXIMUM. Count your characters.
+    WRONG: "The entity begins as a trusted figure but slowly reveals layers of..." (verbose, will exceed 200)
+    RIGHT: "trusted → tested → betrayed" (27 chars)
+
+  CRITICAL: Some models ignore schema maxLength constraints. Count characters manually.
 
   ## Pivot Beat
   The pivot_beat is where the entity's arc TURNS — the beat where the

--- a/prompts/templates/grow_phase8c_overlays.yaml
+++ b/prompts/templates/grow_phase8c_overlays.yaml
@@ -36,6 +36,13 @@ system: |
   - Do NOT propose overlays with empty details
   - Do NOT add explanatory prose before or after the JSON output
 
+  ## CRITICAL: Required Field - details
+  The `details` field MUST contain at least one key-value pair.
+  Every overlay must describe WHAT changes. An empty details dict is invalid.
+
+  WRONG: {"entity_id": "character::hero", "when": ["cw_trust"], "details": {}}
+  RIGHT: {"entity_id": "character::hero", "when": ["cw_trust"], "details": {"attitude": "Wary but not hostile"}}
+
   ## Valid IDs
   Valid entity_ids: {valid_entity_ids}
   Valid codeword_ids (for "when" field): {valid_codeword_ids}

--- a/prompts/templates/grow_phase9_choices.yaml
+++ b/prompts/templates/grow_phase9_choices.yaml
@@ -37,6 +37,13 @@ system: |
   5. Labels should feel natural in the story's voice and tone
   6. Write in second person imperative or infinitive form
 
+  ## Length Requirements (STRICT)
+  - Labels MUST be 3-8 words. Count your words.
+    WRONG: "Go" (1 word — too short)
+    WRONG: "Decide to trust the mentor and follow their advice into the unknown" (12 words — too long)
+    RIGHT: "Trust the mentor's guidance" (4 words)
+    RIGHT: "Demand proof before agreeing" (4 words)
+
   ## What NOT to Do
   - Do NOT use IDs not listed in the Valid IDs section
   - Do NOT produce labels longer than 8 words

--- a/prompts/templates/grow_phase9_continue_labels.yaml
+++ b/prompts/templates/grow_phase9_continue_labels.yaml
@@ -37,6 +37,14 @@ system: |
   4. Write in second person imperative or infinitive form
   5. Vary the verb — don't start every label with the same word
 
+  ## Length Requirements (STRICT)
+  - Labels MUST be 3-6 words. Count your words.
+    WRONG: "Go" (1 word — too short)
+    WRONG: "Proceed to investigate the mysterious room at the end of the hall" (12 words — too long)
+    RIGHT: "Search the room" (3 words)
+    RIGHT: "Follow the trail" (3 words)
+    RIGHT: "Step through the doorway" (4 words)
+
   ## What NOT to Do
   - Do NOT use IDs not listed in the Valid IDs section
   - Do NOT produce labels longer than 6 words

--- a/prompts/templates/serialize_seed_sections.yaml
+++ b/prompts/templates/serialize_seed_sections.yaml
@@ -299,6 +299,21 @@ beats_prompt: |
   - `## VALID PATH IDs` - use ONLY these in `paths` arrays
   - `### Entity IDs` - use ONLY these in `entities` and `location` fields
 
+  ## PATH ID vs DILEMMA ID: THE CRITICAL DISTINCTION
+
+  SHAPE RECOGNITION (memorize this):
+  - **Path IDs** are HIERARCHICAL: `path::dilemma_name__answer` (contains `__` double underscore)
+  - **Dilemma IDs** are BINARY questions: `dilemma::subject_optionA_or_optionB` (contains `_or_`)
+  - **Entity IDs** have CATEGORY prefix: `character::name`, `location::place`, `object::item`
+
+  WRONG: Using `dilemma::...` in the `paths[]` field
+  RIGHT: Using `path::...` in the `paths[]` field
+
+  WRONG: Using `path::...` in the `dilemma_impacts.dilemma_id` field
+  RIGHT: Using `dilemma::...` in the `dilemma_impacts.dilemma_id` field
+
+  If you see `__` (double underscore), it's a PATH. If you see `_or_`, it's a DILEMMA.
+
   WRONG examples that WILL FAIL:
   - `"clock_distortion"` - NOT a valid path (derived from concept)
   - `"the_garden"` - WRONG, use `"garden"` (no prefix)

--- a/prompts/templates/summarize.yaml
+++ b/prompts/templates/summarize.yaml
@@ -14,6 +14,16 @@ system: |
   - Story size: one of "vignette", "short", "standard", or "long" (preserve the exact keyword from the discussion)
   - Content notes (what to include/exclude)
 
+  ## NO DELEGATION (CRITICAL)
+  You are GENERATING the summary, not suggesting how to generate it.
+
+  DO NOT write:
+  - "The genre could be determined by..."
+  - "Based on the discussion, you might want to..."
+  - "Consider including..."
+
+  DO write the actual summary content directly. Your output IS the result.
+
   ## Guidelines
   - Extract concrete decisions, not vague ideas
   - Preserve specific details like word counts, themes, tone descriptors

--- a/prompts/templates/summarize_brainstorm.yaml
+++ b/prompts/templates/summarize_brainstorm.yaml
@@ -37,6 +37,17 @@ system: |
   - **Central entity IDs**: List the exact entity IDs involved (e.g., "[character_id], [location_id]")
   - Why this dilemma matters thematically
 
+  ## NO DELEGATION (CRITICAL)
+  You are GENERATING the summary, not suggesting how to generate it.
+
+  DO NOT write:
+  - "The characters could include..."
+  - "Based on the discussion, you might develop..."
+  - "Consider adding a dilemma about..."
+
+  DO write the actual character descriptions, location details, and dilemmas directly.
+  Your output IS the result.
+
   ## Guidelines
   - Write in flowing prose, not schema fields
   - Capture ALL entities and dilemmas mentioned in discussion

--- a/prompts/templates/summarize_seed.yaml
+++ b/prompts/templates/summarize_seed.yaml
@@ -5,6 +5,17 @@ system: |
   You are summarizing a story architecture discussion into structured output.
   This is the SEED stage output - the committed foundation for the story.
 
+  ## NO DELEGATION (CRITICAL)
+  You are GENERATING the complete story structure, not suggesting how to generate it.
+
+  DO NOT write:
+  - "The paths could be structured as..."
+  - "You might want to explore..."
+  - "Consider making this a major path..."
+
+  DO write the actual entity decisions, paths, and beats directly.
+  Your output IS the committed story structure.
+
   ## CRITICAL: Manifest Completeness
   Your summary MUST include explicit decisions for:
   - ALL {entity_count} entities listed below


### PR DESCRIPTION
## Problem

Chat-optimized models (GPT-4o, Gemini Flash) exhibit behaviors that hurt structured output quality:
- **Anti-delegation**: Models suggest "you could..." instead of generating content directly
- **Length violations**: Gemini Flash ignores schema maxLength constraints (82% exceed 200 char limit)
- **Required field omission**: Models omit `details` dict when empty is semantically invalid
- **ID confusion**: Models confuse path IDs (`path::dilemma__answer`) with dilemma IDs (`dilemma::subject_or_option`)

## Changes

### Pattern C - Anti-Delegation (#666)
- `summarize.yaml`, `summarize_brainstorm.yaml`, `summarize_seed.yaml`, `dress_summarize.yaml`
- Added "NO DELEGATION (CRITICAL)" sections with DO/DO NOT examples

### Pattern A - Required Fields (#671)
- `grow_phase8c_overlays.yaml`
- Added "CRITICAL: Required Field - details" with WRONG/RIGHT examples

### Pattern B - Length Constraints (#672)
- `grow_phase4e_path_arcs.yaml`: path_theme (10-200), path_mood (2-50)
- `grow_phase4f_entity_arcs.yaml`: arc_line (10-200)
- `grow_phase4a_scene_types.yaml`: exit_mood (2-40)
- `grow_phase4d_atmospheric.yaml`: atmospheric_detail (10-200), mood (2-50)
- `grow_phase9_choices.yaml`: label (3-8 words)
- `grow_phase9_continue_labels.yaml`: label (3-6 words)
- `fill_phase0_voice.yaml`: story_title (2-8 words), tone_words (min 1)
- `dress_brief.yaml`: caption (10-60 chars)
- Added "Length Requirements (STRICT)" sections with character counts

### Pattern D - Scope Constraints (#667)
- `serialize_seed_sections.yaml`
- Added "PATH ID vs DILEMMA ID: THE CRITICAL DISTINCTION" with shape recognition rules

## Not Included / Future PRs
- PR 1 (#674) must be merged first for schema changes to be in place
- Runtime validation of length constraints (relies on prompt compliance)

## Test Plan
- Verified YAML syntax for all 14 modified templates
- Manual review of prompt text for clarity and consistency
- Full pipeline testing requires #674 to be merged first

## Risk / Rollback
- Low risk: additive prompt changes only, no behavioral code changes
- Rollback: `git revert` the merge commit

Closes #666, #667, #671, #672

🤖 Generated with [Claude Code](https://claude.com/claude-code)