### PR TITLE
feat(models): update model registry with correct context windows and new models

### DIFF
--- a/src/questfoundry/providers/model_info.py
+++ b/src/questfoundry/providers/model_info.py
@@ -45,37 +45,54 @@ KNOWN_MODELS: dict[str, dict[str, ModelProperties]] = {
     "ollama": {
         "qwen3:4b-instruct-32k": ModelProperties(context_window=32_768),
         "qwen3:8b": ModelProperties(context_window=32_768),
-        "qwen2.5:7b": ModelProperties(context_window=32_768),
+        "qwen2.5:7b": ModelProperties(context_window=128_000),
         "llama3:8b": ModelProperties(context_window=8_192),
         "llama3.1:8b": ModelProperties(context_window=128_000),
         "mistral:7b": ModelProperties(context_window=32_768),
         "deepseek-coder:6.7b": ModelProperties(context_window=16_384),
     },
     "openai": {
-        "gpt-5-mini": ModelProperties(
-            context_window=1_000_000,
+        # GPT-5 family: verbosity + reasoning_effort, rejects stop sequences
+        "gpt-5": ModelProperties(
+            context_window=400_000,
             supports_vision=True,
             supports_verbosity=True,
             supports_reasoning_effort=True,
         ),
+        "gpt-5-mini": ModelProperties(
+            context_window=400_000,
+            supports_vision=True,
+            supports_verbosity=True,
+            supports_reasoning_effort=True,
+        ),
+        "gpt-5-nano": ModelProperties(
+            context_window=400_000,
+            supports_vision=True,
+            supports_verbosity=True,
+            supports_reasoning_effort=True,
+        ),
+        "gpt-5.1": ModelProperties(
+            context_window=400_000,
+            supports_vision=True,
+            supports_verbosity=True,
+            supports_reasoning_effort=True,
+        ),
+        "gpt-5.2": ModelProperties(
+            context_window=400_000,
+            supports_vision=True,
+            supports_verbosity=True,
+            supports_reasoning_effort=True,
+        ),
+        # GPT-4.1 family
+        "gpt-4.1": ModelProperties(context_window=1_000_000, supports_vision=True),
+        "gpt-4.1-mini": ModelProperties(context_window=1_000_000, supports_vision=True),
+        "gpt-4.1-nano": ModelProperties(context_window=1_000_000, supports_vision=True),
+        # GPT-4o family
         "gpt-4o": ModelProperties(context_window=128_000, supports_vision=True),
         "gpt-4o-mini": ModelProperties(context_window=128_000, supports_vision=True),
-        "gpt-4-turbo": ModelProperties(context_window=128_000, supports_vision=True),
-        "gpt-4": ModelProperties(context_window=8_192),
-        "gpt-3.5-turbo": ModelProperties(context_window=16_385),
         # Reasoning models: no tool support, no temperature, no verbosity
         "o1": ModelProperties(
             context_window=200_000,
-            supports_tools=False,
-            supports_reasoning_effort=True,
-        ),
-        "o1-mini": ModelProperties(
-            context_window=128_000,
-            supports_tools=False,
-            supports_reasoning_effort=True,
-        ),
-        "o1-preview": ModelProperties(
-            context_window=128_000,
             supports_tools=False,
             supports_reasoning_effort=True,
         ),
@@ -89,19 +106,32 @@ KNOWN_MODELS: dict[str, dict[str, ModelProperties]] = {
             supports_tools=False,
             supports_reasoning_effort=True,
         ),
+        "o3-pro": ModelProperties(
+            context_window=200_000,
+            supports_tools=False,
+            supports_reasoning_effort=True,
+        ),
+        "o4-mini": ModelProperties(
+            context_window=200_000,
+            supports_tools=False,
+            supports_reasoning_effort=True,
+        ),
     },
     "anthropic": {
+        "claude-opus-4-6": ModelProperties(context_window=200_000, supports_vision=True),
+        "claude-opus-4-5-20251101": ModelProperties(context_window=200_000, supports_vision=True),
+        "claude-sonnet-4-5-20250929": ModelProperties(context_window=200_000, supports_vision=True),
         "claude-sonnet-4-20250514": ModelProperties(context_window=200_000, supports_vision=True),
         "claude-opus-4-20250514": ModelProperties(context_window=200_000, supports_vision=True),
-        "claude-3-5-sonnet-latest": ModelProperties(context_window=200_000, supports_vision=True),
-        "claude-3-5-sonnet-20241022": ModelProperties(context_window=200_000, supports_vision=True),
-        "claude-3-opus-20240229": ModelProperties(context_window=200_000, supports_vision=True),
-        "claude-3-haiku-20240307": ModelProperties(context_window=200_000, supports_vision=True),
+        "claude-haiku-4-5-20251001": ModelProperties(context_window=200_000, supports_vision=True),
     },
     "google": {
         "gemini-2.5-flash": ModelProperties(context_window=1_000_000, supports_vision=True),
+        "gemini-2.5-flash-lite": ModelProperties(context_window=1_000_000, supports_vision=True),
         "gemini-2.5-pro": ModelProperties(context_window=1_000_000, supports_vision=True),
         "gemini-2.0-flash": ModelProperties(context_window=1_000_000, supports_vision=True),
+        "gemini-3-pro-preview": ModelProperties(context_window=1_000_000, supports_vision=True),
+        "gemini-3-flash-preview": ModelProperties(context_window=1_000_000, supports_vision=True),
     },
 }
 

--- a/src/questfoundry/providers/settings.py
+++ b/src/questfoundry/providers/settings.py
@@ -181,8 +181,10 @@ def _detect_model_variant(provider: str, model: str) -> ModelVariant:
     """
     model_lower = model.lower()
 
-    # OpenAI reasoning models (o1, o3 families) don't support temperature/top_p
-    if provider == "openai" and (model_lower.startswith("o1") or model_lower.startswith("o3")):
+    # OpenAI reasoning models (o1, o3, o4 families) don't support temperature/top_p
+    if provider == "openai" and (
+        model_lower.startswith("o1") or model_lower.startswith("o3") or model_lower.startswith("o4")
+    ):
         return ModelVariant(
             rejects_temperature=True,
             rejects_top_p=True,

--- a/tests/unit/test_model_info.py
+++ b/tests/unit/test_model_info.py
@@ -82,6 +82,15 @@ class TestModelPropertiesCapabilityFlags:
         assert props.supports_verbosity is True
         assert props.supports_reasoning_effort is True
 
+    def test_gpt5_family_supports_both(self) -> None:
+        """All GPT-5 family models support verbosity and reasoning_effort."""
+        for model in ("gpt-5", "gpt-5-mini", "gpt-5-nano", "gpt-5.1", "gpt-5.2"):
+            props = KNOWN_MODELS["openai"][model]
+            assert props.supports_verbosity is True, f"{model} should support verbosity"
+            assert props.supports_reasoning_effort is True, (
+                f"{model} should support reasoning_effort"
+            )
+
     def test_o1_supports_reasoning_only(self) -> None:
         """o1 supports reasoning_effort but not verbosity."""
         props = KNOWN_MODELS["openai"]["o1"]
@@ -94,11 +103,24 @@ class TestModelPropertiesCapabilityFlags:
         assert props.supports_reasoning_effort is True
         assert props.supports_verbosity is False
 
+    def test_o4_mini_supports_reasoning_only(self) -> None:
+        """o4-mini supports reasoning_effort but not verbosity."""
+        props = KNOWN_MODELS["openai"]["o4-mini"]
+        assert props.supports_reasoning_effort is True
+        assert props.supports_verbosity is False
+
     def test_gpt4o_no_special_support(self) -> None:
         """GPT-4o does not support verbosity or reasoning_effort."""
         props = KNOWN_MODELS["openai"]["gpt-4o"]
         assert props.supports_verbosity is False
         assert props.supports_reasoning_effort is False
+
+    def test_gpt41_family_no_special_support(self) -> None:
+        """GPT-4.1 family does not support verbosity or reasoning_effort."""
+        for model in ("gpt-4.1", "gpt-4.1-mini", "gpt-4.1-nano"):
+            props = KNOWN_MODELS["openai"][model]
+            assert props.supports_verbosity is False, f"{model}"
+            assert props.supports_reasoning_effort is False, f"{model}"
 
     def test_ollama_models_no_special_support(self) -> None:
         """Ollama models default to no verbosity/reasoning_effort support."""
@@ -117,3 +139,49 @@ class TestModelPropertiesCapabilityFlags:
         props = ModelProperties(context_window=32_768)
         assert props.supports_verbosity is False
         assert props.supports_reasoning_effort is False
+
+
+class TestModelRegistryContextWindows:
+    """Tests for correct context window values in KNOWN_MODELS."""
+
+    def test_gpt5_mini_context_window(self) -> None:
+        """GPT-5-mini has 400K context window."""
+        assert KNOWN_MODELS["openai"]["gpt-5-mini"].context_window == 400_000
+
+    def test_gpt41_family_context_window(self) -> None:
+        """GPT-4.1 family has 1M context window."""
+        for model in ("gpt-4.1", "gpt-4.1-mini", "gpt-4.1-nano"):
+            assert KNOWN_MODELS["openai"][model].context_window == 1_000_000, f"{model}"
+
+    def test_qwen25_7b_context_window(self) -> None:
+        """qwen2.5:7b has 128K context window (not 32K)."""
+        assert KNOWN_MODELS["ollama"]["qwen2.5:7b"].context_window == 128_000
+
+    def test_retired_models_removed(self) -> None:
+        """Retired models are no longer in the registry."""
+        assert "o1-mini" not in KNOWN_MODELS["openai"]
+        assert "o1-preview" not in KNOWN_MODELS["openai"]
+        assert "gpt-4" not in KNOWN_MODELS["openai"]
+        assert "gpt-4-turbo" not in KNOWN_MODELS["openai"]
+        assert "gpt-3.5-turbo" not in KNOWN_MODELS["openai"]
+        assert "claude-3-5-sonnet-latest" not in KNOWN_MODELS["anthropic"]
+        assert "claude-3-5-sonnet-20241022" not in KNOWN_MODELS["anthropic"]
+        assert "claude-3-opus-20240229" not in KNOWN_MODELS["anthropic"]
+        assert "claude-3-haiku-20240307" not in KNOWN_MODELS["anthropic"]
+
+    def test_new_models_present(self) -> None:
+        """New models are present in the registry."""
+        # OpenAI
+        for model in ("gpt-5", "gpt-5-nano", "gpt-5.1", "gpt-5.2", "o3-pro", "o4-mini"):
+            assert model in KNOWN_MODELS["openai"], f"{model} missing"
+        # Anthropic
+        for model in (
+            "claude-opus-4-6",
+            "claude-opus-4-5-20251101",
+            "claude-sonnet-4-5-20250929",
+            "claude-haiku-4-5-20251001",
+        ):
+            assert model in KNOWN_MODELS["anthropic"], f"{model} missing"
+        # Google
+        for model in ("gemini-2.5-flash-lite", "gemini-3-pro-preview", "gemini-3-flash-preview"):
+            assert model in KNOWN_MODELS["google"], f"{model} missing"

--- a/tests/unit/test_orchestrator.py
+++ b/tests/unit/test_orchestrator.py
@@ -251,7 +251,7 @@ def test_orchestrator_model_info_after_model_creation(tmp_path: Path) -> None:
     orchestrator._model_info = get_model_info("openai", "gpt-5-mini")
 
     assert orchestrator.model_info is not None
-    assert orchestrator.model_info.context_window == 1_000_000
+    assert orchestrator.model_info.context_window == 400_000
     assert orchestrator.model_info.supports_vision is True
 
 

--- a/tests/unit/test_provider_factory.py
+++ b/tests/unit/test_provider_factory.py
@@ -707,7 +707,7 @@ def test_get_model_info_known_model() -> None:
     """get_model_info returns known context window for known models."""
     info = get_model_info("openai", "gpt-5-mini")
 
-    assert info.context_window == 1_000_000
+    assert info.context_window == 400_000
     assert info.supports_tools is True
     assert info.supports_vision is True
 
@@ -747,7 +747,7 @@ def test_get_model_info_case_insensitive_provider() -> None:
     """get_model_info is case insensitive for provider name."""
     info = get_model_info("OPENAI", "gpt-5-mini")
 
-    assert info.context_window == 1_000_000
+    assert info.context_window == 400_000
 
 
 def test_model_info_is_frozen() -> None:
@@ -766,18 +766,18 @@ def test_model_info_is_frozen() -> None:
     [
         # o1 family
         ("o1", True),
-        ("o1-mini", True),
-        ("o1-preview", True),
         ("O1", True),
-        ("O1-MINI", True),
         # o3 family
         ("o3", True),
         ("o3-mini", True),
+        ("o3-pro", True),
+        # o4 family
+        ("o4-mini", True),
+        ("O4-MINI", True),
         # Non-reasoning models
         ("gpt-5-mini", False),
         ("gpt-4o-mini", False),
-        ("gpt-4-turbo", False),
-        ("gpt-3.5-turbo", False),
+        ("gpt-4.1", False),
     ],
 )
 def test_is_reasoning_model(model_name: str, expected: bool) -> None:
@@ -789,7 +789,7 @@ def test_is_reasoning_model(model_name: str, expected: bool) -> None:
     assert variant.rejects_temperature is expected
 
 
-@pytest.mark.parametrize("model_name", ["o1", "o1-mini", "o1-preview", "o3", "o3-mini"])
+@pytest.mark.parametrize("model_name", ["o1", "o3", "o3-mini", "o3-pro", "o4-mini"])
 def test_create_chat_model_reasoning_model_no_temperature(model_name: str) -> None:
     """Factory creates reasoning models without temperature parameter."""
     mock_chat = MagicMock()
@@ -831,10 +831,10 @@ def test_create_chat_model_gpt4o_has_temperature() -> None:
     ("model_name", "expected_context", "expected_tools", "expected_vision"),
     [
         ("o1", 200_000, False, False),
-        ("o1-mini", 128_000, False, False),
-        ("o1-preview", 128_000, False, False),
         ("o3", 200_000, False, False),
         ("o3-mini", 200_000, False, False),
+        ("o3-pro", 200_000, False, False),
+        ("o4-mini", 200_000, False, False),
     ],
 )
 def test_get_model_info_reasoning_models_no_tools(

--- a/tests/unit/test_settings.py
+++ b/tests/unit/test_settings.py
@@ -461,6 +461,14 @@ class TestDetectModelVariant:
         assert variant.supports_reasoning_effort is False
         assert variant.rejects_temperature is False
 
+    def test_o4_mini_rejects_temperature(self) -> None:
+        """o4-mini rejects temperature (reasoning model)."""
+        variant = _detect_model_variant("openai", "o4-mini")
+        assert variant.rejects_temperature is True
+        assert variant.rejects_top_p is True
+        assert variant.supports_reasoning_effort is True
+        assert variant.supports_verbosity is False
+
     def test_non_openai_provider_default(self) -> None:
         """Non-OpenAI providers return default variant."""
         variant = _detect_model_variant("anthropic", "claude-3-opus")


### PR DESCRIPTION
## Problem

The model registry in `KNOWN_MODELS` had incorrect context windows, retired models that no longer exist, and was missing many current models across all providers.

## Changes

### Fixes
- **gpt-5-mini**: context window 1,000,000 → 400,000
- **qwen2.5:7b**: context window 32,768 → 128,000

### Removed (retired/deprecated)
- OpenAI: `o1-mini`, `o1-preview`, `gpt-4`, `gpt-4-turbo`, `gpt-3.5-turbo`
- Anthropic: `claude-3-5-sonnet-latest`, `claude-3-5-sonnet-20241022`, `claude-3-opus-20240229`, `claude-3-haiku-20240307`

### Added
- OpenAI: `gpt-5`, `gpt-5-nano`, `gpt-5.1`, `gpt-5.2` (400K, verbosity+reasoning), `gpt-4.1`, `gpt-4.1-mini`, `gpt-4.1-nano` (1M), `o3-pro`, `o4-mini` (200K, reasoning)
- Anthropic: `claude-opus-4-6`, `claude-opus-4-5-20251101`, `claude-sonnet-4-5-20250929`, `claude-haiku-4-5-20251001` (all 200K, vision)
- Google: `gemini-2.5-flash-lite`, `gemini-3-pro-preview`, `gemini-3-flash-preview` (all 1M, vision)

### Variant detection
- Extended `_detect_model_variant` to handle `o4` family (rejects temperature/top_p, supports reasoning_effort)

## Not Included / Future PRs
- Anthropic `effort` parameter support → #723
- Gemini `thinking_level`/`thinking_budget` support → #724

## Test Plan
- `uv run ruff check` — all passed
- `uv run mypy src/questfoundry/providers/` — no issues
- `uv run pytest tests/unit/test_model_info.py tests/unit/test_settings.py tests/unit/test_provider_factory.py -x -q` — 200 passed

## Risk / Rollback
- Registry-only change, no behavioral impact on pipeline logic
- Stacked on #722 (`feat/openai-reasoning-verbosity`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)