### PR TITLE
feat(seed): per-dilemma path serialization

### DIFF
--- a/prompts/templates/serialize_seed_sections.yaml
+++ b/prompts/templates/serialize_seed_sections.yaml
@@ -231,6 +231,87 @@ paths_prompt: |
   ## Output
   Return ONLY valid JSON with the "paths" array.
 
+# Section 3b: Per-Dilemma Paths (used by per-dilemma path serialization)
+# This prompt generates paths for a single dilemma with a fixed dilemma_id.
+# The dilemma_id, explored answers, and expected path IDs are injected at runtime.
+per_dilemma_paths_prompt: |
+  You are generating PATHS for ONE SPECIFIC DILEMMA.
+
+  ## YOUR DILEMMA (MEMORIZE THIS)
+
+  Dilemma ID: `{dilemma_id}`
+  Question: {dilemma_question}
+
+  ## EXPLORED ANSWERS (generate a path for EACH)
+
+  {explored_answers}
+
+  ## UNEXPLORED ANSWERS (do NOT generate paths for these)
+
+  {unexplored_answers}
+
+  ## EXPECTED PATH IDs (use EXACTLY these)
+
+  You MUST generate exactly {path_count} path(s) with these IDs:
+  {expected_path_ids}
+
+  ## Scoped ID Format (CRITICAL)
+  All IDs use type prefixes for disambiguation:
+  - path_id: Use `path::` prefix (e.g., `path::host_benevolent_or_selfish__protector`)
+  - dilemma_id: Use `dilemma::` prefix (e.g., `dilemma::host_benevolent_or_selfish`)
+
+  Path IDs embed their parent dilemma: `path::[dilemma_name]__[answer_id]`
+
+  ## CRITICAL INVARIANT: answer_id MUST match explored
+  Each path's `answer_id` MUST be one of the explored answer IDs listed above.
+
+  ## Schema
+  Return a JSON object with a "paths" array. Each item is a Path:
+  ```json
+  {{
+    "paths": [
+      {{
+        "path_id": "path::{dilemma_name}__{answer_id_example}",
+        "name": "Human-readable path name",
+        "dilemma_id": "{dilemma_id}",
+        "answer_id": "the_explored_answer_id",
+        "unexplored_answer_ids": ["other_answer_ids"],
+        "path_importance": "major",
+        "description": "What this path is about",
+        "consequence_ids": []
+      }}
+    ]
+  }}
+  ```
+
+  Note: `answer_id`, `unexplored_answer_ids`, and `consequence_ids` are raw
+  IDs without prefixes since they are local identifiers.
+
+  ## Rules
+  - Generate exactly {path_count} path(s) — one per explored answer
+  - path_importance must be exactly "major" or "minor" (lowercase)
+  - answer_id MUST be one of the explored answers listed above
+  - unexplored_answer_ids: IDs of answers NOT explored
+  - consequence_ids: Leave empty (will be populated by consequences section)
+  - path_id MUST include the `path::` prefix
+  - dilemma_id MUST be exactly `{dilemma_id}`
+
+  ## What NOT to Do
+  - Do NOT generate paths for unexplored answers
+  - Do NOT generate paths for other dilemmas
+  - Do NOT use answer_ids that aren't in the explored list
+  - Do NOT change the dilemma_id
+  - Do NOT omit the `path::` or `dilemma::` prefixes
+
+  ## FINAL CHECK (verify before output)
+  1. You generated exactly {path_count} path(s)
+  2. Each path's dilemma_id is `{dilemma_id}`
+  3. Each path's answer_id is in the explored list
+  4. Each path_id matches the expected IDs listed above
+
+  ## Output
+  Return ONLY valid JSON with the "paths" array.
+
 # Section 4: Consequences
 consequences_prompt: |
   You are generating CONSEQUENCES for a SEED stage based on paths.

--- a/src/questfoundry/models/seed.py
+++ b/src/questfoundry/models/seed.py
@@ -471,6 +471,27 @@ class PathsSection(BaseModel):
         return self
 
 
+class DilemmaPathsSection(BaseModel):
+    """Wrapper for serializing paths for a single dilemma.
+
+    Used by per-dilemma path serialization to constrain the LLM to generating
+    paths for exactly one dilemma. This prevents trailing dilemmas from being
+    dropped when serializing all paths at once.
+    """
+
+    paths: list[Path] = Field(
+        min_length=1,
+        max_length=4,
+        description="1-4 paths for this specific dilemma",
+    )
+
+    @model_validator(mode="after")
+    def _deduplicate_paths(self) -> DilemmaPathsSection:
+        """Drop identical duplicate paths; raise on conflicting ones."""
+        self.paths = _deduplicate_and_check(self.paths, "path_id", "path_id")
+        return self
+
+
 class ConsequencesSection(BaseModel):
     """Wrapper for serializing consequences separately."""
 


### PR DESCRIPTION
## Problem

SEED path serialization drops trailing dilemmas at scale (#760). When serializing
7+ dilemmas' paths in a single LLM call, the model truncates output before all
dilemmas are covered, losing paths for the last 1-3 dilemmas.

## Changes

- Add `DilemmaPathsSection` model in `models/seed.py` with 1-4 path constraint
  and deduplication validator
- Add `per_dilemma_paths_prompt` template with sandwich pattern (IDs at top AND
  bottom) and explicit output constraints
- Add 3 new functions in `serialize.py` following the existing `per_path_beats`
  pattern:
  - `_build_per_dilemma_path_context()` — builds brief for one dilemma
  - `_serialize_dilemma_paths()` — serializes paths for one dilemma
  - `_serialize_paths_per_dilemma()` — orchestrates all dilemmas with semaphore
    bounded concurrency (max_concurrency=2)
- Remove `("paths", PathsSection, "paths")` from section loop; paths are now
  generated per-dilemma immediately after dilemmas serialize
- Add paths retry block in semantic retry loop (before beats)
- Update `_REQUIRED_SECTION_PROMPT_KEYS` and `_load_seed_section_prompts()` with
  new prompt key

## Not Included / Future PRs

- Pre-filtering dilemmas before serialization (pruning needs all paths first)
- Partial-success handling for per-dilemma failures (current error propagation is fine)

## Test Plan

- Updated 9 tests in `TestSerializeSeedAsFunction` and `TestBeatRetryAndContextRefresh`
  to use non-empty dilemma mocks so per-dilemma paths and per-path beats generation
  triggers from the section loop
- All 59 serialize tests pass
- All 245 serialize/seed tests pass
- mypy and ruff clean

```bash
uv run pytest tests/unit/test_serialize.py -q  # 59 passed
uv run pytest tests/unit/ -k "serialize or seed" -q  # 245 passed
uv run mypy src/questfoundry/agents/serialize.py src/questfoundry/models/seed.py  # Success
uv run ruff check src/ tests/unit/test_serialize.py  # All checks passed
```

## Risk / Rollback

- Low risk: pattern follows existing `_serialize_beats_per_path` which has been
  stable since implementation
- Backwards compatible: `PathsSection` still exists for `serialize_seed_iteratively`
  (deprecated path)
- If issues arise, revert commit and restore `("paths", PathsSection, "paths")`
  to the sections list

Closes #760

🤖 Generated with [Claude Code](https://claude.com/claude-code)