### PR TITLE
fix(grow): inject path sequences into Phase 4c and clarify beat ordering

### DIFF
--- a/prompts/templates/grow_phase4b_narrative_gaps.yaml
+++ b/prompts/templates/grow_phase4b_narrative_gaps.yaml
@@ -24,11 +24,19 @@ system: |
   4. Each gap beat must specify where it goes (after_beat and/or before_beat)
   5. Gap beats should be concise transitions, not major story events
 
+  ## Beat Ordering (CRITICAL)
+  after_beat = the EARLIER beat (the new beat goes AFTER it)
+  before_beat = the LATER beat (the new beat goes BEFORE it)
+
+  The new beat is inserted BETWEEN after_beat and before_beat.
+  after_beat MUST appear earlier in the path sequence than before_beat.
+
   ## What NOT to Do
   - Do NOT propose gaps for paths with only 1-2 beats (those are minimal by design)
   - Do NOT propose gaps between beats that already flow naturally
   - Do NOT use IDs not listed in the Valid IDs section
   - Do NOT propose more than 2 gap beats per path
+  - Do NOT swap after_beat and before_beat — after_beat is ALWAYS earlier
   - Do NOT add explanatory prose before or after the JSON output
 
   ## Valid IDs
@@ -38,8 +46,8 @@ system: |
   ## Output Format
   Return a JSON object with a "gaps" array. Each gap has:
   - path_id: the path this gap belongs to (use prefixed form, e.g., "path::dilemma__answer")
-  - after_beat: the beat this gap comes after (or null for start of path)
-  - before_beat: the beat this gap comes before (or null for end of path)
+  - after_beat: the EARLIER beat (new beat goes after this one, or null for start of path)
+  - before_beat: the LATER beat (new beat goes before this one, or null for end of path)
   - summary: a concise description of the gap beat (1 sentence)
   - scene_type: "scene", "sequel", or "micro_beat" (default: "sequel")
 
@@ -48,6 +56,7 @@ system: |
 user: |
   Analyze the path sequences above and propose gap beats where needed.
 
-  REMINDER: Return ONLY a valid JSON object. Use ONLY IDs from the Valid IDs section. Do NOT add prose before or after the JSON.
+  REMINDER: Return ONLY a valid JSON object. Use ONLY IDs from the Valid IDs section.
+  REMINDER: after_beat is the EARLIER beat, before_beat is the LATER beat. Do NOT reverse them.
 
 components: []

--- a/prompts/templates/grow_phase4c_pacing_gaps.yaml
+++ b/prompts/templates/grow_phase4c_pacing_gaps.yaml
@@ -11,6 +11,9 @@ system: |
   - 3+ sequels in a row feels stagnant (no forward momentum)
   - 3+ micro_beats in a row feels disconnected (no substance)
 
+  ## Full Path Sequences (numbered in story order)
+  {path_sequences}
+
   ## Detected Pacing Issues
   {pacing_issues}
 
@@ -22,10 +25,26 @@ system: |
   5. Place the correction beat where it makes the most narrative sense
   6. One correction beat per issue is usually sufficient
 
+  ## Beat Ordering (CRITICAL)
+  after_beat = the EARLIER beat (the new beat goes AFTER it)
+  before_beat = the LATER beat (the new beat goes BEFORE it)
+
+  The new beat is inserted BETWEEN after_beat and before_beat.
+  after_beat MUST have a LOWER position number than before_beat.
+
+  Example: if a path has beats in this order:
+    #1 beat::example_01 [scene]
+    #2 beat::example_02 [scene]
+    #3 beat::example_03 [scene]
+  To insert a sequel between beat_01 and beat_02:
+    CORRECT: after_beat = "beat::example_01", before_beat = "beat::example_02"
+    WRONG:   after_beat = "beat::example_02", before_beat = "beat::example_01"
+
   ## What NOT to Do
   - Do NOT propose correction beats of the SAME type as the issue
   - Do NOT use IDs not listed in the Valid IDs section
   - Do NOT insert more than 2 correction beats per issue
+  - Do NOT swap after_beat and before_beat — after_beat is ALWAYS earlier
   - Do NOT add explanatory prose before or after the JSON output
 
   ## Valid IDs
@@ -36,8 +55,8 @@ system: |
   ## Output Format
   Return a JSON object with a "gaps" array. Each gap has:
   - path_id: the path this correction belongs to (use prefixed form)
-  - after_beat: the beat this correction comes after
-  - before_beat: the beat this correction comes before
+  - after_beat: the EARLIER beat (new beat goes after this one)
+  - before_beat: the LATER beat (new beat goes before this one)
   - summary: a concise description of the correction beat (1 sentence)
   - scene_type: "scene", "sequel", or "micro_beat" (must differ from the issue type)
 
@@ -46,6 +65,7 @@ system: |
 user: |
   Propose correction beats to fix the pacing issues described above.
 
-  REMINDER: Return ONLY a valid JSON object. Use ONLY IDs from the Valid IDs section. Do NOT add prose before or after the JSON.
+  REMINDER: Return ONLY a valid JSON object. Use ONLY IDs from the Valid IDs section.
+  REMINDER: after_beat is the EARLIER beat, before_beat is the LATER beat. Do NOT reverse them.
 
 components: []

--- a/prompts/templates/grow_phase4c_pacing_gaps.yaml
+++ b/prompts/templates/grow_phase4c_pacing_gaps.yaml
@@ -36,7 +36,7 @@ system: |
     #1 beat::example_01 [scene]
     #2 beat::example_02 [scene]
     #3 beat::example_03 [scene]
-  To insert a sequel between beat_01 and beat_02:
+  To insert a sequel between beat::example_01 and beat::example_02:
     CORRECT: after_beat = "beat::example_01", before_beat = "beat::example_02"
     WRONG:   after_beat = "beat::example_02", before_beat = "beat::example_01"
 

--- a/src/questfoundry/models/grow.py
+++ b/src/questfoundry/models/grow.py
@@ -281,8 +281,14 @@ class GapProposal(BaseModel):
     """Phase 4b/4c: Proposes new beats to fill structural gaps."""
 
     path_id: str = Field(min_length=1)
-    after_beat: str | None = None
-    before_beat: str | None = None
+    after_beat: str | None = Field(
+        default=None,
+        description="The EARLIER beat — new beat is inserted AFTER this one",
+    )
+    before_beat: str | None = Field(
+        default=None,
+        description="The LATER beat — new beat is inserted BEFORE this one",
+    )
     summary: str = Field(min_length=1)
     scene_type: Literal["scene", "sequel", "micro_beat"] = "sequel"
 


### PR DESCRIPTION
## Problem

Phase 4c (pacing gap insertion) has a 100% gap proposal rejection rate. All 9 proposals in test-big-hard were rejected because the LLM (qwen3:4b) consistently reverses `after_beat` and `before_beat` fields.

Root causes identified by prompt-engineer audit:
1. Phase 4c doesn't show the full beat sequence — only the problematic runs
2. `after_beat`/`before_beat` field names are ambiguous with no descriptions
3. Prompt doesn't disambiguate with explicit EARLIER/LATER language or examples

This is also a #784 (insufficient context) instance — same pattern as #783 and #772.

Closes #789

## Changes

- **`grow.py`**: Build full numbered path sequences for affected paths (same pattern as Phase 4b). Use proper `valid_beat_ids` set instead of `beat_nodes` dict.
- **`grow_phase4c_pacing_gaps.yaml`**: Add `{path_sequences}` section, `Beat Ordering (CRITICAL)` section with CORRECT/WRONG example, sandwich reminder in user message.
- **`grow_phase4b_narrative_gaps.yaml`**: Add same ordering section and sandwich reminder (defensive).
- **`models/grow.py`**: Add Field descriptions to `GapProposal.after_beat`/`before_beat` with EARLIER/LATER semantics.

## Not Included / Future PRs

- Full #784 audit of other phases — tracked in #784
- Field rename (`insert_after`/`insert_before`) — noted in #789 as optional longer-term improvement

## Test Plan

- `uv run mypy src/questfoundry/pipeline/stages/grow.py src/questfoundry/models/grow.py` — clean
- `uv run ruff check` — clean
- `uv run pytest tests/unit/test_grow_stage.py -x -q -k "phase_4c"` — 5 passed
- `uv run pytest tests/unit/test_grow_stage.py -x -q -k "phase_4b"` — 4 passed
- `uv run pytest tests/unit/test_grow_stage.py -x -q -k "gap"` — 16 passed

## Risk / Rollback

Low risk. Context enrichment adds more data to the prompt but doesn't change validation or insertion logic. Prompt changes only affect LLM output quality, not code paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)