### PR TITLE
feat: add temporal_hint field to InitialBeat model

### DIFF
--- a/prompts/templates/serialize_seed_sections.yaml
+++ b/prompts/templates/serialize_seed_sections.yaml
@@ -608,16 +608,16 @@ per_path_beats_prompt: |
         ],
         "entities": ["character::character_id"],
         "location": "location::location_id",
-        "location_alternatives": [],
-        "temporal_hint": null
+        "location_alternatives": []
       }}
     ]
   }}
   ```
 
-  NOTE: `temporal_hint` is optional (null or omit entirely). Only include it
-  when this beat must be placed relative to ANOTHER dilemma's key moment.
-  Format: `{{"relative_to": "dilemma::other_dilemma_id", "position": "before_commit"}}`
+  NOTE: `temporal_hint` is optional — omit the field entirely for most beats.
+  Only include it when this beat must be placed relative to ANOTHER dilemma's
+  key moment. When used:
+  `{{"temporal_hint": {{"relative_to": "dilemma::other_dilemma_id", "position": "before_commit"}}}}`
   Valid positions: `before_commit`, `after_commit`, `before_introduce`, `after_introduce`
 
   ## Rules

--- a/prompts/templates/serialize_seed_sections.yaml
+++ b/prompts/templates/serialize_seed_sections.yaml
@@ -422,7 +422,11 @@ beats_prompt: |
         ],
         "entities": ["character::[character_id]", "location::[location_id]"],
         "location": "location::[location_id]",
-        "location_alternatives": ["location::[other_location]"]
+        "location_alternatives": ["location::[other_location]"],
+        "temporal_hint": {
+          "relative_to": "dilemma::[other_dilemma_id]",
+          "position": "before_commit"
+        }
       }
     ]
   }
@@ -436,6 +440,12 @@ beats_prompt: |
   - location can be null; location_alternatives can be empty array
   - Generate 2-4 beats for EACH path in the VALID PATH IDs list
   - dilemma_impacts MUST use dilemma IDs from the Dilemma IDs list — NOT entity names
+  - temporal_hint is OPTIONAL — only include it when a beat's placement relative to
+    ANOTHER dilemma matters. Most beats don't need one. When used:
+    - `relative_to` must be a dilemma ID different from the beat's own parent dilemma
+    - `position` must be: `before_commit`, `after_commit`, `before_introduce`, or `after_introduce`
+    - Example: a beat that sets up context needed before another dilemma's commit point
+      would use `"position": "before_commit"` with that dilemma's ID
 
   ## DILEMMA IMPACT CONSTRAINT (MOST IMPORTANT RULE)
 
@@ -598,11 +608,17 @@ per_path_beats_prompt: |
         ],
         "entities": ["character::character_id"],
         "location": "location::location_id",
-        "location_alternatives": []
+        "location_alternatives": [],
+        "temporal_hint": null
       }}
     ]
   }}
   ```
+
+  NOTE: `temporal_hint` is optional (null or omit entirely). Only include it
+  when this beat must be placed relative to ANOTHER dilemma's key moment.
+  Format: `{{"relative_to": "dilemma::other_dilemma_id", "position": "before_commit"}}`
+  Valid positions: `before_commit`, `after_commit`, `before_introduce`, `after_introduce`
 
   ## Rules
   - Generate exactly 2-4 beats for path `{path_id}`

--- a/src/questfoundry/graph/mutations.py
+++ b/src/questfoundry/graph/mutations.py
@@ -1777,10 +1777,10 @@ def apply_seed_mutations(graph: Graph, output: dict[str, Any]) -> None:
         # Resolve temporal_hint (prefix dilemma reference)
         raw_hint = beat.get("temporal_hint")
         prefixed_hint = None
-        if isinstance(raw_hint, dict) and raw_hint.get("relative_to"):
+        if isinstance(raw_hint, dict) and raw_hint.get("relative_to") and raw_hint.get("position"):
             prefixed_hint = {
                 "relative_to": _prefix_id("dilemma", raw_hint["relative_to"]),
-                "position": raw_hint.get("position"),
+                "position": raw_hint["position"],
             }
 
         beat_data = {

--- a/src/questfoundry/graph/mutations.py
+++ b/src/questfoundry/graph/mutations.py
@@ -1774,6 +1774,15 @@ def apply_seed_mutations(graph: Graph, output: dict[str, Any]) -> None:
                 prefixed_impact["dilemma_id"] = _prefix_id("dilemma", impact["dilemma_id"])
             prefixed_impacts.append(prefixed_impact)
 
+        # Resolve temporal_hint (prefix dilemma reference)
+        raw_hint = beat.get("temporal_hint")
+        prefixed_hint = None
+        if isinstance(raw_hint, dict) and raw_hint.get("relative_to"):
+            prefixed_hint = {
+                "relative_to": _prefix_id("dilemma", raw_hint["relative_to"]),
+                "position": raw_hint.get("position"),
+            }
+
         beat_data = {
             "type": "beat",
             "raw_id": raw_id,
@@ -1782,6 +1791,7 @@ def apply_seed_mutations(graph: Graph, output: dict[str, Any]) -> None:
             "entities": prefixed_entities,
             "location": prefixed_location,
             "location_alternatives": prefixed_location_alts,
+            "temporal_hint": prefixed_hint,
         }
         beat_data = _clean_dict(beat_data)
         graph.create_node(beat_id, beat_data)

--- a/src/questfoundry/models/__init__.py
+++ b/src/questfoundry/models/__init__.py
@@ -111,6 +111,8 @@ from questfoundry.models.seed import (
     PathTier,
     ResidueWeight,
     SeedOutput,
+    TemporalHint,
+    TemporalPosition,
 )
 
 __all__ = [
@@ -199,5 +201,7 @@ __all__ = [
     "SpokeLabelStyle",
     "SpokeLabelUpdate",
     "SpokeProposal",
+    "TemporalHint",
+    "TemporalPosition",
     "VoiceDocument",
 ]

--- a/tests/unit/test_mutations.py
+++ b/tests/unit/test_mutations.py
@@ -1261,6 +1261,141 @@ class TestSeedMutations:
         assert len(edges) == 1
         assert edges[0]["to"] == "path::path_mentor_trust"
 
+    def test_temporal_hint_stored_on_beat(self) -> None:
+        """Temporal hint is stored on beat node with prefixed dilemma ID."""
+        graph = Graph.empty()
+        graph.create_node(
+            "entity::kay", {"type": "entity", "raw_id": "kay", "concept": "Archivist"}
+        )
+        graph.create_node(
+            "dilemma::mentor_trust",
+            {"type": "dilemma", "raw_id": "mentor_trust", "question": "Trust?"},
+        )
+        # fight_or_flee: referenced by temporal_hint, must also be a brainstorm dilemma
+        graph.create_node(
+            "dilemma::fight_or_flee",
+            {"type": "dilemma", "raw_id": "fight_or_flee", "question": "Fight?"},
+        )
+        graph.create_node(
+            "dilemma::mentor_trust::alt::protector",
+            {"type": "answer", "raw_id": "protector", "description": "Protects"},
+        )
+        graph.add_edge(
+            "has_answer", "dilemma::mentor_trust", "dilemma::mentor_trust::alt::protector"
+        )
+        graph.create_node(
+            "dilemma::fight_or_flee::alt::fight",
+            {"type": "answer", "raw_id": "fight", "description": "Fights"},
+        )
+        graph.add_edge("has_answer", "dilemma::fight_or_flee", "dilemma::fight_or_flee::alt::fight")
+
+        output = {
+            "entities": [{"entity_id": "kay", "disposition": "retained"}],
+            "dilemmas": [
+                {"dilemma_id": "mentor_trust", "explored": ["protector"], "unexplored": []},
+                {"dilemma_id": "fight_or_flee", "explored": ["fight"], "unexplored": []},
+            ],
+            "paths": [
+                {
+                    "path_id": "path_mentor_trust",
+                    "name": "Trust Arc",
+                    "dilemma_id": "mentor_trust",
+                    "answer_id": "protector",
+                    "description": "The mentor trust path",
+                },
+                {
+                    "path_id": "path_fight",
+                    "name": "Fight Arc",
+                    "dilemma_id": "fight_or_flee",
+                    "answer_id": "fight",
+                    "description": "The fight path",
+                },
+            ],
+            "initial_beats": [
+                {
+                    "beat_id": "opening_001",
+                    "summary": "Kay meets the mentor",
+                    "paths": ["path_mentor_trust"],
+                    "dilemma_impacts": [
+                        {"dilemma_id": "mentor_trust", "effect": "commits", "note": "Locked"}
+                    ],
+                    "entities": ["kay"],
+                    "temporal_hint": {
+                        "relative_to": "fight_or_flee",
+                        "position": "before_commit",
+                    },
+                },
+                {
+                    "beat_id": "fight_001",
+                    "summary": "Kay prepares for battle",
+                    "paths": ["path_fight"],
+                    "dilemma_impacts": [
+                        {"dilemma_id": "fight_or_flee", "effect": "commits", "note": "Engaged"}
+                    ],
+                    "entities": ["kay"],
+                },
+            ],
+        }
+
+        apply_seed_mutations(graph, output)
+
+        beat = graph.get_node("beat::opening_001")
+        assert beat["temporal_hint"] == {
+            "relative_to": "dilemma::fight_or_flee",
+            "position": "before_commit",
+        }
+
+    def test_temporal_hint_absent_not_stored(self) -> None:
+        """Beat without temporal_hint does not have the key in node data."""
+        graph = Graph.empty()
+        graph.create_node(
+            "entity::kay", {"type": "entity", "raw_id": "kay", "concept": "Archivist"}
+        )
+        graph.create_node(
+            "dilemma::mentor_trust",
+            {"type": "dilemma", "raw_id": "mentor_trust", "question": "Trust?"},
+        )
+        graph.create_node(
+            "dilemma::mentor_trust::alt::protector",
+            {"type": "answer", "raw_id": "protector", "description": "Protects"},
+        )
+        graph.add_edge(
+            "has_answer", "dilemma::mentor_trust", "dilemma::mentor_trust::alt::protector"
+        )
+
+        output = {
+            "entities": [{"entity_id": "kay", "disposition": "retained"}],
+            "dilemmas": [
+                {"dilemma_id": "mentor_trust", "explored": ["protector"], "unexplored": []},
+            ],
+            "paths": [
+                {
+                    "path_id": "path_mentor_trust",
+                    "name": "Trust Arc",
+                    "dilemma_id": "mentor_trust",
+                    "answer_id": "protector",
+                    "description": "The mentor trust path",
+                }
+            ],
+            "initial_beats": [
+                {
+                    "beat_id": "opening_001",
+                    "summary": "Kay meets the mentor",
+                    "paths": ["path_mentor_trust"],
+                    "dilemma_impacts": [
+                        {"dilemma_id": "mentor_trust", "effect": "commits", "note": "Locked"}
+                    ],
+                    "entities": ["kay"],
+                },
+            ],
+        }
+
+        apply_seed_mutations(graph, output)
+
+        beat = graph.get_node("beat::opening_001")
+        # _clean_dict removes None values, so temporal_hint should not be present
+        assert "temporal_hint" not in beat
+
     def test_validates_missing_entities(self) -> None:
         """Raises SeedMutationError when referencing non-existent entities."""
         graph = Graph.empty()


### PR DESCRIPTION
## Summary
- Adds `TemporalHint` model with `relative_to` (dilemma ID) and `position` (before/after commit/introduce)
- Adds `TemporalPosition` literal type for the 4 valid positions
- Adds `temporal_hint: TemporalHint | None` field to `InitialBeat`
- mutations.py: Stores temporal_hint on beat nodes with prefixed dilemma references
- Prompt templates: Adds schema examples and usage guidance for both Section 5 and 5b
- Exports new types from `models/__init__.py`

**Stack**: 5/5 for Phase 1 of #990 (stacked on #1027)

## Test plan
- [x] All unit tests pass (335 seed/mutation tests, 2489 total)
- [x] mypy clean
- [x] ruff clean
- [x] New tests: TemporalHint validation (4 positions, empty rejection), InitialBeat.temporal_hint (default None, roundtrip, null)
- [x] New mutation tests: temporal_hint stored with prefixed dilemma, absent hint not stored

Closes #1001

🤖 Generated with [Claude Code](https://claude.com/claude-code)