### PR TITLE
refactor(graph): extract GraphStore protocol + DictGraphStore

### DIFF
--- a/src/questfoundry/graph/__init__.py
+++ b/src/questfoundry/graph/__init__.py
@@ -57,6 +57,7 @@ from questfoundry.graph.snapshots import (
     rollback_to_snapshot,
     save_snapshot,
 )
+from questfoundry.graph.store import DictGraphStore, GraphStore
 
 __all__ = [
     "ENTITY_CATEGORIES",
@@ -64,10 +65,12 @@ __all__ = [
     "SCOPE_PATH",
     "BrainstormMutationError",
     "BrainstormValidationError",
+    "DictGraphStore",
     "EdgeEndpointError",
     "Graph",
     "GraphCorruptionError",
     "GraphIntegrityError",
+    "GraphStore",
     "GrowErrorCategory",
     "GrowMutationError",
     "GrowValidationError",

--- a/src/questfoundry/graph/__init__.py
+++ b/src/questfoundry/graph/__init__.py
@@ -57,6 +57,7 @@ from questfoundry.graph.snapshots import (
     rollback_to_snapshot,
     save_snapshot,
 )
+from questfoundry.graph.sqlite_store import SqliteGraphStore
 from questfoundry.graph.store import DictGraphStore, GraphStore
 
 __all__ = [
@@ -81,6 +82,7 @@ __all__ = [
     "SeedErrorCategory",
     "SeedMutationError",
     "SeedValidationError",
+    "SqliteGraphStore",
     "apply_brainstorm_mutations",
     "apply_dream_mutations",
     "apply_mutations",

--- a/src/questfoundry/graph/sqlite_store.py
+++ b/src/questfoundry/graph/sqlite_store.py
@@ -1,0 +1,495 @@
+"""SQLite-backed graph storage with mutation audit trail.
+
+SqliteGraphStore implements the GraphStore protocol using stdlib sqlite3.
+Every mutating operation (create/update/delete node or edge) is recorded
+in the ``mutations`` table with stage/phase context for auditing.
+
+Savepoint support enables efficient rollback during GROW phases without
+JSON serialization.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sqlite3
+from pathlib import Path
+from typing import Any, cast
+
+from questfoundry.graph.errors import NodeNotFoundError
+
+# ---------------------------------------------------------------------------
+# Schema
+# ---------------------------------------------------------------------------
+
+_SCHEMA = """\
+CREATE TABLE IF NOT EXISTS nodes (
+    node_id        TEXT PRIMARY KEY,
+    type           TEXT NOT NULL,
+    data           JSON NOT NULL,
+    created_stage  TEXT DEFAULT '',
+    created_phase  TEXT DEFAULT '',
+    modified_stage TEXT DEFAULT '',
+    modified_phase TEXT DEFAULT ''
+);
+CREATE INDEX IF NOT EXISTS idx_nodes_type ON nodes(type);
+
+CREATE TABLE IF NOT EXISTS edges (
+    rowid     INTEGER PRIMARY KEY AUTOINCREMENT,
+    edge_type TEXT NOT NULL,
+    from_id   TEXT NOT NULL,
+    to_id     TEXT NOT NULL,
+    data      JSON,
+    created_stage TEXT DEFAULT '',
+    created_phase TEXT DEFAULT ''
+);
+CREATE INDEX IF NOT EXISTS idx_edges_type ON edges(edge_type);
+CREATE INDEX IF NOT EXISTS idx_edges_from ON edges(from_id);
+CREATE INDEX IF NOT EXISTS idx_edges_to   ON edges(to_id);
+
+CREATE TABLE IF NOT EXISTS meta (
+    key   TEXT PRIMARY KEY,
+    value JSON NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS mutations (
+    id        INTEGER PRIMARY KEY AUTOINCREMENT,
+    timestamp TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%f','now')),
+    stage     TEXT NOT NULL DEFAULT '',
+    phase     TEXT NOT NULL DEFAULT '',
+    operation TEXT NOT NULL,
+    target_id TEXT NOT NULL,
+    delta     JSON,
+    rationale TEXT DEFAULT ''
+);
+CREATE INDEX IF NOT EXISTS idx_mutations_stage  ON mutations(stage);
+CREATE INDEX IF NOT EXISTS idx_mutations_target ON mutations(target_id);
+
+CREATE TABLE IF NOT EXISTS phase_history (
+    id             INTEGER PRIMARY KEY AUTOINCREMENT,
+    stage          TEXT NOT NULL,
+    phase          TEXT NOT NULL,
+    started_at     TEXT,
+    completed_at   TEXT,
+    status         TEXT DEFAULT 'started',
+    mutation_count INTEGER DEFAULT 0,
+    detail         TEXT DEFAULT ''
+);
+"""
+
+VERSION = "5.0"
+
+
+class SqliteGraphStore:
+    """SQLite-backed graph store with mutation recording.
+
+    Every mutating operation records a row in the ``mutations`` table.
+    Use :meth:`set_mutation_context` to set the current stage/phase
+    before running operations — this tags each mutation for auditing.
+
+    Supports SQLite savepoints for efficient in-process rollback.
+    """
+
+    def __init__(
+        self,
+        db_path: str | Path = ":memory:",
+        *,
+        _conn: sqlite3.Connection | None = None,
+    ) -> None:
+        """Open or create a SQLite graph database.
+
+        Args:
+            db_path: Path to ``.db`` file, or ``":memory:"`` for in-memory.
+            _conn: Pre-existing connection (for testing). If provided,
+                   *db_path* is ignored.
+        """
+        if _conn is not None:
+            self._conn = _conn
+        else:
+            self._conn = sqlite3.connect(
+                str(db_path) if isinstance(db_path, Path) else db_path,
+                isolation_level=None,  # autocommit — we manage transactions
+            )
+        self._conn.row_factory = sqlite3.Row
+        self._conn.execute("PRAGMA journal_mode=WAL")
+        self._conn.execute("PRAGMA synchronous=NORMAL")
+        self._conn.execute("PRAGMA foreign_keys=ON")
+        self._conn.executescript(_SCHEMA)
+
+        self._stage: str = ""
+        self._phase: str = ""
+
+    def close(self) -> None:
+        """Close the database connection."""
+        self._conn.close()
+
+    # -- Mutation context ------------------------------------------------------
+
+    def set_mutation_context(self, stage: str = "", phase: str = "") -> None:
+        """Set the current stage/phase for mutation recording.
+
+        Args:
+            stage: Current pipeline stage (e.g., "grow").
+            phase: Current phase within the stage (e.g., "path_agnostic").
+        """
+        self._stage = stage
+        self._phase = phase
+
+    def _record_mutation(
+        self,
+        operation: str,
+        target_id: str,
+        delta: dict[str, Any] | None = None,
+    ) -> None:
+        """Append a mutation record."""
+        self._conn.execute(
+            "INSERT INTO mutations (stage, phase, operation, target_id, delta) "
+            "VALUES (?, ?, ?, ?, ?)",
+            (
+                self._stage,
+                self._phase,
+                operation,
+                target_id,
+                json.dumps(delta) if delta is not None else None,
+            ),
+        )
+
+    # -- Savepoints ------------------------------------------------------------
+
+    _SAVEPOINT_RE = re.compile(r"^[A-Za-z0-9_]+$")
+
+    def _validate_savepoint_name(self, name: str) -> None:
+        """Validate savepoint name to prevent SQL injection."""
+        if not self._SAVEPOINT_RE.match(name):
+            msg = f"Invalid savepoint name {name!r}: must be alphanumeric/underscores only"
+            raise ValueError(msg)
+
+    def savepoint(self, name: str) -> None:
+        """Create a SQLite savepoint.
+
+        Args:
+            name: Savepoint name (alphanumeric + underscores only).
+
+        Raises:
+            ValueError: If *name* contains invalid characters.
+        """
+        self._validate_savepoint_name(name)
+        self._conn.execute(f"SAVEPOINT sp_{name}")
+
+    def rollback_to(self, name: str) -> None:
+        """Rollback to a named savepoint.
+
+        The savepoint remains active after rollback (SQLite behavior).
+
+        Args:
+            name: Savepoint name previously created with :meth:`savepoint`.
+
+        Raises:
+            ValueError: If *name* contains invalid characters.
+        """
+        self._validate_savepoint_name(name)
+        self._conn.execute(f"ROLLBACK TO sp_{name}")
+
+    def release(self, name: str) -> None:
+        """Release (commit) a named savepoint.
+
+        Args:
+            name: Savepoint name to release.
+
+        Raises:
+            ValueError: If *name* contains invalid characters.
+        """
+        self._validate_savepoint_name(name)
+        self._conn.execute(f"RELEASE SAVEPOINT sp_{name}")
+
+    # -- Nodes -----------------------------------------------------------------
+
+    def get_node(self, node_id: str) -> dict[str, Any] | None:
+        row = self._conn.execute("SELECT data FROM nodes WHERE node_id = ?", (node_id,)).fetchone()
+        if row is None:
+            return None
+        return cast("dict[str, Any]", json.loads(row["data"]))
+
+    def has_node(self, node_id: str) -> bool:
+        row = self._conn.execute("SELECT 1 FROM nodes WHERE node_id = ?", (node_id,)).fetchone()
+        return row is not None
+
+    def set_node(self, node_id: str, data: dict[str, Any]) -> None:
+        node_type = data.get("type", "")
+        existing = self.has_node(node_id)
+        self._conn.execute(
+            "INSERT OR REPLACE INTO nodes "
+            "(node_id, type, data, created_stage, created_phase, modified_stage, modified_phase) "
+            "VALUES (?, ?, ?, "
+            "  COALESCE((SELECT created_stage FROM nodes WHERE node_id = ?), ?), "
+            "  COALESCE((SELECT created_phase FROM nodes WHERE node_id = ?), ?), "
+            "  ?, ?)",
+            (
+                node_id,
+                node_type,
+                json.dumps(data),
+                node_id,
+                self._stage,
+                node_id,
+                self._phase,
+                self._stage,
+                self._phase,
+            ),
+        )
+        op = "update_node" if existing else "create_node"
+        self._record_mutation(op, node_id, delta=data)
+
+    def update_node_fields(self, node_id: str, **updates: Any) -> None:
+        row = self._conn.execute("SELECT data FROM nodes WHERE node_id = ?", (node_id,)).fetchone()
+        if row is None:
+            raise NodeNotFoundError(node_id=node_id)
+        current = json.loads(row["data"])
+        current.update(updates)
+        node_type = current.get("type", "")
+        self._conn.execute(
+            "UPDATE nodes SET data = ?, type = ?, modified_stage = ?, modified_phase = ? "
+            "WHERE node_id = ?",
+            (json.dumps(current), node_type, self._stage, self._phase, node_id),
+        )
+        self._record_mutation("update_node", node_id, delta=dict(updates))
+
+    def delete_node(self, node_id: str) -> None:
+        self._conn.execute("DELETE FROM nodes WHERE node_id = ?", (node_id,))
+        self._record_mutation("delete_node", node_id)
+
+    def get_nodes_by_type(self, node_type: str) -> dict[str, dict[str, Any]]:
+        rows = self._conn.execute(
+            "SELECT node_id, data FROM nodes WHERE type = ?", (node_type,)
+        ).fetchall()
+        return {row["node_id"]: json.loads(row["data"]) for row in rows}
+
+    def all_node_ids(self) -> list[str]:
+        rows = self._conn.execute("SELECT node_id FROM nodes").fetchall()
+        return [row["node_id"] for row in rows]
+
+    def node_ids_with_prefix(self, prefix: str) -> list[str]:
+        rows = self._conn.execute(
+            "SELECT node_id FROM nodes WHERE node_id LIKE ?",
+            (prefix + "%",),
+        ).fetchall()
+        return [row["node_id"] for row in rows]
+
+    def node_count(self) -> int:
+        row = self._conn.execute("SELECT COUNT(*) AS cnt FROM nodes").fetchone()
+        return row["cnt"]  # type: ignore[no-any-return]
+
+    # -- Edges -----------------------------------------------------------------
+
+    def add_edge(self, edge: dict[str, Any]) -> None:
+        edge_type = edge.get("type", "")
+        from_id = edge.get("from", "")
+        to_id = edge.get("to", "")
+        # Extra props beyond type/from/to
+        extra = {k: v for k, v in edge.items() if k not in ("type", "from", "to")}
+        self._conn.execute(
+            "INSERT INTO edges (edge_type, from_id, to_id, data, created_stage, created_phase) "
+            "VALUES (?, ?, ?, ?, ?, ?)",
+            (
+                edge_type,
+                from_id,
+                to_id,
+                json.dumps(extra) if extra else None,
+                self._stage,
+                self._phase,
+            ),
+        )
+        target_id = f"edge:{edge_type}:{from_id}:{to_id}"
+        self._record_mutation("add_edge", target_id)
+
+    def remove_edge(self, edge_type: str, from_id: str, to_id: str) -> bool:
+        # Find the first matching row to delete
+        row = self._conn.execute(
+            "SELECT rowid FROM edges WHERE edge_type = ? AND from_id = ? AND to_id = ? LIMIT 1",
+            (edge_type, from_id, to_id),
+        ).fetchone()
+        if row is None:
+            return False
+        self._conn.execute("DELETE FROM edges WHERE rowid = ?", (row["rowid"],))
+        target_id = f"edge:{edge_type}:{from_id}:{to_id}"
+        self._record_mutation("remove_edge", target_id)
+        return True
+
+    def get_edges(
+        self,
+        from_id: str | None = None,
+        to_id: str | None = None,
+        edge_type: str | None = None,
+    ) -> list[dict[str, Any]]:
+        clauses: list[str] = []
+        params: list[str] = []
+        if from_id is not None:
+            clauses.append("from_id = ?")
+            params.append(from_id)
+        if to_id is not None:
+            clauses.append("to_id = ?")
+            params.append(to_id)
+        if edge_type is not None:
+            clauses.append("edge_type = ?")
+            params.append(edge_type)
+
+        where = (" WHERE " + " AND ".join(clauses)) if clauses else ""
+        rows = self._conn.execute(
+            f"SELECT edge_type, from_id, to_id, data FROM edges{where} ORDER BY rowid",
+            params,
+        ).fetchall()
+        return [self._row_to_edge(row) for row in rows]
+
+    def edges_referencing(self, node_id: str) -> list[dict[str, Any]]:
+        rows = self._conn.execute(
+            "SELECT edge_type, from_id, to_id, data FROM edges "
+            "WHERE from_id = ? OR to_id = ? ORDER BY rowid",
+            (node_id, node_id),
+        ).fetchall()
+        return [self._row_to_edge(row) for row in rows]
+
+    def remove_edges_referencing(self, node_id: str) -> None:
+        # Atomic: record mutations and delete in one transaction
+        self._conn.execute("SAVEPOINT sp_remove_refs")
+        try:
+            rows = self._conn.execute(
+                "SELECT edge_type, from_id, to_id FROM edges WHERE from_id = ? OR to_id = ?",
+                (node_id, node_id),
+            ).fetchall()
+            for row in rows:
+                target_id = f"edge:{row['edge_type']}:{row['from_id']}:{row['to_id']}"
+                self._record_mutation("remove_edge", target_id)
+            self._conn.execute(
+                "DELETE FROM edges WHERE from_id = ? OR to_id = ?",
+                (node_id, node_id),
+            )
+            self._conn.execute("RELEASE SAVEPOINT sp_remove_refs")
+        except Exception:
+            self._conn.execute("ROLLBACK TO sp_remove_refs")
+            self._conn.execute("RELEASE SAVEPOINT sp_remove_refs")
+            raise
+
+    def edge_count(self) -> int:
+        row = self._conn.execute("SELECT COUNT(*) AS cnt FROM edges").fetchone()
+        return row["cnt"]  # type: ignore[no-any-return]
+
+    @staticmethod
+    def _row_to_edge(row: sqlite3.Row) -> dict[str, Any]:
+        """Convert an edge row to the dict format expected by Graph."""
+        edge: dict[str, Any] = {
+            "type": row["edge_type"],
+            "from": row["from_id"],
+            "to": row["to_id"],
+        }
+        if row["data"]:
+            extra = json.loads(row["data"])
+            edge.update(extra)
+        return edge
+
+    # -- Meta ------------------------------------------------------------------
+
+    def get_meta(self, key: str) -> Any:
+        row = self._conn.execute("SELECT value FROM meta WHERE key = ?", (key,)).fetchone()
+        if row is None:
+            return None
+        return json.loads(row["value"])
+
+    def set_meta(self, key: str, value: Any) -> None:
+        self._conn.execute(
+            "INSERT OR REPLACE INTO meta (key, value) VALUES (?, ?)",
+            (key, json.dumps(value)),
+        )
+
+    def all_meta(self) -> dict[str, Any]:
+        rows = self._conn.execute("SELECT key, value FROM meta").fetchall()
+        return {row["key"]: json.loads(row["value"]) for row in rows}
+
+    # -- Serialization ---------------------------------------------------------
+
+    def to_dict(self) -> dict[str, Any]:
+        """Reconstruct the full graph dict from SQLite tables."""
+        # Nodes
+        nodes: dict[str, dict[str, Any]] = {}
+        for row in self._conn.execute("SELECT node_id, data FROM nodes").fetchall():
+            nodes[row["node_id"]] = json.loads(row["data"])
+
+        # Edges (preserve insertion order via rowid)
+        edges: list[dict[str, Any]] = []
+        for row in self._conn.execute(
+            "SELECT edge_type, from_id, to_id, data FROM edges ORDER BY rowid"
+        ).fetchall():
+            edges.append(self._row_to_edge(row))
+
+        # Meta
+        meta = self.all_meta()
+
+        return {
+            "version": VERSION,
+            "meta": meta,
+            "nodes": nodes,
+            "edges": edges,
+        }
+
+    @classmethod
+    def from_dict(
+        cls,
+        data: dict[str, Any],
+        db_path: str | Path = ":memory:",
+    ) -> SqliteGraphStore:
+        """Bulk-import a graph dict into a new SqliteGraphStore.
+
+        Args:
+            data: Full graph data dict (version, meta, nodes, edges).
+            db_path: Where to create the database.
+
+        Returns:
+            New SqliteGraphStore populated with the data.
+        """
+        store = cls(db_path)
+
+        # Bulk import in a single transaction for performance
+        store._conn.execute("BEGIN")
+        try:
+            # Meta
+            meta = data.get("meta", {})
+            if meta:
+                store._conn.executemany(
+                    "INSERT OR REPLACE INTO meta (key, value) VALUES (?, ?)",
+                    [(key, json.dumps(value)) for key, value in meta.items()],
+                )
+
+            # Nodes (bulk insert, no mutation recording)
+            nodes = data.get("nodes", {})
+            if nodes:
+                store._conn.executemany(
+                    "INSERT INTO nodes (node_id, type, data) VALUES (?, ?, ?)",
+                    [
+                        (node_id, node_data.get("type", ""), json.dumps(node_data))
+                        for node_id, node_data in nodes.items()
+                    ],
+                )
+
+            # Edges (bulk insert, no mutation recording)
+            edges = data.get("edges", [])
+            if edges:
+                store._conn.executemany(
+                    "INSERT INTO edges (edge_type, from_id, to_id, data) VALUES (?, ?, ?, ?)",
+                    [
+                        (
+                            edge.get("type", ""),
+                            edge.get("from", ""),
+                            edge.get("to", ""),
+                            json.dumps(
+                                {k: v for k, v in edge.items() if k not in ("type", "from", "to")}
+                            )
+                            or None,
+                        )
+                        for edge in edges
+                    ],
+                )
+
+            store._conn.execute("COMMIT")
+        except Exception:
+            store._conn.execute("ROLLBACK")
+            raise
+
+        return store

--- a/src/questfoundry/graph/store.py
+++ b/src/questfoundry/graph/store.py
@@ -1,0 +1,237 @@
+"""Graph storage backend protocol and dict-based implementation.
+
+The GraphStore protocol defines the low-level storage operations that Graph
+delegates to. Implementations handle raw CRUD; Graph provides the public API
+with validation, error messages, and business logic.
+
+DictGraphStore is the default backend, preserving the original in-memory dict
+behavior. SqliteGraphStore (future PR) will provide SQLite-backed storage with
+mutation recording and savepoint support.
+"""
+
+from __future__ import annotations
+
+import copy
+from typing import Any, Protocol, cast, runtime_checkable
+
+
+@runtime_checkable
+class GraphStore(Protocol):
+    """Storage backend protocol for Graph.
+
+    Implementations provide low-level CRUD for nodes, edges, and metadata.
+    Graph wraps a GraphStore and adds validation, error handling, and
+    business logic on top.
+
+    Methods raise no domain-specific errors — Graph is responsible for
+    translating storage failures into NodeNotFoundError, etc.
+    """
+
+    # -- Nodes -----------------------------------------------------------------
+
+    def get_node(self, node_id: str) -> dict[str, Any] | None:
+        """Get node data by ID, or None if not found."""
+        ...
+
+    def has_node(self, node_id: str) -> bool:
+        """Check whether a node exists."""
+        ...
+
+    def set_node(self, node_id: str, data: dict[str, Any]) -> None:
+        """Set node data (create or overwrite)."""
+        ...
+
+    def update_node_fields(self, node_id: str, **updates: Any) -> None:
+        """Merge keyword updates into an existing node's data dict."""
+        ...
+
+    def delete_node(self, node_id: str) -> None:
+        """Delete a node by ID. No cascade — caller handles edges first."""
+        ...
+
+    def get_nodes_by_type(self, node_type: str) -> dict[str, dict[str, Any]]:
+        """Return all nodes whose ``type`` field matches *node_type*."""
+        ...
+
+    def all_node_ids(self) -> list[str]:
+        """Return all node IDs."""
+        ...
+
+    def node_ids_with_prefix(self, prefix: str) -> list[str]:
+        """Return node IDs that start with *prefix*."""
+        ...
+
+    def node_count(self) -> int:
+        """Return total number of nodes."""
+        ...
+
+    # -- Edges -----------------------------------------------------------------
+
+    def add_edge(self, edge: dict[str, Any]) -> None:
+        """Append a pre-built edge dict (no validation)."""
+        ...
+
+    def remove_edge(self, edge_type: str, from_id: str, to_id: str) -> bool:
+        """Remove first matching edge. Return True if removed, False if absent."""
+        ...
+
+    def get_edges(
+        self,
+        from_id: str | None = None,
+        to_id: str | None = None,
+        edge_type: str | None = None,
+    ) -> list[dict[str, Any]]:
+        """Return edges matching optional filters (all edges if no filters)."""
+        ...
+
+    def edges_referencing(self, node_id: str) -> list[dict[str, Any]]:
+        """Return all edges where *node_id* appears as ``from`` or ``to``."""
+        ...
+
+    def remove_edges_referencing(self, node_id: str) -> None:
+        """Remove all edges where *node_id* appears as ``from`` or ``to``."""
+        ...
+
+    def edge_count(self) -> int:
+        """Return total number of edges."""
+        ...
+
+    # -- Meta ------------------------------------------------------------------
+
+    def get_meta(self, key: str) -> Any:
+        """Get a metadata value by key, or None if absent."""
+        ...
+
+    def set_meta(self, key: str, value: Any) -> None:
+        """Set a metadata value."""
+        ...
+
+    def all_meta(self) -> dict[str, Any]:
+        """Return the full metadata dict."""
+        ...
+
+    # -- Serialization ---------------------------------------------------------
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize the entire store to a graph dict (deep copy)."""
+        ...
+
+
+class DictGraphStore:
+    """In-memory dict-based graph store.
+
+    This is the default backend, preserving the original Graph behavior
+    of storing all state in a nested dict.
+    """
+
+    VERSION = "5.0"
+
+    def __init__(self, data: dict[str, Any] | None = None) -> None:
+        self._data: dict[str, Any] = data or {
+            "version": self.VERSION,
+            "meta": {
+                "project_name": None,
+                "last_stage": None,
+                "last_modified": None,
+                "stage_history": [],
+            },
+            "nodes": {},
+            "edges": [],
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> DictGraphStore:
+        """Create a DictGraphStore from a graph data dict."""
+        return cls(data)
+
+    # -- Nodes -----------------------------------------------------------------
+
+    def get_node(self, node_id: str) -> dict[str, Any] | None:
+        result = self._data["nodes"].get(node_id)
+        return cast("dict[str, Any] | None", result)
+
+    def has_node(self, node_id: str) -> bool:
+        return node_id in self._data["nodes"]
+
+    def set_node(self, node_id: str, data: dict[str, Any]) -> None:
+        self._data["nodes"][node_id] = data
+
+    def update_node_fields(self, node_id: str, **updates: Any) -> None:
+        self._data["nodes"][node_id].update(updates)
+
+    def delete_node(self, node_id: str) -> None:
+        del self._data["nodes"][node_id]
+
+    def get_nodes_by_type(self, node_type: str) -> dict[str, dict[str, Any]]:
+        return {
+            nid: ndata
+            for nid, ndata in self._data["nodes"].items()
+            if ndata.get("type") == node_type
+        }
+
+    def all_node_ids(self) -> list[str]:
+        return list(self._data["nodes"].keys())
+
+    def node_ids_with_prefix(self, prefix: str) -> list[str]:
+        return [nid for nid in self._data["nodes"] if nid.startswith(prefix)]
+
+    def node_count(self) -> int:
+        return len(self._data["nodes"])
+
+    # -- Edges -----------------------------------------------------------------
+
+    def add_edge(self, edge: dict[str, Any]) -> None:
+        self._data["edges"].append(edge)
+
+    def remove_edge(self, edge_type: str, from_id: str, to_id: str) -> bool:
+        for i, edge in enumerate(self._data["edges"]):
+            if (
+                edge.get("type") == edge_type
+                and edge.get("from") == from_id
+                and edge.get("to") == to_id
+            ):
+                self._data["edges"].pop(i)
+                return True
+        return False
+
+    def get_edges(
+        self,
+        from_id: str | None = None,
+        to_id: str | None = None,
+        edge_type: str | None = None,
+    ) -> list[dict[str, Any]]:
+        edges: list[dict[str, Any]] = self._data["edges"]
+        if from_id is not None:
+            edges = [e for e in edges if e.get("from") == from_id]
+        if to_id is not None:
+            edges = [e for e in edges if e.get("to") == to_id]
+        if edge_type is not None:
+            edges = [e for e in edges if e.get("type") == edge_type]
+        return edges
+
+    def edges_referencing(self, node_id: str) -> list[dict[str, Any]]:
+        return [e for e in self._data["edges"] if node_id in (e.get("from"), e.get("to"))]
+
+    def remove_edges_referencing(self, node_id: str) -> None:
+        self._data["edges"] = [
+            e for e in self._data["edges"] if node_id not in (e.get("from"), e.get("to"))
+        ]
+
+    def edge_count(self) -> int:
+        return len(self._data["edges"])
+
+    # -- Meta ------------------------------------------------------------------
+
+    def get_meta(self, key: str) -> Any:
+        return self._data["meta"].get(key)
+
+    def set_meta(self, key: str, value: Any) -> None:
+        self._data["meta"][key] = value
+
+    def all_meta(self) -> dict[str, Any]:
+        return cast("dict[str, Any]", self._data["meta"])
+
+    # -- Serialization ---------------------------------------------------------
+
+    def to_dict(self) -> dict[str, Any]:
+        return copy.deepcopy(self._data)

--- a/tests/unit/test_dict_graph_store.py
+++ b/tests/unit/test_dict_graph_store.py
@@ -1,0 +1,244 @@
+"""Tests for DictGraphStore — the in-memory dict storage backend.
+
+These tests exercise the GraphStore protocol through DictGraphStore directly,
+independent of the Graph facade. Graph-level tests in test_graph.py continue
+to verify the full stack.
+"""
+
+from __future__ import annotations
+
+from questfoundry.graph.store import DictGraphStore, GraphStore
+
+
+class TestDictGraphStoreProtocol:
+    """Verify DictGraphStore satisfies the GraphStore protocol."""
+
+    def test_is_runtime_checkable(self) -> None:
+        """DictGraphStore passes isinstance check for GraphStore."""
+        store = DictGraphStore()
+        assert isinstance(store, GraphStore)
+
+    def test_default_state(self) -> None:
+        """Default store has empty nodes, edges, and default meta."""
+        store = DictGraphStore()
+        assert store.node_count() == 0
+        assert store.edge_count() == 0
+        assert store.get_meta("last_stage") is None
+        assert store.get_meta("project_name") is None
+        assert store.get_meta("stage_history") == []
+
+
+class TestDictGraphStoreNodes:
+    """Test node CRUD on DictGraphStore."""
+
+    def test_set_and_get_node(self) -> None:
+        """Can set and retrieve a node."""
+        store = DictGraphStore()
+        store.set_node("entity::alice", {"type": "entity", "name": "Alice"})
+
+        node = store.get_node("entity::alice")
+        assert node is not None
+        assert node["name"] == "Alice"
+
+    def test_get_missing_node_returns_none(self) -> None:
+        """Getting a non-existent node returns None."""
+        store = DictGraphStore()
+        assert store.get_node("missing") is None
+
+    def test_has_node(self) -> None:
+        """has_node returns correct boolean."""
+        store = DictGraphStore()
+        assert not store.has_node("entity::alice")
+        store.set_node("entity::alice", {"type": "entity"})
+        assert store.has_node("entity::alice")
+
+    def test_update_node_fields(self) -> None:
+        """update_node_fields merges into existing data."""
+        store = DictGraphStore()
+        store.set_node("entity::alice", {"type": "entity", "name": "Alice"})
+        store.update_node_fields("entity::alice", disposition="retained", status="active")
+
+        node = store.get_node("entity::alice")
+        assert node is not None
+        assert node["name"] == "Alice"  # preserved
+        assert node["disposition"] == "retained"  # added
+        assert node["status"] == "active"  # added
+
+    def test_delete_node(self) -> None:
+        """delete_node removes the node."""
+        store = DictGraphStore()
+        store.set_node("entity::alice", {"type": "entity"})
+        store.delete_node("entity::alice")
+        assert not store.has_node("entity::alice")
+
+    def test_get_nodes_by_type(self) -> None:
+        """get_nodes_by_type filters by type field."""
+        store = DictGraphStore()
+        store.set_node("entity::alice", {"type": "entity"})
+        store.set_node("entity::bob", {"type": "entity"})
+        store.set_node("dilemma::d1", {"type": "dilemma"})
+
+        entities = store.get_nodes_by_type("entity")
+        assert len(entities) == 2
+        assert "entity::alice" in entities
+        assert "entity::bob" in entities
+        assert "dilemma::d1" not in entities
+
+    def test_all_node_ids(self) -> None:
+        """all_node_ids returns all node IDs."""
+        store = DictGraphStore()
+        store.set_node("a", {"type": "test"})
+        store.set_node("b", {"type": "test"})
+        ids = store.all_node_ids()
+        assert set(ids) == {"a", "b"}
+
+    def test_node_ids_with_prefix(self) -> None:
+        """node_ids_with_prefix filters by prefix."""
+        store = DictGraphStore()
+        store.set_node("entity::alice", {"type": "entity"})
+        store.set_node("entity::bob", {"type": "entity"})
+        store.set_node("path::main", {"type": "path"})
+
+        entity_ids = store.node_ids_with_prefix("entity::")
+        assert set(entity_ids) == {"entity::alice", "entity::bob"}
+
+    def test_node_count(self) -> None:
+        """node_count tracks additions and deletions."""
+        store = DictGraphStore()
+        assert store.node_count() == 0
+        store.set_node("a", {"type": "test"})
+        assert store.node_count() == 1
+        store.set_node("b", {"type": "test"})
+        assert store.node_count() == 2
+        store.delete_node("a")
+        assert store.node_count() == 1
+
+
+class TestDictGraphStoreEdges:
+    """Test edge CRUD on DictGraphStore."""
+
+    def test_add_and_get_edge(self) -> None:
+        """Can add and retrieve an edge."""
+        store = DictGraphStore()
+        store.add_edge({"type": "relates_to", "from": "a", "to": "b"})
+
+        edges = store.get_edges()
+        assert len(edges) == 1
+        assert edges[0]["type"] == "relates_to"
+
+    def test_get_edges_with_filters(self) -> None:
+        """get_edges filters by from, to, and type."""
+        store = DictGraphStore()
+        store.add_edge({"type": "belongs_to", "from": "beat::1", "to": "path::a"})
+        store.add_edge({"type": "belongs_to", "from": "beat::2", "to": "path::a"})
+        store.add_edge({"type": "explores", "from": "path::a", "to": "dilemma::d"})
+
+        assert len(store.get_edges(edge_type="belongs_to")) == 2
+        assert len(store.get_edges(to_id="path::a")) == 2
+        assert len(store.get_edges(from_id="beat::1")) == 1
+        assert len(store.get_edges(from_id="path::a", edge_type="explores")) == 1
+
+    def test_remove_edge(self) -> None:
+        """remove_edge removes first match and returns True."""
+        store = DictGraphStore()
+        store.add_edge({"type": "link", "from": "a", "to": "b"})
+        assert store.remove_edge("link", "a", "b") is True
+        assert store.edge_count() == 0
+
+    def test_remove_edge_no_match(self) -> None:
+        """remove_edge returns False when no match found."""
+        store = DictGraphStore()
+        assert store.remove_edge("link", "a", "b") is False
+
+    def test_edges_referencing(self) -> None:
+        """edges_referencing finds all edges involving a node."""
+        store = DictGraphStore()
+        store.add_edge({"type": "a", "from": "x", "to": "y"})
+        store.add_edge({"type": "b", "from": "y", "to": "z"})
+        store.add_edge({"type": "c", "from": "w", "to": "x"})
+
+        refs = store.edges_referencing("x")
+        assert len(refs) == 2  # from=x and to=x
+
+        refs_y = store.edges_referencing("y")
+        assert len(refs_y) == 2  # to=y and from=y
+
+    def test_remove_edges_referencing(self) -> None:
+        """remove_edges_referencing deletes all edges involving a node."""
+        store = DictGraphStore()
+        store.add_edge({"type": "a", "from": "x", "to": "y"})
+        store.add_edge({"type": "b", "from": "y", "to": "z"})
+        store.add_edge({"type": "c", "from": "w", "to": "v"})
+
+        store.remove_edges_referencing("y")
+        assert store.edge_count() == 1
+        assert store.get_edges()[0]["from"] == "w"
+
+    def test_edge_count(self) -> None:
+        """edge_count tracks additions and removals."""
+        store = DictGraphStore()
+        assert store.edge_count() == 0
+        store.add_edge({"type": "t", "from": "a", "to": "b"})
+        assert store.edge_count() == 1
+        store.add_edge({"type": "t", "from": "c", "to": "d"})
+        assert store.edge_count() == 2
+        store.remove_edge("t", "a", "b")
+        assert store.edge_count() == 1
+
+
+class TestDictGraphStoreMeta:
+    """Test metadata operations on DictGraphStore."""
+
+    def test_set_and_get_meta(self) -> None:
+        """Can set and get metadata values."""
+        store = DictGraphStore()
+        store.set_meta("project_name", "test")
+        assert store.get_meta("project_name") == "test"
+
+    def test_get_meta_missing_key(self) -> None:
+        """get_meta returns None for missing keys."""
+        store = DictGraphStore()
+        assert store.get_meta("nonexistent") is None
+
+    def test_all_meta(self) -> None:
+        """all_meta returns the full metadata dict."""
+        store = DictGraphStore()
+        meta = store.all_meta()
+        assert "project_name" in meta
+        assert "last_stage" in meta
+        assert "stage_history" in meta
+
+
+class TestDictGraphStoreSerialization:
+    """Test serialization round-trips."""
+
+    def test_to_dict_returns_deep_copy(self) -> None:
+        """to_dict returns a deep copy (mutations don't leak)."""
+        store = DictGraphStore()
+        store.set_node("entity::alice", {"type": "entity", "name": "Alice"})
+
+        d = store.to_dict()
+        d["nodes"]["entity::alice"]["name"] = "MUTATED"
+
+        # Original store unchanged
+        assert store.get_node("entity::alice")["name"] == "Alice"
+
+    def test_from_dict_round_trip(self) -> None:
+        """from_dict creates a store from to_dict output."""
+        store = DictGraphStore()
+        store.set_node("a", {"type": "test", "val": 42})
+        store.add_edge({"type": "link", "from": "a", "to": "a", "weight": 1.5})
+        store.set_meta("project_name", "roundtrip")
+
+        data = store.to_dict()
+        restored = DictGraphStore.from_dict(data)
+
+        assert restored.get_node("a")["val"] == 42
+        assert restored.edge_count() == 1
+        assert restored.get_meta("project_name") == "roundtrip"
+
+    def test_to_dict_has_version(self) -> None:
+        """to_dict output includes version field."""
+        store = DictGraphStore()
+        d = store.to_dict()
+        assert d["version"] == "5.0"

--- a/tests/unit/test_sqlite_store.py
+++ b/tests/unit/test_sqlite_store.py
@@ -1,0 +1,512 @@
+"""Tests for SqliteGraphStore — the SQLite storage backend.
+
+All tests use :memory: databases. Tests mirror the DictGraphStore test
+patterns to verify both backends behave identically for the GraphStore protocol.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+
+from questfoundry.graph.sqlite_store import SqliteGraphStore
+from questfoundry.graph.store import GraphStore
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+class TestSqliteStoreProtocol:
+    """Verify SqliteGraphStore satisfies the GraphStore protocol."""
+
+    def test_is_runtime_checkable(self) -> None:
+        """SqliteGraphStore passes isinstance check for GraphStore."""
+        store = SqliteGraphStore()
+        assert isinstance(store, GraphStore)
+
+    def test_default_state(self) -> None:
+        """Default store has empty nodes and edges."""
+        store = SqliteGraphStore()
+        assert store.node_count() == 0
+        assert store.edge_count() == 0
+        assert store.get_meta("last_stage") is None
+
+
+class TestSqliteStoreNodes:
+    """Test node CRUD on SqliteGraphStore."""
+
+    def test_set_and_get_node(self) -> None:
+        store = SqliteGraphStore()
+        store.set_node("entity::alice", {"type": "entity", "name": "Alice"})
+        node = store.get_node("entity::alice")
+        assert node is not None
+        assert node["name"] == "Alice"
+        assert node["type"] == "entity"
+
+    def test_get_missing_node_returns_none(self) -> None:
+        store = SqliteGraphStore()
+        assert store.get_node("missing") is None
+
+    def test_has_node(self) -> None:
+        store = SqliteGraphStore()
+        assert not store.has_node("entity::alice")
+        store.set_node("entity::alice", {"type": "entity"})
+        assert store.has_node("entity::alice")
+
+    def test_set_node_overwrites(self) -> None:
+        store = SqliteGraphStore()
+        store.set_node("entity::alice", {"type": "entity", "name": "Alice"})
+        store.set_node("entity::alice", {"type": "entity", "name": "Bob"})
+        assert store.get_node("entity::alice")["name"] == "Bob"
+
+    def test_update_node_fields(self) -> None:
+        store = SqliteGraphStore()
+        store.set_node("entity::alice", {"type": "entity", "name": "Alice"})
+        store.update_node_fields("entity::alice", disposition="retained", status="active")
+
+        node = store.get_node("entity::alice")
+        assert node is not None
+        assert node["name"] == "Alice"  # preserved
+        assert node["disposition"] == "retained"
+        assert node["status"] == "active"
+
+    def test_delete_node(self) -> None:
+        store = SqliteGraphStore()
+        store.set_node("entity::alice", {"type": "entity"})
+        store.delete_node("entity::alice")
+        assert not store.has_node("entity::alice")
+
+    def test_get_nodes_by_type(self) -> None:
+        store = SqliteGraphStore()
+        store.set_node("entity::alice", {"type": "entity"})
+        store.set_node("entity::bob", {"type": "entity"})
+        store.set_node("dilemma::d1", {"type": "dilemma"})
+
+        entities = store.get_nodes_by_type("entity")
+        assert len(entities) == 2
+        assert "entity::alice" in entities
+        assert "entity::bob" in entities
+        assert "dilemma::d1" not in entities
+
+    def test_all_node_ids(self) -> None:
+        store = SqliteGraphStore()
+        store.set_node("a", {"type": "test"})
+        store.set_node("b", {"type": "test"})
+        assert set(store.all_node_ids()) == {"a", "b"}
+
+    def test_node_ids_with_prefix(self) -> None:
+        store = SqliteGraphStore()
+        store.set_node("entity::alice", {"type": "entity"})
+        store.set_node("entity::bob", {"type": "entity"})
+        store.set_node("path::main", {"type": "path"})
+
+        entity_ids = store.node_ids_with_prefix("entity::")
+        assert set(entity_ids) == {"entity::alice", "entity::bob"}
+
+    def test_node_count(self) -> None:
+        store = SqliteGraphStore()
+        assert store.node_count() == 0
+        store.set_node("a", {"type": "test"})
+        assert store.node_count() == 1
+        store.delete_node("a")
+        assert store.node_count() == 0
+
+
+class TestSqliteStoreEdges:
+    """Test edge CRUD on SqliteGraphStore."""
+
+    def test_add_and_get_edge(self) -> None:
+        store = SqliteGraphStore()
+        store.add_edge({"type": "relates_to", "from": "a", "to": "b"})
+        edges = store.get_edges()
+        assert len(edges) == 1
+        assert edges[0]["type"] == "relates_to"
+        assert edges[0]["from"] == "a"
+        assert edges[0]["to"] == "b"
+
+    def test_edge_with_extra_props(self) -> None:
+        """Extra edge properties are preserved in data column."""
+        store = SqliteGraphStore()
+        store.add_edge(
+            {
+                "type": "choice",
+                "from": "s1",
+                "to": "s2",
+                "label": "Go north",
+                "requires": ["has_key"],
+            }
+        )
+        edges = store.get_edges()
+        assert edges[0]["label"] == "Go north"
+        assert edges[0]["requires"] == ["has_key"]
+
+    def test_get_edges_with_filters(self) -> None:
+        store = SqliteGraphStore()
+        store.add_edge({"type": "belongs_to", "from": "beat::1", "to": "path::a"})
+        store.add_edge({"type": "belongs_to", "from": "beat::2", "to": "path::a"})
+        store.add_edge({"type": "explores", "from": "path::a", "to": "dilemma::d"})
+
+        assert len(store.get_edges(edge_type="belongs_to")) == 2
+        assert len(store.get_edges(to_id="path::a")) == 2
+        assert len(store.get_edges(from_id="beat::1")) == 1
+        assert len(store.get_edges(from_id="path::a", edge_type="explores")) == 1
+
+    def test_get_edges_preserves_insertion_order(self) -> None:
+        """Edges are returned in insertion order (rowid)."""
+        store = SqliteGraphStore()
+        store.add_edge({"type": "a", "from": "x", "to": "y"})
+        store.add_edge({"type": "b", "from": "x", "to": "z"})
+        store.add_edge({"type": "c", "from": "x", "to": "w"})
+
+        edges = store.get_edges()
+        types = [e["type"] for e in edges]
+        assert types == ["a", "b", "c"]
+
+    def test_remove_edge(self) -> None:
+        store = SqliteGraphStore()
+        store.add_edge({"type": "link", "from": "a", "to": "b"})
+        assert store.remove_edge("link", "a", "b") is True
+        assert store.edge_count() == 0
+
+    def test_remove_edge_no_match(self) -> None:
+        store = SqliteGraphStore()
+        assert store.remove_edge("link", "a", "b") is False
+
+    def test_remove_edge_first_only(self) -> None:
+        """remove_edge removes only the first matching edge."""
+        store = SqliteGraphStore()
+        store.add_edge({"type": "link", "from": "a", "to": "b"})
+        store.add_edge({"type": "link", "from": "a", "to": "b"})
+        assert store.edge_count() == 2
+
+        store.remove_edge("link", "a", "b")
+        assert store.edge_count() == 1
+
+    def test_edges_referencing(self) -> None:
+        store = SqliteGraphStore()
+        store.add_edge({"type": "a", "from": "x", "to": "y"})
+        store.add_edge({"type": "b", "from": "y", "to": "z"})
+        store.add_edge({"type": "c", "from": "w", "to": "x"})
+
+        refs = store.edges_referencing("x")
+        assert len(refs) == 2  # from=x and to=x
+
+    def test_remove_edges_referencing(self) -> None:
+        store = SqliteGraphStore()
+        store.add_edge({"type": "a", "from": "x", "to": "y"})
+        store.add_edge({"type": "b", "from": "y", "to": "z"})
+        store.add_edge({"type": "c", "from": "w", "to": "v"})
+
+        store.remove_edges_referencing("y")
+        assert store.edge_count() == 1
+        assert store.get_edges()[0]["from"] == "w"
+
+    def test_edge_count(self) -> None:
+        store = SqliteGraphStore()
+        assert store.edge_count() == 0
+        store.add_edge({"type": "t", "from": "a", "to": "b"})
+        assert store.edge_count() == 1
+        store.remove_edge("t", "a", "b")
+        assert store.edge_count() == 0
+
+
+class TestSqliteStoreMeta:
+    """Test metadata operations on SqliteGraphStore."""
+
+    def test_set_and_get_meta(self) -> None:
+        store = SqliteGraphStore()
+        store.set_meta("project_name", "test")
+        assert store.get_meta("project_name") == "test"
+
+    def test_get_meta_missing_key(self) -> None:
+        store = SqliteGraphStore()
+        assert store.get_meta("nonexistent") is None
+
+    def test_set_meta_overwrites(self) -> None:
+        store = SqliteGraphStore()
+        store.set_meta("key", "value1")
+        store.set_meta("key", "value2")
+        assert store.get_meta("key") == "value2"
+
+    def test_all_meta(self) -> None:
+        store = SqliteGraphStore()
+        store.set_meta("project_name", "test")
+        store.set_meta("last_stage", "dream")
+        meta = store.all_meta()
+        assert meta["project_name"] == "test"
+        assert meta["last_stage"] == "dream"
+
+    def test_meta_stores_complex_values(self) -> None:
+        """Meta values can be lists, dicts, etc. (JSON-serialized)."""
+        store = SqliteGraphStore()
+        store.set_meta(
+            "stage_history",
+            [
+                {"stage": "dream", "completed": "2024-01-01T00:00:00"},
+            ],
+        )
+        history = store.get_meta("stage_history")
+        assert len(history) == 1
+        assert history[0]["stage"] == "dream"
+
+
+class TestSqliteStoreMutations:
+    """Test mutation recording."""
+
+    def test_create_node_records_mutation(self) -> None:
+        store = SqliteGraphStore()
+        store.set_mutation_context(stage="seed", phase="serialize")
+        store.set_node("entity::alice", {"type": "entity", "name": "Alice"})
+
+        rows = store._conn.execute("SELECT * FROM mutations").fetchall()
+        assert len(rows) == 1
+        assert rows[0]["operation"] == "create_node"
+        assert rows[0]["target_id"] == "entity::alice"
+        assert rows[0]["stage"] == "seed"
+        assert rows[0]["phase"] == "serialize"
+        delta = json.loads(rows[0]["delta"])
+        assert delta["name"] == "Alice"
+
+    def test_update_node_records_mutation(self) -> None:
+        store = SqliteGraphStore()
+        store.set_node("entity::alice", {"type": "entity"})
+
+        store.set_mutation_context(stage="grow", phase="path_agnostic")
+        store.update_node_fields("entity::alice", disposition="retained")
+
+        rows = store._conn.execute(
+            "SELECT * FROM mutations WHERE operation = 'update_node'"
+        ).fetchall()
+        assert len(rows) == 1
+        delta = json.loads(rows[0]["delta"])
+        assert delta == {"disposition": "retained"}
+
+    def test_delete_node_records_mutation(self) -> None:
+        store = SqliteGraphStore()
+        store.set_node("entity::alice", {"type": "entity"})
+        store.delete_node("entity::alice")
+
+        rows = store._conn.execute(
+            "SELECT * FROM mutations WHERE operation = 'delete_node'"
+        ).fetchall()
+        assert len(rows) == 1
+        assert rows[0]["target_id"] == "entity::alice"
+
+    def test_add_edge_records_mutation(self) -> None:
+        store = SqliteGraphStore()
+        store.add_edge({"type": "belongs_to", "from": "beat::1", "to": "path::a"})
+
+        rows = store._conn.execute(
+            "SELECT * FROM mutations WHERE operation = 'add_edge'"
+        ).fetchall()
+        assert len(rows) == 1
+        assert rows[0]["target_id"] == "edge:belongs_to:beat::1:path::a"
+
+    def test_remove_edge_records_mutation(self) -> None:
+        store = SqliteGraphStore()
+        store.add_edge({"type": "link", "from": "a", "to": "b"})
+        store.remove_edge("link", "a", "b")
+
+        rows = store._conn.execute(
+            "SELECT * FROM mutations WHERE operation = 'remove_edge'"
+        ).fetchall()
+        assert len(rows) == 1
+
+    def test_overwrite_node_records_update_mutation(self) -> None:
+        """Second set_node on same ID records update_node."""
+        store = SqliteGraphStore()
+        store.set_node("entity::alice", {"type": "entity", "name": "Alice"})
+        store.set_node("entity::alice", {"type": "entity", "name": "Bob"})
+
+        rows = store._conn.execute("SELECT operation FROM mutations").fetchall()
+        ops = [row["operation"] for row in rows]
+        assert ops == ["create_node", "update_node"]
+
+    def test_mutation_context_default_empty(self) -> None:
+        """Without set_mutation_context, stage/phase are empty strings."""
+        store = SqliteGraphStore()
+        store.set_node("a", {"type": "test"})
+
+        row = store._conn.execute("SELECT stage, phase FROM mutations").fetchone()
+        assert row["stage"] == ""
+        assert row["phase"] == ""
+
+    def test_remove_edges_referencing_records_mutations(self) -> None:
+        """remove_edges_referencing records a mutation for each removed edge."""
+        store = SqliteGraphStore()
+        store.add_edge({"type": "a", "from": "x", "to": "y"})
+        store.add_edge({"type": "b", "from": "y", "to": "z"})
+        # Clear the add_edge mutations
+        store._conn.execute("DELETE FROM mutations")
+
+        store.remove_edges_referencing("y")
+
+        rows = store._conn.execute(
+            "SELECT * FROM mutations WHERE operation = 'remove_edge'"
+        ).fetchall()
+        assert len(rows) == 2
+
+
+class TestSqliteStoreSavepoints:
+    """Test savepoint/rollback/release."""
+
+    def test_savepoint_and_rollback(self) -> None:
+        """Can rollback to a savepoint, undoing changes."""
+        store = SqliteGraphStore()
+        store.set_node("before", {"type": "test"})
+
+        store.savepoint("phase1")
+        store.set_node("during", {"type": "test"})
+        assert store.has_node("during")
+
+        store.rollback_to("phase1")
+        assert not store.has_node("during")
+        assert store.has_node("before")
+
+    def test_savepoint_and_release(self) -> None:
+        """Releasing a savepoint commits its changes."""
+        store = SqliteGraphStore()
+        store.savepoint("phase1")
+        store.set_node("new", {"type": "test"})
+        store.release("phase1")
+
+        assert store.has_node("new")
+
+    def test_nested_savepoints(self) -> None:
+        """Nested savepoints work correctly."""
+        store = SqliteGraphStore()
+        store.set_node("base", {"type": "test"})
+
+        store.savepoint("outer")
+        store.set_node("outer_node", {"type": "test"})
+
+        store.savepoint("inner")
+        store.set_node("inner_node", {"type": "test"})
+
+        # Rollback inner only
+        store.rollback_to("inner")
+        assert not store.has_node("inner_node")
+        assert store.has_node("outer_node")
+
+        # Release inner, rollback outer
+        store.release("inner")
+        store.rollback_to("outer")
+        assert not store.has_node("outer_node")
+        assert store.has_node("base")
+
+    def test_rollback_edges(self) -> None:
+        """Savepoint rollback also undoes edge changes."""
+        store = SqliteGraphStore()
+        store.add_edge({"type": "keep", "from": "a", "to": "b"})
+
+        store.savepoint("phase")
+        store.add_edge({"type": "temp", "from": "c", "to": "d"})
+        assert store.edge_count() == 2
+
+        store.rollback_to("phase")
+        assert store.edge_count() == 1
+        assert store.get_edges()[0]["type"] == "keep"
+
+    def test_rollback_meta(self) -> None:
+        """Savepoint rollback also undoes meta changes."""
+        store = SqliteGraphStore()
+        store.set_meta("last_stage", "seed")
+
+        store.savepoint("phase")
+        store.set_meta("last_stage", "grow")
+        assert store.get_meta("last_stage") == "grow"
+
+        store.rollback_to("phase")
+        assert store.get_meta("last_stage") == "seed"
+
+
+class TestSqliteStoreSerialization:
+    """Test to_dict/from_dict round-trips."""
+
+    def test_to_dict_format(self) -> None:
+        """to_dict returns the expected graph dict format."""
+        store = SqliteGraphStore()
+        store.set_meta("project_name", "test")
+        store.set_meta("last_stage", "dream")
+        store.set_node("entity::alice", {"type": "entity", "name": "Alice"})
+        store.add_edge({"type": "link", "from": "entity::alice", "to": "entity::alice"})
+
+        d = store.to_dict()
+        assert d["version"] == "5.0"
+        assert d["meta"]["project_name"] == "test"
+        assert "entity::alice" in d["nodes"]
+        assert len(d["edges"]) == 1
+        assert d["edges"][0]["type"] == "link"
+
+    def test_from_dict_round_trip(self) -> None:
+        """from_dict creates a store from to_dict output."""
+        original = SqliteGraphStore()
+        original.set_meta("project_name", "roundtrip")
+        original.set_meta("stage_history", [])
+        original.set_node("a", {"type": "test", "val": 42})
+        original.add_edge({"type": "link", "from": "a", "to": "a", "weight": 1.5})
+
+        data = original.to_dict()
+        restored = SqliteGraphStore.from_dict(data)
+
+        assert restored.get_node("a")["val"] == 42
+        assert restored.edge_count() == 1
+        assert restored.get_edges()[0]["weight"] == 1.5
+        assert restored.get_meta("project_name") == "roundtrip"
+
+    def test_from_dict_no_mutations_recorded(self) -> None:
+        """from_dict bulk import does not record mutations."""
+        data = {
+            "version": "5.0",
+            "meta": {"last_stage": "seed"},
+            "nodes": {"a": {"type": "test"}},
+            "edges": [{"type": "link", "from": "a", "to": "a"}],
+        }
+        store = SqliteGraphStore.from_dict(data)
+        rows = store._conn.execute("SELECT COUNT(*) AS cnt FROM mutations").fetchone()
+        assert rows["cnt"] == 0
+
+    def test_from_dict_dict_store_compat(self) -> None:
+        """SqliteGraphStore.from_dict is compatible with DictGraphStore.to_dict."""
+        from questfoundry.graph.store import DictGraphStore
+
+        dict_store = DictGraphStore()
+        dict_store.set_node("entity::alice", {"type": "entity", "name": "Alice"})
+        dict_store.set_node("entity::bob", {"type": "entity", "name": "Bob"})
+        dict_store.add_edge({"type": "relates", "from": "entity::alice", "to": "entity::bob"})
+        dict_store.set_meta("project_name", "cross_compat")
+        dict_store.set_meta("last_stage", "dream")
+        dict_store.set_meta("stage_history", [{"stage": "dream", "completed": "2024-01-01"}])
+
+        data = dict_store.to_dict()
+        sqlite_store = SqliteGraphStore.from_dict(data)
+
+        # Verify all data migrated correctly
+        assert sqlite_store.get_node("entity::alice")["name"] == "Alice"
+        assert sqlite_store.get_node("entity::bob")["name"] == "Bob"
+        assert sqlite_store.edge_count() == 1
+        assert sqlite_store.get_meta("project_name") == "cross_compat"
+        assert sqlite_store.get_meta("last_stage") == "dream"
+
+        # And round-trip back to dict
+        roundtrip = sqlite_store.to_dict()
+        assert roundtrip["nodes"]["entity::alice"]["name"] == "Alice"
+        assert len(roundtrip["edges"]) == 1
+
+
+class TestSqliteStoreFileBackend:
+    """Test file-based SQLite (not :memory:)."""
+
+    def test_file_persistence(self, tmp_path: Path) -> None:
+        """Data persists across open/close cycles."""
+        db_path = tmp_path / "test.db"
+
+        store = SqliteGraphStore(db_path)
+        store.set_node("entity::alice", {"type": "entity"})
+        store.set_meta("last_stage", "dream")
+        store.close()
+
+        store2 = SqliteGraphStore(db_path)
+        assert store2.has_node("entity::alice")
+        assert store2.get_meta("last_stage") == "dream"
+        store2.close()


### PR DESCRIPTION
## Problem

Issue #852 requires migrating Graph storage from JSON to SQLite. The current
Graph class has 34 direct `self._data` references scattered through CRUD methods,
making it impossible to swap the storage backend without a massive rewrite.

## Changes

- **New**: `src/questfoundry/graph/store.py` — `GraphStore` protocol (runtime-checkable)
  and `DictGraphStore` class implementing all storage operations
- **Refactored**: `src/questfoundry/graph/graph.py` — replaced all 34 `self._data`
  references with `self._store` delegation; Graph now accepts optional `store` kwarg
- **Updated**: `src/questfoundry/graph/__init__.py` — exports `GraphStore`, `DictGraphStore`
- **New**: `tests/unit/test_dict_graph_store.py` — 24 tests for the store backend

### GraphStore protocol methods:
- **Nodes**: `get_node`, `has_node`, `set_node`, `update_node_fields`, `delete_node`,
  `get_nodes_by_type`, `all_node_ids`, `node_ids_with_prefix`, `node_count`
- **Edges**: `add_edge`, `remove_edge`, `get_edges`, `edges_referencing`,
  `remove_edges_referencing`, `edge_count`
- **Meta**: `get_meta`, `set_meta`, `all_meta`
- **Serialization**: `to_dict`

### Backward compatibility:
- `Graph._data` property delegates to `DictGraphStore._data` for test code that
  injects malformed edges directly (7 usages across test_graph.py and test_orchestrator.py)
- `Graph(data=...)` constructor still works — wraps in DictGraphStore automatically
- `Graph.from_dict()`, `Graph.empty()` unchanged

## Not Included / Future PRs

- SqliteGraphStore implementation (#852, PR 2)
- Graph.load() auto-migration (#852, PR 3)
- Savepoint API on Graph (#852, PR 3)
- Stage integration with savepoints (#852, PR 4)
- CLI audit command (#852, PR 5)

## Test Plan

```
uv run mypy src/questfoundry/graph/ — 0 errors
uv run ruff check src/questfoundry/graph/ — 0 errors
uv run pytest tests/unit/test_graph.py -x -q — 68 passed
uv run pytest tests/unit/test_dict_graph_store.py -x -q — 24 passed
uv run pytest tests/unit/test_orchestrator.py -x -q — 52 passed
uv run pytest tests/unit/ -x -q — 2282 passed (1 pre-existing failure in test_provider_factory)
```

## Risk / Rollback

- **Zero behavior change** — all existing tests pass unchanged
- Pure refactor: if reverted, Graph goes back to direct `self._data` access
- No migration needed, no feature flags

## Review Guide

1. Start with `src/questfoundry/graph/store.py` — the protocol definition and DictGraphStore
2. Then `src/questfoundry/graph/graph.py` — every `self._data` → `self._store` delegation
3. Finally `tests/unit/test_dict_graph_store.py` — store-level tests

Part of #852. PR 1 of 5 in the SQLite graph migration stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)