### PR TITLE
docs: update ontology and procedure docs for branching contract

### DIFF
--- a/docs/design/00-spec.md
+++ b/docs/design/00-spec.md
@@ -822,10 +822,47 @@ seed:
       location: entity_id | null            # primary location
       location_alternatives: entity_id[]    # other valid locations (enables intersection flexibility)
 
-  convergence_sketch:                 # informal guidance for GROW
+  convergence_sketch:                 # informal creative guidance for GROW
     convergence_points: string[]      # "paths should merge by act 2 climax"
     residue_notes: string[]           # "mentor demeanor differs after convergence"
+
+  # --- Convergence Analysis (Sections 7-8) ---
+  # Machine-actionable structural contracts. Generated post-prune,
+  # after all 6 core sections are serialized. See ADR-013.
+
+  dilemma_analyses:
+    - dilemma_id: dilemma_id
+      convergence_policy: hard | soft | flavor
+      payoff_budget: int (2-6)        # minimum exclusive beats before convergence
+      reasoning: string               # chain-of-thought justification
+
+  interaction_constraints:             # sparse — only related dilemma pairs
+    - dilemma_a: dilemma_id
+      dilemma_b: dilemma_id
+      constraint_type: shared_entity | causal_chain | resource_conflict
+      description: string
+      reasoning: string
 ```
+
+#### Convergence Policies (Branching Contract)
+
+Per-dilemma `convergence_policy` declared by SEED, enforced by GROW. Determines how and whether branch arcs reconverge with the spine.
+
+| Policy | Meaning | GROW Behavior |
+|--------|---------|---------------|
+| `hard` | Paths never reconverge structurally | `converges_at` not set. Codeword gating at branch divergence points. Separate endings encouraged. Shared beats (intersections) are still topologically allowed — enforcement is at the gating level, not topology level (see #751). |
+| `soft` | Paths reconverge after `payoff_budget` exclusive beats | Backward scan: last exclusive beat marks convergence boundary. If exclusive beats < budget, no convergence. |
+| `flavor` | Same structure, different prose via overlays | Immediate convergence at first shared beat. Overlays provide tonal variation. |
+
+**Multi-dilemma arcs:** When an arc spans multiple dilemmas, `hard` dominates; `payoff_budget = max(...)` across all dilemmas.
+
+**`convergence_sketch` vs `convergence_policy`:** These are complementary, not redundant. `convergence_policy` is a machine-actionable structural contract enforced by GROW algorithms. `convergence_sketch` is freeform creative guidance from the LLM to itself, used for narrative hints during prose generation.
+
+#### "Residue Must Be Read" Invariant
+
+Every codeword granted must appear in at least one `choice.requires` gate. Current scope: choice gating only. Future extensions may include overlays, ending scoring, and conditional prose as additional "read" mechanisms.
+
+**`converges_at` semantics:** "From this beat onward, all remaining content on this arc is shared with the spine." It is NOT set at intersections (shared beats with later exclusive beats). For `hard` policy, it is never set.
 
 **Human Gate:** Approve seed. After this point, no new paths can be created.
 

--- a/docs/design/00-spec.md
+++ b/docs/design/00-spec.md
@@ -850,7 +850,7 @@ Per-dilemma `convergence_policy` declared by SEED, enforced by GROW. Determines 
 
 | Policy | Meaning | GROW Behavior |
 |--------|---------|---------------|
-| `hard` | Paths never reconverge structurally | `converges_at` not set. Codeword gating at branch divergence points. Separate endings encouraged. Shared beats (intersections) are still topologically allowed — enforcement is at the gating level, not topology level (see #751). |
+| `hard` | Paths never reconverge structurally | `converges_at` is not set. Uses codeword gating at divergence points and encourages separate endings. Shared beats are topologically allowed but gated (see #751). |
 | `soft` | Paths reconverge after `payoff_budget` exclusive beats | Backward scan: last exclusive beat marks convergence boundary. If exclusive beats < budget, no convergence. |
 | `flavor` | Same structure, different prose via overlays | Immediate convergence at first shared beat. Overlays provide tonal variation. |
 


### PR DESCRIPTION
## Problem

The design specification and procedure docs do not reflect the branching contract feature implemented in PRs #748-#750 and #753. Code is fully implemented but docs lag behind — users and maintainers have no reference for convergence policies, "Residue Must Be Read", or how SEED/GROW interact on branching decisions.

Closes #745

## Changes

### `docs/design/00-spec.md` — Ontology update
- Added `DilemmaAnalysis` and `InteractionConstraint` schemas (Sections 7-8)
- Added convergence policy definitions table (hard/soft/flavor semantics)
- Documented "Residue Must Be Read" invariant with precise scope
- Clarified `convergence_sketch` vs `convergence_policy` relationship
- Documented `converges_at` semantics (not set at intersections)

### `docs/design/procedures/seed.md` — SEED phases 7+8
- Added Phase 7: Dilemma Analysis (convergence classification)
- Added Phase 8: Interaction Constraints (sparse pairwise)
- Updated human gates summary table

### `docs/design/procedures/grow.md` — GROW enforcement
- Updated Phase 7 with policy-aware convergence (combine rule, backward scan)
- Updated Phase 9 with codeword requires pre-computation and gating rules

### `docs/architecture/decisions.md` — ADR-013
- Added ADR-013: Branching Contract Design (rationale for SEED extension, gating not topology, sparse interactions, soft failure)

## Not Included / Future PRs
- Topology enforcement docs when #751 is implemented
- Spoke grants docs when #752 is implemented

## Test Plan
- Docs-only change, no code modifications
- Manual review of markdown rendering

## Risk / Rollback
- No code changes — zero risk of runtime regression