### PR TITLE
fix(validation): filter prose_neutrality to actually-diverging dilemmas

### DIFF
--- a/src/questfoundry/graph/grow_validation.py
+++ b/src/questfoundry/graph/grow_validation.py
@@ -1462,10 +1462,15 @@ def check_prose_neutrality(graph: Graph) -> list[ValidationCheck]:
                 continue  # Variant routing exists, prose contract met
 
             if weight == "heavy" or salience == "high":
+                # Warn rather than fail: the grow stage does not yet
+                # wire mid-story variant routing for heavy/high
+                # dilemmas (split_and_reroute handles endings only).
+                # Tracked as a future capability; blocking the pipeline
+                # on an unimplemented feature produces false failures.
                 checks.append(
                     ValidationCheck(
                         name="prose_neutrality",
-                        severity="fail",
+                        severity="warn",
                         message=(
                             f"Shared passage {pid} requires variant routing "
                             f"for dilemma '{label}' "

--- a/src/questfoundry/graph/grow_validation.py
+++ b/src/questfoundry/graph/grow_validation.py
@@ -1430,15 +1430,29 @@ def check_prose_neutrality(graph: Graph) -> list[ValidationCheck]:
         if len(covering_arcs) < 2:
             continue  # Not shared
 
-        # Find dilemmas that diverge across covering arcs
-        # (dilemma appears in some arcs but not all = paths diverged before this beat)
+        # Find dilemmas that actually diverge across covering arcs:
+        # a dilemma diverges only when covering arcs chose *different* paths
+        # for it (i.e., 2+ distinct path IDs for that dilemma).
         all_dilemma_ids: set[str] = set()
         for arc_id in covering_arcs:
             all_dilemma_ids.update(arc_dilemmas.get(arc_id, set()))
 
+        diverging_dilemmas: set[str] = set()
+        for dilemma_id in all_dilemma_ids:
+            paths_for_dilemma: set[str] = set()
+            for arc_id in covering_arcs:
+                for path_raw in arc_nodes.get(arc_id, {}).get("paths", []):
+                    p_id = normalize_scoped_id(path_raw, "path")
+                    p_data = path_nodes.get(p_id, {})
+                    raw_did = p_data.get("dilemma_id", "")
+                    if raw_did and normalize_scoped_id(raw_did, "dilemma") == dilemma_id:
+                        paths_for_dilemma.add(p_id)
+            if len(paths_for_dilemma) > 1:
+                diverging_dilemmas.add(dilemma_id)
+
         has_routing = pid in routed_passages
 
-        for dilemma_id in sorted(all_dilemma_ids):
+        for dilemma_id in sorted(diverging_dilemmas):
             ddata = dilemma_nodes.get(dilemma_id, {})
             weight = ddata.get("residue_weight", "light")
             salience = ddata.get("ending_salience", "low")

--- a/tests/unit/test_grow_validation.py
+++ b/tests/unit/test_grow_validation.py
@@ -2224,20 +2224,20 @@ class TestCheckProseNeutrality:
         assert len(result) == 1
         assert result[0].severity == "pass"
 
-    def test_heavy_without_routing_fails(self) -> None:
+    def test_heavy_without_routing_warns(self) -> None:
         graph = _make_shared_passage_graph(residue_weight="heavy")
         result = check_prose_neutrality(graph)
-        fails = [c for c in result if c.severity == "fail"]
-        assert len(fails) >= 1
-        assert "passage::shared" in fails[0].message
-        assert "residue_weight=heavy" in fails[0].message
+        warns = [c for c in result if c.severity == "warn"]
+        assert len(warns) >= 1
+        assert "passage::shared" in warns[0].message
+        assert "residue_weight=heavy" in warns[0].message
 
-    def test_high_salience_without_routing_fails(self) -> None:
+    def test_high_salience_without_routing_warns(self) -> None:
         graph = _make_shared_passage_graph(ending_salience="high")
         result = check_prose_neutrality(graph)
-        fails = [c for c in result if c.severity == "fail"]
-        assert len(fails) >= 1
-        assert "ending_salience=high" in fails[0].message
+        warns = [c for c in result if c.severity == "warn"]
+        assert len(warns) >= 1
+        assert "ending_salience=high" in warns[0].message
 
     def test_light_without_routing_warns(self) -> None:
         graph = _make_shared_passage_graph(residue_weight="light", ending_salience="low")
@@ -2410,9 +2410,9 @@ class TestCheckProseNeutrality:
         )
 
         result = check_prose_neutrality(graph)
-        fails = [c for c in result if c.severity == "fail"]
-        # Only d1 diverges → exactly 1 failure
-        assert len(fails) == 1
-        assert "d1" in fails[0].message
-        # d2 should NOT produce a failure (arcs agree on q1)
-        assert all("d2" not in c.message for c in result if c.severity == "fail")
+        warns = [c for c in result if c.severity == "warn"]
+        # Only d1 diverges → exactly 1 warning (heavy/high is warn-level)
+        d1_warns = [c for c in warns if "d1" in c.message]
+        assert len(d1_warns) == 1
+        # d2 should NOT produce a warning (arcs agree on q1)
+        assert all("d2" not in c.message for c in warns)

--- a/tests/unit/test_grow_validation.py
+++ b/tests/unit/test_grow_validation.py
@@ -2328,7 +2328,15 @@ class TestCheckProseNeutrality:
 
         graph.create_node(
             "path::p_orphan",
-            {"type": "path", "raw_id": "p_orphan"},
+            {"type": "path", "raw_id": "p_orphan", "dilemma_id": ""},
+        )
+        graph.create_node(
+            "dilemma::d1",
+            {"type": "dilemma", "raw_id": "d1", "question": "q"},
+        )
+        graph.create_node(
+            "path::p_valid",
+            {"type": "path", "raw_id": "p_valid", "dilemma_id": "d1"},
         )
         graph.create_node(
             "beat::shared",
@@ -2350,7 +2358,7 @@ class TestCheckProseNeutrality:
                 "type": "arc",
                 "raw_id": "a1",
                 "arc_type": "spine",
-                "paths": ["path::p_orphan"],
+                "paths": ["p_orphan", "p_valid"],
                 "sequence": ["beat::shared"],
             },
         )
@@ -2360,9 +2368,23 @@ class TestCheckProseNeutrality:
                 "type": "arc",
                 "raw_id": "a2",
                 "arc_type": "branch",
-                "paths": ["path::p_orphan"],
+                "paths": ["p_orphan", "p_valid"],
                 "sequence": ["beat::shared"],
             },
+        )
+
+        result = check_prose_neutrality(graph)
+        assert all(c.severity == "pass" for c in result)
+
+    def test_routing_choice_branches_covered(self) -> None:
+        graph = Graph.empty()
+        graph.create_node(
+            "choice::c2",
+            {"type": "choice", "is_routing": True, "raw_id": "c2"},
+        )
+        graph.create_node(
+            "choice::c3",
+            {"type": "choice", "is_routing": False, "raw_id": "c3"},
         )
 
         result = check_prose_neutrality(graph)

--- a/tests/unit/test_grow_validation.py
+++ b/tests/unit/test_grow_validation.py
@@ -2322,6 +2322,52 @@ class TestCheckProseNeutrality:
         # No divergence on d1, so no failure should be raised
         assert all(c.severity == "pass" for c in result)
 
+    def test_missing_dilemma_id_ignored(self) -> None:
+        """Paths without dilemma_id should be ignored in divergence checks."""
+        graph = Graph.empty()
+
+        graph.create_node(
+            "path::p_orphan",
+            {"type": "path", "raw_id": "p_orphan"},
+        )
+        graph.create_node(
+            "beat::shared",
+            {"type": "beat", "raw_id": "shared", "summary": "shared"},
+        )
+        graph.create_node(
+            "passage::shared",
+            {
+                "type": "passage",
+                "raw_id": "shared",
+                "from_beat": "beat::shared",
+                "summary": "shared",
+            },
+        )
+
+        graph.create_node(
+            "arc::a1",
+            {
+                "type": "arc",
+                "raw_id": "a1",
+                "arc_type": "spine",
+                "paths": ["path::p_orphan"],
+                "sequence": ["beat::shared"],
+            },
+        )
+        graph.create_node(
+            "arc::a2",
+            {
+                "type": "arc",
+                "raw_id": "a2",
+                "arc_type": "branch",
+                "paths": ["path::p_orphan"],
+                "sequence": ["beat::shared"],
+            },
+        )
+
+        result = check_prose_neutrality(graph)
+        assert all(c.severity == "pass" for c in result)
+
     def test_only_diverging_dilemma_flagged_in_multi_dilemma(self) -> None:
         """With 2 dilemmas, only the one that diverges should produce a check.
 

--- a/tests/unit/test_grow_validation.py
+++ b/tests/unit/test_grow_validation.py
@@ -2287,11 +2287,6 @@ class TestCheckProseNeutrality:
             {"type": "path", "raw_id": "p1", "dilemma_id": "dilemma::d1"},
         )
         graph.create_node(
-            "path::p2",
-            {"type": "path", "raw_id": "p2", "dilemma_id": "dilemma::d1"},
-        )
-
-        graph.create_node(
             "passage::shared",
             {
                 "type": "passage",


### PR DESCRIPTION
## Problem

`check_prose_neutrality` (added in #921) has two issues that cause the GROW stage to fail on valid projects:

1. **False positives from non-diverging dilemmas**: Flags shared passages for *all* dilemmas present in covering arcs, rather than only dilemmas where arcs **actually diverge** (chose different paths). In combinatorial arc structures this produces massive false positives — 116 spurious failures in `projects/test-new`.

2. **Severity too strict for current grow capabilities**: Even after filtering to genuinely-diverging dilemmas, the remaining `heavy/high` checks produce `fail` severity — but the grow stage can't yet wire mid-story variant routing (`split_and_reroute` only handles endings). This blocks the pipeline on valid dilemma configurations.

Fixes #938

## Changes

### Commit 1: Filter to actually-diverging dilemmas
- **`grow_validation.py`**: After collecting `all_dilemma_ids` from covering arcs, added a `diverging_dilemmas` filter that only retains dilemmas where covering arcs have 2+ distinct path choices
- **`test_grow_validation.py`**: Added `test_non_diverging_dilemma_not_flagged` and `test_only_diverging_dilemma_flagged_in_multi_dilemma` regression tests

### Commit 2: Downgrade heavy/high severity to warn
- **`grow_validation.py`**: Changed `severity="fail"` to `severity="warn"` for heavy/high without routing, with comment explaining the grow stage limitation
- **`test_grow_validation.py`**: Updated test names and assertions from `fails` → `warns`

## Not Included / Future PRs

- Mid-story variant routing for heavy/high dilemmas: tracked in #914
- Once #914 is implemented, severity should be upgraded back to `fail`

## Test Plan

```
uv run pytest tests/unit/test_grow_validation.py::TestCheckProseNeutrality -x -q
# 10 passed (8 existing + 2 new)
uv run mypy src/questfoundry/graph/grow_validation.py  # clean
uv run ruff check src/ tests/                          # clean
```

Verified against `projects/test-new/graph.db`:
- Before: 116 failures, 238 warnings → pipeline blocked
- After commit 1: 48 failures, 205 warnings (eliminated 68 false positives)
- After commit 2: **0 failures**, 253 warnings → pipeline unblocked

## Risk / Rollback

Low risk — validation-only changes. No impact on graph mutations or stage execution. The divergence filter strictly reduces false positives. The severity downgrade is a conscious trade-off documented in #914.