### PR TITLE
fix(grow): gate hard-policy branches behind spine-exclusive codewords (#782)

### DIFF
--- a/src/questfoundry/graph/grow_algorithms.py
+++ b/src/questfoundry/graph/grow_algorithms.py
@@ -1380,7 +1380,7 @@ def compute_all_choice_requires(
         if any(arc_nodes.get(a, {}).get("arc_type") == "spine" for a in arc_ids):
             continue
 
-        codewords: list[str] = []
+        codewords: set[str] = set()
         for arc_id in sorted(arc_ids):
             arc_data = arc_nodes.get(arc_id, {})
             if arc_data.get("convergence_policy") != "hard":
@@ -1393,11 +1393,11 @@ def compute_all_choice_requires(
             for path_id in sorted(spine_exclusive):
                 for cons_id in path_consequences.get(path_id, []):
                     cw = cons_to_codeword.get(cons_id)
-                    if cw and cw not in codewords:
-                        codewords.append(cw)
+                    if cw:
+                        codewords.add(cw)
 
         if codewords:
-            requires[passage_id] = codewords
+            requires[passage_id] = sorted(codewords)
 
     return requires
 

--- a/src/questfoundry/graph/grow_algorithms.py
+++ b/src/questfoundry/graph/grow_algorithms.py
@@ -1332,20 +1332,74 @@ def compute_passage_arc_membership(graph: Graph) -> dict[str, set[str]]:
 
 
 def compute_all_choice_requires(
-    graph: Graph,  # noqa: ARG001
-    passage_arcs: dict[str, set[str]],  # noqa: ARG001
+    graph: Graph,
+    passage_arcs: dict[str, set[str]],
 ) -> dict[str, list[str]]:
-    """Compute codeword ``requires`` lists for target passages.
+    """Compute codeword ``requires`` for hard-policy branch entry passages.
 
-    Currently returns empty — hard-policy topology isolation is enforced
-    structurally (Phase 3 intersection rejection, separate arc sequences).
-    Codeword gating for branch entries is reserved for future opt-in
-    support (see issue #758).
+    For each passage that appears exclusively in hard-policy branch arcs
+    (not on the spine), collects codewords from **spine-exclusive** paths —
+    paths on the spine that are NOT shared with the branch arc.  These
+    codewords are earnable before the branch divergence point, making the
+    gate satisfiable in a single playthrough.
 
     Returns:
         Mapping of ``passage_id`` → list of required codeword IDs.
+        Empty dict if no spine arc exists or no hard-policy branches.
     """
-    return {}
+    arc_nodes = graph.get_nodes_by_type("arc")
+    if not arc_nodes:
+        return {}
+
+    # 1. Find spine arc and its paths
+    spine_paths: set[str] = set()
+    for arc_data in arc_nodes.values():
+        if arc_data.get("arc_type") == "spine":
+            spine_paths = {normalize_scoped_id(p, "path") for p in arc_data.get("paths", [])}
+            break
+    if not spine_paths:
+        return {}
+
+    # 2. Build consequence→codeword lookup (reverse of tracks edges)
+    tracks_edges = graph.get_edges(from_id=None, to_id=None, edge_type="tracks")
+    cons_to_codeword: dict[str, str] = {}
+    for edge in tracks_edges:
+        cons_to_codeword[edge["to"]] = edge["from"]
+
+    # 3. Build path→consequences lookup
+    has_cons_edges = graph.get_edges(from_id=None, to_id=None, edge_type="has_consequence")
+    path_consequences: dict[str, list[str]] = {}
+    for edge in has_cons_edges:
+        path_consequences.setdefault(edge["from"], []).append(edge["to"])
+
+    # 4. For each passage exclusive to hard-policy branches, collect
+    #    codewords from spine-exclusive paths.
+    requires: dict[str, list[str]] = {}
+    for passage_id, arc_ids in passage_arcs.items():
+        # Skip passages reachable via the spine — no gating needed
+        if any(arc_nodes.get(a, {}).get("arc_type") == "spine" for a in arc_ids):
+            continue
+
+        codewords: list[str] = []
+        for arc_id in sorted(arc_ids):
+            arc_data = arc_nodes.get(arc_id, {})
+            if arc_data.get("convergence_policy") != "hard":
+                continue
+
+            # Spine-exclusive = spine paths NOT shared with this branch
+            branch_paths = {normalize_scoped_id(p, "path") for p in arc_data.get("paths", [])}
+            spine_exclusive = spine_paths - branch_paths
+
+            for path_id in sorted(spine_exclusive):
+                for cons_id in path_consequences.get(path_id, []):
+                    cw = cons_to_codeword.get(cons_id)
+                    if cw and cw not in codewords:
+                        codewords.append(cw)
+
+        if codewords:
+            requires[passage_id] = codewords
+
+    return requires
 
 
 # ---------------------------------------------------------------------------

--- a/src/questfoundry/graph/grow_algorithms.py
+++ b/src/questfoundry/graph/grow_algorithms.py
@@ -1361,10 +1361,10 @@ def compute_all_choice_requires(
         return {}
 
     # 2. Build consequence→codeword lookup (reverse of tracks edges)
-    tracks_edges = graph.get_edges(from_id=None, to_id=None, edge_type="tracks")
-    cons_to_codeword: dict[str, str] = {}
-    for edge in tracks_edges:
-        cons_to_codeword[edge["to"]] = edge["from"]
+    cons_to_codeword = {
+        edge["to"]: edge["from"]
+        for edge in graph.get_edges(from_id=None, to_id=None, edge_type="tracks")
+    }
 
     # 3. Build path→consequences lookup
     has_cons_edges = graph.get_edges(from_id=None, to_id=None, edge_type="has_consequence")


### PR DESCRIPTION
## Problem

`compute_all_choice_requires()` was gutted to return `{}` in PR #759 (fix for #757). The original bug was that it collected codewords from the **branch arc's own paths**, creating self-referential impossible gates. The fix removed all gating instead of fixing the collection logic.

The #740 design specifies that hard-policy branch entries should be gated behind **spine-exclusive** consequence codewords — codewords earned by committing on the spine path, not the branch path.

## Changes

- **Rewrite `compute_all_choice_requires()`** with spine-exclusive logic:
  1. Find spine arc and its paths
  2. For each hard-policy branch arc, compute `spine_exclusive = spine_paths - branch_paths`
  3. Traverse spine-exclusive paths → consequences → codewords via `has_consequence` + `tracks` edges
  4. Map to branch-entry passages via `passage_arcs`
- **Update existing tests** — renamed `test_hard_branch_target_no_requires` to `test_hard_branch_no_spine_consequences` (same assertion, clearer name)
- **Add 3 new tests**: spine-consequences gating, no-spine-arc fallback, empty-graph fallback

## Not Included / Future PRs

- Grant propagation validation (checking that spine-exclusive codewords are actually granted on spine choices) — covered by existing `check_gate_satisfiability()` validation
- #758 (self-referential NG+/time-loop gating) — separate feature

## Test Plan

- `uv run pytest tests/unit/test_grow_algorithms.py::TestComputeAllChoiceRequires -x -q` — 7 passed
- `uv run mypy src/questfoundry/graph/grow_algorithms.py` — clean
- `uv run ruff check src/questfoundry/graph/grow_algorithms.py` — clean

## Risk / Rollback

- Only affects stories with `convergence_policy: "hard"` — currently none are generated (blocked by #783/PR #786)
- Existing `check_gate_satisfiability()` catches unsatisfiable gates at Phase 10
- Existing `check_forward_path_reachability()` warns if all choices from a passage are gated

Closes #782

🤖 Generated with [Claude Code](https://claude.com/claude-code)