### PR TITLE
fix(grow): pre-cluster intersection candidates and add structural retry

### DIFF
--- a/prompts/templates/grow_phase3_intersections.yaml
+++ b/prompts/templates/grow_phase3_intersections.yaml
@@ -1,9 +1,9 @@
 name: grow_phase3_intersections
-description: Cluster beats from different dilemmas into intersection scenes
+description: Evaluate pre-screened candidate groups for intersection scenes
 
 system: |
-  You are analyzing story beats to find "intersections" -- scenes where multiple
-  narrative dilemmas meet in the same location or moment.
+  You are evaluating pre-screened candidate groups for story "intersections" --
+  scenes where beats from DIFFERENT dilemmas meet in the same location or moment.
 
   ## What is an Intersection?
   An intersection occurs when beats from DIFFERENT dilemmas naturally occur in the
@@ -11,54 +11,41 @@ system: |
   - The hero meets the mentor (mentor_trust dilemma) at the market where
     the artifact is displayed (artifact_quest dilemma). These beats form an intersection.
 
-  ## Clustering Rules
+  ## Your Task
+  Each candidate group below contains beats that already share a signal (location
+  or entity) and come from different dilemmas. For each group, decide whether the
+  beats form a natural, compelling scene when combined. Select the groups that work
+  and skip those that feel forced.
+
+  ## Rules
   1. Each intersection must contain beats from at least 2 DIFFERENT dilemmas
   1b. Keep intersections SMALL: prefer 2 beats; 3 beats maximum
   2. Beats in an intersection should share a plausible location or moment
-  3. Prefer location overlap as the strongest signal for clustering
-  4. Entity overlap (same character in both beats) is a secondary signal
-  5. CRITICAL: Each beat can appear in at most ONE intersection. Never assign the
-     same beat to multiple intersections.
+  3. Each beat can appear in at most ONE intersection -- if a beat appears in
+     multiple candidate groups, only use it in one intersection proposal
+  4. Do NOT force intersections where there is no natural scene overlap
+  5. Do NOT use beat IDs not listed in the Valid IDs section
 
-  ## Dilemma Matching (CRITICAL)
-  Each beat below is tagged with `[dilemma: ...]`. Use this tag to ensure
-  every intersection mixes beats from DIFFERENT dilemmas. This also means:
-  - An intersection may include at most ONE beat per dilemma (all dilemma tags must be distinct)
-
-  GOOD: beat from [dilemma: dilemma::A] + beat from [dilemma: dilemma::B] = valid (2 different dilemmas)
-  BAD:  beat from [dilemma: dilemma::A] + beat from [dilemma: dilemma::A] = INVALID (same dilemma)
-  BAD:  beat from [dilemma: dilemma::A] + another beat from [dilemma: dilemma::A] + beat from [dilemma: dilemma::B]
-        = INVALID (multiple beats from the same dilemma)
-
-  ## What NOT to Do
-  - Do NOT group beats that share the same [dilemma: ...] tag
-  - Do NOT propose intersections with 4+ beats (max is 3)
-  - Do NOT propose intersections with only 1 beat
-  - Do NOT use beat IDs not listed in the Valid IDs section
-  - Do NOT force intersections where there is no natural scene overlap
-  - Do NOT reuse a beat ID across multiple intersection proposals
-
-  ## Candidate Beats
-  Each beat is tagged with its dilemma in [dilemma: ...]. Mix different dilemmas.
-  {beat_summaries}
+  ## Candidate Groups
+  {candidate_groups}
 
   ## Valid IDs
   Valid beat_ids (use ONLY these): {valid_beat_ids}
-  Total candidates: {candidate_count}
+  Total candidate groups: {candidate_count}
 
   ## Output Format
   Return a JSON object with an "intersections" array. Each intersection has:
-  - beat_ids: list of beat IDs that form the intersection (minimum 2)
+  - beat_ids: list of beat IDs that form the intersection (minimum 2, from DIFFERENT dilemmas)
   - resolved_location: the location where this combined scene takes place (or null)
   - rationale: a concise sentence explaining why these beats form a natural scene
-    (e.g., "Both beats occur at the market and involve the hero interacting with key NPCs")
 
-  Only propose intersections where the beats genuinely share a scene context.
-  If no natural intersections exist, return an empty intersections array.
+  Select groups that genuinely share a scene context.
+  If no groups form natural intersections, return an empty intersections array.
 
 user: |
-  Analyze the candidate beats above and propose intersection groupings.
+  Evaluate the candidate groups above and select which ones form good intersection scenes.
 
   REMINDER: Return ONLY a valid JSON object. Use ONLY IDs from the Valid IDs section. Do NOT add prose before or after the JSON.
+  {structural_feedback}
 
 components: []

--- a/prompts/templates/grow_phase3_intersections.yaml
+++ b/prompts/templates/grow_phase3_intersections.yaml
@@ -3,28 +3,57 @@ description: Evaluate pre-screened candidate groups for intersection scenes
 
 system: |
   You are evaluating pre-screened candidate groups for story "intersections" --
-  scenes where beats from DIFFERENT dilemmas meet in the same location or moment.
+  scenes where beats from DIFFERENT dilemmas converge in the same location or moment.
 
   ## What is an Intersection?
   An intersection occurs when beats from DIFFERENT dilemmas naturally occur in the
-  same scene. For example:
+  same scene.
+
+  GOOD intersection:
   - The hero meets the mentor (mentor_trust dilemma) at the market where
-    the artifact is displayed (artifact_quest dilemma). These beats form an intersection.
+    the artifact is displayed (artifact_quest dilemma). Two beats, two dilemmas,
+    one scene -- the market naturally hosts both events.
+
+  NOT an intersection (reject):
+  - The hero trains alone in the woods (survival dilemma) while the council
+    debates in the city (political dilemma). Same time, but different locations
+    and no shared scene -- these beats do not form a natural combined moment.
 
   ## Your Task
-  Each candidate group below contains beats that already share a signal (location
-  or entity) and come from different dilemmas. For each group, decide whether the
-  beats form a natural, compelling scene when combined. Select the groups that work
-  and skip those that feel forced.
+  Each candidate group below contains beats that share a connection -- either the
+  same location or a common entity -- and come from different dilemmas. For each
+  group, decide whether the beats form a natural scene when combined.
+
+  Accept groups that work. Reject groups that feel forced.
 
   ## Rules
-  1. Each intersection must contain beats from at least 2 DIFFERENT dilemmas
-  1b. Keep intersections SMALL: prefer 2 beats; 3 beats maximum
-  2. Beats in an intersection should share a plausible location or moment
-  3. Each beat can appear in at most ONE intersection -- if a beat appears in
-     multiple candidate groups, only use it in one intersection proposal
-  4. Do NOT force intersections where there is no natural scene overlap
-  5. Do NOT use beat IDs not listed in the Valid IDs section
+  1. Keep intersections SMALL: prefer 2 beats; 3 beats maximum.
+  2. Beats in an intersection must share a plausible location or moment.
+  3. Each beat can appear in at most ONE intersection. If a beat appears in
+     multiple candidate groups, choose the group where it fits most naturally
+     and skip the others that use that beat.
+  4. Do NOT force intersections. Rejecting a weak group is better than
+     accepting a forced one.
+  5. Use ONLY beat IDs from the Valid IDs section. Do not invent or modify IDs.
+
+  ## Output Format
+  Return a JSON object with an "intersections" array. Each element has:
+  - beat_ids: list of 2-3 beat IDs that form the intersection (from DIFFERENT dilemmas)
+  - resolved_location: where this combined scene takes place (string or null)
+  - rationale: one sentence explaining why these beats form a natural scene
+
+  Example (do not copy these IDs -- use the real IDs from the candidate groups):
+  {
+    "intersections": [
+      {
+        "beat_ids": ["beat::market_encounter", "beat::artifact_reveal"],
+        "resolved_location": "the central market",
+        "rationale": "The mentor introduction and artifact discovery both occur at the market."
+      }
+    ]
+  }
+
+  If no groups form natural intersections, return: {"intersections": []}
 
   ## Candidate Groups
   {candidate_groups}
@@ -33,19 +62,10 @@ system: |
   Valid beat_ids (use ONLY these): {valid_beat_ids}
   Total candidate groups: {candidate_count}
 
-  ## Output Format
-  Return a JSON object with an "intersections" array. Each intersection has:
-  - beat_ids: list of beat IDs that form the intersection (minimum 2, from DIFFERENT dilemmas)
-  - resolved_location: the location where this combined scene takes place (or null)
-  - rationale: a concise sentence explaining why these beats form a natural scene
-
-  Select groups that genuinely share a scene context.
-  If no groups form natural intersections, return an empty intersections array.
-
 user: |
-  Evaluate the candidate groups above and select which ones form good intersection scenes.
+  Select which candidate groups form natural intersection scenes.
 
-  REMINDER: Return ONLY a valid JSON object. Use ONLY IDs from the Valid IDs section. Do NOT add prose before or after the JSON.
+  REMINDER: Return ONLY a valid JSON object. Use ONLY beat IDs from the Valid IDs section. Each beat in at most ONE intersection. Do NOT add prose before or after the JSON.
   {structural_feedback}
 
 components: []


### PR DESCRIPTION
## Problem

GROW Phase 3 intersection detection fails on small models (qwen3:4b): the model
groups same-dilemma beats instead of cross-dilemma beats, causing all proposed
intersections to be rejected. Root cause: `build_intersection_candidates()` computes
valid cross-dilemma groups algorithmically but then discards the structure — all beat
IDs are flattened into a single list, and the LLM must rediscover the groups from
scratch.

Observed in `projects/test-qwen3-corpus` where all 8 proposed intersections were
rejected for pairing beats from the same dilemma.

## Changes

- **Pre-cluster candidates**: `format_intersection_candidates()` helper formats
  algorithmically pre-screened candidate groups as numbered sections showing the
  shared signal (location/entity), involved dilemmas, and beat details. The LLM's
  task changes from "discover cross-dilemma groups in a flat list" to "evaluate
  these pre-validated candidate groups."

- **Structural retry loop**: When all proposed intersections are rejected by
  `check_intersection_compatibility()` (e.g. all same-dilemma), the LLM is
  re-invoked with targeted error feedback describing exactly what went wrong.
  Max 2 attempts before declaring failure.

- **Prompt clarity improvements** (from prompt engineer review):
  - Added negative example showing what to reject
  - Moved candidate data after output format (contiguous instructional block)
  - Added concrete JSON example in output format
  - Replaced jargon "signal" with "connection"
  - Added uniqueness reminder in user message (sandwich pattern)

## Not Included / Future PRs

- Brainstorm quantity/headroom improvements (separate concern)
- Entity overlap guidance in brainstorm prompts (separate concern)

## Test Plan

```bash
uv run pytest tests/unit/test_grow_algorithms.py -x -q -k "format_intersection"  # 6 passed
uv run pytest tests/unit/test_grow_stage.py -x -q -k "phase_3"                   # 8 passed (7 existing + 1 new)
uv run pytest tests/unit/ -x -q                                                  # 2416 passed
uv run mypy src/questfoundry/graph/grow_algorithms.py src/questfoundry/pipeline/stages/grow.py  # clean
uv run ruff check src/                                                           # clean
```

## Risk / Rollback

- Low risk: prompt and context formatting changes only; validation logic unchanged
- Structural retry adds at most 1 extra LLM call per stage run when intersections fail
- Rollback: revert the 3 commits

🤖 Generated with [Claude Code](https://claude.com/claude-code)