### PR TITLE
fix(grow): preserve grants on fork reconverge choices

### DIFF
--- a/src/questfoundry/pipeline/stages/grow.py
+++ b/src/questfoundry/pipeline/stages/grow.py
@@ -2874,6 +2874,10 @@ class GrowStage:
                 log.warning("phase9b_no_choice_found", from_p=fork_at, to_p=next_passage)
                 continue
 
+            # Preserve grants from old choice before removing it
+            old_choice_data = graph.get_node(old_choice_id) or {}
+            old_grants = old_choice_data.get("grants", [])
+
             # Remove old choice node and its edges
             graph.delete_node(old_choice_id, cascade=True)
             forked_passages.add(fork_at)
@@ -2936,7 +2940,7 @@ class GrowStage:
                         "to_passage": next_passage,
                         "label": "continue",
                         "requires": [],
-                        "grants": [],
+                        "grants": old_grants,
                     },
                 )
                 graph.add_edge("choice_from", choice_id, opt_id)


### PR DESCRIPTION
## Problem
Phase 9b (fork_beats) replaces a linear choice with a fork pattern (2 synthetic passages, 4 choices). The reconverge choices (`opt→next_passage`) were hardcoded with `grants=[]`, discarding any codeword grants from the original choice. This caused `gate_satisfiability` failure when downstream intersection choices required the lost codeword.

Found in `test-murder-gpt5mini-retry2`: `codeword::homicide_investigation_committed` was granted on the `homicide_beat_01→beat_02` choice, which Phase 9b replaced with a fork. The 5 intersection choices requiring this codeword became unsatisfiable.

## Changes
- Capture `old_grants` from the replaced choice before deletion
- Pass `old_grants` to both reconverge choice nodes
- Add test `test_fork_preserves_grants_on_reconverge`

## Not Included / Future PRs
- No other phase has this issue (Phase 9c hub spokes correctly use `spoke.grants` from LLM)

## Test Plan
```bash
uv run pytest tests/unit/test_grow_stage.py::TestPhase9bForkBeats -x -q  # 4 passed
uv run mypy src/questfoundry/pipeline/stages/grow.py                     # no issues
```

## Risk / Rollback
- Minimal change (3 lines of logic + test)
- Only affects stories where a fork is inserted at a grants-carrying choice

Closes #833

🤖 Generated with [Claude Code](https://claude.com/claude-code)