### PR TITLE
feat: add POLISH skeleton, shared PhaseRegistry, and entry contract

### DIFF
--- a/src/questfoundry/graph/polish_validation.py
+++ b/src/questfoundry/graph/polish_validation.py
@@ -32,6 +32,8 @@ def validate_grow_output(graph: Graph) -> list[str]:
         for beat_id, beat_data in beat_nodes.items():
             if not beat_data.get("summary"):
                 errors.append(f"Beat {beat_id} missing summary")
+            # Accept both plural "dilemma_impacts" and legacy singular "dilemma_impact"
+            # from older GROW outputs that used the singular key.
             if "dilemma_impacts" not in beat_data and "dilemma_impact" not in beat_data:
                 errors.append(f"Beat {beat_id} missing dilemma_impacts")
 
@@ -63,7 +65,8 @@ def validate_grow_output(graph: Graph) -> list[str]:
     explored_dilemmas = {
         did
         for did, ddata in dilemma_nodes.items()
-        if ddata.get("status") in ("explored", None)  # default to explored
+        # GROW may omit status for dilemmas it fully explored; treat None as "explored".
+        if ddata.get("status") in ("explored", None)
     }
     dilemmas_with_flags: set[str] = set()
     for _flag_id, flag_data in state_flag_nodes.items():
@@ -141,6 +144,7 @@ def _check_intersection_group_paths(
     # Intersection group nodes store beat IDs in node_ids field
     node_ids = group_data.get("node_ids", [])
     if not node_ids:
+        errors.append(f"Intersection group {group_id} has empty node_ids")
         return
 
     paths_seen: set[str] = set()

--- a/src/questfoundry/graph/polish_validation.py
+++ b/src/questfoundry/graph/polish_validation.py
@@ -1,0 +1,157 @@
+"""POLISH entry contract validation.
+
+Validates that GROW's output meets POLISH's input requirements before
+the POLISH stage begins. Failures indicate issues in GROW or SEED
+that must be fixed there, not in POLISH.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from questfoundry.graph.graph import Graph
+
+
+def validate_grow_output(graph: Graph) -> list[str]:
+    """Verify GROW's output meets POLISH's input contract.
+
+    Args:
+        graph: Graph containing GROW stage output.
+
+    Returns:
+        List of error strings. Empty means valid.
+    """
+    errors: list[str] = []
+
+    # 1. Beat nodes exist with summaries and dilemma_impacts
+    beat_nodes = graph.get_nodes_by_type("beat")
+    if not beat_nodes:
+        errors.append("No beat nodes found in graph")
+    else:
+        for beat_id, beat_data in beat_nodes.items():
+            if not beat_data.get("summary"):
+                errors.append(f"Beat {beat_id} missing summary")
+            if "dilemma_impacts" not in beat_data and "dilemma_impact" not in beat_data:
+                errors.append(f"Beat {beat_id} missing dilemma_impacts")
+
+    # 2. No cycles in predecessor DAG
+    if beat_nodes:
+        _check_predecessor_cycles(graph, beat_nodes, errors)
+
+    # 3. Every beat has exactly one belongs_to edge
+    belongs_to_edges = graph.get_edges(edge_type="belongs_to")
+    beats_with_path: dict[str, list[str]] = {}
+    for edge in belongs_to_edges:
+        from_id = edge["from"]
+        to_id = edge["to"]
+        if from_id in beat_nodes:
+            beats_with_path.setdefault(from_id, []).append(to_id)
+
+    for beat_id in beat_nodes:
+        paths = beats_with_path.get(beat_id, [])
+        if len(paths) == 0:
+            errors.append(f"Beat {beat_id} has no belongs_to edge (no path assignment)")
+        elif len(paths) > 1:
+            errors.append(
+                f"Beat {beat_id} has {len(paths)} belongs_to edges (must have exactly 1): {paths}"
+            )
+
+    # 4. State flag nodes exist for explored dilemmas
+    dilemma_nodes = graph.get_nodes_by_type("dilemma")
+    state_flag_nodes = graph.get_nodes_by_type("state_flag")
+    explored_dilemmas = {
+        did
+        for did, ddata in dilemma_nodes.items()
+        if ddata.get("status") in ("explored", None)  # default to explored
+    }
+    dilemmas_with_flags: set[str] = set()
+    for _flag_id, flag_data in state_flag_nodes.items():
+        dilemma_ref = flag_data.get("dilemma_id") or flag_data.get("dilemma")
+        if dilemma_ref:
+            dilemmas_with_flags.add(dilemma_ref)
+
+    for dilemma_id in explored_dilemmas:
+        if dilemma_id not in dilemmas_with_flags:
+            errors.append(f"Explored dilemma {dilemma_id} has no state flag nodes")
+
+    # 5. Dilemma nodes have dilemma_role set
+    for dilemma_id, dilemma_data in dilemma_nodes.items():
+        if not dilemma_data.get("dilemma_role"):
+            errors.append(f"Dilemma {dilemma_id} missing dilemma_role (hard/soft)")
+
+    # 6. Intersection groups reference beats from different paths only
+    intersection_groups = graph.get_nodes_by_type("intersection_group")
+    for group_id, group_data in intersection_groups.items():
+        _check_intersection_group_paths(
+            graph, group_id, group_data, beat_nodes, beats_with_path, errors
+        )
+
+    return errors
+
+
+def _check_predecessor_cycles(
+    graph: Graph,
+    beat_nodes: dict[str, dict[str, Any]],
+    errors: list[str],
+) -> None:
+    """Check for cycles in predecessor edges using Kahn's algorithm."""
+    predecessor_edges = graph.get_edges(edge_type="predecessor")
+
+    # Build adjacency: predecessor edges mean "from depends on to"
+    # i.e., edge from A to B means "A's predecessor is B" (B comes before A)
+    in_degree: dict[str, int] = dict.fromkeys(beat_nodes, 0)
+    adj: dict[str, list[str]] = {bid: [] for bid in beat_nodes}
+
+    for edge in predecessor_edges:
+        from_id = edge["from"]
+        to_id = edge["to"]
+        if from_id in beat_nodes and to_id in beat_nodes:
+            in_degree[from_id] += 1
+            adj[to_id].append(from_id)
+
+    queue = [bid for bid, deg in in_degree.items() if deg == 0]
+    visited = 0
+
+    while queue:
+        node = queue.pop()
+        visited += 1
+        for neighbor in adj[node]:
+            in_degree[neighbor] -= 1
+            if in_degree[neighbor] == 0:
+                queue.append(neighbor)
+
+    if visited != len(beat_nodes):
+        cycle_members = [bid for bid, deg in in_degree.items() if deg > 0]
+        errors.append(
+            f"Cycle detected in predecessor DAG among {len(cycle_members)} beats: "
+            f"{', '.join(sorted(cycle_members)[:5])}" + ("..." if len(cycle_members) > 5 else "")
+        )
+
+
+def _check_intersection_group_paths(
+    graph: Graph,  # noqa: ARG001
+    group_id: str,
+    group_data: dict[str, Any],
+    beat_nodes: dict[str, dict[str, Any]],
+    beats_with_path: dict[str, list[str]],
+    errors: list[str],
+) -> None:
+    """Check that an intersection group's beats come from different paths."""
+    # Intersection group nodes store beat IDs in node_ids field
+    node_ids = group_data.get("node_ids", [])
+    if not node_ids:
+        return
+
+    paths_seen: set[str] = set()
+    for beat_id in node_ids:
+        if beat_id not in beat_nodes:
+            continue
+        beat_paths = beats_with_path.get(beat_id, [])
+        for path_id in beat_paths:
+            if path_id in paths_seen:
+                errors.append(
+                    f"Intersection group {group_id} has multiple beats from the same path {path_id}"
+                )
+                return
+            paths_seen.add(path_id)

--- a/src/questfoundry/pipeline/registry.py
+++ b/src/questfoundry/pipeline/registry.py
@@ -1,0 +1,200 @@
+"""Shared phase registry for multi-phase pipeline stages.
+
+Provides ``PhaseRegistry`` and ``PhaseMeta`` used by both GROW and POLISH
+stages. Each stage creates its own registry instance and decorator.
+
+Usage (in a stage's registry module)::
+
+    from questfoundry.pipeline.registry import PhaseRegistry, PhaseMeta, PHASE_META_ATTR
+
+    _registry = PhaseRegistry()
+
+    def my_stage_phase(name, *, depends_on=None, is_deterministic=False, priority=None):
+        resolved_priority = priority if priority is not None else len(_registry)
+        def decorator(fn):
+            meta = PhaseMeta(name=name, depends_on=tuple(depends_on or []),
+                             is_deterministic=is_deterministic, priority=resolved_priority)
+            _registry.register(fn, meta)
+            setattr(fn, PHASE_META_ATTR, meta)
+            return fn
+        return decorator
+"""
+
+from __future__ import annotations
+
+import heapq
+from collections import defaultdict
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+
+@dataclass(frozen=True)
+class PhaseMeta:
+    """Metadata attached to a registered phase function."""
+
+    name: str
+    depends_on: tuple[str, ...]
+    is_deterministic: bool
+    priority: int
+
+
+PHASE_META_ATTR = "_phase_meta"
+
+
+class PhaseRegistry:
+    """Collects phase-decorated functions and validates their DAG.
+
+    The registry is populated at module import time. Call ``validate()`` to
+    check for missing dependencies, cycles, or duplicates. Call
+    ``execution_order()`` to get a stable topological ordering.
+    """
+
+    def __init__(self) -> None:
+        self._phases: dict[str, PhaseMeta] = {}
+        self._functions: dict[str, Callable[..., Any]] = {}
+
+    # -- Registration ----------------------------------------------------------
+
+    def register(self, fn: Callable[..., Any], meta: PhaseMeta) -> None:
+        """Register a phase function with its metadata.
+
+        Raises:
+            ValueError: If a phase with the same name is already registered.
+        """
+        if meta.name in self._phases:
+            msg = (
+                f"Duplicate phase name {meta.name!r}: "
+                f"already registered by {self._functions[meta.name].__qualname__}"
+            )
+            raise ValueError(msg)
+        self._phases[meta.name] = meta
+        self._functions[meta.name] = fn
+
+    # -- Validation ------------------------------------------------------------
+
+    def validate(self) -> list[str]:
+        """Validate the dependency DAG.
+
+        Returns:
+            List of error strings. Empty means valid.
+        """
+        errors: list[str] = []
+
+        # Check for missing dependencies
+        for meta in self._phases.values():
+            for dep in meta.depends_on:
+                if dep not in self._phases:
+                    errors.append(
+                        f"Phase {meta.name!r} depends on {dep!r}, which is not registered"
+                    )
+
+        # Check for cycles using Kahn's algorithm
+        if not errors:
+            in_degree: dict[str, int] = dict.fromkeys(self._phases, 0)
+            for meta in self._phases.values():
+                for _dep in meta.depends_on:
+                    in_degree[meta.name] += 1
+
+            queue = [name for name, deg in in_degree.items() if deg == 0]
+            visited = 0
+            adj: dict[str, list[str]] = defaultdict(list)
+            for meta in self._phases.values():
+                for dep in meta.depends_on:
+                    adj[dep].append(meta.name)
+
+            temp_queue = list(queue)
+            while temp_queue:
+                node = temp_queue.pop()
+                visited += 1
+                for neighbor in adj[node]:
+                    in_degree[neighbor] -= 1
+                    if in_degree[neighbor] == 0:
+                        temp_queue.append(neighbor)
+
+            if visited != len(self._phases):
+                cycle_members = [name for name, deg in in_degree.items() if deg > 0]
+                errors.append(
+                    f"Dependency cycle detected among: {', '.join(sorted(cycle_members))}"
+                )
+
+        return errors
+
+    # -- Execution order -------------------------------------------------------
+
+    def execution_order(self) -> list[str]:
+        """Return phase names in stable topological order.
+
+        Uses Kahn's algorithm with a min-heap on ``priority`` for stable
+        tiebreaking. Phases with no dependency relationship preserve their
+        registration order.
+
+        Raises:
+            ValueError: If the DAG is invalid (call ``validate()`` first for
+                detailed error messages).
+        """
+        in_degree: dict[str, int] = dict.fromkeys(self._phases, 0)
+        adj: dict[str, list[str]] = defaultdict(list)
+        for meta in self._phases.values():
+            for dep in meta.depends_on:
+                adj[dep].append(meta.name)
+                in_degree[meta.name] += 1
+
+        # Min-heap keyed on priority for stable ordering
+        heap: list[tuple[int, str]] = []
+        for name, deg in in_degree.items():
+            if deg == 0:
+                heapq.heappush(heap, (self._phases[name].priority, name))
+
+        result: list[str] = []
+        while heap:
+            _priority, name = heapq.heappop(heap)
+            result.append(name)
+            for neighbor in adj[name]:
+                in_degree[neighbor] -= 1
+                if in_degree[neighbor] == 0:
+                    heapq.heappush(heap, (self._phases[neighbor].priority, neighbor))
+
+        if len(result) != len(self._phases):
+            msg = "Dependency cycle detected — call validate() for details"
+            raise ValueError(msg)
+
+        return result
+
+    # -- Lookup ----------------------------------------------------------------
+
+    def get_meta(self, name: str) -> PhaseMeta | None:
+        """Get metadata for a registered phase, or None."""
+        return self._phases.get(name)
+
+    def get_function(self, name: str) -> Callable[..., Any] | None:
+        """Get the registered function for a phase, or None."""
+        return self._functions.get(name)
+
+    @property
+    def phase_names(self) -> list[str]:
+        """All registered phase names (insertion order)."""
+        return list(self._phases.keys())
+
+    def __len__(self) -> int:
+        return len(self._phases)
+
+    def __contains__(self, name: str) -> bool:
+        return name in self._phases
+
+    def phase_table(self) -> str:
+        """Human-readable table of registered phases.
+
+        Returns a markdown-formatted table with columns:
+        Priority | Name | Type | Depends On
+        """
+        lines = ["| Priority | Name | Type | Depends On |"]
+        lines.append("|----------|------|------|------------|")
+        for name in self.execution_order():
+            meta = self._phases[name]
+            phase_type = "deterministic" if meta.is_deterministic else "llm"
+            deps = ", ".join(meta.depends_on) if meta.depends_on else "—"
+            lines.append(f"| {meta.priority} | {name} | {phase_type} | {deps} |")
+        return "\n".join(lines)

--- a/src/questfoundry/pipeline/stages/grow/registry.py
+++ b/src/questfoundry/pipeline/stages/grow/registry.py
@@ -29,9 +29,6 @@ if TYPE_CHECKING:
 # Re-export for backward compatibility
 __all__ = ["PHASE_META_ATTR", "PhaseMeta", "PhaseRegistry", "get_registry", "grow_phase"]
 
-# Keep the GROW-specific constant name for backward compatibility
-_PHASE_META_ATTR = PHASE_META_ATTR
-
 
 # -- Module-level singleton ---------------------------------------------------
 

--- a/src/questfoundry/pipeline/stages/polish/__init__.py
+++ b/src/questfoundry/pipeline/stages/polish/__init__.py
@@ -7,6 +7,7 @@ works consistently with other stage packages.
 from __future__ import annotations
 
 from questfoundry.pipeline.stages.polish._helpers import PolishStageError
+from questfoundry.pipeline.stages.polish.registry import get_polish_registry, polish_phase
 from questfoundry.pipeline.stages.polish.stage import (
     PolishStage,
     create_polish_stage,
@@ -17,5 +18,7 @@ __all__ = [
     "PolishStage",
     "PolishStageError",
     "create_polish_stage",
+    "get_polish_registry",
+    "polish_phase",
     "polish_stage",
 ]

--- a/src/questfoundry/pipeline/stages/polish/registry.py
+++ b/src/questfoundry/pipeline/stages/polish/registry.py
@@ -1,19 +1,19 @@
-"""Phase registry with decorator-based dependency validation for GROW.
+"""Phase registry with decorator-based dependency validation for POLISH.
 
-Phases register via the ``@grow_phase`` decorator at import time. The registry
+Phases register via the ``@polish_phase`` decorator at import time. The registry
 validates the dependency DAG and produces a stable topological execution order.
 
 Usage::
 
-    @grow_phase(name="validate_dag", is_deterministic=True)
-    async def phase_validate_dag(graph, model):
+    @polish_phase(name="beat_reordering")
+    async def phase_beat_reordering(graph, model):
         ...
 
-    @grow_phase(name="passages", depends_on=["collapse_linear_beats"], is_deterministic=True)
-    async def phase_passages(graph, model):
+    @polish_phase(name="plan_computation", depends_on=["character_arcs"], is_deterministic=True)
+    async def phase_plan_computation(graph, model):
         ...
 
-The execution order is produced by ``get_registry().execution_order()``.
+The execution order is produced by ``get_polish_registry().execution_order()``.
 """
 
 from __future__ import annotations
@@ -26,31 +26,24 @@ if TYPE_CHECKING:
     from collections.abc import Callable
 
 
-# Re-export for backward compatibility
-__all__ = ["PHASE_META_ATTR", "PhaseMeta", "PhaseRegistry", "get_registry", "grow_phase"]
-
-# Keep the GROW-specific constant name for backward compatibility
-_PHASE_META_ATTR = PHASE_META_ATTR
-
-
 # -- Module-level singleton ---------------------------------------------------
 
 _registry = PhaseRegistry()
 
 
-def get_registry() -> PhaseRegistry:
-    """Return the module-level phase registry singleton."""
+def get_polish_registry() -> PhaseRegistry:
+    """Return the module-level POLISH phase registry singleton."""
     return _registry
 
 
-def grow_phase(
+def polish_phase(
     name: str,
     *,
     depends_on: list[str] | None = None,
     is_deterministic: bool = False,
     priority: int | None = None,
 ) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
-    """Decorator to register a GROW phase function.
+    """Decorator to register a POLISH phase function.
 
     Args:
         name: Unique phase name (used in execution order and logging).

--- a/src/questfoundry/pipeline/stages/polish/stage.py
+++ b/src/questfoundry/pipeline/stages/polish/stage.py
@@ -1,23 +1,40 @@
-"""POLISH stage stub.
+"""POLISH stage implementation.
 
 The POLISH stage transforms GROW's beat DAG into a prose-ready passage
 graph: passages with choices, variants, residue beats, and character
-arc metadata. Implementation will be added in subsequent PRs.
+arc metadata.
 
-This stub registers the stage so that CLI wiring and pipeline
-configuration can reference it immediately.
+POLISH manages its own graph: it loads, mutates, and saves the graph
+within execute(). The orchestrator should skip post-execute
+apply_mutations() for POLISH (same pattern as GROW).
+
+Phase dispatch is sequential via the phase registry. LLM phases use
+direct structured output: context from graph state → single LLM call
+→ validate → retry (max 3).
 """
 
 from __future__ import annotations
 
+from collections.abc import Awaitable, Callable
 from pathlib import Path  # noqa: TC003 - used at runtime
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, ClassVar
 
-from questfoundry.pipeline.stages.polish._helpers import PolishStageError, log
+from questfoundry.graph.graph import Graph
+from questfoundry.graph.polish_validation import validate_grow_output
+from questfoundry.graph.snapshots import save_snapshot
+from questfoundry.models.pipeline import PhaseResult
+from questfoundry.pipeline.gates import AutoApprovePhaseGate
+from questfoundry.pipeline.stages.polish._helpers import (
+    PolishStageError,
+    log,
+)
+from questfoundry.pipeline.stages.polish.registry import get_polish_registry
 
 if TYPE_CHECKING:
+    from langchain_core.callbacks import BaseCallbackHandler
     from langchain_core.language_models import BaseChatModel
 
+    from questfoundry.pipeline.gates import PhaseGateHook
     from questfoundry.pipeline.stages.base import (
         AssistantMessageFn,
         LLMCallbackFn,
@@ -29,8 +46,9 @@ if TYPE_CHECKING:
 class PolishStage:
     """POLISH stage: transforms beat DAG into prose-ready passage graph.
 
-    Stub implementation — raises PolishStageError until phases are
-    wired in subsequent PRs.
+    Executes phases sequentially with gate hooks between phases for
+    review/rollback capability. Follows the same self-managed graph
+    pattern as GrowStage.
 
     Attributes:
         name: Stage name for registry.
@@ -41,60 +59,240 @@ class PolishStage:
     def __init__(
         self,
         project_path: Path | None = None,
+        gate: PhaseGateHook | None = None,
     ) -> None:
         """Initialize POLISH stage.
 
         Args:
             project_path: Path to project directory for graph access.
+            gate: Phase gate hook for inter-phase approval.
+                Defaults to AutoApprovePhaseGate.
         """
         self.project_path = project_path
+        self.gate = gate or AutoApprovePhaseGate()
+        self._callbacks: list[BaseCallbackHandler] | None = None
+        self._provider_name: str | None = None
+        self._serialize_model: BaseChatModel | None = None
+        self._serialize_provider_name: str | None = None
+
+    # Type for async phase functions: (Graph, BaseChatModel) -> PhaseResult
+    PhaseFunc = Callable[["Graph", "BaseChatModel"], Awaitable[PhaseResult]]
+
+    # Map from registry phase name → self method name.
+    # LLM phases that need binding to ``self`` at call time.
+    _METHOD_PHASES: ClassVar[dict[str, str]] = {
+        # Will be populated as phases are implemented:
+        # "beat_reordering": "_phase_1_beat_reordering",
+        # "pacing": "_phase_2_pacing",
+        # "character_arcs": "_phase_3_character_arcs",
+        # "llm_enrichment": "_phase_5_llm_enrichment",
+    }
+
+    # Map from registry phase name → module-level free function.
+    # Deterministic phases resolved at call time for test patchability.
+    _FREE_PHASES: ClassVar[dict[str, str]] = {
+        # Will be populated as phases are implemented:
+        # "plan_computation": "phase_plan_computation",
+        # "plan_application": "phase_plan_application",
+        # "validation": "phase_validation",
+    }
+
+    def _phase_order(self) -> list[tuple[PhaseFunc, str]]:
+        """Return ordered list of (phase_function, phase_name) tuples.
+
+        Uses the phase registry for topological ordering, then resolves
+        each phase to its callable: bound method for LLM phases, module-
+        level import for deterministic free functions.
+        """
+        import questfoundry.pipeline.stages.polish.stage as _this_module
+
+        registry = get_polish_registry()
+        result: list[tuple[PolishStage.PhaseFunc, str]] = []
+
+        for phase_name in registry.execution_order():
+            method_name = self._METHOD_PHASES.get(phase_name)
+            free_name = self._FREE_PHASES.get(phase_name)
+
+            if method_name is not None:
+                fn = getattr(self, method_name)
+            elif free_name is not None:
+                fn = getattr(_this_module, free_name)
+            else:
+                fn = registry.get_function(phase_name)
+
+            result.append((fn, phase_name))
+
+        return result
 
     async def execute(
         self,
-        model: BaseChatModel,  # noqa: ARG002
+        model: BaseChatModel,
         user_prompt: str,  # noqa: ARG002
-        provider_name: str | None = None,  # noqa: ARG002
+        provider_name: str | None = None,
         *,
         interactive: bool = False,  # noqa: ARG002
         user_input_fn: UserInputFn | None = None,  # noqa: ARG002
         on_assistant_message: AssistantMessageFn | None = None,  # noqa: ARG002
         on_llm_start: LLMCallbackFn | None = None,  # noqa: ARG002
         on_llm_end: LLMCallbackFn | None = None,  # noqa: ARG002
-        on_phase_progress: PhaseProgressFn | None = None,  # noqa: ARG002
+        on_phase_progress: PhaseProgressFn | None = None,
         summarize_model: BaseChatModel | None = None,  # noqa: ARG002
-        serialize_model: BaseChatModel | None = None,  # noqa: ARG002
+        serialize_model: BaseChatModel | None = None,
         summarize_provider_name: str | None = None,  # noqa: ARG002
-        serialize_provider_name: str | None = None,  # noqa: ARG002
-        resume_from: str | None = None,  # noqa: ARG002
+        serialize_provider_name: str | None = None,
+        resume_from: str | None = None,
+        project_path: Path | None = None,
+        callbacks: list[BaseCallbackHandler] | None = None,
         **kwargs: Any,  # noqa: ARG002
     ) -> tuple[dict[str, Any], int, int]:
         """Execute the POLISH stage.
 
+        Loads the graph, validates GROW output, runs phases sequentially
+        with gate checks, saves the graph, and returns the result.
+
+        Args:
+            model: LangChain chat model for LLM phases.
+            user_prompt: User guidance (unused — POLISH is graph-driven).
+            provider_name: Provider name for strategy selection.
+            interactive: Interactive mode flag (unused).
+            user_input_fn: User input function (unused).
+            on_assistant_message: Assistant message callback (unused).
+            on_llm_start: LLM start callback (unused).
+            on_llm_end: LLM end callback (unused).
+            on_phase_progress: Callback for phase progress.
+            summarize_model: Summarize model (unused).
+            serialize_model: Model for structured output.
+            summarize_provider_name: Summarize provider name (unused).
+            serialize_provider_name: Provider name for structured output.
+            resume_from: Phase name to resume from.
+            project_path: Override for project path.
+            callbacks: LangChain callback handlers.
+            **kwargs: Additional keyword arguments.
+
         Returns:
-            Tuple of (artifact_data, llm_calls, tokens_used).
+            Tuple of (POLISH artifact dict, total_llm_calls, total_tokens).
 
         Raises:
-            PolishStageError: Always, until implementation is added.
+            PolishStageError: If project_path is not provided or
+                GROW output validation fails.
         """
-        log.info("polish_stage_invoked")
-        raise PolishStageError(
-            "POLISH stage is not yet implemented. "
-            "Phase implementation will be added in subsequent PRs."
+        resolved_path = project_path or self.project_path
+        if resolved_path is None:
+            raise PolishStageError(
+                "project_path is required for POLISH stage. "
+                "Provide it in constructor or execute() call."
+            )
+
+        self._callbacks = callbacks
+        self._provider_name = provider_name
+        self._serialize_model = serialize_model
+        self._serialize_provider_name = serialize_provider_name
+        log.info("stage_start", stage="polish")
+
+        graph = Graph.load(resolved_path)
+
+        # Verify prerequisite stage
+        last_stage = graph.get_last_stage()
+        if last_stage not in ("grow", "polish", "fill", "dress", "ship"):
+            raise PolishStageError(
+                f"POLISH requires completed GROW stage. "
+                f"Current last_stage: '{last_stage}'. Run GROW before POLISH."
+            )
+
+        # Re-run management: rewind any existing polish mutations
+        phases = self._phase_order()
+        phase_map = {name: i for i, (_, name) in enumerate(phases)}
+        start_idx = 0
+
+        if resume_from:
+            if resume_from not in phase_map:
+                raise PolishStageError(
+                    f"Unknown phase: '{resume_from}'. Valid phases: {', '.join(phase_map)}"
+                )
+            start_idx = phase_map[resume_from]
+            graph.rewind_to_phase("polish", resume_from)
+            log.info("resume_via_rewind", phase=resume_from, skipped=start_idx)
+        else:
+            n = graph.rewind_stage("polish")
+            if n > 0:
+                log.info("rewinding_graph", stage="polish", mutations=n)
+            save_snapshot(graph, resolved_path, "polish")
+
+        # Validate GROW output (entry contract)
+        entry_errors = validate_grow_output(graph)
+        if entry_errors:
+            raise PolishStageError(
+                f"GROW output validation failed ({len(entry_errors)} errors):\n"
+                + "\n".join(f"  - {e}" for e in entry_errors)
+            )
+
+        phase_results: list[PhaseResult] = []
+        total_llm_calls = 0
+        total_tokens = 0
+
+        for idx, (phase_fn, phase_name) in enumerate(phases):
+            if idx < start_idx:
+                continue
+
+            log.debug("phase_start", phase=phase_name)
+            graph.savepoint(phase_name)
+
+            with graph.mutation_context(stage="polish", phase=phase_name):
+                result = await phase_fn(graph, model)
+            phase_results.append(result)
+            total_llm_calls += result.llm_calls
+            total_tokens += result.tokens_used
+
+            if result.status == "failed":
+                log.error("phase_failed", phase=phase_name, detail=result.detail)
+                raise PolishStageError(f"POLISH phase '{phase_name}' failed: {result.detail}")
+
+            decision = await self.gate.on_phase_complete("polish", phase_name, result)
+            if decision == "reject":
+                log.info("phase_rejected", phase=phase_name)
+                graph.rollback_to(phase_name)
+                graph.release(phase_name)
+                graph.save(resolved_path / "graph.db")
+                break
+
+            graph.release(phase_name)
+            log.debug("phase_complete", phase=phase_name, status=result.status)
+
+            if on_phase_progress is not None:
+                on_phase_progress(phase_name, result.status, result.detail)
+
+        graph.set_last_stage("polish")
+        graph.save(resolved_path / "graph.db")
+
+        polish_result = {
+            "phases_completed": [r.model_dump() for r in phase_results],
+        }
+
+        log.info(
+            "stage_complete",
+            stage="polish",
+            phases=len(phase_results),
+            llm_calls=total_llm_calls,
         )
+
+        return polish_result, total_llm_calls, total_tokens
 
 
 def create_polish_stage(
     project_path: Path | None = None,
+    gate: PhaseGateHook | None = None,
 ) -> PolishStage:
     """Create a new PolishStage instance.
 
     Args:
         project_path: Path to project directory for graph access.
+        gate: Phase gate hook for inter-phase approval.
 
     Returns:
         Configured PolishStage instance.
     """
-    return PolishStage(project_path=project_path)
+    return PolishStage(project_path=project_path, gate=gate)
 
 
-polish_stage = create_polish_stage()
+# Singleton instance for registration (project_path provided at execution)
+polish_stage = PolishStage()

--- a/tests/unit/test_grow_registry.py
+++ b/tests/unit/test_grow_registry.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import pytest
 
 from questfoundry.pipeline.stages.grow.registry import (
-    _PHASE_META_ATTR,
+    PHASE_META_ATTR,
     PhaseMeta,
     PhaseRegistry,
     get_registry,
@@ -203,10 +203,10 @@ class TestGrowPhaseDecorator:
             pass
 
         reg.register(my_phase, meta)
-        setattr(my_phase, _PHASE_META_ATTR, meta)
+        setattr(my_phase, PHASE_META_ATTR, meta)
 
-        assert hasattr(my_phase, _PHASE_META_ATTR)
-        attached = getattr(my_phase, _PHASE_META_ATTR)
+        assert hasattr(my_phase, PHASE_META_ATTR)
+        attached = getattr(my_phase, PHASE_META_ATTR)
         assert attached.name == "test_deco"
         assert attached.depends_on == ()
         assert attached.is_deterministic is True

--- a/tests/unit/test_polish_cli.py
+++ b/tests/unit/test_polish_cli.py
@@ -58,15 +58,15 @@ def test_polish_stage_class() -> None:
     assert stage.project_path is None
 
 
-def test_polish_stage_execute_raises_not_implemented() -> None:
-    """Stub execute() raises PolishStageError."""
+def test_polish_stage_execute_requires_project_path() -> None:
+    """execute() raises PolishStageError when no project_path is set."""
     import asyncio
     from unittest.mock import MagicMock
 
     stage = PolishStage()
     mock_model = MagicMock()
 
-    with pytest.raises(PolishStageError, match="not yet implemented"):
+    with pytest.raises(PolishStageError, match="project_path is required"):
         asyncio.run(stage.execute(mock_model, "test prompt"))
 
 

--- a/tests/unit/test_polish_entry_contract.py
+++ b/tests/unit/test_polish_entry_contract.py
@@ -148,7 +148,9 @@ class TestValidateGrowOutput:
         graph.add_edge("belongs_to", "beat::intro", "path::coward")
 
         errors = validate_grow_output(graph)
-        assert any("beat::intro" in e and "2 belongs_to" in e for e in errors)
+        multi_errors = [e for e in errors if "beat::intro" in e and "belongs_to" in e]
+        assert multi_errors, f"Expected multiple belongs_to error for beat::intro, got: {errors}"
+        assert any("must have exactly 1" in e for e in multi_errors)
 
     def test_dilemma_missing_role(self) -> None:
         """Dilemma without dilemma_role fails validation."""
@@ -195,6 +197,21 @@ class TestValidateGrowOutput:
 
         errors = validate_grow_output(graph)
         assert any("same path" in e.lower() for e in errors)
+
+    def test_intersection_group_empty_node_ids_fails(self) -> None:
+        """Intersection group with empty node_ids fails validation."""
+        graph = _make_valid_grow_graph()
+        graph.create_node(
+            "intersection_group::ig_empty",
+            {
+                "type": "intersection_group",
+                "raw_id": "ig_empty",
+                "node_ids": [],
+            },
+        )
+
+        errors = validate_grow_output(graph)
+        assert any("ig_empty" in e and "empty node_ids" in e for e in errors)
 
     def test_intersection_group_different_paths_passes(self) -> None:
         """Intersection group with beats from different paths passes."""

--- a/tests/unit/test_polish_entry_contract.py
+++ b/tests/unit/test_polish_entry_contract.py
@@ -1,0 +1,224 @@
+"""Tests for POLISH entry contract validation."""
+
+from __future__ import annotations
+
+from questfoundry.graph.graph import Graph
+from questfoundry.graph.polish_validation import validate_grow_output
+
+
+def _make_valid_grow_graph() -> Graph:
+    """Create a minimal valid GROW output graph for testing.
+
+    Contains:
+    - 2 beat nodes with summaries and dilemma_impacts
+    - 1 dilemma with dilemma_role set
+    - 1 path
+    - belongs_to edges (each beat -> path)
+    - predecessor edge (beat_b -> beat_a)
+    - 1 state_flag node referencing the dilemma
+    """
+    graph = Graph.empty()
+
+    # Create dilemma
+    graph.create_node(
+        "dilemma::courage_or_caution",
+        {
+            "type": "dilemma",
+            "raw_id": "courage_or_caution",
+            "question": "Fight or flee?",
+            "dilemma_role": "hard",
+            "status": "explored",
+        },
+    )
+
+    # Create path
+    graph.create_node(
+        "path::brave",
+        {
+            "type": "path",
+            "raw_id": "brave",
+            "label": "The Brave Path",
+        },
+    )
+
+    # Create beats with required fields
+    graph.create_node(
+        "beat::intro",
+        {
+            "type": "beat",
+            "raw_id": "intro",
+            "summary": "The hero arrives at the crossroads",
+            "dilemma_impacts": [{"dilemma_id": "dilemma::courage_or_caution", "effect": "setup"}],
+        },
+    )
+    graph.create_node(
+        "beat::fight",
+        {
+            "type": "beat",
+            "raw_id": "fight",
+            "summary": "The hero draws their sword",
+            "dilemma_impacts": [{"dilemma_id": "dilemma::courage_or_caution", "effect": "commit"}],
+        },
+    )
+
+    # belongs_to edges: add_edge(edge_type, from_id, to_id)
+    graph.add_edge("belongs_to", "beat::intro", "path::brave")
+    graph.add_edge("belongs_to", "beat::fight", "path::brave")
+
+    # predecessor edge (fight comes after intro)
+    graph.add_edge("predecessor", "beat::fight", "beat::intro")
+
+    # State flag for the dilemma
+    graph.create_node(
+        "state_flag::courage_active",
+        {
+            "type": "state_flag",
+            "raw_id": "courage_active",
+            "dilemma_id": "dilemma::courage_or_caution",
+        },
+    )
+
+    return graph
+
+
+class TestValidateGrowOutput:
+    """Tests for validate_grow_output."""
+
+    def test_valid_graph_passes(self) -> None:
+        """A properly constructed GROW graph passes validation."""
+        graph = _make_valid_grow_graph()
+        errors = validate_grow_output(graph)
+        assert errors == [], f"Unexpected errors: {errors}"
+
+    def test_no_beats_fails(self) -> None:
+        """Empty graph fails validation."""
+        graph = Graph.empty()
+        errors = validate_grow_output(graph)
+        assert any("No beat nodes" in e for e in errors)
+
+    def test_beat_missing_summary(self) -> None:
+        """Beat without summary fails validation."""
+        graph = _make_valid_grow_graph()
+        # Remove summary from one beat by updating with empty summary
+        graph.update_node("beat::intro", summary="")
+
+        errors = validate_grow_output(graph)
+        assert any("beat::intro" in e and "summary" in e for e in errors)
+
+    def test_beat_missing_dilemma_impacts(self) -> None:
+        """Beat without dilemma_impacts fails validation."""
+        graph = _make_valid_grow_graph()
+        # Get current node, remove dilemma_impacts, recreate
+        node = graph.get_node("beat::intro")
+        assert node is not None
+        graph.delete_node("beat::intro", cascade=True)
+        node.pop("dilemma_impacts", None)
+        graph.create_node("beat::intro", node)
+        # Re-add edges
+        graph.add_edge("belongs_to", "beat::intro", "path::brave")
+        graph.add_edge("predecessor", "beat::fight", "beat::intro")
+
+        errors = validate_grow_output(graph)
+        assert any("beat::intro" in e and "dilemma_impacts" in e for e in errors)
+
+    def test_beat_missing_belongs_to(self) -> None:
+        """Beat without belongs_to edge fails validation."""
+        graph = Graph.empty()
+        graph.create_node(
+            "beat::orphan",
+            {
+                "type": "beat",
+                "raw_id": "orphan",
+                "summary": "An orphan beat",
+                "dilemma_impacts": [],
+            },
+        )
+
+        errors = validate_grow_output(graph)
+        assert any("beat::orphan" in e and "belongs_to" in e for e in errors)
+
+    def test_beat_multiple_belongs_to(self) -> None:
+        """Beat with multiple belongs_to edges fails validation."""
+        graph = _make_valid_grow_graph()
+        # Create second path and duplicate belongs_to
+        graph.create_node(
+            "path::coward",
+            {"type": "path", "raw_id": "coward", "label": "Coward Path"},
+        )
+        graph.add_edge("belongs_to", "beat::intro", "path::coward")
+
+        errors = validate_grow_output(graph)
+        assert any("beat::intro" in e and "2 belongs_to" in e for e in errors)
+
+    def test_dilemma_missing_role(self) -> None:
+        """Dilemma without dilemma_role fails validation."""
+        graph = _make_valid_grow_graph()
+        # Recreate dilemma without dilemma_role
+        node = graph.get_node("dilemma::courage_or_caution")
+        assert node is not None
+        graph.delete_node("dilemma::courage_or_caution")
+        node.pop("dilemma_role", None)
+        graph.create_node("dilemma::courage_or_caution", node)
+
+        errors = validate_grow_output(graph)
+        assert any("dilemma_role" in e for e in errors)
+
+    def test_explored_dilemma_missing_state_flags(self) -> None:
+        """Explored dilemma without state flags fails validation."""
+        graph = _make_valid_grow_graph()
+        # Remove the state flag node
+        graph.delete_node("state_flag::courage_active")
+
+        errors = validate_grow_output(graph)
+        assert any("state flag" in e.lower() for e in errors)
+
+    def test_predecessor_cycle_detected(self) -> None:
+        """Cycle in predecessor DAG fails validation."""
+        graph = _make_valid_grow_graph()
+        # Create a cycle: intro -> fight -> intro
+        graph.add_edge("predecessor", "beat::intro", "beat::fight")
+
+        errors = validate_grow_output(graph)
+        assert any("cycle" in e.lower() for e in errors)
+
+    def test_intersection_group_same_path_fails(self) -> None:
+        """Intersection group with beats from the same path fails."""
+        graph = _make_valid_grow_graph()
+        graph.create_node(
+            "intersection_group::ig1",
+            {
+                "type": "intersection_group",
+                "raw_id": "ig1",
+                "node_ids": ["beat::intro", "beat::fight"],
+            },
+        )
+
+        errors = validate_grow_output(graph)
+        assert any("same path" in e.lower() for e in errors)
+
+    def test_intersection_group_different_paths_passes(self) -> None:
+        """Intersection group with beats from different paths passes."""
+        graph = _make_valid_grow_graph()
+
+        # Create second path and move fight there
+        graph.create_node(
+            "path::cautious",
+            {"type": "path", "raw_id": "cautious", "label": "Cautious Path"},
+        )
+        # Remove existing belongs_to for fight and add new one
+        graph.remove_edge("belongs_to", "beat::fight", "path::brave")
+        graph.add_edge("belongs_to", "beat::fight", "path::cautious")
+
+        graph.create_node(
+            "intersection_group::ig1",
+            {
+                "type": "intersection_group",
+                "raw_id": "ig1",
+                "node_ids": ["beat::intro", "beat::fight"],
+            },
+        )
+
+        errors = validate_grow_output(graph)
+        # Should not have intersection-related errors
+        intersection_errors = [e for e in errors if "intersection" in e.lower()]
+        assert intersection_errors == []

--- a/tests/unit/test_polish_registry.py
+++ b/tests/unit/test_polish_registry.py
@@ -1,0 +1,221 @@
+"""Tests for POLISH phase registry."""
+
+from __future__ import annotations
+
+import pytest
+
+from questfoundry.pipeline.registry import PHASE_META_ATTR, PhaseMeta, PhaseRegistry
+
+
+class TestPhaseRegistry:
+    """Tests for the shared PhaseRegistry class."""
+
+    def test_register_phase(self) -> None:
+        """Register a phase and retrieve it."""
+        registry = PhaseRegistry()
+        meta = PhaseMeta(name="test", depends_on=(), is_deterministic=True, priority=0)
+
+        async def dummy(graph, model):
+            pass
+
+        registry.register(dummy, meta)
+        assert "test" in registry
+        assert len(registry) == 1
+        assert registry.get_meta("test") == meta
+        assert registry.get_function("test") is dummy
+
+    def test_duplicate_registration_raises(self) -> None:
+        """Registering the same phase name twice raises ValueError."""
+        registry = PhaseRegistry()
+        meta = PhaseMeta(name="dup", depends_on=(), is_deterministic=True, priority=0)
+
+        async def fn1(graph, model):
+            pass
+
+        async def fn2(graph, model):
+            pass
+
+        registry.register(fn1, meta)
+        with pytest.raises(ValueError, match="Duplicate phase name"):
+            registry.register(fn2, meta)
+
+    def test_validate_missing_dependency(self) -> None:
+        """Validate catches missing dependency references."""
+        registry = PhaseRegistry()
+        meta = PhaseMeta(
+            name="phase_b", depends_on=("nonexistent",), is_deterministic=True, priority=0
+        )
+
+        async def fn(graph, model):
+            pass
+
+        registry.register(fn, meta)
+        errors = registry.validate()
+        assert len(errors) == 1
+        assert "nonexistent" in errors[0]
+
+    def test_validate_cycle_detection(self) -> None:
+        """Validate catches dependency cycles."""
+        registry = PhaseRegistry()
+
+        async def fn(graph, model):
+            pass
+
+        registry.register(
+            fn,
+            PhaseMeta(name="a", depends_on=("b",), is_deterministic=True, priority=0),
+        )
+        registry.register(
+            fn,
+            PhaseMeta(name="b", depends_on=("a",), is_deterministic=True, priority=1),
+        )
+        errors = registry.validate()
+        assert len(errors) == 1
+        assert "cycle" in errors[0].lower()
+
+    def test_validate_empty_is_valid(self) -> None:
+        """Empty registry validates successfully."""
+        registry = PhaseRegistry()
+        assert registry.validate() == []
+
+    def test_execution_order_respects_dependencies(self) -> None:
+        """execution_order returns dependencies before dependents."""
+        registry = PhaseRegistry()
+
+        async def fn(graph, model):
+            pass
+
+        registry.register(
+            fn,
+            PhaseMeta(name="first", depends_on=(), is_deterministic=True, priority=0),
+        )
+        registry.register(
+            fn,
+            PhaseMeta(name="second", depends_on=("first",), is_deterministic=True, priority=1),
+        )
+        registry.register(
+            fn,
+            PhaseMeta(name="third", depends_on=("second",), is_deterministic=True, priority=2),
+        )
+        order = registry.execution_order()
+        assert order == ["first", "second", "third"]
+
+    def test_execution_order_tiebreaks_on_priority(self) -> None:
+        """Independent phases are ordered by priority."""
+        registry = PhaseRegistry()
+
+        async def fn(graph, model):
+            pass
+
+        registry.register(
+            fn,
+            PhaseMeta(name="low", depends_on=(), is_deterministic=True, priority=10),
+        )
+        registry.register(
+            fn,
+            PhaseMeta(name="high", depends_on=(), is_deterministic=True, priority=1),
+        )
+        order = registry.execution_order()
+        assert order.index("high") < order.index("low")
+
+    def test_phase_names_returns_insertion_order(self) -> None:
+        """phase_names returns names in insertion order."""
+        registry = PhaseRegistry()
+
+        async def fn(graph, model):
+            pass
+
+        for i, name in enumerate(["alpha", "beta", "gamma"]):
+            registry.register(
+                fn,
+                PhaseMeta(name=name, depends_on=(), is_deterministic=True, priority=i),
+            )
+        assert registry.phase_names == ["alpha", "beta", "gamma"]
+
+    def test_phase_table_format(self) -> None:
+        """phase_table returns markdown table."""
+        registry = PhaseRegistry()
+
+        async def fn(graph, model):
+            pass
+
+        registry.register(
+            fn,
+            PhaseMeta(name="test_phase", depends_on=(), is_deterministic=False, priority=0),
+        )
+        table = registry.phase_table()
+        assert "test_phase" in table
+        assert "llm" in table
+        assert "Priority" in table
+
+
+class TestPolishPhaseDecorator:
+    """Tests for the @polish_phase decorator."""
+
+    def test_decorator_registers_phase(self) -> None:
+        """@polish_phase registers the function in the POLISH registry."""
+        from questfoundry.pipeline.stages.polish.registry import (
+            get_polish_registry,
+            polish_phase,
+        )
+
+        registry = get_polish_registry()
+        initial_count = len(registry)
+
+        @polish_phase(name=f"test_phase_{initial_count}", is_deterministic=True)
+        async def my_phase(graph, model):
+            pass
+
+        assert len(registry) == initial_count + 1
+        assert hasattr(my_phase, PHASE_META_ATTR)
+
+    def test_decorator_sets_meta_attribute(self) -> None:
+        """@polish_phase sets _phase_meta on the decorated function."""
+        from questfoundry.pipeline.stages.polish.registry import (
+            get_polish_registry,
+            polish_phase,
+        )
+
+        registry = get_polish_registry()
+        phase_name = f"meta_test_{len(registry)}"
+
+        @polish_phase(name=phase_name, depends_on=["other"], is_deterministic=False, priority=42)
+        async def my_phase(graph, model):
+            pass
+
+        meta = getattr(my_phase, PHASE_META_ATTR)
+        assert meta.name == phase_name
+        assert meta.depends_on == ("other",)
+        assert meta.is_deterministic is False
+        assert meta.priority == 42
+
+
+class TestGrowRegistryBackwardCompat:
+    """Verify GROW registry still works after extraction to shared module."""
+
+    def test_grow_registry_imports(self) -> None:
+        """GROW registry classes are importable from both locations."""
+        from questfoundry.pipeline.registry import PhaseMeta as SharedPhaseMeta
+        from questfoundry.pipeline.registry import PhaseRegistry as SharedRegistry
+        from questfoundry.pipeline.stages.grow.registry import PhaseMeta as GrowPhaseMeta
+        from questfoundry.pipeline.stages.grow.registry import PhaseRegistry as GrowRegistry
+
+        # They should be the exact same classes
+        assert SharedPhaseMeta is GrowPhaseMeta
+        assert SharedRegistry is GrowRegistry
+
+    def test_grow_registry_has_phases(self) -> None:
+        """GROW registry should have existing phases registered."""
+        from questfoundry.pipeline.stages.grow.registry import get_registry
+
+        registry = get_registry()
+        assert len(registry) > 0
+        assert "validate_dag" in registry
+
+    def test_grow_registry_validates(self) -> None:
+        """GROW registry DAG should be valid."""
+        from questfoundry.pipeline.stages.grow.registry import get_registry
+
+        registry = get_registry()
+        errors = registry.validate()
+        assert errors == [], f"GROW registry validation errors: {errors}"


### PR DESCRIPTION
## Summary

- Extract `PhaseRegistry` + `PhaseMeta` from `grow/registry.py` to shared `pipeline/registry.py` — GROW imports from shared module for backward compatibility
- Create `polish/registry.py` with `@polish_phase` decorator and module-level singleton
- Create `graph/polish_validation.py` with `validate_grow_output()` entry contract (7 validation checks)
- Replace stub `PolishStage` with real stage class following `GrowStage` pattern: self-managed graph, phase dispatch via registry, gate hooks, rewind/resume support

Stacked on #1034. Part of Epic #990 Phase 4.

## Not Included / Future PRs

- Phase implementations (PRs 3-8) — `_METHOD_PHASES` and `_FREE_PHASES` maps are empty placeholders
- [compute_active_flags_at_beat utility](https://github.com/pvliesdonk/questfoundry/issues/987) — PR 3

## Test plan

- [x] `test_polish_registry.py` — 14 tests: registration, DAG validation, execution order, GROW backward compat
- [x] `test_polish_entry_contract.py` — 11 tests: valid graph, missing beats/summary/impacts/belongs_to/role/flags, cycles, intersection groups
- [x] `test_grow_registry.py` — 17 existing tests pass (no regressions from extraction)
- [x] `test_polish_cli.py` — 8 tests pass (updated for real stage class)

🤖 Generated with [Claude Code](https://claude.com/claude-code)