### PR TITLE
fix(inspect): count ending variants per arc, not per ending passage

### DIFF
--- a/src/questfoundry/inspection.py
+++ b/src/questfoundry/inspection.py
@@ -371,10 +371,8 @@ def _branching_quality_score(
     for pid in ending_ids:
         from_beat = passages[pid].get("from_beat") or passages[pid].get("primary_beat") or ""
         covering_arcs = beat_to_arcs.get(from_beat, [])
-        sig: set[str] = set()
         for arc_id in covering_arcs:
-            sig.update(arc_codewords.get(arc_id, frozenset()))
-        variant_signatures.add(frozenset(sig))
+            variant_signatures.add(arc_codewords.get(arc_id, frozenset()))
 
     # Meaningful choice ratio
     ratio = 0.0


### PR DESCRIPTION
## Problem

The `ending_variants` metric always reports 1 when there is a single ending passage, regardless of how many arcs with distinct codeword signatures reach it.

The bug (lines 370-377 of `inspection.py`) unions all arc codewords into a single set per ending passage:

```python
sig: set[str] = set()
for arc_id in covering_arcs:
    sig.update(arc_codewords.get(arc_id, frozenset()))  # unions everything
variant_signatures.add(frozenset(sig))  # always 1 per passage
```

## Changes

- Fix `_branching_quality_score()` to count per-arc codeword signatures instead of per-passage unions
- Add `test_ending_variants_per_arc` test: 2 arcs with different codewords sharing 1 ending → 2 variants

## Not Included / Future PRs

- The deeper issue of all arcs converging to a single ending passage (#838)
- Linear stretches not collapsed across locations (#839)
- Commits timing distribution (#840)

## Test Plan

```
uv run pytest tests/unit/test_inspection.py -x -q  # 28 passed
```

Verified on `test-murder-gpt5mini-retry2`: metric now reports 64 ending variants (was 1).

## Risk / Rollback

Low risk — pure reporting metric change. Does not affect graph structure or LLM behavior.

Closes #837

🤖 Generated with [Claude Code](https://claude.com/claude-code)