### PR TITLE
refactor(grow): convert grow.py to grow/ package skeleton

### DIFF
--- a/src/questfoundry/pipeline/stages/grow/__init__.py
+++ b/src/questfoundry/pipeline/stages/grow/__init__.py
@@ -6,9 +6,9 @@ continues to work after the single-file → package conversion.
 
 from __future__ import annotations
 
+from questfoundry.pipeline.stages.grow._helpers import GrowStageError
 from questfoundry.pipeline.stages.grow.stage import (
     GrowStage,
-    GrowStageError,
     create_grow_stage,
     grow_stage,
 )

--- a/src/questfoundry/pipeline/stages/grow/__init__.py
+++ b/src/questfoundry/pipeline/stages/grow/__init__.py
@@ -1,0 +1,21 @@
+"""GROW stage package.
+
+Re-exports public API so that ``from questfoundry.pipeline.stages.grow import ...``
+continues to work after the single-file → package conversion.
+"""
+
+from __future__ import annotations
+
+from questfoundry.pipeline.stages.grow.stage import (
+    GrowStage,
+    GrowStageError,
+    create_grow_stage,
+    grow_stage,
+)
+
+__all__ = [
+    "GrowStage",
+    "GrowStageError",
+    "create_grow_stage",
+    "grow_stage",
+]

--- a/src/questfoundry/pipeline/stages/grow/_helpers.py
+++ b/src/questfoundry/pipeline/stages/grow/_helpers.py
@@ -1,0 +1,67 @@
+"""Module-level helpers shared across the GROW stage package."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TypeVar
+
+from pydantic import BaseModel
+
+from questfoundry.graph.mutations import GrowValidationError  # noqa: TC001 - used at runtime
+from questfoundry.observability.logging import get_logger
+
+T = TypeVar("T", bound=BaseModel)
+
+log = get_logger(__name__)
+
+
+class GrowStageError(ValueError):
+    """Error raised when GROW stage cannot proceed."""
+
+    pass
+
+
+def _get_prompts_path() -> Path:
+    """Get the prompts directory path.
+
+    Returns prompts from package first, then falls back to project root.
+    """
+    pkg_path = Path(__file__).parents[5] / "prompts"
+    if pkg_path.exists():
+        return pkg_path
+    return Path.cwd() / "prompts"
+
+
+def _format_structural_feedback(errors: list[GrowValidationError]) -> str:
+    """Format structural compatibility errors as targeted LLM feedback.
+
+    Categorizes errors by type and produces a correction message that
+    tells the LLM exactly what went wrong, enabling targeted repair.
+    """
+    dilemma_substrings = ("same dilemma", "span only", "at most 1 beat per dilemma")
+    same_dilemma_count = sum(
+        1 for e in errors if any(sub in e.issue.lower() for sub in dilemma_substrings)
+    )
+
+    lines = ["\n\n## CORRECTION REQUIRED"]
+    lines.append(f"Your previous {len(errors)} error(s) caused ALL intersections to be REJECTED.")
+
+    if same_dilemma_count > 0:
+        lines.append(
+            "PROBLEM: You grouped beats from the SAME dilemma together. "
+            "Each intersection MUST combine beats from DIFFERENT dilemmas. "
+            "Each candidate group already contains beats from different dilemmas -- "
+            "select beats from WITHIN a group, not across groups."
+        )
+
+    # Show up to 3 specific errors for clarity
+    max_shown = 3
+    for err in errors[:max_shown]:
+        lines.append(f"  - {err.issue}")
+    if len(errors) > max_shown:
+        lines.append(f"  ... and {len(errors) - max_shown} more error(s)")
+
+    lines.append(
+        "Try again. Use the beat IDs from WITHIN each candidate group to form intersections."
+    )
+    return "\n".join(lines)

--- a/src/questfoundry/pipeline/stages/grow/stage.py
+++ b/src/questfoundry/pipeline/stages/grow/stage.py
@@ -22,8 +22,8 @@ from __future__ import annotations
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
 from functools import partial
-from pathlib import Path
-from typing import TYPE_CHECKING, Any, TypeVar
+from pathlib import Path  # noqa: TC003 - used at runtime
+from typing import TYPE_CHECKING, Any
 
 from langchain_core.messages import HumanMessage, SystemMessage
 from pydantic import BaseModel, ValidationError
@@ -47,10 +47,16 @@ from questfoundry.graph.context_compact import (
 from questfoundry.graph.graph import Graph
 from questfoundry.graph.mutations import GrowMutationError, GrowValidationError
 from questfoundry.models.grow import GrowPhaseResult, GrowResult
-from questfoundry.observability.logging import get_logger
 from questfoundry.observability.tracing import traceable
 from questfoundry.pipeline.batching import batch_llm_calls
 from questfoundry.pipeline.gates import AutoApprovePhaseGate
+from questfoundry.pipeline.stages.grow._helpers import (
+    GrowStageError,
+    T,
+    _format_structural_feedback,
+    _get_prompts_path,
+    log,
+)
 from questfoundry.prompts.compiler import safe_format
 from questfoundry.providers.structured_output import (
     unwrap_structured_result,
@@ -72,63 +78,6 @@ if TYPE_CHECKING:
         PhaseProgressFn,
         UserInputFn,
     )
-
-T = TypeVar("T", bound=BaseModel)
-
-
-def _get_prompts_path() -> Path:
-    """Get the prompts directory path.
-
-    Returns prompts from package first, then falls back to project root.
-    """
-    pkg_path = Path(__file__).parents[5] / "prompts"
-    if pkg_path.exists():
-        return pkg_path
-    return Path.cwd() / "prompts"
-
-
-log = get_logger(__name__)
-
-
-class GrowStageError(ValueError):
-    """Error raised when GROW stage cannot proceed."""
-
-    pass
-
-
-def _format_structural_feedback(errors: list[GrowValidationError]) -> str:
-    """Format structural compatibility errors as targeted LLM feedback.
-
-    Categorizes errors by type and produces a correction message that
-    tells the LLM exactly what went wrong, enabling targeted repair.
-    """
-    dilemma_substrings = ("same dilemma", "span only", "at most 1 beat per dilemma")
-    same_dilemma_count = sum(
-        1 for e in errors if any(sub in e.issue.lower() for sub in dilemma_substrings)
-    )
-
-    lines = ["\n\n## CORRECTION REQUIRED"]
-    lines.append(f"Your previous {len(errors)} error(s) caused ALL intersections to be REJECTED.")
-
-    if same_dilemma_count > 0:
-        lines.append(
-            "PROBLEM: You grouped beats from the SAME dilemma together. "
-            "Each intersection MUST combine beats from DIFFERENT dilemmas. "
-            "Each candidate group already contains beats from different dilemmas -- "
-            "select beats from WITHIN a group, not across groups."
-        )
-
-    # Show up to 3 specific errors for clarity
-    max_shown = 3
-    for err in errors[:max_shown]:
-        lines.append(f"  - {err.issue}")
-    if len(errors) > max_shown:
-        lines.append(f"  ... and {len(errors) - max_shown} more error(s)")
-
-    lines.append(
-        "Try again. Use the beat IDs from WITHIN each candidate group to form intersections."
-    )
-    return "\n".join(lines)
 
 
 class GrowStage:

--- a/src/questfoundry/pipeline/stages/grow/stage.py
+++ b/src/questfoundry/pipeline/stages/grow/stage.py
@@ -81,7 +81,7 @@ def _get_prompts_path() -> Path:
 
     Returns prompts from package first, then falls back to project root.
     """
-    pkg_path = Path(__file__).parents[4] / "prompts"
+    pkg_path = Path(__file__).parents[5] / "prompts"
     if pkg_path.exists():
         return pkg_path
     return Path.cwd() / "prompts"

--- a/tests/unit/test_grow_stage.py
+++ b/tests/unit/test_grow_stage.py
@@ -601,7 +601,7 @@ class TestGrowLlmCall:
         mock_model = MagicMock()
 
         with patch(
-            "questfoundry.pipeline.stages.grow.with_structured_output",
+            "questfoundry.pipeline.stages.grow.stage.with_structured_output",
             return_value=mock_structured,
         ) as mock_wso:
             await stage._grow_llm_call(
@@ -2474,14 +2474,14 @@ class TestGrowLLMCallTokens:
 
         with (
             patch(
-                "questfoundry.pipeline.stages.grow.with_structured_output",
+                "questfoundry.pipeline.stages.grow.stage.with_structured_output",
                 return_value=mock_structured,
             ),
             patch(
-                "questfoundry.pipeline.stages.grow.extract_tokens",
+                "questfoundry.pipeline.stages.grow.stage.extract_tokens",
                 return_value=150,
             ),
-            patch("questfoundry.pipeline.stages.grow._get_prompts_path") as mock_path,
+            patch("questfoundry.pipeline.stages.grow.stage._get_prompts_path") as mock_path,
         ):
             mock_path.return_value = Path(__file__).parents[2] / "prompts"
             result, llm_calls, tokens = await stage._grow_llm_call(
@@ -2514,14 +2514,14 @@ class TestGrowLLMCallTokens:
 
         with (
             patch(
-                "questfoundry.pipeline.stages.grow.with_structured_output",
+                "questfoundry.pipeline.stages.grow.stage.with_structured_output",
                 return_value=mock_structured,
             ),
             patch(
-                "questfoundry.pipeline.stages.grow.extract_tokens",
+                "questfoundry.pipeline.stages.grow.stage.extract_tokens",
                 return_value=0,
             ),
-            patch("questfoundry.pipeline.stages.grow._get_prompts_path") as mock_path,
+            patch("questfoundry.pipeline.stages.grow.stage._get_prompts_path") as mock_path,
         ):
             mock_path.return_value = Path(__file__).parents[2] / "prompts"
             result, llm_calls, tokens = await stage._grow_llm_call(
@@ -2560,14 +2560,14 @@ class TestGrowLLMCallTokens:
 
         with (
             patch(
-                "questfoundry.pipeline.stages.grow.with_structured_output",
+                "questfoundry.pipeline.stages.grow.stage.with_structured_output",
                 return_value=mock_structured,
             ),
             patch(
-                "questfoundry.pipeline.stages.grow.extract_tokens",
+                "questfoundry.pipeline.stages.grow.stage.extract_tokens",
                 side_effect=extract_tokens_calls,
             ),
-            patch("questfoundry.pipeline.stages.grow._get_prompts_path") as mock_path,
+            patch("questfoundry.pipeline.stages.grow.stage._get_prompts_path") as mock_path,
         ):
             mock_path.return_value = Path(__file__).parents[2] / "prompts"
             result, llm_calls, tokens = await stage._grow_llm_call(
@@ -2606,10 +2606,10 @@ class TestGrowHybridProviders:
 
         with (
             patch(
-                "questfoundry.pipeline.stages.grow.with_structured_output",
+                "questfoundry.pipeline.stages.grow.stage.with_structured_output",
                 return_value=mock_structured,
             ) as mock_wso,
-            patch("questfoundry.pipeline.stages.grow._get_prompts_path") as mock_path,
+            patch("questfoundry.pipeline.stages.grow.stage._get_prompts_path") as mock_path,
         ):
             mock_path.return_value = Path(__file__).parents[2] / "prompts"
             await stage._grow_llm_call(
@@ -2644,10 +2644,10 @@ class TestGrowHybridProviders:
 
         with (
             patch(
-                "questfoundry.pipeline.stages.grow.with_structured_output",
+                "questfoundry.pipeline.stages.grow.stage.with_structured_output",
                 return_value=mock_structured,
             ) as mock_wso,
-            patch("questfoundry.pipeline.stages.grow._get_prompts_path") as mock_path,
+            patch("questfoundry.pipeline.stages.grow.stage._get_prompts_path") as mock_path,
         ):
             mock_path.return_value = Path(__file__).parents[2] / "prompts"
             await stage._grow_llm_call(
@@ -2809,14 +2809,14 @@ class TestGrowSemanticValidation:
 
         with (
             patch(
-                "questfoundry.pipeline.stages.grow.with_structured_output",
+                "questfoundry.pipeline.stages.grow.stage.with_structured_output",
                 return_value=mock_structured,
             ),
             patch(
-                "questfoundry.pipeline.stages.grow.extract_tokens",
+                "questfoundry.pipeline.stages.grow.stage.extract_tokens",
                 return_value=50,
             ),
-            patch("questfoundry.pipeline.stages.grow._get_prompts_path") as mock_path,
+            patch("questfoundry.pipeline.stages.grow.stage._get_prompts_path") as mock_path,
         ):
             mock_path.return_value = Path(__file__).parents[2] / "prompts"
             result, llm_calls, tokens = await stage._grow_llm_call(
@@ -2892,14 +2892,14 @@ class TestGrowSemanticValidation:
 
         with (
             patch(
-                "questfoundry.pipeline.stages.grow.with_structured_output",
+                "questfoundry.pipeline.stages.grow.stage.with_structured_output",
                 return_value=mock_structured,
             ),
             patch(
-                "questfoundry.pipeline.stages.grow.extract_tokens",
+                "questfoundry.pipeline.stages.grow.stage.extract_tokens",
                 return_value=80,
             ),
-            patch("questfoundry.pipeline.stages.grow._get_prompts_path") as mock_path,
+            patch("questfoundry.pipeline.stages.grow.stage._get_prompts_path") as mock_path,
         ):
             mock_path.return_value = Path(__file__).parents[2] / "prompts"
             result, llm_calls, _tokens = await stage._grow_llm_call(
@@ -2958,14 +2958,14 @@ class TestGrowSemanticValidation:
 
         with (
             patch(
-                "questfoundry.pipeline.stages.grow.with_structured_output",
+                "questfoundry.pipeline.stages.grow.stage.with_structured_output",
                 return_value=mock_structured,
             ),
             patch(
-                "questfoundry.pipeline.stages.grow.extract_tokens",
+                "questfoundry.pipeline.stages.grow.stage.extract_tokens",
                 return_value=60,
             ),
-            patch("questfoundry.pipeline.stages.grow._get_prompts_path") as mock_path,
+            patch("questfoundry.pipeline.stages.grow.stage._get_prompts_path") as mock_path,
         ):
             mock_path.return_value = Path(__file__).parents[2] / "prompts"
             result, llm_calls, tokens = await stage._grow_llm_call(
@@ -3017,14 +3017,14 @@ class TestGrowSemanticValidation:
 
         with (
             patch(
-                "questfoundry.pipeline.stages.grow.with_structured_output",
+                "questfoundry.pipeline.stages.grow.stage.with_structured_output",
                 return_value=mock_structured,
             ),
             patch(
-                "questfoundry.pipeline.stages.grow.extract_tokens",
+                "questfoundry.pipeline.stages.grow.stage.extract_tokens",
                 return_value=100,
             ),
-            patch("questfoundry.pipeline.stages.grow._get_prompts_path") as mock_path,
+            patch("questfoundry.pipeline.stages.grow.stage._get_prompts_path") as mock_path,
         ):
             mock_path.return_value = Path(__file__).parents[2] / "prompts"
             result, llm_calls, tokens = await stage._grow_llm_call(


### PR DESCRIPTION
## Problem

`grow.py` is 3,380 lines — coding agents must load the entire file to work on any single phase, wasting context window. This is the first of a stack of PRs to decompose it into a package.

Closes #851

## Changes

- **`git mv` grow.py → grow/stage.py**: Pure file rename preserving git history
- **grow/__init__.py**: Re-exports `GrowStage`, `GrowStageError`, `create_grow_stage`, `grow_stage` so all external imports continue to work unchanged
- **grow/_helpers.py**: Extract module-level helpers from stage.py — `GrowStageError`, `_get_prompts_path()`, `_format_structural_feedback()`, `T` TypeVar, `log`
- **Fix `_get_prompts_path`**: Update `Path(__file__).parents` offset from 4→5 for new directory depth
- **Update test patches**: `questfoundry.pipeline.stages.grow.*` → `questfoundry.pipeline.stages.grow.stage.*` for mock targets

## Not Included / Future PRs

This PR establishes the package skeleton only. Actual phase extraction into separate modules will follow in stacked PRs (PR 2b: deterministic phases, PR 2c: LLM phases).

## Test Plan

- `uv run pytest tests/unit/test_grow_stage.py tests/unit/test_grow_algorithms.py -x -q` — 325 passed
- `uv run mypy src/questfoundry/pipeline/stages/grow/` — clean
- `uv run ruff check src/questfoundry/pipeline/stages/grow/` — clean
- All pre-commit hooks pass

## Review Guide

1. `grow/__init__.py` — verify re-exports match `stages/__init__.py` imports
2. `grow/_helpers.py` — extracted helpers, no behavior change
3. `grow/stage.py` diff — only import changes, no logic changes
4. `test_grow_stage.py` — mock patch target updates only

## Risk / Rollback

- **Very low risk**: Purely mechanical — file move + import rewiring
- All 325 grow tests pass unchanged (only mock targets updated)
- No behavior changes whatsoever

🤖 Generated with [Claude Code](https://claude.com/claude-code)