### PR TITLE
feat(fill): make exemplar phase strategy-aware (#702)

### DIFF
--- a/src/questfoundry/pipeline/config.py
+++ b/src/questfoundry/pipeline/config.py
@@ -254,9 +254,14 @@ class FillConfig:
         two_step: Use two-step prose generation (write prose first, then
             extract entities). Improves quality by removing JSON constraints
             from creative output.
+        exemplar_strategy: Controls voice exemplar generation.
+            "auto" (default): detect from model capability tier.
+            "corpus_only": corpus exemplars only, no LLM fallback.
+            "full": corpus-first with LLM fallback for missing combos.
     """
 
     two_step: bool = True
+    exemplar_strategy: str = "auto"
 
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> FillConfig:
@@ -270,6 +275,7 @@ class FillConfig:
         """
         return cls(
             two_step=data.get("two_step", True),
+            exemplar_strategy=data.get("exemplar_strategy", "auto"),
         )
 
 

--- a/src/questfoundry/pipeline/orchestrator.py
+++ b/src/questfoundry/pipeline/orchestrator.py
@@ -607,6 +607,10 @@ class PipelineOrchestrator:
                     stage_kwargs["min_priority"] = min_priority
             if stage_name == "fill":
                 stage_kwargs["two_step"] = context.get("two_step", self.config.fill.two_step)
+                stage_kwargs["model_name"] = self._model_name
+                stage_kwargs["exemplar_strategy"] = context.get(
+                    "exemplar_strategy", self.config.fill.exemplar_strategy
+                )
 
             # Resolve size profile from DREAM vision node (for post-DREAM stages)
             if stage_name != "dream":

--- a/src/questfoundry/pipeline/stages/fill.py
+++ b/src/questfoundry/pipeline/stages/fill.py
@@ -277,6 +277,7 @@ class FillStage:
         self.gate = gate or AutoApprovePhaseGate()
         self._callbacks: list[BaseCallbackHandler] | None = None
         self._provider_name: str | None = None
+        self._model_name: str | None = None
         self._serialize_model: BaseChatModel | None = None
         self._serialize_provider_name: str | None = None
         self._size_profile: SizeProfile | None = None
@@ -284,6 +285,7 @@ class FillStage:
         self._max_concurrency: int = 2
         self._lang_instruction: str = ""
         self._two_step: bool = False
+        self._exemplar_strategy: str = "auto"
         # Interactive mode attributes (set in execute(), defaults for direct calls)
         self._interactive: bool = False
         self._user_input_fn: UserInputFn | None = None
@@ -400,6 +402,7 @@ class FillStage:
 
         self._callbacks = callbacks
         self._provider_name = provider_name
+        self._model_name = kwargs.get("model_name")
         self._serialize_model = serialize_model
         self._serialize_provider_name = serialize_provider_name
         self._interactive = interactive
@@ -412,6 +415,7 @@ class FillStage:
         self._language = kwargs.get("language", "en")
         self._lang_instruction = get_output_language_instruction(self._language)
         self._two_step = kwargs.get("two_step", True)
+        self._exemplar_strategy = kwargs.get("exemplar_strategy", "auto")
         self._on_connectivity_error = kwargs.get("on_connectivity_error")
         log.info("stage_start", stage="fill", interactive=interactive)
 

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -583,6 +583,26 @@ class TestFillConfig:
         config = FillConfig.from_dict({})
         assert config.two_step is True
 
+    def test_default_exemplar_strategy_is_auto(self) -> None:
+        """FillConfig defaults to exemplar_strategy='auto'."""
+        config = FillConfig()
+        assert config.exemplar_strategy == "auto"
+
+    def test_from_dict_exemplar_strategy(self) -> None:
+        """FillConfig.from_dict reads exemplar_strategy."""
+        config = FillConfig.from_dict({"exemplar_strategy": "corpus_only"})
+        assert config.exemplar_strategy == "corpus_only"
+
+    def test_from_dict_exemplar_strategy_full(self) -> None:
+        """FillConfig.from_dict reads exemplar_strategy=full."""
+        config = FillConfig.from_dict({"exemplar_strategy": "full"})
+        assert config.exemplar_strategy == "full"
+
+    def test_from_dict_empty_preserves_exemplar_default(self) -> None:
+        """Empty dict keeps exemplar_strategy default."""
+        config = FillConfig.from_dict({})
+        assert config.exemplar_strategy == "auto"
+
 
 class TestProjectConfigFill:
     """Tests for ProjectConfig fill section."""
@@ -606,6 +626,16 @@ class TestProjectConfigFill:
         config = ProjectConfig.from_dict(data)
         assert config.fill.two_step is False
 
+    def test_fill_exemplar_strategy_from_yaml(self) -> None:
+        """ProjectConfig parses fill.exemplar_strategy from dict."""
+        data = {
+            "name": "test",
+            "providers": {"default": "ollama/qwen3:4b-instruct-32k"},
+            "fill": {"exemplar_strategy": "corpus_only"},
+        }
+        config = ProjectConfig.from_dict(data)
+        assert config.fill.exemplar_strategy == "corpus_only"
+
     def test_fill_section_missing_uses_defaults(self) -> None:
         """Missing fill section uses FillConfig defaults."""
         data = {
@@ -615,3 +645,4 @@ class TestProjectConfigFill:
         config = ProjectConfig.from_dict(data)
         assert isinstance(config.fill, FillConfig)
         assert config.fill.two_step is True
+        assert config.fill.exemplar_strategy == "auto"

--- a/tests/unit/test_model_info.py
+++ b/tests/unit/test_model_info.py
@@ -4,7 +4,12 @@ from __future__ import annotations
 
 from unittest.mock import patch
 
-from questfoundry.providers.model_info import ModelInfo, get_model_info
+from questfoundry.providers.model_info import (
+    ModelInfo,
+    ModelProperties,
+    get_capability_tier,
+    get_model_info,
+)
 
 
 class TestModelInfoDefaults:
@@ -66,3 +71,86 @@ class TestModelInfoDataclass:
         info = ModelInfo(context_window=32_768, max_concurrency=5)
         with __import__("pytest").raises(AttributeError):
             info.max_concurrency = 10  # type: ignore[misc]
+
+
+class TestModelPropertiesCapabilityTier:
+    """Tests for capability_tier field on ModelProperties."""
+
+    def test_default_tier_is_small(self) -> None:
+        """ModelProperties defaults to small capability tier."""
+        props = ModelProperties(context_window=32_768)
+        assert props.capability_tier == "small"
+
+    def test_explicit_large_tier(self) -> None:
+        """ModelProperties accepts explicit large tier."""
+        props = ModelProperties(context_window=128_000, capability_tier="large")
+        assert props.capability_tier == "large"
+
+    def test_ollama_models_are_small(self) -> None:
+        """All Ollama models in KNOWN_MODELS are small tier."""
+        from questfoundry.providers.model_info import KNOWN_MODELS
+
+        for model_name, props in KNOWN_MODELS["ollama"].items():
+            assert props.capability_tier == "small", f"ollama/{model_name} should be small"
+
+    def test_cloud_models_are_large(self) -> None:
+        """All cloud provider models in KNOWN_MODELS are large tier."""
+        from questfoundry.providers.model_info import KNOWN_MODELS
+
+        for provider in ("openai", "anthropic", "google"):
+            for model_name, props in KNOWN_MODELS[provider].items():
+                assert props.capability_tier == "large", f"{provider}/{model_name} should be large"
+
+
+class TestGetCapabilityTier:
+    """Tests for get_capability_tier() function."""
+
+    def test_known_ollama_model(self) -> None:
+        """Known Ollama model returns small."""
+        assert get_capability_tier("ollama", "qwen3:4b-instruct-32k") == "small"
+
+    def test_known_openai_model(self) -> None:
+        """Known OpenAI model returns large."""
+        assert get_capability_tier("openai", "gpt-4o") == "large"
+
+    def test_known_anthropic_model(self) -> None:
+        """Known Anthropic model returns large."""
+        assert get_capability_tier("anthropic", "claude-sonnet-4-20250514") == "large"
+
+    def test_known_google_model(self) -> None:
+        """Known Google model returns large."""
+        assert get_capability_tier("google", "gemini-2.5-pro") == "large"
+
+    def test_unknown_ollama_small_pattern(self) -> None:
+        """Unknown Ollama model with small name pattern returns small."""
+        assert get_capability_tier("ollama", "phi3:3.8b") == "small"
+
+    def test_unknown_ollama_large_pattern(self) -> None:
+        """Unknown Ollama model without small pattern defaults to small."""
+        assert get_capability_tier("ollama", "deepseek-r1:70b") == "small"
+
+    def test_unknown_cloud_model_defaults_large(self) -> None:
+        """Unknown cloud provider model defaults to large."""
+        assert get_capability_tier("openai", "gpt-6-turbo") == "large"
+
+    def test_unknown_provider_defaults_small(self) -> None:
+        """Unknown provider defaults to small (conservative)."""
+        assert get_capability_tier("local_llm", "custom-model") == "small"
+
+    def test_case_insensitive_provider(self) -> None:
+        """Provider name is case-insensitive."""
+        assert get_capability_tier("OpenAI", "gpt-4o") == "large"
+        assert get_capability_tier("OLLAMA", "qwen3:4b-instruct-32k") == "small"
+
+    def test_heuristic_detects_7b(self) -> None:
+        """Name pattern heuristic detects 7b as small."""
+        assert get_capability_tier("ollama", "mistral-nemo:7b-q4") == "small"
+
+    def test_heuristic_detects_13b(self) -> None:
+        """Name pattern heuristic detects 13b as small."""
+        assert get_capability_tier("ollama", "codellama:13b") == "small"
+
+    def test_cloud_mini_is_large(self) -> None:
+        """Cloud 'mini' models are large (trained to follow instructions well)."""
+        assert get_capability_tier("openai", "gpt-5-mini") == "large"
+        assert get_capability_tier("openai", "o3-mini") == "large"


### PR DESCRIPTION
## Summary

Makes the FILL stage's exemplar generation phase aware of model capability tiers. Small models (≤13B) that copy exemplar content verbatim into prose now use `corpus_only` strategy (no LLM fallback), while large models get the full corpus-first + LLM-fallback pipeline. This prevents the exemplar contamination problem identified in qwen3:4b test runs.

## Related Issues

Closes #702
Depends on #704 (capability tier) and #705 (exemplar_strategy config)

## Changes

- Add `_resolve_exemplar_strategy()` method that maps `auto` → `corpus_only` for small models, `auto` → `full` for large models using `get_capability_tier()` from model_info
- Modify `_phase_0b_exemplar()` to check resolved strategy before attempting LLM fallback — when `corpus_only`, skip LLM entirely and store whatever corpus returned (even 0 matches)
- Add `_log_corpus_coverage_suggestions()` to help users understand coverage gaps when corpus returns no matches (queries `Corpus.list_exemplar_tags()` for available POV/tense/register/rhythm combos)
- Add `stage_full` test fixture for tests that explicitly need LLM fallback behavior
- Update 5 existing LLM-fallback tests to use `stage_full` fixture (since `auto` now correctly resolves to `corpus_only` for unknown providers)
- Add `TestExemplarStrategy` with 8 new tests covering all strategy resolution paths

## Not Included / Future PRs

- Voice steering toward corpus-covered attribute combos (#703) — deferred to separate PR
- Non-English corpus coverage — ifcraftcorpus exemplars are English-only currently

## Test Plan

- [x] Unit tests pass: `uv run pytest tests/unit/test_fill_exemplars.py tests/unit/test_fill_stage.py -x -q` (115 passed)
- [x] mypy clean: `uv run mypy src/questfoundry/pipeline/stages/fill.py`
- [x] ruff clean: `uv run ruff check src/questfoundry/pipeline/stages/fill.py tests/unit/test_fill_exemplars.py`
- [ ] Manual testing with qwen3:4b (deferred to post-merge of all 3 PRs)

## Risk / Rollback

- **Safe default**: Unknown models default to `small` → `corpus_only`. This is conservative — worst case is missing exemplars, not contaminated prose.
- **Override available**: Users can set `exemplar_strategy: full` in project.yaml or `--exemplar-strategy full` on CLI to force LLM fallback regardless of model size.
- **No schema changes**: All changes are behavioral, no graph/model schema modifications.

## Review Guide

This PR is stacked on #704 and #705 (merged into this branch). Review only the top commit `680a9fe`:
1. `src/questfoundry/pipeline/stages/fill.py` — strategy resolution logic and modified phase_0b
2. `tests/unit/test_fill_exemplars.py` — new TestExemplarStrategy class and stage_full fixture

## Checklist

- [x] Code follows project conventions
- [x] Tests added/updated for changes
- [x] Documentation updated (if applicable)
- [x] No TODO stubs in committed code
- [x] Type hints added for new code