### PR TITLE
feat(grow): phase registry with decorator-based dependency validation

### DIFF
--- a/src/questfoundry/pipeline/stages/grow/__init__.py
+++ b/src/questfoundry/pipeline/stages/grow/__init__.py
@@ -7,6 +7,7 @@ continues to work after the single-file → package conversion.
 from __future__ import annotations
 
 from questfoundry.pipeline.stages.grow._helpers import GrowStageError
+from questfoundry.pipeline.stages.grow.registry import PhaseRegistry, get_registry, grow_phase
 from questfoundry.pipeline.stages.grow.stage import (
     GrowStage,
     create_grow_stage,
@@ -16,6 +17,9 @@ from questfoundry.pipeline.stages.grow.stage import (
 __all__ = [
     "GrowStage",
     "GrowStageError",
+    "PhaseRegistry",
     "create_grow_stage",
+    "get_registry",
+    "grow_phase",
     "grow_stage",
 ]

--- a/src/questfoundry/pipeline/stages/grow/registry.py
+++ b/src/questfoundry/pipeline/stages/grow/registry.py
@@ -1,0 +1,238 @@
+"""Phase registry with decorator-based dependency validation for GROW.
+
+Phases register via the ``@grow_phase`` decorator at import time. The registry
+validates the dependency DAG and produces a stable topological execution order.
+
+Usage::
+
+    @grow_phase(name="validate_dag", is_deterministic=True)
+    async def phase_validate_dag(graph, model):
+        ...
+
+    @grow_phase(name="passages", depends_on=["collapse_linear_beats"], is_deterministic=True)
+    async def phase_passages(graph, model):
+        ...
+
+The execution order is produced by ``get_registry().execution_order()``.
+"""
+
+from __future__ import annotations
+
+import heapq
+from collections import defaultdict
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+
+@dataclass(frozen=True)
+class PhaseMeta:
+    """Metadata attached to a registered GROW phase function."""
+
+    name: str
+    depends_on: tuple[str, ...]
+    is_deterministic: bool
+    priority: int
+
+
+_PHASE_META_ATTR = "_grow_phase_meta"
+
+
+class PhaseRegistry:
+    """Collects ``@grow_phase``-decorated functions and validates their DAG.
+
+    The registry is populated at module import time. Call ``validate()`` to
+    check for missing dependencies, cycles, or duplicates. Call
+    ``execution_order()`` to get a stable topological ordering.
+    """
+
+    def __init__(self) -> None:
+        self._phases: dict[str, PhaseMeta] = {}
+        self._functions: dict[str, Callable[..., Any]] = {}
+
+    # -- Registration ----------------------------------------------------------
+
+    def register(self, fn: Callable[..., Any], meta: PhaseMeta) -> None:
+        """Register a phase function with its metadata.
+
+        Raises:
+            ValueError: If a phase with the same name is already registered.
+        """
+        if meta.name in self._phases:
+            msg = (
+                f"Duplicate phase name {meta.name!r}: "
+                f"already registered by {self._functions[meta.name].__qualname__}"
+            )
+            raise ValueError(msg)
+        self._phases[meta.name] = meta
+        self._functions[meta.name] = fn
+
+    # -- Validation ------------------------------------------------------------
+
+    def validate(self) -> list[str]:
+        """Validate the dependency DAG.
+
+        Returns:
+            List of error strings. Empty means valid.
+        """
+        errors: list[str] = []
+
+        # Check for missing dependencies
+        for meta in self._phases.values():
+            for dep in meta.depends_on:
+                if dep not in self._phases:
+                    errors.append(
+                        f"Phase {meta.name!r} depends on {dep!r}, which is not registered"
+                    )
+
+        # Check for cycles using Kahn's algorithm
+        if not errors:
+            in_degree: dict[str, int] = dict.fromkeys(self._phases, 0)
+            for meta in self._phases.values():
+                for _dep in meta.depends_on:
+                    in_degree[meta.name] += 1
+
+            queue = [name for name, deg in in_degree.items() if deg == 0]
+            visited = 0
+            adj: dict[str, list[str]] = defaultdict(list)
+            for meta in self._phases.values():
+                for dep in meta.depends_on:
+                    adj[dep].append(meta.name)
+
+            temp_queue = list(queue)
+            while temp_queue:
+                node = temp_queue.pop()
+                visited += 1
+                for neighbor in adj[node]:
+                    in_degree[neighbor] -= 1
+                    if in_degree[neighbor] == 0:
+                        temp_queue.append(neighbor)
+
+            if visited != len(self._phases):
+                cycle_members = [name for name, deg in in_degree.items() if deg > 0]
+                errors.append(
+                    f"Dependency cycle detected among: {', '.join(sorted(cycle_members))}"
+                )
+
+        return errors
+
+    # -- Execution order -------------------------------------------------------
+
+    def execution_order(self) -> list[str]:
+        """Return phase names in stable topological order.
+
+        Uses Kahn's algorithm with a min-heap on ``priority`` for stable
+        tiebreaking. Phases with no dependency relationship preserve their
+        registration order.
+
+        Raises:
+            ValueError: If the DAG is invalid (call ``validate()`` first for
+                detailed error messages).
+        """
+        in_degree: dict[str, int] = dict.fromkeys(self._phases, 0)
+        adj: dict[str, list[str]] = defaultdict(list)
+        for meta in self._phases.values():
+            for dep in meta.depends_on:
+                adj[dep].append(meta.name)
+                in_degree[meta.name] += 1
+
+        # Min-heap keyed on priority for stable ordering
+        heap: list[tuple[int, str]] = []
+        for name, deg in in_degree.items():
+            if deg == 0:
+                heapq.heappush(heap, (self._phases[name].priority, name))
+
+        result: list[str] = []
+        while heap:
+            _priority, name = heapq.heappop(heap)
+            result.append(name)
+            for neighbor in adj[name]:
+                in_degree[neighbor] -= 1
+                if in_degree[neighbor] == 0:
+                    heapq.heappush(heap, (self._phases[neighbor].priority, neighbor))
+
+        if len(result) != len(self._phases):
+            msg = "Dependency cycle detected — call validate() for details"
+            raise ValueError(msg)
+
+        return result
+
+    # -- Lookup ----------------------------------------------------------------
+
+    def get_meta(self, name: str) -> PhaseMeta | None:
+        """Get metadata for a registered phase, or None."""
+        return self._phases.get(name)
+
+    def get_function(self, name: str) -> Callable[..., Any] | None:
+        """Get the registered function for a phase, or None."""
+        return self._functions.get(name)
+
+    @property
+    def phase_names(self) -> list[str]:
+        """All registered phase names (insertion order)."""
+        return list(self._phases.keys())
+
+    def __len__(self) -> int:
+        return len(self._phases)
+
+    def __contains__(self, name: str) -> bool:
+        return name in self._phases
+
+    def phase_table(self) -> str:
+        """Human-readable table of registered phases.
+
+        Returns a markdown-formatted table with columns:
+        Priority | Name | Type | Depends On
+        """
+        lines = ["| Priority | Name | Type | Depends On |"]
+        lines.append("|----------|------|------|------------|")
+        for name in self.execution_order():
+            meta = self._phases[name]
+            phase_type = "deterministic" if meta.is_deterministic else "llm"
+            deps = ", ".join(meta.depends_on) if meta.depends_on else "—"
+            lines.append(f"| {meta.priority} | {name} | {phase_type} | {deps} |")
+        return "\n".join(lines)
+
+
+# -- Module-level singleton ---------------------------------------------------
+
+_registry = PhaseRegistry()
+
+
+def get_registry() -> PhaseRegistry:
+    """Return the module-level phase registry singleton."""
+    return _registry
+
+
+def grow_phase(
+    name: str,
+    *,
+    depends_on: list[str] | None = None,
+    is_deterministic: bool = False,
+    priority: int | None = None,
+) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
+    """Decorator to register a GROW phase function.
+
+    Args:
+        name: Unique phase name (used in execution order and logging).
+        depends_on: Phase names that must run before this one.
+        is_deterministic: True for phases that don't call an LLM.
+        priority: Tiebreaker for topological sort. Defaults to registration
+            order (auto-incremented).
+    """
+    resolved_priority = priority if priority is not None else len(_registry)
+
+    def decorator(fn: Callable[..., Any]) -> Callable[..., Any]:
+        meta = PhaseMeta(
+            name=name,
+            depends_on=tuple(depends_on or []),
+            is_deterministic=is_deterministic,
+            priority=resolved_priority,
+        )
+        _registry.register(fn, meta)
+        setattr(fn, _PHASE_META_ATTR, meta)
+        return fn
+
+    return decorator

--- a/tests/unit/test_grow_registry.py
+++ b/tests/unit/test_grow_registry.py
@@ -1,0 +1,279 @@
+"""Tests for the GROW phase registry."""
+
+from __future__ import annotations
+
+import pytest
+
+from questfoundry.pipeline.stages.grow.registry import (
+    _PHASE_META_ATTR,
+    PhaseMeta,
+    PhaseRegistry,
+    get_registry,
+)
+
+
+class TestPhaseRegistry:
+    """Tests for PhaseRegistry core functionality."""
+
+    def test_register_and_lookup(self) -> None:
+        reg = PhaseRegistry()
+        meta = PhaseMeta(name="alpha", depends_on=(), is_deterministic=True, priority=0)
+
+        async def fake_phase(graph, model):
+            pass
+
+        reg.register(fake_phase, meta)
+        assert "alpha" in reg
+        assert len(reg) == 1
+        assert reg.get_meta("alpha") == meta
+        assert reg.get_function("alpha") is fake_phase
+        assert reg.phase_names == ["alpha"]
+
+    def test_duplicate_name_raises(self) -> None:
+        reg = PhaseRegistry()
+        meta = PhaseMeta(name="alpha", depends_on=(), is_deterministic=True, priority=0)
+
+        async def fake_a(graph, model):
+            pass
+
+        async def fake_b(graph, model):
+            pass
+
+        reg.register(fake_a, meta)
+        with pytest.raises(ValueError, match="Duplicate phase name"):
+            reg.register(fake_b, meta)
+
+    def test_get_meta_nonexistent_returns_none(self) -> None:
+        reg = PhaseRegistry()
+        assert reg.get_meta("nonexistent") is None
+
+    def test_get_function_nonexistent_returns_none(self) -> None:
+        reg = PhaseRegistry()
+        assert reg.get_function("nonexistent") is None
+
+
+class TestPhaseRegistryValidation:
+    """Tests for DAG validation."""
+
+    def test_valid_dag(self) -> None:
+        reg = PhaseRegistry()
+
+        async def f(graph, model):
+            pass
+
+        reg.register(f, PhaseMeta("a", (), True, 0))
+
+        async def g(graph, model):
+            pass
+
+        reg.register(g, PhaseMeta("b", ("a",), True, 1))
+
+        async def h(graph, model):
+            pass
+
+        reg.register(h, PhaseMeta("c", ("b",), True, 2))
+
+        errors = reg.validate()
+        assert errors == []
+
+    def test_missing_dependency(self) -> None:
+        reg = PhaseRegistry()
+
+        async def f(graph, model):
+            pass
+
+        reg.register(f, PhaseMeta("b", ("missing_dep",), True, 0))
+
+        errors = reg.validate()
+        assert len(errors) == 1
+        assert "missing_dep" in errors[0]
+
+    def test_cycle_detection(self) -> None:
+        reg = PhaseRegistry()
+
+        async def f(graph, model):
+            pass
+
+        async def g(graph, model):
+            pass
+
+        reg.register(f, PhaseMeta("a", ("b",), True, 0))
+        reg.register(g, PhaseMeta("b", ("a",), True, 1))
+
+        errors = reg.validate()
+        assert len(errors) == 1
+        assert "cycle" in errors[0].lower()
+
+
+class TestPhaseRegistryExecutionOrder:
+    """Tests for topological sort and stable ordering."""
+
+    def test_linear_chain(self) -> None:
+        reg = PhaseRegistry()
+
+        async def f(graph, model):
+            pass
+
+        async def g(graph, model):
+            pass
+
+        async def h(graph, model):
+            pass
+
+        reg.register(f, PhaseMeta("a", (), True, 0))
+        reg.register(g, PhaseMeta("b", ("a",), True, 1))
+        reg.register(h, PhaseMeta("c", ("b",), True, 2))
+
+        assert reg.execution_order() == ["a", "b", "c"]
+
+    def test_stable_sort_by_priority(self) -> None:
+        """When phases have no dependency, priority breaks ties."""
+        reg = PhaseRegistry()
+
+        async def f(graph, model):
+            pass
+
+        async def g(graph, model):
+            pass
+
+        async def h(graph, model):
+            pass
+
+        # All independent, but priorities define order
+        reg.register(f, PhaseMeta("c", (), True, 2))
+        reg.register(g, PhaseMeta("a", (), True, 0))
+        reg.register(h, PhaseMeta("b", (), True, 1))
+
+        assert reg.execution_order() == ["a", "b", "c"]
+
+    def test_diamond_dependency(self) -> None:
+        """A → B, A → C, B → D, C → D."""
+        reg = PhaseRegistry()
+
+        async def f(graph, model):
+            pass
+
+        async def g(graph, model):
+            pass
+
+        async def h(graph, model):
+            pass
+
+        async def i(graph, model):
+            pass
+
+        reg.register(f, PhaseMeta("a", (), True, 0))
+        reg.register(g, PhaseMeta("b", ("a",), True, 1))
+        reg.register(h, PhaseMeta("c", ("a",), True, 2))
+        reg.register(i, PhaseMeta("d", ("b", "c"), True, 3))
+
+        order = reg.execution_order()
+        assert order[0] == "a"
+        assert order[-1] == "d"
+        # b and c must come before d, after a
+        assert order.index("b") < order.index("d")
+        assert order.index("c") < order.index("d")
+
+    def test_cycle_raises_value_error(self) -> None:
+        reg = PhaseRegistry()
+
+        async def f(graph, model):
+            pass
+
+        async def g(graph, model):
+            pass
+
+        reg.register(f, PhaseMeta("a", ("b",), True, 0))
+        reg.register(g, PhaseMeta("b", ("a",), True, 1))
+
+        with pytest.raises(ValueError, match="cycle"):
+            reg.execution_order()
+
+
+class TestGrowPhaseDecorator:
+    """Tests for the @grow_phase decorator."""
+
+    def test_decorator_attaches_metadata(self) -> None:
+        """The decorator sets _grow_phase_meta on the function."""
+        # Test using a fresh registry to avoid polluting the global singleton.
+        reg = PhaseRegistry()
+        meta = PhaseMeta(name="test_deco", depends_on=(), is_deterministic=True, priority=42)
+
+        async def my_phase(graph, model):
+            pass
+
+        reg.register(my_phase, meta)
+        setattr(my_phase, _PHASE_META_ATTR, meta)
+
+        assert hasattr(my_phase, _PHASE_META_ATTR)
+        attached = getattr(my_phase, _PHASE_META_ATTR)
+        assert attached.name == "test_deco"
+        assert attached.depends_on == ()
+        assert attached.is_deterministic is True
+        assert attached.priority == 42
+
+
+class TestGlobalRegistry:
+    """Tests for the global registry populated by actual GROW phases."""
+
+    def test_global_registry_has_23_phases(self) -> None:
+        """All 23 GROW phases are registered."""
+        registry = get_registry()
+        assert len(registry) >= 23, (
+            f"Expected at least 23 phases, got {len(registry)}: {registry.phase_names}"
+        )
+
+    def test_global_registry_validates(self) -> None:
+        """The global registry DAG is valid (no missing deps, no cycles)."""
+        registry = get_registry()
+        errors = registry.validate()
+        assert errors == [], f"Registry validation errors: {errors}"
+
+    def test_global_registry_execution_order_matches_expected(self) -> None:
+        """Execution order matches the original hand-maintained _phase_order() list."""
+        expected = [
+            "validate_dag",
+            "path_agnostic",
+            "scene_types",
+            "narrative_gaps",
+            "pacing_gaps",
+            "atmospheric",
+            "path_arcs",
+            "intersections",
+            "entity_arcs",
+            "enumerate_arcs",
+            "divergence",
+            "convergence",
+            "collapse_linear_beats",
+            "passages",
+            "codewords",
+            "overlays",
+            "choices",
+            "fork_beats",
+            "hub_spokes",
+            "mark_endings",
+            "split_endings",
+            "collapse_passages",
+            "validation",
+            "prune",
+        ]
+        registry = get_registry()
+        actual = registry.execution_order()
+        assert actual == expected, (
+            f"Execution order mismatch.\nExpected: {expected}\nActual:   {actual}"
+        )
+
+    def test_global_registry_phase_table(self) -> None:
+        """phase_table() produces a non-empty markdown table."""
+        registry = get_registry()
+        table = registry.phase_table()
+        assert "| Priority |" in table
+        assert "validate_dag" in table
+        assert "prune" in table
+
+    def test_split_endings_has_two_dependencies(self) -> None:
+        """split_endings depends on both mark_endings and codewords."""
+        registry = get_registry()
+        meta = registry.get_meta("split_endings")
+        assert meta is not None
+        assert set(meta.depends_on) == {"mark_endings", "codewords"}


### PR DESCRIPTION
## Problem

The GROW phase list in `_phase_order()` is a hand-maintained list of 23 function references. Phase ordering invariants (e.g., "4a-4d must run before 3") are enforced only by list position, not by declared dependencies. This makes it easy to introduce ordering bugs and causes spec drift.

Closes #854

## Changes

- **New `registry.py`** (~240 lines): `PhaseRegistry` class and `@grow_phase` decorator
  - Decorator captures metadata: `name`, `depends_on`, `is_deterministic`, `priority`
  - Registry validates DAG (missing deps, cycle detection) and produces stable topological order
  - Kahn's algorithm with priority tiebreaker ensures output matches the original hand-maintained list
- **`deterministic.py`**: Added `@grow_phase(...)` decorators to all 12 deterministic phase functions
- **`llm_phases.py`**: Added `@grow_phase(...)` decorators to all 11 LLM phase methods
- **`stage.py`**: `_phase_order()` delegates to registry for ordering, resolves functions from module scope (free functions) and `self` (methods) for test patchability
- **`__init__.py`**: Export `PhaseRegistry`, `get_registry`, `grow_phase`
- **New `test_grow_registry.py`** (~280 lines): 17 tests covering core operations, DAG validation, cycle detection, stable sort, and exact order match with original list

## Not Included / Future PRs

- Per-phase invariant docstrings (#855) — next PR in stack
- Residue beats (#853) — later PRs will use the registry to self-register new phases
- `qf inspect --phases` CLI command — deferred

## Test Plan

```bash
uv run pytest tests/unit/test_grow_registry.py tests/unit/test_grow_stage.py -x -q
# 119 passed — 17 new registry tests + 102 existing stage tests
uv run mypy src/questfoundry/pipeline/stages/grow/
uv run ruff check src/questfoundry/pipeline/stages/grow/
```

## Risk / Rollback

- **Low risk**: Pure refactor — behavior unchanged. Topological sort with priority tiebreaker produces the exact same execution order as the original hand-maintained list (verified by regression test).
- **Rollback**: Revert the 4 commits. No data migration needed.

## Review Guide

Read in order: `registry.py` (new module) → `deterministic.py` / `llm_phases.py` (decorator additions) → `stage.py` (`_phase_order()` delegation) → `test_grow_registry.py`