### PR TITLE
fix(orchestrator): detect stale artifacts from failed mutation stages

### DIFF
--- a/src/questfoundry/pipeline/orchestrator.py
+++ b/src/questfoundry/pipeline/orchestrator.py
@@ -829,6 +829,12 @@ class PipelineOrchestrator:
         max_completed_idx = -1
         if graph_last_stage and graph_last_stage in self.config.stages:
             max_completed_idx = self.config.stages.index(graph_last_stage)
+        elif graph_last_stage:
+            log.warning(
+                "graph_last_stage_not_in_config",
+                graph_last_stage=graph_last_stage,
+                config_stages=self.config.stages,
+            )
 
         for idx, stage_name in enumerate(self.config.stages):
             stage_artifact_path = self.project_path / "artifacts" / f"{stage_name}.yaml"


### PR DESCRIPTION
## Problem

`get_status()` determines stage completion solely by artifact file existence. When a stage writes its artifact but then fails at graph mutations (e.g., SEED failing with `SeedMutationError` due to duplicate entity IDs), the stale `seed.yaml` artifact remains on disk. This causes:

1. `get_status()` reports SEED as "completed"
2. `--from seed` skips SEED (sees it as done)
3. GROW runs next and crashes: `"GROW requires completed SEED stage. Current last_stage: 'brainstorm'"`

Observed in `test-murder-gpt5mini` project after the SEED duplicate fix in #730.

## Changes

- `get_status()` now cross-references artifact existence with `graph.last_stage()`
- Stages after the graph's last completed stage are marked "pending" even if their artifact file exists
- Stale detection is logged at DEBUG level for diagnostics
- Falls back to artifact-only checking when no graph exists (backwards compatibility)

## Not Included / Future PRs

- No changes to artifact writing logic (artifacts are still written before mutations, which is correct — they serve as LLM output records)

## Test Plan

- `uv run pytest tests/unit/test_orchestrator.py -x -q` — 52 tests pass including 2 new:
  - `test_stale_artifact_detected_as_pending` — SEED artifact + graph at brainstorm → SEED is "pending"
  - `test_status_without_graph_falls_back_to_artifacts` — no graph.json → artifact-only (backwards compat)

## Risk / Rollback

Low risk. Only affects status reporting, not stage execution. The graph cross-reference adds strictness (fewer false "completed" reports). Falls back gracefully when graph is absent or corrupted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)