### PR TITLE
fix(grow): check convergence policy per-dilemma, not per-arc

### DIFF
--- a/src/questfoundry/graph/grow_validation.py
+++ b/src/questfoundry/graph/grow_validation.py
@@ -916,15 +916,41 @@ def _get_spine_sequence(arc_nodes: dict[str, dict[str, object]]) -> set[str]:
     return set()
 
 
-def check_convergence_policy_compliance(graph: Graph) -> list[ValidationCheck]:
-    """Verify branch arcs honor their declared convergence_policy.
+def _build_beat_dilemma_map(graph: Graph) -> dict[str, set[str]]:
+    """Map each beat to its prefixed dilemma IDs via belongs_to → path → dilemma."""
+    path_nodes = graph.get_nodes_by_type("path")
+    dilemma_nodes = graph.get_nodes_by_type("dilemma")
 
-    For each branch arc with convergence metadata:
-    - ``hard``: no beats shared with spine after divergence point
-    - ``soft``: at least ``payoff_budget`` exclusive beats before convergence
+    path_to_dilemma: dict[str, str] = {}
+    for path_id, path_data in path_nodes.items():
+        did = path_data.get("dilemma_id")
+        if did:
+            prefixed = normalize_scoped_id(did, "dilemma")
+            if prefixed in dilemma_nodes:
+                path_to_dilemma[path_id] = prefixed
+
+    beat_dilemmas: dict[str, set[str]] = {}
+    for edge in graph.get_edges(edge_type="belongs_to"):
+        beat_id = edge["from"]
+        path_id = edge["to"]
+        if path_id in path_to_dilemma:
+            beat_dilemmas.setdefault(beat_id, set()).add(path_to_dilemma[path_id])
+
+    return beat_dilemmas
+
+
+def check_convergence_policy_compliance(graph: Graph) -> list[ValidationCheck]:
+    """Verify branch arcs honor their declared convergence_policy per-dilemma.
+
+    For each branch arc, identifies which dilemma paths differ from the spine.
+    For each differing dilemma, checks only THAT dilemma's beats against its policy:
+    - ``hard``: no beats from this dilemma shared with spine after divergence
+    - ``soft``: at least ``payoff_budget`` exclusive beats for this dilemma
     - ``flavor``: always passes (no structural constraint)
 
-    Arcs without a ``convergence_policy`` field (pre-policy graphs) are skipped.
+    This per-dilemma approach is necessary because combinatorial arcs contain
+    beats from ALL dilemmas, and only the flipped dilemma's beats should be
+    checked against its policy.
     """
     arc_nodes = graph.get_nodes_by_type("arc")
     if not arc_nodes:
@@ -938,56 +964,92 @@ def check_convergence_policy_compliance(graph: Graph) -> list[ValidationCheck]:
 
     spine_seq_set = _get_spine_sequence(arc_nodes)
 
+    # Get spine path set for comparison
+    spine_paths: set[str] = set()
+    for _aid, adata in arc_nodes.items():
+        if adata.get("arc_type") == "spine":
+            spine_paths = set(adata.get("paths", []))
+            break
+
+    beat_dilemmas = _build_beat_dilemma_map(graph)
+
+    # Build path (raw ID) → prefixed dilemma mapping
+    path_nodes = graph.get_nodes_by_type("path")
+    raw_path_to_dilemma: dict[str, str] = {}
+    for pid, pdata in path_nodes.items():
+        did = pdata.get("dilemma_id")
+        if did:
+            raw_id = pdata.get("raw_id", pid)
+            raw_path_to_dilemma[raw_id] = normalize_scoped_id(did, "dilemma")
+
+    dilemma_nodes = graph.get_nodes_by_type("dilemma")
+
     violations: list[ValidationCheck] = []
     checked = 0
 
     for arc_id, data in sorted(arc_nodes.items()):
         if data.get("arc_type") == "spine":
             continue
-        policy = data.get("convergence_policy")
-        if policy is None:
-            continue  # pre-policy arc — skip
 
         sequence: list[str] = data.get("sequence", [])
         diverges_at = data.get("diverges_at")
         if not sequence or not diverges_at:
             continue
 
-        checked += 1
-        # Beats after the divergence point
         try:
             div_idx = sequence.index(diverges_at)
         except ValueError:
             continue
         branch_after_div = sequence[div_idx + 1 :]
 
-        exclusive = [b for b in branch_after_div if b not in spine_seq_set]
-        shared_after = [b for b in branch_after_div if b in spine_seq_set]
+        # Find which dilemmas differ from spine (symmetric difference of path sets)
+        arc_paths = set(data.get("paths", []))
+        flipped_dilemmas: set[str] = set()
+        for path_raw in arc_paths.symmetric_difference(spine_paths):
+            if did := raw_path_to_dilemma.get(path_raw):
+                flipped_dilemmas.add(did)
 
-        if policy == "hard" and shared_after:
-            violations.append(
-                ValidationCheck(
-                    name="convergence_policy_compliance",
-                    severity="fail",
-                    message=(
-                        f"{arc_id}: hard policy violated — "
-                        f"{len(shared_after)} shared beat(s) after divergence"
-                    ),
-                )
-            )
-        elif policy == "soft":
-            budget = data.get("payoff_budget", 2)
-            if len(exclusive) < budget:
+        # Check each flipped dilemma's beats against ITS policy
+        for dilemma_id in sorted(flipped_dilemmas):
+            dnode = dilemma_nodes.get(dilemma_id)
+            if not dnode:
+                continue
+            policy = dnode.get("convergence_policy")
+            if policy is None or policy == "flavor":
+                continue
+
+            checked += 1
+            # Filter to beats belonging to this dilemma only
+            dilemma_beats_after = [
+                b for b in branch_after_div if dilemma_id in beat_dilemmas.get(b, set())
+            ]
+            shared = [b for b in dilemma_beats_after if b in spine_seq_set]
+            exclusive = [b for b in dilemma_beats_after if b not in spine_seq_set]
+
+            if policy == "hard" and shared:
                 violations.append(
                     ValidationCheck(
                         name="convergence_policy_compliance",
-                        severity="warn",
+                        severity="fail",
                         message=(
-                            f"{arc_id}: soft policy — "
-                            f"{len(exclusive)} exclusive beat(s), needs {budget}"
+                            f"{arc_id}: hard policy violated for {dilemma_id} — "
+                            f"{len(shared)} shared beat(s) after divergence"
                         ),
                     )
                 )
+            elif policy == "soft":
+                budget = dnode.get("payoff_budget", 2)
+                if len(exclusive) < budget:
+                    violations.append(
+                        ValidationCheck(
+                            name="convergence_policy_compliance",
+                            severity="warn",
+                            message=(
+                                f"{arc_id}: soft policy for {dilemma_id} — "
+                                f"{len(exclusive)} exclusive beat(s), needs {budget}"
+                            ),
+                        )
+                    )
 
     if violations:
         return violations
@@ -995,7 +1057,7 @@ def check_convergence_policy_compliance(graph: Graph) -> list[ValidationCheck]:
         ValidationCheck(
             name="convergence_policy_compliance",
             severity="pass",
-            message=f"All {checked} branch arc(s) comply with convergence policy"
+            message=f"All {checked} dilemma-arc pair(s) comply with convergence policy"
             if checked
             else "No branch arcs with convergence metadata to check",
         )

--- a/src/questfoundry/graph/grow_validation.py
+++ b/src/questfoundry/graph/grow_validation.py
@@ -979,7 +979,7 @@ def check_convergence_policy_compliance(graph: Graph) -> list[ValidationCheck]:
     for pid, pdata in path_nodes.items():
         did = pdata.get("dilemma_id")
         if did:
-            raw_id = pdata.get("raw_id", pid)
+            raw_id = pdata.get("raw_id") or pid
             raw_path_to_dilemma[raw_id] = normalize_scoped_id(did, "dilemma")
 
     dilemma_nodes = graph.get_nodes_by_type("dilemma")

--- a/tests/unit/test_grow_validation.py
+++ b/tests/unit/test_grow_validation.py
@@ -1107,14 +1107,43 @@ def _make_compliance_graph(
 ) -> Graph:
     """Build a graph with spine + one branch arc for compliance testing.
 
+    Creates full graph topology: dilemma → answer → path → beat (belongs_to)
+    so the per-dilemma validation can trace beats back to their dilemma.
+
     Args:
-        policy: Convergence policy for the branch arc.
-        payoff_budget: payoff_budget for the branch arc.
+        policy: Convergence policy for the dilemma.
+        payoff_budget: payoff_budget for the dilemma.
         shared_after_div: Number of spine beats shared after divergence.
         exclusive_count: Number of beats exclusive to the branch.
     """
     graph = Graph.empty()
+
+    # Dilemma with the given policy
+    graph.create_node(
+        "dilemma::d1",
+        {
+            "type": "dilemma",
+            "raw_id": "dilemma::d1",
+            "convergence_policy": policy,
+            "payoff_budget": payoff_budget,
+        },
+    )
+    # Two paths: canon (spine) and rebel (branch)
+    graph.create_node(
+        "path::canon",
+        {"type": "path", "raw_id": "path::canon", "dilemma_id": "dilemma::d1"},
+    )
+    graph.create_node(
+        "path::rebel",
+        {"type": "path", "raw_id": "path::rebel", "dilemma_id": "dilemma::d1"},
+    )
+
+    # Spine beats — all belong to canon path
     spine_beats = [f"beat::s{i}" for i in range(6)]
+    for bid in spine_beats:
+        graph.create_node(bid, {"type": "beat"})
+        graph.add_edge("belongs_to", bid, "path::canon")
+
     graph.create_node(
         "arc::spine",
         {
@@ -1124,12 +1153,21 @@ def _make_compliance_graph(
             "paths": ["path::canon"],
         },
     )
-    # Branch diverges after s1; has exclusive beats, then optionally shares
+
+    # Branch: diverges after s1; has exclusive beats, then optionally shares
     branch_seq = ["beat::s0", "beat::s1"]
-    for i in range(exclusive_count):
-        branch_seq.append(f"beat::b{i}")
+    exclusive_beats = [f"beat::b{i}" for i in range(exclusive_count)]
+    for bid in exclusive_beats:
+        graph.create_node(bid, {"type": "beat"})
+        graph.add_edge("belongs_to", bid, "path::rebel")
+    branch_seq.extend(exclusive_beats)
+
+    # Shared beats after divergence belong to BOTH paths
     for i in range(shared_after_div):
-        branch_seq.append(spine_beats[2 + i])
+        shared_bid = spine_beats[2 + i]
+        graph.add_edge("belongs_to", shared_bid, "path::rebel")
+        branch_seq.append(shared_bid)
+
     graph.create_node(
         "arc::branch_0",
         {
@@ -1137,8 +1175,6 @@ def _make_compliance_graph(
             "arc_type": "branch",
             "sequence": branch_seq,
             "diverges_at": "beat::s1",
-            "convergence_policy": policy,
-            "payoff_budget": payoff_budget,
             "paths": ["path::rebel"],
         },
     )
@@ -1226,6 +1262,234 @@ class TestConvergencePolicyCompliance:
         graph = Graph.empty()
         results = check_convergence_policy_compliance(graph)
         assert results[0].severity == "pass"
+
+    def test_hard_policy_per_dilemma_passes(self) -> None:
+        """Multi-dilemma arc: hard dilemma beats are exclusive, soft beats are shared → passes.
+
+        Each beat belongs to ONE dilemma's path (like in real graphs).
+        The arc flips both dilemmas but d1-hard's beats are all exclusive.
+        """
+        graph = Graph.empty()
+
+        # Dilemma 1: hard policy
+        graph.create_node(
+            "dilemma::d1",
+            {"type": "dilemma", "convergence_policy": "hard", "payoff_budget": 0},
+        )
+        graph.create_node(
+            "path::d1_canon",
+            {"type": "path", "raw_id": "path::d1_canon", "dilemma_id": "dilemma::d1"},
+        )
+        graph.create_node(
+            "path::d1_rebel",
+            {"type": "path", "raw_id": "path::d1_rebel", "dilemma_id": "dilemma::d1"},
+        )
+
+        # Dilemma 2: soft policy
+        graph.create_node(
+            "dilemma::d2",
+            {"type": "dilemma", "convergence_policy": "soft", "payoff_budget": 1},
+        )
+        graph.create_node(
+            "path::d2_canon",
+            {"type": "path", "raw_id": "path::d2_canon", "dilemma_id": "dilemma::d2"},
+        )
+        graph.create_node(
+            "path::d2_rebel",
+            {"type": "path", "raw_id": "path::d2_rebel", "dilemma_id": "dilemma::d2"},
+        )
+
+        # Spine beats — each belongs to ONE dilemma's canon path
+        # d1 canon beats
+        graph.create_node("beat::d1s0", {"type": "beat"})
+        graph.add_edge("belongs_to", "beat::d1s0", "path::d1_canon")
+        graph.create_node("beat::d1s1", {"type": "beat"})
+        graph.add_edge("belongs_to", "beat::d1s1", "path::d1_canon")
+        # d2 canon beats
+        graph.create_node("beat::d2s0", {"type": "beat"})
+        graph.add_edge("belongs_to", "beat::d2s0", "path::d2_canon")
+        graph.create_node("beat::d2s1", {"type": "beat"})
+        graph.add_edge("belongs_to", "beat::d2s1", "path::d2_canon")
+
+        # Exclusive branch beats for d1_rebel (hard dilemma — NOT in spine)
+        graph.create_node("beat::h1", {"type": "beat"})
+        graph.add_edge("belongs_to", "beat::h1", "path::d1_rebel")
+        graph.create_node("beat::h2", {"type": "beat"})
+        graph.add_edge("belongs_to", "beat::h2", "path::d1_rebel")
+
+        # Exclusive beat for d2_rebel (soft dilemma — sufficient for budget=1)
+        graph.create_node("beat::x1", {"type": "beat"})
+        graph.add_edge("belongs_to", "beat::x1", "path::d2_rebel")
+
+        spine_beats = ["beat::d1s0", "beat::d1s1", "beat::d2s0", "beat::d2s1"]
+        graph.create_node(
+            "arc::spine",
+            {
+                "type": "arc",
+                "arc_type": "spine",
+                "sequence": spine_beats,
+                "paths": ["path::d1_canon", "path::d2_canon"],
+            },
+        )
+
+        # Branch: flips both dilemmas
+        # d1 canon beats replaced by h1, h2; d2 canon beats partly replaced by x1
+        # d2s1 still appears (shared from spine, but belongs to d2_canon not d2_rebel)
+        graph.create_node(
+            "arc::branch_0",
+            {
+                "type": "arc",
+                "arc_type": "branch",
+                "sequence": [
+                    "beat::d1s0",  # before divergence
+                    "beat::h1",
+                    "beat::h2",  # d1 rebel beats (exclusive)
+                    "beat::x1",  # d2 rebel beat (exclusive)
+                    "beat::d2s1",  # d2 canon beat (shared with spine)
+                ],
+                "diverges_at": "beat::d1s0",
+                "paths": ["path::d1_rebel", "path::d2_rebel"],
+            },
+        )
+
+        results = check_convergence_policy_compliance(graph)
+        # d1 hard: h1, h2 belong to d1_rebel → not in spine → passes
+        # d2 soft: x1 belongs to d2_rebel (exclusive); d2s1 belongs to d2_canon (shared)
+        #          1 exclusive >= budget 1 → passes
+        assert all(r.severity == "pass" for r in results)
+
+    def test_hard_policy_fails_when_hard_beats_shared(self) -> None:
+        """Multi-dilemma arc: hard dilemma has shared beats after divergence → fails."""
+        graph = Graph.empty()
+
+        # Dilemma 1: hard policy
+        graph.create_node(
+            "dilemma::d1",
+            {"type": "dilemma", "convergence_policy": "hard", "payoff_budget": 0},
+        )
+        graph.create_node(
+            "path::d1_canon",
+            {"type": "path", "raw_id": "path::d1_canon", "dilemma_id": "dilemma::d1"},
+        )
+        graph.create_node(
+            "path::d1_rebel",
+            {"type": "path", "raw_id": "path::d1_rebel", "dilemma_id": "dilemma::d1"},
+        )
+
+        # Dilemma 2: flavor (no constraint)
+        graph.create_node(
+            "dilemma::d2",
+            {"type": "dilemma", "convergence_policy": "flavor", "payoff_budget": 0},
+        )
+        graph.create_node(
+            "path::d2_canon",
+            {"type": "path", "raw_id": "path::d2_canon", "dilemma_id": "dilemma::d2"},
+        )
+
+        # Spine beats belong to d1_canon and d2_canon
+        spine_beats = ["beat::s0", "beat::s1", "beat::s2", "beat::s3"]
+        for bid in spine_beats:
+            graph.create_node(bid, {"type": "beat"})
+            graph.add_edge("belongs_to", bid, "path::d1_canon")
+            graph.add_edge("belongs_to", bid, "path::d2_canon")
+
+        # Make s2 also belong to d1_rebel — this is the hard dilemma beat that IS shared
+        graph.add_edge("belongs_to", "beat::s2", "path::d1_rebel")
+
+        graph.create_node(
+            "arc::spine",
+            {
+                "type": "arc",
+                "arc_type": "spine",
+                "sequence": spine_beats,
+                "paths": ["path::d1_canon", "path::d2_canon"],
+            },
+        )
+
+        # Branch: flips only d1 (d2 stays canon, so it's NOT in flipped_dilemmas)
+        graph.create_node(
+            "arc::branch_0",
+            {
+                "type": "arc",
+                "arc_type": "branch",
+                "sequence": ["beat::s0", "beat::s1", "beat::s2", "beat::s3"],
+                "diverges_at": "beat::s1",
+                "paths": ["path::d1_rebel", "path::d2_canon"],
+            },
+        )
+
+        results = check_convergence_policy_compliance(graph)
+        assert any(r.severity == "fail" for r in results)
+        assert "hard policy violated" in results[0].message
+        assert "dilemma::d1" in results[0].message
+
+    def test_soft_policy_per_dilemma_passes(self) -> None:
+        """Multi-dilemma arc: soft dilemma has enough exclusive beats → passes."""
+        graph = Graph.empty()
+
+        # Dilemma 1: flavor (no constraint)
+        graph.create_node(
+            "dilemma::d1",
+            {"type": "dilemma", "convergence_policy": "flavor", "payoff_budget": 0},
+        )
+        graph.create_node(
+            "path::d1_canon",
+            {"type": "path", "raw_id": "path::d1_canon", "dilemma_id": "dilemma::d1"},
+        )
+
+        # Dilemma 2: soft policy with budget=2
+        graph.create_node(
+            "dilemma::d2",
+            {"type": "dilemma", "convergence_policy": "soft", "payoff_budget": 2},
+        )
+        graph.create_node(
+            "path::d2_canon",
+            {"type": "path", "raw_id": "path::d2_canon", "dilemma_id": "dilemma::d2"},
+        )
+        graph.create_node(
+            "path::d2_rebel",
+            {"type": "path", "raw_id": "path::d2_rebel", "dilemma_id": "dilemma::d2"},
+        )
+
+        # Spine beats
+        spine_beats = ["beat::s0", "beat::s1", "beat::s2", "beat::s3"]
+        for bid in spine_beats:
+            graph.create_node(bid, {"type": "beat"})
+            graph.add_edge("belongs_to", bid, "path::d1_canon")
+            graph.add_edge("belongs_to", bid, "path::d2_canon")
+
+        # Two exclusive beats for d2_rebel (meets budget of 2)
+        graph.create_node("beat::x1", {"type": "beat"})
+        graph.add_edge("belongs_to", "beat::x1", "path::d2_rebel")
+        graph.create_node("beat::x2", {"type": "beat"})
+        graph.add_edge("belongs_to", "beat::x2", "path::d2_rebel")
+
+        graph.create_node(
+            "arc::spine",
+            {
+                "type": "arc",
+                "arc_type": "spine",
+                "sequence": spine_beats,
+                "paths": ["path::d1_canon", "path::d2_canon"],
+            },
+        )
+
+        # Branch: flips only d2 (d1 stays canon)
+        graph.create_node(
+            "arc::branch_0",
+            {
+                "type": "arc",
+                "arc_type": "branch",
+                "sequence": ["beat::s0", "beat::s1", "beat::x1", "beat::x2", "beat::s2"],
+                "diverges_at": "beat::s1",
+                "paths": ["path::d1_canon", "path::d2_rebel"],
+            },
+        )
+
+        results = check_convergence_policy_compliance(graph)
+        # d2 soft: x1, x2 exclusive (2 >= budget 2) → passes
+        # d1 flavor: not checked
+        assert all(r.severity == "pass" for r in results)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

End-to-end testing of the branching contract (#740) on `test-pr-740-big-retry` (8 dilemmas, 16 arcs) passes SEED but fails GROW validation with 7 `convergence_policy_compliance` failures — all `hard policy violated`.

Root cause: `check_convergence_policy_compliance()` checked ALL arc beats against a combined arc-level policy. With Cartesian-product arcs (each picking one answer per dilemma), `_get_effective_policy()` uses "hard dominates" — if ANY dilemma has `hard` policy, the whole arc becomes `hard`. But arcs that flip 1 dilemma still share beats from the other 7 dilemmas.

## Changes

- Rewrote `check_convergence_policy_compliance()` to check per-dilemma instead of per-arc:
  1. Find which dilemma paths differ from spine (symmetric_difference of path sets)
  2. For each flipped dilemma, filter to only THAT dilemma's beats (via `belongs_to` → path → dilemma tracing)
  3. Check those beats against the dilemma's own policy from the dilemma node

- Added `_build_beat_dilemma_map()` helper to trace beat → dilemma ownership via belongs_to edges

- Added 3 multi-dilemma tests:
  - `test_hard_policy_per_dilemma_passes` — hard dilemma beats are exclusive
  - `test_hard_policy_fails_when_hard_beats_shared` — hard dilemma beats ARE shared → fails
  - `test_soft_policy_per_dilemma_passes` — soft dilemma with sufficient exclusive beats

- Updated `_make_compliance_graph()` helper to create full graph topology (dilemma → path → beat with belongs_to edges) instead of flat arc-level policy

## Not Included / Future PRs

- Evaluate `_get_effective_policy()` for convergence point computation (#770)
- `max_consecutive_linear` warnings in large stories (#771)
- `codeword_gate_coverage` — unused codewords (#772)
- `commits_timing` warnings for 4 paths (#773)

## Test Plan

```bash
uv run pytest tests/unit/test_grow_validation.py -x -q -k convergence  # 12 passed
uv run pytest tests/unit/test_grow_validation.py -x -q                  # 72 passed
uv run mypy src/questfoundry/graph/grow_validation.py                   # clean
uv run ruff check src/ tests/                                           # clean
```

Smoke test against actual `grow-pre-validation.json` snapshot: 7 failures → 0 failures.

## Risk / Rollback

- Low risk: only changes the validation check, not convergence point computation or arc enumeration
- No backward compatibility concern — old graphs without dilemma nodes/belongs_to edges will get "No branch arcs with convergence metadata to check" (same as before)

🤖 Generated with [Claude Code](https://claude.com/claude-code)