### PR TITLE
feat(dress): batch Phase 1 briefs (5 per call)

### DIFF
--- a/src/questfoundry/graph/dress_context.py
+++ b/src/questfoundry/graph/dress_context.py
@@ -12,7 +12,7 @@ from typing import TYPE_CHECKING
 import yaml
 
 from questfoundry.graph.context import ENTITY_CATEGORIES, parse_scoped_id, strip_scope_prefix
-from questfoundry.graph.fill_context import format_dream_vision
+from questfoundry.graph.fill_context import format_dream_vision, get_spine_arc_id
 
 if TYPE_CHECKING:
     from questfoundry.graph.graph import Graph
@@ -281,6 +281,44 @@ def format_entity_visuals_for_passage(graph: Graph, passage_id: str) -> str:
     return "\n".join(lines) if lines else ""
 
 
+def describe_priority_context(graph: Graph, passage_id: str, base_score: int) -> str:
+    """Describe the structural position of a passage for the LLM.
+
+    Args:
+        graph: Story graph.
+        passage_id: Passage node ID.
+        base_score: Pre-computed structural score.
+
+    Returns:
+        Human-readable priority context string.
+    """
+    parts: list[str] = [f"Structural base score: {base_score}"]
+
+    passage = graph.get_node(passage_id)
+    if not passage:
+        return parts[0]
+
+    beat_id = passage.get("from_beat", "")
+    beat = graph.get_node(beat_id) if beat_id else None
+    scene_type = beat.get("scene_type", "") if beat else ""
+    if scene_type:
+        parts.append(f"Scene type: {scene_type}")
+
+    spine_id = get_spine_arc_id(graph)
+    if spine_id:
+        spine = graph.get_node(spine_id)
+        if spine and beat_id in spine.get("sequence", []):
+            parts.append("Position: spine arc (main storyline)")
+        else:
+            parts.append("Position: branch arc")
+
+    choices = graph.get_edges(from_id=passage_id, edge_type="choice")
+    if choices:
+        parts.append(f"Divergence point: {len(choices)} choices")
+
+    return "\n".join(parts)
+
+
 def format_passages_batch_for_briefs(
     graph: Graph,
     passage_ids: list[str],
@@ -299,8 +337,6 @@ def format_passages_batch_for_briefs(
     Returns:
         Formatted batch string with sections per passage.
     """
-    from questfoundry.pipeline.stages.dress import describe_priority_context
-
     sections: list[str] = []
     for pid in passage_ids:
         raw_id = (graph.get_node(pid) or {}).get("raw_id", strip_scope_prefix(pid))

--- a/tests/unit/test_dress_stage.py
+++ b/tests/unit/test_dress_stage.py
@@ -14,6 +14,8 @@ if TYPE_CHECKING:
 from questfoundry.graph.graph import Graph
 from questfoundry.models.dress import (
     ArtDirection,
+    BatchedBriefItem,
+    BatchedBriefOutput,
     CodexEntry,
     DressPhase0Output,
     DressPhase1Output,
@@ -884,6 +886,29 @@ class TestMapScoreToPriority:
 # ---------------------------------------------------------------------------
 
 
+def _make_brief_output(passage_id: str = "opening", llm_adjustment: int = 1) -> BatchedBriefOutput:
+    """Helper to build a BatchedBriefOutput for a single passage."""
+    return BatchedBriefOutput(
+        briefs=[
+            BatchedBriefItem(
+                passage_id=passage_id,
+                brief=IllustrationBrief(
+                    priority=2,
+                    category="scene",
+                    subject="Scholar arrives at the ancient bridge",
+                    entities=["protagonist"],
+                    composition="Wide establishing shot",
+                    mood="foreboding",
+                    style_overrides="",
+                    negative="",
+                    caption="The bridge loomed through the mist.",
+                ),
+                llm_adjustment=llm_adjustment,
+            )
+        ]
+    )
+
+
 @pytest.fixture()
 def mock_brief_output() -> DressPhase1Output:
     return DressPhase1Output(
@@ -898,13 +923,13 @@ def mock_brief_output() -> DressPhase1Output:
             negative="",
             caption="The bridge loomed through the mist.",
         ),
-        llm_adjustment=1,  # Enough to push base_score=0 to priority 3
+        llm_adjustment=1,
     )
 
 
 class TestPhase1Briefs:
     @pytest.mark.asyncio()
-    async def test_creates_brief_nodes(self, mock_brief_output: DressPhase1Output) -> None:
+    async def test_creates_brief_nodes(self) -> None:
         """Phase 1 creates illustration_brief nodes for passages with prose."""
         g = Graph()
         g.create_node(
@@ -921,7 +946,7 @@ class TestPhase1Briefs:
             stage,
             "_dress_llm_call",
             new_callable=AsyncMock,
-            return_value=(mock_brief_output, 1, 100),
+            return_value=(_make_brief_output("opening"), 1, 100),
         ):
             result = await stage._phase_1_briefs(g, MagicMock())
 
@@ -954,22 +979,8 @@ class TestPhase1Briefs:
         """Brief with very low combined score is skipped."""
         g = Graph()
         g.create_node(
-            "passage::boring", {"type": "passage", "raw_id": "boring", "prose": "Nothing happened."}
-        )
-
-        low_output = DressPhase1Output(
-            brief=IllustrationBrief(
-                priority=3,
-                category="scene",
-                subject="Nothing",
-                entities=[],
-                composition="Static",
-                mood="flat",
-                style_overrides="",
-                negative="",
-                caption="...",
-            ),
-            llm_adjustment=-2,
+            "passage::boring",
+            {"type": "passage", "raw_id": "boring", "prose": "Nothing happened."},
         )
 
         stage = DressStage()
@@ -977,13 +988,73 @@ class TestPhase1Briefs:
             stage,
             "_dress_llm_call",
             new_callable=AsyncMock,
-            return_value=(low_output, 1, 50),
+            return_value=(_make_brief_output("boring", llm_adjustment=-2), 1, 50),
         ):
             result = await stage._phase_1_briefs(g, MagicMock())
 
         # base_score=0, llm_adj=-2 → total=-2 → priority=0 → skipped
         assert g.get_node("illustration_brief::boring") is None
         assert "skipped" in result.detail
+
+    @pytest.mark.asyncio()
+    async def test_batching_groups_passages(self) -> None:
+        """Multiple passages are grouped into batches of 5."""
+        g = Graph()
+        g.create_node(
+            "art_direction::main",
+            {"type": "art_direction", "style": "ink", "palette": ["grey"]},
+        )
+        # Create 7 passages — should produce 2 batches (5 + 2)
+        passage_ids = []
+        for i in range(7):
+            pid = f"p{i}"
+            g.create_node(
+                f"passage::{pid}",
+                {"type": "passage", "raw_id": pid, "prose": f"Prose for passage {i}."},
+            )
+            passage_ids.append(pid)
+
+        call_count = 0
+
+        async def _mock_llm_call(
+            _model: Any,
+            _template: str,
+            context: dict[str, Any],
+            _schema: type,
+            **_kwargs: Any,
+        ) -> tuple[BatchedBriefOutput, int, int]:
+            nonlocal call_count
+            call_count += 1
+            count = int(context["passage_count"])
+            briefs = []
+            for j in range(count):
+                idx = (call_count - 1) * 5 + j
+                briefs.append(
+                    BatchedBriefItem(
+                        passage_id=passage_ids[idx],
+                        brief=IllustrationBrief(
+                            priority=2,
+                            category="scene",
+                            subject=f"Subject {idx}",
+                            entities=[],
+                            composition=f"Comp {idx}",
+                            mood="neutral",
+                            style_overrides="",
+                            negative="",
+                            caption=f"Caption {idx}",
+                        ),
+                        llm_adjustment=1,
+                    )
+                )
+            return BatchedBriefOutput(briefs=briefs), 1, 100
+
+        stage = DressStage()
+        with patch.object(stage, "_dress_llm_call", side_effect=_mock_llm_call):
+            result = await stage._phase_1_briefs(g, MagicMock())
+
+        assert call_count == 2  # 5 + 2
+        assert result.status == "completed"
+        assert "7 briefs created" in result.detail
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem
DRESS Phase 1 makes one LLM call per passage, repeating ~900 tokens of
identical art direction + instructions each time. For a 70-passage story,
this is ~105k input tokens and 70 round-trips.

## Changes
- Add `format_passages_batch_for_briefs()` and `format_all_entity_visuals()`
  batch context helpers to `dress_context.py`
- Rewrite `_phase_1_briefs()` to batch 5 passages per LLM call using
  `BatchedBriefOutput` schema and `dress_brief_batch` template
- Uses `batch_llm_calls()` for bounded concurrency
- Composition log accumulates across batches for anti-repetition
- Remove unused imports (`format_passage_for_brief`, `format_entity_visuals_for_passage`,
  `DressPhase1Output`)
- Update existing Phase 1 tests to use `BatchedBriefOutput`
- Add test for batch grouping (7 passages -> 2 batches)
- Add 5 context formatter tests

**Depends on PR #709** (batch models + templates)

## Not Included / Future PRs
- Phase 2 codex batching (PR 4, independent)
- Individual item retry fallback (deferred — templates retained for this)

## Test Plan
- `uv run pytest tests/unit/test_dress_stage.py tests/unit/test_dress_context.py -x -q` — 93 passed
- `uv run mypy src/questfoundry/pipeline/stages/dress.py src/questfoundry/graph/dress_context.py` — no issues

## Risk / Rollback
- Changes Phase 1 behavior from per-passage to batched calls
- Old per-passage template (`dress_brief.yaml`) retained for future fallback
- Batch size of 5 is conservative (~1k output tokens, well within small model limits)

## Review Guide
Suggested order: `dress_context.py` (new helpers) -> `dress.py` (batching logic) -> tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)