### PR TITLE
fix(prompts): add anti-helpfulness guards to SEED and DREAM discuss prompts

### DIFF
--- a/prompts/templates/discuss.yaml
+++ b/prompts/templates/discuss.yaml
@@ -66,6 +66,10 @@ non_interactive_section: |
   Complete the required corpus research (see above), then weave what you
   find into confident, specific creative choices.
 
+  After producing your creative vision, STOP. Do not offer next steps,
+  summaries of what could come next, or follow-up work. A separate
+  automated pipeline step handles consolidation.
+
 research_tools_section: |
   ## Craft Corpus Research (REQUIRED)
   You have access to a curated craft corpus containing editorial guidance

--- a/prompts/templates/discuss_seed.yaml
+++ b/prompts/templates/discuss_seed.yaml
@@ -159,6 +159,9 @@ system: |
   - Do NOT invent locations not in the brainstorm material above
   - Do NOT use objects as locations (objects are NOT places)
   - Do NOT ask clarifying questions in non-interactive mode
+  - Do NOT end with "let me know if you need..." or "If you want, next I can..." - this is not a chat
+  - Do NOT offer follow-up work (flow diagrams, scene flows, beat expansions, checklists, etc.)
+  - Do NOT preview what later stages will do — your scope ends at entity curation, paths, and beats
   {output_language_instruction}
   {research_tools_section}
   {mode_section}
@@ -167,6 +170,10 @@ non_interactive_section: |
   ## Mode: Autonomous
   Make confident curation decisions consistent with the creative vision.
   Do NOT ask clarifying questions - commit to choices that serve the story.
+
+  After producing entity decisions, paths, and beats, STOP. Do not offer
+  next steps, summaries of what could come next, or follow-up work. A
+  separate automated pipeline step handles serialization.
 
 research_tools_section: |
   ## Craft Corpus Research (REQUIRED)
@@ -201,5 +208,8 @@ interactive_section: |
   The user can type **/done** or press Enter at any time to end this conversation
   and move forward. You don't need to reach perfect consensus — a rough direction
   is enough. When the user seems satisfied, don't introduce new concerns.
+
+  Your scope is entity curation, paths, and beats only. Do not offer to produce
+  flow diagrams, scene expansions, checklists, or other downstream deliverables.
 
 components: []


### PR DESCRIPTION
## Problem
GPT-5 was offering follow-up work during interactive seed sessions ("If you want, next I can: turn this into a flow diagram, expand paths into scene flows, present retain/cut as a checklist..."). PR #718/#720 added anti-helpfulness guards to BRAINSTORM but missed SEED and DREAM.

## Changes
- **`discuss_seed.yaml`**: Add 3 "Do NOT" items matching brainstorm pattern (no follow-up offers, no previewing later stages, no chat-style endings), STOP instruction in non-interactive section, scope reminder in interactive section
- **`discuss.yaml`**: Add STOP instruction in non-interactive section

## Not Included
- FILL and DRESS discuss templates already have adequate guards

## Test Plan
- Prompt-only change; no code or tests affected
- Verified YAML syntax passes `check yaml` pre-commit hook

## Risk / Rollback
- Zero risk — additive prompt constraints only
- No code changes

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>