### PR TITLE
refactor(grow): wire Phase 15 as advisory-only (S2, Epic #950)

### DIFF
--- a/src/questfoundry/graph/grow_routing.py
+++ b/src/questfoundry/graph/grow_routing.py
@@ -602,7 +602,7 @@ def get_residue_proposals(graph: Graph) -> list[dict[str, Any]]:
     node = graph.get_node(RESIDUE_PROPOSALS_NODE_ID)
     if node is None:
         return []
-    return node.get("proposals", [])
+    return list(node.get("proposals", []))
 
 
 def clear_residue_proposals(graph: Graph) -> None:

--- a/src/questfoundry/graph/grow_routing.py
+++ b/src/questfoundry/graph/grow_routing.py
@@ -576,15 +576,7 @@ def store_residue_proposals(
     Note:
         If proposals already exist (re-run), they are replaced.
     """
-    existing = graph.get_node(RESIDUE_PROPOSALS_NODE_ID)
-    if existing is not None:
-        graph.delete_node(RESIDUE_PROPOSALS_NODE_ID)
-        log.debug(
-            "Replaced existing residue proposals (%d proposals)",
-            len(existing.get("proposals", [])),
-        )
-
-    graph.create_node(
+    graph.upsert_node(
         RESIDUE_PROPOSALS_NODE_ID,
         {
             "type": "meta",
@@ -592,7 +584,7 @@ def store_residue_proposals(
             "proposals": proposals,
         },
     )
-    log.info("Stored %d residue proposals for routing plan", len(proposals))
+    log.info("stored_residue_proposals", count=len(proposals))
 
 
 def get_residue_proposals(graph: Graph) -> list[dict[str, Any]]:
@@ -621,9 +613,9 @@ def clear_residue_proposals(graph: Graph) -> None:
     Args:
         graph: The GROW graph.
     """
-    if graph.get_node(RESIDUE_PROPOSALS_NODE_ID) is not None:
-        graph.delete_node(RESIDUE_PROPOSALS_NODE_ID)
-        log.debug("Cleared residue proposals metadata")
+    if graph.has_node(RESIDUE_PROPOSALS_NODE_ID):
+        graph.delete_node(RESIDUE_PROPOSALS_NODE_ID, cascade=True)
+        log.debug("cleared_residue_proposals")
 
 
 def compute_routing_plan(

--- a/src/questfoundry/graph/grow_routing.py
+++ b/src/questfoundry/graph/grow_routing.py
@@ -549,6 +549,83 @@ def _compute_heavy_residue(
     return operations
 
 
+# ---------------------------------------------------------------------------
+# Proposal storage (Phase 15 advisory mode)
+# ---------------------------------------------------------------------------
+
+RESIDUE_PROPOSALS_NODE_ID = "meta::residue_proposals"
+
+
+def store_residue_proposals(
+    graph: Graph,
+    proposals: list[dict[str, Any]],
+) -> None:
+    """Store LLM residue proposals in the graph for later processing.
+
+    Phase 15 (residue_beats) calls this instead of create_residue_passages
+    when operating in advisory mode. The proposals are stored as a metadata
+    node and later consumed by compute_routing_plan().
+
+    Args:
+        graph: The GROW graph.
+        proposals: List of proposal dicts, each with keys:
+            - passage_id: Target passage for routing
+            - dilemma_id: Dilemma whose paths determine variants
+            - variants: List of {codeword_id, hint} dicts
+
+    Note:
+        If proposals already exist (re-run), they are replaced.
+    """
+    existing = graph.get_node(RESIDUE_PROPOSALS_NODE_ID)
+    if existing is not None:
+        graph.delete_node(RESIDUE_PROPOSALS_NODE_ID)
+        log.debug(
+            "Replaced existing residue proposals (%d proposals)",
+            len(existing.get("proposals", [])),
+        )
+
+    graph.create_node(
+        RESIDUE_PROPOSALS_NODE_ID,
+        {
+            "type": "meta",
+            "raw_id": "residue_proposals",
+            "proposals": proposals,
+        },
+    )
+    log.info("Stored %d residue proposals for routing plan", len(proposals))
+
+
+def get_residue_proposals(graph: Graph) -> list[dict[str, Any]]:
+    """Retrieve stored LLM residue proposals from the graph.
+
+    Called by compute_routing_plan() to include Phase 15 proposals
+    in the unified routing plan.
+
+    Args:
+        graph: The GROW graph.
+
+    Returns:
+        List of proposal dicts, or empty list if none stored.
+    """
+    node = graph.get_node(RESIDUE_PROPOSALS_NODE_ID)
+    if node is None:
+        return []
+    return node.get("proposals", [])
+
+
+def clear_residue_proposals(graph: Graph) -> None:
+    """Remove stored residue proposals after they've been processed.
+
+    Called by apply_routing_plan() after successfully applying the plan.
+
+    Args:
+        graph: The GROW graph.
+    """
+    if graph.get_node(RESIDUE_PROPOSALS_NODE_ID) is not None:
+        graph.delete_node(RESIDUE_PROPOSALS_NODE_ID)
+        log.debug("Cleared residue proposals metadata")
+
+
 def compute_routing_plan(
     graph: Graph,
     residue_proposals: list[dict[str, Any]] | None = None,

--- a/src/questfoundry/pipeline/stages/grow/llm_phases.py
+++ b/src/questfoundry/pipeline/stages/grow/llm_phases.py
@@ -1056,9 +1056,8 @@ class _LLMPhaseMixin:
         - Arc convergence metadata computed (Phase 7 complete).
 
         Postconditions:
-        - Variant passages created for accepted proposals (is_residue=True).
-        - Base passages preserved as fallback.
-        - Each variant has residue_codeword, residue_hint, residue_for metadata.
+        - LLM proposals stored in ``meta::residue_proposals`` graph node.
+        - No passage mutations performed; routing applied atomically by Phase 21 (``apply_routing_plan``).
 
         Invariants:
         - Only soft/flavor dilemma convergences considered.

--- a/tests/unit/test_grow_routing.py
+++ b/tests/unit/test_grow_routing.py
@@ -8,10 +8,15 @@ import pytest
 
 from questfoundry.graph.graph import Graph
 from questfoundry.graph.grow_routing import (
+    RESIDUE_PROPOSALS_NODE_ID,
+    RoutingKind,
     RoutingOperation,
     RoutingPlan,
     VariantPassageSpec,
+    clear_residue_proposals,
     compute_routing_plan,
+    get_residue_proposals,
+    store_residue_proposals,
 )
 
 # ---------------------------------------------------------------------------
@@ -606,3 +611,57 @@ class TestComputeRoutingPlan:
         assert plan.total_variants == 0
         assert len(plan.operations) == 0
         assert len(plan.conflicts) == 0
+
+
+class TestResidueProposalStorage:
+    """Tests for store/get/clear_residue_proposals functions."""
+
+    def test_store_and_retrieve_proposals(self):
+        """Store proposals, retrieve them, verify content."""
+        g = Graph.empty()
+        proposals = [
+            {"passage_id": "passage::p1", "dilemma_id": "dilemma::d1", "variants": []},
+            {
+                "passage_id": "passage::p2",
+                "dilemma_id": "dilemma::d2",
+                "variants": [{"codeword_id": "cw::c1", "hint": "test"}],
+            },
+        ]
+        store_residue_proposals(g, proposals)
+
+        retrieved = get_residue_proposals(g)
+        assert retrieved == proposals
+
+    def test_get_from_empty_graph_returns_empty_list(self):
+        """No proposals stored → empty list."""
+        g = Graph.empty()
+        assert get_residue_proposals(g) == []
+
+    def test_clear_proposals(self):
+        """Clear removes the proposals node."""
+        g = Graph.empty()
+        proposals = [{"passage_id": "p1", "dilemma_id": "d1", "variants": []}]
+        store_residue_proposals(g, proposals)
+        assert get_residue_proposals(g) == proposals
+
+        clear_residue_proposals(g)
+        assert get_residue_proposals(g) == []
+
+    def test_store_overwrites_existing(self):
+        """Second store overwrites first."""
+        g = Graph.empty()
+        store_residue_proposals(g, [{"passage_id": "p1", "dilemma_id": "d1", "variants": []}])
+        store_residue_proposals(g, [{"passage_id": "p2", "dilemma_id": "d2", "variants": []}])
+
+        retrieved = get_residue_proposals(g)
+        assert len(retrieved) == 1
+        assert retrieved[0]["passage_id"] == "p2"
+
+    def test_proposals_node_has_correct_type(self):
+        """Proposals stored in meta::residue_proposals node with correct type."""
+        g = Graph.empty()
+        store_residue_proposals(g, [{"passage_id": "p1", "dilemma_id": "d1", "variants": []}])
+
+        node = g.get_node(RESIDUE_PROPOSALS_NODE_ID)
+        assert node is not None
+        assert node["type"] == "meta"

--- a/tests/unit/test_grow_routing.py
+++ b/tests/unit/test_grow_routing.py
@@ -9,7 +9,6 @@ import pytest
 from questfoundry.graph.graph import Graph
 from questfoundry.graph.grow_routing import (
     RESIDUE_PROPOSALS_NODE_ID,
-    RoutingKind,
     RoutingOperation,
     RoutingPlan,
     VariantPassageSpec,

--- a/tests/unit/test_grow_stage.py
+++ b/tests/unit/test_grow_stage.py
@@ -3502,19 +3502,25 @@ class TestPhase8dResidueBeats:
         assert result.status == "completed"
         assert result.phase == "residue_beats"
         assert result.llm_calls == 1
-        assert "2 residue variants" in result.detail
-        assert "1 proposals" in result.detail
+        # S2 (ADR-017): Phase 15 now stores proposals for unified routing
+        # instead of creating variants directly
+        assert "Stored 1 residue proposals" in result.detail
 
-        # Verify variant passages exist
+        # Verify proposals are stored in graph metadata
+        from questfoundry.graph.grow_routing import get_residue_proposals
+
+        proposals = get_residue_proposals(graph)
+        assert len(proposals) == 1
+        assert proposals[0]["passage_id"] == "passage::aftermath"
+        assert proposals[0]["dilemma_id"] == "dilemma::approach"
+        assert len(proposals[0]["variants"]) == 2
+
+        # Verify variant passages do NOT exist yet (created by apply_routing_plan)
         fight_variant = graph.get_node("passage::aftermath__via_fight")
-        assert fight_variant is not None
-        assert fight_variant["is_residue"] is True
-        assert fight_variant["residue_codeword"] == "codeword::fight_committed"
+        assert fight_variant is None  # Not created until Phase 21
 
         talk_variant = graph.get_node("passage::aftermath__via_talk")
-        assert talk_variant is not None
-        assert talk_variant["is_residue"] is True
-        assert talk_variant["residue_codeword"] == "codeword::talk_committed"
+        assert talk_variant is None  # Not created until Phase 21
 
         # Base passage preserved
         base = graph.get_node("passage::aftermath")


### PR DESCRIPTION
## Summary

Phase 15 (residue_beats) no longer directly mutates the graph. This is **S2** of Epic #950, implementing the advisory-only LLM role from ADR-017.

**Stacked on:** PR #961 (S1: RoutingPlan dataclass)

## Changes

### Phase 15 behavior change
- **Before:** LLM proposes variants → `create_residue_passages()` mutates graph directly
- **After:** LLM proposes variants → `store_residue_proposals()` stores in meta node → unified routing phase (S3) will apply

### New helper functions in `grow_routing.py`
- `store_residue_proposals(graph, proposals)` — stores proposals in `meta::residue_proposals` node
- `get_residue_proposals(graph)` — retrieves for `compute_routing_plan()`
- `clear_residue_proposals(graph)` — cleanup after application

### Tests
- 5 new tests for proposal storage/retrieval
- Updated `test_phase_8d_creates_residue_variants` to verify proposals stored (not variants created)

## Benefits

1. **Fixes Phase 15 timing issue** (T5, #955) — phase no longer needs choices to exist since it doesn't call `split_and_reroute`
2. **Enables unified routing** — all routing decisions made in one place with global conflict detection
3. **Separates LLM advisory from structural mutation** — cleaner architecture per ADR-017

## What's next
- **S3** (#958): `apply_routing_plan()` + collapse Phases 21+23 — will consume stored proposals
- **S4** (#959): Validation alignment with plan metadata

Closes #957
Refs: #950, #955, ADR-017