### PR TITLE
feat(fill): add exemplar_strategy config for model-aware exemplar selection (#701)

### DIFF
--- a/src/questfoundry/pipeline/config.py
+++ b/src/questfoundry/pipeline/config.py
@@ -254,9 +254,14 @@ class FillConfig:
         two_step: Use two-step prose generation (write prose first, then
             extract entities). Improves quality by removing JSON constraints
             from creative output.
+        exemplar_strategy: Controls voice exemplar generation.
+            "auto" (default): detect from model capability tier.
+            "corpus_only": corpus exemplars only, no LLM fallback.
+            "full": corpus-first with LLM fallback for missing combos.
     """
 
     two_step: bool = True
+    exemplar_strategy: str = "auto"
 
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> FillConfig:
@@ -270,6 +275,7 @@ class FillConfig:
         """
         return cls(
             two_step=data.get("two_step", True),
+            exemplar_strategy=data.get("exemplar_strategy", "auto"),
         )
 
 

--- a/src/questfoundry/pipeline/orchestrator.py
+++ b/src/questfoundry/pipeline/orchestrator.py
@@ -607,6 +607,10 @@ class PipelineOrchestrator:
                     stage_kwargs["min_priority"] = min_priority
             if stage_name == "fill":
                 stage_kwargs["two_step"] = context.get("two_step", self.config.fill.two_step)
+                stage_kwargs["model_name"] = self._model_name
+                stage_kwargs["exemplar_strategy"] = context.get(
+                    "exemplar_strategy", self.config.fill.exemplar_strategy
+                )
 
             # Resolve size profile from DREAM vision node (for post-DREAM stages)
             if stage_name != "dream":

--- a/src/questfoundry/pipeline/stages/fill.py
+++ b/src/questfoundry/pipeline/stages/fill.py
@@ -277,6 +277,7 @@ class FillStage:
         self.gate = gate or AutoApprovePhaseGate()
         self._callbacks: list[BaseCallbackHandler] | None = None
         self._provider_name: str | None = None
+        self._model_name: str | None = None
         self._serialize_model: BaseChatModel | None = None
         self._serialize_provider_name: str | None = None
         self._size_profile: SizeProfile | None = None
@@ -284,6 +285,7 @@ class FillStage:
         self._max_concurrency: int = 2
         self._lang_instruction: str = ""
         self._two_step: bool = False
+        self._exemplar_strategy: str = "auto"
         # Interactive mode attributes (set in execute(), defaults for direct calls)
         self._interactive: bool = False
         self._user_input_fn: UserInputFn | None = None
@@ -400,6 +402,7 @@ class FillStage:
 
         self._callbacks = callbacks
         self._provider_name = provider_name
+        self._model_name = kwargs.get("model_name")
         self._serialize_model = serialize_model
         self._serialize_provider_name = serialize_provider_name
         self._interactive = interactive
@@ -412,6 +415,7 @@ class FillStage:
         self._language = kwargs.get("language", "en")
         self._lang_instruction = get_output_language_instruction(self._language)
         self._two_step = kwargs.get("two_step", True)
+        self._exemplar_strategy = kwargs.get("exemplar_strategy", "auto")
         self._on_connectivity_error = kwargs.get("on_connectivity_error")
         log.info("stage_start", stage="fill", interactive=interactive)
 

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -583,6 +583,26 @@ class TestFillConfig:
         config = FillConfig.from_dict({})
         assert config.two_step is True
 
+    def test_default_exemplar_strategy_is_auto(self) -> None:
+        """FillConfig defaults to exemplar_strategy='auto'."""
+        config = FillConfig()
+        assert config.exemplar_strategy == "auto"
+
+    def test_from_dict_exemplar_strategy(self) -> None:
+        """FillConfig.from_dict reads exemplar_strategy."""
+        config = FillConfig.from_dict({"exemplar_strategy": "corpus_only"})
+        assert config.exemplar_strategy == "corpus_only"
+
+    def test_from_dict_exemplar_strategy_full(self) -> None:
+        """FillConfig.from_dict reads exemplar_strategy=full."""
+        config = FillConfig.from_dict({"exemplar_strategy": "full"})
+        assert config.exemplar_strategy == "full"
+
+    def test_from_dict_empty_preserves_exemplar_default(self) -> None:
+        """Empty dict keeps exemplar_strategy default."""
+        config = FillConfig.from_dict({})
+        assert config.exemplar_strategy == "auto"
+
 
 class TestProjectConfigFill:
     """Tests for ProjectConfig fill section."""
@@ -606,6 +626,16 @@ class TestProjectConfigFill:
         config = ProjectConfig.from_dict(data)
         assert config.fill.two_step is False
 
+    def test_fill_exemplar_strategy_from_yaml(self) -> None:
+        """ProjectConfig parses fill.exemplar_strategy from dict."""
+        data = {
+            "name": "test",
+            "providers": {"default": "ollama/qwen3:4b-instruct-32k"},
+            "fill": {"exemplar_strategy": "corpus_only"},
+        }
+        config = ProjectConfig.from_dict(data)
+        assert config.fill.exemplar_strategy == "corpus_only"
+
     def test_fill_section_missing_uses_defaults(self) -> None:
         """Missing fill section uses FillConfig defaults."""
         data = {
@@ -615,3 +645,4 @@ class TestProjectConfigFill:
         config = ProjectConfig.from_dict(data)
         assert isinstance(config.fill, FillConfig)
         assert config.fill.two_step is True
+        assert config.fill.exemplar_strategy == "auto"


### PR DESCRIPTION
## Problem
Need a configuration mechanism to control voice exemplar generation strategy based on model capability. Small models copy exemplar content verbatim, so they need `corpus_only` mode (no LLM fallback). Large models can use `full` mode (corpus + LLM fallback).

## Changes
- Add `exemplar_strategy: str = "auto"` to `FillConfig` with `from_dict` support
- Add `--exemplar-strategy` CLI flag to `fill` and `run` commands
- Add `QF_EXEMPLAR_STRATEGY` env var support (CLI > env var > project config > default)
- Pass `model_name` from orchestrator to `FillStage.execute()` for tier auto-detection
- Store `exemplar_strategy` and `model_name` as instance attributes on `FillStage`
- Add `import os` to cli.py (was previously used without explicit import)
- Add 5 tests for `FillConfig.exemplar_strategy` parsing and project config integration

## Not Included / Future PRs
- Strategy-aware behavior in `_phase_0b_exemplar` (#702) — this PR only adds config plumbing
- Voice steering toward corpus-covered combos (#703)

## Test Plan
```
uv run mypy src/questfoundry/cli.py src/questfoundry/pipeline/config.py src/questfoundry/pipeline/orchestrator.py src/questfoundry/pipeline/stages/fill.py  # Success
uv run ruff check [same files]  # All passed
uv run pytest tests/unit/test_config.py -x -q  # 53 passed
uv run pytest tests/unit/test_fill_stage.py tests/unit/test_orchestrator.py -x -q  # 122 passed
```

## Risk / Rollback
- No behavior changes — exemplar_strategy is stored but not acted upon yet
- Default "auto" preserves existing behavior until PR #702 adds strategy resolution
- Safe to revert by removing the field

🤖 Generated with [Claude Code](https://claude.com/claude-code)