### PR TITLE
feat(graph): add context compaction utility for LLM calls

### DIFF
--- a/src/questfoundry/graph/context_compact.py
+++ b/src/questfoundry/graph/context_compact.py
@@ -1,0 +1,235 @@
+"""Context compaction and enrichment utilities for GROW LLM phases.
+
+Provides building blocks for controlling context size and enriching items
+with narrative data from the graph. Each GROW phase composes these
+primitives differently — this module handles item-level compaction;
+grouping and batching stay in each phase.
+
+See #791 for design rationale.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from questfoundry.graph.graph import Graph
+
+
+@dataclass
+class ContextItem:
+    """A single item to include in LLM context.
+
+    Attributes:
+        id: Node ID for reference.
+        text: Pre-formatted text for this item (one or more lines).
+        priority: Higher values are included first when budget is tight.
+    """
+
+    id: str
+    text: str
+    priority: int = 0
+
+
+@dataclass
+class CompactContextConfig:
+    """Budget and truncation settings for context compaction.
+
+    Attributes:
+        max_chars: Total character budget for compacted output.
+        summary_truncate: Max chars for individual summary fields.
+        truncation_suffix: Appended when text is truncated.
+    """
+
+    max_chars: int = 6000
+    summary_truncate: int = 80
+    truncation_suffix: str = "..."
+
+
+def truncate_summary(text: str, max_chars: int = 80, suffix: str = "...") -> str:
+    """Truncate text to max_chars, preserving word boundaries.
+
+    Args:
+        text: Text to truncate.
+        max_chars: Maximum character count (including suffix).
+        suffix: Appended when truncation occurs.
+
+    Returns:
+        Truncated text, or original if already within limit.
+    """
+    if len(text) <= max_chars:
+        return text
+    # Leave room for suffix
+    limit = max_chars - len(suffix)
+    if limit <= 0:
+        return suffix[:max_chars]
+    # Find last space within limit to preserve word boundary
+    truncated = text[:limit]
+    last_space = truncated.rfind(" ")
+    if last_space > limit // 2:
+        truncated = truncated[:last_space]
+    return truncated + suffix
+
+
+def compact_items(
+    items: list[ContextItem],
+    config: CompactContextConfig | None = None,
+) -> str:
+    """Render items within character budget.
+
+    Items are sorted by priority (descending), then by insertion order.
+    Includes all items that fit within the budget. The last item that
+    would exceed the budget is truncated. Remaining items are reported
+    with a count note.
+
+    Args:
+        items: Context items to render.
+        config: Budget configuration. Uses defaults if None.
+
+    Returns:
+        Rendered items as a string, or empty string if no items.
+    """
+    if not items:
+        return ""
+
+    cfg = config or CompactContextConfig()
+
+    # Stable sort by priority descending (preserves insertion order for ties)
+    sorted_items = sorted(items, key=lambda x: -x.priority)
+
+    output_parts: list[str] = []
+    used_chars = 0
+
+    for item in sorted_items:
+        item_len = len(item.text)
+        if used_chars + item_len <= cfg.max_chars:
+            output_parts.append(item.text)
+            used_chars += item_len + 1  # +1 for newline separator
+        else:
+            # Truncate this item to fill remaining budget
+            remaining = cfg.max_chars - used_chars
+            if remaining > len(cfg.truncation_suffix) + 10:
+                truncated = truncate_summary(item.text, remaining, cfg.truncation_suffix)
+                output_parts.append(truncated)
+            # Count omitted items
+            omitted = len(sorted_items) - len(output_parts)
+            if omitted > 0:
+                output_parts.append(f"({omitted} more items omitted for brevity)")
+            break
+
+    return "\n".join(output_parts)
+
+
+def enrich_beat_line(
+    graph: Graph,
+    beat_id: str,
+    beat_data: dict[str, Any],
+    *,
+    include_entities: bool = False,
+    summary_max: int = 80,
+) -> str:
+    """Format a single beat as a compact enriched line.
+
+    Base format: ``- {beat_id} [{scene_type}, {fn}]: "{summary}"``
+    With entities: appends ``(entities: Name1, Name2)``
+
+    Args:
+        graph: Graph for entity lookups.
+        beat_id: Scoped beat ID.
+        beat_data: Beat node data dict.
+        include_entities: Whether to append entity names.
+        summary_max: Max chars for the summary field.
+
+    Returns:
+        Formatted single-line string.
+    """
+    summary = truncate_summary(beat_data.get("summary", ""), summary_max)
+    scene_type = beat_data.get("scene_type", "")
+    narrative_fn = beat_data.get("narrative_function", "")
+
+    tags: list[str] = []
+    if scene_type:
+        tags.append(scene_type)
+    if narrative_fn:
+        tags.append(narrative_fn)
+    tag_str = ", ".join(tags) if tags else "unclassified"
+
+    line = f'- {beat_id} [{tag_str}]: "{summary}"'
+
+    if include_entities:
+        entity_ids = beat_data.get("entities", [])
+        if entity_ids:
+            names: list[str] = []
+            for eid in entity_ids:
+                enode = graph.get_node(eid)
+                if enode:
+                    names.append(enode.get("name") or enode.get("raw_id", eid))
+                else:
+                    names.append(eid)
+            line += f" (entities: {', '.join(names)})"
+
+    return line
+
+
+def build_narrative_frame(
+    graph: Graph,
+    dilemma_ids: list[str] | None = None,
+    path_ids: list[str] | None = None,
+) -> str:
+    """Build a compact narrative context frame from graph data.
+
+    Assembles dilemma briefs (question, why_it_matters) and optional
+    path briefs (description, path_theme/mood if set) into a compact
+    markdown block suitable for injection at the top of LLM prompts.
+
+    Args:
+        graph: Graph containing dilemma, path, and entity nodes.
+        dilemma_ids: Scoped dilemma IDs to include. If None, includes all.
+        path_ids: Scoped path IDs to include. If None, omits path section.
+
+    Returns:
+        Rendered markdown string, or empty string if no data.
+    """
+    lines: list[str] = []
+
+    # Dilemma briefs
+    if dilemma_ids is None:
+        dilemma_nodes = graph.get_nodes_by_type("dilemma")
+        dilemma_ids = sorted(dilemma_nodes.keys())
+
+    for did in dilemma_ids:
+        node = graph.get_node(did)
+        if not node:
+            continue
+        question = node.get("question", "")
+        stakes = node.get("why_it_matters", "")
+        if not question:
+            continue
+        lines.append(f"**Dilemma ({did}):** {question}")
+        if stakes:
+            lines.append(f"  Stakes: {truncate_summary(stakes, 150)}")
+
+    # Path briefs (if requested)
+    if path_ids:
+        for pid in path_ids:
+            pnode = graph.get_node(pid)
+            if not pnode:
+                continue
+            desc = pnode.get("description", "")
+            theme = pnode.get("path_theme", "")
+            mood = pnode.get("path_mood", "")
+            parts: list[str] = [f"**Path ({pid}):**"]
+            if desc:
+                parts.append(truncate_summary(desc, 120))
+            if theme:
+                parts.append(f"Theme: {theme}")
+            if mood:
+                parts.append(f"Mood: {mood}")
+            if len(parts) > 1:
+                lines.append(" ".join(parts))
+
+    if not lines:
+        return ""
+
+    return "## Story Context\n" + "\n".join(lines)

--- a/tests/unit/test_context_compact.py
+++ b/tests/unit/test_context_compact.py
@@ -1,0 +1,265 @@
+"""Tests for context compaction and enrichment utilities."""
+
+from __future__ import annotations
+
+from questfoundry.graph.context_compact import (
+    CompactContextConfig,
+    ContextItem,
+    build_narrative_frame,
+    compact_items,
+    enrich_beat_line,
+    truncate_summary,
+)
+from questfoundry.graph.graph import Graph
+
+
+class TestTruncateSummary:
+    """Tests for truncate_summary."""
+
+    def test_short_text_unchanged(self) -> None:
+        assert truncate_summary("hello", 80) == "hello"
+
+    def test_exact_length_unchanged(self) -> None:
+        text = "x" * 80
+        assert truncate_summary(text, 80) == text
+
+    def test_truncates_at_word_boundary(self) -> None:
+        text = (
+            "The hero encounters the mentor at the crossroads and they discuss the ancient prophecy"
+        )
+        result = truncate_summary(text, 50)
+        assert len(result) <= 50
+        assert result.endswith("...")
+        # Should break at a word boundary, not mid-word
+        assert not result[-4].isalpha() or result[-4] == " " or result.endswith("...")
+
+    def test_empty_string(self) -> None:
+        assert truncate_summary("", 80) == ""
+
+    def test_custom_suffix(self) -> None:
+        result = truncate_summary("a very long text that needs truncating", 20, suffix="~")
+        assert result.endswith("~")
+        assert len(result) <= 20
+
+
+class TestCompactItems:
+    """Tests for compact_items."""
+
+    def test_all_items_fit(self) -> None:
+        items = [
+            ContextItem(id="a", text="short line"),
+            ContextItem(id="b", text="another line"),
+        ]
+        result = compact_items(items, CompactContextConfig(max_chars=100))
+        assert "short line" in result
+        assert "another line" in result
+
+    def test_empty_list(self) -> None:
+        assert compact_items([]) == ""
+
+    def test_priority_ordering(self) -> None:
+        items = [
+            ContextItem(id="low", text="low priority", priority=0),
+            ContextItem(id="high", text="high priority", priority=10),
+        ]
+        result = compact_items(items, CompactContextConfig(max_chars=500))
+        # High priority should come first
+        assert result.index("high priority") < result.index("low priority")
+
+    def test_drops_overflow_with_count(self) -> None:
+        items = [
+            ContextItem(id="a", text="x" * 50, priority=2),
+            ContextItem(id="b", text="x" * 50, priority=1),
+            ContextItem(id="c", text="x" * 50, priority=0),
+        ]
+        result = compact_items(items, CompactContextConfig(max_chars=80))
+        # Should include first item and note about omitted
+        assert "omitted" in result
+
+    def test_truncates_last_partial_item(self) -> None:
+        items = [
+            ContextItem(id="a", text="short", priority=1),
+            ContextItem(id="b", text="a much longer text that should be truncated", priority=0),
+        ]
+        result = compact_items(items, CompactContextConfig(max_chars=40))
+        assert "short" in result
+        assert "..." in result
+
+    def test_preserves_insertion_order_for_equal_priority(self) -> None:
+        items = [
+            ContextItem(id="first", text="first item"),
+            ContextItem(id="second", text="second item"),
+            ContextItem(id="third", text="third item"),
+        ]
+        result = compact_items(items, CompactContextConfig(max_chars=500))
+        assert result.index("first item") < result.index("second item")
+        assert result.index("second item") < result.index("third item")
+
+    def test_default_config(self) -> None:
+        items = [ContextItem(id="a", text="hello")]
+        result = compact_items(items)
+        assert result == "hello"
+
+
+class TestEnrichBeatLine:
+    """Tests for enrich_beat_line."""
+
+    def test_basic_format(self) -> None:
+        graph = Graph.empty()
+        beat_data = {
+            "summary": "Hero arrives at the village",
+            "scene_type": "scene",
+            "narrative_function": "introduce",
+        }
+        result = enrich_beat_line(graph, "beat::opening", beat_data)
+        assert "beat::opening" in result
+        assert "scene, introduce" in result
+        assert "Hero arrives" in result
+
+    def test_truncates_long_summary(self) -> None:
+        graph = Graph.empty()
+        long_summary = "A" * 200
+        beat_data = {"summary": long_summary, "scene_type": "scene"}
+        result = enrich_beat_line(graph, "beat::x", beat_data, summary_max=50)
+        # The summary portion should be truncated
+        assert "..." in result
+
+    def test_with_entities(self) -> None:
+        graph = Graph.empty()
+        graph.create_node(
+            "character::hero",
+            {
+                "type": "entity",
+                "raw_id": "hero",
+                "name": "Pim",
+                "concept": "A lost scholar",
+                "category": "character",
+            },
+        )
+        graph.create_node(
+            "location::village",
+            {
+                "type": "entity",
+                "raw_id": "village",
+                "name": "Oakvale",
+                "concept": "A quiet hamlet",
+                "category": "location",
+            },
+        )
+        beat_data = {
+            "summary": "Pim arrives at Oakvale",
+            "scene_type": "scene",
+            "narrative_function": "introduce",
+            "entities": ["character::hero", "location::village"],
+        }
+        result = enrich_beat_line(graph, "beat::arrival", beat_data, include_entities=True)
+        assert "(entities: Pim, Oakvale)" in result
+
+    def test_missing_entity_uses_id(self) -> None:
+        graph = Graph.empty()
+        beat_data = {
+            "summary": "Something happens",
+            "entities": ["character::unknown"],
+        }
+        result = enrich_beat_line(graph, "beat::x", beat_data, include_entities=True)
+        assert "character::unknown" in result
+
+    def test_no_tags_shows_unclassified(self) -> None:
+        graph = Graph.empty()
+        beat_data = {"summary": "Something"}
+        result = enrich_beat_line(graph, "beat::x", beat_data)
+        assert "unclassified" in result
+
+
+class TestBuildNarrativeFrame:
+    """Tests for build_narrative_frame."""
+
+    def test_with_dilemma(self) -> None:
+        graph = Graph.empty()
+        graph.create_node(
+            "dilemma::trust",
+            {
+                "type": "dilemma",
+                "raw_id": "trust",
+                "question": "Can the mentor be trusted?",
+                "why_it_matters": "The hero's survival depends on this alliance",
+            },
+        )
+        result = build_narrative_frame(graph, dilemma_ids=["dilemma::trust"])
+        assert "## Story Context" in result
+        assert "Can the mentor be trusted?" in result
+        assert "hero's survival" in result
+
+    def test_with_path(self) -> None:
+        graph = Graph.empty()
+        graph.create_node(
+            "dilemma::trust",
+            {
+                "type": "dilemma",
+                "raw_id": "trust",
+                "question": "Trust?",
+            },
+        )
+        graph.create_node(
+            "path::trust__yes",
+            {
+                "type": "path",
+                "raw_id": "trust__yes",
+                "description": "Hero chooses to trust the mentor",
+                "path_theme": "cautious bond deepens into reliance",
+                "path_mood": "fragile trust",
+            },
+        )
+        result = build_narrative_frame(
+            graph,
+            dilemma_ids=["dilemma::trust"],
+            path_ids=["path::trust__yes"],
+        )
+        assert "Trust?" in result
+        assert "cautious bond" in result
+        assert "fragile trust" in result
+
+    def test_empty_graph(self) -> None:
+        graph = Graph.empty()
+        result = build_narrative_frame(graph)
+        assert result == ""
+
+    def test_all_dilemmas_when_none_specified(self) -> None:
+        graph = Graph.empty()
+        graph.create_node(
+            "dilemma::a",
+            {
+                "type": "dilemma",
+                "raw_id": "a",
+                "question": "Question A?",
+            },
+        )
+        graph.create_node(
+            "dilemma::b",
+            {
+                "type": "dilemma",
+                "raw_id": "b",
+                "question": "Question B?",
+            },
+        )
+        result = build_narrative_frame(graph)
+        assert "Question A?" in result
+        assert "Question B?" in result
+
+    def test_missing_dilemma_skipped(self) -> None:
+        graph = Graph.empty()
+        result = build_narrative_frame(graph, dilemma_ids=["dilemma::nonexistent"])
+        assert result == ""
+
+    def test_path_without_theme_still_shows_description(self) -> None:
+        graph = Graph.empty()
+        graph.create_node(
+            "path::x",
+            {
+                "type": "path",
+                "raw_id": "x",
+                "description": "A journey through darkness",
+            },
+        )
+        result = build_narrative_frame(graph, dilemma_ids=[], path_ids=["path::x"])
+        assert "journey through darkness" in result


### PR DESCRIPTION
## Problem
Multiple GROW phases duplicate the same context-building pattern: collect nodes, format as lines, inject into template. There's no standard way to control context size or enrich items with inline narrative data. 42% of LLM calls exceed the ~8K char safe threshold (#779), while missing key narrative context (#784).

## Changes
- Add `ContextItem` and `CompactContextConfig` dataclasses for budget management
- Add `truncate_summary()`: word-boundary-aware text truncation
- Add `compact_items()`: renders items within character budget with priority ordering, truncation of partial items, and omission count for dropped items
- Add `enrich_beat_line()`: formats a beat as a compact enriched line with optional entity names from graph
- Add `build_narrative_frame()`: assembles dilemma/path briefs (question, stakes, theme, mood) as a compact markdown block for prompt injection
- 23 unit tests covering budget enforcement, truncation, priority ordering, enrichment, and empty inputs

## Not Included / Future PRs
- Phase-specific integration (each consumer phase is a separate PR): #794, #795, #796
- Template restructuring: #797

## Test Plan
```
uv run mypy src/questfoundry/graph/context_compact.py  # passes
uv run ruff check src/questfoundry/graph/context_compact.py  # passes
uv run pytest tests/unit/test_context_compact.py -x -q  # 23 passed
```

## Risk / Rollback
- New module only — no existing code is modified
- No behavior changes to any pipeline phase
- Safe to revert by deleting the file

Closes #792
Part of #791 (epic)

🤖 Generated with [Claude Code](https://claude.com/claude-code)