### PR TITLE
fix(grow): measure commits_timing against arc beat sequence

### DIFF
--- a/src/questfoundry/graph/grow_validation.py
+++ b/src/questfoundry/graph/grow_validation.py
@@ -478,7 +478,7 @@ def check_commits_timing(graph: Graph) -> list[ValidationCheck]:
 
     # Build path → arc sequence mapping (prefer spine arc)
     path_to_arc_seq: dict[str, list[str]] = {}
-    for _arc_id, arc_data in arc_nodes.items():
+    for _arc_id, arc_data in sorted(arc_nodes.items()):
         seq = arc_data.get("sequence", [])
         is_spine = arc_data.get("arc_type") == "spine"
         for path_raw in arc_data.get("paths", []):


### PR DESCRIPTION
## Problem

`check_commits_timing()` measures dilemma commits position against path-local beats. On `test-pr-740-big`, this produced warnings on 9/11 paths (82%) because short branch paths (5 beats) have almost no valid position for commits when thresholds are designed for longer sequences.

The player walks the **arc** (all beats from all paths in topological order), not individual path beats. A commits at path beat 3/5 might be arc beat 10/15, which is perfectly paced.

## Changes

- Rewrite `check_commits_timing()` to build path→arc sequence mapping from arc nodes
- Prefer spine arc when a path appears in multiple arcs
- Scan the arc's beat sequence for dilemma impacts instead of path-local beats
- Return early if no arc nodes exist (pre-GROW graph)
- Update messages to reference "arc position" instead of "beat"
- Extract `_make_timing_graph_with_arc()` test helper to reduce duplication
- Update 5 existing tests + 1 integration test to include arc nodes
- Add `test_commits_timing_short_path_in_long_arc` — 5-beat path in 15-beat arc, no warnings
- Add `test_commits_timing_no_arcs_skips` — no arcs returns empty

## Not Included / Future PRs

- Adjusting threshold constants (current values are reasonable at arc scale)
- Per-dilemma threshold tuning based on convergence_policy

## Test Plan

```
uv run mypy src/questfoundry/graph/grow_validation.py  # Success
uv run ruff check src/questfoundry/graph/grow_validation.py tests/unit/test_grow_validation.py  # All passed
uv run pytest tests/unit/test_grow_validation.py -x -q  # 69 passed
```

## Risk / Rollback

Low risk — timing checks are advisory (warnings only, never blocking). The behavioral change is fewer false positives. Existing constants are reasonable at arc scale (15-20 beat arcs vs 5-beat paths).

Closes #762

🤖 Generated with [Claude Code](https://claude.com/claude-code)