### PR TITLE
fix(seed): scope serialize manifest per section

### DIFF
--- a/src/questfoundry/graph/context.py
+++ b/src/questfoundry/graph/context.py
@@ -585,7 +585,7 @@ def _format_seed_valid_ids(graph: Graph, section: str | None = None) -> str:
             "Missing items WILL cause validation failure.",
             "",
         ]
-    else:  # dilemmas
+    elif section == "dilemmas":
         lines = [
             "## VALID DILEMMA IDS - GENERATE FOR ALL",
             "",


### PR DESCRIPTION
## Problem

The SEED serialize manifest (`_format_seed_valid_ids`) generates a single combined
context with **all** entity IDs, **all** dilemma IDs, and "GENERATE FOR ALL"
instructions. This manifest is injected verbatim into every serialization section.

When gpt-5-mini serializes the entities section, it sees "Generate EXACTLY 4 dilemma
decisions" and stuffs a spurious 18th entry with `dilemma::` prefix into the entities
array, causing `SeedMutationError` and wasting ~476K tokens + 15 minutes of retries.

## Changes

- Add `section: str | None = None` parameter to `format_valid_ids_context()` and
  `_format_seed_valid_ids()` in `context.py`
- When `section="entities"`: emit only entity IDs + entity count requirements
- When `section="dilemmas"`: emit only dilemma IDs + dilemma count requirements
- When `section=None` (default): full manifest (backward compat for monolithic mode)
- Other sections (consequences, paths, beats) return `""` — their IDs come from other
  mechanisms
- Update `serialize.py` `_build_section_brief()` to compute section-scoped context
  per call instead of sharing one combined manifest
- Update `entity_context` initialization to use `section="entities"`
- Update consequences special case and retry loop

## Not Included / Future PRs

- #897: SEED stage reports completion despite unresolved serialization errors
- #899: Incremental graph mutations per serialization section

## Test Plan

- 5 new tests in `TestSectionScopedManifest`: entities excludes dilemmas, dilemmas
  excludes entities, unknown section returns empty, None returns full manifest,
  default matches None
- All 105 context tests pass, all 75 serialize tests pass
- `uv run mypy src/questfoundry/ && uv run ruff check src/` clean

## Risk / Rollback

Low — prompt-only change. Existing monolithic path (`serialize_seed_iteratively`) uses
`section=None` (full manifest) unchanged. The new scoping only affects chunked mode
in `serialize_seed_as_function`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)