### PR TITLE
fix(prompts): add BRAINSTORM scope boundaries and pass content_notes to vision context

### DIFF
--- a/prompts/templates/discuss_brainstorm.yaml
+++ b/prompts/templates/discuss_brainstorm.yaml
@@ -21,6 +21,23 @@ system: |
   But don't force names - if you're thinking in terms of "the mentor" or "the hidden archive",
   that's fine. Names will be generated later for any entities that don't have them yet.
 
+  ## BRAINSTORM Stage Scope
+  BRAINSTORM generates raw creative material: entities and dilemmas. Nothing else.
+
+  **What BRAINSTORM produces:**
+  - Entities (characters, locations, objects, factions) with types, concepts, and notes
+  - Binary dilemmas with two answers, central entities, and why_it_matters
+
+  **What does NOT belong here (handled by later stages):**
+  - Beat maps or scene sequences
+  - Motive matrices or relationship maps
+  - Prose, scene hooks, or opening lines
+  - Timeline placement or pacing structure
+
+  If you find yourself planning scene order, writing character backstory prose,
+  or offering to convert material into a structured format, STOP. You've gone
+  too far. Your scope ends at entities and dilemmas.
+
   ## Entity Diversity Guidance
   - **Locations are particularly valuable** for scene variety - aim for {size_locations} distinct settings
   - If something has a physical space where scenes can occur, consider making it a location not an object
@@ -50,6 +67,7 @@ system: |
   - Every dilemma must explicitly list central entity IDs (use the same IDs you gave the entities)
   - Every dilemma needs a "why_it_matters" explaining thematic stakes
   - Don't self-censor - filtering happens in a later step
+  - Once entities and dilemmas are listed, stop. Later pipeline steps handle consolidation.
   {research_tools_section}
 
   ## Binary Dilemma Examples
@@ -76,6 +94,8 @@ system: |
   - Do NOT end with "let me know if you need..." - this is not a chat
   - Do NOT ask clarifying questions in non-interactive mode
   - Do NOT use short codes like `d1`, `d2` for dilemma IDs - use descriptive names
+  - Do NOT offer follow-up work (beat maps, motive matrices, scene hooks, timelines, etc.)
+  - Do NOT preview what later stages will do — your scope ends at entities and dilemmas
 
   ## Output Format Examples
 
@@ -95,6 +115,14 @@ non_interactive_section: |
   You are running without user interaction. Make confident creative decisions
   consistent with the creative vision above. Do NOT ask clarifying questions -
   generate material that aligns with the established genre, tone, and themes.
+
+  ## Deliverables (nothing more, nothing less)
+  1. {size_entities} entities across characters, locations, objects, and factions
+  2. {size_dilemmas} binary dilemmas with central entity links and why_it_matters
+
+  After producing entities and dilemmas, STOP. Do not offer next steps, summaries
+  of what could come next, or follow-up work. A separate automated pipeline step
+  handles consolidation.
 
   Use search_corpus for character archetypes, setting variety, and faction
   structures for this genre. Use web_search for culturally specific names
@@ -134,5 +162,8 @@ interactive_section: |
   The user can type **/done** or press Enter at any time to end this conversation
   and move forward. You don't need to reach perfect consensus — a rough direction
   is enough. When the user seems satisfied, don't introduce new concerns.
+
+  Your scope is entities and dilemmas only. Do not offer to produce beat maps,
+  scene hooks, or other downstream deliverables.
 
 components: []

--- a/src/questfoundry/pipeline/stages/brainstorm.py
+++ b/src/questfoundry/pipeline/stages/brainstorm.py
@@ -87,11 +87,20 @@ def _format_vision_context(vision_node: dict[str, Any]) -> str:
     if themes := vision_node.get("themes"):
         parts.append(f"**Themes**: {_format_list_or_str(themes)}")
 
+    if content_notes := vision_node.get("content_notes"):
+        if includes := content_notes.get("includes"):
+            parts.append("**Include**: " + "; ".join(includes))
+        if excludes := content_notes.get("excludes"):
+            parts.append("**Avoid**: " + "; ".join(excludes))
+
     if audience := vision_node.get("audience"):
         parts.append(f"**Audience**: {audience}")
 
     if style_notes := vision_node.get("style_notes"):
         parts.append(f"**Style**: {style_notes}")
+
+    if pov_style := vision_node.get("pov_style"):
+        parts.append(f"**POV**: {pov_style}")
 
     if scope := vision_node.get("scope"):
         parts.append(f"**Scope**: {scope}")

--- a/src/questfoundry/pipeline/stages/brainstorm.py
+++ b/src/questfoundry/pipeline/stages/brainstorm.py
@@ -89,9 +89,9 @@ def _format_vision_context(vision_node: dict[str, Any]) -> str:
 
     if content_notes := vision_node.get("content_notes"):
         if includes := content_notes.get("includes"):
-            parts.append("**Include**: " + "; ".join(includes))
+            parts.append(f"**Include**: {'; '.join(includes)}")
         if excludes := content_notes.get("excludes"):
-            parts.append("**Avoid**: " + "; ".join(excludes))
+            parts.append(f"**Avoid**: {'; '.join(excludes)}")
 
     if audience := vision_node.get("audience"):
         parts.append(f"**Audience**: {audience}")


### PR DESCRIPTION
## Problem

After PR #718 fixed DREAM's discuss phase, BRAINSTORM exhibits two issues:

1. **Out-of-bounds offers**: GPT-5-mini finishes generating entities/dilemmas then offers "beat maps", "motive matrices", and "scene hooks" — all SEED/GROW/FILL deliverables. The non-interactive section had no deliverable boundaries or consolidation hint.

2. **Context loss**: DREAM captured `content_notes` with ethical/cultural framing (e.g., "humane portrayals of local/service workers with agency") but `_format_vision_context()` dropped it. BRAINSTORM received a generic vision and immediately built hotel-staff archetypes without the guidance.

## Changes

**Template (`discuss_brainstorm.yaml`):**
- Add `## BRAINSTORM Stage Scope` section mirroring DREAM's proven scope pattern
- Add consolidation hint to Guidelines
- Add deliverable boundaries to non-interactive section with explicit STOP instruction
- Add scope boundary to interactive section
- Strengthen "What NOT to Do" with two additional prohibitions

**Python (`brainstorm.py`):**
- Add `content_notes` (includes/excludes) to `_format_vision_context()` — placed after Themes for natural reading flow
- Add `pov_style` to formatted context
- Uses "Avoid" instead of "Exclude" for softer creative guidance

## Not Included / Future PRs

- Scope boundaries for SEED discuss (#716 follow-up if needed)
- Richer `content_notes` formatting for FILL/DRESS stages

## Test Plan

- `uv run mypy src/questfoundry/pipeline/stages/brainstorm.py` — passes
- `uv run ruff check src/questfoundry/pipeline/stages/brainstorm.py` — passes
- Verified vision context includes content_notes against `test-murder-gpt5mini` graph data
- Pre-commit hooks pass (ruff, mypy, yaml check)

## Risk / Rollback

- Low risk: prompt-only changes + simple field additions to context formatter
- No behavior change for projects without `content_notes` in their DREAM artifact

🤖 Generated with [Claude Code](https://claude.com/claude-code)