### PR TITLE
feat(fill): integrate expand-prose split into Phase 1 pipeline

### DIFF
--- a/prompts/templates/fill_phase1_expand.yaml
+++ b/prompts/templates/fill_phase1_expand.yaml
@@ -41,6 +41,8 @@ system: |
 user: |
   Generate blueprints for the {passage_count} passages listed above.
 
+  CRITICAL: Avoid all items from the Used Imagery blocklist — find fresh sensory material.
+
   Return a JSON object with a "blueprints" array. Each blueprint must have:
   - passage_id (matching the ID above exactly)
   - sensory_palette (3–8 sense-tagged items)

--- a/prompts/templates/fill_phase1_expand.yaml
+++ b/prompts/templates/fill_phase1_expand.yaml
@@ -1,0 +1,52 @@
+name: fill_phase1_expand
+description: Generate scene blueprints for a batch of passages (expand phase)
+
+system: |
+  You are building scene blueprints for interactive fiction passages. Each blueprint
+  provides concrete materials — sensory palette, character gestures, opening move,
+  and an emotional arc word — that the prose writer will render into final text.
+
+  ## Voice Document
+  {voice_document}
+
+  ## Story Identity
+  {story_identity}
+
+  ## Passages to Blueprint
+
+  {passages_batch}
+
+  ## Used Imagery (DO NOT REUSE)
+  {used_imagery_blocklist}
+
+  ## Rules
+
+  1. **Sensory palette**: 3–8 items. Tag each by sense (sight, sound, smell,
+     touch, taste). Avoid items from the blocklist above. Prefer concrete,
+     specific detail over generic atmosphere.
+  2. **Character gestures**: 0–4 physical micro-actions that reveal emotional
+     state without naming the emotion. Leave empty for micro_beats.
+  3. **Opening move**: Choose the strongest entry point for this scene type
+     and narrative function. One of: dialogue, action, sensory_image,
+     internal_thought.
+  4. **Emotional arc word**: A single word capturing the passage's emotional
+     trajectory — not the mood, but the movement (e.g., "dread", "resolve",
+     "unraveling").
+  5. **Craft constraint**: {craft_constraint_instruction}
+  6. One blueprint per passage. Match passage_id exactly.
+  7. Blueprints are materials, not outlines. Do NOT write prose or summary.
+
+  {output_language_instruction}
+
+user: |
+  Generate blueprints for the {passage_count} passages listed above.
+
+  Return a JSON object with a "blueprints" array. Each blueprint must have:
+  - passage_id (matching the ID above exactly)
+  - sensory_palette (3–8 sense-tagged items)
+  - character_gestures (0–4 items, empty list for micro_beats)
+  - opening_move (dialogue | action | sensory_image | internal_thought)
+  - craft_constraint (copy from the passage details above, or empty string)
+  - emotional_arc_word (single word)
+
+components: []

--- a/prompts/templates/fill_phase1_prose_only.yaml
+++ b/prompts/templates/fill_phase1_prose_only.yaml
@@ -34,20 +34,8 @@ system: |
   - **micro_beat**: Brief transition. 1 paragraph. Functional prose that moves
     the story forward without dwelling. Prefer a single concrete action or image.
 
-  ## Narrative Function Guidance
-  - **introduce**: Ground the reader. Establish new elements through sensory detail
-    and action, not exposition. End with a hook or question.
-  - **develop**: Deepen what is already known. Layer in contradiction, nuance, or
-    intimacy. Show character through choice, not description.
-  - **complicate**: Raise stakes or introduce obstacles. The reader should feel
-    the ground shift. End with the situation worse or more uncertain.
-  - **confront**: Direct engagement with tension. Strip away ambiguity. Force
-    characters (and reader) to face what they have been avoiding.
-  - **resolve**: Settle a thread. Provide earned clarity — not easy answers.
-    The resolution should feel inevitable in hindsight.
-
-  ## Atmospheric Detail
-  {atmospheric_detail}
+  ## Scene Blueprint
+  {blueprint_context}
 
   ## Entry States
   {entry_states}
@@ -84,28 +72,18 @@ system: |
 
   1. Follow the voice document for POV, tense, register, rhythm, and tone
   2. Match the scene type guidance for length and structure
-  3. Match the narrative function guidance for dramatic purpose
-  4. Match the target length — do not over-write micro_beats or under-write confrontations
-  5. Cover the beat summary content — do not invent major plot points
-  6. Maintain continuity with the sliding window passages
-  7. Let open dramatic questions create subtext — do not resolve them unless
-     this beat commits to an answer
-  8. Build toward the exit mood through imagery and rhythm — do not state it directly
-  9. DO NOT repeat phrases, metaphors, or sentence structures from the sliding
-      window. Each passage must use fresh imagery and vocabulary. If the previous
-      passages used a metaphor (e.g., "like a wound"), find a different one.
-  10. Every scene and sequel MUST contain at least one line of dialogue or one
-      concrete physical action (a character doing something with their body, not
-      just thinking or feeling).
-  11. Dialogue tags: prefer "said" or no tag. Use action beats instead of
-      adverb-laden tags or said-bookisms.
-      BAD: "she whispered softly", "he retorted angrily"
-      GOOD: She leaned closer. "..." / He slammed the glass down. "..."
-  12. NEVER name the theme, mood, or emotion directly in prose. Show it through
-      what characters do, notice, or fail to notice.
-      BAD: "A wave of grief washed over her." / "He felt angry."
-      GOOD: "She picked up his coffee mug, still warm, and held it with both hands."
-      GOOD: "His jaw tightened. He set down the glass without drinking."
+  3. Match the target length — do not over-write micro_beats or under-write confrontations
+  4. Cover the beat summary content and maintain continuity with the sliding window
+  5. Use the scene blueprint's materials — weave at least 3 sensory palette items
+     into the prose and follow the opening move. Do not substitute generic
+     alternatives. If no blueprint is available, use atmospheric detail and
+     narrative context above.
+  6. Let open dramatic questions create subtext; build toward the exit mood
+     through imagery and rhythm — do not state emotions, themes, or moods
+     directly. Dialogue tags: prefer "said" or action beats.
+     BAD: "A wave of grief washed over her." / "she whispered softly"
+     GOOD: "She picked up his coffee mug, still warm, and held it with both hands."
+     GOOD: She leaned closer. "..." / He slammed the glass down. "..."
 
   {ending_guidance}
 

--- a/prompts/templates/fill_phase3_revision.yaml
+++ b/prompts/templates/fill_phase3_revision.yaml
@@ -13,6 +13,9 @@ system: |
   **Issue Type:** {issue_type}
   **Issue Description:** {issue_description}
 
+  ## Scene Blueprint
+  {blueprint_context}
+
   ## Current Prose
   {current_prose}
 
@@ -33,8 +36,12 @@ system: |
     and correct your version to match.
   - **convergence_awkwardness**: Rewrite to work for all arriving paths. Use
     ambiguous phrasing. Avoid path-specific knowledge.
-  - **flat_prose**: Add sensory detail, emotional interiority, and dilemma
-    tension. Show, don't tell. Ground the reader in the moment.
+  - **flat_prose**: The scene blueprint may have stale materials. Add fresh
+    sensory detail, emotional interiority, and dilemma tension. Show, don't
+    tell. Ground the reader in the moment.
+  - **blueprint_bleed**: The scene blueprint leaked into prose (listing palette
+    items mechanically, clinical opening). Render the materials organically —
+    the blueprint is raw material, not an outline to follow literally.
 
   {output_language_instruction}
 

--- a/src/questfoundry/graph/fill_context.py
+++ b/src/questfoundry/graph/fill_context.py
@@ -2025,3 +2025,70 @@ def extract_used_imagery(
 
     blocklist.extend(repeated_words[: top_n - len(blocklist)])
     return blocklist[:top_n]
+
+
+def format_blueprint_context(blueprint: dict[str, object] | None) -> str:
+    """Format an expand blueprint for the prose generation prompt.
+
+    When a blueprint exists, renders its materials (sensory palette,
+    gestures, opening move, etc.) as structured context. When absent,
+    returns a fallback instruction.
+
+    Args:
+        blueprint: Blueprint dict from passage node, or None.
+
+    Returns:
+        Formatted blueprint context string.
+    """
+    if not blueprint:
+        return "(no blueprint available — use atmospheric detail and narrative context above)"
+
+    lines: list[str] = []
+
+    palette = blueprint.get("sensory_palette", [])
+    if palette and isinstance(palette, list):
+        lines.append("**Sensory Palette** (weave at least 3 into prose):")
+        for item in palette:
+            lines.append(f"  - {item}")
+
+    gestures = blueprint.get("character_gestures", [])
+    if gestures and isinstance(gestures, list):
+        lines.append("**Character Gestures:**")
+        for g in gestures:
+            lines.append(f"  - {g}")
+
+    opening = blueprint.get("opening_move", "")
+    if opening:
+        lines.append(f"**Opening Move:** {opening}")
+
+    constraint = blueprint.get("craft_constraint", "")
+    if constraint:
+        lines.append(f"**Craft Constraint:** {constraint}")
+
+    arc_word = blueprint.get("emotional_arc_word", "")
+    if arc_word:
+        lines.append(f"**Emotional Arc Word:** {arc_word}")
+
+    return "\n".join(lines) if lines else "(empty blueprint)"
+
+
+def format_used_imagery_blocklist(blocklist: list[str]) -> str:
+    """Format an imagery blocklist for the expand prompt.
+
+    Args:
+        blocklist: List of overused imagery strings from
+            :func:`extract_used_imagery`.
+
+    Returns:
+        Formatted blocklist, or a note that no repetition was detected.
+    """
+    if not blocklist:
+        return "(no repeated imagery detected — you have full creative freedom)"
+
+    lines = ["These images and phrases appeared in recent passages. DO NOT reuse them:"]
+    for item in blocklist:
+        lines.append(f'  - "{item}"')
+    lines.append("")
+    lines.append("Find fresh sensory material instead.")
+
+    return "\n".join(lines)

--- a/src/questfoundry/graph/fill_context.py
+++ b/src/questfoundry/graph/fill_context.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 import re
 from collections import Counter
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import yaml
 
@@ -2027,12 +2027,15 @@ def extract_used_imagery(
     return blocklist[:top_n]
 
 
-def format_blueprint_context(blueprint: dict[str, object] | None) -> str:
+def format_blueprint_context(blueprint: dict[str, Any] | None) -> str:
     """Format an expand blueprint for the prose generation prompt.
 
     When a blueprint exists, renders its materials (sensory palette,
     gestures, opening move, etc.) as structured context. When absent,
     returns a fallback instruction.
+
+    Uses ``dict[str, Any]`` because blueprints are stored as plain dicts
+    on graph nodes (not typed models) for serialization flexibility.
 
     Args:
         blueprint: Blueprint dict from passage node, or None.

--- a/src/questfoundry/pipeline/stages/fill.py
+++ b/src/questfoundry/pipeline/stages/fill.py
@@ -35,7 +35,9 @@ from questfoundry.graph.fill_context import (
     compute_first_appearances,
     compute_is_ending,
     compute_lexical_diversity,
+    extract_used_imagery,
     format_atmospheric_detail,
+    format_blueprint_context,
     format_continuity_warning,
     format_dramatic_questions,
     format_dream_vision,
@@ -55,6 +57,7 @@ from questfoundry.graph.fill_context import (
     format_sliding_window,
     format_spoke_context,
     format_story_identity,
+    format_used_imagery_blocklist,
     format_valid_characters,
     format_vocabulary_note,
     format_voice_context,
@@ -63,6 +66,7 @@ from questfoundry.graph.fill_context import (
 )
 from questfoundry.graph.graph import Graph
 from questfoundry.models.fill import (
+    BatchedExpandOutput,
     FillExtractOutput,
     FillPhase0Output,
     FillPhase1Output,
@@ -317,7 +321,9 @@ class FillStage:
         """
         return [
             (self._phase_0_voice, "voice"),
+            (self._phase_1a_expand, "expand"),
             (self._phase_1_generate, "generate"),
+            (self._phase_1c_mechanical_gate, "quality_gate"),
             (self._phase_2_review, "review"),
             (self._phase_3_revision, "revision"),
             (self._phase_4_arc_validation, "arc_validation"),
@@ -951,6 +957,164 @@ class FillStage:
 
         return order
 
+    _EXPAND_BATCH_SIZE = 8
+
+    async def _phase_1a_expand(
+        self,
+        graph: Graph,
+        model: BaseChatModel,
+    ) -> FillPhaseResult:
+        """Phase 1a: Expand — generate scene blueprints for passages.
+
+        Groups passages by arc, chunks of ~8, generates ExpandBlueprint
+        for each passage via batched LLM calls. Blueprints are stored
+        on passage nodes for consumption by Phase 1 generate.
+        """
+        from collections import deque
+        from random import Random
+
+        from questfoundry.pipeline.craft_constraints import select_constraint
+
+        generation_order = self._get_generation_order(graph)
+        if not generation_order:
+            return FillPhaseResult(
+                phase="expand", status="completed", detail="no passages to expand"
+            )
+
+        voice_context = format_voice_context(graph)
+        story_identity_context = format_story_identity(graph)
+
+        # Collect recent prose for imagery blocklist
+        passage_nodes = graph.get_nodes_by_type("passage")
+        recent_prose = [
+            pdata.get("prose", "") for pdata in passage_nodes.values() if pdata.get("prose")
+        ]
+        blocklist = extract_used_imagery(recent_prose)
+        blocklist_text = format_used_imagery_blocklist(blocklist)
+
+        # Craft constraint tracking
+        rng = Random(42)
+        recently_used: deque[str] = deque(maxlen=5)
+
+        # Build chunks across all arcs
+        arc_groups: dict[str, list[str]] = {}
+        for passage_id, arc_id in generation_order:
+            arc_groups.setdefault(arc_id, []).append(passage_id)
+
+        chunks: list[tuple[list[str], str]] = []
+        for arc_id, passage_ids in arc_groups.items():
+            for i in range(0, len(passage_ids), self._EXPAND_BATCH_SIZE):
+                batch = passage_ids[i : i + self._EXPAND_BATCH_SIZE]
+                chunks.append((batch, arc_id))
+
+        # Pre-compute craft constraints for all passages (must be sequential
+        # to maintain recently-used dedup across chunks).
+        passage_constraints: dict[str, str] = {}
+        for passage_id, _arc_id in generation_order:
+            passage = graph.get_node(passage_id)
+            if not passage:
+                continue
+            beat_id = passage.get("from_beat", "")
+            beat = graph.get_node(beat_id) if beat_id else None
+            nf = beat.get("narrative_function", "develop") if beat else "develop"
+            constraint = select_constraint(nf, recently_used, rng=rng)
+            if constraint:
+                recently_used.append(constraint)
+            passage_constraints[passage_id] = constraint
+
+        async def _expand_chunk(
+            chunk_data: tuple[list[str], str],
+        ) -> tuple[list[dict[str, Any]], int, int]:
+            chunk_ids, _chunk_arc = chunk_data
+
+            passage_lines: list[str] = []
+            for pid in chunk_ids:
+                passage = graph.get_node(pid)
+                if not passage:
+                    continue
+                beat_id = passage.get("from_beat", "")
+                beat = graph.get_node(beat_id) if beat_id else None
+                beat_summary = beat.get("summary", "") if beat else ""
+                scene_type = beat.get("scene_type", "scene") if beat else "scene"
+                nf = beat.get("narrative_function", "develop") if beat else "develop"
+                entities = passage.get("entities", [])
+                entity_names = [
+                    (graph.get_node(eid) or {}).get("raw_id", eid)
+                    for eid in entities
+                    if graph.has_node(eid)
+                ]
+                constraint = passage_constraints.get(pid, "")
+                raw_id = passage.get("raw_id", pid)
+
+                passage_lines.append(f"### {raw_id}")
+                passage_lines.append(f"- **Beat Summary:** {beat_summary}")
+                passage_lines.append(f"- **Scene Type:** {scene_type}")
+                passage_lines.append(f"- **Narrative Function:** {nf}")
+                if entity_names:
+                    passage_lines.append(f"- **Characters:** {', '.join(entity_names)}")
+                if constraint:
+                    passage_lines.append(f"- **Craft Constraint:** {constraint}")
+                    passage_lines.append(
+                        "  Follow this unless you can demonstrably serve "
+                        "the scene better with a different approach."
+                    )
+                else:
+                    passage_lines.append("- **Craft Constraint:** (none for this passage)")
+                passage_lines.append("")
+
+            context = {
+                "voice_document": voice_context,
+                "story_identity": story_identity_context,
+                "passages_batch": "\n".join(passage_lines),
+                "used_imagery_blocklist": blocklist_text,
+                "craft_constraint_instruction": (
+                    "Copy the craft constraint from each passage's details above. "
+                    "If a passage has no constraint, leave craft_constraint as an empty string."
+                ),
+                "passage_count": str(len(chunk_ids)),
+                "output_language_instruction": self._lang_instruction,
+            }
+
+            output, llm_calls, tokens = await self._fill_llm_call(
+                model,
+                "fill_phase1_expand",
+                context,
+                BatchedExpandOutput,
+                creative=True,
+            )
+
+            return [bp.model_dump() for bp in output.blueprints], llm_calls, tokens
+
+        results, total_llm_calls, total_tokens, _errors = await batch_llm_calls(
+            chunks, _expand_chunk, self._max_concurrency
+        )
+
+        # Store blueprints on passage nodes
+        blueprints_created = 0
+        for blueprints in results:
+            if blueprints is None:
+                continue
+            for bp_dict in blueprints:
+                pid = bp_dict.get("passage_id", "")
+                full_pid = pid if pid.startswith("passage::") else f"passage::{pid}"
+                if graph.has_node(full_pid):
+                    graph.update_node(full_pid, blueprint=bp_dict)
+                    blueprints_created += 1
+
+        log.info(
+            "expand_complete",
+            blueprints_created=blueprints_created,
+            total_passages=len(generation_order),
+        )
+
+        return FillPhaseResult(
+            phase="expand",
+            status="completed",
+            detail=f"{blueprints_created} blueprints for {len(generation_order)} passages",
+            llm_calls=total_llm_calls,
+            tokens_used=total_tokens,
+        )
+
     async def _phase_1_generate(
         self,
         graph: Graph,
@@ -1025,6 +1189,12 @@ class FillStage:
                 else ""
             )
 
+            # Blueprint from expand phase (if available)
+            blueprint = passage.get("blueprint")
+            blueprint_ctx = format_blueprint_context(blueprint)
+            # When blueprint is present, it subsumes atmospheric detail
+            atmo_detail = "" if blueprint else format_atmospheric_detail(graph, passage_id)
+
             context = {
                 "voice_document": voice_context,
                 "story_identity": story_identity_context,
@@ -1033,7 +1203,8 @@ class FillStage:
                 "scene_type": scene_type,
                 "dramatic_questions": format_dramatic_questions(graph, arc_id, beat_id),
                 "narrative_context": format_narrative_context(graph, passage_id),
-                "atmospheric_detail": format_atmospheric_detail(graph, passage_id),
+                "blueprint_context": blueprint_ctx,
+                "atmospheric_detail": atmo_detail,
                 "entry_states": entry_states_text,
                 "entity_states": format_entity_states(graph, passage_id),
                 "entity_arc_context": format_entity_arc_context(graph, passage_id, arc_id),
@@ -1448,12 +1619,24 @@ class FillStage:
             local_tokens = 0
             outputs: list[FillPhase1Output] = []
 
+            # Blueprint context for revision guidance
+            blueprint = passage.get("blueprint")
+            bp_ctx = format_blueprint_context(blueprint)
+
             for flag_data in flags:
+                issue_type = flag_data.get("issue_type", "")
+
+                # For flat_prose/blueprint_bleed, clear stale blueprint
+                # so the revision prompt doesn't anchor on bad materials.
+                if issue_type in ("flat_prose", "blueprint_bleed") and blueprint:
+                    bp_ctx = format_blueprint_context(None)
+
                 context = {
                     "voice_document": voice_context,
                     "passage_id": passage.get("raw_id", passage_id),
-                    "issue_type": flag_data.get("issue_type", ""),
+                    "issue_type": issue_type,
                     "issue_description": flag_data.get("issue", ""),
+                    "blueprint_context": bp_ctx,
                     "current_prose": current_prose,
                     "extended_window": (
                         format_sliding_window(graph, arc_id, current_idx, window_size=5)


### PR DESCRIPTION
## Problem

Small models (qwen3:4b) produce repetitive, flat prose in FILL — recycled imagery, same emotional register, near-duplicate passages. Even gpt-oss:20b shows early signs ("amber glow" in 5/9 passages, "weight of choice" in 7/9). Splitting prose generation into Expand (scene blueprint) → Prose (render from blueprint) gives the model structured creative material to work with, reducing repetition.

Closes #681

## Changes

- **New prompt** `fill_phase1_expand.yaml`: Batched expand prompt generates scene blueprints (sensory palette, character gestures, opening move, craft constraint, emotional arc word) for chunks of ~8 passages per arc
- **Simplified** `fill_phase1_prose_only.yaml`: Replaced Narrative Function Guidance + Atmospheric Detail with Scene Blueprint section; 12 rules → 6 (rules subsumed by blueprint removed)
- **Updated** `fill_phase3_revision.yaml`: Added blueprint context section and `blueprint_bleed` revision guidance
- **New helpers** in `fill_context.py`: `format_blueprint_context()` and `format_used_imagery_blocklist()`
- **New phase** `_phase_1a_expand()` in `fill.py`: Per-arc batched blueprint generation with craft constraint pre-selection and used-imagery blocklist
- **Modified** `_phase_1_generate()`: Consumes blueprints, clears atmospheric detail when blueprint exists
- **Modified** `_phase_3_revision()`: Blueprint-aware revision routing — clears stale blueprint for `flat_prose`/`blueprint_bleed`, preserves for other flags
- **Wired** expand + quality gate into `_phase_order()` (5 → 7 phases)
- **Backward compatible**: Passages without blueprints fall back to atmospheric detail

## Not Included / Future PRs

- Full re-expand on revision (currently clears blueprint context for flat_prose/blueprint_bleed — a follow-up could regenerate blueprints)
- E2E testing with actual LLM calls

## Test Plan

```bash
uv run pytest tests/unit/test_fill_stage.py tests/unit/test_fill_context.py tests/unit/test_fill_models.py tests/unit/test_craft_constraints.py -x -q
# 67 stage tests, 164 context tests, 59 models/constraints tests — all pass
uv run mypy src/questfoundry/pipeline/stages/fill.py src/questfoundry/graph/fill_context.py  # clean
uv run ruff check src/ prompts/  # clean
```

New tests added:
- `TestPhase1aExpand` (3 tests): blueprint creation, empty graph, blueprint context in generate
- `TestFormatBlueprintContext` (6 tests): None/empty/full/partial blueprints
- `TestFormatUsedImageryBlocklist` (3 tests): empty/single/multiple items
- Updated phase ordering tests for 7-phase pipeline

## Risk / Rollback

- **Backward compatible**: `_phase_1_generate()` checks `passage.get("blueprint")` — if absent, falls back to current behavior
- **No schema changes**: Uses `ExpandBlueprint` and `BatchedExpandOutput` from PR #683
- Rollback: revert this PR; prose generation falls back to atmospheric detail path

## Review Guide

Suggested review order:
1. `prompts/templates/fill_phase1_expand.yaml` — new expand prompt
2. `prompts/templates/fill_phase1_prose_only.yaml` — simplified prose prompt
3. `src/questfoundry/graph/fill_context.py` — new format helpers
4. `src/questfoundry/pipeline/stages/fill.py` — expand phase + pipeline wiring
5. `prompts/templates/fill_phase3_revision.yaml` — revision prompt changes
6. Test files