### PR TITLE
feat(grow): topology enforcement for hard convergence policy

### DIFF
--- a/src/questfoundry/graph/grow_algorithms.py
+++ b/src/questfoundry/graph/grow_algorithms.py
@@ -1505,7 +1505,8 @@ def _get_hard_policy_beats(
     for bid in beat_ids:
         for raw in beat_dilemma_map.get(bid, set()):
             prefixed = raw_to_prefixed.get(raw)
-            if prefixed and dilemma_nodes[prefixed].get("convergence_policy") == "hard":
+            dnode = dilemma_nodes.get(prefixed) if prefixed else None
+            if dnode and dnode.get("convergence_policy") == "hard":
                 hard_beats.add(bid)
                 break
     return hard_beats
@@ -1898,6 +1899,8 @@ def check_intersection_compatibility(
                 category=GrowErrorCategory.STRUCTURAL,
             )
         )
+        # Early return: hard-policy violations are structural and block all
+        # downstream checks (requires edges, conditional prerequisites).
         return errors
 
     # Check requires edges originating from intersection beats.

--- a/tests/unit/test_grow_algorithms.py
+++ b/tests/unit/test_grow_algorithms.py
@@ -4197,3 +4197,95 @@ class TestCollapseLinearPassages:
 
         assert result.chains_collapsed == 0
         assert result.passages_removed == 0
+
+
+# ---------------------------------------------------------------------------
+# Hard-policy intersection rejection
+# ---------------------------------------------------------------------------
+
+
+class TestHardPolicyIntersectionRejection:
+    """check_intersection_compatibility rejects intersections involving hard-policy beats."""
+
+    def _make_two_dilemma_graph(
+        self,
+        d1_policy: str = "hard",
+        d2_policy: str = "soft",
+    ) -> Graph:
+        """Graph with 2 dilemmas, each with 1 path and 1 beat sharing a location."""
+        graph = Graph.empty()
+        graph.create_node(
+            "dilemma::d1",
+            {
+                "type": "dilemma",
+                "raw_id": "d1",
+                "convergence_policy": d1_policy,
+                "payoff_budget": 3,
+            },
+        )
+        graph.create_node(
+            "dilemma::d2",
+            {
+                "type": "dilemma",
+                "raw_id": "d2",
+                "convergence_policy": d2_policy,
+                "payoff_budget": 2,
+            },
+        )
+        graph.create_node("path::p1", {"type": "path", "raw_id": "p1", "dilemma_id": "d1"})
+        graph.create_node("path::p2", {"type": "path", "raw_id": "p2", "dilemma_id": "d2"})
+        graph.create_node("beat::b1", {"type": "beat", "summary": "Scene A", "location": "tavern"})
+        graph.create_node("beat::b2", {"type": "beat", "summary": "Scene B", "location": "tavern"})
+        graph.add_edge("belongs_to", "beat::b1", "path::p1")
+        graph.add_edge("belongs_to", "beat::b2", "path::p2")
+        return graph
+
+    def test_hard_policy_beat_rejected(self) -> None:
+        """Intersection containing a hard-policy beat is rejected."""
+        from questfoundry.graph.grow_algorithms import check_intersection_compatibility
+
+        graph = self._make_two_dilemma_graph(d1_policy="hard", d2_policy="soft")
+        errors = check_intersection_compatibility(graph, ["beat::b1", "beat::b2"])
+        assert len(errors) == 1
+        assert "hard_policy" in errors[0].field_path
+
+    def test_soft_policy_beats_accepted(self) -> None:
+        """Intersection of two soft-policy beats passes hard-policy check."""
+        from questfoundry.graph.grow_algorithms import check_intersection_compatibility
+
+        graph = self._make_two_dilemma_graph(d1_policy="soft", d2_policy="soft")
+        errors = check_intersection_compatibility(graph, ["beat::b1", "beat::b2"])
+        hard_errors = [e for e in errors if "hard_policy" in e.field_path]
+        assert not hard_errors
+
+    def test_flavor_policy_beats_accepted(self) -> None:
+        """Intersection of flavor-policy beats passes hard-policy check."""
+        from questfoundry.graph.grow_algorithms import check_intersection_compatibility
+
+        graph = self._make_two_dilemma_graph(d1_policy="flavor", d2_policy="flavor")
+        errors = check_intersection_compatibility(graph, ["beat::b1", "beat::b2"])
+        hard_errors = [e for e in errors if "hard_policy" in e.field_path]
+        assert not hard_errors
+
+    def test_no_policy_defaults_to_non_hard(self) -> None:
+        """Beats from dilemmas without convergence_policy pass the hard check."""
+        from questfoundry.graph.grow_algorithms import check_intersection_compatibility
+
+        graph = self._make_two_dilemma_graph(d1_policy="soft", d2_policy="soft")
+        # Remove convergence_policy to simulate pre-policy graph
+        graph.update_node("dilemma::d1", convergence_policy=None)
+        graph.update_node("dilemma::d2", convergence_policy=None)
+        errors = check_intersection_compatibility(graph, ["beat::b1", "beat::b2"])
+        hard_errors = [e for e in errors if "hard_policy" in e.field_path]
+        assert not hard_errors
+
+    def test_build_candidates_excludes_hard(self) -> None:
+        """Hard-policy beats are excluded from intersection candidates."""
+        from questfoundry.graph.grow_algorithms import build_intersection_candidates
+
+        graph = self._make_two_dilemma_graph(d1_policy="hard", d2_policy="soft")
+        candidates = build_intersection_candidates(graph)
+        # Hard beat should be filtered out; only soft beat remains.
+        # A single beat can't form an intersection, so no candidates expected.
+        for c in candidates:
+            assert "beat::b1" not in c.beat_ids

--- a/tests/unit/test_grow_algorithms.py
+++ b/tests/unit/test_grow_algorithms.py
@@ -4246,8 +4246,9 @@ class TestHardPolicyIntersectionRejection:
 
         graph = self._make_two_dilemma_graph(d1_policy="hard", d2_policy="soft")
         errors = check_intersection_compatibility(graph, ["beat::b1", "beat::b2"])
-        assert len(errors) == 1
-        assert "hard_policy" in errors[0].field_path
+        hard_errors = [e for e in errors if "hard_policy" in e.field_path]
+        assert len(hard_errors) == 1
+        assert "hard" in hard_errors[0].issue.lower()
 
     def test_soft_policy_beats_accepted(self) -> None:
         """Intersection of two soft-policy beats passes hard-policy check."""


### PR DESCRIPTION
## Problem

Phase 3 intersection detection can make beats multi-path (shared between spine and branch arcs) even when the branch's dilemma has `hard` convergence policy. This violates the topology isolation guarantee — `hard`-policy paths should never share beats with other paths.

## Changes

- Add `_get_hard_policy_beats()` helper that identifies beats belonging to `hard`-policy dilemmas using the existing `_build_beat_dilemmas()` mapping
- Filter hard-policy beats from `build_intersection_candidates()` before location/entity grouping (saves LLM tokens)
- Reject hard-policy intersections in `check_intersection_compatibility()` as a safety net (defense in depth)
- Add 5 tests covering: hard rejected, soft/flavor accepted, no-policy defaults, candidate filtering

## Not Included / Future PRs

- Beat cloning for existing intersections (this PR prevents new ones, doesn't fix pre-existing shared beats)
- Changes to Phase 7 convergence algorithm (already handles `hard` correctly)

## Test Plan

```bash
uv run pytest tests/unit/test_grow_algorithms.py -k "intersection" -x -q  # 15 passed (10 existing + 5 new)
uv run mypy src/questfoundry/graph/grow_algorithms.py  # clean
```

## Risk / Rollback

- Low risk: adds a filter + rejection check, no existing behavior changed
- Pre-policy graphs (no `convergence_policy` on dilemma nodes) are unaffected — beats default to non-hard
- Stories with all-hard dilemmas will have no intersections (correct by design)

Closes #747

🤖 Generated with [Claude Code](https://claude.com/claude-code)