### PR TITLE
fix(grow): use from_passage field in mark_terminal_passages

### DIFF
--- a/src/questfoundry/graph/grow_algorithms.py
+++ b/src/questfoundry/graph/grow_algorithms.py
@@ -562,7 +562,7 @@ def _build_passage_outgoing_count(graph: Graph) -> dict[str, int]:
 def mark_terminal_passages(graph: Graph) -> int:
     """Derive and persist is_ending on passages with no outgoing choices.
 
-    A passage is terminal if no choice node has choice_from pointing to it.
+    A passage is terminal if no choice has from_passage pointing to it.
     Must be called before collapse so that endings are exempt from merging.
 
     Returns:
@@ -572,9 +572,9 @@ def mark_terminal_passages(graph: Graph) -> int:
     choices = graph.get_nodes_by_type("choice")
 
     has_outgoing = {
-        choice_data["choice_from"]
+        choice_data["from_passage"]
         for choice_data in choices.values()
-        if choice_data.get("choice_from")
+        if choice_data.get("from_passage")
     }
 
     terminal = set(passages.keys()) - has_outgoing

--- a/tests/unit/test_grow_algorithms.py
+++ b/tests/unit/test_grow_algorithms.py
@@ -4200,8 +4200,8 @@ class TestMarkTerminalPassages:
             "choice::a_b",
             {
                 "type": "choice",
-                "choice_from": "passage::a",
-                "choice_to": "passage::b",
+                "from_passage": "passage::a",
+                "to_passage": "passage::b",
                 "label": "go",
             },
         )
@@ -4209,8 +4209,8 @@ class TestMarkTerminalPassages:
             "choice::b_c",
             {
                 "type": "choice",
-                "choice_from": "passage::b",
-                "choice_to": "passage::c",
+                "from_passage": "passage::b",
+                "to_passage": "passage::c",
                 "label": "go",
             },
         )


### PR DESCRIPTION
## Problem

`mark_terminal_passages()` (merged in PR #817) checks `choice_data.get("choice_from")` but choice nodes use `from_passage` as their field name. This caused ALL passages to be marked as endings since the field was never found, breaking collapse exemption and likely causing retry cascading (72 GROW calls instead of 36 in test-big-hard-2b).

## Changes

- **grow_algorithms.py**: Change `choice_from` → `from_passage` in `mark_terminal_passages()`
- **test_grow_algorithms.py**: Fix test choice nodes to use `from_passage`/`to_passage` matching production graph structure

## Test Plan

```bash
uv run pytest tests/unit/test_grow_algorithms.py::TestMarkTerminalPassages -x -q  # 3 passed
uv run mypy src/questfoundry/graph/grow_algorithms.py  # Success
```

## Risk / Rollback

Single field name change. Low risk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)