### PR TITLE
refactor: rename requires→sequenced_after (beat ordering) and requires→requires_codewords (choice gate)

### DIFF
--- a/src/questfoundry/export/base.py
+++ b/src/questfoundry/export/base.py
@@ -30,7 +30,7 @@ class ExportChoice:
     from_passage: str
     to_passage: str
     label: str
-    requires: list[str] = field(default_factory=list)
+    requires_codewords: list[str] = field(default_factory=list)
     grants: list[str] = field(default_factory=list)
     is_return: bool = False
 

--- a/src/questfoundry/export/context.py
+++ b/src/questfoundry/export/context.py
@@ -83,7 +83,7 @@ def _extract_choices(graph: Graph) -> list[ExportChoice]:
             from_passage=data["from_passage"],
             to_passage=data["to_passage"],
             label=data.get("label", "continue"),
-            requires=data.get("requires", []),
+            requires_codewords=data.get("requires_codewords", []),
             grants=data.get("grants", []),
             is_return=data.get("is_return", False),
         )

--- a/src/questfoundry/export/html_exporter.py
+++ b/src/questfoundry/export/html_exporter.py
@@ -152,8 +152,10 @@ def _render_passage_div(
             label = html.escape(choice.label)
             requires_attr = ""
             grants_attr = ""
-            if choice.requires:
-                requires_attr = f' data-requires="{html.escape(json.dumps(choice.requires))}"'
+            if choice.requires_codewords:
+                requires_attr = (
+                    f' data-requires="{html.escape(json.dumps(choice.requires_codewords))}"'
+                )
             if choice.grants:
                 grants_attr = f' data-grants="{html.escape(json.dumps(choice.grants))}"'
             parts.append(

--- a/src/questfoundry/export/pdf_exporter.py
+++ b/src/questfoundry/export/pdf_exporter.py
@@ -535,10 +535,10 @@ def _render_choices(
         parts.append('<p class="choice">')
 
         # Handle conditional choices (requires codewords)
-        if choice.requires:
+        if choice.requires_codewords:
             codeword_names = ", ".join(
                 f'<span class="codeword-name">{html.escape(_format_codeword_name(cw))}</span>'
-                for cw in choice.requires
+                for cw in choice.requires_codewords
             )
             parts.append(f'<span class="choice-requires">{if_you_have} {codeword_names}: </span>')
 

--- a/src/questfoundry/export/twee_exporter.py
+++ b/src/questfoundry/export/twee_exporter.py
@@ -207,8 +207,8 @@ def _render_choice(choice: ExportChoice) -> str:
     else:
         link = f"[[{choice.label}->{target}]]"
 
-    if choice.requires:
-        conditions = " and ".join(_codeword_var(cw) for cw in choice.requires)
+    if choice.requires_codewords:
+        conditions = " and ".join(_codeword_var(cw) for cw in choice.requires_codewords)
         return f"<<if {conditions}>>{link}<</if>>"
     return link
 

--- a/src/questfoundry/graph/grow_algorithms.py
+++ b/src/questfoundry/graph/grow_algorithms.py
@@ -3180,13 +3180,13 @@ def check_intersection_compatibility(
         for edge in graph.get_edges(from_id=from_id, to_id=None, edge_type="sequenced_after"):
             to_id = edge["to"]
             if to_id in beat_set:
-                # Circular requires between intersection beats
+                # Circular sequenced_after between intersection beats
                 errors.append(
                     GrowValidationError(
                         field_path="intersection.sequenced_after",
                         issue=(
-                            f"Beat '{from_id}' requires '{to_id}' — "
-                            f"intersection beats cannot have requires "
+                            f"Beat '{from_id}' is sequenced_after '{to_id}' — "
+                            f"intersection beats cannot have sequenced_after "
                             f"dependencies on each other"
                         ),
                         category=GrowErrorCategory.STRUCTURAL,
@@ -3224,7 +3224,7 @@ def check_intersection_compatibility(
                         GrowValidationError(
                             field_path="intersection.conditional_prerequisite",
                             issue=(
-                                f"Beat '{from_id}' requires '{to_id}' which "
+                                f"Beat '{from_id}' is sequenced_after '{to_id}' which "
                                 f"is only on paths {sorted(prereq_paths)}, "
                                 f"but the intersection would span "
                                 f"{sorted(union_paths)}. "

--- a/src/questfoundry/graph/grow_validation.py
+++ b/src/questfoundry/graph/grow_validation.py
@@ -354,13 +354,13 @@ def check_gate_satisfiability(graph: Graph) -> ValidationCheck:
         grants = choice_data.get("grants", [])
         grantable.update(grants)
 
-    # Check each choice's requires
+    # Check each choice's requires_codewords
     unsatisfiable: list[str] = []
     for choice_id, choice_data in sorted(choice_nodes.items()):
         requires = choice_data.get("requires_codewords", [])
         for req in requires:
             if req not in grantable:
-                unsatisfiable.append(f"{choice_id} requires '{req}'")
+                unsatisfiable.append(f"{choice_id} requires_codewords '{req}'")
 
     if not unsatisfiable:
         return ValidationCheck(

--- a/src/questfoundry/graph/grow_validation.py
+++ b/src/questfoundry/graph/grow_validation.py
@@ -357,7 +357,7 @@ def check_gate_satisfiability(graph: Graph) -> ValidationCheck:
     # Check each choice's requires
     unsatisfiable: list[str] = []
     for choice_id, choice_data in sorted(choice_nodes.items()):
-        requires = choice_data.get("requires", [])
+        requires = choice_data.get("requires_codewords", [])
         for req in requires:
             if req not in grantable:
                 unsatisfiable.append(f"{choice_id} requires '{req}'")
@@ -424,7 +424,7 @@ def check_gate_co_satisfiability(graph: Graph) -> ValidationCheck:
     # Check each gated choice
     paradoxical: list[str] = []
     for choice_id, choice_data in sorted(choice_nodes.items()):
-        requires = set(choice_data.get("requires", []))
+        requires = set(choice_data.get("requires_codewords", []))
         if not requires:
             continue
 
@@ -1143,7 +1143,7 @@ def check_codeword_gate_coverage(graph: Graph) -> ValidationCheck:
     """Check that every codeword is consumed by a gate or overlay condition.
 
     Implements the "Residue Must Be Read" invariant: checks that each
-    codeword appears in at least one ``choice.requires`` gate or
+    codeword appears in at least one ``choice.requires_codewords`` gate or
     ``overlay.when`` condition.
     """
     codeword_nodes = graph.get_nodes_by_type("codeword")
@@ -1157,7 +1157,7 @@ def check_codeword_gate_coverage(graph: Graph) -> ValidationCheck:
     choice_nodes = graph.get_nodes_by_type("choice")
     consumed: set[str] = set()
     for choice_data in choice_nodes.values():
-        consumed.update(choice_data.get("requires") or [])
+        consumed.update(choice_data.get("requires_codewords") or [])
 
     # Overlays are embedded arrays on entity nodes (type="entity"),
     # not separate typed nodes.
@@ -1180,7 +1180,7 @@ def check_codeword_gate_coverage(graph: Graph) -> ValidationCheck:
         severity="warn",
         message=(
             f"{len(unconsumed)} of {len(codeword_nodes)} codeword(s) not consumed "
-            f"by any choice.requires or overlay.when: {', '.join(unconsumed[:5])}"
+            f"by any choice.requires_codewords or overlay.when: {', '.join(unconsumed[:5])}"
             f"{'...' if len(unconsumed) > 5 else ''}"
         ),
     )
@@ -1220,7 +1220,7 @@ def check_forward_path_reachability(graph: Graph) -> ValidationCheck:
         forward = [c for c in choices if not c.get("is_return") and not c.get("is_routing")]
         if not forward:
             continue  # ending passage or routing-only — no forward choices
-        ungated = [c for c in forward if not c.get("requires")]
+        ungated = [c for c in forward if not c.get("requires_codewords")]
         if not ungated:
             soft_locked.append(pid)
 
@@ -1307,7 +1307,7 @@ def check_routing_coverage(graph: Graph) -> list[ValidationCheck]:
         # Extract requires sets from routing choices
         route_requires: list[set[str]] = []
         for rc in routing_choices:
-            reqs = rc.get("requires", [])
+            reqs = rc.get("requires_codewords", [])
             route_requires.append(set(reqs) if isinstance(reqs, list) else set())
 
         # CE check: for each covering arc, at least one route is satisfiable

--- a/src/questfoundry/models/grow.py
+++ b/src/questfoundry/models/grow.py
@@ -78,7 +78,7 @@ class Choice(BaseModel):
     from_passage: str = Field(min_length=1)
     to_passage: str = Field(min_length=1)
     label: str = Field(min_length=1)
-    requires: list[str] = Field(default_factory=list)
+    requires_codewords: list[str] = Field(default_factory=list)
     grants: list[str] = Field(default_factory=list)
     is_return: bool = Field(default=False, description="True for spoke→hub return links")
 

--- a/src/questfoundry/pipeline/stages/grow/llm_phases.py
+++ b/src/questfoundry/pipeline/stages/grow/llm_phases.py
@@ -1546,7 +1546,7 @@ class _LLMPhaseMixin:
                     "from_passage": p_id,
                     "to_passage": succ.to_passage,
                     "label": label,
-                    "requires": [],
+                    "requires_codewords": [],
                     "grants": succ.grants,
                 },
             )
@@ -1637,7 +1637,7 @@ class _LLMPhaseMixin:
                             "from_passage": p_id,
                             "to_passage": succ.to_passage,
                             "label": multi_label,
-                            "requires": choice_requires.get(succ.to_passage, []),
+                            "requires_codewords": choice_requires.get(succ.to_passage, []),
                             "grants": succ.grants,
                         },
                     )
@@ -1886,7 +1886,7 @@ class _LLMPhaseMixin:
                         "from_passage": fork_at,
                         "to_passage": opt_id,
                         "label": label,
-                        "requires": [],
+                        "requires_codewords": [],
                         "grants": [],
                     },
                 )
@@ -1905,7 +1905,7 @@ class _LLMPhaseMixin:
                         "from_passage": opt_id,
                         "to_passage": next_passage,
                         "label": "continue",
-                        "requires": [],
+                        "requires_codewords": [],
                         "grants": old_grants,
                     },
                 )
@@ -2063,7 +2063,7 @@ class _LLMPhaseMixin:
                     "type": "choice",
                     "from_passage": hub_id,
                     "to_passage": spoke_pid,
-                    "requires": [],
+                    "requires_codewords": [],
                     "grants": spoke.grants,
                     "label_style": spoke.label_style,
                 }
@@ -2082,7 +2082,7 @@ class _LLMPhaseMixin:
                         "from_passage": spoke_pid,
                         "to_passage": hub_id,
                         "label": "Return",
-                        "requires": [],
+                        "requires_codewords": [],
                         "grants": [],
                         "is_return": True,
                     },

--- a/src/questfoundry/visualization.py
+++ b/src/questfoundry/visualization.py
@@ -57,7 +57,7 @@ class VizEdge:
     to_id: str
     label: str = ""
     is_return: bool = False
-    requires: list[str] = field(default_factory=list)
+    requires_codewords: list[str] = field(default_factory=list)
     grants: list[str] = field(default_factory=list)
 
 
@@ -184,7 +184,7 @@ def build_story_graph(
                 to_id=to_p,
                 label=cdata.get("label", ""),
                 is_return=cdata.get("is_return", False),
-                requires=cdata.get("requires", []),
+                requires_codewords=cdata.get("requires_codewords", []),
                 grants=cdata.get("grants", []),
             )
         )
@@ -239,7 +239,7 @@ def render_dot(sg: StoryGraph, *, no_labels: bool = False) -> str:
             edge_attrs["color"] = '"grey"'
         # Requires (gated) takes precedence over grants (state-changing).
         # Return edges keep their dashed grey style in both renderers.
-        if edge.requires:
+        if edge.requires_codewords:
             edge_attrs["color"] = '"orange"'
             edge_attrs["penwidth"] = '"2"'
         elif edge.grants and not edge.is_return:
@@ -306,7 +306,9 @@ def render_mermaid(sg: StoryGraph, *, no_labels: bool = False) -> str:
     lines.append(f"  classDef endingOverlay fill:#FFB6C1,stroke:{_OVERLAY_BORDER},stroke-width:3px")
     # Mermaid has limited edge styling; grants edges use linkStyle below
     grants_indices = [
-        i for i, e in enumerate(sg.edges) if e.grants and not e.is_return and not e.requires
+        i
+        for i, e in enumerate(sg.edges)
+        if e.grants and not e.is_return and not e.requires_codewords
     ]
     if grants_indices:
         idx_list = ",".join(str(i) for i in grants_indices)

--- a/tests/fixtures/grow_fixtures.py
+++ b/tests/fixtures/grow_fixtures.py
@@ -161,9 +161,9 @@ def make_single_dilemma_graph() -> Graph:
     graph.add_edge("belongs_to", "beat::mentor_commits_alt", "path::mentor_trust_alt")
 
     # Beat ordering (requires edges): opening → mentor_meet → commits
-    graph.add_edge("requires", "beat::mentor_meet", "beat::opening")
-    graph.add_edge("requires", "beat::mentor_commits_canonical", "beat::mentor_meet")
-    graph.add_edge("requires", "beat::mentor_commits_alt", "beat::mentor_meet")
+    graph.add_edge("sequenced_after", "beat::mentor_meet", "beat::opening")
+    graph.add_edge("sequenced_after", "beat::mentor_commits_canonical", "beat::mentor_meet")
+    graph.add_edge("sequenced_after", "beat::mentor_commits_alt", "beat::mentor_meet")
 
     # Consequences
     graph.create_node(
@@ -363,19 +363,19 @@ def make_two_dilemma_graph() -> Graph:
 
     # Beat ordering (requires edges)
     # opening → mentor_meet, artifact_discover
-    graph.add_edge("requires", "beat::mentor_meet", "beat::opening")
-    graph.add_edge("requires", "beat::artifact_discover", "beat::opening")
+    graph.add_edge("sequenced_after", "beat::mentor_meet", "beat::opening")
+    graph.add_edge("sequenced_after", "beat::artifact_discover", "beat::opening")
     # mentor_meet → mentor_commits_*
-    graph.add_edge("requires", "beat::mentor_commits_canonical", "beat::mentor_meet")
-    graph.add_edge("requires", "beat::mentor_commits_alt", "beat::mentor_meet")
+    graph.add_edge("sequenced_after", "beat::mentor_commits_canonical", "beat::mentor_meet")
+    graph.add_edge("sequenced_after", "beat::mentor_commits_alt", "beat::mentor_meet")
     # artifact_discover → artifact_commits_*
-    graph.add_edge("requires", "beat::artifact_commits_canonical", "beat::artifact_discover")
-    graph.add_edge("requires", "beat::artifact_commits_alt", "beat::artifact_discover")
+    graph.add_edge("sequenced_after", "beat::artifact_commits_canonical", "beat::artifact_discover")
+    graph.add_edge("sequenced_after", "beat::artifact_commits_alt", "beat::artifact_discover")
     # commits → finale
-    graph.add_edge("requires", "beat::finale", "beat::mentor_commits_canonical")
-    graph.add_edge("requires", "beat::finale", "beat::mentor_commits_alt")
-    graph.add_edge("requires", "beat::finale", "beat::artifact_commits_canonical")
-    graph.add_edge("requires", "beat::finale", "beat::artifact_commits_alt")
+    graph.add_edge("sequenced_after", "beat::finale", "beat::mentor_commits_canonical")
+    graph.add_edge("sequenced_after", "beat::finale", "beat::mentor_commits_alt")
+    graph.add_edge("sequenced_after", "beat::finale", "beat::artifact_commits_canonical")
+    graph.add_edge("sequenced_after", "beat::finale", "beat::artifact_commits_alt")
 
     # Consequences
     for cons_id, path_id, desc in [
@@ -594,7 +594,7 @@ def make_e2e_fixture_graph() -> Graph:
         ("climax", "aq_corrupt"),
     ]
     for from_beat, to_beat in ordering:
-        graph.add_edge("requires", f"beat::{from_beat}", f"beat::{to_beat}")
+        graph.add_edge("sequenced_after", f"beat::{from_beat}", f"beat::{to_beat}")
 
     # Consequences
     for cons_id, path_id, desc in [
@@ -685,6 +685,6 @@ def make_conditional_prerequisite_graph() -> Graph:
     graph.add_edge("belongs_to", "beat::gap_1", "path::mentor_trust_canonical")
 
     # mentor_meet requires gap_1 (gap_1 must come first)
-    graph.add_edge("requires", "beat::mentor_meet", "beat::gap_1")
+    graph.add_edge("sequenced_after", "beat::mentor_meet", "beat::gap_1")
 
     return graph

--- a/tests/unit/test_export_context.py
+++ b/tests/unit/test_export_context.py
@@ -42,7 +42,7 @@ def _minimal_graph() -> Graph:
             "from_passage": "passage::intro",
             "to_passage": "passage::choice_a",
             "label": "Enter the castle",
-            "requires": [],
+            "requires_codewords": [],
             "grants": ["codeword::entered_castle"],
         },
     )
@@ -53,7 +53,7 @@ def _minimal_graph() -> Graph:
             "from_passage": "passage::intro",
             "to_passage": "passage::choice_b",
             "label": "Flee to the forest",
-            "requires": [],
+            "requires_codewords": [],
             "grants": [],
         },
     )
@@ -167,7 +167,7 @@ class TestBuildExportContext:
                 "from_passage": "passage::intro",
                 "to_passage": "passage::spoke_0",
                 "label": "Look around",
-                "requires": [],
+                "requires_codewords": [],
                 "grants": [],
             },
         )
@@ -181,7 +181,7 @@ class TestBuildExportContext:
                 "to_passage": "passage::intro",
                 "label": "Return",
                 "is_return": True,
-                "requires": [],
+                "requires_codewords": [],
                 "grants": [],
             },
         )

--- a/tests/unit/test_fill_context.py
+++ b/tests/unit/test_fill_context.py
@@ -1656,7 +1656,7 @@ class TestFormatEntityArcContext:
                 "raw_id": "b2",
                 "summary": "Doubts surface",
                 "paths": ["path::trust__yes"],
-                "requires": ["beat::b1"],
+                "sequenced_after": ["beat::b1"],
                 "entities": ["entity::mentor", "entity::letter"],
             },
         )
@@ -1667,7 +1667,7 @@ class TestFormatEntityArcContext:
                 "raw_id": "b3",
                 "summary": "Revelation",
                 "paths": ["path::trust__yes"],
-                "requires": ["beat::b2"],
+                "sequenced_after": ["beat::b2"],
                 "entities": ["entity::mentor"],
             },
         )

--- a/tests/unit/test_grow_models.py
+++ b/tests/unit/test_grow_models.py
@@ -157,15 +157,15 @@ class TestChoice:
             from_passage="p1",
             to_passage="p2",
             label="Go left",
-            requires=["cw1"],
+            requires_codewords=["cw1"],
             grants=["cw2"],
         )
         assert choice.from_passage == "p1"
-        assert choice.requires == ["cw1"]
+        assert choice.requires_codewords == ["cw1"]
 
     def test_empty_requires_grants_allowed(self) -> None:
         choice = Choice(from_passage="p1", to_passage="p2", label="Continue")
-        assert choice.requires == []
+        assert choice.requires_codewords == []
         assert choice.grants == []
 
     def test_empty_label_rejected(self) -> None:

--- a/tests/unit/test_grow_stage.py
+++ b/tests/unit/test_grow_stage.py
@@ -744,7 +744,7 @@ class TestPhase3Knots:
         assert "1 applied" in result.detail
 
     @pytest.mark.asyncio
-    async def test_phase_3_fails_with_requires_conflict(self) -> None:
+    async def test_phase_3_fails_with_sequenced_after_conflict(self) -> None:
         """Phase 3 fails when all intersections have requires dependency."""
         from questfoundry.models.grow import IntersectionProposal, Phase3Output
         from tests.fixtures.grow_fixtures import make_intersection_candidate_graph

--- a/tests/unit/test_grow_stage.py
+++ b/tests/unit/test_grow_stage.py
@@ -753,7 +753,7 @@ class TestPhase3Knots:
         stage = GrowStage()
 
         # Add a cross-dilemma requires: artifact_discover requires mentor_meet
-        graph.add_edge("requires", "beat::artifact_discover", "beat::mentor_meet")
+        graph.add_edge("sequenced_after", "beat::artifact_discover", "beat::mentor_meet")
 
         phase3_output = Phase3Output(
             intersections=[
@@ -1185,8 +1185,8 @@ class TestPhase4cPacingGaps:
         graph.add_edge("belongs_to", "beat::b1", "path::main")
         graph.add_edge("belongs_to", "beat::b2", "path::main")
         graph.add_edge("belongs_to", "beat::b3", "path::main")
-        graph.add_edge("requires", "beat::b2", "beat::b1")
-        graph.add_edge("requires", "beat::b3", "beat::b2")
+        graph.add_edge("sequenced_after", "beat::b2", "beat::b1")
+        graph.add_edge("sequenced_after", "beat::b3", "beat::b2")
 
         stage = GrowStage()
 
@@ -1233,8 +1233,8 @@ class TestPhase4cPacingGaps:
         graph.add_edge("belongs_to", "beat::b1", "path::main")
         graph.add_edge("belongs_to", "beat::b2", "path::main")
         graph.add_edge("belongs_to", "beat::b3", "path::main")
-        graph.add_edge("requires", "beat::b2", "beat::b1")
-        graph.add_edge("requires", "beat::b3", "beat::b2")
+        graph.add_edge("sequenced_after", "beat::b2", "beat::b1")
+        graph.add_edge("sequenced_after", "beat::b3", "beat::b2")
 
         stage = GrowStage()
 
@@ -1278,8 +1278,8 @@ class TestPhase4cPacingGaps:
         graph.add_edge("belongs_to", "beat::b1", "path::main")
         graph.add_edge("belongs_to", "beat::b2", "path::main")
         graph.add_edge("belongs_to", "beat::b3", "path::main")
-        graph.add_edge("requires", "beat::b2", "beat::b1")
-        graph.add_edge("requires", "beat::b3", "beat::b2")
+        graph.add_edge("sequenced_after", "beat::b2", "beat::b1")
+        graph.add_edge("sequenced_after", "beat::b3", "beat::b2")
 
         stage = GrowStage()
         mock_model = MagicMock()
@@ -1771,8 +1771,8 @@ class TestPhase9Choices:
         graph.create_node("beat::a", {"type": "beat", "raw_id": "a", "summary": "Start"})
         graph.create_node("beat::b", {"type": "beat", "raw_id": "b", "summary": "Middle"})
         graph.create_node("beat::c", {"type": "beat", "raw_id": "c", "summary": "End"})
-        graph.add_edge("requires", "beat::b", "beat::a")
-        graph.add_edge("requires", "beat::c", "beat::b")
+        graph.add_edge("sequenced_after", "beat::b", "beat::a")
+        graph.add_edge("sequenced_after", "beat::c", "beat::b")
 
         # Create arc with sequence
         graph.create_node(
@@ -1851,7 +1851,7 @@ class TestPhase9Choices:
         graph = Graph.empty()
         graph.create_node("beat::a", {"type": "beat", "raw_id": "a", "summary": "Start"})
         graph.create_node("beat::b", {"type": "beat", "raw_id": "b", "summary": "End"})
-        graph.add_edge("requires", "beat::b", "beat::a")
+        graph.add_edge("sequenced_after", "beat::b", "beat::a")
 
         graph.create_node(
             "arc::spine",
@@ -2119,7 +2119,7 @@ class TestPhase9Choices:
         graph = Graph.empty()
         graph.create_node("beat::a", {"type": "beat", "raw_id": "a", "summary": "Start"})
         graph.create_node("beat::b", {"type": "beat", "raw_id": "b", "summary": "Commit"})
-        graph.add_edge("requires", "beat::b", "beat::a")
+        graph.add_edge("sequenced_after", "beat::b", "beat::a")
 
         # beat::b grants a codeword
         graph.create_node(
@@ -2195,8 +2195,8 @@ class TestPhase9Choices:
             "beat::path2_end", {"type": "beat", "raw_id": "path2_end", "summary": "End path 2"}
         )
 
-        graph.add_edge("requires", "beat::path1_end", "beat::path1_start")
-        graph.add_edge("requires", "beat::path2_end", "beat::path2_start")
+        graph.add_edge("sequenced_after", "beat::path1_end", "beat::path1_start")
+        graph.add_edge("sequenced_after", "beat::path2_end", "beat::path2_start")
 
         # Arc 1: path1_start → path1_end
         graph.create_node(
@@ -3022,7 +3022,7 @@ class TestPhase9bForkBeats:
                     "from_passage": f"passage::{pids[i]}",
                     "to_passage": f"passage::{pids[i + 1]}",
                     "label": "continue",
-                    "requires": [],
+                    "requires_codewords": [],
                     "grants": [],
                 },
             )
@@ -3117,7 +3117,7 @@ class TestPhase9bForkBeats:
                     "from_passage": f"passage::{pids[i]}",
                     "to_passage": f"passage::{pids[i + 1]}",
                     "label": "continue",
-                    "requires": [],
+                    "requires_codewords": [],
                     "grants": [],
                 },
             )
@@ -3164,7 +3164,7 @@ class TestPhase9bForkBeats:
                 "from_passage": "passage::p1",
                 "to_passage": "passage::p2",
                 "label": "continue",
-                "requires": [],
+                "requires_codewords": [],
                 "grants": ["codeword::truth_committed"],
             },
         )
@@ -3178,7 +3178,7 @@ class TestPhase9bForkBeats:
                 "from_passage": "passage::p2",
                 "to_passage": "passage::p3",
                 "label": "continue",
-                "requires": [],
+                "requires_codewords": [],
                 "grants": [],
             },
         )
@@ -3243,7 +3243,7 @@ class TestPhase9cHubSpokes:
                 "from_passage": "passage::market",
                 "to_passage": "passage::palace",
                 "label": "continue",
-                "requires": [],
+                "requires_codewords": [],
                 "grants": [],
             },
         )
@@ -3317,7 +3317,7 @@ class TestPhase9cHubSpokes:
                 "from_passage": "passage::hub",
                 "to_passage": "passage::spoke",
                 "label": "Explore",
-                "requires": [],
+                "requires_codewords": [],
                 "grants": [],
             },
         )
@@ -3332,7 +3332,7 @@ class TestPhase9cHubSpokes:
                 "from_passage": "passage::spoke",
                 "to_passage": "passage::hub",
                 "label": "Return",
-                "requires": [],
+                "requires_codewords": [],
                 "grants": [],
                 "is_return": True,
             },
@@ -3364,7 +3364,7 @@ class TestPhase9cHubSpokes:
                 "from_passage": "passage::p1",
                 "to_passage": "passage::p2",
                 "label": "continue",
-                "requires": [],
+                "requires_codewords": [],
                 "grants": [],
             },
         )

--- a/tests/unit/test_grow_validation.py
+++ b/tests/unit/test_grow_validation.py
@@ -48,7 +48,7 @@ def _make_linear_passage_graph() -> Graph:
             "from_passage": "passage::p1",
             "to_passage": "passage::p2",
             "label": "continue",
-            "requires": [],
+            "requires_codewords": [],
             "grants": [],
         },
     )
@@ -59,7 +59,7 @@ def _make_linear_passage_graph() -> Graph:
             "from_passage": "passage::p2",
             "to_passage": "passage::p3",
             "label": "continue",
-            "requires": [],
+            "requires_codewords": [],
             "grants": [],
         },
     )
@@ -123,7 +123,7 @@ class TestSingleStart:
                 "from_passage": "passage::p1",
                 "to_passage": "passage::p2",
                 "label": "go",
-                "requires": [],
+                "requires_codewords": [],
                 "grants": [],
             },
         )
@@ -134,7 +134,7 @@ class TestSingleStart:
                 "from_passage": "passage::p2",
                 "to_passage": "passage::p1",
                 "label": "back",
-                "requires": [],
+                "requires_codewords": [],
                 "grants": [],
             },
         )
@@ -165,7 +165,7 @@ class TestSingleStart:
                 "from_passage": "passage::p1",
                 "to_passage": "passage::spoke_0",
                 "label": "Look around",
-                "requires": [],
+                "requires_codewords": [],
                 "grants": [],
             },
         )
@@ -180,7 +180,7 @@ class TestSingleStart:
                 "to_passage": "passage::p1",
                 "label": "Return",
                 "is_return": True,
-                "requires": [],
+                "requires_codewords": [],
                 "grants": [],
             },
         )
@@ -214,7 +214,7 @@ class TestReachability:
                 "from_passage": "passage::isolated",
                 "to_passage": "passage::isolated",
                 "label": "self",
-                "requires": [],
+                "requires_codewords": [],
                 "grants": [],
             },
         )
@@ -257,7 +257,7 @@ class TestEndingsReachable:
                 "from_passage": "passage::start",
                 "to_passage": "passage::middle",
                 "label": "go",
-                "requires": [],
+                "requires_codewords": [],
                 "grants": [],
             },
         )
@@ -271,7 +271,7 @@ class TestEndingsReachable:
                 "from_passage": "passage::middle",
                 "to_passage": "passage::start",
                 "label": "back",
-                "requires": [],
+                "requires_codewords": [],
                 "grants": [],
             },
         )
@@ -352,7 +352,7 @@ class TestGateSatisfiability:
                 "from_passage": "passage::p1",
                 "to_passage": "passage::p2",
                 "label": "go",
-                "requires": [],
+                "requires_codewords": [],
                 "grants": ["codeword::cw1"],
             },
         )
@@ -364,7 +364,7 @@ class TestGateSatisfiability:
                 "from_passage": "passage::p2",
                 "to_passage": "passage::p1",
                 "label": "back",
-                "requires": ["codeword::cw1"],
+                "requires_codewords": ["codeword::cw1"],
                 "grants": [],
             },
         )
@@ -389,7 +389,7 @@ class TestGateSatisfiability:
                 "from_passage": "passage::p1",
                 "to_passage": "passage::p2",
                 "label": "go",
-                "requires": ["codeword::never_granted"],
+                "requires_codewords": ["codeword::never_granted"],
                 "grants": [],
             },
         )
@@ -429,7 +429,7 @@ class TestGateCoSatisfiability:
                 "from_passage": "passage::p",
                 "to_passage": "passage::p",
                 "label": "go",
-                "requires": ["codeword::cw1"],
+                "requires_codewords": ["codeword::cw1"],
                 "grants": [],
             },
         )
@@ -468,7 +468,7 @@ class TestGateCoSatisfiability:
                 "from_passage": "passage::p",
                 "to_passage": "passage::p",
                 "label": "go",
-                "requires": ["codeword::p1_cw", "codeword::p2_cw"],
+                "requires_codewords": ["codeword::p1_cw", "codeword::p2_cw"],
                 "grants": [],
             },
         )
@@ -507,7 +507,7 @@ class TestPassageDagCycles:
                 "from_passage": "passage::p1",
                 "to_passage": "passage::p2",
                 "label": "go",
-                "requires": [],
+                "requires_codewords": [],
                 "grants": [],
             },
         )
@@ -518,7 +518,7 @@ class TestPassageDagCycles:
                 "from_passage": "passage::p2",
                 "to_passage": "passage::p1",
                 "label": "back",
-                "requires": [],
+                "requires_codewords": [],
                 "grants": [],
             },
         )
@@ -561,7 +561,7 @@ def _make_timing_graph_with_arc(
         )
         graph.add_edge("belongs_to", beat_id, "path::th1")
         if i > 0:
-            graph.add_edge("requires", beat_id, f"beat::b{i - 1}")
+            graph.add_edge("sequenced_after", beat_id, f"beat::b{i - 1}")
 
     # Arc with the beat sequence
     graph.create_node(
@@ -887,8 +887,8 @@ class TestRunAllChecks:
         graph.add_edge("belongs_to", "beat::b0", "path::th1")
         graph.add_edge("belongs_to", "beat::b1", "path::th1")
         graph.add_edge("belongs_to", "beat::b2", "path::th1")
-        graph.add_edge("requires", "beat::b1", "beat::b0")
-        graph.add_edge("requires", "beat::b2", "beat::b1")
+        graph.add_edge("sequenced_after", "beat::b1", "beat::b0")
+        graph.add_edge("sequenced_after", "beat::b2", "beat::b1")
         # Update existing spine arc to include the test path and its beats
         graph.update_node(
             "arc::spine",
@@ -1006,8 +1006,8 @@ class TestPhase10Integration:
         graph.add_edge("belongs_to", "beat::b0", "path::th1")
         graph.add_edge("belongs_to", "beat::b1", "path::th1")
         graph.add_edge("belongs_to", "beat::b2", "path::th1")
-        graph.add_edge("requires", "beat::b1", "beat::b0")
-        graph.add_edge("requires", "beat::b2", "beat::b1")
+        graph.add_edge("sequenced_after", "beat::b1", "beat::b0")
+        graph.add_edge("sequenced_after", "beat::b2", "beat::b1")
         # Update existing spine arc to include the test path and its beats
         graph.update_node(
             "arc::spine",
@@ -1048,7 +1048,7 @@ def _make_chain_graph(passage_ids: list[str], beat_data: dict[str, dict] | None 
                 "from_passage": f"passage::{from_p}",
                 "to_passage": f"passage::{to_p}",
                 "label": "continue",
-                "requires": [],
+                "requires_codewords": [],
                 "grants": [],
             },
         )
@@ -1089,7 +1089,7 @@ class TestMaxConsecutiveLinear:
                 "from_passage": "passage::b",
                 "to_passage": "passage::alt",
                 "label": "Take alternative",
-                "requires": [],
+                "requires_codewords": [],
                 "grants": [],
             },
         )
@@ -1152,7 +1152,7 @@ class TestMaxConsecutiveLinear:
                 "from_passage": "passage::x",
                 "to_passage": "passage::c",
                 "label": "go",
-                "requires": [],
+                "requires_codewords": [],
                 "grants": [],
             },
         )
@@ -1654,7 +1654,7 @@ class TestCodewordGateCoverage:
                 "from_passage": "passage::a",
                 "to_passage": "passage::b",
                 "label": "go",
-                "requires": ["codeword::cw1"],
+                "requires_codewords": ["codeword::cw1"],
                 "grants": [],
             },
         )
@@ -1672,7 +1672,7 @@ class TestCodewordGateCoverage:
                 "from_passage": "passage::a",
                 "to_passage": "passage::b",
                 "label": "go",
-                "requires": ["codeword::cw1"],
+                "requires_codewords": ["codeword::cw1"],
                 "grants": [],
             },
         )
@@ -1765,7 +1765,7 @@ class TestForwardPathReachability:
                 "from_passage": "passage::a",
                 "to_passage": "passage::b",
                 "label": "go",
-                "requires": [],
+                "requires_codewords": [],
                 "grants": [],
             },
         )
@@ -1782,7 +1782,7 @@ class TestForwardPathReachability:
                 "from_passage": "passage::a",
                 "to_passage": "passage::b",
                 "label": "go",
-                "requires": ["codeword::x"],
+                "requires_codewords": ["codeword::x"],
                 "grants": [],
             },
         )
@@ -1808,7 +1808,7 @@ class TestForwardPathReachability:
                 "from_passage": "passage::a",
                 "to_passage": "passage::b",
                 "label": "return",
-                "requires": [],
+                "requires_codewords": [],
                 "grants": [],
                 "is_return": True,
             },
@@ -1821,7 +1821,7 @@ class TestForwardPathReachability:
                 "from_passage": "passage::a",
                 "to_passage": "passage::c",
                 "label": "go",
-                "requires": ["codeword::x"],
+                "requires_codewords": ["codeword::x"],
                 "grants": [],
             },
         )
@@ -1850,7 +1850,7 @@ class TestForwardPathReachability:
                 "from_passage": "passage::hub",
                 "to_passage": "passage::next",
                 "label": "continue",
-                "requires": [],
+                "requires_codewords": [],
                 "grants": [],
             },
         )
@@ -1864,7 +1864,7 @@ class TestForwardPathReachability:
                 "to_passage": "passage::end1",
                 "label": "route1",
                 "is_routing": True,
-                "requires": ["codeword::cw1"],
+                "requires_codewords": ["codeword::cw1"],
                 "grants": [],
             },
         )
@@ -1877,7 +1877,7 @@ class TestForwardPathReachability:
                 "to_passage": "passage::end2",
                 "label": "route2",
                 "is_routing": True,
-                "requires": ["codeword::cw2"],
+                "requires_codewords": ["codeword::cw2"],
                 "grants": [],
             },
         )
@@ -1960,7 +1960,7 @@ def _make_routing_graph(
                 "to_passage": target,
                 "label": choice_raw,
                 "is_routing": True,
-                "requires": [f"codeword::{cw}" for cw in reqs],
+                "requires_codewords": [f"codeword::{cw}" for cw in reqs],
                 "grants": [],
             },
         )
@@ -2060,7 +2060,7 @@ class TestCheckRoutingCoverage:
                 "to_passage": "passage::fallback",
                 "label": "fallback",
                 "is_routing": True,
-                "requires": [],
+                "requires_codewords": [],
                 "grants": [],
             },
         )
@@ -2096,7 +2096,7 @@ class TestCheckRoutingCoverage:
                 "to_passage": "passage::end1",
                 "label": "r1",
                 "is_routing": True,
-                "requires": ["codeword::cw1"],
+                "requires_codewords": ["codeword::cw1"],
                 "grants": [],
             },
         )
@@ -2181,7 +2181,7 @@ def _make_shared_passage_graph(
                 "to_passage": "passage::v1",
                 "label": "r1",
                 "is_routing": True,
-                "requires": ["codeword::cw1"],
+                "requires_codewords": ["codeword::cw1"],
                 "grants": [],
             },
         )

--- a/tests/unit/test_html_exporter.py
+++ b/tests/unit/test_html_exporter.py
@@ -89,7 +89,7 @@ class TestHtmlExporter:
                     from_passage="p1",
                     to_passage="p2",
                     label="Enter",
-                    requires=["codeword::has_key"],
+                    requires_codewords=["codeword::has_key"],
                 ),
             ],
         )

--- a/tests/unit/test_inspection.py
+++ b/tests/unit/test_inspection.py
@@ -51,7 +51,7 @@ def _make_full_graph() -> Graph:
             "from_passage": "passage::p0",
             "to_passage": "passage::p1",
             "label": "Enter the forest",
-            "requires": [],
+            "requires_codewords": [],
             "grants": [],
         },
     )
@@ -62,7 +62,7 @@ def _make_full_graph() -> Graph:
             "from_passage": "passage::p0",
             "to_passage": "passage::p1",
             "label": "continue",
-            "requires": [],
+            "requires_codewords": [],
             "grants": [],
         },
     )
@@ -200,7 +200,7 @@ class TestBranchingStats:
                 "from_passage": "passage::p0",
                 "to_passage": "passage::p1",
                 "label": "Search the room",
-                "requires": [],
+                "requires_codewords": [],
                 "grants": [],
             },
         )
@@ -215,7 +215,7 @@ class TestBranchingStats:
                 "from_passage": "passage::p1",
                 "to_passage": "passage::p2",
                 "label": "continue",
-                "requires": [],
+                "requires_codewords": [],
                 "grants": [],
             },
         )
@@ -272,7 +272,7 @@ class TestBranchingStats:
                 "from_passage": "passage::p0",
                 "to_passage": "passage::p1",
                 "label": "continue",
-                "requires": [],
+                "requires_codewords": [],
                 "grants": [],
             },
         )
@@ -285,7 +285,7 @@ class TestBranchingStats:
                 "from_passage": "passage::p0",
                 "to_passage": "passage::spoke_0",
                 "label": "Look around",
-                "requires": [],
+                "requires_codewords": [],
                 "grants": [],
             },
         )
@@ -299,7 +299,7 @@ class TestBranchingStats:
                 "to_passage": "passage::p0",
                 "label": "Return",
                 "is_return": True,
-                "requires": [],
+                "requires_codewords": [],
                 "grants": [],
             },
         )
@@ -583,7 +583,7 @@ class TestBranchingQualityScore:
                 "from_passage": "passage::mid",
                 "to_passage": "passage::ending",
                 "label": "Continue",
-                "requires": [],
+                "requires_codewords": [],
                 "grants": [],
             },
         )
@@ -667,7 +667,7 @@ class TestBranchingQualityScore:
                 "from_passage": "passage::mid",
                 "to_passage": "passage::ending",
                 "label": "Finish",
-                "requires": [],
+                "requires_codewords": [],
                 "grants": [],
             },
         )

--- a/tests/unit/test_json_exporter.py
+++ b/tests/unit/test_json_exporter.py
@@ -25,7 +25,7 @@ def _simple_context() -> ExportContext:
                 from_passage="p1",
                 to_passage="p2",
                 label="Continue",
-                requires=[],
+                requires_codewords=[],
                 grants=["codeword::done"],
             ),
         ],

--- a/tests/unit/test_pdf_exporter.py
+++ b/tests/unit/test_pdf_exporter.py
@@ -237,7 +237,7 @@ class TestRenderHtml:
                     from_passage="p1",
                     to_passage="p2",
                     label="Open the door",
-                    requires=["codeword::golden_key"],
+                    requires_codewords=["codeword::golden_key"],
                 ),
             ],
         )

--- a/tests/unit/test_twee_exporter.py
+++ b/tests/unit/test_twee_exporter.py
@@ -102,7 +102,7 @@ class TestTweeExporter:
                     from_passage="p1",
                     to_passage="p2",
                     label="Enter secret room",
-                    requires=["codeword::has_key"],
+                    requires_codewords=["codeword::has_key"],
                 ),
             ],
         )
@@ -149,7 +149,7 @@ class TestTweeExporter:
                     from_passage="p1",
                     to_passage="p2",
                     label="Use key",
-                    requires=["codeword::has_key"],
+                    requires_codewords=["codeword::has_key"],
                     grants=["codeword::door_opened"],
                 ),
             ],

--- a/tests/unit/test_visualization.py
+++ b/tests/unit/test_visualization.py
@@ -567,7 +567,7 @@ class TestGrantsEdges:
         graph = _make_simple_graph()
         graph.update_node(
             "choice::intro_middle",
-            requires=["has_key"],
+            requires_codewords=["has_key"],
             grants=["saw_truth"],
         )
         sg = build_story_graph(graph)


### PR DESCRIPTION
## Problem

The name `requires` was overloaded for three distinct concepts, causing a real runtime failure (GROW phase 3 crash in `projects/test-new`) and ongoing confusion in spec, code, prompts, and tests:

| Concept | Old name | New name |
|---------|----------|----------|
| Beat topological ordering | `requires` edge (beat→beat), `beat.requires` field | `sequenced_after` edge, `beat.sequenced_after` field |
| Intersection reachability constraint | (implicit, undocumented) | explicit rule in spec |
| Choice codeword gate | `choice.requires`, `"requires"` in choice data | `choice.requires_codewords`, `"requires_codewords"` |

**Root cause of `test-new` GROW failure:** `insert_gap_beat()` creates `requires` edges for positional ordering (semantic #1). `check_intersection_compatibility()` reads those same `requires` edges and applies a cross-path reachability check (semantic #2). Gap beats always fail this check — their ordering predecessor exists on one path only — so every intersection proposal was rejected and GROW crashed. Renaming to `sequenced_after` makes the ordering intent unambiguous and separates the two checks at the naming level. The `is_gap_beat` filter in `build_intersection_candidates()` adds belt-and-suspenders enforcement.

## Changes

**`docs/design/00-spec.md`**
- `beat.requires: beat_id[]` → `beat.sequenced_after: beat_id[]` (with clarified description)
- Edge type `requires (beat→beat)` → `sequenced_after (beat→beat)`
- `choice.requires: codeword[]` → `choice.requires_codewords: codeword[]` everywhere
- New intersection eligibility rule: gap beats (`is_gap_beat: true`) are path-local and never eligible as intersection beats

**`src/questfoundry/`** — 9 `sequenced_after` edge renames + choice data renames across:
- `graph/grow_algorithms.py` (9 beat-ordering sites + 1 choice site + `is_gap_beat` filter in `build_intersection_candidates`)
- `graph/grow_validation.py` (5 choice data reads)
- `pipeline/stages/grow/llm_phases.py` (6 choice node dicts)
- `models/grow.py` (`Choice.requires` field)
- `export/base.py` (`ExportChoice.requires` field)
- `export/context.py`, `export/html_exporter.py`, `export/twee_exporter.py`, `export/pdf_exporter.py`, `visualization.py` (attribute accesses)

**`tests/`** — matching renames in fixtures and 6 test files.

## Not Included / Future PRs

- Prompt templates do not reference `requires` by name (prompts describe beat/choice concepts in prose) — no prompt changes needed
- HTML `data-requires` attribute in the frontend is a presentation-layer name, not renamed (no semantic coupling to the graph layer)
- No backwards compat migration for existing `graph.db` files — user confirmed re-run is acceptable

## Test Plan

```
uv run ruff check src/questfoundry/           # clean
uv run mypy src/questfoundry/<changed files>  # clean
uv run pytest tests/unit/test_grow_validation.py tests/unit/test_grow_algorithms.py -x -q  # 372 passed
uv run pytest tests/unit/test_grow_stage.py tests/unit/test_export_context.py tests/unit/test_inspection.py tests/unit/test_fill_context.py -x -q  # 706 passed
```

## Risk / Rollback

- Pure rename refactor — no behaviour change except the `is_gap_beat` filter in `build_intersection_candidates()` (which enforces a rule now explicit in spec)
- No DB migration needed; existing `graph.db` files with old `requires` edge type will not be read by the new code (user confirmed re-run acceptable)
- Rollback: `git revert` the three commits in reverse order

Closes #944