### PR TITLE
fix(grow): correct shared-beats computation for ending differentiation

### DIFF
--- a/src/questfoundry/graph/grow_algorithms.py
+++ b/src/questfoundry/graph/grow_algorithms.py
@@ -306,10 +306,8 @@ def compute_shared_beats(
         if not paths_in_dilemma:
             continue
         # Beats on EVERY path of this dilemma appear in all arcs
-        intersection = path_beat_sets.get(paths_in_dilemma[0], set()).copy()
-        for pid in paths_in_dilemma[1:]:
-            intersection &= path_beat_sets.get(pid, set())
-        shared |= intersection
+        beat_sets = [path_beat_sets.get(pid, set()) for pid in paths_in_dilemma]
+        shared |= set.intersection(*beat_sets)
     return shared
 
 

--- a/src/questfoundry/graph/grow_algorithms.py
+++ b/src/questfoundry/graph/grow_algorithms.py
@@ -281,11 +281,12 @@ def compute_shared_beats(
     path_beat_sets: dict[str, set[str]],
     path_lists: list[list[str]],
 ) -> set[str]:
-    """Find beats shared by all arc combinations (Cartesian product of path lists).
+    """Find beats guaranteed to appear in every possible arc.
 
-    A beat is "shared" if it appears in the beat set of at least one path
-    from every dilemma. Such beats are common to ALL arcs and cannot
-    differentiate between arc families.
+    A beat is "shared" if it appears on **every** path of the dilemma it
+    belongs to.  Such beats cannot differentiate arcs because every arc
+    must include them.  For single-path (partially-explored) dilemmas all
+    beats qualify automatically.
 
     Args:
         path_beat_sets: Mapping from path ID to the set of beat IDs
@@ -300,18 +301,15 @@ def compute_shared_beats(
     if not path_lists:
         return set()
 
-    # For each dilemma, collect the union of beats across all its paths
-    per_dilemma_unions: list[set[str]] = []
+    shared: set[str] = set()
     for paths_in_dilemma in path_lists:
-        union: set[str] = set()
-        for pid in paths_in_dilemma:
-            union.update(path_beat_sets.get(pid, set()))
-        per_dilemma_unions.append(union)
-
-    # Shared = intersection across all dilemmas
-    shared = per_dilemma_unions[0]
-    for s in per_dilemma_unions[1:]:
-        shared = shared & s
+        if not paths_in_dilemma:
+            continue
+        # Beats on EVERY path of this dilemma appear in all arcs
+        intersection = path_beat_sets.get(paths_in_dilemma[0], set()).copy()
+        for pid in paths_in_dilemma[1:]:
+            intersection &= path_beat_sets.get(pid, set())
+        shared |= intersection
     return shared
 
 

--- a/tests/integration/test_grow_e2e.py
+++ b/tests/integration/test_grow_e2e.py
@@ -186,8 +186,8 @@ class TestGrowFullPipeline:
         assert any(a.get("arc_type") == "spine" for a in result_dict["arcs"])
 
     def test_passages_created(self, pipeline_result: dict[str, Any]) -> None:
-        """Verify passages are created (10 from beats + 4 ending families)."""
-        assert len(pipeline_result["result_dict"]["passages"]) == 14
+        """Verify passages are created (7 after consolidation + 4 ending families)."""
+        assert len(pipeline_result["result_dict"]["passages"]) == 11
 
     def test_codewords_derived(self, pipeline_result: dict[str, Any]) -> None:
         """Verify codewords are created from consequences (4 consequences)."""


### PR DESCRIPTION
## Problem

`compute_shared_beats()` (PR #843) used cross-dilemma intersection of per-dilemma unions to identify beats present in all arcs. Since each dilemma has unique beat IDs (e.g., `captain_beat_01` vs `death_beat_01`), the intersection is **always empty** when dilemmas don't share beats. This meant the priority tie-breaking in `topological_sort_beats()` had no effect — the shared set was always `{}`.

Observed in `test-murder-gpt5mini-retry3`: all 64 arcs still end at `surveillance_tampered_beat_03` with `ending_variants: 0`, identical to pre-fix behavior.

## Changes

- **`compute_shared_beats()`**: Changed from "intersection of per-dilemma unions" to "union of per-dilemma intersections". A beat is shared iff it appears on *every* path of its own dilemma. Single-path (partially-explored) dilemmas contribute all their beats automatically.
- **Tests**: Updated 3 unit tests and 1 integration test to match corrected semantics. Added new test for single-path dilemmas and multi-path disjoint dilemmas.

### Algorithm comparison

| | Old (wrong) | New (correct) |
|---|---|---|
| Per-dilemma step | Union all paths' beats | Intersect all paths' beats |
| Cross-dilemma step | Intersect across dilemmas | Union across dilemmas |
| Single-path dilemma | Contributes to intersection (lost) | All beats → shared |
| Murder mystery (10 dilemmas, 4 partial) | `{}` (empty) | 12 beats shared |

## Not Included / Future PRs

- The fix gives 2 ending families (from the alphabetically-last fully-explored dilemma). For richer differentiation (more families), a different tie-breaking strategy is needed — filed as future work if needed after re-running projects.

## Test Plan

```bash
uv run pytest tests/unit/test_grow_algorithms.py -x -q  # 223 passed
uv run pytest tests/unit/test_grow_stage.py -x -q       # 102 passed
uv run mypy src/questfoundry/graph/grow_algorithms.py    # Success
uv run ruff check src/ --select E,W,F                    # All passed
```

## Risk / Rollback

- Changes beat ordering for all projects → arc sequences and ending families will differ on re-run
- No effect on existing graph.json files (only affects new GROW runs)
- Backward compatible: no API changes, only corrected internal logic

Closes #838

🤖 Generated with [Claude Code](https://claude.com/claude-code)