### PR TITLE
feat(context-compact): derive char budget from model context window

### DIFF
--- a/src/questfoundry/pipeline/orchestrator.py
+++ b/src/questfoundry/pipeline/orchestrator.py
@@ -635,6 +635,7 @@ class PipelineOrchestrator:
             stage_kwargs: dict[str, Any] = {}
             if self._model_info is not None:
                 stage_kwargs["max_concurrency"] = self._model_info.max_concurrency
+                stage_kwargs["context_window"] = self._model_info.context_window
             stage_kwargs["language"] = context.get("language") or self.config.language
             if resume_from:
                 stage_kwargs["resume_from"] = resume_from

--- a/tests/unit/test_context_compact.py
+++ b/tests/unit/test_context_compact.py
@@ -101,6 +101,34 @@ class TestCompactItems:
         assert result == "hello"
 
 
+class TestFromContextWindow:
+    """Tests for CompactContextConfig.from_context_window."""
+
+    def test_default_model_yields_near_6k(self) -> None:
+        """qwen3:4b-instruct-32k (32768 tokens) → ~5734 chars."""
+        cfg = CompactContextConfig.from_context_window(32_768)
+        assert 5000 <= cfg.max_chars <= 7000
+
+    def test_small_context_hits_floor(self) -> None:
+        """Tiny context window should clamp to minimum."""
+        cfg = CompactContextConfig.from_context_window(2_048)
+        assert cfg.max_chars == 2000
+
+    def test_huge_context_hits_ceiling(self) -> None:
+        """1M-token model should cap at 50K."""
+        cfg = CompactContextConfig.from_context_window(1_000_000)
+        assert cfg.max_chars == 50_000
+
+    def test_custom_fraction(self) -> None:
+        cfg = CompactContextConfig.from_context_window(32_768, budget_fraction=0.10)
+        assert cfg.max_chars == int(32_768 * 0.10 * 3.5)
+
+    def test_preserves_other_defaults(self) -> None:
+        cfg = CompactContextConfig.from_context_window(32_768)
+        assert cfg.summary_truncate == 80
+        assert cfg.truncation_suffix == "..."
+
+
 class TestEnrichBeatLine:
     """Tests for enrich_beat_line."""
 


### PR DESCRIPTION
## Problem
`CompactContextConfig.max_chars` was hardcoded to 6000 chars across all 5 call sites in GrowStage. This doesn't adapt to the model's actual context window — a model with 8K context gets the same budget as one with 1M.

## Changes
- Add `CompactContextConfig.from_context_window()` classmethod that derives `max_chars` proportionally (5% of context × 3.5 chars/token, clamped to 2K–50K)
- Pass `context_window` from orchestrator's `ModelInfo` to stage kwargs
- Store `context_window` on `GrowStage`, add `_compact_config()` helper
- Replace all 5 hardcoded `CompactContextConfig(max_chars=6000)` with `self._compact_config()`
- Add 5 unit tests for the classmethod

## Not Included / Future PRs
- Per-phase budget tuning (#810)

## Test Plan
- `uv run mypy src/` — clean
- `uv run ruff check src/` — clean
- `uv run pytest tests/unit/test_context_compact.py -x -q` — 28 passed

## Risk / Rollback
- For qwen3:4b-instruct-32k (32768 tokens), the formula yields ~5734 chars vs previous 6000 — negligible difference
- Falls back to default 6000 if context_window is not available (e.g., tests, direct instantiation)

Closes #804

🤖 Generated with [Claude Code](https://claude.com/claude-code)