### PR TITLE
fix(structured_output): strip $ref sibling keywords for OpenAI strict mode

### DIFF
--- a/tests/unit/test_structured_output.py
+++ b/tests/unit/test_structured_output.py
@@ -175,6 +175,55 @@ class TestMakeAllRequired:
         assert "$ref" in result["properties"]["inner"]
         assert "description" not in result["properties"]["inner"]
 
+    def test_strips_ref_siblings_in_array_items(self) -> None:
+        """Should strip sibling keywords from $ref in array item schemas."""
+
+        class Item(BaseModel):
+            name: str
+
+        class Container(BaseModel):
+            items: list[Item]
+
+        schema = Container.model_json_schema()
+        # Manually inject a $ref + description sibling (simulates Pydantic edge case)
+        schema["properties"]["items"]["items"] = {
+            "$ref": "#/$defs/Item",
+            "description": "An item",
+        }
+
+        result = _make_all_required(schema, schema_name="Container")
+
+        items_schema = result["properties"]["items"]["items"]
+        assert "$ref" in items_schema
+        assert "description" not in items_schema
+
+    def test_strips_ref_siblings_in_anyof(self) -> None:
+        """Should strip sibling keywords from $ref inside anyOf entries."""
+        schema: dict[str, Any] = {
+            "type": "object",
+            "properties": {
+                "value": {
+                    "anyOf": [
+                        {"$ref": "#/$defs/Inner", "description": "An inner"},
+                        {"type": "null"},
+                    ]
+                }
+            },
+            "$defs": {
+                "Inner": {
+                    "type": "object",
+                    "properties": {"x": {"type": "string"}},
+                    "required": ["x"],
+                }
+            },
+        }
+
+        result = _make_all_required(schema, schema_name="Root")
+
+        ref_entry = result["properties"]["value"]["anyOf"][0]
+        assert "$ref" in ref_entry
+        assert "description" not in ref_entry
+
     def test_handles_empty_schema(self) -> None:
         """Should handle schema without properties."""
         schema: dict[str, Any] = {"type": "object"}


### PR DESCRIPTION
## Problem

OpenAI's strict mode JSON schema validation rejects `$ref` properties that have sibling keywords (e.g., `description`). Pydantic generates `{"$ref": "#/$defs/Scope", "description": "Story scope with size preset"}` for fields using `Field(description=...)` with model type references. This causes a 400 Bad Request error:

```
Invalid schema for response_format 'DreamArtifact':
context=('properties', 'scope'), $ref cannot have keywords {'description'}.
```

Two schemas are affected: `DreamArtifact.scope` and `SeedOutput.convergence_sketch`.

Closes #716 (remaining OpenAI strict mode issue after PR #718).

## Changes

- Add `$ref` sibling keyword stripping to `_make_all_required()` in `structured_output.py`
- Update docstring to document this third OpenAI strict mode constraint
- Add `test_strips_ref_sibling_keywords` test case

## Not Included / Future PRs

- OpenAI verbosity/reasoning_effort parameters (#717)

## Test Plan

- `uv run pytest tests/unit/test_structured_output.py -x -q` — 25 tests pass
- Verified against actual `DreamArtifact` and `SeedOutput` schemas programmatically
- Verified against OpenAI structured outputs documentation (via MCP tools)

## Risk / Rollback

- Low risk: only affects OpenAI provider path (when `provider_name` starts with "openai")
- Non-OpenAI providers are unaffected
- Stripping `description` from `$ref` properties is safe — the description is redundant with the referenced `$defs` entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)