### PR TITLE
feat(pipeline): detect connectivity loss and prompt for retry on TTY

### DIFF
--- a/src/questfoundry/pipeline/batching.py
+++ b/src/questfoundry/pipeline/batching.py
@@ -19,6 +19,44 @@ log = get_logger(__name__)
 T = TypeVar("T")
 Item = TypeVar("Item")
 
+_MAX_CONNECTIVITY_RETRIES = 3
+
+
+def is_connectivity_error(exc: Exception) -> bool:
+    """Check if an exception indicates provider connectivity loss.
+
+    Recognises httpx network/timeout errors, Python built-in
+    ConnectionError, and QuestFoundry's ProviderConnectionError.
+    Walks the ``__cause__`` chain so LangChain-wrapped errors are
+    also detected.
+    """
+    import httpx
+
+    from questfoundry.providers.base import ProviderConnectionError
+
+    if isinstance(
+        exc,
+        (
+            httpx.NetworkError,  # ConnectError, ReadError, WriteError, CloseError
+            httpx.TimeoutException,  # ConnectTimeout, ReadTimeout, PoolTimeout
+            ConnectionError,  # Python built-in (Refused, Reset, Aborted)
+            ProviderConnectionError,  # QF's own type
+        ),
+    ):
+        return True
+
+    # LangChain may wrap httpx errors — walk the cause chain
+    cause = exc.__cause__
+    if cause is not None and isinstance(cause, Exception):
+        return is_connectivity_error(cause)
+
+    return False
+
+
+def _is_connectivity_loss(errors: list[tuple[int, Exception]]) -> bool:
+    """Return True when all errors are connectivity errors and >= 2 items failed."""
+    return len(errors) >= 2 and all(is_connectivity_error(e) for _, e in errors)
+
 
 async def batch_llm_calls(
     items: list[Item],
@@ -26,6 +64,7 @@ async def batch_llm_calls(
     max_concurrency: int = 2,
     *,
     fail_fast: bool = False,
+    on_connectivity_error: Callable[[int, int, str], Awaitable[bool]] | None = None,
 ) -> tuple[list[T | None], int, int, list[tuple[int, Exception]]]:
     """Run LLM calls concurrently with bounded parallelism.
 
@@ -36,6 +75,12 @@ async def batch_llm_calls(
         max_concurrency: Maximum concurrent calls (from ModelInfo).
         fail_fast: If True, cancel remaining tasks on first error.
             If False (default), collect errors and continue.
+        on_connectivity_error: Optional async callback invoked when all
+            batch errors are connectivity failures. Receives
+            ``(failed_count, total_count, error_sample)`` and returns
+            ``True`` to retry failed items or ``False`` to accept the
+            failure.  When ``None``, no retry is attempted (backward
+            compatible).
 
     Returns:
         Tuple of:
@@ -54,7 +99,14 @@ async def batch_llm_calls(
     errors: list[tuple[int, Exception]] = []
     errors_lock = asyncio.Lock()
 
-    async def _run_one(idx: int, item: Item) -> None:
+    async def _run_one(
+        idx: int,
+        item: Item,
+        target_errors: list[tuple[int, Exception]],
+        target_lock: asyncio.Lock,
+        *,
+        raise_on_fail: bool = False,
+    ) -> None:
         async with semaphore:
             try:
                 result, calls, tokens = await call_fn(item)
@@ -62,20 +114,22 @@ async def batch_llm_calls(
                 llm_calls_list[idx] = calls
                 tokens_list[idx] = tokens
             except Exception as e:
-                async with errors_lock:
-                    errors.append((idx, e))
+                async with target_lock:
+                    target_errors.append((idx, e))
                 log.warning(
                     "batch_item_failed",
                     index=idx,
                     error=str(e),
                 )
-                if fail_fast:
+                if raise_on_fail:
                     raise
 
-    tasks = [asyncio.create_task(_run_one(i, item)) for i, item in enumerate(items)]
+    tasks = [
+        asyncio.create_task(_run_one(i, item, errors, errors_lock, raise_on_fail=fail_fast))
+        for i, item in enumerate(items)
+    ]
 
     if fail_fast:
-        # Cancel remaining on first failure
         try:
             await asyncio.gather(*tasks)
         except Exception:
@@ -85,6 +139,46 @@ async def batch_llm_calls(
             await asyncio.gather(*tasks, return_exceptions=True)
     else:
         await asyncio.gather(*tasks, return_exceptions=True)
+
+    # --- Connectivity retry loop ---
+    retry_count = 0
+    while (
+        on_connectivity_error is not None
+        and retry_count < _MAX_CONNECTIVITY_RETRIES
+        and _is_connectivity_loss(errors)
+    ):
+        sample_error = str(errors[0][1])
+        should_retry = await on_connectivity_error(len(errors), len(items), sample_error)
+        if not should_retry:
+            break
+
+        retry_count += 1
+        failed_indices = [idx for idx, _ in errors]
+        log.info(
+            "batch_connectivity_retry",
+            retry=retry_count,
+            failed_items=len(failed_indices),
+        )
+
+        # Reset errors — retry only the previously failed items
+        retry_errors: list[tuple[int, Exception]] = []
+        retry_lock = asyncio.Lock()
+
+        retry_tasks = [
+            asyncio.create_task(_run_one(idx, items[idx], retry_errors, retry_lock))
+            for idx in failed_indices
+        ]
+        await asyncio.gather(*retry_tasks, return_exceptions=True)
+        errors = retry_errors
+
+    # Log connectivity loss at ERROR level for visibility (even without hook)
+    if _is_connectivity_loss(errors):
+        log.error(
+            "batch_connectivity_failure",
+            total_items=len(items),
+            failed=len(errors),
+            error_sample=str(errors[0][1]),
+        )
 
     total_llm_calls = sum(llm_calls_list)
     total_tokens = sum(tokens_list)

--- a/src/questfoundry/pipeline/orchestrator.py
+++ b/src/questfoundry/pipeline/orchestrator.py
@@ -580,6 +580,7 @@ class PipelineOrchestrator:
             on_llm_end = context.get("on_llm_end")
             resume_from = context.get("resume_from")
             on_phase_progress = context.get("on_phase_progress")
+            on_connectivity_error = context.get("on_connectivity_error")
 
             # Build stage kwargs, only including optional params if set
             stage_kwargs: dict[str, Any] = {}
@@ -590,6 +591,8 @@ class PipelineOrchestrator:
                 stage_kwargs["resume_from"] = resume_from
             if on_phase_progress:
                 stage_kwargs["on_phase_progress"] = on_phase_progress
+            if on_connectivity_error:
+                stage_kwargs["on_connectivity_error"] = on_connectivity_error
 
             # Stage-specific options
             image_provider = self._get_resolved_image_provider()

--- a/src/questfoundry/pipeline/stages/base.py
+++ b/src/questfoundry/pipeline/stages/base.py
@@ -16,6 +16,8 @@ LLMCallbackFn = Callable[[str], None]
 PhaseProgressFn = Callable[[str, str, str | None], None]
 # Async hook called between pipeline phases to unload Ollama models from VRAM
 UnloadHookFn = Callable[[], Awaitable[None]]
+# Connectivity retry callback: (failed_count, total_count, error_sample) -> should_retry
+ConnectivityRetryFn = Callable[[int, int, str], Awaitable[bool]]
 
 
 class Stage(Protocol):


### PR DESCRIPTION
## Problem

During long-running pipeline stages (FILL, GROW, DRESS), if the LLM server crashes or loses connectivity, `batch_llm_calls()` silently records `None` for all failed items and continues. Callers discard the error list (`_errors`), so the pipeline proceeds with zero results — e.g., skipping all review flags after a 7.5-hour FILL run. The user only discovers this from logs after the fact.

## Changes

- **Error classification** (`batching.py`): Add `is_connectivity_error()` that recognises httpx network/timeout errors, Python `ConnectionError`, QF's `ProviderConnectionError`, and LangChain-wrapped errors via `__cause__` chain walking
- **Retry loop** (`batching.py`): Add `on_connectivity_error` callback parameter to `batch_llm_calls()`. After gather, if all errors are connectivity errors and >= 2 items failed, invoke the callback. If it returns True, retry only the failed items (up to 3 times). ERROR-level logging for connectivity loss regardless of hook presence
- **TTY prompt** (`cli.py`): When running on an interactive TTY, create an async callback that prints a Rich-formatted warning and prompts "Retry failed items? [Y/n]" via `typer.confirm` (wrapped in `asyncio.to_thread`)
- **Wiring** (`orchestrator.py`, `fill.py`, `grow.py`, `dress.py`): Thread the callback from CLI context → orchestrator → stage_kwargs → `batch_llm_calls()` calls (7 sites total)
- **Type alias** (`base.py`): `ConnectivityRetryFn` for the callback signature

## Not Included / Future PRs

- Automatic retry without user confirmation (non-TTY CI mode with exponential backoff)
- Raising `ProviderConnectionError` from the text LLM path (currently only image providers raise it)

## Test Plan

```bash
uv run mypy src/questfoundry/pipeline/batching.py src/questfoundry/pipeline/stages/base.py
uv run ruff check src/
uv run pytest tests/unit/test_batching.py -x -q  # 23 tests pass (16 new)
```

New tests cover:
- `is_connectivity_error()`: httpx ConnectError/ReadTimeout/ConnectTimeout, Python ConnectionRefusedError, single/double-wrapped `__cause__`, non-connectivity errors (ValueError, RuntimeError)
- Retry loop: successful retry on 2nd attempt, declined retry, no-hook backward compat, max retry limit (3), mixed error types (no retry), single-failure threshold (no retry), selective retry of only failed items

## Risk / Rollback

- **Backward compatible**: `on_connectivity_error` defaults to `None`; when absent, behavior is unchanged
- **No new dependencies**: uses existing httpx, typer, asyncio
- **Safe to roll back**: removing the callback parameter restores original behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)