### PR TITLE
fix(seed): filter consequences for non-existent paths

### DIFF
--- a/src/questfoundry/agents/serialize.py
+++ b/src/questfoundry/agents/serialize.py
@@ -1587,16 +1587,19 @@ def _filter_consequences_by_valid_paths(
     are dropped with a warning log. This prevents semantic validation errors
     that the retry loop cannot fix.
     """
-    valid_path_ids = {p.get("path_id", "") for p in paths if p.get("path_id")}
-    filtered = [c for c in consequences if c.get("path_id") in valid_path_ids]
-    dropped = len(consequences) - len(filtered)
-    if dropped:
-        dropped_ids = [
-            c.get("path_id", "?") for c in consequences if c.get("path_id") not in valid_path_ids
-        ]
+    valid_path_ids = {p.get("path_id") for p in paths if p.get("path_id")}
+    filtered: list[dict[str, Any]] = []
+    dropped_ids: list[str] = []
+    for c in consequences:
+        path_id = c.get("path_id")
+        if path_id in valid_path_ids:
+            filtered.append(c)
+        else:
+            dropped_ids.append(path_id if path_id is not None else "?")
+    if dropped_ids:
         log.warning(
             "consequences_filtered_invalid_paths",
-            dropped=dropped,
+            dropped=len(dropped_ids),
             total=len(consequences),
             kept=len(filtered),
             dropped_path_ids=dropped_ids,


### PR DESCRIPTION
## Problem

SEED crashes with `SeedMutationError` when the LLM generates consequences
for non-default paths of non-explored dilemmas. The summarize phase brief
describes ALL conceptual paths (both answers of every dilemma), but only
explored dilemmas get both paths serialized. The 4B model follows the rich
narrative brief (14 paths) over the short valid ID constraint list (10 paths),
generating consequences for non-existent paths. Retry corrections then suggest
semantically nonsensical substitutions (`__sabotaged → __loyal`), exhausting
all retries.

## Changes

Two-layer defense:

- **Layer 1 — Brief replacement**: Replace the contaminated summarize-phase
  `brief_dict["paths"]` with a compact brief built from `collected["paths"]`
  (the actually-serialized paths). This eliminates the contradictory signal
  at its source. Applied at both the initial serialization and retry paths.

- **Layer 2 — Deterministic post-filter**: After consequences are serialized,
  filter out any referencing `path_id`s not present in `collected["paths"]`.
  Logs dropped count as a warning. Applied at both serialization sites.

New helpers:
- `_build_consequences_paths_brief()` — builds compact brief from serialized paths
- `_filter_consequences_by_valid_paths()` — filters invalid consequences with logging

## Not Included / Future PRs

- Prompt template changes to `serialize_seed_sections.yaml` (brief fix addresses root cause)
- Changes to `_format_section_corrections` similarity matching (filter prevents errors from reaching corrections)

## Test Plan

- `uv run pytest tests/unit/test_serialize.py -x -q` — 75 tests pass (8 new)
- `uv run mypy src/questfoundry/agents/serialize.py` — no issues
- `uv run ruff check src/questfoundry/agents/serialize.py` — clean
- Re-ran `uv run qf --log -vvv seed --project test-new` — completed successfully
  (14 consequences on first attempt, no filter activation, no crashes)

## Risk / Rollback

- Low risk: adds filtering that only activates when invalid data is present
- Fallback paths preserve original behavior when `collected["paths"]` is empty

🤖 Generated with [Claude Code](https://claude.com/claude-code)