### PR TITLE
fix(grow): policy-aware arc limit counts only hard dilemmas

### DIFF
--- a/src/questfoundry/graph/grow_algorithms.py
+++ b/src/questfoundry/graph/grow_algorithms.py
@@ -1232,15 +1232,13 @@ def enumerate_arcs(graph: Graph, *, max_arc_count: int | None = None) -> list[Ar
     # still enumerated (downstream phases need soft-variant arcs for convergence
     # metadata and residue), but the limit check counts hard dilemmas only.
     limit = max_arc_count if max_arc_count is not None else _MAX_ARC_COUNT
-    hard_dilemma_count = 0
-    for did in sorted_dilemmas:
-        dnode = dilemma_nodes.get(did, {})
-        if (
-            dnode.get("convergence_policy", "soft") == "hard"
-            and len(dilemma_paths_map.get(did, [])) >= 2
-        ):
-            hard_dilemma_count += 1
-    effective_arc_count = 2**hard_dilemma_count if hard_dilemma_count > 0 else 1
+    hard_dilemma_count = sum(
+        1
+        for did in sorted_dilemmas
+        if dilemma_nodes.get(did, {}).get("convergence_policy", "soft") == "hard"
+        and len(dilemma_paths_map.get(did, [])) >= 2
+    )
+    effective_arc_count = 2**hard_dilemma_count
 
     if effective_arc_count > limit:
         raise ValueError(


### PR DESCRIPTION
## Problem

`enumerate_arcs()` checks the total arc count (2^all_explored_dilemmas) against the 64-arc limit. Soft/flavor dilemmas converge back and don't multiply endings, but they still multiplied the arc count. With 1 hard + 7 soft dilemmas (test-new2), total arcs = 2^8 = 256, which exceeds the limit — even though only 2^1 = 2 ending-distinct arcs exist.

Fixes #904

## Changes

- **`src/questfoundry/graph/grow_algorithms.py`**: Arc count limit now only counts hard-policy dilemmas with 2+ paths. The full Cartesian product is still enumerated (downstream phases need soft-variant arcs for convergence metadata and residue), but the limit check uses effective arc count = 2^(hard dilemmas). Unclassified dilemmas default to soft.
- **`tests/unit/test_grow_algorithms.py`**: Updated `test_combinatorial_limit` to use hard dilemmas. Added `test_soft_dilemmas_do_not_count_toward_limit` (1 hard + 7 soft = 256 total arcs succeeds) and `test_unclassified_dilemmas_default_to_soft` (7 unclassified dilemmas = 128 arcs succeeds).

## Not Included / Future PRs

- N/A — this is a complete fix for the arc limit behavior

## Test Plan

```bash
uv run pytest tests/unit/test_grow_algorithms.py::TestEnumerateArcs -x -q  # 13 passed
uv run pytest tests/unit/test_grow_algorithms.py tests/unit/test_grow_validation.py -x -q  # 323 passed
uv run mypy src/questfoundry/graph/grow_algorithms.py  # clean
uv run ruff check src/questfoundry/graph/grow_algorithms.py  # clean
```

## Risk / Rollback

Low risk. The only change is in the arc count check — the Cartesian product and all downstream processing are unchanged. Worst case: more arcs are enumerated than before (up to 2^8 = 256 for 8 explored dilemmas), but all GROW phases are deterministic and handle this fine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)