### PR TITLE
feat(dress): batch Phase 2 codex (4 per call)

### DIFF
--- a/src/questfoundry/graph/dress_context.py
+++ b/src/questfoundry/graph/dress_context.py
@@ -378,3 +378,22 @@ def format_all_entity_visuals(graph: Graph, passage_ids: list[str]) -> str:
                     lines.append(f"- **{raw_eid}**: {fragment}")
 
     return "\n".join(lines) if lines else ""
+
+
+def format_entities_batch_for_codex(graph: Graph, entity_ids: list[str]) -> str:
+    """Format a batch of entities for codex generation.
+
+    Args:
+        graph: Graph containing entity and codeword nodes.
+        entity_ids: Entity node IDs in this batch.
+
+    Returns:
+        Formatted batch string with sections per entity.
+    """
+    sections: list[str] = []
+    for eid in entity_ids:
+        entity_details = format_entity_for_codex(graph, eid)
+        if entity_details:
+            sections.append(entity_details)
+
+    return "\n\n".join(sections)

--- a/src/questfoundry/pipeline/stages/dress.py
+++ b/src/questfoundry/pipeline/stages/dress.py
@@ -40,7 +40,7 @@ from questfoundry.graph.context import ENTITY_CATEGORIES, strip_scope_prefix
 from questfoundry.graph.dress_context import (
     format_all_entity_visuals,
     format_art_direction_context,
-    format_entity_for_codex,
+    format_entities_batch_for_codex,
     format_passages_batch_for_briefs,
     format_vision_and_entities,
 )
@@ -55,8 +55,8 @@ from questfoundry.graph.fill_context import format_dream_vision, get_spine_arc_i
 from questfoundry.graph.graph import Graph
 from questfoundry.models.dress import (
     BatchedBriefOutput,
+    BatchedCodexOutput,
     DressPhase0Output,
-    DressPhase2Output,
     DressPhaseResult,
 )
 from questfoundry.observability.logging import get_logger
@@ -810,6 +810,8 @@ class DressStage:
     # Phase 2: Codex Entries
     # -------------------------------------------------------------------------
 
+    _CODEX_BATCH_SIZE = 4
+
     async def _phase_2_codex(
         self,
         graph: Graph,
@@ -817,8 +819,9 @@ class DressStage:
     ) -> DressPhaseResult:
         """Phase 2: Generate codex entries for entities.
 
-        Iterates entities, builds per-entity context with codewords,
-        calls LLM for codex tiers, validates, and applies to graph.
+        Batches entities (default 4 per LLM call) to reduce repeated
+        context injection. Shared vision and codewords go in the system
+        message; per-batch entity details in the user message.
         """
         if self._skip_codex:
             log.info("codex_skipped", reason="--no-codex flag")
@@ -840,43 +843,54 @@ class DressStage:
 
         entity_ids = list(entities.keys())
 
-        async def _codex_for_entity(
-            entity_id: str,
-        ) -> tuple[tuple[str, DressPhase2Output], int, int]:
-            entity_details_ctx = format_entity_for_codex(graph, entity_id)
+        # Chunk into batches
+        chunks: list[list[str]] = []
+        for i in range(0, len(entity_ids), self._CODEX_BATCH_SIZE):
+            chunks.append(entity_ids[i : i + self._CODEX_BATCH_SIZE])
+
+        async def _codex_batch(
+            chunk: list[str],
+        ) -> tuple[list[tuple[str, list[dict[str, Any]]]], int, int]:
+            entities_batch = format_entities_batch_for_codex(graph, chunk)
             context = {
                 "vision_context": vision_ctx or "No creative vision available.",
-                "entity_details": entity_details_ctx,
+                "entities_batch": entities_batch,
+                "entity_count": str(len(chunk)),
                 "codewords": codeword_list or "No codewords defined.",
                 "output_language_instruction": self._lang_instruction,
             }
             output, llm_calls, tokens = await self._dress_llm_call(
-                model, "dress_codex", context, DressPhase2Output
+                model, "dress_codex_batch", context, BatchedCodexOutput
             )
-            return (entity_id, output), llm_calls, tokens
+
+            items: list[tuple[str, list[dict[str, Any]]]] = []
+            for codex_item in output.entities:
+                entry_dicts = [e.model_dump() for e in codex_item.entries]
+                items.append((codex_item.entity_id, entry_dicts))
+
+            return items, llm_calls, tokens
 
         results, total_llm_calls, total_tokens, _errors = await batch_llm_calls(
-            entity_ids,
-            _codex_for_entity,
+            chunks,
+            _codex_batch,
             self._max_concurrency,
             on_connectivity_error=self._on_connectivity_error,
         )
 
-        for item in results:
-            if item is None:
+        for batch_result in results:
+            if batch_result is None:
                 continue
-            entity_id, output = item
-            entry_dicts = [e.model_dump() for e in output.entries]
-            errs = validate_dress_codex_entries(graph, entity_id, entry_dicts)
-            if errs:
-                validation_warnings += 1
-                log.warning(
-                    "codex_validation_issues",
-                    entity_id=entity_id,
-                    errors=errs,
-                )
-            apply_dress_codex(graph, entity_id, entry_dicts)
-            codex_created += len(entry_dicts)
+            for entity_id, entry_dicts in batch_result:
+                errs = validate_dress_codex_entries(graph, entity_id, entry_dicts)
+                if errs:
+                    validation_warnings += 1
+                    log.warning(
+                        "codex_validation_issues",
+                        entity_id=entity_id,
+                        errors=errs,
+                    )
+                apply_dress_codex(graph, entity_id, entry_dicts)
+                codex_created += len(entry_dicts)
 
         log.info(
             "codex_phase_complete",

--- a/tests/unit/test_dress_context.py
+++ b/tests/unit/test_dress_context.py
@@ -162,6 +162,32 @@ class TestFormatEntityForCodex:
         assert format_entity_for_codex(dress_graph, "character::nonexistent") == ""
 
 
+class TestFormatEntitiesBatchForCodex:
+    def test_formats_multiple_entities(self, dress_graph: Graph) -> None:
+        from questfoundry.graph.dress_context import format_entities_batch_for_codex
+
+        result = format_entities_batch_for_codex(
+            dress_graph, ["character::protagonist", "character::aldric"]
+        )
+        assert "protagonist" in result
+        assert "aldric" in result
+        assert "court advisor" in result
+
+    def test_skips_missing_entities(self, dress_graph: Graph) -> None:
+        from questfoundry.graph.dress_context import format_entities_batch_for_codex
+
+        result = format_entities_batch_for_codex(
+            dress_graph, ["character::protagonist", "character::nonexistent"]
+        )
+        assert "protagonist" in result
+        assert "nonexistent" not in result
+
+    def test_empty_list(self, dress_graph: Graph) -> None:
+        from questfoundry.graph.dress_context import format_entities_batch_for_codex
+
+        assert format_entities_batch_for_codex(dress_graph, []) == ""
+
+
 class TestFormatEntityVisualsForPassage:
     def test_includes_visual_fragments(self, dress_graph: Graph) -> None:
         from questfoundry.graph.dress_context import format_entity_visuals_for_passage

--- a/tests/unit/test_dress_stage.py
+++ b/tests/unit/test_dress_stage.py
@@ -16,10 +16,11 @@ from questfoundry.models.dress import (
     ArtDirection,
     BatchedBriefItem,
     BatchedBriefOutput,
+    BatchedCodexItem,
+    BatchedCodexOutput,
     CodexEntry,
     DressPhase0Output,
     DressPhase1Output,
-    DressPhase2Output,
     DressPhaseResult,
     EntityVisualWithId,
     IllustrationBrief,
@@ -232,9 +233,16 @@ class TestPhase0ArtDirection:
             ),
             llm_adjustment=0,
         )
-        mock_codex_out = DressPhase2Output(
-            entries=[
-                CodexEntry(title="Test Entity", rank=1, visible_when=[], content="Base knowledge.")
+        mock_codex_out = BatchedCodexOutput(
+            entities=[
+                BatchedCodexItem(
+                    entity_id="entity::protagonist",
+                    entries=[CodexEntry(title="Test", rank=1, visible_when=[], content="Base.")],
+                ),
+                BatchedCodexItem(
+                    entity_id="entity::aldric",
+                    entries=[CodexEntry(title="Test", rank=1, visible_when=[], content="Base.")],
+                ),
             ]
         )
 
@@ -258,12 +266,11 @@ class TestPhase0ArtDirection:
                 stage,
                 "_dress_llm_call",
                 new_callable=AsyncMock,
-                # Order is deterministic: dict insertion order (Python 3.7+).
-                # Phase 1: 1 passage, Phase 2: protagonist then aldric.
+                # Phase 1: 1 passage (per-passage call).
+                # Phase 2: 1 batch with both entities (batch size 4).
                 side_effect=[
                     (mock_brief_output, 1, 50),  # Phase 1: opening passage
-                    (mock_codex_out, 1, 50),  # Phase 2: protagonist
-                    (mock_codex_out, 1, 50),  # Phase 2: aldric
+                    (mock_codex_out, 1, 50),  # Phase 2: batch of 2 entities
                 ],
             ),
         ):
@@ -1062,29 +1069,34 @@ class TestPhase1Briefs:
 # ---------------------------------------------------------------------------
 
 
-@pytest.fixture()
-def mock_codex_output() -> DressPhase2Output:
-    return DressPhase2Output(
-        entries=[
-            CodexEntry(
-                title="Aldric",
-                rank=1,
-                visible_when=[],
-                content="A young scholar of the old academy.",
-            ),
-            CodexEntry(
-                title="Aldric's Secret",
-                rank=2,
-                visible_when=["met_aldric"],
-                content="The scholar secretly studies forbidden texts.",
-            ),
+def _make_codex_output(entity_id: str) -> BatchedCodexOutput:
+    """Helper to create a BatchedCodexOutput for a single entity."""
+    return BatchedCodexOutput(
+        entities=[
+            BatchedCodexItem(
+                entity_id=entity_id,
+                entries=[
+                    CodexEntry(
+                        title="Aldric",
+                        rank=1,
+                        visible_when=[],
+                        content="A young scholar of the old academy.",
+                    ),
+                    CodexEntry(
+                        title="Aldric's Secret",
+                        rank=2,
+                        visible_when=["met_aldric"],
+                        content="The scholar secretly studies forbidden texts.",
+                    ),
+                ],
+            )
         ]
     )
 
 
 class TestPhase2Codex:
     @pytest.mark.asyncio()
-    async def test_creates_codex_nodes(self, mock_codex_output: DressPhase2Output) -> None:
+    async def test_creates_codex_nodes(self) -> None:
         """Phase 2 creates codex nodes for each entity."""
         g = Graph()
         g.create_node(
@@ -1102,11 +1114,12 @@ class TestPhase2Codex:
         )
 
         stage = DressStage()
+        mock_output = _make_codex_output("entity::protagonist")
         with patch.object(
             stage,
             "_dress_llm_call",
             new_callable=AsyncMock,
-            return_value=(mock_codex_output, 1, 150),
+            return_value=(mock_output, 1, 150),
         ):
             result = await stage._phase_2_codex(g, MagicMock())
 
@@ -1138,7 +1151,59 @@ class TestPhase2Codex:
         assert result.detail == "no entities"
 
     @pytest.mark.asyncio()
-    async def test_logs_validation_warnings(self, mock_codex_output: DressPhase2Output) -> None:
+    async def test_batching_groups_entities(self) -> None:
+        """5 entities with batch size 4 produce 2 LLM calls."""
+        g = Graph()
+        for i in range(5):
+            g.create_node(
+                f"entity::e{i}",
+                {"type": "entity", "raw_id": f"e{i}", "entity_type": "character"},
+            )
+
+        def _make_batch_output(chunk: list[str]) -> BatchedCodexOutput:
+            return BatchedCodexOutput(
+                entities=[
+                    BatchedCodexItem(
+                        entity_id=eid,
+                        entries=[
+                            CodexEntry(title=f"E{i}", rank=1, visible_when=[], content="Info.")
+                        ],
+                    )
+                    for i, eid in enumerate(chunk)
+                ]
+            )
+
+        call_count = 0
+
+        async def _mock_llm_call(
+            _model: Any,
+            _template: str,
+            _context: dict[str, Any],
+            _schema: type,
+            **_kwargs: Any,
+        ) -> tuple:
+            nonlocal call_count
+            call_count += 1
+            # Parse entity count from context to build matching output
+            count = int(_context["entity_count"])
+            # Build entity IDs from batch text (rough extraction)
+            eids = [
+                f"entity::e{j}" for j in range((call_count - 1) * 4, (call_count - 1) * 4 + count)
+            ]
+            return (_make_batch_output(eids), 1, 100)
+
+        stage = DressStage()
+        with patch.object(stage, "_dress_llm_call", side_effect=_mock_llm_call):
+            result = await stage._phase_2_codex(g, MagicMock())
+
+        assert call_count == 2  # 4 + 1
+        assert result.llm_calls == 2
+        # All 5 entities should have codex entries
+        for i in range(5):
+            assert g.get_node(f"codex::e{i}_rank1") is not None
+
+    @pytest.mark.asyncio()
+    async def test_logs_validation_warnings(self) -> None:
         """Codex validation warnings are logged but don't fail the phase."""
         g = Graph()
         g.create_node(
@@ -1148,11 +1213,12 @@ class TestPhase2Codex:
         # No codewords defined — met_aldric in visible_when will trigger warning
 
         stage = DressStage()
+        mock_output = _make_codex_output("entity::protagonist")
         with patch.object(
             stage,
             "_dress_llm_call",
             new_callable=AsyncMock,
-            return_value=(mock_codex_output, 1, 150),
+            return_value=(mock_output, 1, 150),
         ):
             result = await stage._phase_2_codex(g, MagicMock())
 


### PR DESCRIPTION
## Problem

DRESS Phase 2 (codex generation) makes 1 LLM call per entity, each injecting
~700 tokens of identical vision + codeword context. For a 25-entity story, this
is 25 round-trips with heavily duplicated context.

## Changes

- Add `format_entities_batch_for_codex()` to `dress_context.py` — formats
  multiple entity profiles into a single markdown string for batch prompts
- Rewrite `_phase_2_codex()` to chunk entities into batches of 4, using
  `batch_llm_calls()` with the `dress_codex_batch` template and
  `BatchedCodexOutput` schema
- Remove now-unused imports (`format_entity_for_codex`, `DressPhase2Output`)
  from `dress.py`
- Update all Phase 2 tests to use `BatchedCodexOutput`
- Add batch grouping test (5 entities → 2 calls)
- Add 3 context formatter tests for `format_entities_batch_for_codex`

## Not Included / Future PRs

- Two-step split for codex (only if quality issues emerge post-batching)
- `creative=True` for codex (separate one-line change if prose quality is flat)

## Test Plan

```
uv run mypy src/questfoundry/pipeline/stages/dress.py src/questfoundry/graph/dress_context.py → Success
uv run ruff check src/ → All checks passed
uv run pytest tests/unit/test_dress_stage.py tests/unit/test_dress_context.py -x -q → 91 passed
```

## Risk / Rollback

- Low risk: batch size 4 is conservative for small models (~1.6k output tokens)
- Per-entity codeword validation still runs after batch parse
- Old per-entity template (`dress_codex.yaml`) retained for potential fallback

Closes #651 (together with PRs #708, #709, #710)

🤖 Generated with [Claude Code](https://claude.com/claude-code)