### PR TITLE
feat(graph): SQLite-first saves + rewind-based phase resume

### DIFF
--- a/src/questfoundry/graph/audit.py
+++ b/src/questfoundry/graph/audit.py
@@ -79,7 +79,8 @@ def query_mutations(
         params.append(limit)
 
         rows = conn.execute(
-            f"SELECT id, timestamp, stage, phase, operation, target_id, delta "
+            f"SELECT id, timestamp, stage, phase, operation, target_id, "
+            f"delta, before_state "
             f"FROM mutations{where} ORDER BY id DESC LIMIT ?",
             params,
         ).fetchall()
@@ -93,6 +94,7 @@ def query_mutations(
                 "operation": row["operation"],
                 "target_id": row["target_id"],
                 "delta": json.loads(row["delta"]) if row["delta"] else None,
+                "before_state": (json.loads(row["before_state"]) if row["before_state"] else None),
             }
             for row in rows
         ]

--- a/src/questfoundry/graph/graph.py
+++ b/src/questfoundry/graph/graph.py
@@ -275,6 +275,60 @@ class Graph:
             self._store.set_mutation_context("", "")
 
     # -------------------------------------------------------------------------
+    # Rewind
+    # -------------------------------------------------------------------------
+
+    def rewind_to_phase(self, stage: str, phase: str) -> int:
+        """Rewind graph by reversing all mutations from a phase onward.
+
+        Requires a SQLite-backed graph with mutation recording. All mutations
+        from the first occurrence of *(stage, phase)* through the latest
+        mutation are reversed in order, and the mutation records deleted.
+
+        Note: Metadata (``last_stage``, ``stage_history``) is NOT updated
+        automatically — callers should update meta after rewind if needed.
+
+        Args:
+            stage: Pipeline stage (e.g., ``"grow"``).
+            phase: Phase within the stage (e.g., ``"path_agnostic"``).
+
+        Returns:
+            Number of mutations reversed.
+
+        Raises:
+            TypeError: If the graph is not SQLite-backed.
+            ValueError: If no mutations found for *(stage, phase)*.
+            RuntimeError: If a mutation lacks data needed for reversal.
+        """
+        if not self.is_sqlite_backed:
+            raise TypeError("Rewind requires SQLite-backed graph")
+        return self.sqlite_store.rewind_to_phase(stage, phase)
+
+    def rewind_stage(self, stage: str) -> int:
+        """Rewind all mutations for an entire stage.
+
+        Requires a SQLite-backed graph. All mutations for the given *stage*
+        (across all phases) are reversed in order.
+
+        Note: Metadata (``last_stage``, ``stage_history``) is NOT updated
+        automatically — callers should update meta after rewind if needed.
+
+        Args:
+            stage: Pipeline stage to rewind (e.g., ``"grow"``).
+
+        Returns:
+            Number of mutations reversed.
+
+        Raises:
+            TypeError: If the graph is not SQLite-backed.
+            ValueError: If no mutations found for the stage.
+            RuntimeError: If a mutation lacks data needed for reversal.
+        """
+        if not self.is_sqlite_backed:
+            raise TypeError("Rewind requires SQLite-backed graph")
+        return self.sqlite_store.rewind_stage(stage)
+
+    # -------------------------------------------------------------------------
     # Store Access
     # -------------------------------------------------------------------------
 

--- a/src/questfoundry/graph/sqlite_store.py
+++ b/src/questfoundry/graph/sqlite_store.py
@@ -467,10 +467,10 @@ class SqliteGraphStore:
             phase: Phase within the stage (e.g., ``"path_agnostic"``).
 
         Returns:
-            Number of mutations reversed.
+            Number of mutations reversed.  Returns 0 if no mutations
+            exist for *(stage, phase)* (already in pre-phase state).
 
         Raises:
-            ValueError: If no mutations found for *(stage, phase)*.
             RuntimeError: If a mutation lacks ``before_state`` needed for
                 reversal (e.g., pre-migration data).
         """
@@ -480,7 +480,7 @@ class SqliteGraphStore:
         ).fetchone()
 
         if row is None or row["min_id"] is None:
-            raise ValueError(f"No mutations found for stage={stage!r}, phase={phase!r}")
+            return 0
 
         return self._rewind_from_id(row["min_id"])
 
@@ -494,10 +494,10 @@ class SqliteGraphStore:
             stage: Pipeline stage to rewind (e.g., ``"grow"``).
 
         Returns:
-            Number of mutations reversed.
+            Number of mutations reversed.  Returns 0 if no mutations
+            exist for the stage (the graph is already in pre-stage state).
 
         Raises:
-            ValueError: If no mutations found for the stage.
             RuntimeError: If a mutation lacks ``before_state`` needed for
                 reversal.
         """
@@ -507,7 +507,7 @@ class SqliteGraphStore:
         ).fetchone()
 
         if row is None or row["min_id"] is None:
-            raise ValueError(f"No mutations found for stage={stage!r}")
+            return 0
 
         return self._rewind_from_id(row["min_id"])
 

--- a/src/questfoundry/graph/sqlite_store.py
+++ b/src/questfoundry/graph/sqlite_store.py
@@ -293,7 +293,7 @@ class SqliteGraphStore:
                 self._phase,
             ),
         )
-        op = "update_node" if existing else "create_node"
+        op = "replace_node" if existing else "create_node"
         self._record_mutation(op, node_id, delta=data, before_state=before)
 
     def update_node_fields(self, node_id: str, **updates: Any) -> None:
@@ -452,6 +452,201 @@ class SqliteGraphStore:
             extra = json.loads(row["data"])
             edge.update(extra)
         return edge
+
+    # -- Rewind ----------------------------------------------------------------
+
+    def rewind_to_phase(self, stage: str, phase: str) -> int:
+        """Rewind graph by reversing all mutations from a phase onward.
+
+        Finds the first mutation matching *(stage, phase)* and applies the
+        inverse of every mutation from that point forward, in reverse order.
+        The reversed mutation records are deleted.
+
+        Args:
+            stage: Pipeline stage (e.g., ``"grow"``).
+            phase: Phase within the stage (e.g., ``"path_agnostic"``).
+
+        Returns:
+            Number of mutations reversed.
+
+        Raises:
+            ValueError: If no mutations found for *(stage, phase)*.
+            RuntimeError: If a mutation lacks ``before_state`` needed for
+                reversal (e.g., pre-migration data).
+        """
+        row = self._conn.execute(
+            "SELECT MIN(id) AS min_id FROM mutations WHERE stage = ? AND phase = ?",
+            (stage, phase),
+        ).fetchone()
+
+        if row is None or row["min_id"] is None:
+            raise ValueError(f"No mutations found for stage={stage!r}, phase={phase!r}")
+
+        return self._rewind_from_id(row["min_id"])
+
+    def rewind_stage(self, stage: str) -> int:
+        """Rewind all mutations for an entire stage.
+
+        Finds the first mutation for *stage* (any phase) and reverses
+        everything from that point forward.
+
+        Args:
+            stage: Pipeline stage to rewind (e.g., ``"grow"``).
+
+        Returns:
+            Number of mutations reversed.
+
+        Raises:
+            ValueError: If no mutations found for the stage.
+            RuntimeError: If a mutation lacks ``before_state`` needed for
+                reversal.
+        """
+        row = self._conn.execute(
+            "SELECT MIN(id) AS min_id FROM mutations WHERE stage = ?",
+            (stage,),
+        ).fetchone()
+
+        if row is None or row["min_id"] is None:
+            raise ValueError(f"No mutations found for stage={stage!r}")
+
+        return self._rewind_from_id(row["min_id"])
+
+    def _rewind_from_id(self, first_id: int) -> int:
+        """Reverse all mutations with ``id >= first_id``.
+
+        Processes mutations in reverse chronological order, applying the
+        inverse of each. The entire rewind is wrapped in a SAVEPOINT for
+        atomicity — on any failure, all changes are rolled back.
+
+        Args:
+            first_id: Mutation ID to start rewinding from (inclusive).
+
+        Returns:
+            Number of mutations reversed.
+        """
+        mutations = self._conn.execute(
+            "SELECT id, operation, target_id, delta, before_state "
+            "FROM mutations WHERE id >= ? ORDER BY id DESC",
+            (first_id,),
+        ).fetchall()
+
+        if not mutations:
+            return 0
+
+        self._conn.execute("SAVEPOINT sp_rewind")
+        try:
+            for mutation in mutations:
+                self._apply_inverse(mutation)
+
+            self._conn.execute("DELETE FROM mutations WHERE id >= ?", (first_id,))
+            self._conn.execute("RELEASE SAVEPOINT sp_rewind")
+        except Exception:
+            self._conn.execute("ROLLBACK TO sp_rewind")
+            self._conn.execute("RELEASE SAVEPOINT sp_rewind")
+            raise
+
+        return len(mutations)
+
+    def _apply_inverse(self, mutation: sqlite3.Row) -> None:
+        """Apply the inverse of a single mutation.
+
+        Args:
+            mutation: Row from the ``mutations`` table with columns:
+                ``operation``, ``target_id``, ``delta``, ``before_state``.
+
+        Raises:
+            RuntimeError: If ``before_state`` is required but missing, or
+                if the operation is unknown.
+        """
+        operation = mutation["operation"]
+        target_id = mutation["target_id"]
+        delta = json.loads(mutation["delta"]) if mutation["delta"] else None
+        before = json.loads(mutation["before_state"]) if mutation["before_state"] else None
+
+        if operation == "create_node":
+            self._conn.execute("DELETE FROM nodes WHERE node_id = ?", (target_id,))
+
+        elif operation == "replace_node":
+            if before is None:
+                raise RuntimeError(
+                    f"Cannot reverse replace_node for {target_id!r}: "
+                    f"before_state is missing (pre-migration mutation?)"
+                )
+            self._conn.execute(
+                "INSERT OR REPLACE INTO nodes (node_id, type, data) VALUES (?, ?, ?)",
+                (target_id, before.get("type", ""), json.dumps(before)),
+            )
+
+        elif operation == "update_node":
+            if before is None:
+                raise RuntimeError(
+                    f"Cannot reverse update_node for {target_id!r}: "
+                    f"before_state is missing (pre-migration mutation?)"
+                )
+            row = self._conn.execute(
+                "SELECT data FROM nodes WHERE node_id = ?", (target_id,)
+            ).fetchone()
+            if row is None:
+                raise RuntimeError(
+                    f"Cannot reverse update_node: node {target_id!r} not found in database"
+                )
+            current = json.loads(row["data"])
+            for k, v in before.items():
+                if v is None:
+                    current.pop(k, None)
+                else:
+                    current[k] = v
+            self._conn.execute(
+                "UPDATE nodes SET data = ?, type = ? WHERE node_id = ?",
+                (json.dumps(current), current.get("type", ""), target_id),
+            )
+
+        elif operation == "delete_node":
+            if before is None:
+                raise RuntimeError(
+                    f"Cannot reverse delete_node for {target_id!r}: "
+                    f"before_state is missing (pre-migration mutation?)"
+                )
+            self._conn.execute(
+                "INSERT INTO nodes (node_id, type, data) VALUES (?, ?, ?)",
+                (target_id, before.get("type", ""), json.dumps(before)),
+            )
+
+        elif operation == "add_edge":
+            if delta is None:
+                raise RuntimeError(f"Cannot reverse add_edge for {target_id!r}: delta is missing")
+            edge_type = delta.get("type", "")
+            from_id = delta.get("from", "")
+            to_id = delta.get("to", "")
+            row = self._conn.execute(
+                "SELECT rowid FROM edges WHERE edge_type = ? AND from_id = ? AND to_id = ? LIMIT 1",
+                (edge_type, from_id, to_id),
+            ).fetchone()
+            if row is not None:
+                self._conn.execute("DELETE FROM edges WHERE rowid = ?", (row["rowid"],))
+
+        elif operation == "remove_edge":
+            if before is None:
+                raise RuntimeError(
+                    f"Cannot reverse remove_edge for {target_id!r}: "
+                    f"before_state is missing (pre-migration mutation?)"
+                )
+            edge_type = before.get("type", "")
+            from_id = before.get("from", "")
+            to_id = before.get("to", "")
+            extra = {k: v for k, v in before.items() if k not in ("type", "from", "to")}
+            self._conn.execute(
+                "INSERT INTO edges (edge_type, from_id, to_id, data) VALUES (?, ?, ?, ?)",
+                (
+                    edge_type,
+                    from_id,
+                    to_id,
+                    json.dumps(extra) if extra else None,
+                ),
+            )
+
+        else:
+            raise RuntimeError(f"Unknown mutation operation: {operation!r}")
 
     # -- Meta ------------------------------------------------------------------
 

--- a/src/questfoundry/graph/store.py
+++ b/src/questfoundry/graph/store.py
@@ -130,6 +130,28 @@ class GraphStore(Protocol):
         """Release (discard) a named savepoint."""
         ...
 
+    # -- Rewind ----------------------------------------------------------------
+
+    def rewind_to_phase(self, stage: str, phase: str) -> int:
+        """Reverse all mutations from (stage, phase) onward.
+
+        Only supported by stores with mutation recording.
+
+        Returns:
+            Number of mutations reversed.
+        """
+        ...
+
+    def rewind_stage(self, stage: str) -> int:
+        """Reverse all mutations for an entire stage.
+
+        Only supported by stores with mutation recording.
+
+        Returns:
+            Number of mutations reversed.
+        """
+        ...
+
     # -- Serialization ---------------------------------------------------------
 
     def to_dict(self) -> dict[str, Any]:
@@ -272,6 +294,16 @@ class DictGraphStore:
     def release(self, name: str) -> None:
         """Discard a named snapshot."""
         self._savepoints.pop(name, None)
+
+    # -- Rewind (not supported) ------------------------------------------------
+
+    def rewind_to_phase(self, stage: str, phase: str) -> int:
+        """Not supported — DictGraphStore does not record mutations."""
+        raise NotImplementedError("Rewind requires SQLite-backed storage with mutation recording")
+
+    def rewind_stage(self, stage: str) -> int:
+        """Not supported — DictGraphStore does not record mutations."""
+        raise NotImplementedError("Rewind requires SQLite-backed storage with mutation recording")
 
     # -- Serialization ---------------------------------------------------------
 

--- a/src/questfoundry/pipeline/orchestrator.py
+++ b/src/questfoundry/pipeline/orchestrator.py
@@ -66,7 +66,9 @@ def _load_graph_for_mutation(project_path: Path, stage_name: str) -> Graph:
     graph = Graph.load(project_path)
     last_stage = graph.get_last_stage()
     prerequisite = _MUTATION_STAGE_PREREQUISITES.get(stage_name)
-    snapshot_path = project_path / "snapshots" / f"pre-{stage_name}.json"
+    db_snapshot = project_path / "snapshots" / f"pre-{stage_name}.db"
+    json_snapshot = project_path / "snapshots" / f"pre-{stage_name}.json"
+    snapshot_path = db_snapshot if db_snapshot.exists() else json_snapshot
 
     if last_stage == prerequisite:
         # First run: save clean pre-stage snapshot
@@ -713,7 +715,7 @@ class PipelineOrchestrator:
                         raise GraphCorruptionError(violations, stage=stage_name)
 
                     graph.set_last_stage(stage_name)
-                    graph.save(self.project_path / "graph.json")
+                    graph.save(self.project_path / "graph.db")
                     log.debug("graph_updated", stage=stage_name)
                 except SeedMutationError:
                     # SeedMutationError at this point indicates a bug - validation

--- a/src/questfoundry/pipeline/stages/ship.py
+++ b/src/questfoundry/pipeline/stages/ship.py
@@ -70,12 +70,6 @@ class ShipStage:
         )
 
         # Load graph
-        graph_file = self._project_path / "graph.json"
-        if not graph_file.exists():
-            raise ShipStageError(
-                f"No graph.json found in {self._project_path}. "
-                "Run pipeline stages (dream → fill) first."
-            )
         graph = Graph.load(self._project_path)
 
         # Validate passages have prose

--- a/tests/unit/test_orchestrator.py
+++ b/tests/unit/test_orchestrator.py
@@ -1105,7 +1105,7 @@ def _simulate_mutation_block(
     graph = _load_graph_for_mutation(project_path, stage_name)
     apply_mutations(graph, stage_name, artifact_data)
     graph.set_last_stage(stage_name)
-    graph.save(project_path / "graph.json")
+    graph.save(project_path / "graph.db")
     return graph
 
 
@@ -1122,7 +1122,7 @@ class TestMutationRerunDetection:
 
         _simulate_mutation_block(tmp_path, "brainstorm", _BRAINSTORM_ARTIFACT)
 
-        snapshot_path = tmp_path / "snapshots" / "pre-brainstorm.json"
+        snapshot_path = tmp_path / "snapshots" / "pre-brainstorm.db"
         assert snapshot_path.exists()
 
         # Snapshot should contain dream-only state (no brainstorm nodes)
@@ -1227,9 +1227,9 @@ class TestMutationRerunDetection:
         graph.set_last_stage("brainstorm")
         graph.save(tmp_path / "graph.json")
 
-        # No pre-brainstorm.json exists — simulate snapshot deletion
-        snapshot_path = tmp_path / "snapshots" / "pre-brainstorm.json"
-        assert not snapshot_path.exists()
+        # No pre-brainstorm snapshot exists (neither .db nor .json)
+        assert not (tmp_path / "snapshots" / "pre-brainstorm.db").exists()
+        assert not (tmp_path / "snapshots" / "pre-brainstorm.json").exists()
 
         # Re-run without snapshot should raise, not silently corrupt
         with pytest.raises(ValueError, match="requires the pre-stage snapshot"):
@@ -1247,6 +1247,6 @@ class TestMutationRerunDetection:
         assert result.get_node("vision") is not None
         assert result.get_last_stage() == "dream"
 
-        # Snapshot saved
-        snapshot_path = tmp_path / "snapshots" / "pre-dream.json"
+        # Snapshot saved (SQLite format after auto-migration)
+        snapshot_path = tmp_path / "snapshots" / "pre-dream.db"
         assert snapshot_path.exists()

--- a/tests/unit/test_ship_stage.py
+++ b/tests/unit/test_ship_stage.py
@@ -186,7 +186,7 @@ class TestShipStage:
         project.mkdir(parents=True)
 
         stage = ShipStage(project)
-        with pytest.raises(ShipStageError, match=r"No graph\.json found"):
+        with pytest.raises(ShipStageError, match="no passages"):
             stage.execute()
 
     def test_missing_prose_raises(self, tmp_path: Path) -> None:

--- a/tests/unit/test_sqlite_store.py
+++ b/tests/unit/test_sqlite_store.py
@@ -312,15 +312,15 @@ class TestSqliteStoreMutations:
         ).fetchall()
         assert len(rows) == 1
 
-    def test_overwrite_node_records_update_mutation(self) -> None:
-        """Second set_node on same ID records update_node."""
+    def test_overwrite_node_records_replace_mutation(self) -> None:
+        """Second set_node on same ID records replace_node."""
         store = SqliteGraphStore()
         store.set_node("entity::alice", {"type": "entity", "name": "Alice"})
         store.set_node("entity::alice", {"type": "entity", "name": "Bob"})
 
         rows = store._conn.execute("SELECT operation FROM mutations").fetchall()
         ops = [row["operation"] for row in rows]
-        assert ops == ["create_node", "update_node"]
+        assert ops == ["create_node", "replace_node"]
 
     def test_mutation_context_default_empty(self) -> None:
         """Without set_mutation_context, stage/phase are empty strings."""


### PR DESCRIPTION
## Problem

Per-phase checkpoint files (44+ full graph serializations per run) are completely
redundant when using SqliteGraphStore with autocommit + WAL. Every mutation is
immediately persisted to the live `.db` file, so per-phase JSON snapshots waste
disk I/O and add complexity.

Part of the SQLite-only persistence stack (#852). Depends on PR #883 (before_state)
and PR #884 (rewind API).

## Changes

- **Auto-migration**: `Graph.load()` auto-migrates `graph.json` → `graph.db` when
  only the JSON file exists (via `migrate_json_to_sqlite`)
- **Tolerant rewind**: `rewind_to_phase()` and `rewind_stage()` return 0 instead of
  raising ValueError when no mutations are found — safe for freshly-migrated databases
- **WAL cleanup**: `_save_db()` removes stale WAL/SHM files after replacing a live
  SQLite database (prevents corruption after rollback)
- **Orchestrator**: saves to `graph.db`, snapshot detection checks `.db` then `.json`
- **Stage checkpoint removal**: removed `CHECKPOINT_DIR`, `_save_checkpoint`,
  `_load_checkpoint`, `_get_checkpoint_path` from grow, fill, and dress stages
- **Rewind-based resume**: stages use `graph.rewind_to_phase()` for resume and
  `graph.rewind_stage()` for re-runs, with dict-backed JSON fallback
- **Ship stage**: removed explicit `graph.json` existence check (Graph.load() +
  "no passages" validation handles it)
- **All graph.save() calls** switched from `.json` to `.db`

## Not Included / Future PRs

- Removing JSON fallback paths entirely (PR 4: #852)
- Cleaning up all 70+ test fixture references to `graph.json` (PR 4)
- Renaming `.json` to `.bak` for migration safety

## Test Plan

```bash
uv run ruff check src/questfoundry/       # ✅ All checks passed
uv run mypy src/questfoundry/              # ✅ No issues found
uv run pytest tests/unit/ -q               # ✅ 3025 passed (2 pre-existing flaky failures)
```

- Deleted checkpoint test classes (TestGrowCheckpoints, TestCheckpointing, TestCheckpoints)
- Updated save path assertions from `.json` to `.db`
- Replaced snapshot-requirement tests with rewind-based tests
- Updated auto-migration and rewind no-op tests

## Risk / Rollback

- **Net -207 lines** (157 added, 364 removed) — well within 400-line target
- Auto-migration preserves backward compatibility with existing `graph.json` projects
- Dict-backed fallback ensures non-SQLite graphs still work via pre-stage JSON snapshots
- No breaking changes to public API — internal persistence format change only

## Review Guide

Suggested review order:
1. `graph.py` + `sqlite_store.py` — auto-migration and tolerant rewind (core changes)
2. `grow/stage.py` — reference implementation of checkpoint→rewind migration
3. `fill.py`, `dress.py` — same pattern as grow
4. `ship.py`, `orchestrator.py` — minimal changes
5. Test files — verify deleted/updated tests match source changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)