### PR TITLE
feat(grow): wire spoke grants for hub-and-spoke codeword minting

### DIFF
--- a/prompts/templates/grow_phase9c_hub_spokes.yaml
+++ b/prompts/templates/grow_phase9c_hub_spokes.yaml
@@ -36,9 +36,13 @@ system: |
      based on the prose it writes. This ensures labels match actual content.
   5. If you DO provide labels: 3-6 words, action phrases in imperative form
   6. Forward label: describes continuing the main story (required)
+  7. Spokes may optionally grant codewords when visited. Only use IDs from
+     the Valid Codewords list. Most spokes should NOT grant — only grant when
+     exploring that spoke naturally reveals something tracked by a codeword.
 
   ## What NOT to Do
   - Do NOT use passage IDs not listed in the Valid IDs section
+  - Do NOT use codeword IDs not listed in the Valid Codewords section
   - Do NOT make spokes plot-critical (they are OPTIONAL)
   - Do NOT add explanatory prose before or after the JSON output
   - Do NOT propose hubs at ending passages (no outgoing choices)
@@ -46,6 +50,9 @@ system: |
 
   ## Valid IDs
   Valid passage IDs: {valid_passage_ids}
+
+  ## Valid Codewords
+  Valid codeword IDs: {valid_codeword_ids}
 
   ## Output Format
   Return a JSON object with a "hubs" array. Each hub has:
@@ -58,6 +65,7 @@ system: |
       - "evocative": Atmospheric — "Trace the faded ink", "Listen to the silence"
       - "character_voice": Internal thought — "That clock... why did it stop?"
       If omitted, defaults to "functional"
+    - grants: (optional) list of codeword IDs this spoke grants when visited (default: empty)
   - forward_label: choice label for continuing the story (3-6 words)
 
 user: |

--- a/src/questfoundry/pipeline/stages/grow.py
+++ b/src/questfoundry/pipeline/stages/grow.py
@@ -2871,9 +2871,15 @@ class GrowStage:
                 detail="No non-ending passages found",
             )
 
+        codeword_nodes = graph.get_nodes_by_type("codeword")
+        valid_codeword_ids = set(codeword_nodes.keys())
+
         context = {
             "passage_context": "\n".join(passage_lines),
             "valid_passage_ids": ", ".join(valid_ids),
+            "valid_codeword_ids": ", ".join(sorted(valid_codeword_ids))
+            if valid_codeword_ids
+            else "none",
             "output_language_instruction": self._lang_instruction,
         }
 
@@ -2882,6 +2888,7 @@ class GrowStage:
         validator = partial(
             validate_phase9c_output,
             valid_passage_ids=set(valid_ids),
+            valid_codeword_ids=valid_codeword_ids,
         )
 
         try:
@@ -2946,7 +2953,7 @@ class GrowStage:
                     "from_passage": hub_id,
                     "to_passage": spoke_pid,
                     "requires": [],
-                    "grants": [],
+                    "grants": spoke.grants,
                     "label_style": spoke.label_style,
                 }
                 if spoke.label:


### PR DESCRIPTION
## Problem

Phase 9c creates hub→spoke choices with hardcoded `grants: []`. The `SpokeProposal.grants` field exists in the model but is never wired through to choice node creation, making spokes permanently flavor-only with no way to grant codewords.

## Changes

- Wire `spoke.grants` into hub→spoke choice creation (line 2949 of `grow.py`)
- Update Phase 9c prompt to document optional spoke grants and provide valid codeword IDs
- Add spoke grant ID validation to `validate_phase9c_output()` using `normalize_scoped_id` for prefix handling
- Add 4 tests for grant validation (valid, invalid, None backward-compat, unscoped normalization)

## Not Included / Future PRs

- Prompt tuning for specific codeword grant heuristics (LLM decides when to grant)
- `qf inspect` spoke-grant-specific coverage checks (existing `check_codeword_gate_coverage` already covers spoke-granted codewords)

## Test Plan

```bash
uv run pytest tests/unit/test_grow_validators.py -x -q  # 42 passed (38 existing + 4 new)
uv run mypy src/questfoundry/graph/grow_validators.py src/questfoundry/pipeline/stages/grow.py  # clean
```

## Risk / Rollback

- Low risk: return choice still has `grants: []`, only hub→spoke entry grants changed
- Backward compatible: `valid_codeword_ids=None` skips grant validation
- No LLM behavior change unless codewords exist in graph at Phase 9c time

Closes #746

🤖 Generated with [Claude Code](https://claude.com/claude-code)