### PR TITLE
feat(graph): add rewind API for phase reversal

### DIFF
--- a/src/questfoundry/graph/graph.py
+++ b/src/questfoundry/graph/graph.py
@@ -267,7 +267,7 @@ class Graph:
 
         Args:
             stage: Pipeline stage (e.g., ``"grow"``).
-            phase: Phase within the stage (e.g., ``"scene_types"``).
+            phase: Phase within the stage (e.g., ``"path_agnostic"``).
 
         Returns:
             Number of mutations reversed.

--- a/src/questfoundry/graph/sqlite_store.py
+++ b/src/questfoundry/graph/sqlite_store.py
@@ -489,10 +489,10 @@ class SqliteGraphStore:
             phase: Phase within the stage (e.g., ``"path_agnostic"``).
 
         Returns:
-            Number of mutations reversed.
+            Number of mutations reversed. Returns 0 if no mutations
+            exist for *(stage, phase)*.
 
         Raises:
-            ValueError: If no mutations found for *(stage, phase)*.
             RuntimeError: If a mutation lacks ``before_state`` needed for
                 reversal (e.g., pre-migration data).
         """
@@ -502,7 +502,7 @@ class SqliteGraphStore:
         ).fetchone()
 
         if row is None or row["min_id"] is None:
-            raise ValueError(f"No mutations found for stage={stage!r}, phase={phase!r}")
+            return 0
 
         return self._rewind_from_id(row["min_id"])
 
@@ -516,10 +516,10 @@ class SqliteGraphStore:
             stage: Pipeline stage to rewind (e.g., ``"grow"``).
 
         Returns:
-            Number of mutations reversed.
+            Number of mutations reversed. Returns 0 if no mutations
+            exist for the stage.
 
         Raises:
-            ValueError: If no mutations found for the stage.
             RuntimeError: If a mutation lacks ``before_state`` needed for
                 reversal.
         """
@@ -529,7 +529,7 @@ class SqliteGraphStore:
         ).fetchone()
 
         if row is None or row["min_id"] is None:
-            raise ValueError(f"No mutations found for stage={stage!r}")
+            return 0
 
         return self._rewind_from_id(row["min_id"])
 

--- a/tests/unit/test_graph_sqlite_integration.py
+++ b/tests/unit/test_graph_sqlite_integration.py
@@ -720,20 +720,18 @@ class TestRewind:
         assert not graph.has_node("p2")
         assert not graph.has_node("p3")
 
-    def test_rewind_nonexistent_phase_raises(self) -> None:
-        """Rewind raises ValueError for a phase with no mutations."""
+    def test_rewind_nonexistent_phase_is_noop(self) -> None:
+        """Rewind returns 0 for a phase with no mutations."""
         store = SqliteGraphStore()
         graph = Graph(store=store)
 
         with graph.mutation_context("grow", "spine"):
             graph.create_node("n1", {"type": "t"})
 
-        raised = False
-        try:
-            graph.rewind_to_phase("grow", "nonexistent")
-        except ValueError:
-            raised = True
-        assert raised, "Expected ValueError for nonexistent phase"
+        count = graph.rewind_to_phase("grow", "nonexistent")
+        assert count == 0
+        # Original node should still exist
+        assert graph.has_node("n1")
 
     def test_rewind_stage_reverses_all(self) -> None:
         """rewind_stage reverses all phases within the stage."""

--- a/tests/unit/test_graph_sqlite_integration.py
+++ b/tests/unit/test_graph_sqlite_integration.py
@@ -375,7 +375,10 @@ class TestBeforeStateMutations:
         assert len(muts) == 2
         assert muts[1]["operation"] == "replace_node"
         assert muts[1]["delta"] == {"type": "t", "name": "Bob"}
-        assert muts[1]["before_state"] == {"type": "t", "name": "Alice"}
+        before = muts[1]["before_state"]
+        meta = before.pop("_meta")
+        assert before == {"type": "t", "name": "Alice"}
+        assert "created_stage" in meta
 
     def test_update_node_fields_captures_old_values(self) -> None:
         """update_node_fields records old values of changed fields."""
@@ -387,7 +390,10 @@ class TestBeforeStateMutations:
         update_mut = muts[-1]
         assert update_mut["operation"] == "update_node"
         assert update_mut["delta"] == {"name": "Bob", "age": 31}
-        assert update_mut["before_state"] == {"name": "Alice", "age": 30}
+        before = update_mut["before_state"]
+        meta = before.pop("_meta")
+        assert before == {"name": "Alice", "age": 30}
+        assert "modified_stage" in meta
 
     def test_update_node_fields_captures_none_for_new_fields(self) -> None:
         """update_node_fields records None for fields that didn't exist before."""
@@ -397,7 +403,9 @@ class TestBeforeStateMutations:
 
         muts = self._get_mutations(store)
         update_mut = muts[-1]
-        assert update_mut["before_state"] == {"mood": None}
+        before = update_mut["before_state"]
+        before.pop("_meta")
+        assert before == {"mood": None}
 
     def test_delete_node_captures_before_state(self) -> None:
         """delete_node records full node data in before_state."""
@@ -408,7 +416,10 @@ class TestBeforeStateMutations:
         muts = self._get_mutations(store)
         delete_mut = muts[-1]
         assert delete_mut["operation"] == "delete_node"
-        assert delete_mut["before_state"] == {"type": "t", "name": "Alice", "age": 30}
+        before = delete_mut["before_state"]
+        meta = before.pop("_meta")
+        assert before == {"type": "t", "name": "Alice", "age": 30}
+        assert "created_stage" in meta
 
     def test_add_edge_stores_full_delta(self) -> None:
         """add_edge records full edge dict in delta."""
@@ -709,18 +720,20 @@ class TestRewind:
         assert not graph.has_node("p2")
         assert not graph.has_node("p3")
 
-    def test_rewind_nonexistent_phase_is_noop(self) -> None:
-        """Rewind returns 0 for a phase with no mutations."""
+    def test_rewind_nonexistent_phase_raises(self) -> None:
+        """Rewind raises ValueError for a phase with no mutations."""
         store = SqliteGraphStore()
         graph = Graph(store=store)
 
         with graph.mutation_context("grow", "spine"):
             graph.create_node("n1", {"type": "t"})
 
-        count = graph.rewind_to_phase("grow", "nonexistent")
-        assert count == 0
-        # Original node should still exist
-        assert graph.has_node("n1")
+        raised = False
+        try:
+            graph.rewind_to_phase("grow", "nonexistent")
+        except ValueError:
+            raised = True
+        assert raised, "Expected ValueError for nonexistent phase"
 
     def test_rewind_stage_reverses_all(self) -> None:
         """rewind_stage reverses all phases within the stage."""
@@ -832,3 +845,42 @@ class TestRewind:
         remaining = store._conn.execute("SELECT stage, phase FROM mutations").fetchone()
         assert remaining["stage"] == "seed"
         assert remaining["phase"] == "core"
+
+    def test_rewind_restores_metadata_columns(self) -> None:
+        """Rewind restores created_stage/phase and modified_stage/phase."""
+        store = SqliteGraphStore()
+        graph = Graph(store=store)
+
+        with graph.mutation_context("seed", "core"):
+            graph.create_node("n1", {"type": "t", "name": "Alice"})
+
+        # Capture original metadata
+        orig = store._conn.execute(
+            "SELECT created_stage, created_phase, modified_stage, modified_phase "
+            "FROM nodes WHERE node_id = ?",
+            ("n1",),
+        ).fetchone()
+        assert orig["created_stage"] == "seed"
+        assert orig["created_phase"] == "core"
+
+        # Modify in a later phase
+        with graph.mutation_context("grow", "spine"):
+            graph.update_node("n1", name="Bob")
+
+        modified = store._conn.execute(
+            "SELECT modified_stage, modified_phase FROM nodes WHERE node_id = ?",
+            ("n1",),
+        ).fetchone()
+        assert modified["modified_stage"] == "grow"
+
+        # Rewind — should restore original metadata
+        graph.rewind_to_phase("grow", "spine")
+        restored = store._conn.execute(
+            "SELECT created_stage, created_phase, modified_stage, modified_phase "
+            "FROM nodes WHERE node_id = ?",
+            ("n1",),
+        ).fetchone()
+        assert restored["created_stage"] == "seed"
+        assert restored["created_phase"] == "core"
+        assert restored["modified_stage"] == "seed"
+        assert restored["modified_phase"] == "core"


### PR DESCRIPTION
## Problem
The mutation trail records all graph changes but has no way to reverse them.
Phase resume currently relies on 44+ per-phase JSON checkpoint files
(`grow-pre-*.json`), each a full graph serialization. With rewind, these
checkpoint files become unnecessary — resuming a phase means rewinding
the database to that phase boundary.

## Changes
- Add `rewind_to_phase(stage, phase)` and `rewind_stage(stage)` to
  `SqliteGraphStore` — find first mutation for (stage, phase), apply
  inverse of every mutation from that point onward in DESC order,
  delete reversed mutation records
- Rename `set_node` update operation from `"update_node"` to
  `"replace_node"` to disambiguate full-node replacement from partial
  field updates (needed for correct reversal)
- Add `_rewind_from_id()` helper wrapped in SAVEPOINT for atomicity
- Add `_apply_inverse()` with handlers for all 6 operation types
- Add `rewind_to_phase`/`rewind_stage` to `GraphStore` protocol
  (`DictGraphStore` raises `NotImplementedError`)
- Add wrapper methods on `Graph` that check `is_sqlite_backed`
- 15 new tests covering all operation types, mixed operations,
  phase preservation, atomicity on failure, and mutation cleanup

## Not Included / Future PRs
- SQLite-first saves (PR 3 in stack)
- Rewind-based resume replacing checkpoint files (PR 3)
- Removing JSON persistence (PR 4)

## Test Plan
```bash
uv run pytest tests/unit/test_graph_sqlite_integration.py -x -q  # 50 passed
uv run mypy src/questfoundry/graph/                               # Success
uv run ruff check src/questfoundry/graph/                         # All passed
```

## Risk / Rollback
- `replace_node` rename is a mutation-recording-only change; existing code
  that queries by operation name (audit.py) passes operation as a filter
  parameter, not a hardcoded string
- Rewind is opt-in — no existing code calls it yet (PR 3 will wire it up)
- Atomicity: entire rewind wrapped in SAVEPOINT; failure rolls back cleanly

## Review Guide
1. `sqlite_store.py` — core rewind logic (`_apply_inverse`, `_rewind_from_id`)
2. `store.py` — protocol additions
3. `graph.py` — wrapper methods
4. `test_graph_sqlite_integration.py` — 15 new `TestRewind` tests

Stacked on #883.