### PR TITLE
fix: enforce singular path ownership on InitialBeat

### DIFF
--- a/prompts/templates/serialize_seed_sections.yaml
+++ b/prompts/templates/serialize_seed_sections.yaml
@@ -380,7 +380,7 @@ beats_prompt: |
   ## CRITICAL: ID CONSTRAINTS (read first!)
 
   The brief contains valid ID lists. You MUST copy IDs exactly from these lists:
-  - `## VALID PATH IDs` - use ONLY these in `paths` arrays
+  - `## VALID PATH IDs` - use ONLY these in `path_id` field
   - `### Entity IDs` - use ONLY these in `entities` and `location` fields
 
   ## PATH ID vs DILEMMA ID: THE CRITICAL DISTINCTION
@@ -390,8 +390,8 @@ beats_prompt: |
   - **Dilemma IDs** are BINARY questions: `dilemma::subject_optionA_or_optionB` (contains `_or_`)
   - **Entity IDs** have CATEGORY prefix: `character::name`, `location::place`, `object::item`
 
-  WRONG: Using `dilemma::...` in the `paths[]` field
-  RIGHT: Using `path::...` in the `paths[]` field
+  WRONG: Using `dilemma::...` in the `path_id` field
+  RIGHT: Using `path::...` in the `path_id` field
 
   WRONG: Using `path::...` in the `dilemma_impacts.dilemma_id` field
   RIGHT: Using `dilemma::...` in the `dilemma_impacts.dilemma_id` field
@@ -412,7 +412,7 @@ beats_prompt: |
       {
         "beat_id": "unique_beat_id",
         "summary": "What happens in this beat",
-        "paths": ["path::[your_path_id]", "path::[another_path]"],
+        "path_id": "path::[your_path_id]",
         "dilemma_impacts": [
           {
             "dilemma_id": "dilemma::[your_dilemma_id]",
@@ -486,7 +486,7 @@ beats_prompt: |
 
   | Field | Prefix | Source List | Shape |
   |-------|--------|-------------|-------|
-  | `paths[]` | `path::` | VALID PATH IDs | hierarchical: `dilemma__answer` |
+  | `path_id` | `path::` | VALID PATH IDs | hierarchical: `dilemma__answer` |
   | `dilemma_impacts.dilemma_id` | `dilemma::` | Dilemma IDs | long: `subject_X_or_Y` |
   | `entities[]` | `character::`, `object::`, `faction::` | Entity IDs (non-locations) | varies |
   | `location` | `location::` | Entity IDs (locations only) | varies |
@@ -520,10 +520,10 @@ beats_prompt: |
 
   ## FINAL CHECK (verify before output)
   Before returning JSON, check each beat one by one:
-  1. Every `paths` item appears in VALID PATH IDs (hierarchical format)
+  1. Every `path_id` appears in VALID PATH IDs (hierarchical format)
   2. Every `dilemma_impacts.dilemma_id` appears in Dilemma IDs (long binary questions)
   3. Every `dilemma_impacts.dilemma_id` contains `_or_` — if it doesn't, you used an entity ID by mistake
-  4. For EACH beat: look up the beat's path in PATH → DILEMMA MAPPING.
+  4. For EACH beat: look up the beat's `path_id` in PATH → DILEMMA MAPPING.
      Does the beat's dilemma_impacts include that mapped dilemma? If NO, fix it.
   5. For EACH path: does at least one of its beats have `effect: "commits"`
      with that path's parent dilemma? If NO, add or fix one.
@@ -544,7 +544,7 @@ per_path_beats_prompt: |
 
   You are generating beats for path: `{path_id}`
 
-  The `paths` field in EVERY beat MUST contain EXACTLY: `["{path_id}"]`
+  The `path_id` field in EVERY beat MUST be EXACTLY: `"{path_id}"`
 
   ## COMMON MISTAKE - DO NOT MAKE THIS ERROR
 
@@ -553,21 +553,21 @@ per_path_beats_prompt: |
 
   WRONG OUTPUT (will fail validation):
   ```json
-  "paths": ["{dilemma_id}"]  // WRONG! This is a DILEMMA ID
+  "path_id": "{dilemma_id}"  // WRONG! This is a DILEMMA ID
   ```
 
   CORRECT OUTPUT:
   ```json
-  "paths": ["{path_id}"]  // RIGHT! This is the PATH ID
+  "path_id": "{path_id}"  // RIGHT! This is the PATH ID
   ```
 
-  RULE: Dilemma IDs go in `dilemma_impacts[].dilemma_id`, never in `paths`.
+  RULE: Dilemma IDs go in `dilemma_impacts[].dilemma_id`, never in `path_id`.
 
   ## YOUR DILEMMA ID (for dilemma_impacts only)
 
   Parent dilemma: `{dilemma_id}`
 
-  This goes in `dilemma_impacts[].dilemma_id`, NOT in `paths`.
+  This goes in `dilemma_impacts[].dilemma_id`, NOT in `path_id`.
 
   ## BEAT ID NAMING (CRITICAL - ensures uniqueness)
 
@@ -586,7 +586,7 @@ per_path_beats_prompt: |
 
   ALL beats you generate MUST:
   1. Have beat_id starting with `{path_name}_beat_` (see BEAT ID NAMING above)
-  2. Have `paths: ["{path_id}"]` (exactly this path ID)
+  2. Have `path_id: "{path_id}"` (exactly this path ID)
   3. Have at least one dilemma_impact with `dilemma_id: "{dilemma_id}"`
   4. Include at least one beat with `effect: "commits"` for `{dilemma_id}`
 
@@ -598,7 +598,7 @@ per_path_beats_prompt: |
       {{
         "beat_id": "{path_name}_beat_01",
         "summary": "What happens in this beat",
-        "paths": ["{path_id}"],
+        "path_id": "{path_id}",
         "dilemma_impacts": [
           {{
             "dilemma_id": "{dilemma_id}",
@@ -623,7 +623,7 @@ per_path_beats_prompt: |
   ## Rules
   - Generate exactly 2-4 beats for path `{path_id}`
   - Beat IDs MUST start with `{path_name}_beat_` (e.g., `{path_name}_beat_01`)
-  - EVERY beat must include `{path_id}` in its `paths` array
+  - EVERY beat must have `path_id: "{path_id}"`
   - EVERY beat must have at least one dilemma_impact for `{dilemma_id}`
   - At least ONE beat must have `effect: "commits"` for `{dilemma_id}`
   - effect must be "advances", "reveals", "commits", or "complicates"
@@ -643,15 +643,15 @@ per_path_beats_prompt: |
   - Do NOT reference other dilemma_ids in your first dilemma_impact
   - Do NOT skip the commits beat
   - Do NOT use IDs not in the manifest
-  - Do NOT put the dilemma ID in the `paths` field (see COMMON MISTAKE above)
+  - Do NOT put the dilemma ID in the `path_id` field (see COMMON MISTAKE above)
 
   ## FINAL VERIFICATION (check before outputting)
 
   For EACH beat you generate, verify:
-  1. `paths` contains `{path_id}`
+  1. `path_id` is `{path_id}`
   2. `dilemma_impacts[0].dilemma_id` is `{dilemma_id}`
 
-  If you see a dilemma ID in your `paths` value, YOU MADE A MISTAKE. Fix it.
+  If you see a dilemma ID in your `path_id` value, YOU MADE A MISTAKE. Fix it.
 
   ## Output
   Return ONLY valid JSON with the "initial_beats" array (2-4 beats).

--- a/src/questfoundry/graph/dilemma_scoring.py
+++ b/src/questfoundry/graph/dilemma_scoring.py
@@ -88,8 +88,8 @@ def _get_paths_for_dilemma(
 
 
 def _get_beats_for_path(seed_output: SeedOutput, path_id: str) -> list[InitialBeat]:
-    """Get all beats that serve a given path."""
-    return [b for b in seed_output.initial_beats if path_id in b.paths]
+    """Get all beats that belong to a given path."""
+    return [b for b in seed_output.initial_beats if b.path_id == path_id]
 
 
 def _get_consequences_for_path(seed_output: SeedOutput, path_id: str) -> list[Consequence]:

--- a/src/questfoundry/graph/seed_pruning.py
+++ b/src/questfoundry/graph/seed_pruning.py
@@ -275,33 +275,12 @@ def _prune_demoted_dilemmas(
         c for c in seed_output.consequences if strip_scope_prefix(c.path_id) not in paths_to_drop
     ]
 
-    # 3. Filter and update beats
-    pruned_beats: list[InitialBeat] = []
-    for beat in seed_output.initial_beats:
-        # Get paths that aren't being dropped (compare raw IDs).
-        # Original ID format (scoped or raw) is intentionally preserved to maintain
-        # consistency with how the artifact was originally generated.
-        kept_paths = [p for p in beat.paths if strip_scope_prefix(p) not in paths_to_drop]
-
-        if kept_paths:
-            # Beat serves at least one kept path
-            if len(kept_paths) < len(beat.paths):
-                # Some paths were dropped - update the beat
-                pruned_beats.append(
-                    InitialBeat(
-                        beat_id=beat.beat_id,
-                        summary=beat.summary,
-                        paths=kept_paths,
-                        dilemma_impacts=beat.dilemma_impacts,
-                        entities=beat.entities,
-                        location=beat.location,
-                        location_alternatives=beat.location_alternatives,
-                    )
-                )
-            else:
-                # All paths kept - use as-is
-                pruned_beats.append(beat)
-        # else: beat only served dropped paths - discard it
+    # 3. Filter beats — each beat belongs to exactly one path
+    pruned_beats: list[InitialBeat] = [
+        beat
+        for beat in seed_output.initial_beats
+        if strip_scope_prefix(beat.path_id) not in paths_to_drop
+    ]
 
     dropped_beat_count = len(seed_output.initial_beats) - len(pruned_beats)
     if dropped_beat_count > 0:

--- a/src/questfoundry/models/seed.py
+++ b/src/questfoundry/models/seed.py
@@ -16,6 +16,7 @@ Terminology (v5):
 
 from __future__ import annotations
 
+import warnings
 from collections import Counter
 from enum import StrEnum
 from typing import Any, Literal
@@ -267,8 +268,6 @@ class InitialBeat(BaseModel):
             if isinstance(paths, list) and len(paths) == 1:
                 data["path_id"] = paths[0]
             elif isinstance(paths, list) and len(paths) > 1:
-                import warnings
-
                 warnings.warn(
                     f"InitialBeat.paths had {len(paths)} entries; using first. "
                     "Multi-path beats are handled via intersection groups.",
@@ -276,6 +275,9 @@ class InitialBeat(BaseModel):
                     stacklevel=2,
                 )
                 data["path_id"] = paths[0]
+            elif isinstance(paths, list) and len(paths) == 0:
+                msg = "InitialBeat.paths is empty — each beat must belong to a path."
+                raise ValueError(msg)
         return data
 
     dilemma_impacts: list[DilemmaImpact] = Field(

--- a/tests/unit/test_mutations.py
+++ b/tests/unit/test_mutations.py
@@ -2412,7 +2412,7 @@ class TestCategorizeError:
     def test_semantic_not_in_seed(self) -> None:
         """'not defined in SEED' errors are SEMANTIC."""
         error = SeedValidationError(
-            field_path="initial_beats.0.paths",
+            field_path="initial_beats.0.path_id",
             issue="Path 'ghost' not defined in SEED paths",
             available=["real_path"],
             provided="ghost",

--- a/tests/unit/test_ontology_explored.py
+++ b/tests/unit/test_ontology_explored.py
@@ -495,7 +495,7 @@ class TestScopedIdStandardization:
                 InitialBeat(
                     beat_id="artifact_beat_01",
                     summary="Discovery of the artifact",
-                    paths=["path::artifact_natural", "path::artifact_crafted"],  # Scoped!
+                    path_id="path::artifact_natural",  # Scoped! belongs to natural path
                     dilemma_impacts=[
                         {
                             "dilemma_id": "dilemma::artifact_origin",
@@ -507,7 +507,7 @@ class TestScopedIdStandardization:
                 InitialBeat(
                     beat_id="artifact_beat_02",
                     summary="Beat only for crafted path",
-                    paths=["path::artifact_crafted"],  # Scoped!
+                    path_id="path::artifact_crafted",  # Scoped! belongs to crafted path
                     dilemma_impacts=[
                         {
                             "dilemma_id": "dilemma::artifact_origin",
@@ -528,15 +528,14 @@ class TestScopedIdStandardization:
         assert "path::artifact_natural" in path_ids
         assert "path::artifact_crafted" not in path_ids
 
-        # Beat 2 should be dropped (only served crafted path)
+        # Beat 2 should be dropped (belonged to crafted path)
         beat_ids = [b.beat_id for b in pruned.initial_beats]
-        assert "artifact_beat_01" in beat_ids  # Kept - serves natural
-        assert "artifact_beat_02" not in beat_ids  # Dropped - only served crafted
+        assert "artifact_beat_01" in beat_ids  # Kept - belongs to natural path
+        assert "artifact_beat_02" not in beat_ids  # Dropped - belonged to crafted path
 
-        # Beat 1 should have crafted path removed from its paths list
+        # Beat 1 should still point to natural path (scoped ID preserved)
         beat_1 = next(b for b in pruned.initial_beats if b.beat_id == "artifact_beat_01")
-        assert "path::artifact_natural" in beat_1.paths
-        assert "path::artifact_crafted" not in beat_1.paths
+        assert beat_1.path_id == "path::artifact_natural"
         # Demoted dilemma should keep canonical and move non-canonical to unexplored
         pruned_dilemma = next(
             d for d in pruned.dilemmas if d.dilemma_id == "dilemma::artifact_origin"
@@ -638,7 +637,7 @@ class TestScopedIdStandardization:
                 InitialBeat(
                     beat_id="keeper_beat_1",
                     summary="Meeting the keeper",
-                    paths=["path::keeper_protector", "path::keeper_manipulator"],
+                    path_id="path::keeper_protector",  # Scoped!
                     dilemma_impacts=[
                         {
                             "dilemma_id": "dilemma::keeper_trust",
@@ -767,7 +766,7 @@ class TestCanonicalAnswerFromGraph:
                 InitialBeat(
                     beat_id="beat_1",
                     summary="Test",
-                    paths=["path_a", "path_b"],
+                    path_id="path_b",  # Belongs to the graph-default path
                     dilemma_impacts=[{"dilemma_id": "t1", "effect": "commits", "note": "n"}],
                 ),
             ],
@@ -817,7 +816,7 @@ class TestCanonicalAnswerFromGraph:
                 InitialBeat(
                     beat_id="beat_1",
                     summary="Test",
-                    paths=["path_a", "path_b"],
+                    path_id="path_a",  # Belongs to explored[0] (canonical without graph)
                     dilemma_impacts=[{"dilemma_id": "t1", "effect": "commits", "note": "n"}],
                 ),
             ],

--- a/tests/unit/test_seed_models.py
+++ b/tests/unit/test_seed_models.py
@@ -934,3 +934,8 @@ class TestInitialBeatPathId:
     def test_empty_path_id_rejected(self) -> None:
         with pytest.raises(ValidationError, match="path_id"):
             InitialBeat(beat_id="b1", summary="Test", path_id="")
+
+    def test_legacy_empty_paths_rejected(self) -> None:
+        """Empty paths list raises ValueError — beats must belong to a path."""
+        with pytest.raises(ValidationError, match="must belong to a path"):
+            InitialBeat(beat_id="b1", summary="Test", paths=[])

--- a/tests/unit/test_seed_stage.py
+++ b/tests/unit/test_seed_stage.py
@@ -130,7 +130,7 @@ async def test_execute_calls_all_three_phases() -> None:
                 {
                     "beat_id": "beat1",
                     "summary": "Opening beat",
-                    "paths": ["path::trust__yes"],
+                    "path_id": "path::trust__yes",
                 }
             ],
         )
@@ -382,7 +382,7 @@ async def test_execute_returns_artifact_as_dict() -> None:
                 {
                     "beat_id": "beat1",
                     "summary": "Test beat",
-                    "paths": ["path::t1__a1"],
+                    "path_id": "path::t1__a1",
                 }
             ],
         )
@@ -478,7 +478,7 @@ def test_seed_output_model_validates() -> None:
             {
                 "beat_id": "beat1",
                 "summary": "Opening scene",
-                "paths": ["path::trust__yes"],
+                "path_id": "path::trust__yes",
             }
         ],
     )

--- a/tests/unit/test_serialize.py
+++ b/tests/unit/test_serialize.py
@@ -1180,7 +1180,7 @@ class TestBeatRetryAndContextRefresh:
         # Beat error - will be in "beats" section after grouping
         beat_errors = [
             SeedValidationError(
-                field_path="initial_beats.0.paths",
+                field_path="initial_beats.0.path_id",
                 issue="Path 'bad_path' not defined in SEED paths",
                 available=["good_path"],
                 provided="bad_path",
@@ -1352,7 +1352,7 @@ class TestBeatRetryAndContextRefresh:
         # Beat error that triggers retry
         beat_errors = [
             SeedValidationError(
-                field_path="initial_beats.0.paths",
+                field_path="initial_beats.0.path_id",
                 issue="Path 'bad_path' not defined",
                 available=["good_path"],
                 provided="bad_path",


### PR DESCRIPTION
## Summary

- `InitialBeat.paths: list[str]` → `InitialBeat.path_id: str` — each beat belongs to exactly one path via a single `belongs_to` edge, per Document 3
- `model_validator` accepts legacy `paths: [single_id]` for backward compatibility with existing LLM output
- Mutations code handles both `path_id` and legacy `paths[0]` in raw dicts
- Seed pruning simplified from per-path filtering loop to direct path comparison
- All prompt templates updated from `paths[]` array to singular `path_id`
- Fixed `dilemma_scoring.py` which directly accessed `beat.paths`

## Rationale

Document 3 requires single `belongs_to` edges. Multi-path beats are handled via intersection groups (#997), not by listing multiple paths on a beat. This was flagged as CRITICAL in Discussion #980.

## Changes

| File | Change |
|------|--------|
| `models/seed.py` | `paths: list[str]` → `path_id: str` + migration validator |
| `mutations.py` | 3 validation + 1 apply site: loop → single path with fallback |
| `seed_pruning.py` | 15-line filter loop → 3-line list comprehension |
| `dilemma_scoring.py` | `path_id in b.paths` → `b.path_id == path_id` |
| `serialize_seed_sections.yaml` | Section 5 + 5b schema/instructions updated |
| Tests | 4 new path_id tests, updated fixtures |

## Test plan

- [x] `uv run pytest tests/unit/test_seed_models.py -x -q` — 105 passed
- [x] `uv run pytest tests/unit/test_mutations.py -x -q` — 186 passed
- [x] `uv run pytest tests/unit/test_seed_stage.py -x -q` — 36 passed
- [x] `uv run pytest tests/unit/test_graph_context.py -x -q` — 105 passed
- [x] `uv run mypy` + `ruff check` — clean

Closes #983

🤖 Generated with [Claude Code](https://claude.com/claude-code)