### PR TITLE
feat(fill): add antislop phrase blocklist (#694)

### DIFF
--- a/src/questfoundry/graph/fill_context.py
+++ b/src/questfoundry/graph/fill_context.py
@@ -2095,3 +2095,93 @@ def format_used_imagery_blocklist(blocklist: list[str]) -> str:
     lines.append("Find fresh sensory material instead.")
 
     return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# Antislop blocklist (#694)
+# ---------------------------------------------------------------------------
+
+ANTISLOP_PHRASES: dict[str, list[str]] = {
+    "en": [
+        # Body / emotion clichés
+        "eyes widened",
+        "breath caught",
+        "heart pounded",
+        "blood ran cold",
+        "knuckles whitened",
+        "jaw clenched",
+        "stomach churned",
+        "pulse quickened",
+        "breath hitched",
+        "heart hammered",
+        "fists clenched",
+        "tears streamed",
+        "breath she didn't know",
+        "breath he didn't know",
+        "let out a breath",
+        # Formulaic transitions
+        "couldn't help but",
+        "a testament to",
+        "sent shivers down",
+        "it was as if",
+        "little did they know",
+        "as if on cue",
+        "time seemed to",
+        "hung in the air",
+        "filled the air",
+        "pierced the silence",
+        "shattered the silence",
+        "broke the silence",
+        # Purple prose markers
+        "cascade of emotions",
+        "waves of emotion",
+        "a symphony of",
+        "tapestry of",
+        "kaleidoscope of",
+        "dance of shadows",
+        "sea of faces",
+        "ocean of",
+        "whirlwind of",
+        "delicate dance",
+        # Overwrought description
+        "seemed to mock",
+        "mocking laughter",
+        "palpable tension",
+        "deafening silence",
+        "tangible silence",
+        "electric tension",
+        "weight of the world",
+        "the world seemed",
+        "reality came crashing",
+        "stark contrast",
+    ],
+}
+
+
+def format_antislop_blocklist(lang: str = "en") -> str:
+    """Format the antislop phrase blocklist for the expand prompt.
+
+    Returns a formatted blocklist of LLM-overused phrases that the model
+    should avoid. Returns empty string for unsupported languages (graceful
+    degradation — no blocklist is better than a wrong-language blocklist).
+
+    Args:
+        lang: Language code for phrase lookup.
+
+    Returns:
+        Formatted blocklist string, or empty string for unsupported languages.
+    """
+    phrases = ANTISLOP_PHRASES.get(lang)
+    if not phrases:
+        return ""
+
+    lines = [
+        "**Overused Phrases (AVOID):** The following phrases are LLM clichés. "
+        "Do NOT use them or close variants:",
+    ]
+    for phrase in phrases:
+        lines.append(f'  - "{phrase}"')
+    lines.append("")
+    lines.append("Find original phrasing instead. Show, don't tell.")
+
+    return "\n".join(lines)

--- a/src/questfoundry/graph/fill_context.py
+++ b/src/questfoundry/graph/fill_context.py
@@ -2103,7 +2103,7 @@ def format_used_imagery_blocklist(blocklist: list[str]) -> str:
 
 ANTISLOP_PHRASES: dict[str, list[str]] = {
     "en": [
-        # Body / emotion clichés
+        # Body / emotion cliches
         "eyes widened",
         "breath caught",
         "heart pounded",
@@ -2155,6 +2155,13 @@ ANTISLOP_PHRASES: dict[str, list[str]] = {
         "reality came crashing",
         "stark contrast",
     ],
+}
+
+# Compiled regex patterns for efficient antislop detection (one alternation
+# per language, compiled once at import time).
+ANTISLOP_PATTERNS: dict[str, re.Pattern[str]] = {
+    lang: re.compile("|".join(re.escape(p) for p in phrases))
+    for lang, phrases in ANTISLOP_PHRASES.items()
 }
 
 

--- a/tests/unit/test_fill_context.py
+++ b/tests/unit/test_fill_context.py
@@ -2487,3 +2487,21 @@ class TestFormatAntislopBlocklist:
 
         assert "en" in ANTISLOP_PHRASES
         assert len(ANTISLOP_PHRASES["en"]) >= 30
+
+    def test_antislop_patterns_compiled(self) -> None:
+        """ANTISLOP_PATTERNS contains compiled regex for each language."""
+        import re
+
+        from questfoundry.graph.fill_context import ANTISLOP_PATTERNS
+
+        assert "en" in ANTISLOP_PATTERNS
+        assert isinstance(ANTISLOP_PATTERNS["en"], re.Pattern)
+        # Should match a known phrase
+        assert ANTISLOP_PATTERNS["en"].search("her eyes widened in shock")
+        # Should not match clean prose
+        assert not ANTISLOP_PATTERNS["en"].search("the door swung open")
+
+    def test_antislop_patterns_unknown_lang(self) -> None:
+        from questfoundry.graph.fill_context import ANTISLOP_PATTERNS
+
+        assert "xx" not in ANTISLOP_PATTERNS

--- a/tests/unit/test_fill_context.py
+++ b/tests/unit/test_fill_context.py
@@ -2460,3 +2460,30 @@ class TestFormatUsedImageryBlocklist:
         for item in items:
             assert f'"{item}"' in result
         assert "DO NOT reuse" in result
+
+
+# ---------------------------------------------------------------------------
+# Antislop blocklist
+# ---------------------------------------------------------------------------
+
+
+class TestFormatAntislopBlocklist:
+    def test_english_non_empty(self) -> None:
+        from questfoundry.graph.fill_context import format_antislop_blocklist
+
+        result = format_antislop_blocklist("en")
+        assert "Overused Phrases" in result
+        assert "eyes widened" in result
+        assert "original phrasing" in result
+
+    def test_unknown_language_empty(self) -> None:
+        from questfoundry.graph.fill_context import format_antislop_blocklist
+
+        assert format_antislop_blocklist("xx") == ""
+        assert format_antislop_blocklist("nl") == ""
+
+    def test_antislop_phrases_dict_has_english(self) -> None:
+        from questfoundry.graph.fill_context import ANTISLOP_PHRASES
+
+        assert "en" in ANTISLOP_PHRASES
+        assert len(ANTISLOP_PHRASES["en"]) >= 30

--- a/tests/unit/test_fill_stage.py
+++ b/tests/unit/test_fill_stage.py
@@ -1741,3 +1741,20 @@ class TestMechanicalQualityGate:
         dup_flags = [f for f in flags if "Near-duplicate" in f.get("issue", "")]
         assert len(dup_flags) >= 1
         assert dup_flags[0]["issue_type"] == "near_duplicate"
+
+    @pytest.mark.asyncio
+    async def test_antislop_detection_runs(self, mock_model: MagicMock) -> None:
+        """Antislop detection runs without error on prose with cliche phrases."""
+        g = Graph.empty()
+        g.create_node(
+            "passage::p1",
+            {
+                "type": "passage",
+                "raw_id": "p1",
+                "prose": "Her eyes widened as her breath caught in the palpable tension.",
+            },
+        )
+        stage = FillStage()
+        stage._language = "en"
+        result = await stage._phase_1c_mechanical_gate(g, mock_model)
+        assert result.status == "completed"


### PR DESCRIPTION
## Problem

Small LLMs (qwen3:4b) fall back to formulaic, overused phrases ("couldn't help but", "sent shivers down", "a testament to", etc.) that are telltale signs of LLM-generated prose. The FILL stage has no mechanism to discourage these clichés.

## Changes

- Add `ANTISLOP_PHRASES` curated blocklist (~50 phrases) in `fill_context.py`, keyed by language (`"en"`)
- Add `format_antislop_blocklist(lang)` formatter that renders blocklist for prompt injection
- Inject antislop blocklist into the expand phase prompt (appended to existing `{used_imagery_blocklist}`)
- Add observational antislop detection in the mechanical gate (log-only when >= 3 phrases detected)
- Add `self._language` default in `__init__` for test compatibility

Phrase list sourced from Paech 2025 / Antislop research — covers common LLM clichés across narrative prose.

## Not Included / Future PRs

- Non-English antislop phrases — requires observing model-specific patterns per language
- Revision trigger on antislop detection — currently observational/log-only

Closes #694

## Test Plan

```bash
uv run mypy src/questfoundry/pipeline/stages/fill.py src/questfoundry/graph/fill_context.py
uv run ruff check src/
uv run pytest tests/unit/test_fill_stage.py tests/unit/test_fill_context.py -x -q
# 237 passed
```

- `test_antislop_blocklist_english_non_empty` — verifies English blocklist returns content
- `test_antislop_blocklist_unknown_lang_empty` — verifies unsupported languages return empty
- `test_antislop_blocklist_contains_phrases` — verifies actual phrases present in output

## Risk / Rollback

- Low risk: antislop is additive (appended to existing blocklist injection)
- Detection is observational only (logs, no revision trigger)
- Unsupported languages gracefully return empty string (no filtering)