### PR TITLE
fix(dress): resolve entity refs across category prefixes

### DIFF
--- a/src/questfoundry/graph/dress_mutations.py
+++ b/src/questfoundry/graph/dress_mutations.py
@@ -137,8 +137,8 @@ def apply_dress_codex(
         from questfoundry.graph.errors import NodeNotFoundError
 
         raise NodeNotFoundError(
-            f"entity::{raw_entity_id}",
-            context="codex entity reference",
+            raw_entity_id,
+            context=f"codex entity reference (tried {', '.join(ENTITY_CATEGORIES)} and legacy entity:: prefix)",
         )
     created_ids: list[str] = []
 

--- a/src/questfoundry/graph/dress_mutations.py
+++ b/src/questfoundry/graph/dress_mutations.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
-from questfoundry.graph.context import strip_scope_prefix
+from questfoundry.graph.context import ENTITY_CATEGORIES, strip_scope_prefix
 
 if TYPE_CHECKING:
     from questfoundry.graph.graph import Graph
@@ -42,8 +42,11 @@ def apply_dress_art_direction(
         art_dir: ArtDirection fields (style, medium, palette, etc.).
         entity_visuals: List of dicts with ``entity_id`` plus EntityVisual fields.
 
-    Raises:
-        NodeNotFoundError: If a referenced entity doesn't exist in the graph.
+    Note:
+        If a referenced entity doesn't exist under any category prefix
+        (character, location, object, faction) or the legacy ``entity::``
+        prefix, the visual node is created but no ``describes_visual`` edge
+        is added.
     """
     # Singleton art direction node
     ad_data = {"type": "art_direction", **_clean_dict(art_dir)}
@@ -56,11 +59,11 @@ def apply_dress_art_direction(
         node_id = f"entity_visual::{entity_id}"
         ev_data = {"type": "entity_visual", **_clean_dict(ev)}
         graph.upsert_node(node_id, ev_data)
-        # Edge: entity_visual → entity
-        entity_ref = graph.ref("entity", entity_id)
-        # Remove existing edge if re-running
-        _remove_edges(graph, from_id=node_id, edge_type="describes_visual")
-        graph.add_edge("describes_visual", node_id, entity_ref)
+        # Edge: entity_visual → entity (entities use subtype prefixes)
+        entity_ref = _resolve_entity_ref(graph, entity_id)
+        if entity_ref:
+            _remove_edges(graph, from_id=node_id, edge_type="describes_visual")
+            graph.add_edge("describes_visual", node_id, entity_ref)
 
 
 # ---------------------------------------------------------------------------
@@ -129,7 +132,14 @@ def apply_dress_codex(
         NodeNotFoundError: If the entity doesn't exist.
     """
     raw_entity_id = strip_scope_prefix(entity_id)
-    entity_ref = graph.ref("entity", raw_entity_id)
+    entity_ref = _resolve_entity_ref(graph, raw_entity_id)
+    if not entity_ref:
+        from questfoundry.graph.errors import NodeNotFoundError
+
+        raise NodeNotFoundError(
+            f"entity::{raw_entity_id}",
+            context="codex entity reference",
+        )
     created_ids: list[str] = []
 
     for entry in entries:
@@ -277,6 +287,19 @@ def validate_dress_codex_entries(
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
+
+
+def _resolve_entity_ref(graph: Graph, raw_id: str) -> str | None:
+    """Resolve entity ID across category prefixes (character, location, etc.)."""
+    for category in ENTITY_CATEGORIES:
+        candidate = f"{category}::{raw_id}"
+        if graph.has_node(candidate):
+            return candidate
+    # Legacy fallback
+    legacy = f"entity::{raw_id}"
+    if graph.has_node(legacy):
+        return legacy
+    return None
 
 
 def _clean_dict(data: dict[str, Any]) -> dict[str, Any]:

--- a/tests/unit/test_dress_mutations.py
+++ b/tests/unit/test_dress_mutations.py
@@ -217,29 +217,35 @@ class TestApplyDressArtDirection:
         )
         assert len(edges) == 1
 
-    def test_nonexistent_entity_raises(self) -> None:
+    def test_nonexistent_entity_skips_edge(self) -> None:
+        """Unresolvable entity creates visual node but no describes_visual edge."""
         from questfoundry.graph.dress_mutations import apply_dress_art_direction
-        from questfoundry.graph.errors import NodeNotFoundError
 
-        with pytest.raises(NodeNotFoundError):
-            apply_dress_art_direction(
-                Graph(),
-                art_dir={
-                    "style": "ink",
-                    "medium": "d",
-                    "palette": ["b"],
-                    "composition_notes": "c",
-                    "negative_defaults": "n",
-                },
-                entity_visuals=[
-                    {
-                        "entity_id": "nonexistent",
-                        "description": "d",
-                        "distinguishing_features": ["f"],
-                        "reference_prompt_fragment": "frag",
-                    }
-                ],
-            )
+        g = Graph()
+        apply_dress_art_direction(
+            g,
+            art_dir={
+                "style": "ink",
+                "medium": "d",
+                "palette": ["b"],
+                "composition_notes": "c",
+                "negative_defaults": "n",
+            },
+            entity_visuals=[
+                {
+                    "entity_id": "nonexistent",
+                    "description": "d",
+                    "distinguishing_features": ["f"],
+                    "reference_prompt_fragment": "frag",
+                }
+            ],
+        )
+
+        # Visual node created
+        assert g.get_node("entity_visual::nonexistent") is not None
+        # No edge because entity doesn't exist in any category
+        edges = g.get_edges(from_id="entity_visual::nonexistent", edge_type="describes_visual")
+        assert len(edges) == 0
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

Entities migrated from `entity::` to subtype prefixes (`character::`, `location::`, `object::`, `faction::`) but DRESS mutations still used `graph.ref("entity", id)`, constructing `entity::agatha_raisin` when the actual node is `character::agatha_raisin`. This caused `NodeNotFoundError` in DRESS Phase 0 (art direction) and Phase 2 (codex).

## Changes

- Add `_resolve_entity_ref()` helper in `dress_mutations.py` that tries all `ENTITY_CATEGORIES` with legacy `entity::` fallback
- `apply_dress_art_direction`: silently skips unresolvable entities (creates visual node, no edge) — appropriate for bulk operation
- `apply_dress_codex`: raises `NodeNotFoundError` if entity unresolvable — codex entries require a valid target
- Update test: `test_nonexistent_entity_raises` → `test_nonexistent_entity_skips_edge`

## Not Included / Future PRs

- Migrating test fixture entities from `entity::` to `character::`/`location::` (legacy fallback handles them)

## Test Plan

```
uv run pytest tests/unit/test_dress_mutations.py -x -q  # 22 passed
uv run mypy src/questfoundry/graph/dress_mutations.py    # no issues
uv run ruff check src/ tests/                            # all passed
```

## Risk / Rollback

Low risk — adds resolution logic with full backward compatibility via `entity::` fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)