### PR TITLE
feat(grow): add deterministic heavy residue routing

### DIFF
--- a/src/questfoundry/graph/grow_algorithms.py
+++ b/src/questfoundry/graph/grow_algorithms.py
@@ -2135,6 +2135,262 @@ def create_residue_passages(
 
 
 # ---------------------------------------------------------------------------
+# Heavy-residue variant routing
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class HeavyDivergenceTarget:
+    """A shared passage needing mandatory variant routing for a heavy dilemma.
+
+    Produced by :func:`find_heavy_divergence_targets` for each
+    (passage, dilemma) pair where:
+
+    * The passage is shared across 2+ arcs,
+    * Those arcs chose *different* paths for the dilemma, and
+    * The dilemma has ``residue_weight == "heavy"`` or
+      ``ending_salience == "high"``.
+    """
+
+    passage_id: str
+    dilemma_id: str
+    residue_weight: str
+    ending_salience: str
+    path_codewords: dict[str, str]  # path_id → codeword_id
+
+
+def find_heavy_divergence_targets(graph: Graph) -> list[HeavyDivergenceTarget]:
+    """Identify shared mid-story passages needing heavy-residue variant routing.
+
+    Reuses the same graph traversal logic as
+    :func:`~questfoundry.graph.grow_validation.check_prose_neutrality` but
+    returns structured targets suitable for :func:`split_and_reroute`.
+
+    Only passages meeting *all* of these criteria are returned:
+
+    * Covered by 2+ arcs (shared).
+    * Arcs diverge on a dilemma (chose different paths).
+    * The dilemma has ``residue_weight == "heavy"`` **or**
+      ``ending_salience == "high"``.
+    * The passage is **not** already routed (no ``is_routing`` choices).
+    * The passage is **not** an ending.
+    """
+    arc_nodes = graph.get_nodes_by_type("arc")
+    passage_nodes = graph.get_nodes_by_type("passage")
+    dilemma_nodes = graph.get_nodes_by_type("dilemma")
+    path_nodes = graph.get_nodes_by_type("path")
+    choice_nodes = graph.get_nodes_by_type("choice")
+    codeword_nodes = graph.get_nodes_by_type("codeword")
+
+    if not arc_nodes or not passage_nodes or not dilemma_nodes:
+        return []
+
+    # Beat → covering arc IDs
+    beat_arcs: dict[str, set[str]] = {}
+    for arc_id, adata in arc_nodes.items():
+        for beat_id in adata.get("sequence", []):
+            beat_arcs.setdefault(str(beat_id), set()).add(arc_id)
+
+    # Arc → set of (dilemma_id, path_id) tuples
+    arc_dilemma_paths: dict[str, set[tuple[str, str]]] = {}
+    for arc_id, adata in arc_nodes.items():
+        for path_raw in adata.get("paths", []):
+            path_id = normalize_scoped_id(path_raw, "path")
+            pdata = path_nodes.get(path_id, {})
+            raw_did = pdata.get("dilemma_id", "")
+            if raw_did:
+                dilemma_id = normalize_scoped_id(raw_did, "dilemma")
+                arc_dilemma_paths.setdefault(arc_id, set()).add((dilemma_id, path_id))
+
+    # Path → codeword mapping (via consequence → codeword.tracks)
+    path_to_codeword: dict[str, str] = {}
+    has_consequence_edges = graph.get_edges(edge_type="has_consequence")
+    cons_to_path: dict[str, str] = {}
+    for edge in has_consequence_edges:
+        cons_to_path[edge["to"]] = edge["from"]
+    for cw_id, cw_data in codeword_nodes.items():
+        tracks = cw_data.get("tracks", "")
+        path_id_for_tracks = cons_to_path.get(tracks)
+        if path_id_for_tracks:
+            path_to_codeword[path_id_for_tracks] = cw_id
+
+    # Already-routed passages
+    routed_passages: set[str] = set()
+    for _cid, cdata in choice_nodes.items():
+        if cdata.get("is_routing"):
+            source = str(cdata.get("from_passage", ""))
+            if source:
+                routed_passages.add(source)
+
+    targets: list[HeavyDivergenceTarget] = []
+    seen: set[tuple[str, str]] = set()  # (passage_id, dilemma_id) dedup
+
+    for pid, pdata in passage_nodes.items():
+        # Skip endings — handled by split_ending_families
+        if pdata.get("is_ending"):
+            continue
+        # Skip residue variants (avoid re-routing synthetic passages)
+        if pdata.get("is_residue") or pdata.get("residue_for"):
+            continue
+        # Skip already-routed passages
+        if pid in routed_passages:
+            continue
+
+        from_beat = str(pdata.get("from_beat") or "")
+        if not from_beat:
+            continue
+
+        covering_arcs = beat_arcs.get(from_beat, set())
+        if len(covering_arcs) < 2:
+            continue
+
+        # For each dilemma, check if covering arcs diverge
+        all_dilemma_ids: set[str] = set()
+        for arc_id in covering_arcs:
+            for did, _pid in arc_dilemma_paths.get(arc_id, set()):
+                all_dilemma_ids.add(did)
+
+        for dilemma_id in sorted(all_dilemma_ids):
+            key = (pid, dilemma_id)
+            if key in seen:
+                continue
+
+            ddata = dilemma_nodes.get(dilemma_id, {})
+            weight = ddata.get("residue_weight", "light")
+            salience = ddata.get("ending_salience", "low")
+
+            # Only target heavy/high dilemmas
+            if weight != "heavy" and salience != "high":
+                continue
+
+            # Check arcs diverge on this dilemma (2+ distinct paths)
+            paths_for_dilemma: set[str] = set()
+            for arc_id in covering_arcs:
+                for did, p_id in arc_dilemma_paths.get(arc_id, set()):
+                    if did == dilemma_id:
+                        paths_for_dilemma.add(p_id)
+
+            if len(paths_for_dilemma) < 2:
+                continue  # Arcs agree — no divergence
+
+            # Build path → codeword mapping for the diverging paths
+            pcw: dict[str, str] = {}
+            for p_id in sorted(paths_for_dilemma):
+                cw = path_to_codeword.get(p_id)
+                if cw:
+                    pcw[p_id] = cw
+
+            if len(pcw) < 2:
+                continue  # Need at least 2 gatable codewords
+
+            seen.add(key)
+            targets.append(
+                HeavyDivergenceTarget(
+                    passage_id=pid,
+                    dilemma_id=dilemma_id,
+                    residue_weight=weight,
+                    ending_salience=salience,
+                    path_codewords=pcw,
+                )
+            )
+
+    return targets
+
+
+@dataclass
+class HeavyRoutingResult:
+    """Summary of heavy-residue variant routing."""
+
+    targets_found: int
+    variants_created: int
+    passages_routed: int
+    skipped_no_incoming: int
+
+
+def wire_heavy_residue_routing(graph: Graph) -> HeavyRoutingResult:
+    """Create mandatory variant passages for heavy/high dilemma divergences.
+
+    For each shared mid-story passage where a heavy-residue or
+    high-salience dilemma's arcs diverge, creates variant passages
+    and wires them via :func:`split_and_reroute` with
+    ``keep_fallback=True`` (the base passage is preserved for arcs
+    that don't diverge on this specific dilemma).
+
+    This is the deterministic counterpart to the LLM-driven
+    ``residue_beats`` phase — it ensures heavy dilemmas always get
+    variant routing, regardless of whether the LLM proposed them.
+    """
+    targets = find_heavy_divergence_targets(graph)
+    if not targets:
+        return HeavyRoutingResult(0, 0, 0, 0)
+
+    passage_nodes = graph.get_nodes_by_type("passage")
+    variants_created = 0
+    passages_routed = 0
+    skipped = 0
+    processed_passages: set[str] = set()
+
+    for target in targets:
+        if target.passage_id in processed_passages:
+            skipped += 1
+            continue
+
+        base_data = passage_nodes.get(target.passage_id, {})
+        if not base_data:
+            skipped += 1
+            continue
+
+        raw_id = strip_scope_prefix(target.passage_id)
+
+        # Create one variant passage per diverging path
+        variant_specs: list[VariantSpec] = []
+        for _path_id, cw_id in sorted(target.path_codewords.items()):
+            cw_suffix = strip_scope_prefix(cw_id).removesuffix("_committed")
+            variant_pid = f"passage::{raw_id}__heavy_{cw_suffix}"
+            # Ensure unique ID
+            counter = 1
+            while graph.get_node(variant_pid):
+                variant_pid = f"passage::{raw_id}__heavy_{cw_suffix}_{counter}"
+                counter += 1
+
+            graph.create_node(
+                variant_pid,
+                {
+                    "type": "passage",
+                    "raw_id": variant_pid.removeprefix("passage::"),
+                    "summary": base_data.get("summary", ""),
+                    "entities": list(base_data.get("entities", [])),
+                    "from_beat": base_data.get("from_beat"),
+                    "is_residue": True,
+                    "is_synthetic": True,
+                    "residue_for": target.passage_id,
+                    "residue_codeword": cw_id,
+                    "residue_dilemma": target.dilemma_id,
+                },
+            )
+            variant_specs.append(VariantSpec(variant_pid, [cw_id]))
+            variants_created += 1
+
+        if not variant_specs:
+            skipped += 1
+            continue
+
+        created = split_and_reroute(graph, target.passage_id, variant_specs, keep_fallback=True)
+        if created:
+            passages_routed += 1
+            processed_passages.add(target.passage_id)
+        else:
+            skipped += 1
+
+    return HeavyRoutingResult(
+        targets_found=len(targets),
+        variants_created=variants_created,
+        passages_routed=passages_routed,
+        skipped_no_incoming=skipped,
+    )
+
+
+# ---------------------------------------------------------------------------
 # Phase 9 helpers: passage-arc membership and choice requires
 # ---------------------------------------------------------------------------
 

--- a/src/questfoundry/pipeline/stages/grow/deterministic.py
+++ b/src/questfoundry/pipeline/stages/grow/deterministic.py
@@ -14,6 +14,7 @@ from typing import TYPE_CHECKING, Any
 
 from questfoundry.graph.context import normalize_scoped_id, strip_scope_prefix
 from questfoundry.graph.graph import Graph  # noqa: TC001 - used at runtime
+from questfoundry.graph.grow_algorithms import wire_heavy_residue_routing
 from questfoundry.models.grow import GrowPhaseResult
 from questfoundry.pipeline.stages.grow._helpers import log
 from questfoundry.pipeline.stages.grow.registry import grow_phase
@@ -684,8 +685,6 @@ async def phase_heavy_residue_routing(
     - Deterministic: no LLM calls.
     - No-op when no heavy-residue targets are found.
     """
-    from questfoundry.graph.grow_algorithms import wire_heavy_residue_routing
-
     result = wire_heavy_residue_routing(graph)
 
     if result.targets_found == 0:

--- a/tests/unit/test_grow_algorithms.py
+++ b/tests/unit/test_grow_algorithms.py
@@ -6391,6 +6391,18 @@ class TestHeavyResidueRouting:
         result = wire_heavy_residue_routing(graph)
 
         assert result.targets_found == 0
+        assert result.variants_created == 0
+
+    def test_no_incoming_edges_skips(self) -> None:
+        from questfoundry.graph.grow_algorithms import wire_heavy_residue_routing
+
+        graph = self._make_shared_passage_graph()
+        graph.delete_node("choice::to_shared", cascade=True)
+        result = wire_heavy_residue_routing(graph)
+
+        assert result.targets_found == 1
+        assert result.variants_created == 0
+        assert result.skipped_no_incoming == 1
 
 
 class TestSplitAndReroute:

--- a/tests/unit/test_grow_algorithms.py
+++ b/tests/unit/test_grow_algorithms.py
@@ -6207,6 +6207,192 @@ class TestBuildArcCodewords:
         assert result == {}
 
 
+class TestHeavyResidueRouting:
+    """Tests for deterministic heavy-residue routing."""
+
+    @staticmethod
+    def _make_shared_passage_graph(*, diverging: bool = True, routed: bool = False) -> Graph:
+        """Create a minimal shared-passage graph for heavy routing tests."""
+        graph = Graph.empty()
+
+        # Dilemma + paths
+        graph.create_node(
+            "dilemma::d1",
+            {
+                "type": "dilemma",
+                "raw_id": "d1",
+                "question": "Trust or betray?",
+                "residue_weight": "heavy",
+                "ending_salience": "low",
+            },
+        )
+        graph.create_node(
+            "path::d1__yes",
+            {"type": "path", "raw_id": "d1__yes", "dilemma_id": "d1"},
+        )
+        graph.create_node(
+            "path::d1__no",
+            {"type": "path", "raw_id": "d1__no", "dilemma_id": "d1"},
+        )
+
+        # Consequences + codewords
+        graph.create_node(
+            "consequence::yes_result",
+            {"type": "consequence", "raw_id": "yes_result", "path_id": "d1__yes"},
+        )
+        graph.create_node(
+            "consequence::no_result",
+            {"type": "consequence", "raw_id": "no_result", "path_id": "d1__no"},
+        )
+        graph.add_edge("has_consequence", "path::d1__yes", "consequence::yes_result")
+        graph.add_edge("has_consequence", "path::d1__no", "consequence::no_result")
+        graph.create_node(
+            "codeword::yes_result_committed",
+            {
+                "type": "codeword",
+                "raw_id": "yes_result_committed",
+                "tracks": "consequence::yes_result",
+            },
+        )
+        graph.create_node(
+            "codeword::no_result_committed",
+            {
+                "type": "codeword",
+                "raw_id": "no_result_committed",
+                "tracks": "consequence::no_result",
+            },
+        )
+        graph.add_edge("tracks", "codeword::yes_result_committed", "consequence::yes_result")
+        graph.add_edge("tracks", "codeword::no_result_committed", "consequence::no_result")
+
+        # Shared beat + passage
+        graph.create_node(
+            "beat::shared",
+            {"type": "beat", "raw_id": "shared", "summary": "Shared beat"},
+        )
+        graph.create_node(
+            "passage::shared",
+            {
+                "type": "passage",
+                "raw_id": "shared",
+                "from_beat": "beat::shared",
+                "summary": "Shared passage",
+            },
+        )
+        graph.create_node(
+            "passage::intro",
+            {"type": "passage", "raw_id": "intro"},
+        )
+
+        # Incoming choice
+        graph.create_node(
+            "choice::to_shared",
+            {
+                "type": "choice",
+                "from_passage": "passage::intro",
+                "to_passage": "passage::shared",
+            },
+        )
+        graph.add_edge("choice_from", "choice::to_shared", "passage::intro")
+        graph.add_edge("choice_to", "choice::to_shared", "passage::shared")
+
+        # Two arcs covering shared beat
+        yes_path = "d1__yes"
+        no_path = "d1__no"
+        if not diverging:
+            no_path = "d1__yes"
+
+        graph.create_node(
+            "arc::a1",
+            {
+                "type": "arc",
+                "raw_id": "a1",
+                "arc_type": "spine",
+                "paths": [yes_path],
+                "sequence": ["beat::shared"],
+            },
+        )
+        graph.create_node(
+            "arc::a2",
+            {
+                "type": "arc",
+                "raw_id": "a2",
+                "arc_type": "branch",
+                "paths": [no_path],
+                "sequence": ["beat::shared"],
+            },
+        )
+
+        if routed:
+            graph.create_node(
+                "passage::variant",
+                {
+                    "type": "passage",
+                    "raw_id": "variant",
+                    "from_beat": "beat::shared",
+                    "is_residue": True,
+                    "residue_for": "passage::shared",
+                },
+            )
+            graph.create_node(
+                "choice::routed",
+                {
+                    "type": "choice",
+                    "from_passage": "passage::shared",
+                    "to_passage": "passage::variant",
+                    "is_routing": True,
+                    "requires": ["codeword::yes_result_committed"],
+                },
+            )
+            graph.add_edge("choice_from", "choice::routed", "passage::shared")
+            graph.add_edge("choice_to", "choice::routed", "passage::variant")
+
+        return graph
+
+    def test_heavy_routing_creates_variants(self) -> None:
+        from questfoundry.graph.grow_algorithms import wire_heavy_residue_routing
+
+        graph = self._make_shared_passage_graph()
+        result = wire_heavy_residue_routing(graph)
+
+        assert result.targets_found == 1
+        assert result.passages_routed == 1
+        assert result.variants_created == 2
+
+        passages = graph.get_nodes_by_type("passage")
+        variants = [
+            data
+            for _pid, data in passages.items()
+            if data.get("is_residue") and data.get("residue_dilemma") == "dilemma::d1"
+        ]
+        assert len(variants) == 2
+
+        choices = graph.get_nodes_by_type("choice")
+        routing = [data for _cid, data in choices.items() if data.get("is_routing")]
+        assert len(routing) == 2
+        assert all(choice.get("requires") for choice in routing)
+
+        # Original choice remains as fallback
+        assert graph.get_node("choice::to_shared") is not None
+
+    def test_non_diverging_skips(self) -> None:
+        from questfoundry.graph.grow_algorithms import wire_heavy_residue_routing
+
+        graph = self._make_shared_passage_graph(diverging=False)
+        result = wire_heavy_residue_routing(graph)
+
+        assert result.targets_found == 0
+        assert result.variants_created == 0
+
+    def test_already_routed_skips(self) -> None:
+        from questfoundry.graph.grow_algorithms import wire_heavy_residue_routing
+
+        graph = self._make_shared_passage_graph(routed=True)
+        result = wire_heavy_residue_routing(graph)
+
+        assert result.targets_found == 0
+
+
 class TestSplitAndReroute:
     """Tests for split_and_reroute() incoming-edge rewriting primitive."""
 

--- a/tests/unit/test_grow_registry.py
+++ b/tests/unit/test_grow_registry.py
@@ -216,11 +216,11 @@ class TestGrowPhaseDecorator:
 class TestGlobalRegistry:
     """Tests for the global registry populated by actual GROW phases."""
 
-    def test_global_registry_has_23_phases(self) -> None:
-        """All 23 GROW phases are registered."""
+    def test_global_registry_has_25_phases(self) -> None:
+        """All 25 GROW phases are registered."""
         registry = get_registry()
-        assert len(registry) >= 23, (
-            f"Expected at least 23 phases, got {len(registry)}: {registry.phase_names}"
+        assert len(registry) >= 25, (
+            f"Expected at least 25 phases, got {len(registry)}: {registry.phase_names}"
         )
 
     def test_global_registry_validates(self) -> None:
@@ -254,6 +254,7 @@ class TestGlobalRegistry:
             "mark_endings",
             "split_endings",
             "collapse_passages",
+            "heavy_residue_routing",
             "validation",
             "prune",
         ]

--- a/tests/unit/test_grow_stage.py
+++ b/tests/unit/test_grow_stage.py
@@ -182,10 +182,10 @@ class TestGrowStageExecute:
 
 
 class TestGrowStagePhaseOrder:
-    def test_phase_order_returns_twenty_four_phases(self) -> None:
+    def test_phase_order_returns_twenty_five_phases(self) -> None:
         stage = GrowStage()
         phases = stage._phase_order()
-        assert len(phases) == 24
+        assert len(phases) == 25
 
     def test_phase_order_names(self) -> None:
         stage = GrowStage()
@@ -213,6 +213,7 @@ class TestGrowStagePhaseOrder:
             "mark_endings",
             "split_endings",
             "collapse_passages",
+            "heavy_residue_routing",
             "validation",
             "prune",
         ]


### PR DESCRIPTION
## Problem

`residue_weight=heavy` dilemmas require mid-story variant routing, but GROW currently relies on the LLM-driven residue phase to propose variants. That means heavy residue is **not guaranteed**, and the prose-neutrality validator had to be downgraded to warn to avoid blocking the pipeline. This leaves a gap in #914’s acceptance criteria (heavy dilemmas always create residue variants).

Refs #914

## Changes

- **`src/questfoundry/graph/grow_algorithms.py`**
  - Added `find_heavy_divergence_targets()` to locate shared passages where arcs diverge on a heavy/high dilemma.
  - Added `wire_heavy_residue_routing()` to create deterministic variant passages and gate them via `split_and_reroute()`.
  - Skips endings, already routed passages, and residue variants.
- **`src/questfoundry/pipeline/stages/grow/deterministic.py`**
  - New deterministic phase `heavy_residue_routing` (priority 23) inserted after `collapse_passages` and before `validation`.
- **`tests/unit/test_grow_algorithms.py`**
  - Added `TestHeavyResidueRouting` with coverage for heavy routing, non-diverging skips, and already-routed skips.

## Not Included / Future PRs

- Upgrade prose neutrality severity back to `fail` for heavy/high without routing (planned in stacked PR 2)
- Fix integration test mocks broken by split_and_reroute rewrite (#927) (planned in stacked PR 2)
- Consolidate negative obligations table in spec (planned in stacked PR 3)

## Test Plan

```
uv run pytest tests/unit/test_grow_algorithms.py::TestHeavyResidueRouting -x -q
uv run ruff check src/questfoundry/graph/grow_algorithms.py src/questfoundry/pipeline/stages/grow/deterministic.py tests/unit/test_grow_algorithms.py
uv run mypy src/questfoundry/graph/grow_algorithms.py src/questfoundry/pipeline/stages/grow/deterministic.py
```

## Risk / Rollback

Moderate. This adds a new deterministic routing phase that rewires incoming choice edges for heavy-residue divergences. If issues arise, rollback by reverting this commit or temporarily disabling the `heavy_residue_routing` phase registration.