### PR TITLE
feat(providers): add model capability tier to ModelProperties (#700)

### DIFF
--- a/tests/unit/test_model_info.py
+++ b/tests/unit/test_model_info.py
@@ -4,7 +4,12 @@ from __future__ import annotations
 
 from unittest.mock import patch
 
-from questfoundry.providers.model_info import ModelInfo, get_model_info
+from questfoundry.providers.model_info import (
+    ModelInfo,
+    ModelProperties,
+    get_capability_tier,
+    get_model_info,
+)
 
 
 class TestModelInfoDefaults:
@@ -66,3 +71,86 @@ class TestModelInfoDataclass:
         info = ModelInfo(context_window=32_768, max_concurrency=5)
         with __import__("pytest").raises(AttributeError):
             info.max_concurrency = 10  # type: ignore[misc]
+
+
+class TestModelPropertiesCapabilityTier:
+    """Tests for capability_tier field on ModelProperties."""
+
+    def test_default_tier_is_small(self) -> None:
+        """ModelProperties defaults to small capability tier."""
+        props = ModelProperties(context_window=32_768)
+        assert props.capability_tier == "small"
+
+    def test_explicit_large_tier(self) -> None:
+        """ModelProperties accepts explicit large tier."""
+        props = ModelProperties(context_window=128_000, capability_tier="large")
+        assert props.capability_tier == "large"
+
+    def test_ollama_models_are_small(self) -> None:
+        """All Ollama models in KNOWN_MODELS are small tier."""
+        from questfoundry.providers.model_info import KNOWN_MODELS
+
+        for model_name, props in KNOWN_MODELS["ollama"].items():
+            assert props.capability_tier == "small", f"ollama/{model_name} should be small"
+
+    def test_cloud_models_are_large(self) -> None:
+        """All cloud provider models in KNOWN_MODELS are large tier."""
+        from questfoundry.providers.model_info import KNOWN_MODELS
+
+        for provider in ("openai", "anthropic", "google"):
+            for model_name, props in KNOWN_MODELS[provider].items():
+                assert props.capability_tier == "large", f"{provider}/{model_name} should be large"
+
+
+class TestGetCapabilityTier:
+    """Tests for get_capability_tier() function."""
+
+    def test_known_ollama_model(self) -> None:
+        """Known Ollama model returns small."""
+        assert get_capability_tier("ollama", "qwen3:4b-instruct-32k") == "small"
+
+    def test_known_openai_model(self) -> None:
+        """Known OpenAI model returns large."""
+        assert get_capability_tier("openai", "gpt-4o") == "large"
+
+    def test_known_anthropic_model(self) -> None:
+        """Known Anthropic model returns large."""
+        assert get_capability_tier("anthropic", "claude-sonnet-4-20250514") == "large"
+
+    def test_known_google_model(self) -> None:
+        """Known Google model returns large."""
+        assert get_capability_tier("google", "gemini-2.5-pro") == "large"
+
+    def test_unknown_ollama_small_pattern(self) -> None:
+        """Unknown Ollama model with small name pattern returns small."""
+        assert get_capability_tier("ollama", "phi3:3.8b") == "small"
+
+    def test_unknown_ollama_large_pattern(self) -> None:
+        """Unknown Ollama model without small pattern defaults to small."""
+        assert get_capability_tier("ollama", "deepseek-r1:70b") == "small"
+
+    def test_unknown_cloud_model_defaults_large(self) -> None:
+        """Unknown cloud provider model defaults to large."""
+        assert get_capability_tier("openai", "gpt-6-turbo") == "large"
+
+    def test_unknown_provider_defaults_small(self) -> None:
+        """Unknown provider defaults to small (conservative)."""
+        assert get_capability_tier("local_llm", "custom-model") == "small"
+
+    def test_case_insensitive_provider(self) -> None:
+        """Provider name is case-insensitive."""
+        assert get_capability_tier("OpenAI", "gpt-4o") == "large"
+        assert get_capability_tier("OLLAMA", "qwen3:4b-instruct-32k") == "small"
+
+    def test_heuristic_detects_7b(self) -> None:
+        """Name pattern heuristic detects 7b as small."""
+        assert get_capability_tier("ollama", "mistral-nemo:7b-q4") == "small"
+
+    def test_heuristic_detects_13b(self) -> None:
+        """Name pattern heuristic detects 13b as small."""
+        assert get_capability_tier("ollama", "codellama:13b") == "small"
+
+    def test_cloud_mini_is_large(self) -> None:
+        """Cloud 'mini' models are large (trained to follow instructions well)."""
+        assert get_capability_tier("openai", "gpt-5-mini") == "large"
+        assert get_capability_tier("openai", "o3-mini") == "large"


### PR DESCRIPTION
## Problem
The FILL exemplar phase falls back to LLM-generated exemplars when the corpus has no match. Small models (<=8B params like qwen3:4b) copy exemplar *content* verbatim instead of abstracting *style*, contaminating prose with exemplar imagery. Test data showed LLM-generated exemplars leaked into 36-39 of 67 passages, worsening TTR (0.1015 → 0.0957).

We need a way to classify models as "small" vs "large" to gate features appropriately.

## Changes
- Add `capability_tier: str = "small"` field to `ModelProperties` dataclass
- Annotate all entries in `KNOWN_MODELS` registry (ollama 4b-8b: small, all cloud providers: large)
- Add `get_capability_tier(provider, model) -> str` helper function with:
  - KNOWN_MODELS lookup (highest priority)
  - Name-pattern heuristic for unknown models (detects `4b`, `7b`, `8b`, `13b` patterns)
  - Cloud provider default (large) for OpenAI/Anthropic/Google
  - Conservative default (small) for unknown local models
- Add 17 unit tests covering tier resolution for all paths

## Not Included / Future PRs
- Exemplar strategy config plumbing (#701)
- Strategy-aware exemplar phase behavior (#702)
- Voice steering toward corpus-covered combos (#703)

## Test Plan
```
uv run mypy src/questfoundry/providers/model_info.py  # Success
uv run ruff check src/questfoundry/providers/model_info.py tests/unit/test_model_info.py  # All passed
uv run pytest tests/unit/test_model_info.py -x -q  # 26 passed
```

## Risk / Rollback
- No behavior changes — this PR only adds a new field and helper function
- Default `capability_tier="small"` is backwards-compatible (existing code never reads it)
- Safe to revert by removing the field

🤖 Generated with [Claude Code](https://claude.com/claude-code)