### PR TITLE
feat(models): enum-constrained dilemma schema for SEED (#777)

### DIFF
--- a/tests/unit/test_seed_models.py
+++ b/tests/unit/test_seed_models.py
@@ -18,6 +18,7 @@ from questfoundry.models.seed import (
     PathBeatsSection,
     PathsSection,
     SeedOutput,
+    make_constrained_dilemmas_section,
 )
 
 
@@ -478,3 +479,158 @@ class TestSeedOutputBackwardCompat:
         assert len(restored.dilemma_analyses) == 1
         assert len(restored.interaction_constraints) == 1
         assert restored.dilemma_analyses[0].convergence_policy == "soft"
+
+
+# ---------------------------------------------------------------------------
+# Constrained dilemma schema factory (#777)
+# ---------------------------------------------------------------------------
+
+_ANSWER_IDS_BY_DILEMMA: dict[str, list[str]] = {
+    "trust_or_betray": ["trust", "betray"],
+    "fight_or_flee": ["fight", "flee"],
+}
+
+
+class TestMakeConstrainedDilemmasSection:
+    """make_constrained_dilemmas_section produces enum-constrained models."""
+
+    def test_valid_input_accepted(self) -> None:
+        """Valid dilemma/answer IDs pass validation."""
+        schema = make_constrained_dilemmas_section(_ANSWER_IDS_BY_DILEMMA)
+        result = schema.model_validate(
+            {
+                "dilemmas": [
+                    {
+                        "dilemma_id": "dilemma::trust_or_betray",
+                        "explored": ["trust"],
+                        "unexplored": ["betray"],
+                    },
+                    {
+                        "dilemma_id": "dilemma::fight_or_flee",
+                        "explored": ["fight", "flee"],
+                    },
+                ]
+            }
+        )
+        assert len(result.dilemmas) == 2
+
+    def test_invalid_answer_id_rejected(self) -> None:
+        """An answer ID not in the brainstorm enum is rejected."""
+        schema = make_constrained_dilemmas_section(_ANSWER_IDS_BY_DILEMMA)
+        with pytest.raises(ValidationError, match="trust_strength"):
+            schema.model_validate(
+                {
+                    "dilemmas": [
+                        {
+                            "dilemma_id": "dilemma::trust_or_betray",
+                            "explored": ["trust_strength"],
+                        },
+                    ]
+                }
+            )
+
+    def test_invalid_dilemma_id_rejected(self) -> None:
+        """A dilemma ID not in the brainstorm enum is rejected."""
+        schema = make_constrained_dilemmas_section(_ANSWER_IDS_BY_DILEMMA)
+        with pytest.raises(ValidationError, match="dilemma_id"):
+            schema.model_validate(
+                {
+                    "dilemmas": [
+                        {
+                            "dilemma_id": "dilemma::unknown",
+                            "explored": ["trust"],
+                        },
+                    ]
+                }
+            )
+
+    def test_empty_input_returns_unconstrained(self) -> None:
+        """Empty answer map falls back to plain DilemmasSection."""
+        schema = make_constrained_dilemmas_section({})
+        assert schema is DilemmasSection
+
+    def test_json_schema_has_enum_constraint(self) -> None:
+        """Generated JSON schema includes enum arrays for constrained decoding."""
+        schema = make_constrained_dilemmas_section(_ANSWER_IDS_BY_DILEMMA)
+        json_schema = schema.model_json_schema()
+
+        # Navigate to the dilemma decision definition
+        defs = json_schema.get("$defs", {})
+        decision_schema = defs.get("ConstrainedDilemmaDecision", {})
+        props = decision_schema.get("properties", {})
+
+        # Check dilemma_id has enum
+        dilemma_id_ref = props.get("dilemma_id", {})
+        # Could be a direct enum or a $ref — resolve either way
+        if "$ref" in dilemma_id_ref:
+            ref_name = dilemma_id_ref["$ref"].split("/")[-1]
+            dilemma_id_schema = defs[ref_name]
+        else:
+            dilemma_id_schema = dilemma_id_ref
+        assert "enum" in dilemma_id_schema
+        assert "dilemma::trust_or_betray" in dilemma_id_schema["enum"]
+
+        # Check explored items have enum
+        explored_items = props.get("explored", {}).get("items", {})
+        if "$ref" in explored_items:
+            ref_name = explored_items["$ref"].split("/")[-1]
+            answer_schema = defs[ref_name]
+        else:
+            answer_schema = explored_items
+        assert "enum" in answer_schema
+        assert set(answer_schema["enum"]) == {"trust", "betray", "fight", "flee"}
+
+    def test_model_dump_returns_plain_strings(self) -> None:
+        """model_dump() produces plain strings, not StrEnum objects."""
+        schema = make_constrained_dilemmas_section(_ANSWER_IDS_BY_DILEMMA)
+        result = schema.model_validate(
+            {
+                "dilemmas": [
+                    {
+                        "dilemma_id": "dilemma::trust_or_betray",
+                        "explored": ["trust"],
+                        "unexplored": ["betray"],
+                    },
+                ]
+            }
+        )
+        data = result.model_dump()
+        dilemma = data["dilemmas"][0]
+        assert dilemma["dilemma_id"] == "dilemma::trust_or_betray"
+        assert isinstance(dilemma["dilemma_id"], str)
+        assert dilemma["explored"] == ["trust"]
+
+    def test_deduplication_preserved(self) -> None:
+        """Constrained section still deduplicates identical entries."""
+        schema = make_constrained_dilemmas_section(_ANSWER_IDS_BY_DILEMMA)
+        result = schema.model_validate(
+            {
+                "dilemmas": [
+                    {
+                        "dilemma_id": "dilemma::trust_or_betray",
+                        "explored": ["trust"],
+                    },
+                    {
+                        "dilemma_id": "dilemma::trust_or_betray",
+                        "explored": ["trust"],
+                    },
+                ]
+            }
+        )
+        assert len(result.dilemmas) == 1
+
+    def test_considered_field_migration(self) -> None:
+        """Old 'considered' field is migrated to 'explored'."""
+        schema = make_constrained_dilemmas_section(_ANSWER_IDS_BY_DILEMMA)
+        result = schema.model_validate(
+            {
+                "dilemmas": [
+                    {
+                        "dilemma_id": "dilemma::trust_or_betray",
+                        "considered": ["trust"],
+                    },
+                ]
+            }
+        )
+        data = result.model_dump()
+        assert data["dilemmas"][0]["explored"] == ["trust"]


### PR DESCRIPTION
## Problem

SEED stage dilemma serialization on large stories can produce hallucinated answer IDs (e.g., `trust_strength` instead of `strength`) because the LLM is free to emit any string for answer/dilemma ID fields. Even with valid IDs in the brief, small models (qwen3:4b) reconstruct IDs from context rather than copying them.

This is PR 3/3 in the stacked PR series for #777. PR 1 (#778) added chunked summarization. PR 2 (#780) wired it into the pipeline with early validation. This PR adds the final defense: token-level constraints.

## Changes

- **`models/seed.py`**: Added `make_constrained_dilemmas_section()` factory that creates dynamic Pydantic models with `StrEnum`-constrained `dilemma_id`, `explored`, and `unexplored` fields. The JSON schema produced contains `enum` arrays, enabling constrained decoding in llama.cpp/Ollama — the LLM literally cannot emit tokens forming invalid IDs.
- **`agents/serialize.py`**: When a graph is available, builds the constrained schema from brainstorm answer IDs and uses it for dilemma serialization (initial + early validation retries + semantic retries).
- **`tests/unit/test_seed_models.py`**: 8 tests covering valid/invalid IDs, fallback, JSON schema enum presence, model_dump types, deduplication, and field migration.

## Not Included / Future PRs

- Per-dilemma enum constraints (answer X must belong to dilemma Y). Currently uses a global pool of all answer IDs; per-dilemma validation is handled by `_early_validate_dilemma_answers` from PR 2.
- Constrained schemas for other section types (entities, paths, etc.).

## Test Plan

- `uv run pytest tests/unit/test_seed_models.py -x -q` → 64 passed
- `uv run pytest tests/unit/test_serialize.py -x -q` → 67 passed
- `uv run pytest tests/unit/test_seed_stage.py -x -q` → 26 passed
- `uv run mypy src/questfoundry/models/seed.py src/questfoundry/agents/serialize.py` → clean
- `uv run ruff check src/` → clean

## Risk / Rollback

- **Low risk**: Falls back to unconstrained `DilemmasSection` when graph is unavailable or has no answer data, preserving backward compatibility.
- **StrEnum serialization**: `model_dump()` produces plain strings (StrEnum inherits from str), so downstream code is unaffected.
- **Dynamic classes**: Created inside a factory function; mypy `misc` ignores are needed for dynamic StrEnum construction but runtime behavior is correct.

## Review Guide

1. `src/questfoundry/models/seed.py` — factory function at the bottom
2. `src/questfoundry/agents/serialize.py` — schema construction and wiring (search for `dilemma_schema`)
3. `tests/unit/test_seed_models.py` — `TestMakeConstrainedDilemmasSection` at the bottom

🤖 Generated with [Claude Code](https://claude.com/claude-code)