### PR TITLE
feat(viz): add overlay and grants styling to graph visualization

### DIFF
--- a/src/questfoundry/visualization.py
+++ b/src/questfoundry/visualization.py
@@ -118,7 +118,7 @@ def build_story_graph(
     # Track which passages contain overlay-affected entities
     overlay_passages: set[str] = set()
     for pid, pdata in passages.items():
-        for ent in pdata.get("entities", []):
+        for ent in pdata.get("entities") or []:
             # Check both raw ID and scoped forms
             if ent in overlay_entity_ids:
                 overlay_passages.add(pid)

--- a/tests/unit/test_visualization.py
+++ b/tests/unit/test_visualization.py
@@ -418,3 +418,119 @@ class TestRenderMermaid:
         mmd = render_mermaid(sg)
         return_lines = [row for row in mmd.split("\n") if "passage_spoke" in row and "-.->" in row]
         assert len(return_lines) == 1
+
+
+def _make_overlay_graph() -> Graph:
+    """Build a graph with overlay-affected entities on passages."""
+    graph = _make_simple_graph()
+
+    # Entity with overlays
+    graph.create_node(
+        "character::alice",
+        {
+            "type": "entity",
+            "entity_type": "character",
+            "name": "Alice",
+            "overlays": [{"codeword": "saw_truth", "field": "mood", "value": "angry"}],
+        },
+    )
+
+    # Attach entity to intro passage
+    graph.update_node("passage::intro", entities=["character::alice"])
+
+    return graph
+
+
+def _make_grants_graph() -> Graph:
+    """Build a graph with a choice that grants codewords."""
+    graph = _make_simple_graph()
+
+    # Update existing choice to grant a codeword
+    graph.update_node("choice::intro_middle", grants=["saw_truth"])
+
+    return graph
+
+
+class TestOverlayPassages:
+    """Tests for overlay-affected passage detection."""
+
+    def test_overlay_passage_detected(self) -> None:
+        graph = _make_overlay_graph()
+        sg = build_story_graph(graph)
+        node_map = {n.id: n for n in sg.nodes}
+        assert node_map["passage::intro"].has_overlays is True
+
+    def test_non_overlay_passage_clean(self) -> None:
+        graph = _make_overlay_graph()
+        sg = build_story_graph(graph)
+        node_map = {n.id: n for n in sg.nodes}
+        assert node_map["passage::middle"].has_overlays is False
+        assert node_map["passage::ending"].has_overlays is False
+
+    def test_dot_overlay_border(self) -> None:
+        graph = _make_overlay_graph()
+        sg = build_story_graph(graph)
+        dot = render_dot(sg)
+        intro_line = next(
+            row for row in dot.split("\n") if '"passage::intro"' in row and "->" not in row
+        )
+        assert "#FF4500" in intro_line
+        assert "penwidth" in intro_line
+
+    def test_mermaid_overlay_class(self) -> None:
+        graph = _make_overlay_graph()
+        sg = build_story_graph(graph)
+        mmd = render_mermaid(sg)
+        # Start node with overlay gets startOverlay class
+        assert ":::startOverlay" in mmd
+        assert "classDef overlay" in mmd
+
+
+class TestGrantsEdges:
+    """Tests for state-changing choice edges."""
+
+    def test_grants_field_populated(self) -> None:
+        graph = _make_grants_graph()
+        sg = build_story_graph(graph)
+        edge = next(e for e in sg.edges if e.from_id == "passage::intro")
+        assert edge.grants == ["saw_truth"]
+
+    def test_dot_grants_color(self) -> None:
+        graph = _make_grants_graph()
+        sg = build_story_graph(graph)
+        dot = render_dot(sg)
+        grants_line = next(
+            row for row in dot.split("\n") if '"passage::intro" -> "passage::middle"' in row
+        )
+        assert "#6A5ACD" in grants_line
+
+    def test_mermaid_grants_linkstyle(self) -> None:
+        graph = _make_grants_graph()
+        sg = build_story_graph(graph)
+        mmd = render_mermaid(sg)
+        assert "linkStyle" in mmd
+        assert "#6A5ACD" in mmd
+
+
+class TestOutgoingCount:
+    """Tests for outgoing edge counting."""
+
+    def test_linear_passage_count(self) -> None:
+        graph = _make_simple_graph()
+        sg = build_story_graph(graph)
+        node_map = {n.id: n for n in sg.nodes}
+        assert node_map["passage::intro"].outgoing_count == 1
+        assert node_map["passage::middle"].outgoing_count == 1
+
+    def test_branching_passage_count(self) -> None:
+        graph = _make_branching_graph()
+        sg = build_story_graph(graph)
+        node_map = {n.id: n for n in sg.nodes}
+        # intro has 2 outgoing: middle + branch
+        assert node_map["passage::intro"].outgoing_count == 2
+
+    def test_ending_passage_zero_count(self) -> None:
+        graph = _make_simple_graph()
+        sg = build_story_graph(graph)
+        node_map = {n.id: n for n in sg.nodes}
+        assert node_map["passage::ending"].outgoing_count == 0


### PR DESCRIPTION
## Problem
The `qf graph` command showed basic passage/choice structure but didn't visually distinguish state-changing elements: passages with codeword-dependent prose (overlays) looked identical to regular passages, and choices that grant codewords were indistinguishable from plain choices.

## Changes
- **Overlay passages** (containing entities with codeword-dependent content) get a thick orange-red border in DOT output and dedicated CSS classes (`overlay`, `startOverlay`, `endingOverlay`) in Mermaid
- **Grants edges** (choices that set codewords) rendered in slate blue (`#6A5ACD`) with thick lines in both DOT and Mermaid
- `VizNode` gains `has_overlays` (bool) and `outgoing_count` (int) fields
- `VizEdge` gains `grants` (list[str]) field
- `build_story_graph` detects overlay-affected passages by tracing entity overlays through both raw and scoped ID formats
- 16 new tests covering overlay detection, grants edge rendering, and outgoing count calculation

## Not Included / Future PRs
- Visual distinction for linear vs branching passages (data is available via `outgoing_count` but no rendering difference yet)
- Legend/key in output explaining color coding

## Test Plan
```bash
uv run pytest tests/unit/test_visualization.py -x -q  # 37 passed
uv run mypy src/questfoundry/visualization.py          # no issues
uv run ruff check src/questfoundry/visualization.py    # all passed
uv run qf graph -p test-murder-gpt5mini-retry -f dot   # verified overlay borders + grants colors
uv run qf graph -p test-murder-gpt5mini-retry -f json  # verified new fields in JSON output
```

Test project stats: 55/74 overlay passages, 17/97 grants edges, 0 gated choices.

## Risk / Rollback
- Additive change only — no existing behavior modified
- JSON output gains new fields (`has_overlays`, `outgoing_count`, `grants`) which is backward compatible

🤖 Generated with [Claude Code](https://claude.com/claude-code)