### PR TITLE
fix(grow): tactical routing fixes for GROW stage (Epic #950, T1-T5)

### DIFF
--- a/src/questfoundry/graph/grow_algorithms.py
+++ b/src/questfoundry/graph/grow_algorithms.py
@@ -815,10 +815,12 @@ def split_ending_families(graph: Graph) -> EndingSplitResult:
             variant_specs.append(VariantSpec(ending_pid, distinguishing))
             families_created += 1
 
-        # Reroute incoming choices to variant endings (no extra hops)
-        split_and_reroute(graph, terminal_id, variant_specs, keep_fallback=False)
-        # Mark the original terminal as non-ending (it may still exist
-        # if it had no incoming choices, e.g. a start passage)
+        # Reroute incoming choices to variant endings; keep the original
+        # as a fallback (CE validation will verify exhaustiveness).
+        split_and_reroute(graph, terminal_id, variant_specs, keep_fallback=True)
+        # The base passage is now a fallback — mark it as non-ending so
+        # variant endings are the real terminals.  If the routing plan is
+        # CE-complete the fallback will be unreachable and prunable.
         if graph.get_node(terminal_id):
             graph.update_node(terminal_id, is_ending=False)
 

--- a/src/questfoundry/graph/grow_algorithms.py
+++ b/src/questfoundry/graph/grow_algorithms.py
@@ -2223,13 +2223,15 @@ def find_heavy_divergence_targets(graph: Graph) -> list[HeavyDivergenceTarget]:
             continue
         path_to_codeword[path_id_for_tracks] = cw_id
 
-    # Already-routed passages
+    # Already-routed passages — identified by variant passages that
+    # reference them via ``residue_for`` metadata.  We do NOT use
+    # ``from_passage`` on routing choices (that is the upstream source
+    # passage, not the base passage that was split).
     routed_passages: set[str] = set()
-    for _cid, cdata in choice_nodes.items():
-        if cdata.get("is_routing"):
-            source = str(cdata.get("from_passage", ""))
-            if source:
-                routed_passages.add(source)
+    for _pid, _pdata in passage_nodes.items():
+        residue_for = _pdata.get("residue_for")
+        if residue_for:
+            routed_passages.add(str(residue_for))
 
     targets: list[HeavyDivergenceTarget] = []
     seen: set[tuple[str, str]] = set()  # (passage_id, dilemma_id) dedup

--- a/src/questfoundry/graph/grow_validation.py
+++ b/src/questfoundry/graph/grow_validation.py
@@ -1392,7 +1392,6 @@ def check_prose_neutrality(graph: Graph) -> list[ValidationCheck]:
     arc_nodes = graph.get_nodes_by_type("arc")
     passage_nodes = graph.get_nodes_by_type("passage")
     dilemma_nodes = graph.get_nodes_by_type("dilemma")
-    choice_nodes = graph.get_nodes_by_type("choice")
 
     if not arc_nodes or not passage_nodes or not dilemma_nodes:
         return [
@@ -1429,22 +1428,12 @@ def check_prose_neutrality(graph: Graph) -> list[ValidationCheck]:
     # *source* passage, not the base passage that was split.
     routed_passages: set[str] = set()
     for _pid, _pdata in passage_nodes.items():
+        # Both heavy-residue variants and ending-family variants set
+        # ``residue_for`` pointing to the base passage they were split
+        # from.  Collecting these is sufficient — no sibling scan needed.
         residue_for = _pdata.get("residue_for")
         if residue_for:
             routed_passages.add(str(residue_for))
-        if _pdata.get("family_codewords"):
-            # Ending variant — its base terminal is routed
-            from_beat = str(_pdata.get("from_beat") or "")
-            if from_beat:
-                # Find sibling passages sharing the same beat that are
-                # the original (non-synthetic) base passage.
-                for other_pid, other_pdata in passage_nodes.items():
-                    if (
-                        other_pid != _pid
-                        and str(other_pdata.get("from_beat") or "") == from_beat
-                        and not other_pdata.get("family_codewords")
-                    ):
-                        routed_passages.add(other_pid)
 
     checks: list[ValidationCheck] = []
 

--- a/src/questfoundry/graph/grow_validation.py
+++ b/src/questfoundry/graph/grow_validation.py
@@ -1248,14 +1248,14 @@ def check_routing_coverage(graph: Graph) -> list[ValidationCheck]:
     - CE: every arc reaching the source has at least one satisfiable route
     - ME: at most one routing choice is satisfiable per arc (excluding fallback)
 
-    Uses arc codeword signatures from ``_build_arc_codewords()`` to evaluate
+    Uses arc codeword signatures from ``build_arc_codewords()`` to evaluate
     route satisfiability deterministically.
 
     Returns:
         List of ValidationCheck results (one per routing set with issues,
         or a single pass check if all sets are valid).
     """
-    from questfoundry.graph.grow_algorithms import _build_arc_codewords
+    from questfoundry.graph.grow_algorithms import build_arc_codewords
 
     choices = graph.get_nodes_by_type("choice")
     arc_nodes = graph.get_nodes_by_type("arc")
@@ -1269,7 +1269,7 @@ def check_routing_coverage(graph: Graph) -> list[ValidationCheck]:
             )
         ]
 
-    arc_codewords = _build_arc_codewords(graph, arc_nodes)
+    arc_codewords = build_arc_codewords(graph, arc_nodes, scope="routing")
 
     # Group routing choices by source passage
     routing_sets: dict[str, list[dict[str, object]]] = {}

--- a/src/questfoundry/pipeline/stages/grow/llm_phases.py
+++ b/src/questfoundry/pipeline/stages/grow/llm_phases.py
@@ -1036,11 +1036,7 @@ class _LLMPhaseMixin:
     # Late LLM phases (codewords → validation)
     # -------------------------------------------------------------------------
 
-    @grow_phase(
-        name="residue_beats",
-        depends_on=["codewords", "choices", "hub_spokes", "mark_endings"],
-        priority=20,
-    )
+    @grow_phase(name="residue_beats", depends_on=["codewords"], priority=15)
     async def _phase_8d_residue_beats(self, graph: Graph, model: BaseChatModel) -> GrowPhaseResult:
         """Phase 8d: Propose and create residue beat variants at convergence points.
 
@@ -1050,9 +1046,6 @@ class _LLMPhaseMixin:
 
         Preconditions:
         - Codeword nodes exist (Phase 8b complete).
-        - Choice nodes and edges exist (Phase 8a-choices complete).
-        - Hub spokes wired (Phase 9a complete).
-        - Endings marked (Phase 9b complete).
         - Passage nodes exist with from_beat edges.
         - Arc convergence metadata computed (Phase 7 complete).
 
@@ -1177,7 +1170,7 @@ class _LLMPhaseMixin:
             tokens_used=tokens,
         )
 
-    @grow_phase(name="overlays", depends_on=["residue_beats"], priority=20)
+    @grow_phase(name="overlays", depends_on=["residue_beats"], priority=16)
     async def _phase_8c_overlays(self, graph: Graph, model: BaseChatModel) -> GrowPhaseResult:
         """Phase 8c: Create cosmetic entity overlays conditioned on codewords.
 

--- a/src/questfoundry/pipeline/stages/grow/llm_phases.py
+++ b/src/questfoundry/pipeline/stages/grow/llm_phases.py
@@ -1044,6 +1044,15 @@ class _LLMPhaseMixin:
         that should have path-specific prose variants. Each variant is gated by
         a codeword so FILL generates different prose per path.
 
+        .. warning:: Known timing issue (#955)
+           This phase runs at priority 15, before choices (17) and hub_spokes
+           (19). ``split_and_reroute()`` called from ``create_residue_passages()``
+           looks for ``choice_to`` edges that don't exist yet and returns empty.
+           Variant passages are created but never wired — effectively a no-op
+           for routing. Moving priority higher creates a dependency cycle
+           (residue_beats → choices → overlays → residue_beats). The strategic
+           fix (Epic #950, S2) will restructure this phase to be advisory-only.
+
         Preconditions:
         - Codeword nodes exist (Phase 8b complete).
         - Passage nodes exist with from_beat edges.

--- a/src/questfoundry/pipeline/stages/grow/llm_phases.py
+++ b/src/questfoundry/pipeline/stages/grow/llm_phases.py
@@ -1036,7 +1036,11 @@ class _LLMPhaseMixin:
     # Late LLM phases (codewords → validation)
     # -------------------------------------------------------------------------
 
-    @grow_phase(name="residue_beats", depends_on=["codewords"], priority=15)
+    @grow_phase(
+        name="residue_beats",
+        depends_on=["codewords", "choices", "hub_spokes", "mark_endings"],
+        priority=20,
+    )
     async def _phase_8d_residue_beats(self, graph: Graph, model: BaseChatModel) -> GrowPhaseResult:
         """Phase 8d: Propose and create residue beat variants at convergence points.
 
@@ -1046,6 +1050,9 @@ class _LLMPhaseMixin:
 
         Preconditions:
         - Codeword nodes exist (Phase 8b complete).
+        - Choice nodes and edges exist (Phase 8a-choices complete).
+        - Hub spokes wired (Phase 9a complete).
+        - Endings marked (Phase 9b complete).
         - Passage nodes exist with from_beat edges.
         - Arc convergence metadata computed (Phase 7 complete).
 
@@ -1170,7 +1177,7 @@ class _LLMPhaseMixin:
             tokens_used=tokens,
         )
 
-    @grow_phase(name="overlays", depends_on=["residue_beats"], priority=16)
+    @grow_phase(name="overlays", depends_on=["residue_beats"], priority=20)
     async def _phase_8c_overlays(self, graph: Graph, model: BaseChatModel) -> GrowPhaseResult:
         """Phase 8c: Create cosmetic entity overlays conditioned on codewords.
 

--- a/tests/unit/test_grow_algorithms.py
+++ b/tests/unit/test_grow_algorithms.py
@@ -5636,9 +5636,13 @@ class TestSplitEndingFamilies:
         graph = self._make_shared_ending_graph()
         split_ending_families(graph)
 
-        # Original incoming choices (c3, c4) should be deleted
-        assert graph.get_node("choice::c3") is None
-        assert graph.get_node("choice::c4") is None
+        # Original incoming choices (c3, c4) should be kept as fallbacks
+        # (keep_fallback=True per ADR-017)
+        assert graph.get_node("choice::c3") is not None
+        assert graph.get_node("choice::c4") is not None
+        # Fallback choices should NOT be marked is_routing
+        assert not graph.get_node("choice::c3").get("is_routing")
+        assert not graph.get_node("choice::c4").get("is_routing")
 
         # Routing choices should exist pointing to ending passages
         choices = graph.get_nodes_by_type("choice")

--- a/tests/unit/test_grow_validation.py
+++ b/tests/unit/test_grow_validation.py
@@ -2171,7 +2171,13 @@ def _make_shared_passage_graph(
     if add_routing:
         graph.create_node(
             "passage::v1",
-            {"type": "passage", "raw_id": "v1", "summary": "v1"},
+            {
+                "type": "passage",
+                "raw_id": "v1",
+                "summary": "v1",
+                "residue_for": "passage::shared",
+                "is_residue": True,
+            },
         )
         graph.create_node(
             "choice::r1",


### PR DESCRIPTION
## Summary

Five tactical fixes to unblock GROW routing failures, implementing Track 1 of Epic #950 (ADR-017).

These address 5 of the 8 bugs discovered during the multi-agent deliberation in [Discussion #948](https://github.com/pvliesdonk/questfoundry/discussions/948).

## Changes

### T1: Fix `routed_passages` semantic inversion (#951)
- `check_prose_neutrality()` and `find_heavy_divergence_targets()` built `routed_passages` from `from_passage` on routing choices — which is the *upstream source*, not the base passage that was split
- Now builds from `residue_for`/`family_codewords` metadata on variant passages
- **Primary driver of 680 `prose_neutrality` warnings in #933**

### T2: Fix `build_arc_codewords` codeword scope (#952)
- Renamed `_build_arc_codewords` → `build_arc_codewords` with `scope: Literal["ending", "routing", "all"]`
- `check_routing_coverage` now calls with `scope="routing"` to see heavy-residue codewords, not just high-salience

### T3: Switch `split_ending_families` to `keep_fallback=True` + fallback-aware CE (#953)
- Never use `keep_fallback=False` — it permanently destroys edges later phases need
- CE check now detects non-`is_routing` fallback choices and treats unmatched arcs as covered

### T4: Fix per-dilemma guard in `find_heavy_divergence_targets` (#954)
- Changed `processed_passages` from per-passage to per-(passage, dilemma) tracking
- Multi-dilemma routing no longer silently dropped

### T5: Document Phase 15 timing issue (#955)
- Phase 15 runs before choices exist (priority 15 < 17) — `split_and_reroute` is a no-op
- Cannot fix with priority change due to dependency cycle (`residue_beats → overlays → choices → residue_beats`)
- Documented as known issue; strategic fix in S2 will restructure phase to advisory-only

## Test changes
- Updated `test_split_ending_families_creates_routing_choices` to expect fallback kept (was: original deleted)
- Updated `_make_shared_passage_graph` to set `residue_for` metadata on variant passages

## Pre-existing failure
- `test_openai_provider_conforms` fails on main too — unrelated to these changes

Closes #951, #952, #953, #954
Refs: #950, #933, #955