### PR TITLE
feat(fill): improve mechanical quality gate

### DIFF
--- a/src/questfoundry/pipeline/stages/fill.py
+++ b/src/questfoundry/pipeline/stages/fill.py
@@ -1283,7 +1283,7 @@ class FillStage:
 
                 # Track prose for lexical diversity monitoring
                 recent_prose.append(prose)
-                window = recent_prose[-5:]
+                window = recent_prose[-self._DIVERSITY_WINDOW_SIZE :]
                 ratio = compute_lexical_diversity(window)
                 vocabulary_note = format_vocabulary_note(
                     ratio, recent_prose=window, lang=self._language
@@ -1378,6 +1378,7 @@ class FillStage:
     _TRIGRAM_COLLISION_MAX = 2  # max passages sharing opening trigram
     _ROOT_TTR_THRESHOLD = 4.5  # root type-token ratio below this = flag
     _SENTENCE_LEN_STDEV_MIN = 3.0  # sentence length stdev below this = flag
+    _DIVERSITY_WINDOW_SIZE = 5  # number of recent passages for diversity check
 
     async def _phase_1c_mechanical_gate(
         self,

--- a/tests/unit/test_fill_stage.py
+++ b/tests/unit/test_fill_stage.py
@@ -1601,9 +1601,9 @@ class TestMechanicalQualityGate:
         assert flagged >= 1
 
     @pytest.mark.asyncio
-    async def test_low_ttr_flagged(self, mock_model: MagicMock) -> None:
+    async def test_low_root_ttr_flagged(self, mock_model: MagicMock) -> None:
         g = Graph.empty()
-        # Extremely repetitive prose
+        # Extremely repetitive prose: 70 words, 3 unique → root-TTR ≈ 0.36
         g.create_node(
             "passage::p1",
             {
@@ -1617,7 +1617,7 @@ class TestMechanicalQualityGate:
         p1 = g.get_node("passage::p1")
         assert p1 is not None
         flags = p1.get("review_flags", [])
-        assert any("diversity" in f.get("issue", "").lower() for f in flags)
+        assert any("root-ttr" in f.get("issue", "").lower() for f in flags)
 
     @pytest.mark.asyncio
     async def test_good_prose_not_flagged(self, mock_model: MagicMock) -> None:


### PR DESCRIPTION
## Problem

After merging PR #686, analysis of test-qwen3-murder bigram data showed the
content-word filter (`len < 4 AND len < 4`) lets through all bigrams containing
an article + a content word ("the corridor", "a breath" — all 226 logged
bigrams). Additionally, raw TTR is length-dependent (longer passages score
lower regardless of quality), the vocabulary note was stale (only recomputed
every 5 passages), and the imagery blocklist had no stopword filtering.

## Changes

- **Stopword filtering (#690):** Add curated English stopword set (~80 words)
  with OR-logic — bigrams containing any stopword are skipped. Language-aware:
  unknown languages skip filtering gracefully
- **Root-TTR (#691):** Replace raw TTR (`unique/total`) with root-TTR
  (`unique/sqrt(total)`), threshold 4.5. Length-independent per McCarthy & Jarvis 2010.
  Calibrated: repetitive=0.36, good=6.10
- **Document frequency (#692):** Count each bigram at most once per passage
  (document frequency) instead of raw occurrence count
- **Vocabulary staleness (#693):** Remove 5-passage check interval, recompute
  after every passage so vocabulary alerts clear when diversity recovers
- **Language threading:** Store `self._language` on FillStage with default "en",
  thread as `lang` param to fill_context.py functions

## Not Included / Future PRs

- Dutch stopwords (#690 comment) — English only for now
- Antislop blocklist (#694) — separate PR
- Exemplar generation (#695, #696) — separate PR

## Test Plan

```bash
uv run mypy src/questfoundry/pipeline/stages/fill.py src/questfoundry/graph/fill_context.py
uv run ruff check src/
uv run pytest tests/unit/test_fill_stage.py tests/unit/test_fill_context.py -x -q
# 237 passed
```

- Updated `TestExtractTopBigrams` for stopword filtering + document frequency
- Updated `test_low_root_ttr_flagged` for new metric name
- `test_good_prose_not_flagged` unchanged (root-TTR ≈ 6.10, well above 4.5)

## Risk / Rollback

Low risk — all changes are to deterministic quality checks, no LLM behavior
changes. Root-TTR threshold calibrated from existing test data.

Closes #690, closes #691, closes #692, closes #693

🤖 Generated with [Claude Code](https://claude.com/claude-code)