### PR TITLE
feat(graph): add SqliteGraphStore with mutation audit trail

### DIFF
--- a/src/questfoundry/graph/__init__.py
+++ b/src/questfoundry/graph/__init__.py
@@ -57,6 +57,7 @@ from questfoundry.graph.snapshots import (
     rollback_to_snapshot,
     save_snapshot,
 )
+from questfoundry.graph.sqlite_store import SqliteGraphStore
 from questfoundry.graph.store import DictGraphStore, GraphStore
 
 __all__ = [
@@ -81,6 +82,7 @@ __all__ = [
     "SeedErrorCategory",
     "SeedMutationError",
     "SeedValidationError",
+    "SqliteGraphStore",
     "apply_brainstorm_mutations",
     "apply_dream_mutations",
     "apply_mutations",

--- a/src/questfoundry/graph/sqlite_store.py
+++ b/src/questfoundry/graph/sqlite_store.py
@@ -1,0 +1,447 @@
+"""SQLite-backed graph storage with mutation audit trail.
+
+SqliteGraphStore implements the GraphStore protocol using stdlib sqlite3.
+Every mutating operation (create/update/delete node or edge) is recorded
+in the ``mutations`` table with stage/phase context for auditing.
+
+Savepoint support enables efficient rollback during GROW phases without
+JSON serialization.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from pathlib import Path
+from typing import Any, cast
+
+# ---------------------------------------------------------------------------
+# Schema
+# ---------------------------------------------------------------------------
+
+_SCHEMA = """\
+CREATE TABLE IF NOT EXISTS nodes (
+    node_id        TEXT PRIMARY KEY,
+    type           TEXT NOT NULL,
+    data           JSON NOT NULL,
+    created_stage  TEXT DEFAULT '',
+    created_phase  TEXT DEFAULT '',
+    modified_stage TEXT DEFAULT '',
+    modified_phase TEXT DEFAULT ''
+);
+CREATE INDEX IF NOT EXISTS idx_nodes_type ON nodes(type);
+
+CREATE TABLE IF NOT EXISTS edges (
+    rowid     INTEGER PRIMARY KEY AUTOINCREMENT,
+    edge_type TEXT NOT NULL,
+    from_id   TEXT NOT NULL,
+    to_id     TEXT NOT NULL,
+    data      JSON,
+    created_stage TEXT DEFAULT '',
+    created_phase TEXT DEFAULT ''
+);
+CREATE INDEX IF NOT EXISTS idx_edges_type ON edges(edge_type);
+CREATE INDEX IF NOT EXISTS idx_edges_from ON edges(from_id);
+CREATE INDEX IF NOT EXISTS idx_edges_to   ON edges(to_id);
+
+CREATE TABLE IF NOT EXISTS meta (
+    key   TEXT PRIMARY KEY,
+    value JSON NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS mutations (
+    id        INTEGER PRIMARY KEY AUTOINCREMENT,
+    timestamp TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%f','now')),
+    stage     TEXT NOT NULL DEFAULT '',
+    phase     TEXT NOT NULL DEFAULT '',
+    operation TEXT NOT NULL,
+    target_id TEXT NOT NULL,
+    delta     JSON,
+    rationale TEXT DEFAULT ''
+);
+CREATE INDEX IF NOT EXISTS idx_mutations_stage  ON mutations(stage);
+CREATE INDEX IF NOT EXISTS idx_mutations_target ON mutations(target_id);
+
+CREATE TABLE IF NOT EXISTS phase_history (
+    id             INTEGER PRIMARY KEY AUTOINCREMENT,
+    stage          TEXT NOT NULL,
+    phase          TEXT NOT NULL,
+    started_at     TEXT,
+    completed_at   TEXT,
+    status         TEXT DEFAULT 'started',
+    mutation_count INTEGER DEFAULT 0,
+    detail         TEXT DEFAULT ''
+);
+"""
+
+VERSION = "5.0"
+
+
+class SqliteGraphStore:
+    """SQLite-backed graph store with mutation recording.
+
+    Every mutating operation records a row in the ``mutations`` table.
+    Use :meth:`set_mutation_context` to set the current stage/phase
+    before running operations — this tags each mutation for auditing.
+
+    Supports SQLite savepoints for efficient in-process rollback.
+    """
+
+    def __init__(
+        self,
+        db_path: str | Path = ":memory:",
+        *,
+        _conn: sqlite3.Connection | None = None,
+    ) -> None:
+        """Open or create a SQLite graph database.
+
+        Args:
+            db_path: Path to ``.db`` file, or ``":memory:"`` for in-memory.
+            _conn: Pre-existing connection (for testing). If provided,
+                   *db_path* is ignored.
+        """
+        if _conn is not None:
+            self._conn = _conn
+        else:
+            self._conn = sqlite3.connect(
+                str(db_path) if isinstance(db_path, Path) else db_path,
+                isolation_level=None,  # autocommit — we manage transactions
+            )
+        self._conn.row_factory = sqlite3.Row
+        self._conn.execute("PRAGMA journal_mode=WAL")
+        self._conn.execute("PRAGMA foreign_keys=ON")
+        self._conn.executescript(_SCHEMA)
+
+        self._stage: str = ""
+        self._phase: str = ""
+
+    def close(self) -> None:
+        """Close the database connection."""
+        self._conn.close()
+
+    # -- Mutation context ------------------------------------------------------
+
+    def set_mutation_context(self, stage: str = "", phase: str = "") -> None:
+        """Set the current stage/phase for mutation recording.
+
+        Args:
+            stage: Current pipeline stage (e.g., "grow").
+            phase: Current phase within the stage (e.g., "path_agnostic").
+        """
+        self._stage = stage
+        self._phase = phase
+
+    def _record_mutation(
+        self,
+        operation: str,
+        target_id: str,
+        delta: dict[str, Any] | None = None,
+    ) -> None:
+        """Append a mutation record."""
+        self._conn.execute(
+            "INSERT INTO mutations (stage, phase, operation, target_id, delta) "
+            "VALUES (?, ?, ?, ?, ?)",
+            (
+                self._stage,
+                self._phase,
+                operation,
+                target_id,
+                json.dumps(delta) if delta is not None else None,
+            ),
+        )
+
+    # -- Savepoints ------------------------------------------------------------
+
+    def savepoint(self, name: str) -> None:
+        """Create a SQLite savepoint.
+
+        Args:
+            name: Savepoint name (alphanumeric + underscores).
+        """
+        self._conn.execute(f"SAVEPOINT sp_{name}")
+
+    def rollback_to(self, name: str) -> None:
+        """Rollback to a named savepoint.
+
+        The savepoint remains active after rollback (SQLite behavior).
+
+        Args:
+            name: Savepoint name previously created with :meth:`savepoint`.
+        """
+        self._conn.execute(f"ROLLBACK TO sp_{name}")
+
+    def release(self, name: str) -> None:
+        """Release (commit) a named savepoint.
+
+        Args:
+            name: Savepoint name to release.
+        """
+        self._conn.execute(f"RELEASE SAVEPOINT sp_{name}")
+
+    # -- Nodes -----------------------------------------------------------------
+
+    def get_node(self, node_id: str) -> dict[str, Any] | None:
+        row = self._conn.execute("SELECT data FROM nodes WHERE node_id = ?", (node_id,)).fetchone()
+        if row is None:
+            return None
+        return cast("dict[str, Any]", json.loads(row["data"]))
+
+    def has_node(self, node_id: str) -> bool:
+        row = self._conn.execute("SELECT 1 FROM nodes WHERE node_id = ?", (node_id,)).fetchone()
+        return row is not None
+
+    def set_node(self, node_id: str, data: dict[str, Any]) -> None:
+        node_type = data.get("type", "")
+        existing = self.has_node(node_id)
+        self._conn.execute(
+            "INSERT OR REPLACE INTO nodes "
+            "(node_id, type, data, created_stage, created_phase, modified_stage, modified_phase) "
+            "VALUES (?, ?, ?, "
+            "  COALESCE((SELECT created_stage FROM nodes WHERE node_id = ?), ?), "
+            "  COALESCE((SELECT created_phase FROM nodes WHERE node_id = ?), ?), "
+            "  ?, ?)",
+            (
+                node_id,
+                node_type,
+                json.dumps(data),
+                node_id,
+                self._stage,
+                node_id,
+                self._phase,
+                self._stage,
+                self._phase,
+            ),
+        )
+        op = "update_node" if existing else "create_node"
+        self._record_mutation(op, node_id, delta=data)
+
+    def update_node_fields(self, node_id: str, **updates: Any) -> None:
+        row = self._conn.execute("SELECT data FROM nodes WHERE node_id = ?", (node_id,)).fetchone()
+        if row is None:
+            return  # Graph checks existence before calling
+        current = json.loads(row["data"])
+        current.update(updates)
+        node_type = current.get("type", "")
+        self._conn.execute(
+            "UPDATE nodes SET data = ?, type = ?, modified_stage = ?, modified_phase = ? "
+            "WHERE node_id = ?",
+            (json.dumps(current), node_type, self._stage, self._phase, node_id),
+        )
+        self._record_mutation("update_node", node_id, delta=dict(updates))
+
+    def delete_node(self, node_id: str) -> None:
+        self._conn.execute("DELETE FROM nodes WHERE node_id = ?", (node_id,))
+        self._record_mutation("delete_node", node_id)
+
+    def get_nodes_by_type(self, node_type: str) -> dict[str, dict[str, Any]]:
+        rows = self._conn.execute(
+            "SELECT node_id, data FROM nodes WHERE type = ?", (node_type,)
+        ).fetchall()
+        return {row["node_id"]: json.loads(row["data"]) for row in rows}
+
+    def all_node_ids(self) -> list[str]:
+        rows = self._conn.execute("SELECT node_id FROM nodes").fetchall()
+        return [row["node_id"] for row in rows]
+
+    def node_ids_with_prefix(self, prefix: str) -> list[str]:
+        rows = self._conn.execute(
+            "SELECT node_id FROM nodes WHERE node_id LIKE ?",
+            (prefix + "%",),
+        ).fetchall()
+        return [row["node_id"] for row in rows]
+
+    def node_count(self) -> int:
+        row = self._conn.execute("SELECT COUNT(*) AS cnt FROM nodes").fetchone()
+        return row["cnt"]  # type: ignore[no-any-return]
+
+    # -- Edges -----------------------------------------------------------------
+
+    def add_edge(self, edge: dict[str, Any]) -> None:
+        edge_type = edge.get("type", "")
+        from_id = edge.get("from", "")
+        to_id = edge.get("to", "")
+        # Extra props beyond type/from/to
+        extra = {k: v for k, v in edge.items() if k not in ("type", "from", "to")}
+        self._conn.execute(
+            "INSERT INTO edges (edge_type, from_id, to_id, data, created_stage, created_phase) "
+            "VALUES (?, ?, ?, ?, ?, ?)",
+            (
+                edge_type,
+                from_id,
+                to_id,
+                json.dumps(extra) if extra else None,
+                self._stage,
+                self._phase,
+            ),
+        )
+        target_id = f"edge:{edge_type}:{from_id}:{to_id}"
+        self._record_mutation("add_edge", target_id)
+
+    def remove_edge(self, edge_type: str, from_id: str, to_id: str) -> bool:
+        # Find the first matching row to delete
+        row = self._conn.execute(
+            "SELECT rowid FROM edges WHERE edge_type = ? AND from_id = ? AND to_id = ? LIMIT 1",
+            (edge_type, from_id, to_id),
+        ).fetchone()
+        if row is None:
+            return False
+        self._conn.execute("DELETE FROM edges WHERE rowid = ?", (row["rowid"],))
+        target_id = f"edge:{edge_type}:{from_id}:{to_id}"
+        self._record_mutation("remove_edge", target_id)
+        return True
+
+    def get_edges(
+        self,
+        from_id: str | None = None,
+        to_id: str | None = None,
+        edge_type: str | None = None,
+    ) -> list[dict[str, Any]]:
+        clauses: list[str] = []
+        params: list[str] = []
+        if from_id is not None:
+            clauses.append("from_id = ?")
+            params.append(from_id)
+        if to_id is not None:
+            clauses.append("to_id = ?")
+            params.append(to_id)
+        if edge_type is not None:
+            clauses.append("edge_type = ?")
+            params.append(edge_type)
+
+        where = (" WHERE " + " AND ".join(clauses)) if clauses else ""
+        rows = self._conn.execute(
+            f"SELECT edge_type, from_id, to_id, data FROM edges{where} ORDER BY rowid",
+            params,
+        ).fetchall()
+        return [self._row_to_edge(row) for row in rows]
+
+    def edges_referencing(self, node_id: str) -> list[dict[str, Any]]:
+        rows = self._conn.execute(
+            "SELECT edge_type, from_id, to_id, data FROM edges "
+            "WHERE from_id = ? OR to_id = ? ORDER BY rowid",
+            (node_id, node_id),
+        ).fetchall()
+        return [self._row_to_edge(row) for row in rows]
+
+    def remove_edges_referencing(self, node_id: str) -> None:
+        # Record mutations before deleting
+        rows = self._conn.execute(
+            "SELECT edge_type, from_id, to_id FROM edges WHERE from_id = ? OR to_id = ?",
+            (node_id, node_id),
+        ).fetchall()
+        for row in rows:
+            target_id = f"edge:{row['edge_type']}:{row['from_id']}:{row['to_id']}"
+            self._record_mutation("remove_edge", target_id)
+        self._conn.execute(
+            "DELETE FROM edges WHERE from_id = ? OR to_id = ?",
+            (node_id, node_id),
+        )
+
+    def edge_count(self) -> int:
+        row = self._conn.execute("SELECT COUNT(*) AS cnt FROM edges").fetchone()
+        return row["cnt"]  # type: ignore[no-any-return]
+
+    @staticmethod
+    def _row_to_edge(row: sqlite3.Row) -> dict[str, Any]:
+        """Convert an edge row to the dict format expected by Graph."""
+        edge: dict[str, Any] = {
+            "type": row["edge_type"],
+            "from": row["from_id"],
+            "to": row["to_id"],
+        }
+        if row["data"]:
+            extra = json.loads(row["data"])
+            edge.update(extra)
+        return edge
+
+    # -- Meta ------------------------------------------------------------------
+
+    def get_meta(self, key: str) -> Any:
+        row = self._conn.execute("SELECT value FROM meta WHERE key = ?", (key,)).fetchone()
+        if row is None:
+            return None
+        return json.loads(row["value"])
+
+    def set_meta(self, key: str, value: Any) -> None:
+        self._conn.execute(
+            "INSERT OR REPLACE INTO meta (key, value) VALUES (?, ?)",
+            (key, json.dumps(value)),
+        )
+
+    def all_meta(self) -> dict[str, Any]:
+        rows = self._conn.execute("SELECT key, value FROM meta").fetchall()
+        return {row["key"]: json.loads(row["value"]) for row in rows}
+
+    # -- Serialization ---------------------------------------------------------
+
+    def to_dict(self) -> dict[str, Any]:
+        """Reconstruct the full graph dict from SQLite tables."""
+        # Nodes
+        nodes: dict[str, dict[str, Any]] = {}
+        for row in self._conn.execute("SELECT node_id, data FROM nodes").fetchall():
+            nodes[row["node_id"]] = json.loads(row["data"])
+
+        # Edges (preserve insertion order via rowid)
+        edges: list[dict[str, Any]] = []
+        for row in self._conn.execute(
+            "SELECT edge_type, from_id, to_id, data FROM edges ORDER BY rowid"
+        ).fetchall():
+            edges.append(self._row_to_edge(row))
+
+        # Meta
+        meta = self.all_meta()
+
+        return {
+            "version": VERSION,
+            "meta": meta,
+            "nodes": nodes,
+            "edges": edges,
+        }
+
+    @classmethod
+    def from_dict(
+        cls,
+        data: dict[str, Any],
+        db_path: str | Path = ":memory:",
+    ) -> SqliteGraphStore:
+        """Bulk-import a graph dict into a new SqliteGraphStore.
+
+        Args:
+            data: Full graph data dict (version, meta, nodes, edges).
+            db_path: Where to create the database.
+
+        Returns:
+            New SqliteGraphStore populated with the data.
+        """
+        store = cls(db_path)
+
+        # Meta
+        meta = data.get("meta", {})
+        for key, value in meta.items():
+            store._conn.execute(
+                "INSERT OR REPLACE INTO meta (key, value) VALUES (?, ?)",
+                (key, json.dumps(value)),
+            )
+
+        # Nodes (bulk insert, no mutation recording)
+        nodes = data.get("nodes", {})
+        for node_id, node_data in nodes.items():
+            node_type = node_data.get("type", "")
+            store._conn.execute(
+                "INSERT INTO nodes (node_id, type, data) VALUES (?, ?, ?)",
+                (node_id, node_type, json.dumps(node_data)),
+            )
+
+        # Edges (bulk insert, no mutation recording)
+        edges = data.get("edges", [])
+        for edge in edges:
+            edge_type = edge.get("type", "")
+            from_id = edge.get("from", "")
+            to_id = edge.get("to", "")
+            extra = {k: v for k, v in edge.items() if k not in ("type", "from", "to")}
+            store._conn.execute(
+                "INSERT INTO edges (edge_type, from_id, to_id, data) VALUES (?, ?, ?, ?)",
+                (edge_type, from_id, to_id, json.dumps(extra) if extra else None),
+            )
+
+        return store

--- a/src/questfoundry/graph/sqlite_store.py
+++ b/src/questfoundry/graph/sqlite_store.py
@@ -11,9 +11,12 @@ JSON serialization.
 from __future__ import annotations
 
 import json
+import re
 import sqlite3
 from pathlib import Path
 from typing import Any, cast
+
+from questfoundry.graph.errors import NodeNotFoundError
 
 # ---------------------------------------------------------------------------
 # Schema
@@ -109,6 +112,7 @@ class SqliteGraphStore:
             )
         self._conn.row_factory = sqlite3.Row
         self._conn.execute("PRAGMA journal_mode=WAL")
+        self._conn.execute("PRAGMA synchronous=NORMAL")
         self._conn.execute("PRAGMA foreign_keys=ON")
         self._conn.executescript(_SCHEMA)
 
@@ -152,12 +156,24 @@ class SqliteGraphStore:
 
     # -- Savepoints ------------------------------------------------------------
 
+    _SAVEPOINT_RE = re.compile(r"^[A-Za-z0-9_]+$")
+
+    def _validate_savepoint_name(self, name: str) -> None:
+        """Validate savepoint name to prevent SQL injection."""
+        if not self._SAVEPOINT_RE.match(name):
+            msg = f"Invalid savepoint name {name!r}: must be alphanumeric/underscores only"
+            raise ValueError(msg)
+
     def savepoint(self, name: str) -> None:
         """Create a SQLite savepoint.
 
         Args:
-            name: Savepoint name (alphanumeric + underscores).
+            name: Savepoint name (alphanumeric + underscores only).
+
+        Raises:
+            ValueError: If *name* contains invalid characters.
         """
+        self._validate_savepoint_name(name)
         self._conn.execute(f"SAVEPOINT sp_{name}")
 
     def rollback_to(self, name: str) -> None:
@@ -167,7 +183,11 @@ class SqliteGraphStore:
 
         Args:
             name: Savepoint name previously created with :meth:`savepoint`.
+
+        Raises:
+            ValueError: If *name* contains invalid characters.
         """
+        self._validate_savepoint_name(name)
         self._conn.execute(f"ROLLBACK TO sp_{name}")
 
     def release(self, name: str) -> None:
@@ -175,7 +195,11 @@ class SqliteGraphStore:
 
         Args:
             name: Savepoint name to release.
+
+        Raises:
+            ValueError: If *name* contains invalid characters.
         """
+        self._validate_savepoint_name(name)
         self._conn.execute(f"RELEASE SAVEPOINT sp_{name}")
 
     # -- Nodes -----------------------------------------------------------------
@@ -218,7 +242,7 @@ class SqliteGraphStore:
     def update_node_fields(self, node_id: str, **updates: Any) -> None:
         row = self._conn.execute("SELECT data FROM nodes WHERE node_id = ?", (node_id,)).fetchone()
         if row is None:
-            return  # Graph checks existence before calling
+            raise NodeNotFoundError(node_id=node_id)
         current = json.loads(row["data"])
         current.update(updates)
         node_type = current.get("type", "")
@@ -324,18 +348,25 @@ class SqliteGraphStore:
         return [self._row_to_edge(row) for row in rows]
 
     def remove_edges_referencing(self, node_id: str) -> None:
-        # Record mutations before deleting
-        rows = self._conn.execute(
-            "SELECT edge_type, from_id, to_id FROM edges WHERE from_id = ? OR to_id = ?",
-            (node_id, node_id),
-        ).fetchall()
-        for row in rows:
-            target_id = f"edge:{row['edge_type']}:{row['from_id']}:{row['to_id']}"
-            self._record_mutation("remove_edge", target_id)
-        self._conn.execute(
-            "DELETE FROM edges WHERE from_id = ? OR to_id = ?",
-            (node_id, node_id),
-        )
+        # Atomic: record mutations and delete in one transaction
+        self._conn.execute("SAVEPOINT sp_remove_refs")
+        try:
+            rows = self._conn.execute(
+                "SELECT edge_type, from_id, to_id FROM edges WHERE from_id = ? OR to_id = ?",
+                (node_id, node_id),
+            ).fetchall()
+            for row in rows:
+                target_id = f"edge:{row['edge_type']}:{row['from_id']}:{row['to_id']}"
+                self._record_mutation("remove_edge", target_id)
+            self._conn.execute(
+                "DELETE FROM edges WHERE from_id = ? OR to_id = ?",
+                (node_id, node_id),
+            )
+            self._conn.execute("RELEASE SAVEPOINT sp_remove_refs")
+        except Exception:
+            self._conn.execute("ROLLBACK TO sp_remove_refs")
+            self._conn.execute("RELEASE SAVEPOINT sp_remove_refs")
+            raise
 
     def edge_count(self) -> int:
         row = self._conn.execute("SELECT COUNT(*) AS cnt FROM edges").fetchone()
@@ -415,33 +446,50 @@ class SqliteGraphStore:
         """
         store = cls(db_path)
 
-        # Meta
-        meta = data.get("meta", {})
-        for key, value in meta.items():
-            store._conn.execute(
-                "INSERT OR REPLACE INTO meta (key, value) VALUES (?, ?)",
-                (key, json.dumps(value)),
-            )
+        # Bulk import in a single transaction for performance
+        store._conn.execute("BEGIN")
+        try:
+            # Meta
+            meta = data.get("meta", {})
+            if meta:
+                store._conn.executemany(
+                    "INSERT OR REPLACE INTO meta (key, value) VALUES (?, ?)",
+                    [(key, json.dumps(value)) for key, value in meta.items()],
+                )
 
-        # Nodes (bulk insert, no mutation recording)
-        nodes = data.get("nodes", {})
-        for node_id, node_data in nodes.items():
-            node_type = node_data.get("type", "")
-            store._conn.execute(
-                "INSERT INTO nodes (node_id, type, data) VALUES (?, ?, ?)",
-                (node_id, node_type, json.dumps(node_data)),
-            )
+            # Nodes (bulk insert, no mutation recording)
+            nodes = data.get("nodes", {})
+            if nodes:
+                store._conn.executemany(
+                    "INSERT INTO nodes (node_id, type, data) VALUES (?, ?, ?)",
+                    [
+                        (node_id, node_data.get("type", ""), json.dumps(node_data))
+                        for node_id, node_data in nodes.items()
+                    ],
+                )
 
-        # Edges (bulk insert, no mutation recording)
-        edges = data.get("edges", [])
-        for edge in edges:
-            edge_type = edge.get("type", "")
-            from_id = edge.get("from", "")
-            to_id = edge.get("to", "")
-            extra = {k: v for k, v in edge.items() if k not in ("type", "from", "to")}
-            store._conn.execute(
-                "INSERT INTO edges (edge_type, from_id, to_id, data) VALUES (?, ?, ?, ?)",
-                (edge_type, from_id, to_id, json.dumps(extra) if extra else None),
-            )
+            # Edges (bulk insert, no mutation recording)
+            edges = data.get("edges", [])
+            if edges:
+                store._conn.executemany(
+                    "INSERT INTO edges (edge_type, from_id, to_id, data) VALUES (?, ?, ?, ?)",
+                    [
+                        (
+                            edge.get("type", ""),
+                            edge.get("from", ""),
+                            edge.get("to", ""),
+                            json.dumps(
+                                {k: v for k, v in edge.items() if k not in ("type", "from", "to")}
+                            )
+                            or None,
+                        )
+                        for edge in edges
+                    ],
+                )
+
+            store._conn.execute("COMMIT")
+        except Exception:
+            store._conn.execute("ROLLBACK")
+            raise
 
         return store

--- a/tests/unit/test_sqlite_store.py
+++ b/tests/unit/test_sqlite_store.py
@@ -1,0 +1,512 @@
+"""Tests for SqliteGraphStore — the SQLite storage backend.
+
+All tests use :memory: databases. Tests mirror the DictGraphStore test
+patterns to verify both backends behave identically for the GraphStore protocol.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+
+from questfoundry.graph.sqlite_store import SqliteGraphStore
+from questfoundry.graph.store import GraphStore
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+class TestSqliteStoreProtocol:
+    """Verify SqliteGraphStore satisfies the GraphStore protocol."""
+
+    def test_is_runtime_checkable(self) -> None:
+        """SqliteGraphStore passes isinstance check for GraphStore."""
+        store = SqliteGraphStore()
+        assert isinstance(store, GraphStore)
+
+    def test_default_state(self) -> None:
+        """Default store has empty nodes and edges."""
+        store = SqliteGraphStore()
+        assert store.node_count() == 0
+        assert store.edge_count() == 0
+        assert store.get_meta("last_stage") is None
+
+
+class TestSqliteStoreNodes:
+    """Test node CRUD on SqliteGraphStore."""
+
+    def test_set_and_get_node(self) -> None:
+        store = SqliteGraphStore()
+        store.set_node("entity::alice", {"type": "entity", "name": "Alice"})
+        node = store.get_node("entity::alice")
+        assert node is not None
+        assert node["name"] == "Alice"
+        assert node["type"] == "entity"
+
+    def test_get_missing_node_returns_none(self) -> None:
+        store = SqliteGraphStore()
+        assert store.get_node("missing") is None
+
+    def test_has_node(self) -> None:
+        store = SqliteGraphStore()
+        assert not store.has_node("entity::alice")
+        store.set_node("entity::alice", {"type": "entity"})
+        assert store.has_node("entity::alice")
+
+    def test_set_node_overwrites(self) -> None:
+        store = SqliteGraphStore()
+        store.set_node("entity::alice", {"type": "entity", "name": "Alice"})
+        store.set_node("entity::alice", {"type": "entity", "name": "Bob"})
+        assert store.get_node("entity::alice")["name"] == "Bob"
+
+    def test_update_node_fields(self) -> None:
+        store = SqliteGraphStore()
+        store.set_node("entity::alice", {"type": "entity", "name": "Alice"})
+        store.update_node_fields("entity::alice", disposition="retained", status="active")
+
+        node = store.get_node("entity::alice")
+        assert node is not None
+        assert node["name"] == "Alice"  # preserved
+        assert node["disposition"] == "retained"
+        assert node["status"] == "active"
+
+    def test_delete_node(self) -> None:
+        store = SqliteGraphStore()
+        store.set_node("entity::alice", {"type": "entity"})
+        store.delete_node("entity::alice")
+        assert not store.has_node("entity::alice")
+
+    def test_get_nodes_by_type(self) -> None:
+        store = SqliteGraphStore()
+        store.set_node("entity::alice", {"type": "entity"})
+        store.set_node("entity::bob", {"type": "entity"})
+        store.set_node("dilemma::d1", {"type": "dilemma"})
+
+        entities = store.get_nodes_by_type("entity")
+        assert len(entities) == 2
+        assert "entity::alice" in entities
+        assert "entity::bob" in entities
+        assert "dilemma::d1" not in entities
+
+    def test_all_node_ids(self) -> None:
+        store = SqliteGraphStore()
+        store.set_node("a", {"type": "test"})
+        store.set_node("b", {"type": "test"})
+        assert set(store.all_node_ids()) == {"a", "b"}
+
+    def test_node_ids_with_prefix(self) -> None:
+        store = SqliteGraphStore()
+        store.set_node("entity::alice", {"type": "entity"})
+        store.set_node("entity::bob", {"type": "entity"})
+        store.set_node("path::main", {"type": "path"})
+
+        entity_ids = store.node_ids_with_prefix("entity::")
+        assert set(entity_ids) == {"entity::alice", "entity::bob"}
+
+    def test_node_count(self) -> None:
+        store = SqliteGraphStore()
+        assert store.node_count() == 0
+        store.set_node("a", {"type": "test"})
+        assert store.node_count() == 1
+        store.delete_node("a")
+        assert store.node_count() == 0
+
+
+class TestSqliteStoreEdges:
+    """Test edge CRUD on SqliteGraphStore."""
+
+    def test_add_and_get_edge(self) -> None:
+        store = SqliteGraphStore()
+        store.add_edge({"type": "relates_to", "from": "a", "to": "b"})
+        edges = store.get_edges()
+        assert len(edges) == 1
+        assert edges[0]["type"] == "relates_to"
+        assert edges[0]["from"] == "a"
+        assert edges[0]["to"] == "b"
+
+    def test_edge_with_extra_props(self) -> None:
+        """Extra edge properties are preserved in data column."""
+        store = SqliteGraphStore()
+        store.add_edge(
+            {
+                "type": "choice",
+                "from": "s1",
+                "to": "s2",
+                "label": "Go north",
+                "requires": ["has_key"],
+            }
+        )
+        edges = store.get_edges()
+        assert edges[0]["label"] == "Go north"
+        assert edges[0]["requires"] == ["has_key"]
+
+    def test_get_edges_with_filters(self) -> None:
+        store = SqliteGraphStore()
+        store.add_edge({"type": "belongs_to", "from": "beat::1", "to": "path::a"})
+        store.add_edge({"type": "belongs_to", "from": "beat::2", "to": "path::a"})
+        store.add_edge({"type": "explores", "from": "path::a", "to": "dilemma::d"})
+
+        assert len(store.get_edges(edge_type="belongs_to")) == 2
+        assert len(store.get_edges(to_id="path::a")) == 2
+        assert len(store.get_edges(from_id="beat::1")) == 1
+        assert len(store.get_edges(from_id="path::a", edge_type="explores")) == 1
+
+    def test_get_edges_preserves_insertion_order(self) -> None:
+        """Edges are returned in insertion order (rowid)."""
+        store = SqliteGraphStore()
+        store.add_edge({"type": "a", "from": "x", "to": "y"})
+        store.add_edge({"type": "b", "from": "x", "to": "z"})
+        store.add_edge({"type": "c", "from": "x", "to": "w"})
+
+        edges = store.get_edges()
+        types = [e["type"] for e in edges]
+        assert types == ["a", "b", "c"]
+
+    def test_remove_edge(self) -> None:
+        store = SqliteGraphStore()
+        store.add_edge({"type": "link", "from": "a", "to": "b"})
+        assert store.remove_edge("link", "a", "b") is True
+        assert store.edge_count() == 0
+
+    def test_remove_edge_no_match(self) -> None:
+        store = SqliteGraphStore()
+        assert store.remove_edge("link", "a", "b") is False
+
+    def test_remove_edge_first_only(self) -> None:
+        """remove_edge removes only the first matching edge."""
+        store = SqliteGraphStore()
+        store.add_edge({"type": "link", "from": "a", "to": "b"})
+        store.add_edge({"type": "link", "from": "a", "to": "b"})
+        assert store.edge_count() == 2
+
+        store.remove_edge("link", "a", "b")
+        assert store.edge_count() == 1
+
+    def test_edges_referencing(self) -> None:
+        store = SqliteGraphStore()
+        store.add_edge({"type": "a", "from": "x", "to": "y"})
+        store.add_edge({"type": "b", "from": "y", "to": "z"})
+        store.add_edge({"type": "c", "from": "w", "to": "x"})
+
+        refs = store.edges_referencing("x")
+        assert len(refs) == 2  # from=x and to=x
+
+    def test_remove_edges_referencing(self) -> None:
+        store = SqliteGraphStore()
+        store.add_edge({"type": "a", "from": "x", "to": "y"})
+        store.add_edge({"type": "b", "from": "y", "to": "z"})
+        store.add_edge({"type": "c", "from": "w", "to": "v"})
+
+        store.remove_edges_referencing("y")
+        assert store.edge_count() == 1
+        assert store.get_edges()[0]["from"] == "w"
+
+    def test_edge_count(self) -> None:
+        store = SqliteGraphStore()
+        assert store.edge_count() == 0
+        store.add_edge({"type": "t", "from": "a", "to": "b"})
+        assert store.edge_count() == 1
+        store.remove_edge("t", "a", "b")
+        assert store.edge_count() == 0
+
+
+class TestSqliteStoreMeta:
+    """Test metadata operations on SqliteGraphStore."""
+
+    def test_set_and_get_meta(self) -> None:
+        store = SqliteGraphStore()
+        store.set_meta("project_name", "test")
+        assert store.get_meta("project_name") == "test"
+
+    def test_get_meta_missing_key(self) -> None:
+        store = SqliteGraphStore()
+        assert store.get_meta("nonexistent") is None
+
+    def test_set_meta_overwrites(self) -> None:
+        store = SqliteGraphStore()
+        store.set_meta("key", "value1")
+        store.set_meta("key", "value2")
+        assert store.get_meta("key") == "value2"
+
+    def test_all_meta(self) -> None:
+        store = SqliteGraphStore()
+        store.set_meta("project_name", "test")
+        store.set_meta("last_stage", "dream")
+        meta = store.all_meta()
+        assert meta["project_name"] == "test"
+        assert meta["last_stage"] == "dream"
+
+    def test_meta_stores_complex_values(self) -> None:
+        """Meta values can be lists, dicts, etc. (JSON-serialized)."""
+        store = SqliteGraphStore()
+        store.set_meta(
+            "stage_history",
+            [
+                {"stage": "dream", "completed": "2024-01-01T00:00:00"},
+            ],
+        )
+        history = store.get_meta("stage_history")
+        assert len(history) == 1
+        assert history[0]["stage"] == "dream"
+
+
+class TestSqliteStoreMutations:
+    """Test mutation recording."""
+
+    def test_create_node_records_mutation(self) -> None:
+        store = SqliteGraphStore()
+        store.set_mutation_context(stage="seed", phase="serialize")
+        store.set_node("entity::alice", {"type": "entity", "name": "Alice"})
+
+        rows = store._conn.execute("SELECT * FROM mutations").fetchall()
+        assert len(rows) == 1
+        assert rows[0]["operation"] == "create_node"
+        assert rows[0]["target_id"] == "entity::alice"
+        assert rows[0]["stage"] == "seed"
+        assert rows[0]["phase"] == "serialize"
+        delta = json.loads(rows[0]["delta"])
+        assert delta["name"] == "Alice"
+
+    def test_update_node_records_mutation(self) -> None:
+        store = SqliteGraphStore()
+        store.set_node("entity::alice", {"type": "entity"})
+
+        store.set_mutation_context(stage="grow", phase="path_agnostic")
+        store.update_node_fields("entity::alice", disposition="retained")
+
+        rows = store._conn.execute(
+            "SELECT * FROM mutations WHERE operation = 'update_node'"
+        ).fetchall()
+        assert len(rows) == 1
+        delta = json.loads(rows[0]["delta"])
+        assert delta == {"disposition": "retained"}
+
+    def test_delete_node_records_mutation(self) -> None:
+        store = SqliteGraphStore()
+        store.set_node("entity::alice", {"type": "entity"})
+        store.delete_node("entity::alice")
+
+        rows = store._conn.execute(
+            "SELECT * FROM mutations WHERE operation = 'delete_node'"
+        ).fetchall()
+        assert len(rows) == 1
+        assert rows[0]["target_id"] == "entity::alice"
+
+    def test_add_edge_records_mutation(self) -> None:
+        store = SqliteGraphStore()
+        store.add_edge({"type": "belongs_to", "from": "beat::1", "to": "path::a"})
+
+        rows = store._conn.execute(
+            "SELECT * FROM mutations WHERE operation = 'add_edge'"
+        ).fetchall()
+        assert len(rows) == 1
+        assert rows[0]["target_id"] == "edge:belongs_to:beat::1:path::a"
+
+    def test_remove_edge_records_mutation(self) -> None:
+        store = SqliteGraphStore()
+        store.add_edge({"type": "link", "from": "a", "to": "b"})
+        store.remove_edge("link", "a", "b")
+
+        rows = store._conn.execute(
+            "SELECT * FROM mutations WHERE operation = 'remove_edge'"
+        ).fetchall()
+        assert len(rows) == 1
+
+    def test_overwrite_node_records_update_mutation(self) -> None:
+        """Second set_node on same ID records update_node."""
+        store = SqliteGraphStore()
+        store.set_node("entity::alice", {"type": "entity", "name": "Alice"})
+        store.set_node("entity::alice", {"type": "entity", "name": "Bob"})
+
+        rows = store._conn.execute("SELECT operation FROM mutations").fetchall()
+        ops = [row["operation"] for row in rows]
+        assert ops == ["create_node", "update_node"]
+
+    def test_mutation_context_default_empty(self) -> None:
+        """Without set_mutation_context, stage/phase are empty strings."""
+        store = SqliteGraphStore()
+        store.set_node("a", {"type": "test"})
+
+        row = store._conn.execute("SELECT stage, phase FROM mutations").fetchone()
+        assert row["stage"] == ""
+        assert row["phase"] == ""
+
+    def test_remove_edges_referencing_records_mutations(self) -> None:
+        """remove_edges_referencing records a mutation for each removed edge."""
+        store = SqliteGraphStore()
+        store.add_edge({"type": "a", "from": "x", "to": "y"})
+        store.add_edge({"type": "b", "from": "y", "to": "z"})
+        # Clear the add_edge mutations
+        store._conn.execute("DELETE FROM mutations")
+
+        store.remove_edges_referencing("y")
+
+        rows = store._conn.execute(
+            "SELECT * FROM mutations WHERE operation = 'remove_edge'"
+        ).fetchall()
+        assert len(rows) == 2
+
+
+class TestSqliteStoreSavepoints:
+    """Test savepoint/rollback/release."""
+
+    def test_savepoint_and_rollback(self) -> None:
+        """Can rollback to a savepoint, undoing changes."""
+        store = SqliteGraphStore()
+        store.set_node("before", {"type": "test"})
+
+        store.savepoint("phase1")
+        store.set_node("during", {"type": "test"})
+        assert store.has_node("during")
+
+        store.rollback_to("phase1")
+        assert not store.has_node("during")
+        assert store.has_node("before")
+
+    def test_savepoint_and_release(self) -> None:
+        """Releasing a savepoint commits its changes."""
+        store = SqliteGraphStore()
+        store.savepoint("phase1")
+        store.set_node("new", {"type": "test"})
+        store.release("phase1")
+
+        assert store.has_node("new")
+
+    def test_nested_savepoints(self) -> None:
+        """Nested savepoints work correctly."""
+        store = SqliteGraphStore()
+        store.set_node("base", {"type": "test"})
+
+        store.savepoint("outer")
+        store.set_node("outer_node", {"type": "test"})
+
+        store.savepoint("inner")
+        store.set_node("inner_node", {"type": "test"})
+
+        # Rollback inner only
+        store.rollback_to("inner")
+        assert not store.has_node("inner_node")
+        assert store.has_node("outer_node")
+
+        # Release inner, rollback outer
+        store.release("inner")
+        store.rollback_to("outer")
+        assert not store.has_node("outer_node")
+        assert store.has_node("base")
+
+    def test_rollback_edges(self) -> None:
+        """Savepoint rollback also undoes edge changes."""
+        store = SqliteGraphStore()
+        store.add_edge({"type": "keep", "from": "a", "to": "b"})
+
+        store.savepoint("phase")
+        store.add_edge({"type": "temp", "from": "c", "to": "d"})
+        assert store.edge_count() == 2
+
+        store.rollback_to("phase")
+        assert store.edge_count() == 1
+        assert store.get_edges()[0]["type"] == "keep"
+
+    def test_rollback_meta(self) -> None:
+        """Savepoint rollback also undoes meta changes."""
+        store = SqliteGraphStore()
+        store.set_meta("last_stage", "seed")
+
+        store.savepoint("phase")
+        store.set_meta("last_stage", "grow")
+        assert store.get_meta("last_stage") == "grow"
+
+        store.rollback_to("phase")
+        assert store.get_meta("last_stage") == "seed"
+
+
+class TestSqliteStoreSerialization:
+    """Test to_dict/from_dict round-trips."""
+
+    def test_to_dict_format(self) -> None:
+        """to_dict returns the expected graph dict format."""
+        store = SqliteGraphStore()
+        store.set_meta("project_name", "test")
+        store.set_meta("last_stage", "dream")
+        store.set_node("entity::alice", {"type": "entity", "name": "Alice"})
+        store.add_edge({"type": "link", "from": "entity::alice", "to": "entity::alice"})
+
+        d = store.to_dict()
+        assert d["version"] == "5.0"
+        assert d["meta"]["project_name"] == "test"
+        assert "entity::alice" in d["nodes"]
+        assert len(d["edges"]) == 1
+        assert d["edges"][0]["type"] == "link"
+
+    def test_from_dict_round_trip(self) -> None:
+        """from_dict creates a store from to_dict output."""
+        original = SqliteGraphStore()
+        original.set_meta("project_name", "roundtrip")
+        original.set_meta("stage_history", [])
+        original.set_node("a", {"type": "test", "val": 42})
+        original.add_edge({"type": "link", "from": "a", "to": "a", "weight": 1.5})
+
+        data = original.to_dict()
+        restored = SqliteGraphStore.from_dict(data)
+
+        assert restored.get_node("a")["val"] == 42
+        assert restored.edge_count() == 1
+        assert restored.get_edges()[0]["weight"] == 1.5
+        assert restored.get_meta("project_name") == "roundtrip"
+
+    def test_from_dict_no_mutations_recorded(self) -> None:
+        """from_dict bulk import does not record mutations."""
+        data = {
+            "version": "5.0",
+            "meta": {"last_stage": "seed"},
+            "nodes": {"a": {"type": "test"}},
+            "edges": [{"type": "link", "from": "a", "to": "a"}],
+        }
+        store = SqliteGraphStore.from_dict(data)
+        rows = store._conn.execute("SELECT COUNT(*) AS cnt FROM mutations").fetchone()
+        assert rows["cnt"] == 0
+
+    def test_from_dict_dict_store_compat(self) -> None:
+        """SqliteGraphStore.from_dict is compatible with DictGraphStore.to_dict."""
+        from questfoundry.graph.store import DictGraphStore
+
+        dict_store = DictGraphStore()
+        dict_store.set_node("entity::alice", {"type": "entity", "name": "Alice"})
+        dict_store.set_node("entity::bob", {"type": "entity", "name": "Bob"})
+        dict_store.add_edge({"type": "relates", "from": "entity::alice", "to": "entity::bob"})
+        dict_store.set_meta("project_name", "cross_compat")
+        dict_store.set_meta("last_stage", "dream")
+        dict_store.set_meta("stage_history", [{"stage": "dream", "completed": "2024-01-01"}])
+
+        data = dict_store.to_dict()
+        sqlite_store = SqliteGraphStore.from_dict(data)
+
+        # Verify all data migrated correctly
+        assert sqlite_store.get_node("entity::alice")["name"] == "Alice"
+        assert sqlite_store.get_node("entity::bob")["name"] == "Bob"
+        assert sqlite_store.edge_count() == 1
+        assert sqlite_store.get_meta("project_name") == "cross_compat"
+        assert sqlite_store.get_meta("last_stage") == "dream"
+
+        # And round-trip back to dict
+        roundtrip = sqlite_store.to_dict()
+        assert roundtrip["nodes"]["entity::alice"]["name"] == "Alice"
+        assert len(roundtrip["edges"]) == 1
+
+
+class TestSqliteStoreFileBackend:
+    """Test file-based SQLite (not :memory:)."""
+
+    def test_file_persistence(self, tmp_path: Path) -> None:
+        """Data persists across open/close cycles."""
+        db_path = tmp_path / "test.db"
+
+        store = SqliteGraphStore(db_path)
+        store.set_node("entity::alice", {"type": "entity"})
+        store.set_meta("last_stage", "dream")
+        store.close()
+
+        store2 = SqliteGraphStore(db_path)
+        assert store2.has_node("entity::alice")
+        assert store2.get_meta("last_stage") == "dream"
+        store2.close()


### PR DESCRIPTION
## Problem

Issue #852 requires migrating graph storage from JSON to SQLite. This PR adds the `SqliteGraphStore` backend that implements the `GraphStore` protocol (from PR #866) with full mutation recording and SQLite savepoint support.

## Changes

- **`src/questfoundry/graph/sqlite_store.py`** (~450 lines): New `SqliteGraphStore` class implementing `GraphStore` protocol using stdlib `sqlite3`
  - 5 SQL tables: `nodes`, `edges`, `meta`, `mutations`, `phase_history`
  - WAL mode + foreign keys for concurrent read performance
  - Every mutating operation records a row in the `mutations` table with stage/phase context
  - `set_mutation_context(stage, phase)` for context tracking
  - `savepoint(name)`, `rollback_to(name)`, `release(name)` for efficient in-process rollback
  - `to_dict()` reconstructs full graph dict from SQL tables
  - `from_dict(data)` for bulk import (no mutation recording)
- **`tests/unit/test_sqlite_store.py`** (~510 lines): 45 comprehensive tests
  - All CRUD operations (nodes, edges, meta)
  - Mutation recording verification (every operation checked)
  - Savepoint/rollback/release (including nested savepoints)
  - Serialization round-trip fidelity
  - File-backed persistence across open/close cycles
  - Cross-compatibility with DictGraphStore via `to_dict()`
- **`src/questfoundry/graph/__init__.py`**: Export `SqliteGraphStore`

## Not Included / Future PRs

- Graph integration (`Graph.load()` / `Graph.save()` with SQLite) — PR 3
- Auto-migration from `graph.json` → `graph.db` — PR 3
- Stage integration (GROW savepoints) — PR 4
- CLI audit command — PR 5

Part of #852 (Phase 1 of epic #858).

## Test Plan

```bash
uv run pytest tests/unit/test_sqlite_store.py -x -q       # 45 passed
uv run pytest tests/unit/test_graph.py -x -q               # 68 passed (unchanged)
uv run pytest tests/unit/test_dict_graph_store.py -x -q    # 24 passed (unchanged)
uv run mypy src/questfoundry/graph/                         # Success
uv run ruff check src/questfoundry/graph/                   # All checks passed
```

## Risk / Rollback

- No existing behavior changed — this is a purely additive PR
- `SqliteGraphStore` is not wired into `Graph` yet (that's PR 3)
- Uses stdlib `sqlite3` — no new dependencies

## Review Guide

Suggested review order:
1. `sqlite_store.py` — schema at top, then CRUD methods, then mutations, savepoints, serialization
2. `test_sqlite_store.py` — organized by feature area, mirrors the implementation structure
3. `__init__.py` — trivial export addition