### PR TITLE
feat(providers): add reasoning_effort and verbosity per-role settings

### DIFF
--- a/src/questfoundry/cli.py
+++ b/src/questfoundry/cli.py
@@ -2507,6 +2507,8 @@ def _show_available_models(discovered: dict[str, list[str]]) -> None:
     table.add_column("Context", justify="right", style="dim")
     table.add_column("Vision", justify="center")
     table.add_column("Tools", justify="center")
+    table.add_column("Verbose", justify="center")
+    table.add_column("Reason", justify="center")
 
     for provider in sorted(discovered.keys()):
         models = discovered[provider]
@@ -2518,12 +2520,16 @@ def _show_available_models(discovered: dict[str, list[str]]) -> None:
                 ctx = _format_context_window(props.context_window)
                 vision = "[green]✓[/green]" if props.supports_vision else "[dim]-[/dim]"
                 tools = "[green]✓[/green]" if props.supports_tools else "[dim]-[/dim]"
+                verbose = "[green]✓[/green]" if props.supports_verbosity else "[dim]-[/dim]"
+                reason = "[green]✓[/green]" if props.supports_reasoning_effort else "[dim]-[/dim]"
             else:
                 ctx = "[dim]?[/dim]"
                 vision = "[dim]?[/dim]"
                 tools = "[dim]?[/dim]"
+                verbose = "[dim]?[/dim]"
+                reason = "[dim]?[/dim]"
 
-            table.add_row(provider, model_name, ctx, vision, tools)
+            table.add_row(provider, model_name, ctx, vision, tools, verbose, reason)
 
     console.print(table)
     console.print()

--- a/src/questfoundry/providers/model_info.py
+++ b/src/questfoundry/providers/model_info.py
@@ -35,6 +35,8 @@ class ModelProperties:
     context_window: int
     supports_vision: bool = False
     supports_tools: bool = True  # Most models support tools; o1 family doesn't
+    supports_verbosity: bool = False  # GPT-5 family only
+    supports_reasoning_effort: bool = False  # GPT-5 family + o1/o3
 
 
 # Known model properties by provider and model name.
@@ -50,18 +52,43 @@ KNOWN_MODELS: dict[str, dict[str, ModelProperties]] = {
         "deepseek-coder:6.7b": ModelProperties(context_window=16_384),
     },
     "openai": {
-        "gpt-5-mini": ModelProperties(context_window=1_000_000, supports_vision=True),
+        "gpt-5-mini": ModelProperties(
+            context_window=1_000_000,
+            supports_vision=True,
+            supports_verbosity=True,
+            supports_reasoning_effort=True,
+        ),
         "gpt-4o": ModelProperties(context_window=128_000, supports_vision=True),
         "gpt-4o-mini": ModelProperties(context_window=128_000, supports_vision=True),
         "gpt-4-turbo": ModelProperties(context_window=128_000, supports_vision=True),
         "gpt-4": ModelProperties(context_window=8_192),
         "gpt-3.5-turbo": ModelProperties(context_window=16_385),
-        # Reasoning models: no tool support, no temperature parameter
-        "o1": ModelProperties(context_window=200_000, supports_tools=False),
-        "o1-mini": ModelProperties(context_window=128_000, supports_tools=False),
-        "o1-preview": ModelProperties(context_window=128_000, supports_tools=False),
-        "o3": ModelProperties(context_window=200_000, supports_tools=False),
-        "o3-mini": ModelProperties(context_window=200_000, supports_tools=False),
+        # Reasoning models: no tool support, no temperature, no verbosity
+        "o1": ModelProperties(
+            context_window=200_000,
+            supports_tools=False,
+            supports_reasoning_effort=True,
+        ),
+        "o1-mini": ModelProperties(
+            context_window=128_000,
+            supports_tools=False,
+            supports_reasoning_effort=True,
+        ),
+        "o1-preview": ModelProperties(
+            context_window=128_000,
+            supports_tools=False,
+            supports_reasoning_effort=True,
+        ),
+        "o3": ModelProperties(
+            context_window=200_000,
+            supports_tools=False,
+            supports_reasoning_effort=True,
+        ),
+        "o3-mini": ModelProperties(
+            context_window=200_000,
+            supports_tools=False,
+            supports_reasoning_effort=True,
+        ),
     },
     "anthropic": {
         "claude-sonnet-4-20250514": ModelProperties(context_window=200_000, supports_vision=True),

--- a/src/questfoundry/providers/settings.py
+++ b/src/questfoundry/providers/settings.py
@@ -166,6 +166,7 @@ class ModelVariant:
     rejects_stop: bool = False
     rejects_top_p: bool = False
     supports_reasoning_effort: bool = False
+    supports_verbosity: bool = False
 
 
 def _detect_model_variant(provider: str, model: str) -> ModelVariant:
@@ -188,9 +189,13 @@ def _detect_model_variant(provider: str, model: str) -> ModelVariant:
             supports_reasoning_effort=True,
         )
 
-    # GPT-5-mini currently rejects stop sequences
-    if provider == "openai" and "gpt-5-mini" in model_lower:
-        return ModelVariant(rejects_stop=True)
+    # GPT-5 family: supports verbosity + reasoning_effort, rejects stop sequences
+    if provider == "openai" and model_lower.startswith("gpt-5"):
+        return ModelVariant(
+            rejects_stop=True,
+            supports_reasoning_effort=True,
+            supports_verbosity=True,
+        )
 
     return ModelVariant()
 
@@ -275,6 +280,34 @@ def filter_model_kwargs(
             )
             continue
 
+        # Filter reasoning_effort for models that don't support it
+        if key == "reasoning_effort" and not variant.supports_reasoning_effort:
+            log.warning(
+                "param_not_supported",
+                param=key,
+                model=model,
+                reason="model_does_not_support_reasoning_effort",
+            )
+            continue
+
+        # Filter verbosity for models that don't support it.
+        # Also strip verbosity from model_kwargs sub-dict.
+        if (
+            key == "model_kwargs"
+            and isinstance(value, dict)
+            and "verbosity" in value
+            and not variant.supports_verbosity
+        ):
+            log.warning(
+                "param_not_supported",
+                param="verbosity",
+                model=model,
+                reason="model_does_not_support_verbosity",
+            )
+            value = {k: v for k, v in value.items() if k != "verbosity"}
+            if not value:
+                continue  # Skip empty model_kwargs
+
         # Translate max_tokens to provider-specific param name
         if key == "max_tokens" and caps.max_tokens_param != "max_tokens":
             filtered[caps.max_tokens_param] = value
@@ -285,6 +318,10 @@ def filter_model_kwargs(
     return filtered
 
 
+VALID_REASONING_EFFORT = {"none", "minimal", "low", "medium", "high", "xhigh"}
+VALID_VERBOSITY = {"low", "medium", "high"}
+
+
 @dataclass
 class PhaseSettings:
     """Model settings for a specific pipeline phase.
@@ -293,11 +330,15 @@ class PhaseSettings:
         temperature: Override temperature, or None to use phase/provider default.
         top_p: Nucleus sampling parameter, or None to use provider default.
         seed: Random seed for reproducibility, or None.
+        reasoning_effort: OpenAI reasoning depth (GPT-5/o1/o3), or None.
+        verbosity: OpenAI output verbosity (GPT-5 family), or None.
     """
 
     temperature: float | None = None
     top_p: float | None = None
     seed: int | None = None
+    reasoning_effort: str | None = None
+    verbosity: str | None = None
 
     def to_model_kwargs(self, phase: str, provider: str) -> dict[str, Any]:
         """Convert to kwargs for model creation.
@@ -344,6 +385,22 @@ class PhaseSettings:
             else:
                 kwargs["seed"] = self.seed
 
+        if self.reasoning_effort is not None:
+            kwargs["reasoning_effort"] = self.reasoning_effort
+            # GPT-5 family rejects temperature/top_p when reasoning_effort != "none"
+            if self.reasoning_effort != "none":
+                for param in ("temperature", "top_p"):
+                    if param in kwargs:
+                        log.debug(
+                            "param_suppressed_by_reasoning_effort",
+                            param=param,
+                            reasoning_effort=self.reasoning_effort,
+                        )
+                        del kwargs[param]
+
+        if self.verbosity is not None:
+            kwargs["model_kwargs"] = {"verbosity": self.verbosity}
+
         return kwargs
 
     @classmethod
@@ -365,6 +422,8 @@ class PhaseSettings:
         temperature = data.get("temperature")
         top_p = data.get("top_p")
         seed = data.get("seed")
+        reasoning_effort = data.get("reasoning_effort")
+        verbosity = data.get("verbosity")
 
         # Validate temperature (non-negative)
         if temperature is not None and temperature < 0:
@@ -381,10 +440,26 @@ class PhaseSettings:
             msg = f"seed must be an integer, got {type(seed).__name__}"
             raise ValueError(msg)
 
+        # Validate reasoning_effort
+        if reasoning_effort is not None:
+            reasoning_effort = str(reasoning_effort).lower()
+            if reasoning_effort not in VALID_REASONING_EFFORT:
+                msg = f"reasoning_effort must be one of {sorted(VALID_REASONING_EFFORT)}, got '{reasoning_effort}'"
+                raise ValueError(msg)
+
+        # Validate verbosity
+        if verbosity is not None:
+            verbosity = str(verbosity).lower()
+            if verbosity not in VALID_VERBOSITY:
+                msg = f"verbosity must be one of {sorted(VALID_VERBOSITY)}, got '{verbosity}'"
+                raise ValueError(msg)
+
         return cls(
             temperature=temperature,
             top_p=top_p,
             seed=seed,
+            reasoning_effort=reasoning_effort,
+            verbosity=verbosity,
         )
 
 

--- a/src/questfoundry/providers/settings.py
+++ b/src/questfoundry/providers/settings.py
@@ -399,7 +399,7 @@ class PhaseSettings:
                         del kwargs[param]
 
         if self.verbosity is not None:
-            kwargs["model_kwargs"] = {"verbosity": self.verbosity}
+            kwargs.setdefault("model_kwargs", {})["verbosity"] = self.verbosity
 
         return kwargs
 

--- a/tests/unit/test_model_info.py
+++ b/tests/unit/test_model_info.py
@@ -4,7 +4,12 @@ from __future__ import annotations
 
 from unittest.mock import patch
 
-from questfoundry.providers.model_info import ModelInfo, get_model_info
+from questfoundry.providers.model_info import (
+    KNOWN_MODELS,
+    ModelInfo,
+    ModelProperties,
+    get_model_info,
+)
 
 
 class TestModelInfoDefaults:
@@ -66,3 +71,49 @@ class TestModelInfoDataclass:
         info = ModelInfo(context_window=32_768, max_concurrency=5)
         with __import__("pytest").raises(AttributeError):
             info.max_concurrency = 10  # type: ignore[misc]
+
+
+class TestModelPropertiesCapabilityFlags:
+    """Tests for supports_verbosity and supports_reasoning_effort flags."""
+
+    def test_gpt5_mini_supports_both(self) -> None:
+        """GPT-5-mini supports both verbosity and reasoning_effort."""
+        props = KNOWN_MODELS["openai"]["gpt-5-mini"]
+        assert props.supports_verbosity is True
+        assert props.supports_reasoning_effort is True
+
+    def test_o1_supports_reasoning_only(self) -> None:
+        """o1 supports reasoning_effort but not verbosity."""
+        props = KNOWN_MODELS["openai"]["o1"]
+        assert props.supports_reasoning_effort is True
+        assert props.supports_verbosity is False
+
+    def test_o3_mini_supports_reasoning_only(self) -> None:
+        """o3-mini supports reasoning_effort but not verbosity."""
+        props = KNOWN_MODELS["openai"]["o3-mini"]
+        assert props.supports_reasoning_effort is True
+        assert props.supports_verbosity is False
+
+    def test_gpt4o_no_special_support(self) -> None:
+        """GPT-4o does not support verbosity or reasoning_effort."""
+        props = KNOWN_MODELS["openai"]["gpt-4o"]
+        assert props.supports_verbosity is False
+        assert props.supports_reasoning_effort is False
+
+    def test_ollama_models_no_special_support(self) -> None:
+        """Ollama models default to no verbosity/reasoning_effort support."""
+        props = KNOWN_MODELS["ollama"]["qwen3:4b-instruct-32k"]
+        assert props.supports_verbosity is False
+        assert props.supports_reasoning_effort is False
+
+    def test_anthropic_models_no_special_support(self) -> None:
+        """Anthropic models default to no verbosity/reasoning_effort support."""
+        props = KNOWN_MODELS["anthropic"]["claude-sonnet-4-20250514"]
+        assert props.supports_verbosity is False
+        assert props.supports_reasoning_effort is False
+
+    def test_model_properties_default_flags(self) -> None:
+        """ModelProperties defaults both flags to False."""
+        props = ModelProperties(context_window=32_768)
+        assert props.supports_verbosity is False
+        assert props.supports_reasoning_effort is False


### PR DESCRIPTION
## Problem

GPT-5-mini and o1/o3 models support `reasoning_effort` and `verbosity` parameters that can improve output quality (tighter briefs, better entity coherence), but these parameters weren't available in the provider configuration stack. Closes #717 (reasoning_effort/verbosity portion — convergence/chattiness was fixed in #718/#720).

## Changes

- **`src/questfoundry/providers/settings.py`**:
  - Add `reasoning_effort` and `verbosity` fields to `PhaseSettings`
  - Parse and validate in `from_dict()` (reasoning_effort: none/minimal/low/medium/high/xhigh; verbosity: low/medium/high)
  - Generate kwargs in `to_model_kwargs()` — verbosity goes in `model_kwargs` sub-dict, reasoning_effort suppresses temperature/top_p when not "none"
  - Add `supports_verbosity` to `ModelVariant` and detect GPT-5 family in `_detect_model_variant()`
  - Filter `reasoning_effort` and `verbosity` for unsupported models in `filter_model_kwargs()`
- **`src/questfoundry/providers/model_info.py`**:
  - Add `supports_verbosity` and `supports_reasoning_effort` flags to `ModelProperties`
  - Update `KNOWN_MODELS`: GPT-5-mini gets both, o1/o3 get reasoning_effort only
- **`src/questfoundry/cli.py`**:
  - Add "Verbose" and "Reason" columns to `qf doctor` model table

## Not Included / Future PRs

- No default values are set — users configure in project.yaml per the recommended table in #717
- No CLI flags for reasoning_effort/verbosity (configure via project.yaml `providers.serialize.reasoning_effort: high`)

## Test Plan

- `uv run mypy src/questfoundry/providers/ src/questfoundry/cli.py` — clean
- `uv run ruff check` — clean
- `uv run pytest tests/unit/test_settings.py tests/unit/test_model_info.py tests/unit/test_provider_factory.py -x -q` — 192 passed

New tests cover:
- PhaseSettings parsing/validation for reasoning_effort and verbosity (valid values, case normalization, rejection of invalid values)
- `to_model_kwargs()`: reasoning_effort in output, temperature/top_p suppression when reasoning_effort != "none", verbosity in model_kwargs sub-dict
- `_detect_model_variant()`: GPT-5 family detection, o1 vs GPT-4o behavior
- `filter_model_kwargs()`: pass-through for supported models, filtering for unsupported
- `ModelProperties` capability flags in KNOWN_MODELS registry

## Risk / Rollback

- Additive only — no behavior change for existing configs (new fields default to None)
- No breaking changes to existing provider configurations

🤖 Generated with [Claude Code](https://claude.com/claude-code)