### PR TITLE
fix(grow): scan entity type for overlay codeword consumption (#815)

### DIFF
--- a/src/questfoundry/graph/grow_validation.py
+++ b/src/questfoundry/graph/grow_validation.py
@@ -15,7 +15,7 @@ from collections import deque
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Literal
 
-from questfoundry.graph.context import ENTITY_CATEGORIES, normalize_scoped_id
+from questfoundry.graph.context import normalize_scoped_id
 
 if TYPE_CHECKING:
     from questfoundry.graph.graph import Graph
@@ -1088,11 +1088,11 @@ def check_codeword_gate_coverage(graph: Graph) -> ValidationCheck:
     for choice_data in choice_nodes.values():
         consumed.update(choice_data.get("requires") or [])
 
-    # Overlays are embedded arrays on entity nodes, not separate typed nodes.
-    for category in ENTITY_CATEGORIES:
-        for entity_data in graph.get_nodes_by_type(category).values():
-            for overlay in entity_data.get("overlays") or []:
-                consumed.update(overlay.get("when") or [])
+    # Overlays are embedded arrays on entity nodes (type="entity"),
+    # not separate typed nodes.
+    for entity_data in graph.get_nodes_by_type("entity").values():
+        for overlay in entity_data.get("overlays") or []:
+            consumed.update(overlay.get("when") or [])
 
     unconsumed = sorted(set(codeword_nodes.keys()) - consumed)
     if not unconsumed:

--- a/src/questfoundry/graph/grow_validation.py
+++ b/src/questfoundry/graph/grow_validation.py
@@ -1090,9 +1090,12 @@ def check_codeword_gate_coverage(graph: Graph) -> ValidationCheck:
 
     # Overlays are embedded arrays on entity nodes (type="entity"),
     # not separate typed nodes.
-    for entity_data in graph.get_nodes_by_type("entity").values():
-        for overlay in entity_data.get("overlays") or []:
-            consumed.update(overlay.get("when") or [])
+    consumed.update(
+        cw
+        for entity_data in graph.get_nodes_by_type("entity").values()
+        for overlay in entity_data.get("overlays") or []
+        for cw in overlay.get("when") or []
+    )
 
     unconsumed = sorted(set(codeword_nodes.keys()) - consumed)
     if not unconsumed:

--- a/tests/unit/test_grow_validation.py
+++ b/tests/unit/test_grow_validation.py
@@ -1617,9 +1617,10 @@ class TestCodewordGateCoverage:
         graph.create_node(
             "character::hero",
             {
-                "type": "character",
+                "type": "entity",
                 "raw_id": "hero",
                 "name": "Hero",
+                "category": "character",
                 "overlays": [
                     {"when": ["codeword::cw1"], "details": {"attitude": "weary"}},
                 ],
@@ -1637,9 +1638,10 @@ class TestCodewordGateCoverage:
         graph.create_node(
             "character::hero",
             {
-                "type": "character",
+                "type": "entity",
                 "raw_id": "hero",
                 "name": "Hero",
+                "category": "character",
                 "overlays": [
                     {"when": ["codeword::cw1"], "details": {"attitude": "weary"}},
                 ],
@@ -1648,9 +1650,10 @@ class TestCodewordGateCoverage:
         graph.create_node(
             "location::village",
             {
-                "type": "location",
+                "type": "entity",
                 "raw_id": "village",
                 "name": "Village",
+                "category": "location",
                 "overlays": [
                     {"when": ["codeword::cw2"], "details": {"mood": "tense"}},
                 ],


### PR DESCRIPTION
## Problem

PR #817 fixed overlay scanning to look at entity-embedded overlays instead of
`overlay::` typed nodes. However, it iterated `ENTITY_CATEGORIES` (character,
location, object, faction) and called `get_nodes_by_type("character")` etc.

In production, ALL entity nodes have `type="entity"` — the category (character,
location, etc.) is the ID scope prefix, not the type field. So
`get_nodes_by_type("character")` returns empty, and all overlay codewords
remain "unconsumed".

## Changes

- Use `get_nodes_by_type("entity")` instead of iterating `ENTITY_CATEGORIES`
- Remove unused `ENTITY_CATEGORIES` import from grow_validation.py
- Fix test entity nodes to use `type="entity"` matching production structure

## Verification

```
$ uv run qf inspect -p projects/test-big-hard-2b --json | jq '.validation_checks[] | select(.name == "codeword_gate_coverage")'
{
  "name": "codeword_gate_coverage",
  "severity": "pass",
  "message": "All 9 codeword(s) consumed by gates or overlays"
}
```

Before fix: `severity: "warn"`, 5/9 unconsumed.

## Test Plan

- `uv run pytest tests/unit/test_grow_validation.py::TestCodewordGateCoverage -x -q` — 5 passed
- `uv run mypy src/questfoundry/graph/grow_validation.py` — clean
- `uv run qf inspect` against test-big-hard-2b confirms pass

## Risk / Rollback

Minimal — single function, same intent as #817, just correct type lookup.

Closes #815

🤖 Generated with [Claude Code](https://claude.com/claude-code)