### PR TITLE
feat(grow): enrich Phase 4e path_arcs with narrative context

### DIFF
--- a/prompts/templates/grow_phase4e_path_arcs.yaml
+++ b/prompts/templates/grow_phase4e_path_arcs.yaml
@@ -9,6 +9,14 @@ system: |
   ## Path Information
   **Path ID:** {path_id}
   **Dilemma:** {dilemma_question}
+  **Stakes:** {dilemma_stakes}
+  **Path Description:** {path_description}
+
+  ## Key Entities
+  {entity_context}
+
+  ## Entity Arcs (character transformations on this path)
+  {entity_arcs}
 
   ## Beat Sequence (in order)
   {beat_sequence}

--- a/src/questfoundry/pipeline/stages/grow.py
+++ b/src/questfoundry/pipeline/stages/grow.py
@@ -1587,17 +1587,21 @@ class GrowStage:
                 for eid in bdata.get("entities", []):
                     beat_entity_ids.add(eid)
 
-            # Format entity context (name + concept)
+            # Format entity context (name + concept for all entities)
             entity_lines: list[str] = []
             for eid in sorted(beat_entity_ids):
                 enode = graph.get_node(eid)
                 if enode:
                     name = enode.get("name") or enode.get("raw_id", eid)
                     concept = enode.get("concept", "")
-                    if concept:
-                        entity_lines.append(f"- {name}: {concept}")
+                    entity_lines.append(
+                        f"- {name}: {concept}" if concept else f"- {name}: (no concept yet)"
+                    )
+                else:
+                    entity_lines.append(f"- {eid}: (not in graph)")
 
-            # Format entity arcs from path node (if established)
+            # Format entity arcs from path node (subset: entity_id + arc_line only;
+            # pivot_beat and arc_type are not needed for thematic context)
             arc_lines: list[str] = []
             for arc in pdata.get("entity_arcs", []):
                 arc_entity = arc.get("entity_id", "")
@@ -1611,12 +1615,12 @@ class GrowStage:
 
             context = {
                 "path_id": pid,
-                "dilemma_question": dilemma_question or "(no dilemma question)",
-                "dilemma_stakes": dilemma_stakes or "(not specified)",
-                "path_description": path_description or "(not specified)",
-                "entity_context": "\n".join(entity_lines) if entity_lines else "(no entities)",
-                "entity_arcs": "\n".join(arc_lines) if arc_lines else "(none yet)",
-                "beat_sequence": "\n".join(beat_lines) if beat_lines else "(no beats)",
+                "dilemma_question": dilemma_question or "(none)",
+                "dilemma_stakes": dilemma_stakes or "(none)",
+                "path_description": path_description or "(none)",
+                "entity_context": "\n".join(entity_lines) if entity_lines else "(none)",
+                "entity_arcs": "\n".join(arc_lines) if arc_lines else "(none)",
+                "beat_sequence": "\n".join(beat_lines) if beat_lines else "(none)",
             }
             path_items.append((pid, context))
 

--- a/src/questfoundry/pipeline/stages/grow.py
+++ b/src/questfoundry/pipeline/stages/grow.py
@@ -1558,6 +1558,8 @@ class GrowStage:
             dilemma_id = pdata.get("dilemma_id", "")
             dilemma_node = graph.get_node(dilemma_id) if dilemma_id else None
             dilemma_question = dilemma_node.get("question", "") if dilemma_node else ""
+            dilemma_stakes = dilemma_node.get("why_it_matters", "") if dilemma_node else ""
+            path_description = pdata.get("description", "")
 
             try:
                 beat_ids = get_path_beat_sequence(graph, pid)
@@ -1569,6 +1571,8 @@ class GrowStage:
                 log.warning("phase4e_no_beats_for_path", path_id=pid)
                 continue
 
+            # Collect entity IDs from all beats in this path
+            beat_entity_ids: set[str] = set()
             beat_lines: list[str] = []
             for i, bid in enumerate(beat_ids, 1):
                 bdata = graph.get_node(bid)
@@ -1580,10 +1584,38 @@ class GrowStage:
                 beat_lines.append(
                     f"{i}. {bid}: {summary} [function={narrative_fn}, scene_type={scene_type}]"
                 )
+                for eid in bdata.get("entities", []):
+                    beat_entity_ids.add(eid)
+
+            # Format entity context (name + concept)
+            entity_lines: list[str] = []
+            for eid in sorted(beat_entity_ids):
+                enode = graph.get_node(eid)
+                if enode:
+                    name = enode.get("name") or enode.get("raw_id", eid)
+                    concept = enode.get("concept", "")
+                    if concept:
+                        entity_lines.append(f"- {name}: {concept}")
+
+            # Format entity arcs from path node (if established)
+            arc_lines: list[str] = []
+            for arc in pdata.get("entity_arcs", []):
+                arc_entity = arc.get("entity_id", "")
+                arc_line = arc.get("arc_line", "")
+                if arc_entity and arc_line:
+                    ename = arc_entity
+                    enode = graph.get_node(arc_entity)
+                    if enode:
+                        ename = enode.get("name") or enode.get("raw_id", arc_entity)
+                    arc_lines.append(f"- {ename}: {arc_line}")
 
             context = {
                 "path_id": pid,
                 "dilemma_question": dilemma_question or "(no dilemma question)",
+                "dilemma_stakes": dilemma_stakes or "(not specified)",
+                "path_description": path_description or "(not specified)",
+                "entity_context": "\n".join(entity_lines) if entity_lines else "(no entities)",
+                "entity_arcs": "\n".join(arc_lines) if arc_lines else "(none yet)",
                 "beat_sequence": "\n".join(beat_lines) if beat_lines else "(no beats)",
             }
             path_items.append((pid, context))


### PR DESCRIPTION
## Problem
Phase 4e (path_arcs) generates `path_theme` and `path_mood` for each path, but the LLM only sees `dilemma.question` + beat summaries. It's missing critical context to make informed thematic decisions: dilemma stakes, path description, entity concepts, and entity arcs.

## Changes
- Add `dilemma.why_it_matters` (thematic stakes) to Phase 4e context
- Add `path.description` (what this path explores)
- Collect and format entity `name` + `concept` for all entities in the path's beats
- Format `entity_arcs` from path node (character transformation arcs)
- Update `grow_phase4e_path_arcs.yaml` template with new sections

## Not Included / Future PRs
- Context compaction (not needed here — Phase 4e is 3.9K avg, enrichment adds ~500-800 chars, stays well under 8K) — tracked in #792
- Template restructuring for 4B attention patterns — tracked in #797

## Test Plan
- `uv run mypy src/questfoundry/pipeline/stages/grow.py` — passes
- `uv run ruff check src/questfoundry/pipeline/stages/grow.py` — passes
- Pre-commit hooks all pass

## Risk / Rollback
- Additive only — adds new template variables without removing anything
- safe_format() ignores unused variables, so backward-compatible
- Each call grows by ~500-800 chars (3.9K → ~4.5K), well within 8K threshold

Closes #793
Part of #791 (epic)

🤖 Generated with [Claude Code](https://claude.com/claude-code)