### PR TITLE
fix(seed): fail fast when outer retry exhausts with errors

### DIFF
--- a/src/questfoundry/pipeline/stages/seed.py
+++ b/src/questfoundry/pipeline/stages/seed.py
@@ -441,6 +441,14 @@ class SeedStage:
             # This shouldn't happen with current logic, but handle defensively
             raise SeedStageError("SEED serialization failed: artifact is None after all retries")
 
+        # Fail fast if outer retry exhausted with unresolved semantic errors
+        if result.semantic_errors:
+            error_summary = "; ".join(str(e) for e in result.semantic_errors[:3])
+            raise SeedStageError(
+                f"SEED serialization failed: outer retry exhausted with "
+                f"{len(result.semantic_errors)} unresolved errors: {error_summary}"
+            )
+
         # Phase 4: Convergence analysis (Section 7) — runs BEFORE pruning
         # so that policy-aware pruning can keep hard dilemmas and demote
         # soft/flavor first.  Only hard dilemmas multiply endings.

--- a/src/questfoundry/pipeline/stages/seed.py
+++ b/src/questfoundry/pipeline/stages/seed.py
@@ -443,7 +443,9 @@ class SeedStage:
 
         # Fail fast if outer retry exhausted with unresolved semantic errors
         if result.semantic_errors:
-            error_summary = "; ".join(str(e) for e in result.semantic_errors[:3])
+            error_summary = "; ".join(
+                f"{e.field_path}: {e.issue}" for e in result.semantic_errors[:3]
+            )
             raise SeedStageError(
                 f"SEED serialization failed: outer retry exhausted with "
                 f"{len(result.semantic_errors)} unresolved errors: {error_summary}"


### PR DESCRIPTION
## Problem

The SEED stage reports `seed_stage_completed` even when serialization has unresolved errors (outer retry exhausted). Convergence analysis, interaction constraints, and artifact export all run on the invalid artifact, wasting ~476K tokens and 15 minutes before the orchestrator catches the `SeedMutationError`.

Closes #897

## Changes

- Add `result.semantic_errors` check after the outer retry loop in `seed.py`, before convergence analysis
- Raise `SeedStageError` immediately with a summary of unresolved errors
- Update `test_outer_loop_respects_max_retries` to expect the error
- Add `test_outer_loop_exhaustion_skips_convergence_analysis` to verify downstream phases are not called

## Not Included / Future PRs

- Stripping invalid entries and continuing with valid subset (#897 mentions this as option 2)

## Test Plan

```bash
uv run pytest tests/unit/test_seed_stage.py -x -q  # 27 passed
uv run mypy src/questfoundry/ && uv run ruff check src/  # clean
```

## Risk / Rollback

- Low risk: fail-fast is strictly safer than silent continuation
- Existing successful paths (no errors) are unaffected
- Rollback: revert the single `if result.semantic_errors` check

🤖 Generated with [Claude Code](https://claude.com/claude-code)