### PR TITLE
feat(models): add DRESS batch output schemas and templates

### DIFF
--- a/prompts/templates/dress_brief_batch.yaml
+++ b/prompts/templates/dress_brief_batch.yaml
@@ -1,0 +1,91 @@
+name: dress_brief_batch
+description: Generate illustration briefs for a batch of passages
+
+system: |
+  You are creating illustration briefs for passages in an interactive fiction story.
+  Your task is to design one compelling image per passage that captures its essence.
+
+  ## Art Direction
+  {art_direction}
+
+  ## Entity Visual References
+  {entity_visuals}
+
+  ## Composition and Mood Mapping
+  Use the passage's **narrative function** and **exit mood** to drive visual choices:
+  - introduce -> wide/establishing shot, open framing, environmental detail
+  - develop -> medium shot, character focus, layered composition
+  - complicate -> off-balance framing, Dutch angle, cropped elements, visual tension
+  - confront -> tight close-up or claustrophobic framing, direct eye contact, minimal negative space
+  - resolve -> balanced composition, breathing room, symmetry or stillness
+
+  The **exit mood** IS the brief's mood. Do not default to "haunting" — use the exit
+  mood directly or a close synonym. If exit mood says "tense anticipation", the brief
+  mood should reflect anticipation, not generic dread.
+
+  These are starting points, not rigid rules. Deviate when the passage content demands it.
+
+  ## Recent Compositions (Anti-Repetition)
+  {composition_log}
+
+  ## Output Schema
+  Return a JSON object with a "briefs" array. Each element must have:
+
+  **passage_id**: Passage ID (must match exactly from the list below)
+
+  **brief** (object):
+  - priority: 1-3 (1=must-have, 2=important, 3=nice-to-have)
+  - category: One of "scene", "portrait", "vista", "item_detail"
+  - subject: What the image depicts (concise description)
+  - entities: List of entity IDs present in the image (raw IDs, no scope prefix)
+  - caption: Short descriptive caption (10-60 chars). Format: "[Subject] [action/state]"
+  - mood: Emotional tone of the image
+  - composition: Framing and camera notes (2-4 sentences)
+  - style_overrides: Deviations from global art direction (usually empty string)
+  - negative: Things to avoid in this specific image (1-2 sentences; empty string if none)
+
+  **llm_adjustment**: Integer from -2 to +2 adjusting priority based on narrative importance.
+    - +2: Pivotal scene that defines the story visually
+    - +1: Strong visual moment worth highlighting
+    - 0: Standard scene, no adjustment
+    - -1: Less visually interesting than structure suggests
+    - -2: Mostly dialogue/internal, poor illustration candidate
+
+  {output_language_instruction}
+
+  ## Guidelines
+  - Match the global art direction style and palette
+  - Use entity visual references for consistent depiction
+
+  ## Caption Length (STRICT)
+  Captions MUST be 10-60 characters. Count your characters.
+  WRONG: "A scene" (8 chars — too short)
+  WRONG: "I remember the first time I saw a garden bloom in the spring light..." (70 chars — too long, too narrative)
+  RIGHT: "Kay reading the letter" (22 chars)
+  RIGHT: "The manor at dusk" (17 chars)
+  RIGHT: "Dr. Aris pouring tea" (20 chars)
+
+  - Format: "[Subject] [action/state]" — descriptive alt-text, NOT prose excerpts.
+  - COMPOSITION VARIETY: Do NOT use the same camera angle and framing for every
+    brief. Vary between: low-angle, high-angle, eye-level, bird's-eye, close-up,
+    medium shot, wide establishing shot, over-the-shoulder, Dutch angle.
+  - MOOD VARIETY: Use the full emotional spectrum. Not every scene is "haunting".
+  - NEGATIVE FIELD: Only list negatives SPECIFIC to this brief that go beyond
+    the global negative_defaults. If no brief-specific negatives apply, use an
+    empty string.
+  - PATH UNDERTONE: If present, let the path's emotional undertone subtly tint the
+    image — a color choice, a shadow direction, an expression — not dominate the subject.
+  - ENTITIES: List the entity IDs of characters, locations, or items that appear
+    in the image. Use the raw entity IDs (e.g., "kael_vex", not "entity_visual::kael_vex").
+    Do NOT leave this empty if characters are depicted.
+  - Return ONLY valid JSON. No prose before or after.
+
+user: |
+  ## Passages ({passage_count} total)
+  {passages_batch}
+
+  Create illustration briefs for ALL {passage_count} passages listed above.
+  Return a JSON object with a "briefs" array containing one entry per passage.
+  Each entry must have passage_id, brief, and llm_adjustment fields.
+
+components: []

--- a/prompts/templates/dress_codex_batch.yaml
+++ b/prompts/templates/dress_codex_batch.yaml
@@ -1,0 +1,45 @@
+name: dress_codex_batch
+description: Generate codex entries for a batch of entities
+
+system: |
+  You are creating encyclopedia (codex) entries for entities in an interactive fiction story.
+  Codex entries are player-facing — written in-world, revealing information as the player
+  unlocks codewords through gameplay.
+
+  ## Creative Vision
+  {vision_context}
+
+  ## Available Codewords
+  {codewords}
+
+  ## Output Schema
+  Return a JSON object with an "entities" array. Each element must have:
+
+  **entity_id**: Entity ID (must match exactly from the list below)
+
+  **entries** (list of objects):
+  - title: Short display title for this entry (e.g., character name, location name, faction name)
+  - rank: Display order (1 = base knowledge, higher = deeper revelation)
+  - visible_when: List of codeword IDs that must be unlocked to see this entry (empty for rank 1)
+  - content: Diegetic text — written in the story's voice, not meta-commentary
+
+  {output_language_instruction}
+
+  ## Rules
+  - Rank 1 entry MUST have empty visible_when (always visible to player)
+  - Higher rank entries should require relevant codewords
+  - Content must be diegetic — written as if it exists in the story world
+  - Do NOT spoil future plot events — each tier reveals only what the player has earned
+  - Codeword IDs in visible_when MUST be from the available codewords list
+  - Each rank must be unique per entity — no duplicate rank numbers
+  - Return ONLY valid JSON. No prose before or after.
+
+user: |
+  ## Entities ({entity_count} total)
+  {entities_batch}
+
+  Create codex entries for ALL {entity_count} entities listed above.
+  CRITICAL: Use ONLY codeword IDs from the available list. Rank 1 must have empty visible_when.
+  Return a JSON object with an "entities" array containing one element per entity.
+
+components: []

--- a/src/questfoundry/models/__init__.py
+++ b/src/questfoundry/models/__init__.py
@@ -28,6 +28,10 @@ from questfoundry.models.dream import (
 )
 from questfoundry.models.dress import (
     ArtDirection,
+    BatchedBriefItem,
+    BatchedBriefOutput,
+    BatchedCodexItem,
+    BatchedCodexOutput,
     CodexEntry,
     DressPhase0Output,
     DressPhase1Output,
@@ -110,6 +114,10 @@ __all__ = [
     "Arc",
     "ArtDirection",
     "AtmosphericDetail",
+    "BatchedBriefItem",
+    "BatchedBriefOutput",
+    "BatchedCodexItem",
+    "BatchedCodexOutput",
     "BatchedExpandOutput",
     "BrainstormOutput",
     "Choice",

--- a/src/questfoundry/models/dress.py
+++ b/src/questfoundry/models/dress.py
@@ -198,6 +198,42 @@ class DressPhase2Output(BaseModel):
 
 
 # ---------------------------------------------------------------------------
+# Batched LLM output wrappers
+# ---------------------------------------------------------------------------
+
+
+class BatchedBriefItem(BaseModel):
+    """One brief within a batched response."""
+
+    passage_id: str = Field(min_length=1, description="Passage ID (must match exactly)")
+    brief: IllustrationBrief
+    llm_adjustment: int = Field(
+        ge=-2,
+        le=2,
+        description="LLM priority adjustment (-2 to +2)",
+    )
+
+
+class BatchedBriefOutput(BaseModel):
+    """Phase 1 batched output: briefs for multiple passages."""
+
+    briefs: list[BatchedBriefItem] = Field(min_length=1)
+
+
+class BatchedCodexItem(BaseModel):
+    """Codex entries for one entity within a batch."""
+
+    entity_id: str = Field(min_length=1, description="Entity ID (must match exactly)")
+    entries: list[CodexEntry] = Field(min_length=1)
+
+
+class BatchedCodexOutput(BaseModel):
+    """Phase 2 batched output: codex entries for multiple entities."""
+
+    entities: list[BatchedCodexItem] = Field(min_length=1)
+
+
+# ---------------------------------------------------------------------------
 # Stage result
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Problem
DRESS Phase 1 and Phase 2 make one LLM call per passage/entity, repeating
~900/~700 tokens of identical context each time. Batching requires new
output schemas and prompt templates.

## Changes
- Add `BatchedBriefItem`, `BatchedBriefOutput`, `BatchedCodexItem`,
  `BatchedCodexOutput` models to `src/questfoundry/models/dress.py`
- Export new models from `models/__init__.py`
- Add `dress_brief_batch.yaml` template (shared context in system,
  `{passages_batch}` in user message)
- Add `dress_codex_batch.yaml` template (shared context in system,
  `{entities_batch}` in user message)
- Add 12 unit tests for batch model validation

## Not Included / Future PRs
- Phase 1 brief batching implementation (PR 3, depends on this PR)
- Phase 2 codex batching implementation (PR 4, independent)

## Test Plan
- `uv run pytest tests/unit/test_dress_models.py -x -q` — 52 passed
- `uv run mypy src/questfoundry/models/dress.py src/questfoundry/models/__init__.py` — no issues
- `uv run ruff check src/ prompts/` — all passed

## Risk / Rollback
- Additive models only — no existing code references them yet
- Templates are new files — no behavioral change until batching PRs land

🤖 Generated with [Claude Code](https://claude.com/claude-code)