### PR TITLE
feat(agents): chunked SEED summarization (PR 1/3)

### DIFF
--- a/prompts/templates/summarize_seed_sections.yaml
+++ b/prompts/templates/summarize_seed_sections.yaml
@@ -71,7 +71,7 @@ dilemmas_system: |
   - dilemma::weather_storm_or_clear: explored=[storm], unexplored=[clear]
   ```
   VERIFY: Your list MUST have exactly {dilemma_count} items.
-  VERIFY: Every answer ID appears in EITHER explored OR unexplored, not both.
+  VERIFY: For each dilemma, EVERY answer ID MUST appear in EITHER explored OR unexplored (not both, not missing).
   {output_language_instruction}
 
 paths_system: |

--- a/prompts/templates/summarize_seed_sections.yaml
+++ b/prompts/templates/summarize_seed_sections.yaml
@@ -1,0 +1,155 @@
+name: summarize_seed_sections
+description: Per-section summarize prompts for chunked SEED summarization
+
+# Each section gets its own focused summarize call instead of one monolithic call.
+# This reduces context size for downstream serialize calls from ~33K to ~4-10K chars.
+# Prior sections' output is injected at runtime into the user message.
+
+entities_system: |
+  You are extracting entity decisions from a story architecture discussion.
+  This is the SEED stage - you are committing which brainstorm entities to keep.
+
+  ## NO DELEGATION
+  Write the actual decisions directly. Do not suggest or delegate.
+
+  ## CRITICAL: Exact ID Matching
+  Use IDs EXACTLY as they appear below. Copy-paste, do not paraphrase.
+  Typos like `dr_elara_vinoss` vs `dr_elara_voss` cause validation failure.
+
+  ## Required Entity IDs ({entity_count} total)
+  {entity_manifest}
+
+  ## Your Task
+  For EACH entity listed above, extract the decision from the discussion:
+  - entity_id: the exact entity ID from the manifest above
+  - disposition: "retained" or "cut"
+  - reason: brief justification (1 sentence)
+
+  If an entity was not discussed, write disposition "retained" with reason "not discussed, kept by default".
+
+  ## Output Format
+  List EVERY entity with its decision:
+  ```
+  - character::hero: retained - protagonist
+  - location::castle: retained - main setting
+  - object::unused_item: cut - not relevant to core story
+  ```
+  VERIFY: Your list MUST have exactly {entity_count} items.
+  {output_language_instruction}
+
+dilemmas_system: |
+  You are extracting dilemma exploration decisions from a story architecture discussion.
+  This is the SEED stage - you are deciding which dilemma answers become story paths.
+
+  ## NO DELEGATION
+  Write the actual decisions directly. Do not suggest or delegate.
+
+  ## CRITICAL: Exact ID Matching
+  Use dilemma IDs and answer IDs EXACTLY as listed below. Copy-paste them.
+  Do NOT reconstruct IDs from dilemma names or descriptions.
+
+  ## Required Dilemma IDs ({dilemma_count} total)
+  {dilemma_manifest}
+
+  ## Valid Answer IDs per Dilemma
+  {dilemma_answers}
+
+  ## Your Task
+  For EACH dilemma listed above, extract from the discussion:
+  - dilemma_id: the exact dilemma ID from the manifest
+  - explored: list of answer IDs that become paths (copy from Valid Answer IDs above)
+  - unexplored: remaining answer IDs not explored
+
+  CRITICAL: The answer IDs in `explored` and `unexplored` MUST come from the
+  Valid Answer IDs list above. Do NOT invent answer IDs or derive them from
+  dilemma names.
+
+  ## Output Format
+  List EVERY dilemma with its decision:
+  ```
+  - dilemma::trust_or_betray: explored=[trust, betray], unexplored=[]
+  - dilemma::weather_storm_or_clear: explored=[storm], unexplored=[clear]
+  ```
+  VERIFY: Your list MUST have exactly {dilemma_count} items.
+  VERIFY: Every answer ID appears in EITHER explored OR unexplored, not both.
+  {output_language_instruction}
+
+paths_system: |
+  You are describing story paths from a story architecture discussion.
+  Each explored dilemma answer becomes a path with consequences.
+
+  ## NO DELEGATION
+  Write the actual path descriptions directly.
+
+  ## Your Task
+  For each explored answer (from the dilemma decisions above), describe:
+  - path name: human-readable name
+  - dilemma_id: which dilemma this explores
+  - answer_id: which answer this explores (MUST match an explored answer ID exactly)
+  - tier: "major" or "minor"
+  - description: what this path is about (2-3 sentences)
+  - consequences: what happens narratively on this path
+
+  For each consequence:
+  - description: what happens (1-2 sentences)
+  - ripples: downstream story effects
+
+  ## Path ID Convention
+  Path IDs follow the pattern: `dilemma_id__answer_id` (double underscore).
+  Example: dilemma `mentor_trust_or_betrayal` with answer `trust` becomes path `mentor_trust_or_betrayal__trust`.
+
+  ## Output Format
+  For each explored answer, describe the path and its consequences clearly.
+  Group by dilemma for clarity.
+  {output_language_instruction}
+
+beats_system: |
+  You are sketching initial beats (opening scenes) for a branching story.
+  Each path needs {size_beats_per_path} opening beats.
+
+  ## NO DELEGATION
+  Write the actual beat sketches directly.
+
+  ## Location Constraint (CRITICAL)
+  You CANNOT invent new locations. Beats MUST use retained location entity IDs.
+  WRONG: `character_name_office` (invented), `building_basement` (invented suffix)
+  RIGHT: Use a retained location ID and put scene details in the summary.
+
+  **Location Diversity**: Use at least 2 different locations across your beats.
+
+  ## Your Task
+  For each path, sketch {size_beats_per_path} opening beats:
+  - beat_id: unique identifier
+  - summary: one sentence describing what happens
+  - location: a RETAINED location entity ID
+  - entities: key entity IDs present in this beat
+  - paths: which path IDs this beat serves
+
+  Beats can serve multiple paths (shared opening scenes).
+
+  ## Output Format
+  List beats grouped by the path(s) they serve.
+  {output_language_instruction}
+
+convergence_system: |
+  You are designing convergence points where branching story paths merge back.
+
+  ## NO DELEGATION
+  Write the actual convergence sketch directly.
+
+  ## Your Task
+  Based on the paths and beats described above, describe:
+  - convergence_points: where and how paths should merge ({size_convergence_points} points)
+  - residue_notes: what differences persist after convergence (choices should matter)
+
+  Convergence means paths rejoin the same narrative thread, but the player's
+  earlier choices should still have visible consequences (residue).
+
+  ## Output Format
+  Describe each convergence point with:
+  - Which paths converge
+  - How they merge narratively
+  - What residue (lasting differences) each path leaves
+  {output_language_instruction}
+
+components: []

--- a/src/questfoundry/agents/__init__.py
+++ b/src/questfoundry/agents/__init__.py
@@ -7,6 +7,7 @@ from questfoundry.agents.prompts import (
     get_brainstorm_summarize_prompt,
     get_discuss_prompt,
     get_seed_discuss_prompt,
+    get_seed_section_summarize_prompts,
     get_seed_serialize_prompt,
     get_seed_summarize_prompt,
     get_serialize_prompt,
@@ -20,7 +21,7 @@ from questfoundry.agents.serialize import (
     serialize_seed_iteratively,
     serialize_to_artifact,
 )
-from questfoundry.agents.summarize import summarize_discussion
+from questfoundry.agents.summarize import summarize_discussion, summarize_seed_chunked
 
 __all__ = [
     "SerializationError",
@@ -31,6 +32,7 @@ __all__ = [
     "get_brainstorm_summarize_prompt",
     "get_discuss_prompt",
     "get_seed_discuss_prompt",
+    "get_seed_section_summarize_prompts",
     "get_seed_serialize_prompt",
     "get_seed_summarize_prompt",
     "get_serialize_prompt",
@@ -41,4 +43,5 @@ __all__ = [
     "serialize_seed_iteratively",
     "serialize_to_artifact",
     "summarize_discussion",
+    "summarize_seed_chunked",
 ]

--- a/src/questfoundry/agents/summarize.py
+++ b/src/questfoundry/agents/summarize.py
@@ -301,7 +301,7 @@ async def summarize_seed_chunked(
             "Here is the discussion to summarize:\n\n" + formatted_discussion,
         ]
 
-        # Inject prior sections' output as context
+        # Inject prior sections' output as context (dict preserves insertion order)
         if section_briefs:
             prior_context_parts = []
             for prev_section, prev_brief in section_briefs.items():

--- a/src/questfoundry/agents/summarize.py
+++ b/src/questfoundry/agents/summarize.py
@@ -3,11 +3,11 @@
 from __future__ import annotations
 
 import json
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from langchain_core.messages import AIMessage, BaseMessage, HumanMessage, SystemMessage, ToolMessage
 
-from questfoundry.agents.prompts import get_summarize_prompt
+from questfoundry.agents.prompts import get_seed_section_summarize_prompts, get_summarize_prompt
 from questfoundry.observability.logging import get_logger
 from questfoundry.observability.tracing import build_runnable_config, traceable
 from questfoundry.providers.content import extract_text
@@ -16,7 +16,14 @@ if TYPE_CHECKING:
     from langchain_core.callbacks import BaseCallbackHandler
     from langchain_core.language_models import BaseChatModel
 
+    from questfoundry.graph.graph import Graph
+    from questfoundry.pipeline.size import SizeProfile
+
 log = get_logger(__name__)
+
+# Ordered sections for chunked summarization.
+# Each section builds on prior sections' output.
+SEED_SUMMARY_SECTIONS = ("entities", "dilemmas", "paths", "beats", "convergence")
 
 
 @traceable(name="Summarize Phase", run_type="chain", tags=["phase:summarize"])
@@ -81,19 +88,7 @@ async def summarize_discussion(
     summary = extract_text(response.content)
 
     # Extract token usage
-    # LangChain tracks token usage in different places:
-    # - OpenAI: response_metadata["token_usage"]
-    # - Ollama: usage_metadata attribute on AIMessage
-    tokens = 0
-    if isinstance(response, AIMessage):
-        # First check usage_metadata attribute (Ollama, newer providers)
-        if hasattr(response, "usage_metadata") and response.usage_metadata:
-            tokens = response.usage_metadata.get("total_tokens") or 0
-        # Then check response_metadata (OpenAI)
-        elif hasattr(response, "response_metadata") and response.response_metadata:
-            metadata = response.response_metadata
-            if "token_usage" in metadata:
-                tokens = metadata["token_usage"].get("total_tokens") or 0
+    tokens = _extract_tokens(response) if isinstance(response, AIMessage) else 0
 
     log.info("summarize_completed", summary_length=len(summary), tokens=tokens)
 
@@ -166,3 +161,195 @@ def _format_messages_for_summary(messages: list[BaseMessage]) -> str:
             formatted_parts.append(f"Message: {content}")
 
     return "\n\n".join(formatted_parts)
+
+
+def _extract_tokens(response: AIMessage) -> int:
+    """Extract total token count from an AIMessage response.
+
+    Checks usage_metadata (Ollama) first, then response_metadata (OpenAI).
+
+    Args:
+        response: AIMessage from model.ainvoke().
+
+    Returns:
+        Total token count, or 0 if not available.
+    """
+    if hasattr(response, "usage_metadata") and response.usage_metadata:
+        return response.usage_metadata.get("total_tokens") or 0
+    if hasattr(response, "response_metadata") and response.response_metadata:
+        metadata = response.response_metadata
+        if "token_usage" in metadata:
+            return metadata["token_usage"].get("total_tokens") or 0
+    return 0
+
+
+def _format_dilemma_answers_from_graph(graph: Graph) -> str:
+    """Format valid answer IDs per dilemma from the graph.
+
+    Builds a concise listing of each dilemma and its valid answer IDs,
+    for injection into the dilemmas summarize section prompt.
+
+    Args:
+        graph: Graph containing brainstorm dilemma and answer nodes.
+
+    Returns:
+        Formatted string listing answer IDs per dilemma.
+    """
+    from questfoundry.graph.context import SCOPE_DILEMMA, normalize_scoped_id
+
+    dilemmas = graph.get_nodes_by_type("dilemma")
+    if not dilemmas:
+        return "(No dilemmas)"
+
+    # Pre-build answer edges map
+    answer_edges_by_dilemma: dict[str, list[dict[str, Any]]] = {}
+    for edge in graph.get_edges(edge_type="has_answer"):
+        from_id = edge.get("from")
+        if from_id:
+            answer_edges_by_dilemma.setdefault(from_id, []).append(edge)
+
+    lines: list[str] = []
+    for did, ddata in sorted(dilemmas.items()):
+        raw_id = ddata.get("raw_id")
+        if not raw_id:
+            continue
+
+        answers: list[str] = []
+        for edge in answer_edges_by_dilemma.get(did, []):
+            answer_node = graph.get_node(edge.get("to", ""))
+            if answer_node:
+                ans_id = answer_node.get("raw_id")
+                if ans_id:
+                    default = " (default)" if answer_node.get("is_default_path") else ""
+                    answers.append(f"`{ans_id}`{default}")
+
+        if answers:
+            answers.sort()
+            scoped = normalize_scoped_id(raw_id, SCOPE_DILEMMA)
+            lines.append(f"- `{scoped}` -> valid answers: [{', '.join(answers)}]")
+
+    return "\n".join(lines) if lines else "(No dilemma answers)"
+
+
+@traceable(name="Summarize Seed Chunked", run_type="chain", tags=["phase:summarize", "chunked"])
+async def summarize_seed_chunked(
+    model: BaseChatModel,
+    messages: list[BaseMessage],
+    graph: Graph,
+    *,
+    size_profile: SizeProfile | None = None,
+    output_language_instruction: str = "",
+    stage_name: str = "seed",
+    callbacks: list[BaseCallbackHandler] | None = None,
+) -> tuple[dict[str, str], int]:
+    """Summarize SEED discussion into per-section briefs.
+
+    Instead of one monolithic summarize call producing ~31K chars, this
+    makes 5 sequential calls — one per section (entities, dilemmas, paths,
+    beats, convergence). Each call receives the discussion history plus
+    prior sections' output as context. The result is a dict of ~2-8K
+    briefs that downstream serialize calls can use individually.
+
+    Args:
+        model: Chat model for summarization.
+        messages: Conversation history from the Discuss phase.
+        graph: Graph containing brainstorm data (for manifests and answer IDs).
+        size_profile: Size profile for parameterizing count guidance.
+        output_language_instruction: Language instruction for non-English output.
+        stage_name: Stage name for logging/tagging.
+        callbacks: LangChain callback handlers for logging.
+
+    Returns:
+        Tuple of (section_briefs, total_tokens) where section_briefs maps
+        section name to its summarized brief text.
+    """
+    from questfoundry.graph.context import format_summarize_manifest, get_expected_counts
+
+    log.info(
+        "summarize_seed_chunked_started",
+        message_count=len(messages),
+        sections=len(SEED_SUMMARY_SECTIONS),
+    )
+
+    # Gather manifest data from graph
+    counts = get_expected_counts(graph)
+    manifests = format_summarize_manifest(graph)
+    dilemma_answers = _format_dilemma_answers_from_graph(graph)
+
+    # Build per-section system prompts
+    section_prompts = get_seed_section_summarize_prompts(
+        entity_count=counts["entities"],
+        dilemma_count=counts["dilemmas"],
+        entity_manifest=manifests["entity_manifest"],
+        dilemma_manifest=manifests["dilemma_manifest"],
+        dilemma_answers=dilemma_answers,
+        size_profile=size_profile,
+        output_language_instruction=output_language_instruction,
+    )
+
+    # Format discussion once (reused across all section calls)
+    formatted_discussion = _format_messages_for_summary(messages)
+
+    section_briefs: dict[str, str] = {}
+    total_tokens = 0
+
+    for section in SEED_SUMMARY_SECTIONS:
+        system_prompt = section_prompts[section]
+
+        # Build user message: discussion + prior sections' output
+        user_parts = [
+            "Here is the discussion to summarize:\n\n" + formatted_discussion,
+        ]
+
+        # Inject prior sections' output as context
+        if section_briefs:
+            prior_context_parts = []
+            for prev_section, prev_brief in section_briefs.items():
+                prior_context_parts.append(
+                    f"### {prev_section.title()} (already decided)\n{prev_brief}"
+                )
+            user_parts.append("\n\n---\n\n## Prior Decisions\n" + "\n\n".join(prior_context_parts))
+
+        user_parts.append(f"\n\nNow summarize ONLY the **{section}** section from the discussion.")
+
+        call_messages: list[BaseMessage] = [
+            SystemMessage(content=system_prompt),
+            HumanMessage(content="\n".join(user_parts)),
+        ]
+
+        config = build_runnable_config(
+            run_name=f"Summarize Seed Section: {section}",
+            tags=[stage_name, "summarize", "chunked", section],
+            metadata={
+                "stage": stage_name,
+                "phase": "summarize",
+                "section": section,
+                "message_count": len(messages),
+            },
+            callbacks=callbacks,
+        )
+
+        log.debug("summarize_seed_section_start", section=section)
+        response = await model.ainvoke(call_messages, config=config)
+
+        brief_text = extract_text(response.content)
+        tokens = _extract_tokens(response) if isinstance(response, AIMessage) else 0
+
+        section_briefs[section] = brief_text
+        total_tokens += tokens
+
+        log.debug(
+            "summarize_seed_section_done",
+            section=section,
+            brief_length=len(brief_text),
+            tokens=tokens,
+        )
+
+    log.info(
+        "summarize_seed_chunked_completed",
+        total_brief_length=sum(len(b) for b in section_briefs.values()),
+        total_tokens=total_tokens,
+        sections=list(section_briefs.keys()),
+    )
+
+    return section_briefs, total_tokens

--- a/tests/unit/test_summarize.py
+++ b/tests/unit/test_summarize.py
@@ -7,8 +7,15 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 from langchain_core.messages import AIMessage, HumanMessage, SystemMessage, ToolMessage
 
-from questfoundry.agents.prompts import get_summarize_prompt
-from questfoundry.agents.summarize import _format_messages_for_summary, summarize_discussion
+from questfoundry.agents.prompts import get_seed_section_summarize_prompts, get_summarize_prompt
+from questfoundry.agents.summarize import (
+    SEED_SUMMARY_SECTIONS,
+    _extract_tokens,
+    _format_dilemma_answers_from_graph,
+    _format_messages_for_summary,
+    summarize_discussion,
+    summarize_seed_chunked,
+)
 
 
 class TestGetSummarizePrompt:
@@ -378,3 +385,321 @@ class TestFormatMessagesToolCalls:
         # Tool calls should still be included
         assert "[Tool Call: search]" in result
         assert '"q": "test"' in result
+
+
+class TestExtractTokens:
+    """Test _extract_tokens helper."""
+
+    def test_extract_from_usage_metadata(self) -> None:
+        """Should extract tokens from usage_metadata (Ollama-style)."""
+        msg = AIMessage(content="test")
+        msg.usage_metadata = {"total_tokens": 42}
+        assert _extract_tokens(msg) == 42
+
+    def test_extract_from_response_metadata(self) -> None:
+        """Should extract tokens from response_metadata (OpenAI-style)."""
+        msg = AIMessage(content="test")
+        msg.response_metadata = {"token_usage": {"total_tokens": 99}}
+        assert _extract_tokens(msg) == 99
+
+    def test_returns_zero_when_no_metadata(self) -> None:
+        """Should return 0 when no token metadata is available."""
+        msg = AIMessage(content="test")
+        assert _extract_tokens(msg) == 0
+
+    def test_handles_none_total_tokens(self) -> None:
+        """Should return 0 when total_tokens is None."""
+        msg = AIMessage(content="test")
+        msg.usage_metadata = {"total_tokens": None}
+        assert _extract_tokens(msg) == 0
+
+
+def _make_mock_graph() -> MagicMock:
+    """Build a mock graph with brainstorm entities, dilemmas, and answers.
+
+    Creates 2 entities and 1 dilemma with 2 answers for testing.
+    """
+    graph = MagicMock()
+
+    entities = {
+        "character::hero": {
+            "raw_id": "hero",
+            "entity_type": "character",
+            "concept": "Protagonist",
+        },
+        "location::castle": {
+            "raw_id": "castle",
+            "entity_type": "location",
+            "concept": "Main setting",
+        },
+    }
+    dilemmas = {
+        "dilemma::trust_or_betray": {
+            "raw_id": "trust_or_betray",
+            "question": "Trust or betray?",
+        },
+    }
+
+    def get_nodes_by_type(t: str) -> dict:
+        if t == "entity":
+            return entities
+        if t == "dilemma":
+            return dilemmas
+        return {}
+
+    graph.get_nodes_by_type.side_effect = get_nodes_by_type
+
+    # Answer edges and nodes
+    answer_edges = [
+        {"from": "dilemma::trust_or_betray", "to": "answer::trust", "type": "has_answer"},
+        {"from": "dilemma::trust_or_betray", "to": "answer::betray", "type": "has_answer"},
+    ]
+    answer_nodes = {
+        "answer::trust": {"raw_id": "trust", "is_default_path": True},
+        "answer::betray": {"raw_id": "betray", "is_default_path": False},
+    }
+
+    def get_edges(*, edge_type: str = "", from_id: str = "") -> list:
+        if edge_type == "has_answer":
+            if from_id:
+                return [e for e in answer_edges if e["from"] == from_id]
+            return answer_edges
+        return []
+
+    graph.get_edges.side_effect = get_edges
+
+    def get_node(node_id: str) -> dict | None:
+        return answer_nodes.get(node_id)
+
+    graph.get_node.side_effect = get_node
+
+    return graph
+
+
+class TestFormatDilemmaAnswersFromGraph:
+    """Test _format_dilemma_answers_from_graph."""
+
+    def test_formats_dilemma_answers(self) -> None:
+        """Should format dilemma answer IDs from graph."""
+        graph = _make_mock_graph()
+        result = _format_dilemma_answers_from_graph(graph)
+
+        assert "dilemma::trust_or_betray" in result
+        assert "`betray`" in result
+        assert "`trust`" in result
+
+    def test_handles_empty_graph(self) -> None:
+        """Should return placeholder for graph with no dilemmas."""
+        graph = MagicMock()
+        graph.get_nodes_by_type.return_value = {}
+        result = _format_dilemma_answers_from_graph(graph)
+        assert result == "(No dilemmas)"
+
+    def test_marks_default_answer(self) -> None:
+        """Should mark the default answer."""
+        graph = _make_mock_graph()
+        result = _format_dilemma_answers_from_graph(graph)
+        assert "(default)" in result
+
+
+class TestGetSeedSectionSummarizePrompts:
+    """Test get_seed_section_summarize_prompts loader."""
+
+    def test_returns_all_sections(self) -> None:
+        """Should return prompts for all 5 sections."""
+        prompts = get_seed_section_summarize_prompts(
+            entity_count=2,
+            dilemma_count=1,
+            entity_manifest="- hero\n- castle",
+            dilemma_manifest="- trust_or_betray",
+        )
+        assert set(prompts.keys()) == set(SEED_SUMMARY_SECTIONS)
+
+    def test_entities_prompt_has_manifest(self) -> None:
+        """Entities section should include entity manifest."""
+        prompts = get_seed_section_summarize_prompts(
+            entity_count=2,
+            entity_manifest="- character::hero\n- location::castle",
+        )
+        assert "character::hero" in prompts["entities"]
+        assert "2" in prompts["entities"]
+
+    def test_dilemmas_prompt_has_answers(self) -> None:
+        """Dilemmas section should include answer IDs."""
+        prompts = get_seed_section_summarize_prompts(
+            dilemma_count=1,
+            dilemma_manifest="- dilemma::trust_or_betray",
+            dilemma_answers="- `dilemma::trust_or_betray` -> [trust, betray]",
+        )
+        assert "trust_or_betray" in prompts["dilemmas"]
+        assert "trust" in prompts["dilemmas"]
+
+    def test_all_prompts_are_nonempty_strings(self) -> None:
+        """All section prompts should be non-empty strings."""
+        prompts = get_seed_section_summarize_prompts()
+        for section, prompt in prompts.items():
+            assert isinstance(prompt, str), f"{section} should be a string"
+            assert len(prompt) > 50, f"{section} should be non-trivial"
+
+
+class TestSummarizeSeedChunked:
+    """Test summarize_seed_chunked function."""
+
+    @pytest.mark.asyncio
+    async def test_returns_all_sections(self) -> None:
+        """Should return briefs for all 5 sections."""
+        graph = _make_mock_graph()
+        mock_model = MagicMock()
+
+        # Each call returns a different brief
+        responses = []
+        for section in SEED_SUMMARY_SECTIONS:
+            msg = AIMessage(content=f"Brief for {section}")
+            msg.usage_metadata = {"total_tokens": 50}
+            responses.append(msg)
+
+        mock_model.ainvoke = AsyncMock(side_effect=responses)
+
+        messages = [HumanMessage(content="Let's triage the brainstorm")]
+
+        briefs, tokens = await summarize_seed_chunked(
+            model=mock_model,
+            messages=messages,
+            graph=graph,
+        )
+
+        assert set(briefs.keys()) == set(SEED_SUMMARY_SECTIONS)
+        assert tokens == 250  # 5 sections * 50 tokens
+
+    @pytest.mark.asyncio
+    async def test_makes_five_sequential_calls(self) -> None:
+        """Should make exactly 5 model calls (one per section)."""
+        graph = _make_mock_graph()
+        mock_model = MagicMock()
+
+        response = AIMessage(content="Section brief")
+        response.usage_metadata = {"total_tokens": 10}
+        mock_model.ainvoke = AsyncMock(return_value=response)
+
+        messages = [HumanMessage(content="Test")]
+
+        await summarize_seed_chunked(
+            model=mock_model,
+            messages=messages,
+            graph=graph,
+        )
+
+        assert mock_model.ainvoke.call_count == 5
+
+    @pytest.mark.asyncio
+    async def test_later_sections_include_prior_context(self) -> None:
+        """Later sections should receive prior sections' output as context."""
+        graph = _make_mock_graph()
+        mock_model = MagicMock()
+
+        call_count = [0]
+
+        async def track_calls(messages, config=None):  # noqa: ARG001
+            call_count[0] += 1
+            msg = AIMessage(content=f"Brief {call_count[0]}")
+            msg.usage_metadata = {"total_tokens": 10}
+            return msg
+
+        mock_model.ainvoke = track_calls
+
+        messages = [HumanMessage(content="Test")]
+
+        await summarize_seed_chunked(
+            model=mock_model,
+            messages=messages,
+            graph=graph,
+        )
+
+        # We can't easily inspect the calls since ainvoke is a plain async function,
+        # but we verify the function completes and returns all sections
+        assert call_count[0] == 5
+
+    @pytest.mark.asyncio
+    async def test_each_call_has_system_and_human_messages(self) -> None:
+        """Each call should have a SystemMessage and HumanMessage."""
+        graph = _make_mock_graph()
+        mock_model = MagicMock()
+
+        captured_calls: list[list] = []
+
+        async def capture_calls(call_messages, config=None):  # noqa: ARG001
+            captured_calls.append(list(call_messages))
+            msg = AIMessage(content="Brief")
+            msg.usage_metadata = {"total_tokens": 10}
+            return msg
+
+        mock_model.ainvoke = capture_calls
+
+        messages = [HumanMessage(content="Discussion content")]
+
+        await summarize_seed_chunked(
+            model=mock_model,
+            messages=messages,
+            graph=graph,
+        )
+
+        assert len(captured_calls) == 5
+        for call_msgs in captured_calls:
+            assert len(call_msgs) == 2
+            assert isinstance(call_msgs[0], SystemMessage)
+            assert isinstance(call_msgs[1], HumanMessage)
+
+    @pytest.mark.asyncio
+    async def test_second_call_includes_first_output(self) -> None:
+        """The dilemmas call should include entities brief as prior context."""
+        graph = _make_mock_graph()
+        mock_model = MagicMock()
+
+        captured_calls: list[list] = []
+
+        async def capture_calls(call_messages, config=None):  # noqa: ARG001
+            captured_calls.append(list(call_messages))
+            idx = len(captured_calls) - 1
+            section = list(SEED_SUMMARY_SECTIONS)[idx]
+            msg = AIMessage(
+                content="Entities are retained" if section == "entities" else f"Brief for {section}"
+            )
+            msg.usage_metadata = {"total_tokens": 10}
+            return msg
+
+        mock_model.ainvoke = capture_calls
+
+        messages = [HumanMessage(content="Test")]
+
+        await summarize_seed_chunked(
+            model=mock_model,
+            messages=messages,
+            graph=graph,
+        )
+
+        # First call (entities) should NOT have prior decisions
+        entities_msg = captured_calls[0][1].content
+        assert "Prior Decisions" not in entities_msg
+
+        # Second call (dilemmas) SHOULD have entities prior context
+        dilemmas_msg = captured_calls[1][1].content
+        assert "Prior Decisions" in dilemmas_msg
+        assert "Entities are retained" in dilemmas_msg
+
+    @pytest.mark.asyncio
+    async def test_handles_empty_messages(self) -> None:
+        """Should handle empty message list."""
+        graph = _make_mock_graph()
+        mock_model = MagicMock()
+
+        response = AIMessage(content="Brief")
+        response.usage_metadata = {"total_tokens": 10}
+        mock_model.ainvoke = AsyncMock(return_value=response)
+
+        briefs, _tokens = await summarize_seed_chunked(
+            model=mock_model,
+            messages=[],
+            graph=graph,
+        )
+
+        assert len(briefs) == 5


### PR DESCRIPTION
## Problem
SEED stage fails on large stories (test-big: 8 dilemmas, 16 entities) because the dilemma
serializer receives the entire ~33K-char monolithic summarize brief. This pushes the valid IDs
manifest ~30K tokens from the generation point, causing qwen3:4b to reconstruct answer IDs
from dilemma names instead of copying from the manifest. Concrete failure: `strength` became
`trust_strength` because the dilemma name contains `trust_strength_or_flaw`.

## Changes
- **New prompt templates** (`summarize_seed_sections.yaml`): 5 focused per-section templates
  for entities, dilemmas, paths, beats, and convergence (~30-50 lines each vs 134-line monolith)
- **New `summarize_seed_chunked()`** function: Makes 5 sequential LLM calls instead of 1
  monolithic call. Each call receives the discussion history + prior sections' output as context.
  Returns `dict[str, str]` mapping section name to its brief text.
- **Dilemma answer IDs injected close to generation point**: `_format_dilemma_answers_from_graph()`
  provides valid answer IDs directly in the dilemmas section system prompt, preventing the
  contextual-inference-over-verbatim-copying failure pattern
- **`_extract_tokens()` helper**: DRY refactor extracting token counting logic from `summarize_discussion()`
- **Prompt loader** (`get_seed_section_summarize_prompts()`): Loads and renders all 5 section templates

## Not Included / Future PRs
- **PR 2**: Wire `summarize_seed_chunked()` into serialize + seed stage (`serialize.py`,
  `seed.py`, `context.py`). See plan in #777.
- **PR 3** (optional): Enum-constrained JSON schema for dilemma answer IDs

## Test Plan
- `uv run pytest tests/unit/test_summarize.py -x -q` — 39 tests pass
- `uv run mypy src/questfoundry/agents/` — clean
- `uv run ruff check src/ tests/` — clean
- Pre-commit hooks pass on all commits

## Risk / Rollback
- No behavior change yet — `summarize_seed_chunked()` is added but not wired into the
  pipeline. The existing monolithic `summarize_discussion()` continues to be used.
- Safe to revert independently without affecting existing functionality.

## Review Guide
1. Start with `prompts/templates/summarize_seed_sections.yaml` — the 5 section templates
2. Then `src/questfoundry/agents/prompts.py` — the loader function
3. Then `src/questfoundry/agents/summarize.py` — the main `summarize_seed_chunked()` function
4. Finally `tests/unit/test_summarize.py` — test coverage

Closes: Part of #777

🤖 Generated with [Claude Code](https://claude.com/claude-code)