### PR TITLE
fix(seed): catch duplicate IDs during SEED serialization inner loop

### DIFF
--- a/prompts/templates/serialize_seed_sections.yaml
+++ b/prompts/templates/serialize_seed_sections.yaml
@@ -56,6 +56,7 @@ entities_prompt: |
   - For RETAINED entities marked "(needs name)", provide a fitting `name`
 
   ## What NOT to Do
+  - Do NOT include the same entity_id more than once — each entity must appear EXACTLY once
   - Do NOT skip entities because they aren't mentioned in the brief
   - Do NOT invent entities not in the manifest
   - Do NOT partially complete the list
@@ -136,6 +137,7 @@ dilemmas_prompt: |
   overwhelming the GROW stage.
 
   ## What NOT to Do
+  - Do NOT include the same dilemma_id more than once — each dilemma must appear EXACTLY once
   - Do NOT skip dilemmas because they aren't mentioned in the brief
   - Do NOT invent dilemmas not in the manifest
   - Do NOT partially complete the list
@@ -219,6 +221,7 @@ paths_prompt: |
   - dilemma_id MUST include the `dilemma::` prefix
 
   ## What NOT to Do
+  - Do NOT include the same path_id more than once — each path must appear EXACTLY once
   - Do NOT reuse dilemma IDs as path IDs
   - Do NOT skip answers marked as "explored"
   - Do NOT create paths for "unexplored" answers (they become shadows, not paths)

--- a/src/questfoundry/agents/serialize.py
+++ b/src/questfoundry/agents/serialize.py
@@ -1109,6 +1109,9 @@ def _format_section_corrections(errors: list[SeedValidationError]) -> str:
             if "exceeds limit" in error.issue.lower() or "maximum" in error.issue.lower():
                 corrections.append(f"- LIMIT EXCEEDED: {error.issue}")
                 continue
+            if "duplicate" in error.issue.lower():
+                corrections.append(f"- DUPLICATE: {error.issue}")
+                continue
             # Skip other errors without available suggestions
             continue
 

--- a/src/questfoundry/models/seed.py
+++ b/src/questfoundry/models/seed.py
@@ -308,6 +308,18 @@ class EntitiesSection(BaseModel):
         description="Entity curation decisions",
     )
 
+    @model_validator(mode="after")
+    def _check_entity_ids_unique(self) -> EntitiesSection:
+        """Validate that entity IDs are unique."""
+        from collections import Counter
+
+        ids = [e.entity_id for e in self.entities]
+        dupes = [eid for eid, count in Counter(ids).items() if count > 1]
+        if dupes:
+            msg = f"Duplicate entity_ids found: {sorted(dupes)}. Each entity must appear exactly once."
+            raise ValueError(msg)
+        return self
+
 
 class DilemmasSection(BaseModel):
     """Wrapper for serializing dilemma decisions separately."""
@@ -316,6 +328,18 @@ class DilemmasSection(BaseModel):
         default_factory=list,
         description="Dilemma exploration decisions",
     )
+
+    @model_validator(mode="after")
+    def _check_dilemma_ids_unique(self) -> DilemmasSection:
+        """Validate that dilemma IDs are unique."""
+        from collections import Counter
+
+        ids = [d.dilemma_id for d in self.dilemmas]
+        dupes = [did for did, count in Counter(ids).items() if count > 1]
+        if dupes:
+            msg = f"Duplicate dilemma_ids found: {sorted(dupes)}. Each dilemma must appear exactly once."
+            raise ValueError(msg)
+        return self
 
 
 class PathsSection(BaseModel):
@@ -326,6 +350,18 @@ class PathsSection(BaseModel):
         description="Created plot paths",
     )
 
+    @model_validator(mode="after")
+    def _check_path_ids_unique(self) -> PathsSection:
+        """Validate that path IDs are unique."""
+        from collections import Counter
+
+        ids = [p.path_id for p in self.paths]
+        dupes = [pid for pid, count in Counter(ids).items() if count > 1]
+        if dupes:
+            msg = f"Duplicate path_ids found: {sorted(dupes)}. Each path must appear exactly once."
+            raise ValueError(msg)
+        return self
+
 
 class ConsequencesSection(BaseModel):
     """Wrapper for serializing consequences separately."""
@@ -334,6 +370,18 @@ class ConsequencesSection(BaseModel):
         default_factory=list,
         description="Narrative consequences for paths",
     )
+
+    @model_validator(mode="after")
+    def _check_consequence_ids_unique(self) -> ConsequencesSection:
+        """Validate that consequence IDs are unique."""
+        from collections import Counter
+
+        ids = [c.consequence_id for c in self.consequences]
+        dupes = [cid for cid, count in Counter(ids).items() if count > 1]
+        if dupes:
+            msg = f"Duplicate consequence_ids found: {sorted(dupes)}. Each consequence must appear exactly once."
+            raise ValueError(msg)
+        return self
 
 
 class BeatsSection(BaseModel):

--- a/src/questfoundry/models/seed.py
+++ b/src/questfoundry/models/seed.py
@@ -16,6 +16,7 @@ Terminology (v5):
 
 from __future__ import annotations
 
+from collections import Counter
 from typing import Any, Literal
 
 from pydantic import BaseModel, Field, model_validator
@@ -300,6 +301,18 @@ class SeedOutput(BaseModel):
 # These allow serializing SEED output in chunks to avoid output truncation
 
 
+def _check_ids_unique(items: list[Any], id_attr: str, type_name: str) -> None:
+    """Check that IDs are unique in a collection of Pydantic models.
+
+    Raises ValueError with a descriptive message listing duplicates.
+    """
+    ids = [getattr(item, id_attr) for item in items]
+    dupes = [item_id for item_id, count in Counter(ids).items() if count > 1]
+    if dupes:
+        msg = f"Duplicate {type_name}s found: {sorted(dupes)}. Each {type_name.split('_')[0]} must appear exactly once."
+        raise ValueError(msg)
+
+
 class EntitiesSection(BaseModel):
     """Wrapper for serializing entity decisions separately."""
 
@@ -311,13 +324,7 @@ class EntitiesSection(BaseModel):
     @model_validator(mode="after")
     def _check_entity_ids_unique(self) -> EntitiesSection:
         """Validate that entity IDs are unique."""
-        from collections import Counter
-
-        ids = [e.entity_id for e in self.entities]
-        dupes = [eid for eid, count in Counter(ids).items() if count > 1]
-        if dupes:
-            msg = f"Duplicate entity_ids found: {sorted(dupes)}. Each entity must appear exactly once."
-            raise ValueError(msg)
+        _check_ids_unique(self.entities, "entity_id", "entity_id")
         return self
 
 
@@ -332,13 +339,7 @@ class DilemmasSection(BaseModel):
     @model_validator(mode="after")
     def _check_dilemma_ids_unique(self) -> DilemmasSection:
         """Validate that dilemma IDs are unique."""
-        from collections import Counter
-
-        ids = [d.dilemma_id for d in self.dilemmas]
-        dupes = [did for did, count in Counter(ids).items() if count > 1]
-        if dupes:
-            msg = f"Duplicate dilemma_ids found: {sorted(dupes)}. Each dilemma must appear exactly once."
-            raise ValueError(msg)
+        _check_ids_unique(self.dilemmas, "dilemma_id", "dilemma_id")
         return self
 
 
@@ -353,13 +354,7 @@ class PathsSection(BaseModel):
     @model_validator(mode="after")
     def _check_path_ids_unique(self) -> PathsSection:
         """Validate that path IDs are unique."""
-        from collections import Counter
-
-        ids = [p.path_id for p in self.paths]
-        dupes = [pid for pid, count in Counter(ids).items() if count > 1]
-        if dupes:
-            msg = f"Duplicate path_ids found: {sorted(dupes)}. Each path must appear exactly once."
-            raise ValueError(msg)
+        _check_ids_unique(self.paths, "path_id", "path_id")
         return self
 
 
@@ -374,13 +369,7 @@ class ConsequencesSection(BaseModel):
     @model_validator(mode="after")
     def _check_consequence_ids_unique(self) -> ConsequencesSection:
         """Validate that consequence IDs are unique."""
-        from collections import Counter
-
-        ids = [c.consequence_id for c in self.consequences]
-        dupes = [cid for cid, count in Counter(ids).items() if count > 1]
-        if dupes:
-            msg = f"Duplicate consequence_ids found: {sorted(dupes)}. Each consequence must appear exactly once."
-            raise ValueError(msg)
+        _check_ids_unique(self.consequences, "consequence_id", "consequence_id")
         return self
 
 

--- a/tests/unit/test_seed_models.py
+++ b/tests/unit/test_seed_models.py
@@ -26,7 +26,7 @@ class TestEntitiesSectionUniqueness:
         assert len(section.entities) == 2
 
     def test_duplicate_entities_rejected(self) -> None:
-        with pytest.raises(ValidationError, match="Duplicate entity_ids"):
+        with pytest.raises(ValidationError, match="Duplicate entity_id"):
             EntitiesSection(
                 entities=[
                     {"entity_id": "character::alice", "disposition": "retained"},
@@ -37,6 +37,23 @@ class TestEntitiesSectionUniqueness:
     def test_empty_entities_accepted(self) -> None:
         section = EntitiesSection(entities=[])
         assert len(section.entities) == 0
+
+    def test_single_entity_accepted(self) -> None:
+        section = EntitiesSection(
+            entities=[{"entity_id": "character::alice", "disposition": "retained"}]
+        )
+        assert len(section.entities) == 1
+
+    def test_non_adjacent_duplicate_rejected(self) -> None:
+        """Duplicate not adjacent — ensures we check all items, not just neighbors."""
+        with pytest.raises(ValidationError, match="Duplicate entity_id"):
+            EntitiesSection(
+                entities=[
+                    {"entity_id": "character::alice", "disposition": "retained"},
+                    {"entity_id": "character::bob", "disposition": "cut"},
+                    {"entity_id": "character::alice", "disposition": "retained"},
+                ]
+            )
 
 
 class TestDilemmasSectionUniqueness:
@@ -52,13 +69,17 @@ class TestDilemmasSectionUniqueness:
         assert len(section.dilemmas) == 2
 
     def test_duplicate_dilemmas_rejected(self) -> None:
-        with pytest.raises(ValidationError, match="Duplicate dilemma_ids"):
+        with pytest.raises(ValidationError, match="Duplicate dilemma_id"):
             DilemmasSection(
                 dilemmas=[
                     {"dilemma_id": "dilemma::trust_or_betray", "explored": ["trust"]},
                     {"dilemma_id": "dilemma::trust_or_betray", "explored": ["betray"]},
                 ]
             )
+
+    def test_empty_dilemmas_accepted(self) -> None:
+        section = DilemmasSection(dilemmas=[])
+        assert len(section.dilemmas) == 0
 
 
 class TestPathsSectionUniqueness:
@@ -88,7 +109,7 @@ class TestPathsSectionUniqueness:
         assert len(section.paths) == 2
 
     def test_duplicate_paths_rejected(self) -> None:
-        with pytest.raises(ValidationError, match="Duplicate path_ids"):
+        with pytest.raises(ValidationError, match="Duplicate path_id"):
             PathsSection(
                 paths=[
                     {
@@ -109,6 +130,10 @@ class TestPathsSectionUniqueness:
                     },
                 ]
             )
+
+    def test_empty_paths_accepted(self) -> None:
+        section = PathsSection(paths=[])
+        assert len(section.paths) == 0
 
 
 class TestConsequencesSectionUniqueness:
@@ -132,7 +157,7 @@ class TestConsequencesSectionUniqueness:
         assert len(section.consequences) == 2
 
     def test_duplicate_consequences_rejected(self) -> None:
-        with pytest.raises(ValidationError, match="Duplicate consequence_ids"):
+        with pytest.raises(ValidationError, match="Duplicate consequence_id"):
             ConsequencesSection(
                 consequences=[
                     {
@@ -147,3 +172,7 @@ class TestConsequencesSectionUniqueness:
                     },
                 ]
             )
+
+    def test_empty_consequences_accepted(self) -> None:
+        section = ConsequencesSection(consequences=[])
+        assert len(section.consequences) == 0

--- a/tests/unit/test_seed_models.py
+++ b/tests/unit/test_seed_models.py
@@ -1,0 +1,149 @@
+"""Tests for SEED stage Pydantic models, especially section uniqueness validators."""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from questfoundry.models.seed import (
+    ConsequencesSection,
+    DilemmasSection,
+    EntitiesSection,
+    PathsSection,
+)
+
+
+class TestEntitiesSectionUniqueness:
+    """EntitiesSection should reject duplicate entity_ids."""
+
+    def test_unique_entities_accepted(self) -> None:
+        section = EntitiesSection(
+            entities=[
+                {"entity_id": "character::alice", "disposition": "retained"},
+                {"entity_id": "character::bob", "disposition": "cut"},
+            ]
+        )
+        assert len(section.entities) == 2
+
+    def test_duplicate_entities_rejected(self) -> None:
+        with pytest.raises(ValidationError, match="Duplicate entity_ids"):
+            EntitiesSection(
+                entities=[
+                    {"entity_id": "character::alice", "disposition": "retained"},
+                    {"entity_id": "character::alice", "disposition": "retained"},
+                ]
+            )
+
+    def test_empty_entities_accepted(self) -> None:
+        section = EntitiesSection(entities=[])
+        assert len(section.entities) == 0
+
+
+class TestDilemmasSectionUniqueness:
+    """DilemmasSection should reject duplicate dilemma_ids."""
+
+    def test_unique_dilemmas_accepted(self) -> None:
+        section = DilemmasSection(
+            dilemmas=[
+                {"dilemma_id": "dilemma::trust_or_betray", "explored": ["trust"]},
+                {"dilemma_id": "dilemma::fight_or_flee", "explored": ["fight"]},
+            ]
+        )
+        assert len(section.dilemmas) == 2
+
+    def test_duplicate_dilemmas_rejected(self) -> None:
+        with pytest.raises(ValidationError, match="Duplicate dilemma_ids"):
+            DilemmasSection(
+                dilemmas=[
+                    {"dilemma_id": "dilemma::trust_or_betray", "explored": ["trust"]},
+                    {"dilemma_id": "dilemma::trust_or_betray", "explored": ["betray"]},
+                ]
+            )
+
+
+class TestPathsSectionUniqueness:
+    """PathsSection should reject duplicate path_ids."""
+
+    def test_unique_paths_accepted(self) -> None:
+        section = PathsSection(
+            paths=[
+                {
+                    "path_id": "path::trust_or_betray__trust",
+                    "name": "Trust Path",
+                    "dilemma_id": "dilemma::trust_or_betray",
+                    "answer_id": "trust",
+                    "path_importance": "major",
+                    "description": "The trust storyline",
+                },
+                {
+                    "path_id": "path::trust_or_betray__betray",
+                    "name": "Betray Path",
+                    "dilemma_id": "dilemma::trust_or_betray",
+                    "answer_id": "betray",
+                    "path_importance": "minor",
+                    "description": "The betrayal storyline",
+                },
+            ]
+        )
+        assert len(section.paths) == 2
+
+    def test_duplicate_paths_rejected(self) -> None:
+        with pytest.raises(ValidationError, match="Duplicate path_ids"):
+            PathsSection(
+                paths=[
+                    {
+                        "path_id": "path::trust_or_betray__trust",
+                        "name": "Trust Path",
+                        "dilemma_id": "dilemma::trust_or_betray",
+                        "answer_id": "trust",
+                        "path_importance": "major",
+                        "description": "The trust storyline",
+                    },
+                    {
+                        "path_id": "path::trust_or_betray__trust",
+                        "name": "Trust Path Duplicate",
+                        "dilemma_id": "dilemma::trust_or_betray",
+                        "answer_id": "trust",
+                        "path_importance": "major",
+                        "description": "Duplicate",
+                    },
+                ]
+            )
+
+
+class TestConsequencesSectionUniqueness:
+    """ConsequencesSection should reject duplicate consequence_ids."""
+
+    def test_unique_consequences_accepted(self) -> None:
+        section = ConsequencesSection(
+            consequences=[
+                {
+                    "consequence_id": "trust_rewarded",
+                    "path_id": "path::trust_or_betray__trust",
+                    "description": "Trust pays off",
+                },
+                {
+                    "consequence_id": "betrayal_revealed",
+                    "path_id": "path::trust_or_betray__betray",
+                    "description": "Betrayal is exposed",
+                },
+            ]
+        )
+        assert len(section.consequences) == 2
+
+    def test_duplicate_consequences_rejected(self) -> None:
+        with pytest.raises(ValidationError, match="Duplicate consequence_ids"):
+            ConsequencesSection(
+                consequences=[
+                    {
+                        "consequence_id": "trust_rewarded",
+                        "path_id": "path::trust_or_betray__trust",
+                        "description": "Trust pays off",
+                    },
+                    {
+                        "consequence_id": "trust_rewarded",
+                        "path_id": "path::trust_or_betray__trust",
+                        "description": "Duplicate consequence",
+                    },
+                ]
+            )


### PR DESCRIPTION
## Problem

When LLMs (observed with gpt-5-mini) output duplicate entity/dilemma/path IDs during SEED serialization, the duplicates pass through Pydantic validation and only fail at the semantic validation stage (`validate_seed_mutations()` check #0). The semantic errors are categorized as `INNER` but `_format_section_corrections()` silently drops them because they have `provided` but no `available` suggestions. This causes the outer retry loop to re-summarize and retry without ever telling the LLM what went wrong — wasting 87 LLM calls across 3 attempts without recovery.

Diagnosed from `test-murder-gpt5mini` where `character_beatrice_ashford` and `location_helipad_dock` were duplicated.

## Changes

Three-layer defense-in-depth fix:

1. **Pydantic validators** (`models/seed.py`): Added `model_validator(mode="after")` uniqueness checks to `EntitiesSection`, `DilemmasSection`, `PathsSection`, `ConsequencesSection` — following the existing `PathBeatsSection._check_beat_ids_unique` pattern. Duplicates are now caught at parse time so the inner retry loop can surface them immediately.

2. **Error formatting** (`agents/serialize.py`): `_format_section_corrections()` now detects "duplicate" in the error issue and formats it as a `DUPLICATE` correction instead of silently dropping it.

3. **Prompt warning** (`serialize_seed_sections.yaml`): Added "Do NOT include the same X_id more than once" to entities, dilemmas, and paths prompt sections.

## Not Included / Future PRs

- No changes to `BeatsSection` (already handled by `PathBeatsSection._check_beat_ids_unique`)
- No changes to outer retry loop logic (the inner loop fix should prevent duplicates from reaching it)

## Test Plan

- `uv run pytest tests/unit/test_seed_models.py -x -q` — 9 new tests for all 4 section validators (unique accepted, duplicate rejected, empty accepted)
- `uv run pytest tests/unit/test_serialize.py::TestFormatSectionCorrections -x -q` — 7 tests including 2 new duplicate error formatting tests
- `uv run pytest tests/unit/test_mutations.py -x -q` — 169 existing tests still pass

## Risk / Rollback

Low risk. Validators only add strictness (reject what was previously accepted). The error formatting change only adds a new branch before an existing silent skip. Prompt changes are additive "Do NOT" lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)