### PR TITLE
feat(cli): add `qf graph` story visualization command

### DIFF
--- a/src/questfoundry/visualization.py
+++ b/src/questfoundry/visualization.py
@@ -1,0 +1,328 @@
+"""Story graph visualization.
+
+Extracts passage/choice structure from the graph and renders it as
+DOT (Graphviz) or Mermaid markup. Pure graph analysis — no LLM calls.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+from questfoundry.graph.fill_context import get_arc_passage_order
+from questfoundry.observability.logging import get_logger
+
+if TYPE_CHECKING:
+    from questfoundry.graph.graph import Graph
+
+log = get_logger(__name__)
+
+# Arc color palette: spine first, then branches.
+_ARC_COLORS = [
+    "#ADD8E6",  # light blue (spine)
+    "#FFD700",  # gold
+    "#FFA07A",  # light salmon
+    "#98FB98",  # pale green
+    "#DDA0DD",  # plum
+    "#87CEEB",  # sky blue
+    "#F0E68C",  # khaki
+]
+_SHARED_COLOR = "#D3D3D3"  # light grey for multi-arc passages
+_START_COLOR = "#90EE90"  # light green
+_ENDING_COLOR = "#FFB6C1"  # light pink
+
+
+@dataclass
+class VizNode:
+    """A passage node in the visualization."""
+
+    id: str
+    label: str
+    arc_id: str | None = None
+    is_start: bool = False
+    is_ending: bool = False
+    is_hub: bool = False
+
+
+@dataclass
+class VizEdge:
+    """A choice edge in the visualization."""
+
+    from_id: str
+    to_id: str
+    label: str = ""
+    is_return: bool = False
+    requires: list[str] = field(default_factory=list)
+
+
+@dataclass
+class StoryGraph:
+    """Complete visualization data extracted from the story graph."""
+
+    nodes: list[VizNode]
+    edges: list[VizEdge]
+    arc_names: dict[str, str] = field(default_factory=dict)
+
+
+def build_story_graph(
+    graph: Graph,
+    *,
+    spine_only: bool = False,
+) -> StoryGraph:
+    """Extract visualization data from the story graph.
+
+    Args:
+        graph: Loaded story graph (must have passages and choices).
+        spine_only: If True, include only passages on the spine arc.
+
+    Returns:
+        StoryGraph with nodes, edges, and arc metadata.
+    """
+    passages = graph.get_nodes_by_type("passage")
+    choices = graph.get_nodes_by_type("choice")
+    arcs = graph.get_nodes_by_type("arc")
+
+    # Build passage→arc mapping
+    passage_to_arc: dict[str, str | None] = {}
+    arc_names: dict[str, str] = {}
+    spine_passages: set[str] = set()
+
+    for arc_id, arc_data in arcs.items():
+        arc_type = arc_data.get("arc_type", "branch")
+        arc_names[arc_id] = arc_type
+        arc_passage_ids = get_arc_passage_order(graph, arc_id)
+
+        if arc_type == "spine":
+            spine_passages.update(arc_passage_ids)
+
+        for pid in arc_passage_ids:
+            if pid in passage_to_arc:
+                # Passage on multiple arcs — mark as shared
+                passage_to_arc[pid] = None
+            else:
+                passage_to_arc[pid] = arc_id
+
+    # Determine start/ending passages
+    has_incoming: set[str] = set()
+    has_outgoing: set[str] = set()
+    hub_passages: set[str] = set()
+
+    for _cid, cdata in choices.items():
+        from_p = cdata.get("from_passage", "")
+        to_p = cdata.get("to_passage", "")
+        if cdata.get("is_return"):
+            hub_passages.add(to_p)
+        else:
+            has_incoming.add(to_p)
+        has_outgoing.add(from_p)
+
+    # Filter passages if spine_only
+    visible_passages = spine_passages if spine_only else set(passages.keys())
+
+    # Build nodes
+    nodes: list[VizNode] = []
+    for pid, pdata in sorted(passages.items()):
+        if pid not in visible_passages:
+            continue
+        summary = pdata.get("summary", pid)
+        label = _truncate(summary, 40)
+        nodes.append(
+            VizNode(
+                id=pid,
+                label=label,
+                arc_id=passage_to_arc.get(pid),
+                is_start=pid not in has_incoming,
+                is_ending=pid not in has_outgoing,
+                is_hub=pid in hub_passages,
+            )
+        )
+
+    # Build edges
+    edges: list[VizEdge] = []
+    for _cid, cdata in sorted(choices.items()):
+        from_p = cdata.get("from_passage", "")
+        to_p = cdata.get("to_passage", "")
+        if from_p not in visible_passages or to_p not in visible_passages:
+            continue
+        edges.append(
+            VizEdge(
+                from_id=from_p,
+                to_id=to_p,
+                label=cdata.get("label", ""),
+                is_return=cdata.get("is_return", False),
+                requires=cdata.get("requires", []),
+            )
+        )
+
+    log.info(
+        "story_graph_built",
+        nodes=len(nodes),
+        edges=len(edges),
+        arcs=len(arc_names),
+        spine_only=spine_only,
+    )
+
+    return StoryGraph(nodes=nodes, edges=edges, arc_names=arc_names)
+
+
+def render_dot(sg: StoryGraph, *, no_labels: bool = False) -> str:
+    """Render a StoryGraph as DOT (Graphviz) markup.
+
+    Args:
+        sg: Story graph data.
+        no_labels: If True, omit choice labels on edges.
+
+    Returns:
+        DOT format string.
+    """
+    # Assign colors to arcs
+    arc_color = _assign_arc_colors(sg.arc_names)
+
+    lines = [
+        "digraph story {",
+        "  rankdir=LR;",
+        '  node [fontname="Helvetica" fontsize=10 style=filled];',
+        '  edge [fontname="Helvetica" fontsize=8];',
+        "",
+    ]
+
+    # Nodes
+    for node in sg.nodes:
+        attrs = _dot_node_attrs(node, arc_color)
+        attr_str = " ".join(f"{k}={v}" for k, v in attrs.items())
+        lines.append(f'  "{node.id}" [{attr_str}];')
+
+    lines.append("")
+
+    # Edges
+    for edge in sg.edges:
+        edge_attrs: dict[str, str] = {}
+        if not no_labels and edge.label:
+            edge_attrs["label"] = f'"{_dot_escape(edge.label)}"'
+        if edge.is_return:
+            edge_attrs["style"] = '"dashed"'
+            edge_attrs["color"] = '"grey"'
+        if edge.requires:
+            edge_attrs["color"] = '"orange"'
+            edge_attrs["penwidth"] = '"2"'
+        edge_attr_str = " ".join(f"{k}={v}" for k, v in edge_attrs.items())
+        suffix = f" [{edge_attr_str}]" if edge_attr_str else ""
+        lines.append(f'  "{edge.from_id}" -> "{edge.to_id}"{suffix};')
+
+    lines.append("}")
+    return "\n".join(lines)
+
+
+def render_mermaid(sg: StoryGraph, *, no_labels: bool = False) -> str:
+    """Render a StoryGraph as Mermaid markup.
+
+    Args:
+        sg: Story graph data.
+        no_labels: If True, omit choice labels on edges.
+
+    Returns:
+        Mermaid format string.
+    """
+    lines = ["graph LR"]
+
+    # Node definitions
+    for node in sg.nodes:
+        safe_id = _mermaid_id(node.id)
+        label = _mermaid_escape(node.label)
+        if node.is_start:
+            lines.append(f'  {safe_id}["{label}"]:::start')
+        elif node.is_ending:
+            lines.append(f'  {safe_id}["{label}"]:::ending')
+        elif node.is_hub:
+            lines.append(f"  {safe_id}{{{{{label}}}}}")
+        else:
+            lines.append(f'  {safe_id}["{label}"]')
+
+    lines.append("")
+
+    # Edges
+    for edge in sg.edges:
+        src = _mermaid_id(edge.from_id)
+        dst = _mermaid_id(edge.to_id)
+        arrow = "-.->" if edge.is_return else "-->"
+        if not no_labels and edge.label:
+            label = _mermaid_escape(edge.label)
+            lines.append(f'  {src} {arrow}|"{label}"| {dst}')
+        else:
+            lines.append(f"  {src} {arrow} {dst}")
+
+    # Style classes
+    lines.append("")
+    lines.append("  classDef start fill:#90EE90,stroke:#333")
+    lines.append("  classDef ending fill:#FFB6C1,stroke:#333")
+
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _truncate(text: str, max_len: int) -> str:
+    """Truncate text with ellipsis if too long."""
+    if len(text) <= max_len:
+        return text
+    return text[: max_len - 3] + "..."
+
+
+def _assign_arc_colors(arc_names: dict[str, str]) -> dict[str, str]:
+    """Assign a color to each arc ID. Spine gets index 0."""
+    color_map: dict[str, str] = {}
+    idx = 0
+    # Spine first
+    for arc_id, arc_type in sorted(arc_names.items()):
+        if arc_type == "spine":
+            color_map[arc_id] = _ARC_COLORS[0]
+    # Then branches
+    idx = 1
+    for arc_id, arc_type in sorted(arc_names.items()):
+        if arc_type != "spine":
+            color_map[arc_id] = _ARC_COLORS[idx % len(_ARC_COLORS)]
+            idx += 1
+    return color_map
+
+
+def _dot_node_attrs(node: VizNode, arc_color: dict[str, str]) -> dict[str, str]:
+    """Build DOT attribute dict for a node."""
+    attrs: dict[str, str] = {}
+    label_parts = [node.label]
+
+    if node.is_start:
+        attrs["shape"] = "doubleoctagon"
+        attrs["fillcolor"] = f'"{_START_COLOR}"'
+    elif node.is_ending:
+        attrs["shape"] = "octagon"
+        attrs["fillcolor"] = f'"{_ENDING_COLOR}"'
+    elif node.is_hub:
+        attrs["shape"] = "diamond"
+        color = arc_color.get(node.arc_id or "", _SHARED_COLOR)
+        attrs["fillcolor"] = f'"{color}"'
+    else:
+        attrs["shape"] = "box"
+        color = arc_color.get(node.arc_id, _SHARED_COLOR) if node.arc_id else _SHARED_COLOR
+        attrs["fillcolor"] = f'"{color}"'
+
+    joined_label = "\\n".join(label_parts)
+    attrs["label"] = f'"{_dot_escape(joined_label)}"'
+    return attrs
+
+
+def _dot_escape(text: str) -> str:
+    """Escape special characters for DOT labels."""
+    return text.replace('"', '\\"').replace("\n", "\\n")
+
+
+def _mermaid_id(node_id: str) -> str:
+    """Convert a node ID to a Mermaid-safe identifier."""
+    return node_id.replace("::", "_").replace(" ", "_").replace("-", "_")
+
+
+def _mermaid_escape(text: str) -> str:
+    """Escape special characters for Mermaid labels."""
+    return text.replace('"', "'").replace("\n", " ")

--- a/tests/unit/test_visualization.py
+++ b/tests/unit/test_visualization.py
@@ -1,0 +1,420 @@
+"""Tests for story graph visualization module."""
+
+from __future__ import annotations
+
+from questfoundry.graph.graph import Graph
+from questfoundry.visualization import (
+    build_story_graph,
+    render_dot,
+    render_mermaid,
+)
+
+
+def _make_simple_graph() -> Graph:
+    """Build a minimal graph with 3 passages, 2 choices, 1 arc."""
+    graph = Graph.empty()
+
+    # Beats (arcs reference these in sequence)
+    graph.create_node("beat::intro", {"type": "beat", "summary": "intro"})
+    graph.create_node("beat::middle", {"type": "beat", "summary": "middle"})
+    graph.create_node("beat::ending", {"type": "beat", "summary": "ending"})
+
+    # Passages
+    graph.create_node(
+        "passage::intro",
+        {
+            "type": "passage",
+            "raw_id": "intro",
+            "from_beat": "beat::intro",
+            "summary": "The story begins",
+        },
+    )
+    graph.create_node(
+        "passage::middle",
+        {
+            "type": "passage",
+            "raw_id": "middle",
+            "from_beat": "beat::middle",
+            "summary": "A choice appears",
+        },
+    )
+    graph.create_node(
+        "passage::ending",
+        {
+            "type": "passage",
+            "raw_id": "ending",
+            "from_beat": "beat::ending",
+            "summary": "The story ends",
+        },
+    )
+
+    # passage_from edges (passage -> beat)
+    graph.add_edge("passage_from", "passage::intro", "beat::intro")
+    graph.add_edge("passage_from", "passage::middle", "beat::middle")
+    graph.add_edge("passage_from", "passage::ending", "beat::ending")
+
+    # Choices
+    graph.create_node(
+        "choice::intro_middle",
+        {
+            "type": "choice",
+            "from_passage": "passage::intro",
+            "to_passage": "passage::middle",
+            "label": "Continue",
+        },
+    )
+    graph.create_node(
+        "choice::middle_ending",
+        {
+            "type": "choice",
+            "from_passage": "passage::middle",
+            "to_passage": "passage::ending",
+            "label": "End it",
+        },
+    )
+    graph.add_edge("choice_from", "choice::intro_middle", "passage::intro")
+    graph.add_edge("choice_to", "choice::intro_middle", "passage::middle")
+    graph.add_edge("choice_from", "choice::middle_ending", "passage::middle")
+    graph.add_edge("choice_to", "choice::middle_ending", "passage::ending")
+
+    # Arc (spine)
+    graph.create_node(
+        "arc::spine",
+        {
+            "type": "arc",
+            "arc_type": "spine",
+            "paths": ["path::main"],
+            "sequence": ["beat::intro", "beat::middle", "beat::ending"],
+        },
+    )
+
+    return graph
+
+
+def _make_branching_graph() -> Graph:
+    """Build a graph with spine + branch arc and a hub."""
+    graph = _make_simple_graph()
+
+    # Add a branch beat and passage
+    graph.create_node("beat::branch", {"type": "beat", "summary": "branch"})
+    graph.create_node(
+        "passage::branch",
+        {
+            "type": "passage",
+            "raw_id": "branch",
+            "from_beat": "beat::branch",
+            "summary": "A side path",
+        },
+    )
+    graph.add_edge("passage_from", "passage::branch", "beat::branch")
+
+    # Branch arc
+    graph.create_node(
+        "arc::branch_1",
+        {
+            "type": "arc",
+            "arc_type": "branch",
+            "paths": ["path::alt"],
+            "sequence": ["beat::intro", "beat::branch", "beat::ending"],
+        },
+    )
+
+    # Choice from intro to branch (branching point)
+    graph.create_node(
+        "choice::intro_branch",
+        {
+            "type": "choice",
+            "from_passage": "passage::intro",
+            "to_passage": "passage::branch",
+            "label": "Take the side path",
+        },
+    )
+    graph.add_edge("choice_from", "choice::intro_branch", "passage::intro")
+    graph.add_edge("choice_to", "choice::intro_branch", "passage::branch")
+
+    # Choice from branch back to ending (convergence)
+    graph.create_node(
+        "choice::branch_ending",
+        {
+            "type": "choice",
+            "from_passage": "passage::branch",
+            "to_passage": "passage::ending",
+            "label": "Rejoin the path",
+        },
+    )
+    graph.add_edge("choice_from", "choice::branch_ending", "passage::branch")
+    graph.add_edge("choice_to", "choice::branch_ending", "passage::ending")
+
+    return graph
+
+
+def _make_hub_graph() -> Graph:
+    """Build a graph with a hub-and-spoke pattern."""
+    graph = _make_simple_graph()
+
+    # Spoke passage
+    graph.create_node("beat::spoke", {"type": "beat", "summary": "spoke"})
+    graph.create_node(
+        "passage::spoke",
+        {
+            "type": "passage",
+            "raw_id": "spoke",
+            "from_beat": "beat::spoke",
+            "summary": "Explore an alcove",
+        },
+    )
+    graph.add_edge("passage_from", "passage::spoke", "beat::spoke")
+
+    # Choice: middle -> spoke
+    graph.create_node(
+        "choice::middle_spoke",
+        {
+            "type": "choice",
+            "from_passage": "passage::middle",
+            "to_passage": "passage::spoke",
+            "label": "Look around",
+        },
+    )
+    graph.add_edge("choice_from", "choice::middle_spoke", "passage::middle")
+    graph.add_edge("choice_to", "choice::middle_spoke", "passage::spoke")
+
+    # Return choice: spoke -> middle (is_return=True)
+    graph.create_node(
+        "choice::spoke_middle",
+        {
+            "type": "choice",
+            "from_passage": "passage::spoke",
+            "to_passage": "passage::middle",
+            "label": "Go back",
+            "is_return": True,
+        },
+    )
+    graph.add_edge("choice_from", "choice::spoke_middle", "passage::spoke")
+    graph.add_edge("choice_to", "choice::spoke_middle", "passage::middle")
+
+    return graph
+
+
+class TestBuildStoryGraph:
+    """Tests for build_story_graph()."""
+
+    def test_simple_graph_nodes(self) -> None:
+        graph = _make_simple_graph()
+        sg = build_story_graph(graph)
+        assert len(sg.nodes) == 3
+        ids = {n.id for n in sg.nodes}
+        assert ids == {"passage::intro", "passage::middle", "passage::ending"}
+
+    def test_simple_graph_edges(self) -> None:
+        graph = _make_simple_graph()
+        sg = build_story_graph(graph)
+        assert len(sg.edges) == 2
+        edge_pairs = {(e.from_id, e.to_id) for e in sg.edges}
+        assert ("passage::intro", "passage::middle") in edge_pairs
+        assert ("passage::middle", "passage::ending") in edge_pairs
+
+    def test_start_and_ending_detected(self) -> None:
+        graph = _make_simple_graph()
+        sg = build_story_graph(graph)
+        node_map = {n.id: n for n in sg.nodes}
+        assert node_map["passage::intro"].is_start is True
+        assert node_map["passage::intro"].is_ending is False
+        assert node_map["passage::ending"].is_ending is True
+        assert node_map["passage::ending"].is_start is False
+        assert node_map["passage::middle"].is_start is False
+        assert node_map["passage::middle"].is_ending is False
+
+    def test_arc_names_populated(self) -> None:
+        graph = _make_simple_graph()
+        sg = build_story_graph(graph)
+        assert "arc::spine" in sg.arc_names
+        assert sg.arc_names["arc::spine"] == "spine"
+
+    def test_arc_id_assigned_to_nodes(self) -> None:
+        graph = _make_simple_graph()
+        sg = build_story_graph(graph)
+        for node in sg.nodes:
+            assert node.arc_id == "arc::spine"
+
+    def test_spine_only_filters_branch_passages(self) -> None:
+        graph = _make_branching_graph()
+        sg = build_story_graph(graph, spine_only=True)
+        ids = {n.id for n in sg.nodes}
+        assert "passage::branch" not in ids
+        assert "passage::intro" in ids
+        assert "passage::middle" in ids
+
+    def test_branching_graph_has_both_arcs(self) -> None:
+        graph = _make_branching_graph()
+        sg = build_story_graph(graph)
+        assert len(sg.arc_names) == 2
+        assert "spine" in sg.arc_names.values()
+        assert "branch" in sg.arc_names.values()
+
+    def test_hub_detection(self) -> None:
+        graph = _make_hub_graph()
+        sg = build_story_graph(graph)
+        node_map = {n.id: n for n in sg.nodes}
+        assert node_map["passage::middle"].is_hub is True
+        assert node_map["passage::intro"].is_hub is False
+
+    def test_return_edge_marked(self) -> None:
+        graph = _make_hub_graph()
+        sg = build_story_graph(graph)
+        return_edges = [e for e in sg.edges if e.is_return]
+        assert len(return_edges) == 1
+        assert return_edges[0].from_id == "passage::spoke"
+        assert return_edges[0].to_id == "passage::middle"
+
+    def test_empty_graph(self) -> None:
+        graph = Graph.empty()
+        sg = build_story_graph(graph)
+        assert sg.nodes == []
+        assert sg.edges == []
+        assert sg.arc_names == {}
+
+    def test_label_truncation(self) -> None:
+        graph = Graph.empty()
+        graph.create_node("beat::long", {"type": "beat", "summary": "long"})
+        graph.create_node(
+            "passage::long",
+            {
+                "type": "passage",
+                "raw_id": "long",
+                "from_beat": "beat::long",
+                "summary": "A" * 60,
+            },
+        )
+        graph.add_edge("passage_from", "passage::long", "beat::long")
+        sg = build_story_graph(graph)
+        assert len(sg.nodes) == 1
+        assert len(sg.nodes[0].label) <= 40
+        assert sg.nodes[0].label.endswith("...")
+
+
+class TestRenderDot:
+    """Tests for DOT output rendering."""
+
+    def test_dot_contains_digraph(self) -> None:
+        graph = _make_simple_graph()
+        sg = build_story_graph(graph)
+        dot = render_dot(sg)
+        assert dot.startswith("digraph story {")
+        assert dot.endswith("}")
+
+    def test_dot_contains_all_nodes(self) -> None:
+        graph = _make_simple_graph()
+        sg = build_story_graph(graph)
+        dot = render_dot(sg)
+        assert '"passage::intro"' in dot
+        assert '"passage::middle"' in dot
+        assert '"passage::ending"' in dot
+
+    def test_dot_contains_edges(self) -> None:
+        graph = _make_simple_graph()
+        sg = build_story_graph(graph)
+        dot = render_dot(sg)
+        assert '"passage::intro" -> "passage::middle"' in dot
+        assert '"passage::middle" -> "passage::ending"' in dot
+
+    def test_dot_edge_labels(self) -> None:
+        graph = _make_simple_graph()
+        sg = build_story_graph(graph)
+        dot = render_dot(sg)
+        assert 'label="Continue"' in dot
+        assert 'label="End it"' in dot
+
+    def test_dot_no_labels_flag(self) -> None:
+        graph = _make_simple_graph()
+        sg = build_story_graph(graph)
+        dot = render_dot(sg, no_labels=True)
+        # Edge lines should not have labels
+        edge_lines = [row for row in dot.split("\n") if "->" in row]
+        for row in edge_lines:
+            assert "label=" not in row
+
+    def test_dot_start_node_shape(self) -> None:
+        graph = _make_simple_graph()
+        sg = build_story_graph(graph)
+        dot = render_dot(sg)
+        intro_line = next(
+            row for row in dot.split("\n") if '"passage::intro"' in row and "->" not in row
+        )
+        assert "doubleoctagon" in intro_line
+
+    def test_dot_ending_node_shape(self) -> None:
+        graph = _make_simple_graph()
+        sg = build_story_graph(graph)
+        dot = render_dot(sg)
+        ending_line = next(
+            row for row in dot.split("\n") if '"passage::ending"' in row and "->" not in row
+        )
+        assert "octagon" in ending_line
+
+    def test_dot_return_edge_dashed(self) -> None:
+        graph = _make_hub_graph()
+        sg = build_story_graph(graph)
+        dot = render_dot(sg)
+        return_line = next(
+            row for row in dot.split("\n") if '"passage::spoke" -> "passage::middle"' in row
+        )
+        assert "dashed" in return_line
+
+
+class TestRenderMermaid:
+    """Tests for Mermaid output rendering."""
+
+    def test_mermaid_starts_with_graph(self) -> None:
+        graph = _make_simple_graph()
+        sg = build_story_graph(graph)
+        mmd = render_mermaid(sg)
+        assert mmd.startswith("graph LR")
+
+    def test_mermaid_contains_nodes(self) -> None:
+        graph = _make_simple_graph()
+        sg = build_story_graph(graph)
+        mmd = render_mermaid(sg)
+        assert "passage_intro" in mmd
+        assert "passage_middle" in mmd
+        assert "passage_ending" in mmd
+
+    def test_mermaid_contains_edges(self) -> None:
+        graph = _make_simple_graph()
+        sg = build_story_graph(graph)
+        mmd = render_mermaid(sg)
+        assert "passage_intro -->" in mmd
+        assert "passage_middle -->" in mmd
+
+    def test_mermaid_start_class(self) -> None:
+        graph = _make_simple_graph()
+        sg = build_story_graph(graph)
+        mmd = render_mermaid(sg)
+        assert ":::start" in mmd
+
+    def test_mermaid_ending_class(self) -> None:
+        graph = _make_simple_graph()
+        sg = build_story_graph(graph)
+        mmd = render_mermaid(sg)
+        assert ":::ending" in mmd
+
+    def test_mermaid_no_labels_flag(self) -> None:
+        graph = _make_simple_graph()
+        sg = build_story_graph(graph)
+        mmd = render_mermaid(sg, no_labels=True)
+        edge_lines = [row for row in mmd.split("\n") if "-->" in row]
+        for row in edge_lines:
+            assert '|"' not in row
+
+    def test_mermaid_hub_diamond(self) -> None:
+        graph = _make_hub_graph()
+        sg = build_story_graph(graph)
+        mmd = render_mermaid(sg)
+        middle_lines = [row for row in mmd.split("\n") if "passage_middle{" in row]
+        assert len(middle_lines) == 1
+
+    def test_mermaid_return_edge_dotted(self) -> None:
+        graph = _make_hub_graph()
+        sg = build_story_graph(graph)
+        mmd = render_mermaid(sg)
+        return_lines = [row for row in mmd.split("\n") if "passage_spoke" in row and "-.->" in row]
+        assert len(return_lines) == 1


### PR DESCRIPTION
## Problem
There's no way to visualize the branching story structure after GROW/FILL stages.
Users must manually parse `graph.json` to understand passage connectivity and arc layout.

## Changes
- New `src/questfoundry/visualization.py` module with:
  - `build_story_graph()` — extracts passages, choices, and arcs from the graph
  - `render_dot()` — outputs DOT (Graphviz) format with node shapes by role and colors by arc
  - `render_mermaid()` — outputs Mermaid diagram format
- New `qf graph` CLI command with options:
  - `--format` (`dot`, `mermaid`, `json`)
  - `--output` (file path, stdout default)
  - `--spine-only` (filter to spine arc)
  - `--no-labels` (omit choice labels for cleaner output)
- 27 unit tests covering graph extraction, DOT rendering, Mermaid rendering, and edge cases

## Not Included / Future PRs
- Graphviz rendering (SVG/PNG) — users pipe to `dot` directly
- Subgraph clustering by arc (could add `--cluster-arcs` later)

## Test Plan
- `uv run ruff check src/questfoundry/visualization.py` — passes
- `uv run mypy src/questfoundry/visualization.py` — passes
- `uv run pytest tests/unit/test_visualization.py -x -q` — 27 passed
- Manual: `qf graph -p test-murder-gpt5mini` — produces valid DOT output
- Manual: `qf graph -p test-murder-gpt5mini --format mermaid` — produces valid Mermaid output

## Usage
```bash
qf graph -p myproject | dot -Tsvg -o story.svg   # Render SVG
qf graph -p myproject --format mermaid            # Mermaid output
qf graph -p myproject --spine-only --no-labels    # Clean spine view
```

## Risk / Rollback
- Pure additive change — new module and CLI command, no existing code modified (except CLI wiring)
- No new dependencies

🤖 Generated with [Claude Code](https://claude.com/claude-code)