### PR TITLE
feat(dress): add --no-codex flag and deduplicate brief template (#651)

### DIFF
--- a/prompts/templates/dress_brief.yaml
+++ b/prompts/templates/dress_brief.yaml
@@ -80,8 +80,7 @@ system: |
     Consider: wonder, dread, fury, tenderness, humor, triumph, melancholy, awe,
     confusion, serenity, panic, relief. Match the mood to what actually happens
     in the passage.
-  - CAPTION LENGTH: Captions MUST be under 60 characters. They are for alt-text
-    and figure labels, not narrative prose. If your caption exceeds 60 chars, shorten it.
+  - CAPTION: See format above (10-60 chars, "[Subject] [action/state]")
   - NEGATIVE FIELD: Only list negatives SPECIFIC to this brief that go beyond
     the global negative_defaults. If no brief-specific negatives apply, use an
     empty string.

--- a/src/questfoundry/cli.py
+++ b/src/questfoundry/cli.py
@@ -476,6 +476,7 @@ def _run_stage_command(
     min_priority: int = 3,
     two_step: bool | None = None,
     language: str | None = None,
+    skip_codex: bool = False,
 ) -> None:
     """Common logic for running a stage command.
 
@@ -501,6 +502,7 @@ def _run_stage_command(
         min_priority: Only generate briefs with this priority or higher (1-3).
         two_step: Whether to use two-step prose generation in FILL stage.
         language: ISO 639-1 language code override (e.g., "nl", "ja").
+        skip_codex: Skip codex generation in DRESS stage.
     """
     log = get_logger(__name__)
 
@@ -536,6 +538,8 @@ def _run_stage_command(
         context["two_step"] = two_step
     if language:
         context["language"] = language
+    if skip_codex:
+        context["skip_codex"] = True
 
     # Add phase progress callback (used by GROW, and optionally by other stages)
     def _on_phase_progress(phase: str, status: str, detail: str | None) -> None:
@@ -1471,6 +1475,10 @@ def dress(
         str | None,
         typer.Option("--language", "-l", help="Output language (ISO 639-1 code, e.g., nl, ja, de)"),
     ] = None,
+    no_codex: Annotated[
+        bool,
+        typer.Option("--no-codex", help="Skip codex generation (Phase 2)"),
+    ] = False,
 ) -> None:
     """Run DRESS stage - art direction, illustrations, and codex.
 
@@ -1501,6 +1509,7 @@ def dress(
         image_provider=image_provider,
         image_budget=image_budget,
         language=language,
+        skip_codex=no_codex,
     )
 
 

--- a/src/questfoundry/pipeline/orchestrator.py
+++ b/src/questfoundry/pipeline/orchestrator.py
@@ -605,6 +605,8 @@ class PipelineOrchestrator:
                 min_priority = context.get("min_priority", 3)
                 if isinstance(min_priority, int) and min_priority < 3:
                     stage_kwargs["min_priority"] = min_priority
+                if context.get("skip_codex"):
+                    stage_kwargs["skip_codex"] = True
             if stage_name == "fill":
                 stage_kwargs["two_step"] = context.get("two_step", self.config.fill.two_step)
 

--- a/src/questfoundry/pipeline/stages/dress.py
+++ b/src/questfoundry/pipeline/stages/dress.py
@@ -164,6 +164,7 @@ class DressStage:
         self._max_concurrency: int = 2
         self._lang_instruction: str = ""
         self._on_connectivity_error: ConnectivityRetryFn | None = None
+        self._skip_codex: bool = False
 
     CHECKPOINT_DIR = "snapshots"
 
@@ -274,6 +275,7 @@ class DressStage:
         self._image_budget = kwargs.get("image_budget", 0)
         self._min_priority = kwargs.get("min_priority", 3)
         self._max_concurrency = kwargs.get("max_concurrency", 2)
+        self._skip_codex = kwargs.get("skip_codex", False)
         self._on_connectivity_error = kwargs.get("on_connectivity_error")
         self._lang_instruction = get_output_language_instruction(kwargs.get("language", "en"))
 
@@ -779,6 +781,10 @@ class DressStage:
         Iterates entities, builds per-entity context with codewords,
         calls LLM for codex tiers, validates, and applies to graph.
         """
+        if self._skip_codex:
+            log.info("codex_skipped", reason="--no-codex flag")
+            return DressPhaseResult(phase="codex", status="skipped", detail="--no-codex")
+
         entities = graph.get_nodes_by_type("entity")
         if not entities:
             return DressPhaseResult(phase="codex", status="completed", detail="no entities")

--- a/tests/unit/test_dress_stage.py
+++ b/tests/unit/test_dress_stage.py
@@ -1045,6 +1045,21 @@ class TestPhase2Codex:
         assert g.get_node("codex::protagonist_rank2") is not None
 
     @pytest.mark.asyncio()
+    async def test_skip_codex_flag(self) -> None:
+        """--no-codex flag skips Phase 2 entirely."""
+        g = Graph()
+        g.create_node(
+            "entity::protagonist",
+            {"type": "entity", "raw_id": "protagonist", "entity_type": "character"},
+        )
+        stage = DressStage()
+        stage._skip_codex = True
+        result = await stage._phase_2_codex(g, MagicMock())
+        assert result.status == "skipped"
+        assert result.detail == "--no-codex"
+        assert result.llm_calls == 0
+
+    @pytest.mark.asyncio()
     async def test_no_entities(self) -> None:
         g = Graph()
         stage = DressStage()


### PR DESCRIPTION
## Problem
DRESS codex generation (Phase 2) adds ~25k tokens of LLM calls that may go
unused. Issue #651 requests making codex generation optional.

## Changes
- Add `--no-codex` CLI flag to `qf dress` command
- Pass `skip_codex` through `_run_stage_command` -> orchestrator context -> stage kwargs
- Early-return in `_phase_2_codex()` with `status="skipped"` when flag is set
- Initialize `_skip_codex` in `DressStage.__init__` for test compatibility
- Deduplicate caption length constraint in `dress_brief.yaml` (appeared 3 times, consolidated to cross-reference)

## Not Included / Future PRs
- Brief batching (PR 2-3 in DRESS optimization plan)
- Codex batching (PR 4 in DRESS optimization plan)
- Lighter art direction (#651 item 2 — separate concern)

## Test Plan
- `uv run pytest tests/unit/test_dress_stage.py::TestPhase2Codex -x -q` — 4 passed
- `uv run mypy src/questfoundry/cli.py src/questfoundry/pipeline/stages/dress.py src/questfoundry/pipeline/orchestrator.py` — no issues
- `uv run ruff check src/` — all passed

## Risk / Rollback
- Additive flag with `False` default — zero behavioral change unless explicitly opted in
- Template dedup is cosmetic — removes 1 line of redundant instruction

Closes #651

🤖 Generated with [Claude Code](https://claude.com/claude-code)