### PR TITLE
fix(prompts): rewrite summarize prompts to enforce condensation contract

### DIFF
--- a/prompts/templates/summarize.yaml
+++ b/prompts/templates/summarize.yaml
@@ -15,7 +15,7 @@ system: |
   - Content notes (what to include/exclude)
 
   ## NO DELEGATION (CRITICAL)
-  You are GENERATING the summary, not suggesting how to generate it.
+  You are writing the summary, not suggesting how to write it.
 
   DO NOT write:
   - "The genre could be determined by..."

--- a/prompts/templates/summarize_brainstorm.yaml
+++ b/prompts/templates/summarize_brainstorm.yaml
@@ -8,19 +8,19 @@ system: |
   Condense the conversation into a **prose brief** that captures all discussed story elements.
   Write in natural language paragraphs and bullet points - NOT structured data fields.
 
-  ### Characters (aim for {size_characters})
+  ### Characters (list all discussed)
   Describe each character discussed:
   - Who they are and their role in the story
   - Key traits, motivations, or secrets
   - Any relationships or conflicts mentioned
 
-  ### Locations (aim for {size_locations})
+  ### Locations (list all discussed)
   Describe each location discussed:
   - What the place is and its atmosphere
   - Why it matters to the story
   - Any secrets or special features
 
-  ### Objects (aim for {size_objects})
+  ### Objects (list all discussed)
   Describe significant objects discussed:
   - What the object is
   - Why it's important (clue, macguffin, symbol, etc.)
@@ -30,7 +30,7 @@ system: |
   - What they are and their goals
   - Key members or relationships
 
-  ### Dramatic Dilemmas (aim for {size_dilemmas})
+  ### Dramatic Dilemmas (list all discussed)
   For each dilemma, describe in prose:
   - The central question or conflict
   - The two possible answers/outcomes (one being the "default path")

--- a/prompts/templates/summarize_brainstorm.yaml
+++ b/prompts/templates/summarize_brainstorm.yaml
@@ -38,7 +38,7 @@ system: |
   - Why this dilemma matters thematically
 
   ## NO DELEGATION (CRITICAL)
-  You are GENERATING the summary, not suggesting how to generate it.
+  You are writing the summary, not suggesting how to write it.
 
   DO NOT write:
   - "The characters could include..."

--- a/prompts/templates/summarize_seed.yaml
+++ b/prompts/templates/summarize_seed.yaml
@@ -83,7 +83,7 @@ system: |
 
   ### Initial Beats ({size_beats_per_path} per path)
   For each opening beat, provide a beat sketch:
-  - id: unique beat identifier
+  - beat_id: unique beat identifier
   - summary: one sentence describing what happens
   - location: primary location entity ID (must be a retained location)
   - entities: key entity IDs present in this beat

--- a/prompts/templates/summarize_seed.yaml
+++ b/prompts/templates/summarize_seed.yaml
@@ -6,7 +6,7 @@ system: |
   This is the SEED stage output - the committed foundation for the story.
 
   ## NO DELEGATION (CRITICAL)
-  You are GENERATING the complete story structure, not suggesting how to generate it.
+  You are condensing a story architecture discussion into structured output, not suggesting how to do it.
 
   DO NOT write:
   - "The paths could be structured as..."
@@ -14,15 +14,15 @@ system: |
   - "Consider making this a major path..."
 
   DO write the actual entity decisions, paths, and beats directly.
-  Your output IS the committed story structure.
+  Your output captures the committed decisions from the discussion.
 
   ## CRITICAL: Manifest Completeness
   Your summary MUST include explicit decisions for:
   - ALL {entity_count} entities listed below
   - ALL {dilemma_count} dilemmas listed below
 
-  This is GENERATION, not extraction. Even if an entity/dilemma wasn't discussed,
-  you must still include a decision for it (use your judgment to retain or cut).
+  If an entity or dilemma was not discussed, write "not decided" for that item.
+  Do not invent decisions that were not made in the conversation.
 
   ## Summarization Priority Order
 
@@ -82,17 +82,12 @@ system: |
   - ripples: story effects this implies
 
   ### Initial Beats ({size_beats_per_path} per path)
-  For each opening beat:
+  For each opening beat, provide a beat sketch:
   - id: unique beat identifier
-  - summary: what happens in this beat
-  - paths: list of path IDs this beat serves
-  - dilemma_impacts: how this beat affects dilemmas
-    - dilemma_id: which dilemma
-    - effect: "advances", "reveals", "commits", or "complicates"
-    - note: explanation of the impact
-  - entities: entity IDs present in this beat
+  - summary: one sentence describing what happens
   - location: primary location entity ID (must be a retained location)
-  - location_alternatives: other valid location IDs for flexibility
+  - entities: key entity IDs present in this beat
+  - paths: list of path IDs this beat serves
 
   **Location Diversity**: Use at least 2 different locations across your beats.
 

--- a/src/questfoundry/agents/serialize.py
+++ b/src/questfoundry/agents/serialize.py
@@ -1384,9 +1384,9 @@ async def serialize_seed_as_function(
             # retried upstream data is available for downstream retries.
             sorted_section_names = sorted(
                 section_errors.keys(),
-                key=lambda s: _SECTION_ORDER.index(s)
-                if s in _SECTION_ORDER
-                else len(_SECTION_ORDER),
+                key=lambda s: (
+                    _SECTION_ORDER.index(s) if s in _SECTION_ORDER else len(_SECTION_ORDER)
+                ),
             )
 
             for section_name in sorted_section_names:


### PR DESCRIPTION
## Problem

The SEED summarize prompt says "This is GENERATION, not extraction" and instructs the LLM to invent decisions for undiscussed items (#680). This violates the discuss-summarize-serialize contract, causing 1.87x output inflation and 20-min latency on slow models. A cross-stage audit also found BRAINSTORM's "aim for {size_X}" targets nudge invention beyond what was discussed.

## Changes

- **`summarize_seed.yaml`**: Rewrite to enforce condensation contract:
  - Remove "GENERATING the complete story structure" framing → "condensing a discussion into structured output"
  - Replace "GENERATION, not extraction" gap-filling → gap-flagging ("not decided" for undiscussed items)
  - Simplify beat schema from 7-field objects (with `dilemma_impacts`, `location_alternatives`) to beat sketches (summary, location, entities, paths)
- **`summarize_brainstorm.yaml`**: Replace "aim for {size_X}" count targets with "list all discussed"
- **`summarize.yaml`**: Cosmetic consistency — "GENERATING" → "writing"

## Not Included / Future PRs

- FILL prose quality improvements (expand-prose split, mechanical quality gate) → #681
- No Python code changes — prompt-only fix

## Test Plan

```
uv run pytest tests/unit/test_seed_prompts.py tests/unit/test_summarize.py tests/unit/test_prompt_human_prefix.py -x -q
# 35 passed
```

## Risk / Rollback

- Prompt-only change, no code modifications
- Existing SEED runs may produce different (less inflated) output — this is the desired effect
- Rollback: revert the 3 prompt files

Closes #680