### PR TITLE
fix(fill): make bigram check observational and batch revision per passage

### DIFF
--- a/prompts/templates/fill_phase3_revision.yaml
+++ b/prompts/templates/fill_phase3_revision.yaml
@@ -1,17 +1,17 @@
 name: fill_phase3_revision
-description: Revise a flagged passage to address a specific issue
+description: Revise a flagged passage to address all flagged issues in one pass
 
 system: |
-  You are revising a single interactive fiction passage to fix a specific quality
-  issue. Follow the voice document exactly and address the flagged problem.
+  You are revising a single interactive fiction passage to fix ALL flagged quality
+  issues. Follow the voice document exactly and address every problem listed.
 
   ## Voice Document
   {voice_document}
 
-  ## Issue to Fix
+  ## Flagged Issues
   **Passage ID:** {passage_id}
-  **Issue Type:** {issue_type}
-  **Issue Description:** {issue_description}
+
+  {issues_list}
 
   ## Scene Blueprint
   {blueprint_context}
@@ -42,29 +42,36 @@ system: |
   - **blueprint_bleed**: The scene blueprint leaked into prose (listing palette
     items mechanically, clinical opening). Render the materials organically —
     the blueprint is raw material, not an outline to follow literally.
+  - **near_duplicate**: This passage is too similar to another. Rewrite to
+    differentiate — vary the opening, choose different sensory details, or
+    restructure the paragraph flow.
+  - **opening_trigram**: Too many passages share the same opening words. Change
+    the first sentence to start differently while preserving meaning.
+  - **low_vocabulary**: The prose reuses too few distinct words. Introduce
+    synonyms, varied phrasing, and richer vocabulary without losing clarity.
 
   {output_language_instruction}
 
   ## Rules
 
-  1. Fix the flagged issue specifically — don't rewrite from scratch unless necessary
+  1. Fix ALL flagged issues in a single revision — do not address them one at a time
   2. Maintain consistency with the sliding window
   3. Follow the voice document
-  4. Preserve entity details from the original prose unless they caused the issue
+  4. Preserve entity details from the original prose unless they caused an issue
 
   ## Output Format
   Return a JSON object with a "passage" field containing:
   - passage_id: the passage ID
   - prose: the revised text
-  - flag: "ok" (revision should resolve the issue)
+  - flag: "ok" (revision should resolve the issues)
   - flag_reason: empty string
   - entity_updates: list of {{entity_id, field, value}} (may be empty)
 
 user: |
-  Revise passage {passage_id} to fix the {issue_type} issue described above.
+  Revise passage {passage_id} to fix ALL the flagged issues listed above.
 
   CRITICAL REMINDERS:
-  - Fix the flagged issue specifically — do not rewrite from scratch unless necessary
+  - Fix ALL flagged issues in a single revision — do not rewrite from scratch unless necessary
   - Follow the voice document EXACTLY — POV, tense, register, rhythm, tone
   - Maintain continuity with the sliding window
   - Return ONLY a valid JSON object. Do NOT add prose before or after the JSON.

--- a/src/questfoundry/models/fill.py
+++ b/src/questfoundry/models/fill.py
@@ -199,6 +199,9 @@ class ReviewFlag(BaseModel):
         "convergence_awkwardness",
         "flat_prose",
         "blueprint_bleed",
+        "near_duplicate",
+        "opening_trigram",
+        "low_vocabulary",
     ] = Field(description="Category of the review issue")
 
 

--- a/src/questfoundry/pipeline/stages/fill.py
+++ b/src/questfoundry/pipeline/stages/fill.py
@@ -1475,7 +1475,11 @@ class FillStage:
                 lengths = [len(s.split()) for s in sentences]
                 stdev = statistics.stdev(lengths)
                 if stdev < self._SENTENCE_LEN_STDEV_MIN:
-                    _add_flag(pid, f"Low sentence length variance (stdev: {stdev:.1f})")
+                    _add_flag(
+                        pid,
+                        f"Low sentence length variance (stdev: {stdev:.1f})",
+                        issue_type="flat_prose",
+                    )
 
         # 5. Cross-passage bigram repetition — observational only
         # Proactive layers handle repetition (expand blocklist + vocabulary alerts).

--- a/tests/unit/test_fill_models.py
+++ b/tests/unit/test_fill_models.py
@@ -250,6 +250,9 @@ class TestReviewFlag:
             "convergence_awkwardness",
             "flat_prose",
             "blueprint_bleed",
+            "near_duplicate",
+            "opening_trigram",
+            "low_vocabulary",
         ]
         for issue_type in types:
             flag = ReviewFlag(

--- a/tests/unit/test_fill_stage.py
+++ b/tests/unit/test_fill_stage.py
@@ -1693,11 +1693,11 @@ class TestMechanicalQualityGate:
         assert "overused bigrams logged" in result.detail or "0 mechanical flags" in result.detail
 
     @pytest.mark.asyncio
-    async def test_bigram_check_filters_short_words(self, mock_model: MagicMock) -> None:
-        """Bigrams of only short words (< 4 chars) should be filtered out."""
+    async def test_bigram_check_no_flags_with_mixed_content(self, mock_model: MagicMock) -> None:
+        """Bigram check is log-only — no flags injected even with repeated bigrams."""
         g = Graph.empty()
-        # "in the" — both words < 4 chars — should be filtered
-        # "amber glow" — both words >= 4 chars — should be counted
+        # Passages share both short-word ("in the") and content-word ("amber glow")
+        # bigrams. Neither should produce flags — bigram check is observational.
         for i in range(20):
             g.create_node(
                 f"passage::p{i}",
@@ -1712,8 +1712,7 @@ class TestMechanicalQualityGate:
             )
         stage = FillStage()
         await stage._phase_1c_mechanical_gate(g, mock_model)
-        # "in the" should NOT appear in logged bigrams
-        # We can only verify no flags are added (bigram check is log-only)
+        # Bigram check is log-only — verify no bigram flags in graph
         for i in range(20):
             node = g.get_node(f"passage::p{i}")
             if node:

--- a/tests/unit/test_fill_stage.py
+++ b/tests/unit/test_fill_stage.py
@@ -1039,19 +1039,20 @@ class TestPhase3Revision:
         assert result.llm_calls == 0
 
     @pytest.mark.asyncio
-    async def test_multiple_flags_chained(self) -> None:
-        """Multiple flags on same passage should chain revisions."""
+    async def test_multiple_flags_batched(self) -> None:
+        """Multiple flags on same passage should be batched into one LLM call."""
         graph = _make_reviewed_graph()
         graph.update_node(
             "passage::p1",
             review_flags=[
                 {"passage_id": "p1", "issue": "Voice drift", "issue_type": "voice_drift"},
-                {"passage_id": "p1", "issue": "Pacing issue", "issue_type": "pacing"},
+                {"passage_id": "p1", "issue": "Flat prose", "issue_type": "flat_prose"},
             ],
         )
         stage = FillStage()
 
         call_count = 0
+        captured_issues: str = ""
 
         async def mock_llm_call(
             model: MagicMock,  # noqa: ARG001
@@ -1061,13 +1062,13 @@ class TestPhase3Revision:
             max_retries: int = 3,  # noqa: ARG001
             **kwargs: object,  # noqa: ARG001
         ) -> tuple:
-            nonlocal call_count
+            nonlocal call_count, captured_issues
             call_count += 1
-            # Each revision builds on the previous prose
+            captured_issues = context.get("issues_list", "")
             return (
                 FillPhase1Output(
                     passage=FillPassageOutput(
-                        passage_id="p1", prose=f"Revision {call_count}: {context['current_prose']}"
+                        passage_id="p1", prose="Revised prose addressing all issues."
                     )
                 ),
                 1,
@@ -1081,14 +1082,17 @@ class TestPhase3Revision:
         # Both flags should be addressed
         assert "2 of 2 flags addressed" in (result.detail or "")
 
-        # LLM called twice (once per flag)
-        assert call_count == 2
+        # LLM called once (batched) not twice (per-flag)
+        assert call_count == 1
 
-        # Final prose should be the chained result (revision 2 includes revision 1)
+        # issues_list should contain both flags
+        assert "voice_drift" in captured_issues
+        assert "flat_prose" in captured_issues
+
+        # Prose updated
         p1 = graph.get_node("passage::p1")
         assert p1 is not None
-        assert p1["prose"].startswith("Revision 2:")
-        assert "Revision 1:" in p1["prose"]
+        assert p1["prose"] == "Revised prose addressing all issues."
 
         # Flags should be cleared
         assert p1.get("review_flags") == []
@@ -1654,3 +1658,87 @@ class TestMechanicalQualityGate:
         stage = FillStage()
         result = await stage._phase_1c_mechanical_gate(g, mock_model)
         assert "no passages" in result.detail
+
+    @pytest.mark.asyncio
+    async def test_bigram_check_logs_only(self, mock_model: MagicMock) -> None:
+        """Bigram check should NOT add flags to graph, only log."""
+        g = Graph.empty()
+        # Create many passages sharing the same content-word bigram
+        for i in range(20):
+            g.create_node(
+                f"passage::p{i}",
+                {
+                    "type": "passage",
+                    "raw_id": f"p{i}",
+                    "prose": (
+                        f"The amber glow illuminated passage {i} with "
+                        f"warm light. Different words here to avoid TTR flags."
+                    ),
+                },
+            )
+        stage = FillStage()
+        result = await stage._phase_1c_mechanical_gate(g, mock_model)
+
+        # No flags should be added for bigram repetition
+        total_flags = 0
+        for i in range(20):
+            node = g.get_node(f"passage::p{i}")
+            if node:
+                flags = node.get("review_flags", [])
+                total_flags += len(flags)
+                # Verify no bigram-related flags exist
+                assert not any("bigram" in f.get("issue", "").lower() for f in flags)
+
+        # Detail should mention overused bigrams logged (if threshold exceeded)
+        assert "overused bigrams logged" in result.detail or "0 mechanical flags" in result.detail
+
+    @pytest.mark.asyncio
+    async def test_bigram_check_filters_short_words(self, mock_model: MagicMock) -> None:
+        """Bigrams of only short words (< 4 chars) should be filtered out."""
+        g = Graph.empty()
+        # "in the" — both words < 4 chars — should be filtered
+        # "amber glow" — both words >= 4 chars — should be counted
+        for i in range(20):
+            g.create_node(
+                f"passage::p{i}",
+                {
+                    "type": "passage",
+                    "raw_id": f"p{i}",
+                    "prose": (
+                        f"In the darkness of passage {i}, the amber glow "
+                        f"flickered softly. Unique vocabulary item{i} here."
+                    ),
+                },
+            )
+        stage = FillStage()
+        await stage._phase_1c_mechanical_gate(g, mock_model)
+        # "in the" should NOT appear in logged bigrams
+        # We can only verify no flags are added (bigram check is log-only)
+        for i in range(20):
+            node = g.get_node(f"passage::p{i}")
+            if node:
+                assert not any(
+                    "bigram" in f.get("issue", "").lower() for f in node.get("review_flags", [])
+                )
+
+    @pytest.mark.asyncio
+    async def test_mechanical_flag_types_differentiated(self, mock_model: MagicMock) -> None:
+        """Different checks should produce different issue_type values."""
+        g = Graph.empty()
+        # Near-duplicate pair
+        g.create_node(
+            "passage::p1",
+            {"type": "passage", "raw_id": "p1", "prose": "The amber light flickered in the hall."},
+        )
+        g.create_node(
+            "passage::p2",
+            {"type": "passage", "raw_id": "p2", "prose": "The amber light flickered in the hall."},
+        )
+        stage = FillStage()
+        await stage._phase_1c_mechanical_gate(g, mock_model)
+        p2 = g.get_node("passage::p2")
+        assert p2 is not None
+        flags = p2.get("review_flags", [])
+        dup_flags = [f for f in flags if "Near-duplicate" in f.get("issue", "")]
+        assert len(dup_flags) >= 1
+        assert dup_flags[0]["issue_type"] == "near_duplicate"


### PR DESCRIPTION
## Problem

In `projects/test-qwen3-murder` (60 passages, qwen3:4b), the FILL mechanical quality gate generated ~3,728 flags from its cross-passage bigram check. The revision phase processed one flag per LLM call, producing 4,424+ calls over 3+ hours before the run was manually aborted.

The bigram check reimplemented bigram extraction without the content-word filtering already present in `extract_used_imagery()`. The codebase already has two proactive repetition prevention layers (expand blocklist + vocabulary alerts), and the LLM review independently found only 18 genuine issues.

## Changes

- **Bigram check → log-only with content-word filter**: Check 5 now logs findings at INFO level instead of injecting flags into the graph. Applies content-word filter (skip bigrams where both words < 4 chars) and proportional threshold `max(5, len(prose_entries) // 10)`. Removes `_BIGRAM_PASSAGE_MAX` constant.
- **Differentiate mechanical flag types**: `_add_flag` now accepts `issue_type` parameter. Checks 1-4 produce distinct types: `near_duplicate`, `opening_trigram`, `low_vocabulary`, `flat_prose`. Added 3 new types to `ReviewFlag` Literal.
- **Batch revision per passage**: Replace per-flag loop in `_revise_passage` with single LLM call using `{issues_list}` containing all numbered flags. Update prompt template to accept batched issues.
- **Tests**: Update chained→batched test (1 LLM call for 2 flags), add bigram log-only test, bigram short-word filter test, flag type differentiation test, new model issue types.

## Not Included / Future PRs

- Re-enabling bigram check as active flag generator after assessing log data from real runs (issue to be created)

## Test Plan

```
uv run mypy src/questfoundry/pipeline/stages/fill.py src/questfoundry/models/fill.py  # ✅ Success
uv run ruff check src/ prompts/  # ✅ All checks passed
uv run pytest tests/unit/test_fill_stage.py tests/unit/test_fill_models.py -x -q  # ✅ 116 passed
```

## Risk / Rollback

- Bigram check is still computed and logged — can be re-enabled by replacing `log.info()` with `_add_flag()` calls
- Batched revision reduces LLM calls but gives the model all issues at once — if quality degrades, can revert to per-flag loop
- No breaking changes to graph format or CLI interface

## Expected Impact

| Metric | Before | After |
|--------|--------|-------|
| Mechanical flags injected | ~3,728 | ~3 (checks 1-4 only) |
| LLM review flags | ~18 | ~18 (unchanged) |
| Revision LLM calls | ~4,424 | ~20 (one per flagged passage) |
| Revision wall time | 3+ hours | ~2 min |

## Review Guide

1. `src/questfoundry/models/fill.py` — 3 new issue types in ReviewFlag Literal
2. `src/questfoundry/pipeline/stages/fill.py` — bigram check log-only (lines 1477-1510), `_add_flag` typed (line 1411), `_revise_passage` batched (lines 1666-1717)
3. `prompts/templates/fill_phase3_revision.yaml` — `{issues_list}` replaces `{issue_type}`/`{issue_description}`
4. Tests — `test_fill_models.py` and `test_fill_stage.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)