### PR TITLE
feat(inspect): add convergence policy compliance and branching quality checks

### DIFF
--- a/src/questfoundry/cli.py
+++ b/src/questfoundry/cli.py
@@ -2696,6 +2696,21 @@ def _render_inspection_report(report: InspectionReport) -> None:
         console.print(f"  Start passages: {b.start_passages}  Endings: {b.ending_passages}")
         console.print()
 
+    # Branching quality score
+    if report.branching_quality:
+        q = report.branching_quality
+        console.print("[bold]Branching Quality[/bold]")
+        if q.policy_distribution:
+            dist = ", ".join(f"{k}={v}" for k, v in q.policy_distribution.items())
+            console.print(f"  Policy distribution: {dist}")
+        console.print(f"  Avg exclusive beats per branch: [bold]{q.avg_exclusive_beats}[/bold]")
+        console.print(f"  Meaningful choice ratio: [bold]{q.meaningful_choice_ratio}[/bold]")
+        console.print(
+            f"  Terminal passages: [bold]{q.terminal_count}[/bold]  "
+            f"Ending variants: [bold]{q.ending_variants}[/bold]"
+        )
+        console.print()
+
     # Coverage stats
     c = report.coverage
     if c.entity_count:

--- a/src/questfoundry/graph/grow_validation.py
+++ b/src/questfoundry/graph/grow_validation.py
@@ -899,6 +899,18 @@ def check_max_consecutive_linear(graph: Graph, max_run: int = 2) -> ValidationCh
     )
 
 
+def _get_spine_sequence(arc_nodes: dict[str, dict[str, object]]) -> set[str]:
+    """Extract the spine arc's beat sequence as a set.
+
+    Returns an empty set if no spine arc is found.
+    """
+    for data in arc_nodes.values():
+        if data.get("arc_type") == "spine":
+            seq = data.get("sequence", [])
+            return set(seq) if isinstance(seq, list) else set()
+    return set()
+
+
 def check_convergence_policy_compliance(graph: Graph) -> list[ValidationCheck]:
     """Verify branch arcs honor their declared convergence_policy.
 
@@ -919,11 +931,7 @@ def check_convergence_policy_compliance(graph: Graph) -> list[ValidationCheck]:
             )
         ]
 
-    spine_seq_set: set[str] = set()
-    for _arc_id, data in arc_nodes.items():
-        if data.get("arc_type") == "spine":
-            spine_seq_set = set(data.get("sequence", []))
-            break
+    spine_seq_set = _get_spine_sequence(arc_nodes)
 
     violations: list[ValidationCheck] = []
     checked = 0

--- a/tests/unit/test_grow_validation.py
+++ b/tests/unit/test_grow_validation.py
@@ -1070,7 +1070,7 @@ class TestMaxConsecutiveLinear:
 
 def _make_compliance_graph(
     policy: str,
-    budget: int,
+    payoff_budget: int,
     *,
     shared_after_div: int = 0,
     exclusive_count: int = 3,
@@ -1079,7 +1079,7 @@ def _make_compliance_graph(
 
     Args:
         policy: Convergence policy for the branch arc.
-        budget: payoff_budget for the branch arc.
+        payoff_budget: payoff_budget for the branch arc.
         shared_after_div: Number of spine beats shared after divergence.
         exclusive_count: Number of beats exclusive to the branch.
     """
@@ -1108,7 +1108,7 @@ def _make_compliance_graph(
             "sequence": branch_seq,
             "diverges_at": "beat::s1",
             "convergence_policy": policy,
-            "payoff_budget": budget,
+            "payoff_budget": payoff_budget,
             "paths": ["path::rebel"],
         },
     )
@@ -1164,6 +1164,33 @@ class TestConvergencePolicyCompliance:
         results = check_convergence_policy_compliance(graph)
         assert all(r.severity == "pass" for r in results)
         assert "No branch arcs with convergence metadata" in results[0].message
+
+    def test_diverges_at_end_of_sequence(self) -> None:
+        """diverges_at is the last beat — no beats after divergence → passes."""
+        graph = Graph.empty()
+        graph.create_node(
+            "arc::spine",
+            {
+                "type": "arc",
+                "arc_type": "spine",
+                "sequence": ["beat::s0", "beat::s1"],
+                "paths": [],
+            },
+        )
+        graph.create_node(
+            "arc::branch_0",
+            {
+                "type": "arc",
+                "arc_type": "branch",
+                "sequence": ["beat::s0", "beat::s1"],
+                "diverges_at": "beat::s1",
+                "convergence_policy": "hard",
+                "payoff_budget": 2,
+                "paths": [],
+            },
+        )
+        results = check_convergence_policy_compliance(graph)
+        assert all(r.severity == "pass" for r in results)
 
     def test_no_arcs_passes(self) -> None:
         graph = Graph.empty()


### PR DESCRIPTION
## Problem

`qf inspect` has no way to verify that the branching contract (convergence_policy) is being honored, codewords are consumed, or forward paths are reachable. After PR3 (#750) wired convergence enforcement and codeword requires into GROW, we need inspection checks to validate the contract post-hoc.

Closes #744

## Changes

### Validation checks (`grow_validation.py`)
- **`check_convergence_policy_compliance`**: verifies branch arcs honor their declared policy — `hard` arcs must not share beats after divergence (fail), `soft` arcs must meet payoff_budget (warn), `flavor` always passes. Pre-policy arcs are skipped for backward compatibility.
- **`check_codeword_gate_coverage`**: warns when codewords are not consumed by any `choice.requires` gate ("Residue Must Be Read" invariant, narrow scope — does not check overlays or ending scoring).
- **`check_forward_path_reachability`**: warns when non-ending passages have only gated outgoing choices (soft-lock risk). Excludes `is_return` spoke→hub links. v1 does not check "already satisfiable" (would need path simulation).

### Branching quality metrics (`inspection.py` + `cli.py`)
- **`BranchingQualityScore`** dataclass: terminal_count, ending_variants, policy_distribution, avg_exclusive_beats, meaningful_choice_ratio
- Rendered in CLI output under "Branching Quality" section
- Included in JSON output via `branching_quality` field

### Tests
- 17 new tests across `test_grow_validation.py` (14) and `test_inspection.py` (3)

## Not Included / Future PRs
- Interaction constraint enforcement reporting
- "Already satisfiable" analysis for forward-path check (requires path simulation)
- Overlay-based codeword consumption checks
- Automated remediation suggestions

## Test Plan
```bash
uv run mypy src/questfoundry/graph/grow_validation.py src/questfoundry/inspection.py  # Success
uv run ruff check src/questfoundry/graph/grow_validation.py src/questfoundry/inspection.py src/questfoundry/cli.py  # All passed
uv run pytest tests/unit/test_grow_validation.py tests/unit/test_inspection.py -x -q  # 89 passed
```

## Risk / Rollback
- All new checks are additive — existing validation checks unchanged
- Pre-policy graphs (without `convergence_policy` on arc nodes) pass silently
- New `branching_quality` field on `InspectionReport` defaults to None for pre-GROW graphs