### PR TITLE
fix(grow): compact Phase 3 intersection candidates and add dilemma context

### DIFF
--- a/src/questfoundry/pipeline/stages/grow.py
+++ b/src/questfoundry/pipeline/stages/grow.py
@@ -854,7 +854,7 @@ class GrowStage:
 
         # Format candidates as pre-clustered groups for the LLM
         candidate_groups_text = format_intersection_candidates(
-            candidates, beat_nodes, beat_dilemmas
+            candidates, beat_nodes, beat_dilemmas, graph=graph
         )
 
         context: dict[str, str] = {

--- a/tests/unit/test_grow_algorithms.py
+++ b/tests/unit/test_grow_algorithms.py
@@ -2401,12 +2401,12 @@ class TestFormatIntersectionCandidates:
         result = format_intersection_candidates(candidates, beat_nodes, beat_dilemmas)
 
         assert '### Candidate Group 1 (shared location: "market")' in result
-        assert "Dilemmas represented: artifact_quest, mentor_trust" in result
-        assert "beat::mentor_meet [dilemma: mentor_trust]:" in result
-        assert "beat::artifact_discover [dilemma: artifact_quest]:" in result
-        assert 'summary="Hero meets mentor"' in result
-        assert 'location="market"' in result
-        assert "entities=['mentor', 'hero']" in result
+        assert "artifact_quest" in result
+        assert "mentor_trust" in result
+        assert "beat::mentor_meet [mentor_trust" in result
+        assert "beat::artifact_discover [artifact_quest" in result
+        assert "Hero meets mentor" in result
+        assert "(loc: market)" in result
 
     def test_formats_entity_group(self) -> None:
         """Entity-based candidate group shows entity signal in header."""
@@ -2434,7 +2434,8 @@ class TestFormatIntersectionCandidates:
         result = format_intersection_candidates(candidates, beat_nodes, beat_dilemmas)
 
         assert '### Candidate Group 1 (shared entity: "hero")' in result
-        assert "Dilemmas represented: dilemma_x, dilemma_y" in result
+        assert "dilemma_x" in result
+        assert "dilemma_y" in result
 
     def test_multiple_groups_numbered(self) -> None:
         """Multiple candidate groups are numbered sequentially."""
@@ -2543,8 +2544,8 @@ class TestFormatIntersectionCandidates:
         result = format_intersection_candidates(candidates, beat_nodes, beat_dilemmas)
 
         assert "beat::missing" in result
-        assert 'summary=""' in result
-        assert 'location="unspecified"' in result
+        assert '""' in result  # empty summary
+        assert "(loc: unspecified)" in result
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem
Phase 3 (intersections) was the largest LLM call in the pipeline at **44K chars** (11K tokens). The `format_intersection_candidates()` function dumps five fields per beat across 8-12 candidate groups, including redundant `location_alternatives` and raw `entities` arrays. Meanwhile, it provides no dilemma narrative context.

## Changes
- Remove `location_alternatives` field (redundant - group header already shows the shared location/entity signal)
- Remove raw `entities` array (replace with implicit entity context from group signal)
- Truncate beat summaries to 80 chars using `truncate_summary()` from #792
- Add `narrative_function` inline per beat: `[dilemma_tag, narrative_fn]`
- Add dilemma context per group when `graph` is provided: question + stakes (truncated to 100 chars)
- Pass `graph=graph` at Phase 3 call site in grow.py
- Update 6 existing format tests for new compact output

## Not Included / Future PRs
- Phases 4a-4d compaction: #795
- Phase 9 family compaction: #796

## Test Plan
```
uv run mypy src/questfoundry/graph/grow_algorithms.py  # passes
uv run ruff check src/questfoundry/graph/grow_algorithms.py  # passes
uv run pytest tests/unit/test_grow_algorithms.py::TestFormatIntersectionCandidates -x -q  # 6 passed
```

## Risk / Rollback
- Format change is output-visible but only affects LLM prompt content (not validated output)
- The `graph` parameter is optional with default `None` — backward-compatible for any callers without graph
- Per-beat: 5 lines/~200 chars -> 1 line/~120 chars. Expected: 44K -> 8-12K

Closes #794
Part of #791 (epic). Stacks on #799 (context compaction utility).

🤖 Generated with [Claude Code](https://claude.com/claude-code)