### PR TITLE
feat(seed): ending tone hints for GROW ending differentiation

### DIFF
--- a/prompts/templates/serialize_seed_sections.yaml
+++ b/prompts/templates/serialize_seed_sections.yaml
@@ -718,7 +718,8 @@ dilemma_analyses_prompt: |
         "payoff_budget": 5,
         "reasoning": "Murder vs accident produces incompatible crime scenes, suspect lists, and endings.",
         "convergence_point": null,
-        "residue_note": null
+        "residue_note": null,
+        "ending_tone": "cold justice"
       }},
       {{
         "dilemma_id": "dilemma::example_soft",
@@ -726,7 +727,8 @@ dilemma_analyses_prompt: |
         "payoff_budget": 3,
         "reasoning": "Trust vs suspicion changes the relationship tone but both paths lead to the same confrontation.",
         "convergence_point": "paths converge at council_chamber for the final confrontation",
-        "residue_note": "suspicious-path characters remain wary of the host"
+        "residue_note": "suspicious-path characters remain wary of the host",
+        "ending_tone": null
       }}
     ]
   }}
@@ -741,6 +743,7 @@ dilemma_analyses_prompt: |
   - BAD reasoning: "It is soft." / "Only one path."
   - `convergence_point`: null for `hard`; location-based description for `soft`/`flavor`
   - `residue_note`: null for `hard` or if no differences persist; short description otherwise
+  - `ending_tone`: 2-5 word emotional descriptor for how endings shaped by this dilemma should feel (e.g. "cold justice", "bittersweet triumph", "quiet dread"). Required for `hard` dilemmas (they multiply endings). null for `soft`/`flavor` (their paths converge, so ending tone comes from the shared continuation).
 
   ## REMINDER
   Classify ALL dilemmas. Ask: "Could the SAME scene follow both answers?"

--- a/src/questfoundry/graph/fill_context.py
+++ b/src/questfoundry/graph/fill_context.py
@@ -1671,7 +1671,7 @@ def compute_is_ending(graph: Graph, passage_id: str) -> bool:
     return len(choice_from_edges) == 0
 
 
-def format_ending_guidance(is_ending: bool) -> str:
+def format_ending_guidance(is_ending: bool, *, ending_tone: str = "") -> str:
     """Format ending-specific prose guidance.
 
     When a passage is a story ending, returns craft instructions for
@@ -1679,13 +1679,15 @@ def format_ending_guidance(is_ending: bool) -> str:
 
     Args:
         is_ending: Whether this passage is a story ending.
+        ending_tone: Optional emotional tone hint from SEED's DilemmaAnalysis
+            (e.g. "bittersweet triumph"). Appended to guidance when present.
 
     Returns:
         Ending guidance string, or empty string.
     """
     if not is_ending:
         return ""
-    return (
+    guidance = (
         "## Ending Passage (THIS IS A FINAL PASSAGE)\n\n"
         "This passage ends the reader's journey on this path. "
         "It must feel like an ending, not a chapter break or a pause.\n\n"
@@ -1703,6 +1705,13 @@ def format_ending_guidance(is_ending: bool) -> str:
         "GOOD: A final gesture or physical action that echoes the path's theme\n"
         "GOOD: A line of dialogue that lands with double meaning"
     )
+    if ending_tone:
+        guidance += (
+            f"\n\n## Ending Tone\n"
+            f"This ending should feel: **{ending_tone}**\n"
+            f"Let this emotional quality infuse the final image and rhythm."
+        )
+    return guidance
 
 
 def compute_first_appearances(

--- a/src/questfoundry/graph/mutations.py
+++ b/src/questfoundry/graph/mutations.py
@@ -1807,7 +1807,7 @@ def apply_seed_mutations(graph: Graph, output: dict[str, Any]) -> None:
                 "convergence_policy": data.get("convergence_policy", "soft"),
                 "payoff_budget": data.get("payoff_budget", 2),
             }
-            for key in ("convergence_point", "residue_note"):
+            for key in ("convergence_point", "residue_note", "ending_tone"):
                 if key in data:
                     update_fields[key] = data[key]
             graph.update_node(dilemma_node_id, **update_fields)

--- a/src/questfoundry/models/seed.py
+++ b/src/questfoundry/models/seed.py
@@ -280,6 +280,15 @@ class DilemmaAnalysis(BaseModel):
         max_length=200,
         description="Differences that persist after convergence for this dilemma",
     )
+    ending_tone: str | None = Field(
+        default=None,
+        min_length=2,
+        max_length=80,
+        description=(
+            "Emotional quality of endings shaped by this dilemma's resolution "
+            "(2-5 words, e.g. 'bittersweet triumph', 'cold justice')"
+        ),
+    )
 
 
 class InteractionConstraint(BaseModel):

--- a/src/questfoundry/pipeline/stages/fill.py
+++ b/src/questfoundry/pipeline/stages/fill.py
@@ -1268,7 +1268,9 @@ class FillStage:
                 "shadow_states": shadow_states_text,
                 "path_arcs": format_path_arc_context(graph, passage_id, arc_id),
                 "vocabulary_note": vocabulary_note,
-                "ending_guidance": format_ending_guidance(is_ending),
+                "ending_guidance": format_ending_guidance(
+                    is_ending, ending_tone=passage.get("ending_tone", "")
+                ),
                 "introduction_guidance": format_introduction_guidance(
                     first_names,
                     arc_hints=compute_arc_hints(graph, first_eids, arc_id),

--- a/tests/unit/test_fill_context.py
+++ b/tests/unit/test_fill_context.py
@@ -1523,6 +1523,20 @@ class TestEndingGuidance:
     def test_non_ending_returns_empty(self) -> None:
         assert format_ending_guidance(False) == ""
 
+    def test_ending_with_tone(self) -> None:
+        guidance = format_ending_guidance(True, ending_tone="cold justice")
+        assert "FINAL PASSAGE" in guidance
+        assert "## Ending Tone" in guidance
+        assert "cold justice" in guidance
+
+    def test_ending_without_tone(self) -> None:
+        guidance = format_ending_guidance(True, ending_tone="")
+        assert "FINAL PASSAGE" in guidance
+        assert "Ending Tone" not in guidance
+
+    def test_non_ending_ignores_tone(self) -> None:
+        assert format_ending_guidance(False, ending_tone="cold justice") == ""
+
 
 # ---------------------------------------------------------------------------
 # Echo prompt at convergence

--- a/tests/unit/test_seed_models.py
+++ b/tests/unit/test_seed_models.py
@@ -335,6 +335,22 @@ class TestDilemmaAnalysis:
         assert da.convergence_point is None
         assert da.residue_note is None
 
+    def test_ending_tone_accepted(self) -> None:
+        da = DilemmaAnalysis(**{**_ANALYSIS_KWARGS, "ending_tone": "cold justice"})
+        assert da.ending_tone == "cold justice"
+
+    def test_ending_tone_default_none(self) -> None:
+        da = DilemmaAnalysis(**_ANALYSIS_KWARGS)
+        assert da.ending_tone is None
+
+    def test_ending_tone_empty_rejected(self) -> None:
+        with pytest.raises(ValidationError, match="ending_tone"):
+            DilemmaAnalysis(**{**_ANALYSIS_KWARGS, "ending_tone": ""})
+
+    def test_ending_tone_too_long_rejected(self) -> None:
+        with pytest.raises(ValidationError, match="ending_tone"):
+            DilemmaAnalysis(**{**_ANALYSIS_KWARGS, "ending_tone": "x" * 81})
+
 
 class TestInteractionConstraint:
     """InteractionConstraint normalizes pair order and validates fields."""


### PR DESCRIPTION
## Problem

PRs #842 and #843 fixed the structural single-ending problem (arcs now get distinct ending passages), but those endings are structurally identical — they share the same summary and have no guidance about what emotional tone to convey. Different arc families should feel different at their endings.

This is PR 3 of 3 for #838 (Gap 2: SEED doesn't design endings).

## Changes

- Add optional `ending_tone` field to `DilemmaAnalysis` model (2-80 chars, e.g. "cold justice", "bittersweet triumph")
- Store `ending_tone` on dilemma graph nodes via mutations
- Add `ending_tone` to serialize prompt schema example and rules (required for `hard` dilemmas, null for `soft`/`flavor`)
- Add `_collect_family_tones()` helper in GROW that traces dilemma tones through arc→paths→dilemma to synthetic ending passages
- Extend `format_ending_guidance()` in FILL to append an "Ending Tone" section when the passage carries one
- Add 9 new tests across seed models (4), grow algorithms (2), and fill context (3)

Data flow: `SEED DilemmaAnalysis.ending_tone → graph dilemma node → GROW split_ending_families → synthetic ending passage → FILL format_ending_guidance`

## Not Included / Future PRs

- All 3 PRs for #838 are now complete. No further work planned for this issue.

## Test Plan

```bash
# All targeted tests pass
uv run pytest tests/unit/test_seed_models.py -x -q -k "ending_tone"        # 4 passed
uv run pytest tests/unit/test_grow_algorithms.py -x -q -k "SplitEnding"    # 7 passed
uv run pytest tests/unit/test_fill_context.py -x -q -k "EndingGuidance"    # 5 passed

# Full module tests pass (473 total)
uv run pytest tests/unit/test_seed_models.py tests/unit/test_grow_algorithms.py tests/unit/test_fill_context.py -x -q

# Type check + lint clean
uv run mypy src/questfoundry/models/seed.py src/questfoundry/graph/grow_algorithms.py src/questfoundry/graph/fill_context.py
```

## Risk / Rollback

- **Backward compatible**: `ending_tone` defaults to `None`. Existing SEED outputs and graph nodes work without it.
- **No LLM calls affected**: The GROW-side change is pure graph manipulation. The FILL-side change only adds context when `ending_tone` is present.
- **Prompt change is additive**: New field in serialize schema example; existing LLM outputs that omit it still validate.

Closes #838

🤖 Generated with [Claude Code](https://claude.com/claude-code)