### PR TITLE
fix(validation,grow): overlay scanning + terminal passage marking (#815, #816)

### DIFF
--- a/src/questfoundry/graph/grow_algorithms.py
+++ b/src/questfoundry/graph/grow_algorithms.py
@@ -571,18 +571,16 @@ def mark_terminal_passages(graph: Graph) -> int:
     passages = graph.get_nodes_by_type("passage")
     choices = graph.get_nodes_by_type("choice")
 
-    has_outgoing: set[str] = set()
-    for choice_data in choices.values():
-        src = choice_data.get("choice_from")
-        if src:
-            has_outgoing.add(str(src))
+    has_outgoing = {
+        choice_data["choice_from"]
+        for choice_data in choices.values()
+        if choice_data.get("choice_from")
+    }
 
-    marked = 0
-    for pid in passages:
-        if pid not in has_outgoing:
-            graph.update_node(pid, is_ending=True)
-            marked += 1
-    return marked
+    terminal = set(passages.keys()) - has_outgoing
+    for pid in terminal:
+        graph.update_node(pid, is_ending=True)
+    return len(terminal)
 
 
 def _build_collapse_exempt_passages(

--- a/src/questfoundry/graph/grow_algorithms.py
+++ b/src/questfoundry/graph/grow_algorithms.py
@@ -559,6 +559,32 @@ def _build_passage_outgoing_count(graph: Graph) -> dict[str, int]:
     return outgoing
 
 
+def mark_terminal_passages(graph: Graph) -> int:
+    """Derive and persist is_ending on passages with no outgoing choices.
+
+    A passage is terminal if no choice node has choice_from pointing to it.
+    Must be called before collapse so that endings are exempt from merging.
+
+    Returns:
+        Count of passages marked as ending.
+    """
+    passages = graph.get_nodes_by_type("passage")
+    choices = graph.get_nodes_by_type("choice")
+
+    has_outgoing: set[str] = set()
+    for choice_data in choices.values():
+        src = choice_data.get("choice_from")
+        if src:
+            has_outgoing.add(str(src))
+
+    marked = 0
+    for pid in passages:
+        if pid not in has_outgoing:
+            graph.update_node(pid, is_ending=True)
+            marked += 1
+    return marked
+
+
 def _build_collapse_exempt_passages(
     graph: Graph, passages: dict[str, dict[str, object]]
 ) -> set[str]:

--- a/src/questfoundry/graph/grow_validation.py
+++ b/src/questfoundry/graph/grow_validation.py
@@ -15,7 +15,7 @@ from collections import deque
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Literal
 
-from questfoundry.graph.context import normalize_scoped_id
+from questfoundry.graph.context import ENTITY_CATEGORIES, normalize_scoped_id
 
 if TYPE_CHECKING:
     from questfoundry.graph.graph import Graph
@@ -1088,9 +1088,11 @@ def check_codeword_gate_coverage(graph: Graph) -> ValidationCheck:
     for choice_data in choice_nodes.values():
         consumed.update(choice_data.get("requires") or [])
 
-    overlay_nodes = graph.get_nodes_by_type("overlay")
-    for overlay_data in overlay_nodes.values():
-        consumed.update(overlay_data.get("when") or [])
+    # Overlays are embedded arrays on entity nodes, not separate typed nodes.
+    for category in ENTITY_CATEGORIES:
+        for entity_data in graph.get_nodes_by_type(category).values():
+            for overlay in entity_data.get("overlays") or []:
+                consumed.update(overlay.get("when") or [])
 
     unconsumed = sorted(set(codeword_nodes.keys()) - consumed)
     if not unconsumed:

--- a/src/questfoundry/pipeline/stages/grow.py
+++ b/src/questfoundry/pipeline/stages/grow.py
@@ -246,6 +246,7 @@ class GrowStage:
             (self._phase_9_choices, "choices"),
             (self._phase_9b_fork_beats, "fork_beats"),
             (self._phase_9c_hub_spokes, "hub_spokes"),
+            (self._phase_9c2_mark_endings, "mark_endings"),
             (self._phase_9d_collapse_passages, "collapse_passages"),
             (self._phase_10_validation, "validation"),
             (self._phase_11_prune, "prune"),
@@ -3105,6 +3106,25 @@ class GrowStage:
             detail=f"Inserted {hubs_inserted} hub(s) with spokes",
             llm_calls=llm_calls,
             tokens_used=tokens,
+        )
+
+    async def _phase_9c2_mark_endings(
+        self,
+        graph: Graph,
+        model: BaseChatModel,  # noqa: ARG002
+    ) -> GrowPhaseResult:
+        """Phase 9c2: Mark terminal passages with is_ending flag.
+
+        Derives ending status from graph structure (no outgoing choices).
+        Must run before collapse so endings are exempt from merging.
+        """
+        from questfoundry.graph.grow_algorithms import mark_terminal_passages
+
+        count = mark_terminal_passages(graph)
+        return GrowPhaseResult(
+            phase="mark_endings",
+            status="completed",
+            detail=f"Marked {count} terminal passage(s) as endings",
         )
 
     async def _phase_9d_collapse_passages(

--- a/tests/unit/test_grow_stage.py
+++ b/tests/unit/test_grow_stage.py
@@ -209,10 +209,10 @@ class TestGrowStageExecute:
 
 
 class TestGrowStagePhaseOrder:
-    def test_phase_order_returns_twenty_two_phases(self) -> None:
+    def test_phase_order_returns_twenty_three_phases(self) -> None:
         stage = GrowStage()
         phases = stage._phase_order()
-        assert len(phases) == 22
+        assert len(phases) == 23
 
     def test_phase_order_names(self) -> None:
         stage = GrowStage()
@@ -237,6 +237,7 @@ class TestGrowStagePhaseOrder:
             "choices",
             "fork_beats",
             "hub_spokes",
+            "mark_endings",
             "collapse_passages",
             "validation",
             "prune",

--- a/tests/unit/test_grow_validation.py
+++ b/tests/unit/test_grow_validation.py
@@ -1611,21 +1611,54 @@ class TestCodewordGateCoverage:
         assert result.severity == "pass"
 
     def test_overlay_when_counts_as_consumed(self) -> None:
-        """Codewords referenced in overlay.when are counted as consumed."""
+        """Codewords in entity overlay.when are counted as consumed."""
         graph = Graph.empty()
         graph.create_node("codeword::cw1", {"type": "codeword", "raw_id": "cw1"})
         graph.create_node(
-            "overlay::o1",
+            "character::hero",
             {
-                "type": "overlay",
-                "entity_id": "character::hero",
-                "when": ["codeword::cw1"],
-                "description": "Hero looks weary",
+                "type": "character",
+                "raw_id": "hero",
+                "name": "Hero",
+                "overlays": [
+                    {"when": ["codeword::cw1"], "details": {"attitude": "weary"}},
+                ],
             },
         )
         result = check_codeword_gate_coverage(graph)
         assert result.severity == "pass"
         assert "consumed" in result.message
+
+    def test_overlay_multiple_entity_categories_consumed(self) -> None:
+        """Overlays on different entity categories all contribute to consumption."""
+        graph = Graph.empty()
+        graph.create_node("codeword::cw1", {"type": "codeword", "raw_id": "cw1"})
+        graph.create_node("codeword::cw2", {"type": "codeword", "raw_id": "cw2"})
+        graph.create_node(
+            "character::hero",
+            {
+                "type": "character",
+                "raw_id": "hero",
+                "name": "Hero",
+                "overlays": [
+                    {"when": ["codeword::cw1"], "details": {"attitude": "weary"}},
+                ],
+            },
+        )
+        graph.create_node(
+            "location::village",
+            {
+                "type": "location",
+                "raw_id": "village",
+                "name": "Village",
+                "overlays": [
+                    {"when": ["codeword::cw2"], "details": {"mood": "tense"}},
+                ],
+            },
+        )
+        result = check_codeword_gate_coverage(graph)
+        assert result.severity == "pass"
+        assert "2 codeword(s) consumed" in result.message
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

Two independent bugs in GROW validation and collapse:

1. **#815**: `check_codeword_gate_coverage()` reports false warnings about unconsumed codewords because it calls `graph.get_nodes_by_type("overlay")` which returns empty — overlays are stored as embedded arrays on entity nodes, not as separate typed nodes.

2. **#816**: `is_ending` is never persisted on passage nodes, making `_build_collapse_exempt_passages()`'s ending check dead code. Terminal passages can be collapsed into non-terminal merged passages, breaking story structure.

## Changes

- **grow_validation.py**: Replace `get_nodes_by_type("overlay")` with iteration over all `ENTITY_CATEGORIES`, scanning embedded `overlays` arrays for `when` conditions
- **grow_algorithms.py**: Add `mark_terminal_passages()` that derives ending status from graph structure (passages with no outgoing choices)
- **grow.py**: Add Phase 9c2 (`mark_endings`) between hub_spokes and collapse_passages
- **test_grow_validation.py**: Fix overlay test to use production graph structure (entity-embedded overlays), add multi-category test
- **test_grow_algorithms.py**: Add 3 tests for `mark_terminal_passages`

## Not Included / Future PRs

- Convergence funneling fix (#814) — separate PR

## Test Plan

```bash
uv run pytest tests/unit/test_grow_validation.py::TestCodewordGateCoverage -x -q  # 5 passed
uv run pytest tests/unit/test_grow_algorithms.py::TestMarkTerminalPassages -x -q  # 3 passed
uv run pytest tests/unit/test_grow_algorithms.py::TestCollapseLinearPassages::test_exempts_ending_passages -x -q  # 1 passed
uv run mypy src/questfoundry/graph/grow_validation.py src/questfoundry/graph/grow_algorithms.py src/questfoundry/pipeline/stages/grow.py  # Success
```

## Risk / Rollback

- Low risk: validation fix only affects diagnostic output, not story structure
- Ending marking is additive (sets a new flag) and only affects collapse behavior
- Both changes are backward-compatible with existing graphs

Closes #815
Closes #816

🤖 Generated with [Claude Code](https://claude.com/claude-code)