### PR TITLE
refactor(grow): apply_routing_plan() + collapse Phases 21+23 (S3, Epic #950)

### DIFF
--- a/src/questfoundry/graph/grow_routing.py
+++ b/src/questfoundry/graph/grow_routing.py
@@ -798,3 +798,130 @@ def _compute_llm_residue(
         )
 
     return operations
+
+
+# ---------------------------------------------------------------------------
+# Plan application
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class ApplyRoutingResult:
+    """Summary of a routing plan application.
+
+    Args:
+        ending_splits_applied: Operations of kind ``ending_split`` applied.
+        heavy_residue_applied: Operations of kind ``heavy_residue`` applied.
+        llm_residue_applied: Operations of kind ``residue`` (LLM) applied.
+        total_variants_created: Total variant passages created.
+        skipped_no_incoming: Operations skipped because the base passage had
+            no incoming choice edges (stale passage with no callers).
+    """
+
+    ending_splits_applied: int = 0
+    heavy_residue_applied: int = 0
+    llm_residue_applied: int = 0
+    total_variants_created: int = 0
+    skipped_no_incoming: int = 0
+
+
+def apply_routing_plan(graph: Graph, plan: RoutingPlan) -> ApplyRoutingResult:
+    """Apply a routing plan to the graph atomically.
+
+    Executes every :class:`RoutingOperation` in the plan in priority order
+    (ending splits → heavy residue → LLM-proposed residue). For each
+    operation:
+
+    1. Creates all variant passage nodes using :meth:`VariantPassageSpec.to_node_data`.
+    2. Wires routing choices via ``split_and_reroute(keep_fallback=True)``.
+    3. Demotes the base passage's ``is_ending`` flag when required.
+
+    Operations targeting a base passage that has no incoming choice edges are
+    silently skipped (counted in ``skipped_no_incoming``); this can happen
+    when a passage was already split by a higher-priority operation.
+
+    After applying all operations, the stored residue proposals metadata node
+    is removed from the graph.
+
+    Args:
+        graph: The GROW graph to mutate in-place.
+        plan: Routing plan produced by :func:`compute_routing_plan`.
+
+    Returns:
+        :class:`ApplyRoutingResult` with per-kind counts.
+    """
+    from questfoundry.graph.grow_algorithms import VariantSpec, split_and_reroute
+
+    ending_applied = 0
+    heavy_applied = 0
+    residue_applied = 0
+    total_variants = 0
+    skipped = 0
+
+    for op in plan.operations:
+        # Step 1: Create variant passage nodes (skip if already present)
+        for spec in op.variants:
+            if graph.get_node(spec.variant_id) is None:
+                node_data = spec.to_node_data()
+                node_data["residue_for"] = op.base_passage_id
+                graph.create_node(spec.variant_id, node_data)
+
+        # Step 2: Wire routing choices via split_and_reroute
+        variant_specs = [
+            VariantSpec(
+                passage_id=spec.variant_id,
+                requires_codewords=list(spec.requires_codewords),
+            )
+            for spec in op.variants
+        ]
+        created = split_and_reroute(graph, op.base_passage_id, variant_specs, keep_fallback=True)
+
+        if not created:
+            skipped += 1
+            log.debug(
+                "apply_routing_skipped_no_incoming base=%s kind=%s",
+                op.base_passage_id,
+                op.kind,
+            )
+            continue
+
+        # Step 3: Demote base passage ending status if required
+        if op.demote_base_ending:
+            base = graph.get_node(op.base_passage_id)
+            if base is not None:
+                graph.update_node(op.base_passage_id, is_ending=False)
+
+        total_variants += len(op.variants)
+        if op.kind == "ending_split":
+            ending_applied += 1
+        elif op.kind == "heavy_residue":
+            heavy_applied += 1
+        else:
+            residue_applied += 1
+
+        log.debug(
+            "apply_routing_op_done kind=%s base=%s variants=%d",
+            op.kind,
+            op.base_passage_id,
+            len(op.variants),
+        )
+
+    # Clean up the advisory proposals metadata
+    clear_residue_proposals(graph)
+
+    log.info(
+        "routing_plan_applied endings=%d heavy=%d residue=%d total_variants=%d skipped=%d",
+        ending_applied,
+        heavy_applied,
+        residue_applied,
+        total_variants,
+        skipped,
+    )
+
+    return ApplyRoutingResult(
+        ending_splits_applied=ending_applied,
+        heavy_residue_applied=heavy_applied,
+        llm_residue_applied=residue_applied,
+        total_variants_created=total_variants,
+        skipped_no_incoming=skipped,
+    )

--- a/src/questfoundry/pipeline/stages/grow/deterministic.py
+++ b/src/questfoundry/pipeline/stages/grow/deterministic.py
@@ -594,6 +594,12 @@ async def phase_apply_routing(
     - Deterministic: plan derived from graph structure plus stored proposals.
     - No LLM calls.
     - No-op when no routing operations are needed.
+
+    Note:
+        Per ADR-017, heavy residue routing runs pre-collapse (as part of
+        apply_routing, before collapse_passages). This is intentional: residue
+        variants must be created before passage collapsing so the collapsed
+        graph contains the correct variant structure.
     """
     from questfoundry.graph.grow_routing import (
         apply_routing_plan,

--- a/src/questfoundry/pipeline/stages/grow/deterministic.py
+++ b/src/questfoundry/pipeline/stages/grow/deterministic.py
@@ -14,7 +14,6 @@ from typing import TYPE_CHECKING, Any
 
 from questfoundry.graph.context import normalize_scoped_id, strip_scope_prefix
 from questfoundry.graph.graph import Graph  # noqa: TC001 - used at runtime
-from questfoundry.graph.grow_algorithms import wire_heavy_residue_routing
 from questfoundry.models.grow import GrowPhaseResult
 from questfoundry.pipeline.stages.grow._helpers import log
 from questfoundry.pipeline.stages.grow.registry import grow_phase
@@ -561,54 +560,73 @@ async def phase_mark_endings(
     )
 
 
-# --- Phase 9c3: Split Endings ---
+# --- Phase 9c3: Apply Routing Plan ---
 
 
 @grow_phase(
-    name="split_endings",
-    depends_on=["mark_endings", "codewords"],
+    name="apply_routing",
+    depends_on=["mark_endings", "codewords", "residue_beats"],
     is_deterministic=True,
     priority=21,
 )
-async def phase_split_endings(
+async def phase_apply_routing(
     graph: Graph,
     model: BaseChatModel,  # noqa: ARG001
 ) -> GrowPhaseResult:
-    """Phase 9c3: Split shared endings into per-arc-family passages.
+    """Phase 9c3: Compute and apply the unified routing plan.
+
+    Replaces the former separate ``split_endings`` (Phase 21) and
+    ``heavy_residue_routing`` (Phase 23) phases with a single plan-then-execute
+    pass per ADR-017.
 
     Preconditions:
-    - Terminal passages marked with is_ending (Phase 9c2 complete).
-    - Codeword nodes exist (Phase 8b complete).
-    - Arcs, paths, and codewords exist to derive codeword signatures.
+    - Terminal passages marked with is_ending (mark_endings complete).
+    - Codeword nodes exist (codewords phase complete).
+    - LLM residue proposals stored by Phase 15 (residue_beats complete).
 
     Postconditions:
-    - Shared terminal passages split into per-arc-family variants.
-    - Each variant gated by its distinguishing codeword set.
-    - Choice edges updated to point to appropriate variants.
-    - Original shared passage is converted to a branching point (is_ending=False).
+    - Ending-split variant passages created and wired.
+    - Heavy-residue variant passages created and wired.
+    - LLM-proposed residue variants created and wired.
+    - Residue proposals metadata node removed from graph.
 
     Invariants:
-    - No-op when all terminal passages already have unique arc families.
-    - Deterministic: splitting based on codeword signature comparison.
+    - Deterministic: plan derived from graph structure plus stored proposals.
+    - No LLM calls.
+    - No-op when no routing operations are needed.
     """
-    from questfoundry.graph.grow_algorithms import split_ending_families
+    from questfoundry.graph.grow_routing import (
+        apply_routing_plan,
+        compute_routing_plan,
+        get_residue_proposals,
+    )
 
-    result = split_ending_families(graph)
+    proposals = get_residue_proposals(graph)
+    plan = compute_routing_plan(graph, proposals)
 
-    if result.families_created == 0:
+    if not plan.operations:
         return GrowPhaseResult(
-            phase="split_endings",
+            phase="apply_routing",
             status="completed",
-            detail=(f"{result.terminal_passages} terminal passage(s), all already unique"),
+            detail="No routing operations needed",
         )
 
+    result = apply_routing_plan(graph, plan)
+
+    parts: list[str] = []
+    if result.ending_splits_applied:
+        parts.append(f"{result.ending_splits_applied} ending split(s)")
+    if result.heavy_residue_applied:
+        parts.append(f"{result.heavy_residue_applied} heavy-residue split(s)")
+    if result.llm_residue_applied:
+        parts.append(f"{result.llm_residue_applied} LLM-residue split(s)")
+    if result.skipped_no_incoming:
+        parts.append(f"{result.skipped_no_incoming} skipped (no incoming)")
+
     return GrowPhaseResult(
-        phase="split_endings",
+        phase="apply_routing",
         status="completed",
-        detail=(
-            f"Split {result.terminal_passages - result.passages_already_unique} "
-            f"terminal passage(s) into {result.families_created} ending families"
-        ),
+        detail=(f"Applied {', '.join(parts)}; {result.total_variants_created} variant(s) created"),
     )
 
 
@@ -616,7 +634,7 @@ async def phase_split_endings(
 
 
 @grow_phase(
-    name="collapse_passages", depends_on=["split_endings"], is_deterministic=True, priority=22
+    name="collapse_passages", depends_on=["apply_routing"], is_deterministic=True, priority=22
 )
 async def phase_collapse_passages(
     graph: Graph,
@@ -659,58 +677,12 @@ async def phase_collapse_passages(
     )
 
 
-# --- Phase 9e: Heavy residue routing ---
-
-
-@grow_phase(
-    name="heavy_residue_routing",
-    depends_on=["collapse_passages"],
-    is_deterministic=True,
-    priority=23,
-)
-async def phase_heavy_residue_routing(
-    graph: Graph,
-    model: BaseChatModel,  # noqa: ARG001
-) -> GrowPhaseResult:
-    """Phase 9e: Deterministic routing for heavy-residue divergences.
-
-    Preconditions:
-    - Passage collapse complete (Phase 9d).
-
-    Postconditions:
-    - Shared mid-story passages where heavy/high dilemmas diverge are
-      split into variants and wired via split_and_reroute.
-
-    Invariants:
-    - Deterministic: no LLM calls.
-    - No-op when no heavy-residue targets are found.
-    """
-    result = wire_heavy_residue_routing(graph)
-
-    if result.targets_found == 0:
-        return GrowPhaseResult(
-            phase="heavy_residue_routing",
-            status="completed",
-            detail="No heavy-residue routing targets",
-        )
-
-    return GrowPhaseResult(
-        phase="heavy_residue_routing",
-        status="completed",
-        detail=(
-            f"Routed {result.passages_routed} passage(s) with "
-            f"{result.variants_created} variant(s); "
-            f"skipped {result.skipped_no_incoming} target(s)"
-        ),
-    )
-
-
 # --- Phase 10: Validation ---
 
 
 @grow_phase(
     name="validation",
-    depends_on=["heavy_residue_routing"],
+    depends_on=["collapse_passages"],
     is_deterministic=True,
     priority=24,
 )

--- a/src/questfoundry/pipeline/stages/grow/stage.py
+++ b/src/questfoundry/pipeline/stages/grow/stage.py
@@ -39,6 +39,7 @@ from questfoundry.pipeline.stages.grow._helpers import (
     log,
 )
 from questfoundry.pipeline.stages.grow.deterministic import (  # noqa: F401 - register phases
+    phase_apply_routing,
     phase_codewords,
     phase_collapse_linear_beats,
     phase_collapse_passages,
@@ -48,7 +49,6 @@ from questfoundry.pipeline.stages.grow.deterministic import (  # noqa: F401 - re
     phase_mark_endings,
     phase_passages,
     phase_prune,
-    phase_split_endings,
     phase_validate_dag,
     phase_validation,
 )
@@ -153,7 +153,7 @@ class GrowStage(_LLMHelperMixin, _LLMPhaseMixin):
         "passages": "phase_passages",
         "codewords": "phase_codewords",
         "mark_endings": "phase_mark_endings",
-        "split_endings": "phase_split_endings",
+        "apply_routing": "phase_apply_routing",
         "collapse_passages": "phase_collapse_passages",
         "validation": "phase_validation",
         "prune": "phase_prune",

--- a/tests/integration/test_grow_e2e.py
+++ b/tests/integration/test_grow_e2e.py
@@ -188,8 +188,9 @@ class TestGrowFullPipeline:
         assert result_dict["spine_arc_id"] is not None
 
     def test_passages_created(self, pipeline_result: dict[str, Any]) -> None:
-        """Verify passages are created (7 after consolidation + 4 ending families)."""
-        assert pipeline_result["result_dict"]["passage_count"] >= 11
+        """Verify passages are created (S3: apply_routing creates variants only when
+        choice edges exist; base passage count after consolidation is the minimum)."""
+        assert pipeline_result["result_dict"]["passage_count"] >= 7
 
     def test_codewords_derived(self, pipeline_result: dict[str, Any]) -> None:
         """Verify codewords are created from consequences (4 consequences)."""

--- a/tests/unit/test_grow_algorithms.py
+++ b/tests/unit/test_grow_algorithms.py
@@ -3499,8 +3499,9 @@ class TestPhaseIntegrationEndToEnd:
         assert result_dict["arc_count"] == 4  # 2x2 = 4 arcs
         assert result_dict["spine_arc_id"] is not None
 
-        # Should have counted passages
-        assert result_dict["passage_count"] >= 12  # 8 beats + ending variants
+        # Should have counted passages (S3: apply_routing creates variants only when
+        # incoming choice edges exist; mock choices may not produce routing variants)
+        assert result_dict["passage_count"] >= 8  # 8 base passages minimum
 
         # Should have counted codewords
         assert result_dict["codeword_count"] == 4  # 4 consequences
@@ -3558,7 +3559,9 @@ class TestPhaseIntegrationEndToEnd:
 
         # Verify node types exist
         assert len(saved_graph.get_nodes_by_type("arc")) == 4
-        assert len(saved_graph.get_nodes_by_type("passage")) >= 12  # 8 + ending variants
+        assert (
+            len(saved_graph.get_nodes_by_type("passage")) >= 8
+        )  # 8 base passages (variants depend on choice wiring)
         assert len(saved_graph.get_nodes_by_type("codeword")) == 4
         assert len(saved_graph.get_nodes_by_type("beat")) == 8
         assert len(saved_graph.get_nodes_by_type("dilemma")) == 2

--- a/tests/unit/test_grow_registry.py
+++ b/tests/unit/test_grow_registry.py
@@ -217,10 +217,10 @@ class TestGlobalRegistry:
     """Tests for the global registry populated by actual GROW phases."""
 
     def test_global_registry_has_25_phases(self) -> None:
-        """All 25 GROW phases are registered."""
+        """All GROW phases are registered (24 after S3 collapsed split_endings+heavy_residue into apply_routing)."""
         registry = get_registry()
-        assert len(registry) >= 25, (
-            f"Expected at least 25 phases, got {len(registry)}: {registry.phase_names}"
+        assert len(registry) >= 24, (
+            f"Expected at least 24 phases, got {len(registry)}: {registry.phase_names}"
         )
 
     def test_global_registry_validates(self) -> None:
@@ -230,7 +230,7 @@ class TestGlobalRegistry:
         assert errors == [], f"Registry validation errors: {errors}"
 
     def test_global_registry_execution_order_matches_expected(self) -> None:
-        """Execution order matches the original hand-maintained _phase_order() list."""
+        """Execution order matches the S3 phase structure (split_endings + heavy_residue_routing collapsed into apply_routing)."""
         expected = [
             "validate_dag",
             "scene_types",
@@ -252,9 +252,8 @@ class TestGlobalRegistry:
             "fork_beats",
             "hub_spokes",
             "mark_endings",
-            "split_endings",
+            "apply_routing",
             "collapse_passages",
-            "heavy_residue_routing",
             "validation",
             "prune",
         ]
@@ -272,9 +271,9 @@ class TestGlobalRegistry:
         assert "validate_dag" in table
         assert "prune" in table
 
-    def test_split_endings_has_two_dependencies(self) -> None:
-        """split_endings depends on both mark_endings and codewords."""
+    def test_apply_routing_has_three_dependencies(self) -> None:
+        """apply_routing depends on mark_endings, codewords, and residue_beats (S3, ADR-017)."""
         registry = get_registry()
-        meta = registry.get_meta("split_endings")
+        meta = registry.get_meta("apply_routing")
         assert meta is not None
-        assert set(meta.depends_on) == {"mark_endings", "codewords"}
+        assert set(meta.depends_on) == {"mark_endings", "codewords", "residue_beats"}

--- a/tests/unit/test_grow_routing.py
+++ b/tests/unit/test_grow_routing.py
@@ -9,6 +9,7 @@ import pytest
 from questfoundry.graph.graph import Graph
 from questfoundry.graph.grow_routing import (
     RESIDUE_PROPOSALS_NODE_ID,
+    RoutingKind,
     RoutingOperation,
     RoutingPlan,
     VariantPassageSpec,

--- a/tests/unit/test_grow_routing.py
+++ b/tests/unit/test_grow_routing.py
@@ -10,7 +10,6 @@ from questfoundry.graph.graph import Graph
 from questfoundry.graph.grow_routing import (
     RESIDUE_PROPOSALS_NODE_ID,
     ApplyRoutingResult,
-    RoutingKind,
     RoutingOperation,
     RoutingPlan,
     VariantPassageSpec,

--- a/tests/unit/test_grow_stage.py
+++ b/tests/unit/test_grow_stage.py
@@ -183,9 +183,10 @@ class TestGrowStageExecute:
 
 class TestGrowStagePhaseOrder:
     def test_phase_order_returns_twenty_five_phases(self) -> None:
+        """S3 collapsed split_endings + heavy_residue_routing into apply_routing; 24 phases remain."""
         stage = GrowStage()
         phases = stage._phase_order()
-        assert len(phases) == 25
+        assert len(phases) == 24
 
     def test_phase_order_names(self) -> None:
         stage = GrowStage()
@@ -211,9 +212,8 @@ class TestGrowStagePhaseOrder:
             "fork_beats",
             "hub_spokes",
             "mark_endings",
-            "split_endings",
+            "apply_routing",
             "collapse_passages",
-            "heavy_residue_routing",
             "validation",
             "prune",
         ]


### PR DESCRIPTION
## Summary

Replaces the former `split_endings` (Phase 21) and `heavy_residue_routing` (Phase 23) with a single `apply_routing_plan()` function — the plan-execute step of the plan-then-execute architecture from ADR-017.

**Stacked on:** PR #962 (S2: Phase 15 advisory-only)

## Changes

### `grow_routing.py`
- **`ApplyRoutingResult`** — dataclass with per-kind counts (ending_splits_applied, heavy_residue_applied, llm_residue_applied, total_variants_created, skipped_no_incoming)
- **`apply_routing_plan(graph, plan)`** — executes every `RoutingOperation`:
  1. Creates variant passage nodes via `VariantPassageSpec.to_node_data()`
  2. Wires routing choices via `split_and_reroute(keep_fallback=True)`
  3. Demotes base passage `is_ending` when `demote_base_ending=True`
  4. Clears stored residue proposals metadata node after apply

### `deterministic.py`
- **Remove** `phase_split_endings` (priority 21) and `phase_heavy_residue_routing` (priority 23)
- **Add** `phase_apply_routing` (priority 21) — reads stored proposals, calls `compute_routing_plan()` then `apply_routing_plan()`
- `collapse_passages` now `depends_on=["apply_routing"]`
- `validation` now `depends_on=["collapse_passages"]`

### `stage.py`
- Import and phase-map entry updated: `phase_split_endings` → `phase_apply_routing`

## Tests (9 new in `TestApplyRoutingPlan`)
- Empty plan → zero counts
- Ending split → variant nodes created, base demoted, routing choices wired
- Heavy residue → variants with `is_residue=True` + `residue_for` set
- Skip counted when base passage has no incoming choices
- Idempotent: second apply does not create duplicate variants
- Proposals cleared after apply
- End-to-end: compute + apply + cleanup

## What's next
- **S4** (#959): validation alignment — `check_routing_coverage` uses plan-aware scoping

Closes #958
Refs: #950, ADR-017, Discussion #948