### PR TITLE
prompt: nudge DREAM/BRAINSTORM to use tools for creative variety

### DIFF
--- a/prompts/templates/discuss.yaml
+++ b/prompts/templates/discuss.yaml
@@ -61,16 +61,25 @@ non_interactive_section: |
   based on the initial prompt. Do NOT ask clarifying questions - interpret
   the prompt and commit to choices that best serve the story idea presented.
 
+  Use search_corpus to find genre conventions and tone techniques for your
+  chosen genre before finalizing your vision.
+
 research_tools_section: |
   ## Research Tools Available
-  You have access to research tools to find relevant examples and techniques:
+  You have access to research tools to expand your creative palette:
   - search_corpus: Search IF Craft Corpus for techniques and examples
   - get_document: Retrieve full documents from the corpus
   - list_clusters: Discover available topic clusters
   - web_search: Search the web for information
   - web_fetch: Fetch content from URLs
 
-  Use these tools when helpful, but don't overuse them - focus on the creative discussion.
+  ### Suggested Searches
+  Consider searching early in the conversation for:
+  - Genre conventions and audience expectations for the chosen genre
+  - Tone and atmosphere techniques that suit the themes
+  - Scope guidance for interactive fiction at the target length
+
+  These searches surface patterns and possibilities beyond your defaults.
 
   ## Structured Options (Interactive Mode)
   When offering the user a choice between distinct options, INVOKE the

--- a/prompts/templates/discuss.yaml
+++ b/prompts/templates/discuss.yaml
@@ -61,8 +61,8 @@ non_interactive_section: |
   based on the initial prompt. Do NOT ask clarifying questions - interpret
   the prompt and commit to choices that best serve the story idea presented.
 
-  Use search_corpus to find genre conventions and tone techniques for your
-  chosen genre before finalizing your vision.
+  Use search_corpus to find genre conventions, tone techniques, and scope
+  guidance. Use web_search for audience expectations or recent genre trends.
 
 research_tools_section: |
   ## Research Tools Available

--- a/prompts/templates/discuss_brainstorm.yaml
+++ b/prompts/templates/discuss_brainstorm.yaml
@@ -96,16 +96,27 @@ non_interactive_section: |
   consistent with the creative vision above. Do NOT ask clarifying questions -
   generate material that aligns with the established genre, tone, and themes.
 
+  Use search_corpus for character archetypes and setting variety for this genre.
+  Use web_search for culturally specific names or real-world inspiration that
+  fits the story's setting.
+
 research_tools_section: |
   ## Research Tools Available
-  You have access to research tools to find relevant examples and techniques:
+  You have access to research tools to expand your creative palette:
   - search_corpus: Search IF Craft Corpus for techniques and examples
   - get_document: Retrieve full documents from the corpus
   - list_clusters: Discover available topic clusters
   - web_search: Search the web for information
   - web_fetch: Fetch content from URLs
 
-  Use these tools when helpful, but focus on creative brainstorming.
+  ### Suggested Searches
+  Consider searching for:
+  - Character archetypes and naming traditions for this genre and cultural setting
+  - Location types and setting variety for interactive fiction
+  - Faction and power structures common to the genre
+
+  Web search can supplement the corpus for culturally specific names, real-world
+  locations, or mythology that fits the story's setting.
 
   ## Structured Options (Interactive Mode)
   INVOKE the `present_options` tool through function calling for structured choices:

--- a/prompts/templates/discuss_brainstorm.yaml
+++ b/prompts/templates/discuss_brainstorm.yaml
@@ -96,9 +96,9 @@ non_interactive_section: |
   consistent with the creative vision above. Do NOT ask clarifying questions -
   generate material that aligns with the established genre, tone, and themes.
 
-  Use search_corpus for character archetypes and setting variety for this genre.
-  Use web_search for culturally specific names or real-world inspiration that
-  fits the story's setting.
+  Use search_corpus for character archetypes, setting variety, and faction
+  structures for this genre. Use web_search for culturally specific names
+  or real-world inspiration that fits the story's setting.
 
 research_tools_section: |
   ## Research Tools Available


### PR DESCRIPTION
## Problem
Small local models (qwen3:4b) produce repetitive creative content — same name patterns, generic tropes, limited cultural diversity. Research tools (corpus search, web search) already exist but the model doesn't reach for them because the current prompt says "use when helpful, but don't overuse them" — too passive.

## Changes
- Replace passive tool-use language in `discuss.yaml` and `discuss_brainstorm.yaml` with concrete `### Suggested Searches` sections listing specific query topics
- Add tool-use directives to autonomous mode sections (naming tools explicitly: `search_corpus`, `web_search`)
- Reframe tools as "expand your creative palette" instead of "find relevant examples"

**DREAM template**: suggests searching for genre conventions, tone techniques, scope guidance
**BRAINSTORM template**: suggests searching for character archetypes, naming traditions, location types, faction structures; highlights web search for culturally specific names

## Not Included / Future PRs
- Corpus content (name databases, trope catalogs) — tracked in [if-craft-corpus#25](https://github.com/pvliesdonk/if-craft-corpus/issues/25)
- Prompt-only approaches to creative variety — tracked in #669

## Test Plan
- `uv run mypy src/` — passed
- `uv run ruff check src/` — passed
- Pre-commit hooks passed (YAML validation, whitespace, etc.)
- Prompt templates are not unit-tested; effectiveness verified via integration runs

## Risk / Rollback
- Low risk — prompt-only change, no code changes
- If models over-search, the "consider" framing (not "must") allows them to skip
- Easily reverted by restoring previous tool-use language

Closes #670

🤖 Generated with [Claude Code](https://claude.com/claude-code)