### PR TITLE
fix(inspect): ending_variants metric handles synthetic endings

### DIFF
--- a/src/questfoundry/inspection.py
+++ b/src/questfoundry/inspection.py
@@ -377,10 +377,17 @@ def _branching_quality_score(
 
     variant_signatures: set[frozenset[str]] = set()
     for pid in ending_ids:
-        from_beat = passages[pid].get("from_beat") or passages[pid].get("primary_beat") or ""
-        covering_arcs = beat_to_arcs.get(from_beat, [])
-        for arc_id in covering_arcs:
-            variant_signatures.add(arc_codewords.get(arc_id, frozenset()))
+        pdata = passages[pid]
+        # Synthetic endings (from split_ending_families) carry family_codewords
+        # directly; non-synthetic endings need beat→arc→codeword lookup.
+        family_cws = pdata.get("family_codewords")
+        if family_cws is not None:
+            variant_signatures.add(frozenset(family_cws))
+        else:
+            from_beat = pdata.get("from_beat") or pdata.get("primary_beat") or ""
+            covering_arcs = beat_to_arcs.get(from_beat, [])
+            for arc_id in covering_arcs:
+                variant_signatures.add(arc_codewords.get(arc_id, frozenset()))
 
     # Meaningful choice ratio
     ratio = 0.0


### PR DESCRIPTION
## Problem

The `ending_variants` metric in `qf inspect` always reports 0 for projects with synthetic endings (created by `split_ending_families()`). Synthetic endings have no `from_beat` field, so the beat→arc→codeword lookup finds zero covering arcs and adds no variant signatures.

Observed in `test-murder-gpt5mini-retry3`: 64 endings with 2 distinct summaries, but `ending_variants: 0`.

## Changes

- **`inspection.py`**: Check for `family_codewords` on synthetic endings before falling back to beat-based arc lookup. Synthetic endings carry their distinguishing codewords directly.
- **`test_inspection.py`**: Added `test_ending_variants_synthetic_endings` verifying 2 synthetic endings with different `family_codewords` produce `ending_variants == 2`.

## Test Plan

```bash
uv run pytest tests/unit/test_inspection.py -x -q  # 29 passed
uv run mypy src/questfoundry/inspection.py          # Success
```

## Risk / Rollback

- Read-only metric change, no effect on pipeline behavior
- Existing tests for non-synthetic endings still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)