### PR TITLE
fix: store Entity.name in brainstorm mutations, remove is_protagonist

### DIFF
--- a/prompts/templates/serialize_brainstorm.yaml
+++ b/prompts/templates/serialize_brainstorm.yaml
@@ -23,7 +23,6 @@ system: |
     name was established - SEED will generate one. Do NOT just title-case the entity_id.
   - `concept`: One-line essence from the brief
   - `notes`: Optional additional context from the brief
-  - `is_protagonist`: true for ONE character if story has defined protagonist (default: false)
 
   ## Dilemma Structure
 

--- a/src/questfoundry/graph/fill_context.py
+++ b/src/questfoundry/graph/fill_context.py
@@ -1047,10 +1047,7 @@ def format_pov_context(graph: Graph) -> str:
         if pov_style:
             lines.append(f"**Suggested POV:** {pov_style}")
         if vision.get("protagonist_defined"):
-            lines.append("**Protagonist Defined:** Yes")
-
-    if vision_nodes and next(iter(vision_nodes.values())).get("protagonist_defined"):
-        lines.append("\n**Protagonist:** Defined (see character entities)")
+            lines.append("**Protagonist:** Defined (see character entities)")
 
     return "\n".join(lines) if lines else ""
 
@@ -1058,9 +1055,8 @@ def format_pov_context(graph: Graph) -> str:
 def format_valid_characters(graph: Graph) -> str:
     """Format valid character entities for POV selection in discuss phase.
 
-    Lists all character entities by raw_id with their concept,
-    highlighting the protagonist if defined. This prevents the LLM from
-    inventing phantom characters during voice determination.
+    Lists all character entities by raw_id with their concept. This prevents
+    the LLM from inventing phantom characters during voice determination.
 
     Note: Assumes all character entities have raw_id field (guaranteed by
     SEED stage). Falls back to scope-stripped entity ID if missing.

--- a/src/questfoundry/graph/mutations.py
+++ b/src/questfoundry/graph/mutations.py
@@ -708,36 +708,6 @@ def validate_brainstorm_mutations(output: dict[str, Any]) -> list[BrainstormVali
                 )
             )
 
-    # 4. Validate is_protagonist constraints
-    protagonist_count = 0
-    protagonist_indices: list[int] = []
-    for i, entity in enumerate(entities):
-        if entity.get("is_protagonist"):
-            protagonist_count += 1
-            protagonist_indices.append(i)
-            # is_protagonist only valid for character entities
-            entity_category = entity.get("entity_category", "")
-            if entity_category != "character":
-                errors.append(
-                    BrainstormValidationError(
-                        field_path=f"entities.{i}.is_protagonist",
-                        issue=f"is_protagonist=true only valid for character entities, not '{entity_category}'",
-                        available=["character"],
-                        provided=entity_category,
-                    )
-                )
-
-    # At most one protagonist allowed
-    if protagonist_count > 1:
-        errors.append(
-            BrainstormValidationError(
-                field_path="entities",
-                issue=f"Multiple protagonists defined ({protagonist_count} at indices {protagonist_indices}). Only one character can be the protagonist.",
-                available=[],
-                provided=str(protagonist_count),
-            )
-        )
-
     return errors
 
 
@@ -875,6 +845,7 @@ def apply_brainstorm_mutations(graph: Graph, output: dict[str, Any]) -> None:
         node_data = {
             "type": "entity",
             "raw_id": raw_id,
+            "name": entity.get("name"),
             "category": category,  # Store category for easy access
             "entity_type": category,  # Backwards compat: some code still uses entity_type
             "concept": entity.get("concept"),

--- a/src/questfoundry/models/brainstorm.py
+++ b/src/questfoundry/models/brainstorm.py
@@ -51,10 +51,6 @@ class Entity(BaseModel):
     )
     concept: str = Field(min_length=1, description="One-line essence of the entity")
     notes: str | None = Field(default=None, description="Freeform notes from discussion")
-    is_protagonist: bool = Field(
-        default=False,
-        description="True if this character is the primary POV character (only valid for characters)",
-    )
 
 
 class Answer(BaseModel):


### PR DESCRIPTION
## Summary

- **#1010**: `apply_brainstorm_mutations()` now stores `Entity.name` on graph nodes. Previously the name field was silently discarded, meaning names assigned during brainstorming were lost until SEED re-assigned them.
- **#1011**: Removed `Entity.is_protagonist` field entirely. It was validated but never stored in the graph, making all `fill_context.py` protagonist detection dead code. The FILL discuss phase determines the protagonist from character entities instead.

## Changes

| File | Change |
|------|--------|
| `models/brainstorm.py` | Remove `is_protagonist` field from `Entity` |
| `mutations.py` | Add `name` to brainstorm entity `node_data`; remove `is_protagonist` validation block |
| `fill_context.py` | Remove dead `is_protagonist` lookups from `format_pov_context`, `format_valid_characters`, `get_path_pov_character` |
| `serialize_brainstorm.yaml` | Remove `is_protagonist` from prompt instructions |
| Tests | Add `test_stores_entity_name`; remove 3 protagonist validation tests; update fill_context tests |

Net: **-166 lines** (50 added, 216 removed)

## Test plan

- [x] `uv run pytest tests/unit/test_mutations.py -x -q` — 184 passed
- [x] `uv run pytest tests/unit/test_fill_context.py -x -q` — 192 passed
- [x] `uv run mypy src/` + `ruff check` — clean
- [x] No remaining `is_protagonist` references in codebase

Closes #1010
Closes #1011

🤖 Generated with [Claude Code](https://claude.com/claude-code)