### PR TITLE
fix(grow): remove self-referential codeword gates on branch entries

### DIFF
--- a/src/questfoundry/graph/grow_algorithms.py
+++ b/src/questfoundry/graph/grow_algorithms.py
@@ -1240,58 +1240,20 @@ def compute_passage_arc_membership(graph: Graph) -> dict[str, set[str]]:
 
 
 def compute_all_choice_requires(
-    graph: Graph,
-    passage_arcs: dict[str, set[str]],
+    graph: Graph,  # noqa: ARG001
+    passage_arcs: dict[str, set[str]],  # noqa: ARG001
 ) -> dict[str, list[str]]:
-    """Compute codeword ``requires`` lists for all target passages at once.
+    """Compute codeword ``requires`` lists for target passages.
 
-    Only target passages exclusive to hard-policy branch arcs get non-empty
-    lists.  Passages reachable from the spine always return ``[]``.
-
-    The caller is responsible for only applying requires at multi-choice
-    divergence points (single-outgoing-choice passages must never be gated).
+    Currently returns empty — hard-policy topology isolation is enforced
+    structurally (Phase 3 intersection rejection, separate arc sequences).
+    Codeword gating for branch entries is reserved for future opt-in
+    support (see issue #758).
 
     Returns:
         Mapping of ``passage_id`` → list of required codeword IDs.
     """
-    arc_nodes = graph.get_nodes_by_type("arc")
-
-    # Pre-build consequence → codeword lookup from tracks edges
-    tracks_edges = graph.get_edges(from_id=None, to_id=None, edge_type="tracks")
-    cons_to_codeword: dict[str, str] = {}
-    for edge in tracks_edges:
-        cons_to_codeword[edge["to"]] = edge["from"]
-
-    # Pre-build path → consequences lookup from has_consequence edges
-    has_cons_edges = graph.get_edges(from_id=None, to_id=None, edge_type="has_consequence")
-    path_consequences: dict[str, list[str]] = {}
-    for edge in has_cons_edges:
-        path_consequences.setdefault(edge["from"], []).append(edge["to"])
-
-    requires: dict[str, list[str]] = {}
-
-    for passage_id, arc_ids in passage_arcs.items():
-        # If reachable from spine, no gating needed
-        if any(arc_nodes.get(a, {}).get("arc_type") == "spine" for a in arc_ids):
-            continue
-
-        codewords: list[str] = []
-        for arc_id in sorted(arc_ids):
-            arc_data = arc_nodes.get(arc_id, {})
-            if arc_data.get("convergence_policy") != "hard":
-                continue
-
-            for raw_path_id in arc_data.get("paths", []):
-                path_id = normalize_scoped_id(raw_path_id, "path")
-                for cons_id in path_consequences.get(path_id, []):
-                    cw = cons_to_codeword.get(cons_id)
-                    if cw and cw not in codewords:
-                        codewords.append(cw)
-
-        if codewords:
-            requires[passage_id] = codewords
-
-    return requires
+    return {}
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_grow_algorithms.py
+++ b/tests/unit/test_grow_algorithms.py
@@ -1204,13 +1204,13 @@ class TestComputeAllChoiceRequires:
         # pb is spine-only → no requires
         assert result.get("passage::pb", []) == []
 
-    def test_hard_branch_target_gets_codewords(self) -> None:
-        """Target exclusive to hard-policy branch gets codeword requirements."""
+    def test_hard_branch_target_no_requires(self) -> None:
+        """Hard-policy branch target gets no requires (structural enforcement)."""
         graph, passage_arcs = self._make_requires_graph("hard")
         result = compute_all_choice_requires(graph, passage_arcs)
 
-        # px is exclusive to branch (hard policy) → requires codeword
-        assert "codeword::alt_outcome_committed" in result.get("passage::px", [])
+        # Structural isolation enforces hard policy; no codeword gating (#757)
+        assert result.get("passage::px", []) == []
 
     def test_soft_branch_target_no_requires(self) -> None:
         """Target exclusive to soft-policy branch gets no requires."""

--- a/tests/unit/test_grow_validation.py
+++ b/tests/unit/test_grow_validation.py
@@ -1246,6 +1246,23 @@ class TestCodewordGateCoverage:
         result = check_codeword_gate_coverage(graph)
         assert result.severity == "pass"
 
+    def test_overlay_when_counts_as_consumed(self) -> None:
+        """Codewords referenced in overlay.when are counted as consumed."""
+        graph = Graph.empty()
+        graph.create_node("codeword::cw1", {"type": "codeword", "raw_id": "cw1"})
+        graph.create_node(
+            "overlay::o1",
+            {
+                "type": "overlay",
+                "entity_id": "character::hero",
+                "when": ["codeword::cw1"],
+                "description": "Hero looks weary",
+            },
+        )
+        result = check_codeword_gate_coverage(graph)
+        assert result.severity == "pass"
+        assert "consumed" in result.message
+
 
 # ---------------------------------------------------------------------------
 # Forward path reachability


### PR DESCRIPTION
## Problem

`compute_all_choice_requires()` (introduced in PR #750) collects codewords from the branch arc's own paths, creating impossible gates at branch entry choices:

- **Self-referential**: branch-exclusive path codewords require committing X to enter the path that commits X
- **Late grants**: shared-path codewords are granted after the divergence point, not before

This causes `gate_satisfiability` to fail during GROW Phase 10 validation. Discovered during end-to-end testing of #740.

## Changes

- **`compute_all_choice_requires()`**: Returns `{}` — hard-policy topology is already enforced structurally via Phase 3 intersection rejection (#756) and separate arc sequences. Codeword gating deferred to future opt-in (#758).
- **`check_codeword_gate_coverage()`**: Widened to also count `overlay.when` conditions as codeword consumption, not just `choice.requires`.
- Updated test to match new behavior; added test for overlay consumption.

## Not Included / Future PRs

- Time-loop / NG+ branch gating — #758 (opt-in spine-exclusive codeword gating)
- Grant propagation gap (Phase 9b fork insertion creates choices with hardcoded empty grants) — tracked in #758

## Test Plan

```bash
uv run mypy src/questfoundry/graph/grow_algorithms.py src/questfoundry/graph/grow_validation.py  # pass
uv run ruff check src/ tests/  # pass
uv run pytest tests/unit/test_grow_algorithms.py tests/unit/test_grow_validation.py -x -q  # 259 passed
```

## Risk / Rollback

Low risk — removes broken gating logic, no behavior change for stories without hard-policy branches. Structural enforcement remains intact.

Closes #757

🤖 Generated with [Claude Code](https://claude.com/claude-code)