### PR TITLE
fix: add SEED beat scaffold arc structure validation

### DIFF
--- a/src/questfoundry/graph/mutations.py
+++ b/src/questfoundry/graph/mutations.py
@@ -157,6 +157,7 @@ class SeedErrorCategory(Enum):
     - INNER: Schema/type errors - retry with Pydantic feedback
     - SEMANTIC: Invalid ID references - retry with valid ID list
     - COMPLETENESS: Missing items - retry with manifest counts
+    - WARNING: Non-blocking issues (logged but don't prevent mutation)
     - FATAL: Reserved for unrecoverable errors (corruption, impossible states)
     """
 
@@ -166,6 +167,7 @@ class SeedErrorCategory(Enum):
     CROSS_REFERENCE = (
         auto()
     )  # Cross-section ID mismatch (e.g. path answer_id not in dilemma explored)
+    WARNING = auto()  # Non-blocking scaffold warnings (e.g., minimal arc structure)
     # FATAL is reserved for future use - e.g., graph corruption that requires
     # manual intervention. Currently no errors are classified as FATAL since
     # all known error types can be retried with appropriate feedback.
@@ -1080,6 +1082,8 @@ def validate_seed_mutations(graph: Graph, output: dict[str, Any]) -> list[SeedVa
     11. All dilemmas have at least one path (completeness)
     12. Each beat references its path's parent dilemma in dilemma_impacts
     13. Each path has at least one beat with effect="commits" for its dilemma
+    14. Each path has advances/reveals beat before commit (WARNING, non-blocking)
+    15. Each path has at least one beat after commit (WARNING, non-blocking)
 
     Args:
         graph: Graph containing BRAINSTORM data (entities, dilemmas, answers).
@@ -1531,7 +1535,10 @@ def validate_seed_mutations(graph: Graph, output: dict[str, Any]) -> list[SeedVa
 
     # 12. Check beats reference their path's parent dilemma
     # 13. Check each path has at least one commits beat for its dilemma
+    # Also collect per-path beat data for arc structure checks (14, 15)
     paths_with_commits: set[str] = set()  # path_ids that have a commits beat
+    # Per-path: list of (beat_index, effects_set) for parent dilemma impacts
+    path_beat_effects: dict[str, list[tuple[int, set[str]]]] = {}
     for i, beat in enumerate(output.get("initial_beats", [])):
         beat_path_ids: list[str] = []
         for raw_path_id in beat.get("paths", []):
@@ -1541,12 +1548,16 @@ def validate_seed_mutations(graph: Graph, output: dict[str, Any]) -> list[SeedVa
         # Collect normalized dilemma_ids referenced in this beat's impacts
         beat_impact_dilemmas: set[str] = set()
         beat_impact_commits_dilemmas: set[str] = set()
+        # Effects keyed by normalized dilemma_id
+        beat_effects_by_dilemma: dict[str, set[str]] = {}
         for impact in beat.get("dilemma_impacts", []):
             raw_did = impact.get("dilemma_id")
             if raw_did:
                 normalized_did, _ = _normalize_id(raw_did, "dilemma")
                 beat_impact_dilemmas.add(normalized_did)
-                if impact.get("effect") == "commits":
+                effect = impact.get("effect", "")
+                beat_effects_by_dilemma.setdefault(normalized_did, set()).add(effect)
+                if effect == "commits":
                     beat_impact_commits_dilemmas.add(normalized_did)
 
         # For each path this beat belongs to, check it references the parent dilemma
@@ -1576,6 +1587,10 @@ def validate_seed_mutations(graph: Graph, output: dict[str, Any]) -> list[SeedVa
             if expected_dilemma in beat_impact_commits_dilemmas:
                 paths_with_commits.add(path_id)
 
+            # Track beat effects for arc structure checks
+            effects = beat_effects_by_dilemma.get(expected_dilemma, set())
+            path_beat_effects.setdefault(path_id, []).append((i, effects))
+
     # Report paths missing commits beats
     for path_id in sorted(path_dilemma_map.keys()):
         if path_id not in paths_with_commits:
@@ -1592,6 +1607,69 @@ def validate_seed_mutations(graph: Graph, output: dict[str, Any]) -> list[SeedVa
                     available=[expected_dilemma],
                     provided="",
                     category=SeedErrorCategory.COMPLETENESS,
+                )
+            )
+
+    # 14. Check arc structure: advances/reveals before commit (WARNING)
+    # 15. Check arc structure: beat exists after commit (WARNING)
+    # Doc 1 Part 2: "This scaffold must be complete — the arc from beginning
+    # to end must be present."
+    for path_id in sorted(path_dilemma_map.keys()):
+        if path_id not in paths_with_commits:
+            continue  # No commit beat; already reported as error in check 13
+
+        beat_entries = path_beat_effects.get(path_id, [])
+        if not beat_entries:
+            continue
+
+        # Find the index of the first commit beat for this path
+        commit_index: int | None = None
+        for beat_idx, effects in beat_entries:
+            if "commits" in effects:
+                commit_index = beat_idx
+                break
+
+        if commit_index is None:
+            continue  # Shouldn't happen given paths_with_commits check
+
+        # 14. Check for advances/reveals before the commit beat
+        has_pre_commit_development = any(
+            effects & {"advances", "reveals"}
+            for beat_idx, effects in beat_entries
+            if beat_idx < commit_index
+        )
+        if not has_pre_commit_development:
+            expected_dilemma = path_dilemma_map[path_id]
+            errors.append(
+                SeedValidationError(
+                    field_path=f"paths.{path_id}.arc_structure",
+                    issue=(
+                        f"Path '{path_id}' has no beat with effect 'advances' "
+                        f"or 'reveals' before its commit beat for dilemma "
+                        f"'{expected_dilemma}'. A complete arc should develop "
+                        f"the dilemma before committing to a resolution."
+                    ),
+                    available=["advances", "reveals"],
+                    provided="",
+                    category=SeedErrorCategory.WARNING,
+                )
+            )
+
+        # 15. Check for at least one beat after the commit beat
+        has_post_commit_beat = any(beat_idx > commit_index for beat_idx, _effects in beat_entries)
+        if not has_post_commit_beat:
+            expected_dilemma = path_dilemma_map[path_id]
+            errors.append(
+                SeedValidationError(
+                    field_path=f"paths.{path_id}.arc_structure",
+                    issue=(
+                        f"Path '{path_id}' has no beat after its commit beat "
+                        f"for dilemma '{expected_dilemma}'. A complete arc "
+                        f"should include consequence beats after the commit."
+                    ),
+                    available=[],
+                    provided="",
+                    category=SeedErrorCategory.WARNING,
                 )
             )
 
@@ -1626,7 +1704,14 @@ def apply_seed_mutations(graph: Graph, output: dict[str, Any]) -> None:
     _backfill_explored_from_paths(output)
 
     # Validate cross-references first
-    errors = validate_seed_mutations(graph, output)
+    all_issues = validate_seed_mutations(graph, output)
+    warnings = [e for e in all_issues if e.category == SeedErrorCategory.WARNING]
+    errors = [e for e in all_issues if e.category != SeedErrorCategory.WARNING]
+
+    # Log warnings (non-blocking scaffold issues)
+    for w in warnings:
+        log.warning("seed_scaffold_warning", path=w.field_path, issue=w.issue)
+
     if errors:
         raise SeedMutationError(errors)
 

--- a/tests/unit/test_mutations.py
+++ b/tests/unit/test_mutations.py
@@ -2429,6 +2429,7 @@ class TestSeedArcStructureValidation:
         errors = validate_seed_mutations(graph, output)
 
         warnings = [e for e in errors if e.category == SeedErrorCategory.WARNING]
+        assert not _blocking_errors(errors)
         assert len(warnings) == 1
         assert "advances" in warnings[0].issue
 


### PR DESCRIPTION
## Summary

- Add checks 14 and 15 to `validate_seed_mutations()` for beat scaffold arc structure validation
- Check 14: each path must have an `advances` or `reveals` beat before its `commits` beat
- Check 15: each path must have at least one beat after its `commits` beat
- New `SeedErrorCategory.WARNING` category — logged but non-blocking (doesn't prevent mutation)
- Updated `apply_seed_mutations()` to filter warnings and log them via structlog

## Test plan

- [x] 8 new tests in `TestSeedArcStructureValidation` covering:
  - Complete arc (no warnings)
  - `reveals` before commit satisfies check 14
  - Missing pre-commit development warns
  - Missing post-commit beat warns
  - Single commit beat produces both warnings
  - `complicates` doesn't satisfy check 14
  - Warnings don't block `apply_seed_mutations`
  - Path without commits skips arc checks (only check 13 error)
- [x] 8 existing tests updated to use `_blocking_errors()` filter (tests not concerned with arc structure)
- [x] `test_complete_decisions_valid` updated with complete 3-beat arc (strict `errors == []` assertion)
- [x] mypy, ruff, all 194 mutation tests pass, 27 seed stage tests pass

Closes #1016

🤖 Generated with [Claude Code](https://claude.com/claude-code)