### PR TITLE
feat(seed): add convergence analysis serialization (sections 7+8)

### DIFF
--- a/prompts/templates/serialize_seed_sections.yaml
+++ b/prompts/templates/serialize_seed_sections.yaml
@@ -622,9 +622,9 @@ dilemma_analyses_prompt: |
   ## payoff_budget
 
   Minimum number of exclusive beats before paths can converge (2-6).
-  - 2: Minimal divergence (flavor-adjacent soft). Use for `flavor` dilemmas.
-  - 3-4: Standard (most soft dilemmas)
-  - 5-6: Deep divergence (hard-adjacent soft). Use for `hard` dilemmas.
+  - 2: Use for `flavor` dilemmas (paths converge immediately, budget is minimal).
+  - 3-4: Standard for most `soft` dilemmas.
+  - 5-6: Deep divergence for `hard` dilemmas (paths stay separate longer).
 
   ## Context
 

--- a/prompts/templates/serialize_seed_sections.yaml
+++ b/prompts/templates/serialize_seed_sections.yaml
@@ -600,4 +600,134 @@ convergence_prompt: |
   ## Output
   Return ONLY valid JSON with the "convergence_sketch" object.
 
+# Section 7: Dilemma Convergence Analysis (post-prune)
+dilemma_analyses_prompt: |
+  You are classifying dilemma convergence policies for a SEED stage.
+
+  Each dilemma has a convergence policy that tells GROW how strictly to
+  enforce path separation. Classify EVERY dilemma listed below.
+
+  ## Convergence Policies
+
+  - **hard**: Paths are mutually exclusive world states. They CANNOT share beats
+    or converge until an explicit convergence point. Example: "alive vs dead" —
+    fundamentally incompatible realities.
+  - **soft**: Paths have meaningful differences but CAN share some beats after
+    a minimum number of exclusive beats (payoff_budget). Default choice.
+    Example: "trust vs betray" — different approaches to the same situation.
+  - **flavor**: Cosmetic difference only. Paths converge immediately and only
+    differ through entity overlays (appearance, dialogue tone). Example:
+    "polite vs blunt greeting" — same events, different flavor text.
+
+  ## payoff_budget
+
+  Minimum number of exclusive beats before paths can converge (2-6).
+  - 2: Minimal divergence (flavor-adjacent soft). Use for `flavor` dilemmas.
+  - 3-4: Standard (most soft dilemmas)
+  - 5-6: Deep divergence (hard-adjacent soft). Use for `hard` dilemmas.
+
+  ## Context
+
+  {dilemma_context}
+
+  ## Schema
+  Return a JSON object with a "dilemma_analyses" array:
+  ```json
+  {{
+    "dilemma_analyses": [
+      {{
+        "dilemma_id": "dilemma::example_id",
+        "convergence_policy": "soft",
+        "payoff_budget": 3,
+        "reasoning": "Explain your classification in 1-2 sentences."
+      }}
+    ]
+  }}
+  ```
+
+  ## Rules
+  - Classify EVERY dilemma from the ### Valid Dilemma IDs list in the Context
+  - If unsure, use `soft` with `payoff_budget: 2`
+  - Dilemmas with only 1 path are typically `flavor` (no real branching)
+  - `reasoning` must be 1-2 sentences explaining WHY you chose that policy
+  - GOOD reasoning: "Trust vs betrayal creates genuinely different arcs needing 3 exclusive beats to develop."
+  - BAD reasoning: "It is soft." (too short, no justification)
+
+  ## REMINDER
+  Classify ALL dilemmas. hard = mutually exclusive, soft = meaningful but mergeable (DEFAULT), flavor = cosmetic only.
+
+  ## Output
+  Return ONLY valid JSON with the "dilemma_analyses" array. Classify ALL dilemmas.
+
+# Section 8: Interaction Constraints (post-prune)
+interaction_constraints_prompt: |
+  You are identifying pairwise dilemma interactions for a SEED stage.
+
+  Some dilemmas interact with each other — they share characters, have causal
+  dependencies, or compete for narrative resources. MOST pairs have NO
+  interaction. It is normal and expected to return an empty list.
+
+  ## Constraint Types
+
+  - **shared_entity**: Both dilemmas involve the same character, location, or
+    object as a central element. Example: "both dilemmas center on the mentor
+    character, so the mentor's arc must be consistent across both."
+  - **causal_chain**: Resolving dilemma A directly affects dilemma B. Example:
+    "whether the bridge is destroyed (dilemma A) determines access to the
+    fortress (dilemma B)."
+  - **resource_conflict**: Both dilemmas compete for the same limited narrative
+    resource (time, character attention, location availability). Example:
+    "both dilemmas need the protagonist at the same location simultaneously."
+
+  ## What NOT to Do
+  - Do NOT invent constraints for pairs not in the Candidate Pairs list
+  - Do NOT force constraints where none exist — empty list is fine
+  - Do NOT use constraint_type values other than the three above
+
+  GOOD constraint: "Both dilemmas involve the mentor (shared_entity), so the
+  mentor's betrayal in dilemma A affects trust in dilemma B."
+  BAD constraint: "Both dilemmas are thematically about trust" (thematic
+  similarity is NOT a structural constraint).
+
+  ## Context
+
+  {candidate_pairs_context}
+
+  ## Schema
+  Return a JSON object with an "interaction_constraints" array:
+  ```json
+  {{
+    "interaction_constraints": [
+      {{
+        "dilemma_a": "dilemma::first_id",
+        "dilemma_b": "dilemma::second_id",
+        "constraint_type": "shared_entity",
+        "description": "The observable structural fact (1-3 sentences, max ~500 chars).",
+        "reasoning": "Why this matters for story structure (1-2 sentences)."
+      }}
+    ]
+  }}
+  ```
+
+  If no interactions exist (common), return an empty array:
+  ```json
+  {{
+    "interaction_constraints": []
+  }}
+  ```
+
+  If the Context says "No candidate pairs", return the empty array above immediately.
+
+  ## Rules
+  - ONLY consider pairs from the ### Candidate Pairs list in the Context
+  - Use canonical ordering: dilemma_a < dilemma_b (alphabetically)
+  - Most stories have 0-2 constraints. Empty list is expected and normal.
+  - `reasoning` must explain the structural (not thematic) relationship
+
+  ## REMINDER
+  ONLY use pairs from the Candidate Pairs list. Empty list is normal. Do NOT invent constraints.
+
+  ## Output
+  Return ONLY valid JSON with the "interaction_constraints" array. An empty array is expected.
+
 components: []

--- a/src/questfoundry/agents/__init__.py
+++ b/src/questfoundry/agents/__init__.py
@@ -15,6 +15,7 @@ from questfoundry.agents.prompts import (
 from questfoundry.agents.serialize import (
     SerializationError,
     SerializeResult,
+    serialize_post_prune_analysis,
     serialize_seed_as_function,
     serialize_seed_iteratively,
     serialize_to_artifact,
@@ -35,6 +36,7 @@ __all__ = [
     "get_serialize_prompt",
     "get_summarize_prompt",
     "run_discuss_phase",
+    "serialize_post_prune_analysis",
     "serialize_seed_as_function",
     "serialize_seed_iteratively",
     "serialize_to_artifact",

--- a/src/questfoundry/agents/serialize.py
+++ b/src/questfoundry/agents/serialize.py
@@ -491,6 +491,8 @@ _REQUIRED_SECTION_PROMPT_KEYS = [
     "beats_prompt",
     "per_path_beats_prompt",
     "convergence_prompt",
+    "dilemma_analyses_prompt",
+    "interaction_constraints_prompt",
 ]
 
 
@@ -539,6 +541,8 @@ def _load_seed_section_prompts() -> dict[str, str]:
         "beats": data["beats_prompt"],
         "per_path_beats": data["per_path_beats_prompt"],
         "convergence": data["convergence_prompt"],
+        "dilemma_analyses": data["dilemma_analyses_prompt"],
+        "interaction_constraints": data["interaction_constraints_prompt"],
     }
 
 

--- a/src/questfoundry/graph/mutations.py
+++ b/src/questfoundry/graph/mutations.py
@@ -23,9 +23,12 @@ from questfoundry.graph.context import (
     parse_scoped_id,
     strip_scope_prefix,
 )
+from questfoundry.observability.logging import get_logger
 
 if TYPE_CHECKING:
     from questfoundry.graph.graph import Graph
+
+log = get_logger(__name__)
 
 # Display limits for error messages
 _MAX_ERRORS_DISPLAY = 8
@@ -1790,6 +1793,47 @@ def apply_seed_mutations(graph: Graph, output: dict[str, Any]) -> None:
                 "convergence_points": sketch.get("convergence_points", []),
                 "residue_notes": sketch.get("residue_notes", []),
             },
+        )
+
+    # Store convergence analysis on dilemma nodes (from sections 7+8)
+    analysis_by_id: dict[str, dict[str, Any]] = {}
+    for analysis in output.get("dilemma_analyses", []):
+        raw_did = analysis.get("dilemma_id", "")
+        analysis_by_id[raw_did] = analysis
+
+    if analysis_by_id:
+        for dilemma_decision in output.get("dilemmas", []):
+            raw_id = dilemma_decision.get("dilemma_id", "")
+            dilemma_node_id = _prefix_id("dilemma", raw_id)
+            if not graph.has_node(dilemma_node_id):
+                continue
+            analysis = analysis_by_id.get(raw_id)
+            graph.update_node(
+                dilemma_node_id,
+                convergence_policy=analysis["convergence_policy"] if analysis else "soft",
+                payoff_budget=analysis.get("payoff_budget", 2) if analysis else 2,
+            )
+
+    # Create interaction constraint edges between dilemma pairs
+    for constraint in output.get("interaction_constraints", []):
+        a_raw = constraint.get("dilemma_a", "")
+        b_raw = constraint.get("dilemma_b", "")
+        a_node = _prefix_id("dilemma", a_raw)
+        b_node = _prefix_id("dilemma", b_raw)
+        if not graph.has_node(a_node) or not graph.has_node(b_node):
+            log.warning(
+                "interaction_constraint_edge_skipped",
+                dilemma_a=a_raw,
+                dilemma_b=b_raw,
+                reason="node_missing",
+            )
+            continue
+        graph.add_edge(
+            "interaction_constraint",
+            a_node,
+            b_node,
+            constraint_type=constraint.get("constraint_type", "shared_entity"),
+            description=constraint.get("description", ""),
         )
 
 

--- a/src/questfoundry/graph/mutations.py
+++ b/src/questfoundry/graph/mutations.py
@@ -1808,10 +1808,17 @@ def apply_seed_mutations(graph: Graph, output: dict[str, Any]) -> None:
             if not graph.has_node(dilemma_node_id):
                 continue
             analysis = analysis_by_id.get(raw_id)
+            if analysis is None:
+                log.warning(
+                    "dilemma_analysis_missing",
+                    dilemma_id=raw_id,
+                    fallback="soft/2",
+                )
+            data = analysis or {}
             graph.update_node(
                 dilemma_node_id,
-                convergence_policy=analysis["convergence_policy"] if analysis else "soft",
-                payoff_budget=analysis.get("payoff_budget", 2) if analysis else 2,
+                convergence_policy=data.get("convergence_policy", "soft"),
+                payoff_budget=data.get("payoff_budget", 2),
             )
 
     # Create interaction constraint edges between dilemma pairs

--- a/src/questfoundry/graph/seed_pruning.py
+++ b/src/questfoundry/graph/seed_pruning.py
@@ -231,6 +231,8 @@ def _prune_demoted_dilemmas(
         consequences=pruned_consequences,
         initial_beats=pruned_beats,
         convergence_sketch=seed_output.convergence_sketch,
+        dilemma_analyses=seed_output.dilemma_analyses,
+        interaction_constraints=seed_output.interaction_constraints,
     )
 
 

--- a/src/questfoundry/pipeline/stages/seed.py
+++ b/src/questfoundry/pipeline/stages/seed.py
@@ -471,7 +471,12 @@ class SeedStage:
 
         # Phase 5: Post-prune convergence analysis (sections 7+8)
         log.debug("seed_phase", phase="post_prune_analysis")
-        analyses, constraints, analysis_tokens = await serialize_post_prune_analysis(
+        (
+            analyses,
+            constraints,
+            analysis_tokens,
+            analysis_calls,
+        ) = await serialize_post_prune_analysis(
             model=serialize_model or model,
             pruned_artifact=pruned_artifact,
             graph=graph,
@@ -479,7 +484,7 @@ class SeedStage:
             callbacks=callbacks,
             on_phase_progress=on_phase_progress,
         )
-        total_llm_calls += 2
+        total_llm_calls += analysis_calls
         total_tokens += analysis_tokens
 
         # Merge analysis into pruned artifact


### PR DESCRIPTION
## Problem

Closes #742

SEED currently lacks per-dilemma convergence analysis. After serializing the core sections (1-6) and pruning to arc limits, there is no mechanism to classify each dilemma's convergence policy (hard/soft/flavor) or detect pairwise interactions between dilemmas. GROW needs this contract to decide how paths merge.

## Changes

- **Context builders** (`graph/context.py`): `format_dilemma_analysis_context()` lists surviving dilemmas with path counts and valid IDs; `format_interaction_candidates_context()` pre-filters candidate pairs by shared central entities
- **Prompt templates** (`serialize_seed_sections.yaml`): Section 7 (dilemma convergence classification) and Section 8 (interaction constraints) with sandwich patterns, good/bad examples, and empty-array guidance
- **Serialization function** (`agents/serialize.py`): `serialize_post_prune_analysis()` runs sections 7+8 after prune with soft failure (defaults to empty on LLM errors), candidate-set validation for section 8
- **Stage wiring** (`pipeline/stages/seed.py`): Phase 5 call inserted between prune and model_dump, merges results via `model_copy(update=...)`
- **Pruning pass-through** (`graph/seed_pruning.py`): Preserves `dilemma_analyses` and `interaction_constraints` fields during SeedOutput reconstruction
- **Graph mutations** (`graph/mutations.py`): Stores `convergence_policy`/`payoff_budget` on dilemma nodes, creates `interaction_constraint` edges between dilemma pairs

## Not Included / Future PRs

- GROW enforcement of convergence policies (#743)
- `qf inspect` convergence report (#744)
- Full integration test with real LLM (#745)

## Test Plan

- `uv run pytest tests/unit/test_graph_context.py -x -q` — 7 new tests for context builders (all pass)
- `uv run pytest tests/unit/test_mutations.py::TestApplySeedConvergenceAnalysis -x -q` — 5 new tests for graph mutations (all pass)
- `uv run mypy src/` — clean
- `uv run ruff check src/` — clean
- Pre-commit hooks pass on all commits

## Risk / Rollback

- **Backward compatible**: new fields default to empty lists, existing projects unaffected
- **Soft failure**: if analysis LLM calls fail, pipeline continues with empty defaults (logged as WARNING)
- **No schema migration needed**: `dilemma_analyses` and `interaction_constraints` are optional fields added in PR #748

## Review Guide

Suggested file review order:
1. `prompts/templates/serialize_seed_sections.yaml` — new prompt templates (sections 7+8)
2. `src/questfoundry/graph/context.py` — context formatting functions
3. `src/questfoundry/agents/serialize.py` — `serialize_post_prune_analysis()` function
4. `src/questfoundry/pipeline/stages/seed.py` — stage wiring (small diff)
5. `src/questfoundry/graph/mutations.py` — graph mutation logic
6. Tests last

🤖 Generated with [Claude Code](https://claude.com/claude-code)