### PR TITLE
feat(dress): add --min-priority flag to skip low-priority brief generation

### DIFF
--- a/src/questfoundry/cli.py
+++ b/src/questfoundry/cli.py
@@ -1768,8 +1768,8 @@ def generate_images(
                     f"Priority {dress_min + 1}-{min_priority} briefs were not generated.\n"
                     f"Re-run [bold]qf dress --min-priority {min_priority}[/bold] to generate them."
                 )
-    except Exception:
-        pass  # Graph load failure will be caught by run_generate_only
+    except Exception as e:
+        log.debug("priority_check_failed", error=str(e))
 
     console.print()
     console.print(f"[dim]Generating images with {resolved_provider}...[/dim]")

--- a/src/questfoundry/cli.py
+++ b/src/questfoundry/cli.py
@@ -1475,6 +1475,7 @@ def dress(
         str | None,
         typer.Option("--language", "-l", help="Output language (ISO 639-1 code, e.g., nl, ja, de)"),
     ] = None,
+    min_priority: MinPriorityOption = 2,
     no_codex: Annotated[
         bool,
         typer.Option("--no-codex", help="Skip codex generation (Phase 2)"),
@@ -1485,6 +1486,10 @@ def dress(
     Establishes visual identity, generates illustration briefs for
     passages, creates codex entries for entities, and optionally
     generates images via an image provider.
+
+    By default, only generates briefs for priority 1-2 passages
+    (--min-priority 2). Use --min-priority 3 to generate briefs
+    for all passages.
 
     Requires FILL stage to have completed first.
     """
@@ -1508,6 +1513,7 @@ def dress(
         resume_from=resume_from,
         image_provider=image_provider,
         image_budget=image_budget,
+        min_priority=min_priority,
         language=language,
         skip_codex=no_codex,
     )
@@ -1746,6 +1752,24 @@ def generate_images(
         else:
             status_icon = "[yellow]○[/yellow]"
         console.print(f"  {status_icon} {phase}{detail_str}")
+
+    # Warn if requesting briefs that were never generated
+    from questfoundry.graph.graph import Graph
+
+    try:
+        _graph = Graph.load(project_path)
+        brief_config = _graph.get_node("dress_meta::brief_config")
+        if brief_config:
+            dress_min = brief_config.get("min_priority", 3)
+            if min_priority > dress_min:
+                console.print(
+                    f"[yellow]Warning:[/yellow] Requesting priority {min_priority} briefs, "
+                    f"but dress was run with --min-priority {dress_min}. "
+                    f"Priority {dress_min + 1}-{min_priority} briefs were not generated.\n"
+                    f"Re-run [bold]qf dress --min-priority {min_priority}[/bold] to generate them."
+                )
+    except Exception:
+        pass  # Graph load failure will be caught by run_generate_only
 
     console.print()
     console.print(f"[dim]Generating images with {resolved_provider}...[/dim]")


### PR DESCRIPTION
## Problem

DRESS Phase 1 generates illustration briefs for ALL passages with prose, including low-priority ones (nice-to-have, priority 3) that may never be rendered as images. This wastes LLM tokens on content that won't be used.

Closes #712

## Changes

- Add `--min-priority` option to `qf dress` command (default: **2**)
  - Same option as `generate-images` already has, reuses `MinPriorityOption` type
  - Default 2 means: skip generating briefs for nice-to-have passages
  - Use `--min-priority 3` for current behavior (generate all)
- Pre-filter passages in Phase 1 using best-possible priority (structural score + max LLM adjustment of +2) to avoid filtering passages the LLM might promote
- Store `dress_min_priority` in graph metadata (`dress_meta::brief_config` node)
- Add priority mismatch warning in both:
  - `run_generate_only()` (structured log warning)
  - `generate-images` CLI command (console warning to user)
  - Warns when `generate-images --min-priority 3` but dress was run with `--min-priority 2`

## Not Included / Future PRs

- No changes to `generate-images` default (remains 3 = all)
- No changes to Phase 2 codex generation

## Test Plan

```
uv run mypy src/questfoundry/cli.py src/questfoundry/pipeline/stages/dress.py  # pass
uv run ruff check src/ tests/                                                   # pass
uv run pytest tests/unit/test_dress_stage.py -x -q                              # 83 passed
```

New tests:
- `test_min_priority_filters_low_priority_passages` — passages below threshold are skipped before LLM
- `test_min_priority_stores_config_in_graph` — config metadata stored for mismatch detection
- `test_min_priority_3_generates_all` — default behavior preserved with --min-priority 3
- `test_warns_on_priority_mismatch` — run_generate_only accepts mismatched priority

## Risk / Rollback

- Default changed from 3 (generate all) to 2 (skip nice-to-have). Users wanting the old behavior use `--min-priority 3`.
- Pre-filtering uses best-possible priority (structural + max boost), so borderline passages still get a chance from LLM adjustment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)