### PR TITLE
fix: redesign intersection model to group nodes + intersection edges

### DIFF
--- a/src/questfoundry/graph/fill_context.py
+++ b/src/questfoundry/graph/fill_context.py
@@ -654,11 +654,13 @@ def format_continuity_warning(
         cur_beat = cur.get("from_beat", "")
         if not prev_beat or not cur_beat:
             return False
-        prev_b = graph.get_node(prev_beat) or {}
-        cur_b = graph.get_node(cur_beat) or {}
-        prev_group = set(prev_b.get("intersection_group") or [])
-        cur_group = set(cur_b.get("intersection_group") or [])
-        return (cur_beat in prev_group) or (prev_beat in cur_group)
+        # Two beats share an intersection group if they both have
+        # intersection edges to the same group node.
+        prev_groups = {
+            e["to"] for e in graph.get_edges(from_id=prev_beat, edge_type="intersection")
+        }
+        cur_groups = {e["to"] for e in graph.get_edges(from_id=cur_beat, edge_type="intersection")}
+        return bool(prev_groups & cur_groups)
 
     passage_order = get_arc_passage_order(graph, arc_id)
     if not passage_order or current_idx <= 0 or current_idx >= len(passage_order):

--- a/src/questfoundry/graph/grow_algorithms.py
+++ b/src/questfoundry/graph/grow_algorithms.py
@@ -3309,8 +3309,12 @@ def apply_intersection_mark(
     """
     # Derive a stable group ID from the sorted beat IDs
     sorted_ids = sorted(beat_ids)
-    raw_group_id = "_".join(strip_scope_prefix(b) for b in sorted_ids)
+    raw_group_id = "--".join(strip_scope_prefix(b) for b in sorted_ids)
     group_node_id = f"intersection_group::{raw_group_id}"
+
+    # Idempotency: skip if this group already exists (same beat pair proposed twice)
+    if graph.get_node(group_node_id) is not None:
+        return
 
     # Build group node data
     group_data: dict[str, Any] = {

--- a/src/questfoundry/graph/grow_algorithms.py
+++ b/src/questfoundry/graph/grow_algorithms.py
@@ -3296,47 +3296,39 @@ def apply_intersection_mark(
     beat_ids: list[str],
     resolved_location: str | None,
 ) -> None:
-    """Mark beats as belonging to an intersection (multi-path scene).
+    """Mark beats as co-occurring in an intersection group (Doc 3, Part 4).
 
-    Updates beat nodes with:
-    - intersection_group: list of other beat IDs in the intersection
-    - resolved_location: the location chosen for the combined scene
-
-    Also adds additional belongs_to edges so each beat is assigned to
-    all paths from all beats in the intersection.
+    Creates an ``intersection_group`` node and links each participating
+    beat to it via ``intersection`` edges.  Each beat keeps its single
+    ``belongs_to`` edge to its original path — no cross-path assignment.
 
     Args:
         graph: Graph to mutate.
         beat_ids: Beat IDs to group into intersection.
         resolved_location: Resolved location, or None.
     """
-    beat_set = set(beat_ids)
+    # Derive a stable group ID from the sorted beat IDs
+    sorted_ids = sorted(beat_ids)
+    raw_group_id = "_".join(strip_scope_prefix(b) for b in sorted_ids)
+    group_node_id = f"intersection_group::{raw_group_id}"
 
-    # Collect all path assignments across all intersection beats
-    all_path_ids: set[str] = set()
-    belongs_to_edges = graph.get_edges(from_id=None, to_id=None, edge_type="belongs_to")
-    for edge in belongs_to_edges:
-        if edge["from"] in beat_set:
-            all_path_ids.add(edge["to"])
+    # Build group node data
+    group_data: dict[str, Any] = {
+        "type": "intersection_group",
+        "raw_id": raw_group_id,
+        "beat_ids": sorted_ids,
+    }
+    if resolved_location:
+        group_data["resolved_location"] = resolved_location
 
-    # Collect new edges to add (batch to avoid stale reads)
-    new_edges: list[tuple[str, str]] = []
+    graph.create_node(group_node_id, group_data)
+
+    # Link each beat to the group via intersection edges
     for bid in beat_ids:
-        current_paths = {e["to"] for e in belongs_to_edges if e["from"] == bid}
-        for path_id in all_path_ids - current_paths:
-            new_edges.append((bid, path_id))
-
-    # Update each beat's node data
-    for bid in beat_ids:
-        others = sorted(b for b in beat_ids if b != bid)
-        update_data: dict[str, Any] = {"intersection_group": others}
+        graph.add_edge("intersection", bid, group_node_id)
+        # Update beat's location if a resolved location was determined
         if resolved_location:
-            update_data["location"] = resolved_location
-        graph.update_node(bid, **update_data)
-
-    # Apply cross-path edges
-    for from_id, to_id in new_edges:
-        graph.add_edge("belongs_to", from_id, to_id)
+            graph.update_node(bid, location=resolved_location)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_fill_continuity_warning.py
+++ b/tests/unit/test_fill_continuity_warning.py
@@ -77,7 +77,13 @@ def test_continuity_warning_suppressed_for_micro_beat() -> None:
 
 def test_continuity_warning_suppressed_for_intersection_hint() -> None:
     graph, arc_id = _make_two_passages_graph(shared_entity=False)
-    graph.update_node("beat::a", intersection_group=["beat::b"])
+    # Create intersection group node and edges (Doc 3 model)
+    graph.create_node(
+        "intersection_group::a_b",
+        {"type": "intersection_group", "raw_id": "a_b", "beat_ids": ["beat::a", "beat::b"]},
+    )
+    graph.add_edge("intersection", "beat::a", "intersection_group::a_b")
+    graph.add_edge("intersection", "beat::b", "intersection_group::a_b")
     assert format_continuity_warning(graph, arc_id, 1) == ""
 
 

--- a/tests/unit/test_fill_continuity_warning.py
+++ b/tests/unit/test_fill_continuity_warning.py
@@ -79,11 +79,11 @@ def test_continuity_warning_suppressed_for_intersection_hint() -> None:
     graph, arc_id = _make_two_passages_graph(shared_entity=False)
     # Create intersection group node and edges (Doc 3 model)
     graph.create_node(
-        "intersection_group::a_b",
-        {"type": "intersection_group", "raw_id": "a_b", "beat_ids": ["beat::a", "beat::b"]},
+        "intersection_group::a--b",
+        {"type": "intersection_group", "raw_id": "a--b", "beat_ids": ["beat::a", "beat::b"]},
     )
-    graph.add_edge("intersection", "beat::a", "intersection_group::a_b")
-    graph.add_edge("intersection", "beat::b", "intersection_group::a_b")
+    graph.add_edge("intersection", "beat::a", "intersection_group::a--b")
+    graph.add_edge("intersection", "beat::b", "intersection_group::a--b")
     assert format_continuity_warning(graph, arc_id, 1) == ""
 
 

--- a/tests/unit/test_grow_algorithms.py
+++ b/tests/unit/test_grow_algorithms.py
@@ -3109,8 +3109,66 @@ class TestResolveKnotLocation:
 
 
 class TestApplyKnotMark:
-    def test_marks_beats_with_intersection_group(self) -> None:
-        """Applying intersection mark updates beat nodes."""
+    def test_creates_intersection_group_node(self) -> None:
+        """Applying intersection mark creates an intersection_group node."""
+        from questfoundry.graph.grow_algorithms import apply_intersection_mark
+        from tests.fixtures.grow_fixtures import make_intersection_candidate_graph
+
+        graph = make_intersection_candidate_graph()
+        apply_intersection_mark(
+            graph,
+            ["beat::mentor_meet", "beat::artifact_discover"],
+            "market",
+        )
+
+        # Group node exists with expected data
+        group_nodes = graph.get_nodes_by_type("intersection_group")
+        assert len(group_nodes) == 1
+        group_id = next(iter(group_nodes))
+        group = group_nodes[group_id]
+        assert group["type"] == "intersection_group"
+        assert set(group["beat_ids"]) == {"beat::artifact_discover", "beat::mentor_meet"}
+        assert group["resolved_location"] == "market"
+
+    def test_creates_intersection_edges(self) -> None:
+        """Each beat gets an intersection edge to the group node."""
+        from questfoundry.graph.grow_algorithms import apply_intersection_mark
+        from tests.fixtures.grow_fixtures import make_intersection_candidate_graph
+
+        graph = make_intersection_candidate_graph()
+        apply_intersection_mark(
+            graph,
+            ["beat::mentor_meet", "beat::artifact_discover"],
+            "market",
+        )
+
+        # Both beats have intersection edges to the group
+        mentor_edges = graph.get_edges(from_id="beat::mentor_meet", edge_type="intersection")
+        artifact_edges = graph.get_edges(
+            from_id="beat::artifact_discover", edge_type="intersection"
+        )
+        assert len(mentor_edges) == 1
+        assert len(artifact_edges) == 1
+        assert mentor_edges[0]["to"] == artifact_edges[0]["to"]  # Same group
+
+    def test_no_cross_path_belongs_to_edges(self) -> None:
+        """Intersection does NOT add cross-path belongs_to edges (Doc 3)."""
+        from questfoundry.graph.grow_algorithms import apply_intersection_mark
+        from tests.fixtures.grow_fixtures import make_intersection_candidate_graph
+
+        graph = make_intersection_candidate_graph()
+        # Count belongs_to edges before
+        before = len(graph.get_edges(edge_type="belongs_to"))
+        apply_intersection_mark(
+            graph,
+            ["beat::mentor_meet", "beat::artifact_discover"],
+            "market",
+        )
+        after = len(graph.get_edges(edge_type="belongs_to"))
+        assert after == before  # No new belongs_to edges
+
+    def test_resolved_location_applied_to_beats(self) -> None:
+        """Resolved location is applied to each beat node."""
         from questfoundry.graph.grow_algorithms import apply_intersection_mark
         from tests.fixtures.grow_fixtures import make_intersection_candidate_graph
 
@@ -3122,37 +3180,12 @@ class TestApplyKnotMark:
         )
 
         mentor = graph.get_node("beat::mentor_meet")
-        assert mentor["intersection_group"] == ["beat::artifact_discover"]
-        assert mentor["location"] == "market"
-
         artifact = graph.get_node("beat::artifact_discover")
-        assert artifact["intersection_group"] == ["beat::mentor_meet"]
+        assert mentor["location"] == "market"
         assert artifact["location"] == "market"
 
-    def test_adds_cross_path_belongs_to_edges(self) -> None:
-        """Intersection marking adds belongs_to edges for cross-path assignment."""
-        from questfoundry.graph.grow_algorithms import apply_intersection_mark
-        from tests.fixtures.grow_fixtures import make_intersection_candidate_graph
-
-        graph = make_intersection_candidate_graph()
-        apply_intersection_mark(
-            graph,
-            ["beat::mentor_meet", "beat::artifact_discover"],
-            "market",
-        )
-
-        # mentor_meet should now also belong to artifact paths
-        mentor_edges = graph.get_edges(
-            from_id="beat::mentor_meet", to_id=None, edge_type="belongs_to"
-        )
-        mentor_paths = {e["to"] for e in mentor_edges}
-        # Originally: mentor_trust_canonical, mentor_trust_alt
-        # Now also: artifact_quest_canonical, artifact_quest_alt
-        assert "path::artifact_quest_canonical" in mentor_paths
-        assert "path::artifact_quest_alt" in mentor_paths
-
-    def test_no_location_leaves_location_unchanged(self) -> None:
-        """When resolved_location is None, location field is not added."""
+    def test_no_location_leaves_beats_unchanged(self) -> None:
+        """When resolved_location is None, beat location is not modified."""
         from questfoundry.graph.grow_algorithms import apply_intersection_mark
 
         graph = make_two_dilemma_graph()
@@ -3163,8 +3196,12 @@ class TestApplyKnotMark:
         )
 
         mentor = graph.get_node("beat::mentor_meet")
-        assert mentor["intersection_group"] == ["beat::artifact_discover"]
         assert "location" not in mentor
+        # Group node still exists
+        group_nodes = graph.get_nodes_by_type("intersection_group")
+        assert len(group_nodes) == 1
+        group = next(iter(group_nodes.values()))
+        assert "resolved_location" not in group
 
 
 class TestFormatIntersectionCandidates:

--- a/tests/unit/test_grow_algorithms.py
+++ b/tests/unit/test_grow_algorithms.py
@@ -3184,6 +3184,26 @@ class TestApplyKnotMark:
         assert mentor["location"] == "market"
         assert artifact["location"] == "market"
 
+    def test_idempotent_when_called_twice(self) -> None:
+        """Calling apply_intersection_mark twice with same beats is a no-op."""
+        from questfoundry.graph.grow_algorithms import apply_intersection_mark
+        from tests.fixtures.grow_fixtures import make_intersection_candidate_graph
+
+        graph = make_intersection_candidate_graph()
+        apply_intersection_mark(
+            graph,
+            ["beat::mentor_meet", "beat::artifact_discover"],
+            "market",
+        )
+        # Second call should not crash or create duplicates
+        apply_intersection_mark(
+            graph,
+            ["beat::mentor_meet", "beat::artifact_discover"],
+            "market",
+        )
+        group_nodes = graph.get_nodes_by_type("intersection_group")
+        assert len(group_nodes) == 1
+
     def test_no_location_leaves_beats_unchanged(self) -> None:
         """When resolved_location is None, beat location is not modified."""
         from questfoundry.graph.grow_algorithms import apply_intersection_mark

--- a/tests/unit/test_grow_stage.py
+++ b/tests/unit/test_grow_stage.py
@@ -555,14 +555,20 @@ class TestPhase3Knots:
         assert result.llm_calls == 1
         assert "1 applied" in result.detail
 
-        # Verify intersection was applied
-        mentor_beat = graph.get_node("beat::mentor_meet")
-        assert mentor_beat["intersection_group"] == ["beat::artifact_discover"]
-        assert mentor_beat["location"] == "market"
+        # Verify intersection group node was created
+        group_nodes = graph.get_nodes_by_type("intersection_group")
+        assert len(group_nodes) == 1
+        group = next(iter(group_nodes.values()))
+        assert set(group["beat_ids"]) == {"beat::artifact_discover", "beat::mentor_meet"}
+        assert group["resolved_location"] == "market"
 
-        artifact_beat = graph.get_node("beat::artifact_discover")
-        assert artifact_beat["intersection_group"] == ["beat::mentor_meet"]
-        assert artifact_beat["location"] == "market"
+        # Verify beats have intersection edges (not cross-path belongs_to)
+        mentor_edges = graph.get_edges(from_id="beat::mentor_meet", edge_type="intersection")
+        artifact_edges = graph.get_edges(
+            from_id="beat::artifact_discover", edge_type="intersection"
+        )
+        assert len(mentor_edges) == 1
+        assert len(artifact_edges) == 1
 
     @pytest.mark.asyncio
     async def test_phase_3_resolves_location_when_missing(self) -> None:

--- a/tests/unit/test_grow_stage.py
+++ b/tests/unit/test_grow_stage.py
@@ -570,6 +570,10 @@ class TestPhase3Knots:
         assert len(mentor_edges) == 1
         assert len(artifact_edges) == 1
 
+        # Verify beat locations were updated
+        assert graph.get_node("beat::mentor_meet")["location"] == "market"
+        assert graph.get_node("beat::artifact_discover")["location"] == "market"
+
     @pytest.mark.asyncio
     async def test_phase_3_resolves_location_when_missing(self) -> None:
         """Phase 3 resolves location when LLM leaves it null."""


### PR DESCRIPTION
## Summary

- Replaces the denormalized `intersection_group: [beat_ids]` property with proper `intersection_group` graph nodes linked via `intersection` edges (Document 3, Part 4)
- **No more cross-path `belongs_to` edges** — the root cause of the hard-convergence bug
- Each beat keeps its single `belongs_to` edge; co-occurrence is modeled separately

## Before / After

| Aspect | Before | After (Doc 3) |
|--------|--------|---------------|
| Group storage | `beat.intersection_group = [other_ids]` | `intersection_group::X` node |
| Beat linkage | Cross-path `belongs_to` edges | `intersection` edges to group node |
| Path membership | Beats "belong to" multiple paths | Single `belongs_to` preserved |
| Query pattern | `beat_data.get("intersection_group")` | `graph.get_edges(edge_type="intersection")` |

## Changes

| File | Change |
|------|--------|
| `grow_algorithms.py` | Rewrite `apply_intersection_mark`: create group node + intersection edges |
| `fill_context.py` | `_intersection_hint` queries intersection edges via set intersection |
| `test_grow_algorithms.py` | 5 tests: group node creation, edges, no cross-path, location, no-location |
| `test_grow_stage.py` | Updated Phase 3 integration test assertions |
| `test_fill_continuity_warning.py` | Updated to create group node + edges |

Supersedes #970

## Test plan

- [x] `uv run pytest tests/unit/test_grow_algorithms.py::TestApplyKnotMark -x -q` — 5 passed
- [x] `uv run pytest tests/unit/test_grow_stage.py -x -q` — 97 passed
- [x] `uv run pytest tests/unit/test_fill_continuity_warning.py -x -q` — 9 passed
- [x] `uv run mypy` + `ruff check` — clean

**Stacked on:** PR #1030 (#983 — InitialBeat singular path)

Closes #997

🤖 Generated with [Claude Code](https://claude.com/claude-code)