### PR TITLE
fix(brainstorm): reject dilemma IDs with trailing _or_ suffix

### DIFF
--- a/prompts/templates/discuss_brainstorm.yaml
+++ b/prompts/templates/discuss_brainstorm.yaml
@@ -76,15 +76,22 @@ system: |
   Bad: "What is the mentor's alignment?" (open-ended, not binary)
 
   ## Dilemma ID Naming
-  Use descriptive binary format: `[subject]_[optionA]_or_[optionB]`
+  Dilemma IDs use the pattern: `subject_optionA_or_optionB`
+  The word `_or_` appears exactly ONCE, between the two options. The ID must END with optionB.
 
-  FORMAT: `[subject]_[optionA]_or_[optionB]`
-  Examples for different genres:
-  - Mystery: `detective_corrupt_or_honorable`, `witness_truthful_or_lying`
-  - Fantasy: `mentor_benevolent_or_manipulative`, `artifact_blessed_or_cursed`
-  - Sci-fi: `ai_helpful_or_hostile`, `colony_thriving_or_doomed`
+  GOOD examples:
+  - `detective_corrupt_or_honorable` (ends with `honorable`, not `_or_`)
+  - `witness_truthful_or_lying` (ends with `lying`, not `_or_`)
+  - `mentor_benevolent_or_manipulative` (ends with `manipulative`, not `_or_`)
+  - `artifact_blessed_or_cursed` (ends with `cursed`, not `_or_`)
+  - `ai_helpful_or_hostile` (ends with `hostile`, not `_or_`)
 
-  BAD: `d1`, `character_motivation`, `trust_issue` (too short or ambiguous)
+  BAD examples (will break the pipeline):
+  - `detective_corrupt_or_honorable_or_` (WRONG: trailing `_or_`)
+  - `witness_truthful_or_lying_or_` (WRONG: trailing `_or_`)
+  - `d1`, `character_motivation`, `trust_issue` (too short or ambiguous)
+
+  NEVER end a dilemma ID with `_or_` -- the last word must be the second option.
 
   **DO NOT copy example IDs** - generate IDs specific to YOUR story's characters and dilemmas.
 
@@ -94,6 +101,7 @@ system: |
   - Do NOT end with "let me know if you need..." - this is not a chat
   - Do NOT ask clarifying questions in non-interactive mode
   - Do NOT use short codes like `d1`, `d2` for dilemma IDs - use descriptive names
+  - Do NOT end dilemma IDs with `_or_` — the ID must end with the second option word
   - Do NOT offer follow-up work (beat maps, motive matrices, scene hooks, timelines, etc.)
   - Do NOT preview what later stages will do — your scope ends at entities and dilemmas
 

--- a/prompts/templates/serialize_brainstorm.yaml
+++ b/prompts/templates/serialize_brainstorm.yaml
@@ -39,24 +39,25 @@ system: |
 
   ## Dilemma ID Naming (CRITICAL)
 
-  Use descriptive binary format that shows both options: `subject_optionA_or_optionB`
+  Dilemma IDs use the pattern: `subject_optionA_or_optionB`
+  The word `_or_` appears exactly ONCE, between the two options. The ID MUST END with optionB.
 
-  FORMAT: `[subject]_[optionA]_or_[optionB]`
-
-  Good patterns (generate YOUR OWN based on your story):
-  - `[character]_[trait1]_or_[trait2]` for character dilemmas
-  - `[object]_[state1]_or_[state2]` for artifact mysteries
-  - `[faction]_[stance1]_or_[stance2]` for group conflicts
+  GOOD examples (generate YOUR OWN based on your story):
+  - `mentor_benevolent_or_manipulative` (ends with `manipulative`)
+  - `artifact_blessed_or_cursed` (ends with `cursed`)
+  - `faction_allied_or_hostile` (ends with `hostile`)
 
   BAD examples (will cause downstream failures):
+  - `mentor_benevolent_or_manipulative_or_` (WRONG: trailing `_or_`)
+  - `artifact_blessed_or_cursed_or_` (WRONG: trailing `_or_`)
   - `d1`, `d2`, `dilemma_a` (too short, not descriptive)
   - `character_motivation` (ambiguous, could be confused with path name)
   - `trust_issue` (too vague)
   - `single_word` (could be mistaken for a path ID)
 
-  **DO NOT copy IDs from other stories** - generate IDs specific to YOUR story.
+  NEVER end a dilemma ID with `_or_` -- the last word must always be the second option.
 
-  The dilemma_id should clearly show the binary choice being made.
+  **DO NOT copy IDs from other stories** - generate IDs specific to YOUR story.
 
   ## Guidelines
 

--- a/tests/unit/test_brainstorm_stage.py
+++ b/tests/unit/test_brainstorm_stage.py
@@ -487,6 +487,45 @@ def test_dilemma_requires_one_default_path_answer() -> None:
         )
 
 
+def test_dilemma_rejects_trailing_or_in_id() -> None:
+    """Dilemma model rejects IDs ending with '_or_' (common LLM error)."""
+    from pydantic import ValidationError
+
+    from questfoundry.models.brainstorm import Dilemma
+
+    _TWO_ANSWERS = [
+        {"answer_id": "benevolent", "description": "Kind", "is_default_path": True},
+        {"answer_id": "selfish", "description": "Mean", "is_default_path": False},
+    ]
+
+    # Trailing _or_ with underscore
+    with pytest.raises(ValidationError, match="ends with '_or_'"):
+        Dilemma(
+            dilemma_id="dilemma::host_benevolent_or_selfish_or_",
+            question="Is the host benevolent?",
+            answers=_TWO_ANSWERS,
+            why_it_matters="Trust",
+        )
+
+    # Trailing _or without underscore
+    with pytest.raises(ValidationError, match="ends with '_or_'"):
+        Dilemma(
+            dilemma_id="dilemma::host_benevolent_or_selfish_or",
+            question="Is the host benevolent?",
+            answers=_TWO_ANSWERS,
+            why_it_matters="Trust",
+        )
+
+    # Valid ID passes
+    d = Dilemma(
+        dilemma_id="dilemma::host_benevolent_or_selfish",
+        question="Is the host benevolent?",
+        answers=_TWO_ANSWERS,
+        why_it_matters="Trust",
+    )
+    assert d.dilemma_id == "dilemma::host_benevolent_or_selfish"
+
+
 def test_entity_types() -> None:
     """Entity model accepts all valid category types."""
     from questfoundry.models.brainstorm import Entity


### PR DESCRIPTION
## Problem

qwen3:4b generates dilemma IDs like `elara_friendly_or_suspicious_or_` instead of
`elara_friendly_or_suspicious`. The bracket-template format `[subject]_[optionA]_or_[optionB]`
in the prompts was causing the model to treat `_or_` as a suffix/delimiter rather than a
separator. The malformed IDs then cascade into path IDs (e.g., `path::teacup_name_known_or_unknown_or___unknown`).

Closes #767

## Changes

- **Prompt fix** (discuss + serialize brainstorm templates): Replace bracket-template format
  with concrete examples annotated with `(ends with X, not _or_)`, add explicit BAD examples
  showing the exact failure pattern, and sandwich the rule in the "What NOT to Do" list
- **Validation fix** (`models/brainstorm.py`): Add `field_validator` on `Dilemma.dilemma_id`
  that rejects IDs ending with `_or_` or `_or`, triggering the serialize retry loop so the
  LLM gets error feedback and can self-correct
- **Test**: Add `test_dilemma_rejects_trailing_or_in_id` covering both `_or_` and `_or` variants

## Not Included / Future PRs

- Re-running test-pr-740-big-retry (user will do this manually)

## Test Plan

- `uv run pytest tests/unit/test_brainstorm_stage.py -x -q` — 19 passed
- `uv run pytest tests/unit/test_mutations.py tests/unit/test_entity_naming.py -x -q` — 192 passed
- `uv run mypy src/questfoundry/models/brainstorm.py` — clean
- Manual validation: confirmed `Dilemma(dilemma_id="dilemma::host_benevolent_or_selfish_or_", ...)` raises `ValidationError`

## Risk / Rollback

- Low risk: validator only rejects a specific malformed pattern
- Existing valid IDs (containing `_or_` as separator) are not affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)