### PR TITLE
refactor: rename sequenced_after → predecessor edge type

### DIFF
--- a/tests/fixtures/grow_fixtures.py
+++ b/tests/fixtures/grow_fixtures.py
@@ -161,9 +161,9 @@ def make_single_dilemma_graph() -> Graph:
     graph.add_edge("belongs_to", "beat::mentor_commits_alt", "path::mentor_trust_alt")
 
     # Beat ordering (requires edges): opening → mentor_meet → commits
-    graph.add_edge("sequenced_after", "beat::mentor_meet", "beat::opening")
-    graph.add_edge("sequenced_after", "beat::mentor_commits_canonical", "beat::mentor_meet")
-    graph.add_edge("sequenced_after", "beat::mentor_commits_alt", "beat::mentor_meet")
+    graph.add_edge("predecessor", "beat::mentor_meet", "beat::opening")
+    graph.add_edge("predecessor", "beat::mentor_commits_canonical", "beat::mentor_meet")
+    graph.add_edge("predecessor", "beat::mentor_commits_alt", "beat::mentor_meet")
 
     # Consequences
     graph.create_node(
@@ -363,19 +363,19 @@ def make_two_dilemma_graph() -> Graph:
 
     # Beat ordering (requires edges)
     # opening → mentor_meet, artifact_discover
-    graph.add_edge("sequenced_after", "beat::mentor_meet", "beat::opening")
-    graph.add_edge("sequenced_after", "beat::artifact_discover", "beat::opening")
+    graph.add_edge("predecessor", "beat::mentor_meet", "beat::opening")
+    graph.add_edge("predecessor", "beat::artifact_discover", "beat::opening")
     # mentor_meet → mentor_commits_*
-    graph.add_edge("sequenced_after", "beat::mentor_commits_canonical", "beat::mentor_meet")
-    graph.add_edge("sequenced_after", "beat::mentor_commits_alt", "beat::mentor_meet")
+    graph.add_edge("predecessor", "beat::mentor_commits_canonical", "beat::mentor_meet")
+    graph.add_edge("predecessor", "beat::mentor_commits_alt", "beat::mentor_meet")
     # artifact_discover → artifact_commits_*
-    graph.add_edge("sequenced_after", "beat::artifact_commits_canonical", "beat::artifact_discover")
-    graph.add_edge("sequenced_after", "beat::artifact_commits_alt", "beat::artifact_discover")
+    graph.add_edge("predecessor", "beat::artifact_commits_canonical", "beat::artifact_discover")
+    graph.add_edge("predecessor", "beat::artifact_commits_alt", "beat::artifact_discover")
     # commits → finale
-    graph.add_edge("sequenced_after", "beat::finale", "beat::mentor_commits_canonical")
-    graph.add_edge("sequenced_after", "beat::finale", "beat::mentor_commits_alt")
-    graph.add_edge("sequenced_after", "beat::finale", "beat::artifact_commits_canonical")
-    graph.add_edge("sequenced_after", "beat::finale", "beat::artifact_commits_alt")
+    graph.add_edge("predecessor", "beat::finale", "beat::mentor_commits_canonical")
+    graph.add_edge("predecessor", "beat::finale", "beat::mentor_commits_alt")
+    graph.add_edge("predecessor", "beat::finale", "beat::artifact_commits_canonical")
+    graph.add_edge("predecessor", "beat::finale", "beat::artifact_commits_alt")
 
     # Consequences
     for cons_id, path_id, desc in [
@@ -594,7 +594,7 @@ def make_e2e_fixture_graph() -> Graph:
         ("climax", "aq_corrupt"),
     ]
     for from_beat, to_beat in ordering:
-        graph.add_edge("sequenced_after", f"beat::{from_beat}", f"beat::{to_beat}")
+        graph.add_edge("predecessor", f"beat::{from_beat}", f"beat::{to_beat}")
 
     # Consequences
     for cons_id, path_id, desc in [
@@ -685,6 +685,6 @@ def make_conditional_prerequisite_graph() -> Graph:
     graph.add_edge("belongs_to", "beat::gap_1", "path::mentor_trust_canonical")
 
     # mentor_meet requires gap_1 (gap_1 must come first)
-    graph.add_edge("sequenced_after", "beat::mentor_meet", "beat::gap_1")
+    graph.add_edge("predecessor", "beat::mentor_meet", "beat::gap_1")
 
     return graph

--- a/tests/unit/test_fill_context.py
+++ b/tests/unit/test_fill_context.py
@@ -1656,7 +1656,7 @@ class TestFormatEntityArcContext:
                 "raw_id": "b2",
                 "summary": "Doubts surface",
                 "paths": ["path::trust__yes"],
-                "sequenced_after": ["beat::b1"],
+                "predecessor": ["beat::b1"],
                 "entities": ["entity::mentor", "entity::letter"],
             },
         )
@@ -1667,7 +1667,7 @@ class TestFormatEntityArcContext:
                 "raw_id": "b3",
                 "summary": "Revelation",
                 "paths": ["path::trust__yes"],
-                "sequenced_after": ["beat::b2"],
+                "predecessor": ["beat::b2"],
                 "entities": ["entity::mentor"],
             },
         )

--- a/tests/unit/test_grow_stage.py
+++ b/tests/unit/test_grow_stage.py
@@ -744,7 +744,7 @@ class TestPhase3Knots:
         assert "1 applied" in result.detail
 
     @pytest.mark.asyncio
-    async def test_phase_3_fails_with_sequenced_after_conflict(self) -> None:
+    async def test_phase_3_fails_with_predecessor_conflict(self) -> None:
         """Phase 3 fails when all intersections have requires dependency."""
         from questfoundry.models.grow import IntersectionProposal, Phase3Output
         from tests.fixtures.grow_fixtures import make_intersection_candidate_graph
@@ -753,7 +753,7 @@ class TestPhase3Knots:
         stage = GrowStage()
 
         # Add a cross-dilemma requires: artifact_discover requires mentor_meet
-        graph.add_edge("sequenced_after", "beat::artifact_discover", "beat::mentor_meet")
+        graph.add_edge("predecessor", "beat::artifact_discover", "beat::mentor_meet")
 
         phase3_output = Phase3Output(
             intersections=[
@@ -1185,8 +1185,8 @@ class TestPhase4cPacingGaps:
         graph.add_edge("belongs_to", "beat::b1", "path::main")
         graph.add_edge("belongs_to", "beat::b2", "path::main")
         graph.add_edge("belongs_to", "beat::b3", "path::main")
-        graph.add_edge("sequenced_after", "beat::b2", "beat::b1")
-        graph.add_edge("sequenced_after", "beat::b3", "beat::b2")
+        graph.add_edge("predecessor", "beat::b2", "beat::b1")
+        graph.add_edge("predecessor", "beat::b3", "beat::b2")
 
         stage = GrowStage()
 
@@ -1233,8 +1233,8 @@ class TestPhase4cPacingGaps:
         graph.add_edge("belongs_to", "beat::b1", "path::main")
         graph.add_edge("belongs_to", "beat::b2", "path::main")
         graph.add_edge("belongs_to", "beat::b3", "path::main")
-        graph.add_edge("sequenced_after", "beat::b2", "beat::b1")
-        graph.add_edge("sequenced_after", "beat::b3", "beat::b2")
+        graph.add_edge("predecessor", "beat::b2", "beat::b1")
+        graph.add_edge("predecessor", "beat::b3", "beat::b2")
 
         stage = GrowStage()
 
@@ -1278,8 +1278,8 @@ class TestPhase4cPacingGaps:
         graph.add_edge("belongs_to", "beat::b1", "path::main")
         graph.add_edge("belongs_to", "beat::b2", "path::main")
         graph.add_edge("belongs_to", "beat::b3", "path::main")
-        graph.add_edge("sequenced_after", "beat::b2", "beat::b1")
-        graph.add_edge("sequenced_after", "beat::b3", "beat::b2")
+        graph.add_edge("predecessor", "beat::b2", "beat::b1")
+        graph.add_edge("predecessor", "beat::b3", "beat::b2")
 
         stage = GrowStage()
         mock_model = MagicMock()
@@ -1771,8 +1771,8 @@ class TestPhase9Choices:
         graph.create_node("beat::a", {"type": "beat", "raw_id": "a", "summary": "Start"})
         graph.create_node("beat::b", {"type": "beat", "raw_id": "b", "summary": "Middle"})
         graph.create_node("beat::c", {"type": "beat", "raw_id": "c", "summary": "End"})
-        graph.add_edge("sequenced_after", "beat::b", "beat::a")
-        graph.add_edge("sequenced_after", "beat::c", "beat::b")
+        graph.add_edge("predecessor", "beat::b", "beat::a")
+        graph.add_edge("predecessor", "beat::c", "beat::b")
 
         # Create arc with sequence
         graph.create_node(
@@ -1851,7 +1851,7 @@ class TestPhase9Choices:
         graph = Graph.empty()
         graph.create_node("beat::a", {"type": "beat", "raw_id": "a", "summary": "Start"})
         graph.create_node("beat::b", {"type": "beat", "raw_id": "b", "summary": "End"})
-        graph.add_edge("sequenced_after", "beat::b", "beat::a")
+        graph.add_edge("predecessor", "beat::b", "beat::a")
 
         graph.create_node(
             "arc::spine",
@@ -2119,7 +2119,7 @@ class TestPhase9Choices:
         graph = Graph.empty()
         graph.create_node("beat::a", {"type": "beat", "raw_id": "a", "summary": "Start"})
         graph.create_node("beat::b", {"type": "beat", "raw_id": "b", "summary": "Commit"})
-        graph.add_edge("sequenced_after", "beat::b", "beat::a")
+        graph.add_edge("predecessor", "beat::b", "beat::a")
 
         # beat::b grants a codeword
         graph.create_node(
@@ -2195,8 +2195,8 @@ class TestPhase9Choices:
             "beat::path2_end", {"type": "beat", "raw_id": "path2_end", "summary": "End path 2"}
         )
 
-        graph.add_edge("sequenced_after", "beat::path1_end", "beat::path1_start")
-        graph.add_edge("sequenced_after", "beat::path2_end", "beat::path2_start")
+        graph.add_edge("predecessor", "beat::path1_end", "beat::path1_start")
+        graph.add_edge("predecessor", "beat::path2_end", "beat::path2_start")
 
         # Arc 1: path1_start → path1_end
         graph.create_node(

--- a/tests/unit/test_grow_validation.py
+++ b/tests/unit/test_grow_validation.py
@@ -561,7 +561,7 @@ def _make_timing_graph_with_arc(
         )
         graph.add_edge("belongs_to", beat_id, "path::th1")
         if i > 0:
-            graph.add_edge("sequenced_after", beat_id, f"beat::b{i - 1}")
+            graph.add_edge("predecessor", beat_id, f"beat::b{i - 1}")
 
     # Arc with the beat sequence
     graph.create_node(
@@ -887,8 +887,8 @@ class TestRunAllChecks:
         graph.add_edge("belongs_to", "beat::b0", "path::th1")
         graph.add_edge("belongs_to", "beat::b1", "path::th1")
         graph.add_edge("belongs_to", "beat::b2", "path::th1")
-        graph.add_edge("sequenced_after", "beat::b1", "beat::b0")
-        graph.add_edge("sequenced_after", "beat::b2", "beat::b1")
+        graph.add_edge("predecessor", "beat::b1", "beat::b0")
+        graph.add_edge("predecessor", "beat::b2", "beat::b1")
         # Update existing spine arc to include the test path and its beats
         graph.update_node(
             "arc::spine",
@@ -1006,8 +1006,8 @@ class TestPhase10Integration:
         graph.add_edge("belongs_to", "beat::b0", "path::th1")
         graph.add_edge("belongs_to", "beat::b1", "path::th1")
         graph.add_edge("belongs_to", "beat::b2", "path::th1")
-        graph.add_edge("sequenced_after", "beat::b1", "beat::b0")
-        graph.add_edge("sequenced_after", "beat::b2", "beat::b1")
+        graph.add_edge("predecessor", "beat::b1", "beat::b0")
+        graph.add_edge("predecessor", "beat::b2", "beat::b1")
         # Update existing spine arc to include the test path and its beats
         graph.update_node(
             "arc::spine",


### PR DESCRIPTION
## Summary
- Renames `sequenced_after` edge type to `predecessor` across the codebase (107 occurrences in 6 source files)
- Aligns with Document 3 ontology terminology where `predecessor` is the canonical edge name (Beat → Beat)
- No behavioral change — pure 1:1 rename with same semantics

**Stack**: 1/5 for Phase 1 of #990
**Next**: #984 (dilemma_role, is_canonical, anchored_to)

## Test plan
- [x] All 671 unit tests pass
- [x] mypy clean
- [x] ruff clean

Closes #992

🤖 Generated with [Claude Code](https://claude.com/claude-code)