### PR TITLE
feat(grow): implement Phase 8d residue beats LLM phase

### DIFF
--- a/prompts/templates/grow_phase8d_residue.yaml
+++ b/prompts/templates/grow_phase8d_residue.yaml
@@ -1,0 +1,75 @@
+name: grow_phase8d_residue
+description: Propose residue beats where path-specific prose should differ at convergence points
+
+system: |
+  You are identifying passages near convergence points where the narrative
+  should acknowledge which path the player took. These are called "residue
+  beats" -- moments where the prose should be different depending on the
+  player's earlier choices.
+
+  ## What is a Residue Beat?
+  When two paths converge (merge back together), the first shared passage
+  is a natural place to acknowledge what happened on the path the player
+  chose. For example:
+  - After a fight vs. negotiation choice, the shared passage might mention
+    bruises (fight) or a new alliance (negotiation)
+  - After a risky shortcut vs. safe route, the shared passage might note
+    exhaustion (shortcut) or supplies running low (safe route, took longer)
+
+  Each residue beat produces one variant per path, gated by the codeword
+  that tracks which path was taken.
+
+  ## Convergence Points and Available Codewords
+  {convergence_context}
+
+  ## Passage Summaries
+  {passage_context}
+
+  ## Rules
+  1. Only propose residue beats for the passages listed above
+  2. Each proposal targets ONE passage and ONE dilemma
+  3. Each variant is gated by exactly ONE codeword from the available list
+  4. The hint field tells the prose writer HOW to differentiate this variant
+     (10-200 characters, specific and concrete)
+  5. Maximum {max_proposals} proposals total
+  6. Focus on the MOST narratively impactful convergence points first
+
+  ## Hint Quality
+  GOOD hints (specific, actionable):
+  - "mention the scar from the fistfight"
+  - "reference the fragile truce with the guards"
+  - "describe lingering guilt over the betrayal"
+
+  BAD hints (vague, generic):
+  - "acknowledge the player's choice"
+  - "reflect on what happened"
+  - "show consequences"
+
+  ## Valid IDs
+  Valid passage_ids: {valid_passage_ids}
+  Valid codeword_ids (for variant gating): {valid_codeword_ids}
+  Valid dilemma_ids: {valid_dilemma_ids}
+
+  ## Output Format
+  Return a JSON object with a "proposals" array. Each proposal has:
+  - passage_id: passage to split into variants
+  - dilemma_id: dilemma whose paths are converging at this point
+  - rationale: why this passage needs path-specific variants (1 sentence)
+  - variants: array of objects, each with:
+    - codeword_id: the codeword that gates this variant
+    - hint: specific prose guidance (10-200 chars)
+
+  If no passages warrant residue variants, return an empty proposals array.
+
+user: |
+  Review the convergence points above and propose residue beats where the
+  prose should differ based on the player's path.
+
+  Focus on the strongest candidates first -- where the player's choice
+  would most naturally be reflected in the shared passage.
+
+  REMINDER: Use ONLY IDs from the Valid IDs section.
+  Maximum {max_proposals} proposals.
+  Return ONLY a valid JSON object.
+
+components: []

--- a/src/questfoundry/graph/grow_algorithms.py
+++ b/src/questfoundry/graph/grow_algorithms.py
@@ -859,6 +859,7 @@ def _build_collapse_exempt_passages(
     - Climax/resolution beats (narrative_function in {"confront", "resolve"})
     - Ending passages (is_ending=True)
     - Passages with transition_style="cut" in their beat
+    - Residue variant passages (is_residue=True)
     """
     beats = graph.get_nodes_by_type("beat")
     exempt: set[str] = set()
@@ -866,6 +867,11 @@ def _build_collapse_exempt_passages(
     for pid, pdata in passages.items():
         # Check ending status
         if pdata.get("is_ending"):
+            exempt.add(pid)
+            continue
+
+        # Check residue variant status
+        if pdata.get("is_residue"):
             exempt.add(pid)
             continue
 

--- a/src/questfoundry/graph/grow_validators.py
+++ b/src/questfoundry/graph/grow_validators.py
@@ -23,6 +23,7 @@ if TYPE_CHECKING:
         Phase4bOutput,
         Phase4fOutput,
         Phase8cOutput,
+        Phase8dOutput,
         Phase9bOutput,
         Phase9cOutput,
         Phase9Output,
@@ -165,6 +166,52 @@ def validate_phase8c_output(
                         field_path=f"overlays.{i}.when",
                         issue=f"Codeword ID not found: {cw_id}",
                         provided=cw_id,
+                        available=sorted(valid_codeword_ids)[:10],
+                    )
+                )
+    return errors
+
+
+def validate_phase8d_output(
+    result: Phase8dOutput,
+    valid_passage_ids: set[str],
+    valid_codeword_ids: set[str],
+    valid_dilemma_ids: set[str],
+) -> list[GrowValidationError]:
+    """Validate Phase 8d residue beat proposals.
+
+    Checks:
+    - passage_id exists in graph
+    - dilemma_id exists in graph
+    - codeword IDs in variants exist
+    """
+    errors: list[GrowValidationError] = []
+    for i, proposal in enumerate(result.proposals):
+        if proposal.passage_id not in valid_passage_ids:
+            errors.append(
+                GrowValidationError(
+                    field_path=f"proposals.{i}.passage_id",
+                    issue=f"Passage ID not found: {proposal.passage_id}",
+                    provided=proposal.passage_id,
+                    available=sorted(valid_passage_ids)[:10],
+                )
+            )
+        if proposal.dilemma_id not in valid_dilemma_ids:
+            errors.append(
+                GrowValidationError(
+                    field_path=f"proposals.{i}.dilemma_id",
+                    issue=f"Dilemma ID not found: {proposal.dilemma_id}",
+                    provided=proposal.dilemma_id,
+                    available=sorted(valid_dilemma_ids)[:10],
+                )
+            )
+        for j, variant in enumerate(proposal.variants):
+            if variant.codeword_id not in valid_codeword_ids:
+                errors.append(
+                    GrowValidationError(
+                        field_path=f"proposals.{i}.variants.{j}.codeword_id",
+                        issue=f"Codeword ID not found: {variant.codeword_id}",
+                        provided=variant.codeword_id,
                         available=sorted(valid_codeword_ids)[:10],
                     )
                 )

--- a/src/questfoundry/graph/grow_validators.py
+++ b/src/questfoundry/graph/grow_validators.py
@@ -186,6 +186,10 @@ def validate_phase8d_output(
     - codeword IDs in variants exist
     """
     errors: list[GrowValidationError] = []
+    available_passages = sorted(valid_passage_ids)[:10]
+    available_codewords = sorted(valid_codeword_ids)[:10]
+    available_dilemmas = sorted(valid_dilemma_ids)[:10]
+
     for i, proposal in enumerate(result.proposals):
         if proposal.passage_id not in valid_passage_ids:
             errors.append(
@@ -193,7 +197,7 @@ def validate_phase8d_output(
                     field_path=f"proposals.{i}.passage_id",
                     issue=f"Passage ID not found: {proposal.passage_id}",
                     provided=proposal.passage_id,
-                    available=sorted(valid_passage_ids)[:10],
+                    available=available_passages,
                 )
             )
         if proposal.dilemma_id not in valid_dilemma_ids:
@@ -202,7 +206,7 @@ def validate_phase8d_output(
                     field_path=f"proposals.{i}.dilemma_id",
                     issue=f"Dilemma ID not found: {proposal.dilemma_id}",
                     provided=proposal.dilemma_id,
-                    available=sorted(valid_dilemma_ids)[:10],
+                    available=available_dilemmas,
                 )
             )
         for j, variant in enumerate(proposal.variants):
@@ -212,7 +216,7 @@ def validate_phase8d_output(
                         field_path=f"proposals.{i}.variants.{j}.codeword_id",
                         issue=f"Codeword ID not found: {variant.codeword_id}",
                         provided=variant.codeword_id,
-                        available=sorted(valid_codeword_ids)[:10],
+                        available=available_codewords,
                     )
                 )
     return errors

--- a/src/questfoundry/pipeline/stages/grow/deterministic.py
+++ b/src/questfoundry/pipeline/stages/grow/deterministic.py
@@ -531,7 +531,7 @@ async def phase_codewords(graph: Graph, model: BaseChatModel) -> GrowPhaseResult
 # --- Phase 9c2: Mark Endings ---
 
 
-@grow_phase(name="mark_endings", depends_on=["hub_spokes"], is_deterministic=True, priority=19)
+@grow_phase(name="mark_endings", depends_on=["hub_spokes"], is_deterministic=True, priority=20)
 async def phase_mark_endings(
     graph: Graph,
     model: BaseChatModel,  # noqa: ARG001
@@ -567,7 +567,7 @@ async def phase_mark_endings(
     name="split_endings",
     depends_on=["mark_endings", "codewords"],
     is_deterministic=True,
-    priority=20,
+    priority=21,
 )
 async def phase_split_endings(
     graph: Graph,
@@ -615,7 +615,7 @@ async def phase_split_endings(
 
 
 @grow_phase(
-    name="collapse_passages", depends_on=["split_endings"], is_deterministic=True, priority=21
+    name="collapse_passages", depends_on=["split_endings"], is_deterministic=True, priority=22
 )
 async def phase_collapse_passages(
     graph: Graph,
@@ -661,7 +661,7 @@ async def phase_collapse_passages(
 # --- Phase 10: Validation ---
 
 
-@grow_phase(name="validation", depends_on=["collapse_passages"], is_deterministic=True, priority=22)
+@grow_phase(name="validation", depends_on=["collapse_passages"], is_deterministic=True, priority=23)
 async def phase_validation(graph: Graph, model: BaseChatModel) -> GrowPhaseResult:  # noqa: ARG001
     """Phase 10: Graph validation.
 
@@ -717,7 +717,7 @@ async def phase_validation(graph: Graph, model: BaseChatModel) -> GrowPhaseResul
 # --- Phase 11: Prune ---
 
 
-@grow_phase(name="prune", depends_on=["validation"], is_deterministic=True, priority=23)
+@grow_phase(name="prune", depends_on=["validation"], is_deterministic=True, priority=24)
 async def phase_prune(graph: Graph, model: BaseChatModel) -> GrowPhaseResult:  # noqa: ARG001
     """Phase 11: Prune unreachable passages.
 

--- a/src/questfoundry/pipeline/stages/grow/llm_phases.py
+++ b/src/questfoundry/pipeline/stages/grow/llm_phases.py
@@ -1253,7 +1253,7 @@ class _LLMPhaseMixin:
         )
 
     # -------------------------------------------------------------------------
-    # Late LLM phases (8d, 8c, 9, 9b, 9c)
+    # Late LLM phases (codewords → validation)
     # -------------------------------------------------------------------------
 
     @grow_phase(name="residue_beats", depends_on=["codewords"], priority=15)
@@ -1297,19 +1297,13 @@ class _LLMPhaseMixin:
         # Build convergence context for LLM — rich narrative per candidate
         convergence_lines: list[str] = []
         passage_nodes = graph.get_nodes_by_type("passage")
-        valid_passage_ids: list[str] = []
-        valid_codeword_ids: list[str] = []
-        valid_dilemma_ids: list[str] = []
+        valid_passage_ids: list[str] = list(dict.fromkeys(c.passage_id for c in candidates))
+        valid_dilemma_ids: list[str] = list(dict.fromkeys(c.dilemma_id for c in candidates))
+        valid_codeword_ids: list[str] = list(
+            dict.fromkeys(cw_id for c in candidates for cw_id in c.codeword_ids)
+        )
 
         for candidate in candidates:
-            if candidate.passage_id not in valid_passage_ids:
-                valid_passage_ids.append(candidate.passage_id)
-            if candidate.dilemma_id not in valid_dilemma_ids:
-                valid_dilemma_ids.append(candidate.dilemma_id)
-            for cw_id in candidate.codeword_ids:
-                if cw_id not in valid_codeword_ids:
-                    valid_codeword_ids.append(cw_id)
-
             passage_data = passage_nodes.get(candidate.passage_id, {})
             summary = truncate_summary(str(passage_data.get("summary", "")), 120)
 

--- a/src/questfoundry/pipeline/stages/grow/stage.py
+++ b/src/questfoundry/pipeline/stages/grow/stage.py
@@ -164,6 +164,7 @@ class GrowStage(_LLMHelperMixin, _LLMPhaseMixin):
         "path_arcs": "_phase_4e_path_arcs",
         "intersections": "_phase_3_intersections",
         "entity_arcs": "_phase_4f_entity_arcs",
+        "residue_beats": "_phase_8d_residue_beats",
         "overlays": "_phase_8c_overlays",
         "choices": "_phase_9_choices",
         "fork_beats": "_phase_9b_fork_beats",

--- a/tests/unit/test_grow_algorithms.py
+++ b/tests/unit/test_grow_algorithms.py
@@ -4857,6 +4857,23 @@ class TestCollapseLinearPassages:
         assert result.chains_collapsed == 0
         assert result.passages_removed == 0
 
+    def test_exempts_residue_passages(self) -> None:
+        """Does not include residue variant passages in collapse."""
+        from questfoundry.graph.grow_algorithms import collapse_linear_passages
+
+        graph = self._make_linear_chain_graph(chain_length=4)
+        # Mark middle passage as a residue variant
+        graph.update_node("passage::b1", is_residue=True)
+
+        collapse_linear_passages(graph, min_chain_length=3)
+
+        # b1 should not be absorbed into any merged passage
+        merged_passages = [
+            p for _pid, p in graph.get_nodes_by_type("passage").items() if p.get("merged_from")
+        ]
+        for merged in merged_passages:
+            assert "passage::b1" not in merged.get("merged_from", [])
+
 
 # ---------------------------------------------------------------------------
 # Hard-policy intersection rejection

--- a/tests/unit/test_grow_registry.py
+++ b/tests/unit/test_grow_registry.py
@@ -247,6 +247,7 @@ class TestGlobalRegistry:
             "collapse_linear_beats",
             "passages",
             "codewords",
+            "residue_beats",
             "overlays",
             "choices",
             "fork_beats",


### PR DESCRIPTION
## Summary

Implement Phase 8d (`residue_beats`), a new LLM phase that identifies convergence points needing path-specific prose and creates variant passages gated by codewords. Also extends passage collapse to exempt residue variants.

## Related Issues

Partial #853 (Design docs D1 + D3: LLM phase + absorption)
Part of Epic #858 (GROW stage redesign, Phase 2)

**PR Stack:** PR1 (#877, merged) → PR2 (#878) → PR3 (#879) → **PR4 (this)** → PR5

## Changes

- Add `_phase_8d_residue_beats()` LLM phase method to `_LLMPhaseMixin`
- Register `residue_beats` phase in `stage.py` (depends on `codewords`, before `overlays`)
- Create `grow_phase8d_residue.yaml` prompt template for convergence point analysis
- Add `validate_phase8d_output()` semantic validator for passage/codeword/dilemma IDs
- Extend `_build_collapse_exempt_passages()` to skip `is_residue=True` passages
- Bump phase priorities to accommodate new phase (15→residue_beats, 16→overlays, 17→choices, etc.)
- Update phase count from 24 to 25 in tests

## Not Included / Future PRs

- Simplification of existing phases (PR5)
- FILL integration for residue variant prose generation (separate epic)

## Test Plan

- [x] 4 Phase 8d stage tests: creates variants, no-candidates skip, empty proposals, error handling
- [x] 5 Phase 8d validator tests: valid output, invalid passage/dilemma/codeword, empty proposals
- [x] 1 collapse exemption test: residue passages excluded from merge
- [x] Phase order/count tests updated (24→25 phases, `residue_beats` in correct position)
- [x] 516 total tests pass (no regressions)
- [x] mypy and ruff clean

```
uv run pytest tests/unit/test_grow_stage.py tests/unit/test_grow_algorithms.py \
  tests/unit/test_grow_registry.py tests/unit/test_grow_validators.py \
  tests/unit/test_grow_models.py -x -q
# 516 passed
```

## Risk / Rollback

- Low risk: new phase returns completed with no mutations when no candidates exist
- Existing phases unaffected (only priority numbers changed, dependency chain preserved)
- Phase 8d is skippable — empty graph/no convergences → no LLM call

## Checklist

- [x] Code follows project conventions
- [x] Tests added/updated for changes
- [x] No TODO stubs in committed code
- [x] Type hints added for new code

## Review Guide

1. `prompts/templates/grow_phase8d_residue.yaml` — prompt template (standalone)
2. `src/questfoundry/graph/grow_validators.py` — `validate_phase8d_output()` (small addition)
3. `src/questfoundry/pipeline/stages/grow/llm_phases.py` — `_phase_8d_residue_beats()` (main logic)
4. `src/questfoundry/pipeline/stages/grow/stage.py` — one-line registration
5. `src/questfoundry/graph/grow_algorithms.py` — 4-line collapse exemption
6. Tests: `test_grow_stage.py`, `test_grow_validators.py`, `test_grow_algorithms.py`