### PR TITLE
fix(seed): make ending_salience/residue_weight required, rebalance convergence guidance

### DIFF
--- a/prompts/templates/serialize_seed_sections.yaml
+++ b/prompts/templates/serialize_seed_sections.yaml
@@ -867,9 +867,9 @@ dilemma_analyses_prompt: |
 
   ## Self-Check
   Count your classifications and verify ALL of these:
-  1. HARD count is 1-3. If 0 are hard: re-read each dilemma and find the one
-     with the MOST incompatible world states — promote it to hard. If more
-     than 3 are hard: demote the weakest to soft.
+  1. HARD count is 1-3. If 0 are hard: you skipped Pass 1 — go back and
+     classify the strongest dilemma as hard. If more than 3 are hard:
+     demote the weakest to soft.
   2. SOFT count is the majority.
   3. FLAVOR count is 0-2.
   4. At most 2 have `ending_salience: "high"`.

--- a/prompts/templates/serialize_seed_sections.yaml
+++ b/prompts/templates/serialize_seed_sections.yaml
@@ -655,22 +655,26 @@ dilemma_analyses_prompt: |
 
   ## Expected Distribution
 
-  Most dilemmas should be `soft` (different middles, same ending). At most
-  1-2 per story should be `hard` (0 is fine if no dilemma truly requires
-  separate endings). Use `flavor` for cosmetic-only differences.
+  Most dilemmas should be `soft` (different middles, same ending). Target
+  1-3 `hard` dilemmas per story — every story benefits from at least one
+  structural branch point. Use `flavor` for cosmetic-only differences.
   Each `hard` dilemma DOUBLES the ending count: 2 hard = 4 endings,
-  3 hard = 8 endings, 4 hard = 16 endings (unmanageable).
+  3 hard = 8 endings (unmanageable beyond 3).
 
   ## Decision Process
 
-  For each dilemma, ask: "Could the SAME scene plausibly follow BOTH answers?"
-  1. Start with `soft` — this is the most common and correct policy
-  2. Downgrade to `flavor` if differences are purely cosmetic (tone/style only)
-  3. Escalate to `hard` ONLY if convergence is truly IMPOSSIBLE — the world
-     states are incompatible and no shared scene could follow both answers
+  Classify dilemmas in TWO passes:
 
-  After classifying all dilemmas, count your `hard` classifications.
-  If more than 2 are hard, re-evaluate. (See Self-Check section below.)
+  ### Pass 1: Find the hardest dilemma
+  Read ALL dilemmas. Pick the ONE whose answers create the MOST incompatible
+  world states (someone lives vs dies, identity irrevocably changed, key
+  entity permanently destroyed). Classify it as `hard`.
+
+  ### Pass 2: Classify the rest
+  For each remaining dilemma, ask: "Could the SAME scene plausibly follow BOTH answers?"
+  - YES, with meaningful differences -> `soft` (most common)
+  - YES, nearly identical -> `flavor` (cosmetic only)
+  - NO, world states are incompatible -> `hard` (max 3 total including Pass 1)
 
   ## Convergence Policies
 
@@ -687,7 +691,7 @@ dilemma_analyses_prompt: |
   Examples: polite vs blunt greeting, left door vs right door (same room),
   diplomatic vs forceful persuasion with identical outcome.
 
-  **hard** (rare, max 1-2 per story) -- Different endings. Paths create
+  **hard** (1-3 per story) -- Different endings. Paths create
   incompatible world states that NEVER converge. Use `hard` ONLY when ALL
   of these conditions are met:
   - The answers produce a mutually exclusive world state caused by at
@@ -789,6 +793,14 @@ dilemma_analyses_prompt: |
   For dilemmas with `ending_salience: "low"` or `"none"`: set
   ending_tone to null (endings do not depend on this choice).
 
+  ## Story Tone Signal
+
+  If the story's genre/tone includes words like "dark", "gritty", "cascading
+  disaster", "hard choices", "consequences", "horror", "thriller" — lean toward
+  MORE hard dilemmas (2-3). If the tone includes "light", "cozy", "whimsical",
+  "comedy", "adventure" — lean toward FEWER hard dilemmas (1). The story tone
+  is provided in the Context section below.
+
   ## Context
 
   {dilemma_context}
@@ -838,10 +850,10 @@ dilemma_analyses_prompt: |
   ## Rules
   - Classify EVERY dilemma from the ### Valid Dilemma IDs list
   - Classify based on the dilemma's QUESTION and STAKES, not path count
-  - Start with `soft` (most common); downgrade to `flavor` for cosmetic differences; escalate to `hard` ONLY if world states are truly incompatible
+  - Follow the two-pass procedure above (find hardest first, then classify the rest)
   - Do NOT classify as `hard` just because paths have different activities or approaches
   - Do NOT classify as `hard` unless convergence is IMPOSSIBLE (not just difficult)
-  - If in doubt between `soft` and `hard`, choose `soft` — it preserves variety without multiplying endings
+  - If in doubt between `soft` and `hard`, check: does one answer involve death, destruction, or irrevocable identity change? If YES -> `hard`. If NO -> `soft`
   - `reasoning` must be 1-2 sentences explaining WHY (reference the question/stakes)
   - GOOD reasoning: "Homicide vs accident creates incompatible suspect lists and requires different endings."
   - BAD reasoning: "It is soft." / "Only one path."
@@ -854,18 +866,27 @@ dilemma_analyses_prompt: |
   - `residue_weight` is INDEPENDENT of `convergence_policy` and `ending_salience` — a `soft` dilemma with `high` ending_salience can have `cosmetic` residue_weight
 
   ## Self-Check
-  Count your classifications:
-  - If more than 2 are `hard`, re-evaluate — most stories need at most 1-2 hard dilemmas.
-  - If more than 2 have `ending_salience: "high"`, re-evaluate — most stories need at most 1-2 ending-shaping dilemmas.
-  - Check: every dilemma with `ending_tone` set also has `ending_salience: "high"`. If not, fix it.
-  - If more than 2 have `residue_weight: "heavy"`, re-evaluate — most stories need at most 1-2 dilemmas that leave persistent traces in shared scenes.
+  Count your classifications and verify ALL of these:
+  1. HARD count is 1-3. If 0 are hard: re-read each dilemma and find the one
+     with the MOST incompatible world states — promote it to hard. If more
+     than 3 are hard: demote the weakest to soft.
+  2. SOFT count is the majority.
+  3. FLAVOR count is 0-2.
+  4. At most 2 have `ending_salience: "high"`.
+  5. Every dilemma with `ending_tone` set also has `ending_salience: "high"`.
+  6. At most 2 have `residue_weight: "heavy"`.
 
   ## REMINDER
-  Classify ALL dilemmas. Most should be `soft`. Only 1-2 should be `hard`.
-  Ask: "Could the SAME scene follow both answers?"
-  YES with differences -> soft (most common). YES nearly identical -> flavor. NO (incompatible world states) -> hard (rare).
-  Most dilemmas get `ending_salience: "low"`. Only 1-2 get `"high"`. Set `ending_tone` ONLY when `ending_salience` is `"high"`.
-  Most dilemmas get `residue_weight: "light"`. Only 1-2 get `"heavy"`.
+  Classify ALL dilemmas. Follow this procedure:
+  STEP 1: Find your STRONGEST dilemma — the one where answers create the MOST
+  incompatible world states. Classify it as `hard`.
+  STEP 2: For each remaining dilemma, ask: "Could the SAME scene follow both answers?"
+    YES with differences -> soft. YES nearly identical -> flavor.
+    NO (incompatible world states) -> hard (max 3 total).
+  STEP 3: Count. You should have 1-3 hard, majority soft, 0-2 flavor.
+  If you have 0 hard, go back to STEP 1.
+  Set `ending_salience` and `residue_weight` for EVERY dilemma (required fields).
+  Set `ending_tone` ONLY when `ending_salience` is "high", null otherwise.
 
   ## Output
   Return ONLY valid JSON with the "dilemma_analyses" array. Classify ALL dilemmas.

--- a/src/questfoundry/graph/context.py
+++ b/src/questfoundry/graph/context.py
@@ -970,21 +970,40 @@ def format_dilemma_analysis_context(
 
     valid_ids = [f"`dilemma::{strip_scope_prefix(d.dilemma_id)}`" for d in seed_output.dilemmas]
 
+    # Fetch story tone from DREAM vision node
+    tone_lines: list[str] = []
+    if graph is not None:
+        vision = graph.get_node("vision")
+        if vision is not None:
+            parts: list[str] = []
+            if vision.get("genre"):
+                parts.append(f"**Genre:** {vision['genre']}")
+            tone_val = vision.get("tone")
+            if isinstance(tone_val, list) and tone_val:
+                parts.append(f"**Tone:** {', '.join(tone_val)}")
+            if parts:
+                tone_lines = ["## Story Tone", "", *parts, ""]
+
     lines = [
         "## Dilemma Convergence Brief",
         "",
-        "Classify each dilemma below. Most dilemmas are `soft` — paths diverge",
-        "then reconverge. Reserve `hard` for at most 1-2 dilemmas where the",
-        "QUESTION creates incompatible world states (e.g., someone lives vs dies).",
-        "Use `flavor` for cosmetic-only differences.",
-        "",
-        *dilemma_blocks,
-        "",
-        "### Valid Dilemma IDs",
-        "",
-        "You MUST use only these dilemma IDs: " + ", ".join(sorted(valid_ids)),
+        "Classify each dilemma below. Target 1-3 `hard` dilemmas per story.",
+        "Start by finding the strongest dilemma and classifying it `hard`.",
+        "Use `soft` for most others. Use `flavor` only for cosmetic differences.",
         "",
     ]
+    if tone_lines:
+        lines.extend(tone_lines)
+    lines.extend(
+        [
+            *dilemma_blocks,
+            "",
+            "### Valid Dilemma IDs",
+            "",
+            "You MUST use only these dilemma IDs: " + ", ".join(sorted(valid_ids)),
+            "",
+        ]
+    )
     return "\n".join(lines)
 
 

--- a/src/questfoundry/models/seed.py
+++ b/src/questfoundry/models/seed.py
@@ -262,7 +262,6 @@ class DilemmaAnalysis(BaseModel):
         description="How strictly paths must stay separate (hard|soft|flavor)",
     )
     ending_salience: EndingSalience = Field(
-        default="low",
         description=(
             "How much this dilemma drives ending differentiation. "
             "'high' = endings MUST differ; 'low' = endings MAY acknowledge; "
@@ -270,7 +269,6 @@ class DilemmaAnalysis(BaseModel):
         ),
     )
     residue_weight: ResidueWeight = Field(
-        default="light",
         description=(
             "How much mid-story prose varies based on this dilemma's outcome. "
             "'heavy' = shared passages MUST show state-specific differences; "
@@ -281,7 +279,6 @@ class DilemmaAnalysis(BaseModel):
     payoff_budget: int = Field(
         ge=2,
         le=6,
-        default=2,
         description="Minimum exclusive beats before convergence",
     )
     reasoning: str = Field(


### PR DESCRIPTION
## Problem

Epic #911 added `ending_salience` and `residue_weight` to `DilemmaAnalysis`, but both had Pydantic defaults making them optional in the JSON schema. Small models (qwen3:4b) skip optional fields entirely, so every dilemma silently defaults to `ending_salience: low` and `residue_weight: light`. Additionally, the serialize prompt biased heavily toward `soft` convergence with no floor for `hard` — a story prompted with "hard dilemmas" produced 0 hard classifications.

## Changes

- **Schema fix**: Remove `default=` from `ending_salience`, `residue_weight`, and `payoff_budget` in `DilemmaAnalysis` — all three are now required in the JSON schema
- **Prompt rewrite**: Replace "start with soft" decision process with anchor-then-evaluate two-pass procedure (find hardest dilemma first, then classify rest)
- **Two-sided guardrails**: Self-check now enforces 1-3 hard (floor + ceiling) instead of just a ceiling
- **Story tone injection**: `format_dilemma_analysis_context` now fetches the DREAM `vision` node to inject genre/tone into convergence context
- **Story Tone Signal section**: Prompt now maps dark/gritty tones to more hard dilemmas, light/cozy tones to fewer

## Not Included / Future PRs

- #933: Variant routing choices with empty gates (`requires=[]`, `is_routing=None`) — needs separate investigation of `split_and_reroute`

## Test Plan

- `uv run python -c "..."` verified `ending_salience`, `residue_weight`, `payoff_budget` all in `required` list
- `uv run mypy` and `uv run ruff check` pass on all changed files
- `uv run pytest tests/unit/test_seed_models.py tests/unit/test_mutations.py -x -q` — 270 passed
- `uv run pytest tests/unit/ -x -q` — 2428 passed, 4 xfailed (1 flaky unrelated failure)
- Updated tests: replaced 3 "defaults to X" tests with "field required" rejection tests

## Risk / Rollback

- Making fields required is a breaking change for any existing code that constructs `DilemmaAnalysis` without these fields. The mutations layer (which uses raw dicts) is unaffected — only the Pydantic validation boundary changes.
- Prompt changes affect LLM output quality — should be validated with a test-new re-run.

Closes #931
Closes #932

🤖 Generated with [Claude Code](https://claude.com/claude-code)