### PR TITLE
refactor(prompts): replace anti-helpfulness blacklists with task sandbox guardrails

### DIFF
--- a/prompts/components/task_sandbox.yaml
+++ b/prompts/components/task_sandbox.yaml
@@ -1,0 +1,20 @@
+name: task_sandbox
+description: Shared task boundary enforcement for all discuss phases
+
+content: |
+  ## Task Boundary
+
+  You are one stage in a multi-stage pipeline. Your deliverables are defined
+  above — everything outside them is handled by other stages with their own
+  prompts, context, and validation.
+
+  Work beyond your deliverables is discarded by the pipeline. Later stages
+  cannot see your conversation, only the structured artifact this stage
+  produces. Offering downstream work (diagrams, expansions, checklists,
+  scene flows) is wasted effort — the pipeline discards it.
+
+  **When your deliverables are complete, end your response.** Do not:
+  - Summarize what you produced
+  - Suggest next steps or offer follow-up work
+  - Preview what later stages will do
+  - End with "let me know if..." or "If you want, next I can..."

--- a/prompts/templates/discuss.yaml
+++ b/prompts/templates/discuss.yaml
@@ -3,7 +3,11 @@ description: Creative exploration phase for interactive fiction development
 
 system: |
   You are a creative collaborator establishing HIGH-LEVEL VISION for interactive fiction.
-  Your goal is genre, tone, and themes - NOT characters, plot, or mechanics.
+
+  ## Task Contract
+  Stage: DREAM (1 of 6: DREAM → BRAINSTORM → SEED → GROW → FILL → SHIP)
+  Deliverables: genre/subgenre, tone, themes, audience, scope, style guidance
+  Completion: when the creative vision is established
 
   ## Your Goal
   Help the user arrive at answers (even rough ones) for these creative questions:
@@ -57,6 +61,7 @@ system: |
   Remember: DREAM = vision only. A sparse, evocative vision (50-100 words) is better
   than a comprehensive treatment. If you're naming characters or designing mechanics,
   you've gone too far.
+  {sandbox_section}
   {mode_section}
 
 non_interactive_section: |
@@ -123,5 +128,9 @@ interactive_section: |
   The user can type **/done** or press Enter at any time to end this conversation
   and move forward. You don't need to reach perfect consensus — a rough direction
   is enough. When the user seems satisfied, don't introduce new concerns.
+
+  If the user asks about downstream work (characters, plot structure, mechanics),
+  acknowledge their interest and redirect: "That's handled in a later stage.
+  For now, let's focus on the creative vision."
 
 components: []

--- a/prompts/templates/discuss_brainstorm.yaml
+++ b/prompts/templates/discuss_brainstorm.yaml
@@ -4,6 +4,11 @@ description: Creative exploration phase for generating story entities and dilemm
 system: |
   You are a creative collaborator helping to brainstorm story elements for an interactive fiction project.
 
+  ## Task Contract
+  Stage: BRAINSTORM (2 of 6: DREAM → BRAINSTORM → SEED → GROW → FILL → SHIP)
+  Deliverables: {size_entities} entities and {size_dilemmas} binary dilemmas
+  Completion: when all entities and dilemmas are produced
+
   ## Creative Vision Context
   {vision_context}
 
@@ -95,15 +100,12 @@ system: |
 
   **DO NOT copy example IDs** - generate IDs specific to YOUR story's characters and dilemmas.
 
-  ## What NOT to Do
+  ## Format Pitfalls
   - Do NOT write prose paragraphs with backstories - use concise notes
   - Do NOT include atmospheric descriptions - save prose for later stages
-  - Do NOT end with "let me know if you need..." - this is not a chat
   - Do NOT ask clarifying questions in non-interactive mode
   - Do NOT use short codes like `d1`, `d2` for dilemma IDs - use descriptive names
   - Do NOT end dilemma IDs with `_or_` — the ID must end with the second option word
-  - Do NOT offer follow-up work (beat maps, motive matrices, scene hooks, timelines, etc.)
-  - Do NOT preview what later stages will do — your scope ends at entities and dilemmas
 
   ## Output Format Examples
 
@@ -116,6 +118,7 @@ system: |
   "Concept: Seasoned detective with sharp wit. Notes: Classical music lover,
   impeccable dresser - surface polish hiding relentless curiosity."
   {output_language_instruction}
+  {sandbox_section}
   {mode_section}
 
 non_interactive_section: |
@@ -127,10 +130,6 @@ non_interactive_section: |
   ## Deliverables (nothing more, nothing less)
   1. {size_entities} entities across characters, locations, objects, and factions
   2. {size_dilemmas} binary dilemmas with central entity links and why_it_matters
-
-  After producing entities and dilemmas, STOP. Do not offer next steps, summaries
-  of what could come next, or follow-up work. A separate automated pipeline step
-  handles consolidation.
 
   Complete the required corpus research (see above). Use `web_search` for
   culturally specific names or real-world inspiration that fits the
@@ -185,7 +184,8 @@ interactive_section: |
   and move forward. You don't need to reach perfect consensus — a rough direction
   is enough. When the user seems satisfied, don't introduce new concerns.
 
-  Your scope is entities and dilemmas only. Do not offer to produce beat maps,
-  scene hooks, or other downstream deliverables.
+  If the user asks about downstream work (beat maps, scene hooks, path design),
+  acknowledge their interest and redirect: "That's handled in a later stage.
+  For now, let's focus on entities and dilemmas."
 
 components: []

--- a/prompts/templates/discuss_seed.yaml
+++ b/prompts/templates/discuss_seed.yaml
@@ -6,6 +6,11 @@ system: |
   story structure. This is the SEED stage - the last point where new paths
   can be created.
 
+  ## Task Contract
+  Stage: SEED (3 of 6: DREAM → BRAINSTORM → SEED → GROW → FILL → SHIP)
+  Deliverables: entity decisions (retain/cut), paths with beats, convergence design
+  Completion: when all entities are triaged and paths have beats
+
   ## What You're Working With
 
   **Entities** are your cast and stage:
@@ -153,7 +158,7 @@ system: |
   - **commits**: Point of no return - answer is locked in
   - **complicates**: Introduces doubt or new dimension
 
-  ## What NOT to Do
+  ## Format Pitfalls
   - Do NOT skip beat creation - every path needs beats
   - Do NOT reuse dilemma IDs as path IDs
   - Do NOT invent locations not in the brainstorm material above
@@ -161,6 +166,7 @@ system: |
   - Do NOT ask clarifying questions in non-interactive mode
   {output_language_instruction}
   {research_tools_section}
+  {sandbox_section}
   {mode_section}
 
 non_interactive_section: |
@@ -201,5 +207,9 @@ interactive_section: |
   The user can type **/done** or press Enter at any time to end this conversation
   and move forward. You don't need to reach perfect consensus — a rough direction
   is enough. When the user seems satisfied, don't introduce new concerns.
+
+  If the user asks about downstream work (scene prose, graph structure, exports),
+  acknowledge their interest and redirect: "That's handled in a later stage.
+  For now, let's focus on entity curation, paths, and beats."
 
 components: []

--- a/prompts/templates/dress_discuss.yaml
+++ b/prompts/templates/dress_discuss.yaml
@@ -5,6 +5,11 @@ system: |
   You are a creative collaborator establishing the VISUAL IDENTITY for an interactive fiction story.
   The story's narrative is complete — you are designing how it looks, not what it says.
 
+  ## Task Contract
+  Stage: DRESS (after FILL: DREAM → BRAINSTORM → SEED → GROW → FILL → DRESS → SHIP)
+  Deliverables: art style, entity visual profiles, negative defaults, aspect ratio
+  Completion: when visual identity is established
+
   ## Your Goal
   Help establish the art direction for illustrations and visual presentation:
   - Art style and medium (watercolor, ink, digital painting, pixel art, etc.)
@@ -30,7 +35,6 @@ system: |
   - The reference_prompt_fragment for each entity should describe APPEARANCE ONLY (clothing, colors, build, distinguishing features — no camera angles, framing, poses, or actions)
   - Think about what should be AVOIDED globally (photorealism for a stylized story, etc.)
   {research_tools_section}
-  {mode_section}
 
   ## DRESS Stage Scope (CRITICAL)
   DRESS establishes VISUAL IDENTITY only. Do NOT modify the story's narrative.
@@ -45,6 +49,8 @@ system: |
   - Story changes, plot modifications, or new characters
   - Prose or dialogue
   - Mechanical or gameplay changes
+  {sandbox_section}
+  {mode_section}
 
 research_tools_section: |
   ## Craft Corpus Research (REQUIRED)
@@ -87,5 +93,9 @@ interactive_section: |
   The user can type **/done** or press Enter at any time to end this conversation
   and move forward. You don't need to reach perfect consensus — a rough direction
   is enough. When the user seems satisfied, don't introduce new concerns.
+
+  If the user asks about downstream work (image generation, codex entries, exports),
+  acknowledge their interest and redirect: "That's handled in a later stage.
+  For now, let's focus on art direction and visual identity."
 
 components: []

--- a/prompts/templates/fill_phase0_discuss.yaml
+++ b/prompts/templates/fill_phase0_discuss.yaml
@@ -6,6 +6,11 @@ system: |
   The story's structure (beats, arcs, passages) is already complete. Your task is to determine
   HOW the story will be told: POV, tense, register, and voice characteristics.
 
+  ## Task Contract
+  Stage: FILL (5 of 6: DREAM → BRAINSTORM → SEED → GROW → FILL → SHIP)
+  Deliverables: POV choice, tense choice, voice register decisions
+  Completion: when voice decisions are established
+
   ## Your Goal
   Establish the voice document contract that will govern all prose generation:
   - Point of view (whose perspective, what distance)
@@ -68,7 +73,6 @@ system: |
 
   Do NOT skip research because you think you already know the answer.
   The corpus may contain guidance that contradicts or refines your assumptions.
-  {mode_section}
 
   ## FILL Stage Scope (CRITICAL)
   FILL establishes VOICE only. Do NOT modify the story's structure.
@@ -83,6 +87,8 @@ system: |
   - Plot changes, beat modifications, or new characters
   - Mechanical or gameplay changes
   - Art direction (handled separately)
+  {sandbox_section}
+  {mode_section}
 
 non_interactive_section: |
   ## Mode: Autonomous
@@ -102,5 +108,9 @@ interactive_section: |
   The user can type **/done** or press Enter at any time to end this conversation
   and move forward. You don't need to reach perfect consensus — a rough direction
   is enough. When the user seems satisfied, don't introduce new concerns.
+
+  If the user asks about downstream work (prose generation, art direction, exports),
+  acknowledge their interest and redirect: "That's handled in a later stage.
+  For now, let's focus on voice and style decisions."
 
 components: []

--- a/src/questfoundry/agents/prompts.py
+++ b/src/questfoundry/agents/prompts.py
@@ -115,6 +115,17 @@ def _load_raw_template(template_name: str) -> dict[str, Any]:
         return dict(yaml.load(f))
 
 
+def load_sandbox_section() -> str:
+    """Load shared task sandbox guardrails from components."""
+    from ruamel.yaml import YAML
+
+    path = _get_prompts_path() / "components" / "task_sandbox.yaml"
+    yaml = YAML()
+    with path.open("r", encoding="utf-8") as f:
+        data = dict(yaml.load(f))
+    return str(data.get("content", ""))
+
+
 def _render_discuss_template(
     template_name: str,
     research_tools_available: bool,
@@ -144,6 +155,7 @@ def _render_discuss_template(
     section_key = "interactive_section" if interactive else "non_interactive_section"
     mode_section = raw_data.get(section_key, "")
     size_presets_section = raw_data.get("size_presets_section", "")
+    sandbox_section = load_sandbox_section()
 
     system_template = raw_data.get("system", "")
     prompt = PromptTemplate.from_template(system_template)
@@ -152,6 +164,7 @@ def _render_discuss_template(
         research_tools_section=research_section,
         mode_section=mode_section,
         size_presets_section=size_presets_section,
+        sandbox_section=sandbox_section,
         **kwargs,
     )
 

--- a/src/questfoundry/pipeline/stages/dress.py
+++ b/src/questfoundry/pipeline/stages/dress.py
@@ -449,10 +449,13 @@ class DressStage:
         # Include corpus research section only when tools are available
         research_section = getattr(discuss_template, "research_tools_section", "") if tools else ""
 
+        from questfoundry.agents.prompts import load_sandbox_section
+
         system_prompt = discuss_template.system.format(
             vision_context=vision_context,
             entity_list=entity_list,
             research_tools_section=research_section,
+            sandbox_section=load_sandbox_section(),
             mode_section=mode_section,
         )
 

--- a/src/questfoundry/pipeline/stages/fill.py
+++ b/src/questfoundry/pipeline/stages/fill.py
@@ -826,11 +826,14 @@ class FillStage:
             else:
                 mode_section = str(raw_mode_section)
 
+        from questfoundry.agents.prompts import load_sandbox_section
+
         system_prompt = template.system.format(
             dream_vision=format_dream_vision(graph),
             grow_summary=format_grow_summary(graph),
             valid_characters=format_valid_characters(graph),
             pov_context=format_pov_context(graph),
+            sandbox_section=load_sandbox_section(),
             mode_section=mode_section,
         )
 


### PR DESCRIPTION
## Problem

GPT-5's RLHF training causes it to offer follow-up work after completing stage tasks (flow diagrams, scene expansions, checklists). PR #835 attempted to fix this with "Do NOT offer follow-up" blacklists, but this fights the model's training — the model treats prohibitions as suppressible suggestions. Reframing as **task sandboxing** leverages the training instead: define what the task IS, explain WHY out-of-scope work is discarded.

Replaces (closed) PR #835.

## Changes

- **New shared component** `prompts/components/task_sandbox.yaml` — single source of truth for task boundary enforcement, explains that the pipeline discards out-of-scope work
- **Task Contract** added to all 5 discuss templates (DREAM, BRAINSTORM, SEED, FILL, DRESS) — front-loads stage position, deliverables, and completion condition
- **Sandbox injection** via `{sandbox_section}` placeholder in all templates, loaded by `load_sandbox_section()` in `agents/prompts.py`
- **Format Pitfalls** — renamed from "What NOT to Do", retaining only format/validation-specific items (ID naming, prose vs notes)
- **Interactive redirect** — gives model behavior TO DO ("acknowledge interest, redirect back to scope") instead of prohibition
- **Simplified mode sections** — removed redundant STOP/follow-up instructions now handled by sandbox

### Design Principles (from prompt-engineer + llm-architect consultation)

1. **Positive framing** — "Your task is COMPLETE when X" instead of "Do NOT offer Y"
2. **Causal explanation** — "pipeline discards it" aligns with RLHF (model wants to be helpful → learns this IS helpful)
3. **One check, not eight** — model checks against contract once, not against N prohibitions
4. **Shared component** — consistency across all stages, single place to update

## Not Included / Future PRs

- Full `components` field / PromptCompiler component system (components: [] field exists but is never wired)
- System-level response trimming in `run_discuss_phase` (if data shows models still escape sandbox)
- Provider-aware sandwich repetition (if GPT-5 specifically needs end-of-prompt reinforcement)

## Test Plan

- `pre-commit run check-yaml` on all template files — passed
- `uv run mypy` on all 3 modified Python files — passed
- `uv run ruff check` on all 3 modified Python files — passed
- Import + rendering test for all 5 templates — passed (sandbox section injected, Task Contract present)
- No unit tests exist for prompt text content (prompts are tested at integration level)

## Risk / Rollback

- Low risk: prompt text changes only affect LLM behavior, not pipeline correctness
- Rollback: revert commit, re-add blacklists
- Templates validated by rendering test — no placeholder mismatches

🤖 Generated with [Claude Code](https://claude.com/claude-code)