### PR TITLE
feat: add compute_active_flags_at_beat() utility

### DIFF
--- a/src/questfoundry/graph/algorithms.py
+++ b/src/questfoundry/graph/algorithms.py
@@ -1,0 +1,128 @@
+"""Shared graph algorithms for pipeline stages.
+
+Pure functions that operate on the graph without modifying it. These
+replace Arc-dependent computations and can be used by both GROW
+(for validation) and POLISH (for plan computation).
+"""
+
+from __future__ import annotations
+
+from itertools import product
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from questfoundry.graph.graph import Graph
+
+
+def compute_active_flags_at_beat(graph: Graph, beat_id: str) -> set[frozenset[str]]:
+    """Compute all valid state flag combinations at a beat position.
+
+    Returns a set of frozensets, where each frozenset is one possible
+    combination of active state flags at this beat's position in the DAG.
+
+    A "state flag" here is a string identifier derived from a commit beat's
+    dilemma/path membership. When a player reaches beat B, they have
+    necessarily traversed some subset of commit beats. This function
+    computes all valid subsets respecting mutual exclusivity (cannot
+    have committed to both paths of the same dilemma).
+
+    Algorithm:
+        1. Find all commit beats in the DAG.
+        2. Reverse BFS from beat_id to find ancestor commit beats.
+        3. Group ancestor commits by dilemma.
+        4. Compute Cartesian product of per-dilemma options, filtered
+           by mutual exclusivity.
+
+    Args:
+        graph: Graph containing beat DAG with predecessor edges.
+        beat_id: Beat node ID to compute flags for.
+
+    Returns:
+        Set of frozensets. Each frozenset contains the active state
+        flag IDs for one valid traversal path. Returns ``{frozenset()}``
+        if no commit beats are ancestors (empty flag set).
+
+    Raises:
+        ValueError: If beat_id is not a valid beat node.
+    """
+    beat_node = graph.get_node(beat_id)
+    if beat_node is None or beat_node.get("type") != "beat":
+        msg = f"Node {beat_id!r} is not a valid beat node"
+        raise ValueError(msg)
+
+    # Step 1: Build predecessor adjacency (child → parents)
+    beat_nodes = graph.get_nodes_by_type("beat")
+    predecessor_edges = graph.get_edges(edge_type="predecessor")
+
+    # predecessor edge: from=child, to=parent (child depends on parent)
+    parents: dict[str, list[str]] = {bid: [] for bid in beat_nodes}
+    for edge in predecessor_edges:
+        from_id = edge["from"]
+        to_id = edge["to"]
+        if from_id in beat_nodes and to_id in beat_nodes:
+            parents[from_id].append(to_id)
+
+    # Step 2: Reverse BFS to find all ancestors of beat_id
+    ancestors: set[str] = set()
+    queue = list(parents.get(beat_id, []))
+    while queue:
+        current = queue.pop()
+        if current in ancestors:
+            continue
+        ancestors.add(current)
+        queue.extend(parents.get(current, []))
+
+    # Step 3: Find commit beats among ancestors and group by dilemma
+    # A commit beat has dilemma_impacts with effect="commits"
+    belongs_to_edges = graph.get_edges(edge_type="belongs_to")
+    beat_to_path: dict[str, str] = {}
+    for edge in belongs_to_edges:
+        if edge["from"] in beat_nodes:
+            beat_to_path[edge["from"]] = edge["to"]
+
+    # dilemma_id → list of state flag identifiers from different paths
+    dilemma_flags: dict[str, list[str]] = {}
+
+    for ancestor_id in ancestors:
+        ancestor_data = beat_nodes.get(ancestor_id, {})
+        impacts = ancestor_data.get("dilemma_impacts", [])
+        for impact in impacts:
+            if impact.get("effect") == "commits":
+                dilemma_id = impact.get("dilemma_id", "")
+                path_id = beat_to_path.get(ancestor_id, "")
+                if dilemma_id and path_id:
+                    # State flag: "{dilemma_id}:{path_id}"
+                    flag = f"{dilemma_id}:{path_id}"
+                    dilemma_flags.setdefault(dilemma_id, []).append(flag)
+
+    # Also check if beat_id itself is a commit beat
+    beat_data = beat_nodes.get(beat_id, {})
+    for impact in beat_data.get("dilemma_impacts", []):
+        if impact.get("effect") == "commits":
+            dilemma_id = impact.get("dilemma_id", "")
+            path_id = beat_to_path.get(beat_id, "")
+            if dilemma_id and path_id:
+                flag = f"{dilemma_id}:{path_id}"
+                dilemma_flags.setdefault(dilemma_id, []).append(flag)
+
+    if not dilemma_flags:
+        return {frozenset()}
+
+    # Step 4: Deduplicate flags per dilemma and compute Cartesian product
+    # For each dilemma, the player can only be on one path, so each dilemma
+    # contributes exactly one flag (or none if not yet committed).
+    # We include "no flag for this dilemma" as an option only if the
+    # beat is NOT downstream of a commit for that dilemma. But since
+    # we only collected flags from ancestors that ARE commits, having
+    # a flag means the dilemma IS committed. We just need unique flags.
+    per_dilemma_options: list[list[str]] = []
+    for _dilemma_id, flags in sorted(dilemma_flags.items()):
+        unique_flags = sorted(set(flags))
+        per_dilemma_options.append(unique_flags)
+
+    # Cartesian product: one flag per committed dilemma
+    result: set[frozenset[str]] = set()
+    for combo in product(*per_dilemma_options):
+        result.add(frozenset(combo))
+
+    return result

--- a/tests/unit/test_algorithms.py
+++ b/tests/unit/test_algorithms.py
@@ -1,0 +1,317 @@
+"""Tests for shared graph algorithms."""
+
+from __future__ import annotations
+
+import pytest
+
+from questfoundry.graph.algorithms import compute_active_flags_at_beat
+from questfoundry.graph.graph import Graph
+
+
+def _make_beat(graph: Graph, beat_id: str, summary: str, impacts: list[dict]) -> None:
+    """Helper to create a beat node."""
+    graph.create_node(
+        beat_id,
+        {
+            "type": "beat",
+            "raw_id": beat_id.split("::")[-1],
+            "summary": summary,
+            "dilemma_impacts": impacts,
+        },
+    )
+
+
+def _add_belongs_to(graph: Graph, beat_id: str, path_id: str) -> None:
+    """Helper to create a belongs_to edge."""
+    graph.add_edge("belongs_to", beat_id, path_id)
+
+
+def _add_predecessor(graph: Graph, child: str, parent: str) -> None:
+    """Helper to create a predecessor edge (child depends on parent)."""
+    graph.add_edge("predecessor", child, parent)
+
+
+class TestComputeActiveFlagsNoPredecessors:
+    """Tests with no commit beat ancestors."""
+
+    def test_no_commit_ancestors_returns_empty_flagset(self) -> None:
+        """Beat with no commit ancestors returns {frozenset()}."""
+        graph = Graph.empty()
+        graph.create_node("path::p1", {"type": "path", "raw_id": "p1"})
+        _make_beat(graph, "beat::start", "Start", [])
+        _add_belongs_to(graph, "beat::start", "path::p1")
+
+        result = compute_active_flags_at_beat(graph, "beat::start")
+        assert result == {frozenset()}
+
+    def test_single_beat_no_predecessors(self) -> None:
+        """Lone beat with no predecessors and no commits."""
+        graph = Graph.empty()
+        graph.create_node("path::p1", {"type": "path", "raw_id": "p1"})
+        _make_beat(graph, "beat::only", "Only beat", [{"dilemma_id": "d1", "effect": "setup"}])
+        _add_belongs_to(graph, "beat::only", "path::p1")
+
+        result = compute_active_flags_at_beat(graph, "beat::only")
+        assert result == {frozenset()}
+
+    def test_invalid_beat_raises(self) -> None:
+        """Non-beat node raises ValueError."""
+        graph = Graph.empty()
+        graph.create_node("path::p1", {"type": "path", "raw_id": "p1"})
+
+        with pytest.raises(ValueError, match="not a valid beat"):
+            compute_active_flags_at_beat(graph, "path::p1")
+
+    def test_missing_node_raises(self) -> None:
+        """Non-existent node raises ValueError."""
+        graph = Graph.empty()
+
+        with pytest.raises(ValueError, match="not a valid beat"):
+            compute_active_flags_at_beat(graph, "beat::nonexistent")
+
+
+class TestComputeActiveFlagsSingleDilemma:
+    """Tests with one dilemma."""
+
+    def test_one_commit_ancestor(self) -> None:
+        """Beat downstream of one commit has one flag combination."""
+        graph = Graph.empty()
+        graph.create_node("path::brave", {"type": "path", "raw_id": "brave"})
+        graph.create_node(
+            "dilemma::courage",
+            {"type": "dilemma", "raw_id": "courage", "dilemma_role": "hard"},
+        )
+
+        _make_beat(
+            graph,
+            "beat::commit_brave",
+            "Commits to bravery",
+            [{"dilemma_id": "dilemma::courage", "effect": "commits"}],
+        )
+        _make_beat(graph, "beat::after", "After commitment", [])
+
+        _add_belongs_to(graph, "beat::commit_brave", "path::brave")
+        _add_belongs_to(graph, "beat::after", "path::brave")
+        _add_predecessor(graph, "beat::after", "beat::commit_brave")
+
+        result = compute_active_flags_at_beat(graph, "beat::after")
+        assert result == {frozenset({"dilemma::courage:path::brave"})}
+
+    def test_commit_beat_itself_has_own_flag(self) -> None:
+        """A commit beat includes its own flag in the result."""
+        graph = Graph.empty()
+        graph.create_node("path::bold", {"type": "path", "raw_id": "bold"})
+        graph.create_node(
+            "dilemma::bravery",
+            {"type": "dilemma", "raw_id": "bravery", "dilemma_role": "hard"},
+        )
+
+        _make_beat(
+            graph,
+            "beat::the_commit",
+            "The moment of commitment",
+            [{"dilemma_id": "dilemma::bravery", "effect": "commits"}],
+        )
+        _add_belongs_to(graph, "beat::the_commit", "path::bold")
+
+        result = compute_active_flags_at_beat(graph, "beat::the_commit")
+        assert result == {frozenset({"dilemma::bravery:path::bold"})}
+
+    def test_deep_chain(self) -> None:
+        """Commit at start of a long chain is still found."""
+        graph = Graph.empty()
+        graph.create_node("path::p1", {"type": "path", "raw_id": "p1"})
+        graph.create_node(
+            "dilemma::d1",
+            {"type": "dilemma", "raw_id": "d1", "dilemma_role": "soft"},
+        )
+
+        _make_beat(
+            graph,
+            "beat::b0",
+            "Commit",
+            [{"dilemma_id": "dilemma::d1", "effect": "commits"}],
+        )
+        _add_belongs_to(graph, "beat::b0", "path::p1")
+
+        # Chain: b0 → b1 → b2 → b3 → b4
+        for i in range(1, 5):
+            _make_beat(graph, f"beat::b{i}", f"Beat {i}", [])
+            _add_belongs_to(graph, f"beat::b{i}", "path::p1")
+            _add_predecessor(graph, f"beat::b{i}", f"beat::b{i - 1}")
+
+        result = compute_active_flags_at_beat(graph, "beat::b4")
+        assert result == {frozenset({"dilemma::d1:path::p1"})}
+
+
+class TestComputeActiveFlagsTwoDilemmas:
+    """Tests with two dilemmas — cross-product behavior."""
+
+    def _build_two_dilemma_graph(self) -> Graph:
+        """Build graph with 2 dilemmas, 2 paths each, commits on both.
+
+        Structure:
+            beat::commit_d1_a (path_a, commits d1)
+                ↓
+            beat::commit_d2_x (path_x, commits d2)
+                ↓
+            beat::final (path_a)
+        """
+        graph = Graph.empty()
+
+        # Paths
+        graph.create_node("path::path_a", {"type": "path", "raw_id": "path_a"})
+        graph.create_node("path::path_x", {"type": "path", "raw_id": "path_x"})
+
+        # Dilemmas
+        graph.create_node(
+            "dilemma::d1",
+            {"type": "dilemma", "raw_id": "d1", "dilemma_role": "hard"},
+        )
+        graph.create_node(
+            "dilemma::d2",
+            {"type": "dilemma", "raw_id": "d2", "dilemma_role": "soft"},
+        )
+
+        # Beats
+        _make_beat(
+            graph,
+            "beat::commit_d1_a",
+            "Commit to d1 on path a",
+            [{"dilemma_id": "dilemma::d1", "effect": "commits"}],
+        )
+        _make_beat(
+            graph,
+            "beat::commit_d2_x",
+            "Commit to d2 on path x",
+            [{"dilemma_id": "dilemma::d2", "effect": "commits"}],
+        )
+        _make_beat(graph, "beat::final", "Final beat", [])
+
+        # Path assignments
+        _add_belongs_to(graph, "beat::commit_d1_a", "path::path_a")
+        _add_belongs_to(graph, "beat::commit_d2_x", "path::path_x")
+        _add_belongs_to(graph, "beat::final", "path::path_a")
+
+        # Ordering
+        _add_predecessor(graph, "beat::commit_d2_x", "beat::commit_d1_a")
+        _add_predecessor(graph, "beat::final", "beat::commit_d2_x")
+
+        return graph
+
+    def test_two_dilemmas_produce_single_combination(self) -> None:
+        """Two committed dilemmas → one combination with both flags."""
+        graph = self._build_two_dilemma_graph()
+
+        result = compute_active_flags_at_beat(graph, "beat::final")
+        expected = {frozenset({"dilemma::d1:path::path_a", "dilemma::d2:path::path_x"})}
+        assert result == expected
+
+    def test_intermediate_beat_has_fewer_flags(self) -> None:
+        """Beat between two commits only has the first dilemma's flag."""
+        graph = self._build_two_dilemma_graph()
+
+        result = compute_active_flags_at_beat(graph, "beat::commit_d2_x")
+        # commit_d2_x is downstream of commit_d1_a, and IS itself a commit
+        expected = {frozenset({"dilemma::d1:path::path_a", "dilemma::d2:path::path_x"})}
+        assert result == expected
+
+
+class TestComputeActiveFlagsBranching:
+    """Tests with branching DAG structures."""
+
+    def test_different_positions_different_flags(self) -> None:
+        """Beats at different positions in the DAG get different flag sets.
+
+        Structure:
+            beat::start (no commits)
+               ↓          ↓
+            beat::a      beat::b
+            (commits d1   (commits d1
+             on path_a)    on path_b)
+        """
+        graph = Graph.empty()
+        graph.create_node("path::pa", {"type": "path", "raw_id": "pa"})
+        graph.create_node("path::pb", {"type": "path", "raw_id": "pb"})
+        graph.create_node(
+            "dilemma::d1",
+            {"type": "dilemma", "raw_id": "d1", "dilemma_role": "hard"},
+        )
+
+        _make_beat(graph, "beat::start", "Start", [])
+        _make_beat(
+            graph,
+            "beat::a",
+            "Path A commit",
+            [{"dilemma_id": "dilemma::d1", "effect": "commits"}],
+        )
+        _make_beat(
+            graph,
+            "beat::b",
+            "Path B commit",
+            [{"dilemma_id": "dilemma::d1", "effect": "commits"}],
+        )
+
+        _add_belongs_to(graph, "beat::start", "path::pa")
+        _add_belongs_to(graph, "beat::a", "path::pa")
+        _add_belongs_to(graph, "beat::b", "path::pb")
+
+        _add_predecessor(graph, "beat::a", "beat::start")
+        _add_predecessor(graph, "beat::b", "beat::start")
+
+        # Beat A only sees path_a's commit
+        result_a = compute_active_flags_at_beat(graph, "beat::a")
+        assert result_a == {frozenset({"dilemma::d1:path::pa"})}
+
+        # Beat B only sees path_b's commit
+        result_b = compute_active_flags_at_beat(graph, "beat::b")
+        assert result_b == {frozenset({"dilemma::d1:path::pb"})}
+
+    def test_shared_beat_downstream_of_two_paths(self) -> None:
+        """A shared beat downstream of commits from different paths of same dilemma.
+
+        This represents a convergence point where both paths merge.
+
+        Structure:
+            beat::commit_a (path_a, commits d1)
+               ↓
+            beat::shared ← beat::commit_b (path_b, commits d1)
+
+        The shared beat has two possible flag sets.
+        """
+        graph = Graph.empty()
+        graph.create_node("path::pa", {"type": "path", "raw_id": "pa"})
+        graph.create_node("path::pb", {"type": "path", "raw_id": "pb"})
+        graph.create_node(
+            "dilemma::d1",
+            {"type": "dilemma", "raw_id": "d1", "dilemma_role": "soft"},
+        )
+
+        _make_beat(
+            graph,
+            "beat::commit_a",
+            "Commit on A",
+            [{"dilemma_id": "dilemma::d1", "effect": "commits"}],
+        )
+        _make_beat(
+            graph,
+            "beat::commit_b",
+            "Commit on B",
+            [{"dilemma_id": "dilemma::d1", "effect": "commits"}],
+        )
+        _make_beat(graph, "beat::shared", "Shared beat", [])
+
+        _add_belongs_to(graph, "beat::commit_a", "path::pa")
+        _add_belongs_to(graph, "beat::commit_b", "path::pb")
+        _add_belongs_to(graph, "beat::shared", "path::pa")  # doesn't matter which
+
+        _add_predecessor(graph, "beat::shared", "beat::commit_a")
+        _add_predecessor(graph, "beat::shared", "beat::commit_b")
+
+        result = compute_active_flags_at_beat(graph, "beat::shared")
+        # Two possible flag sets: one for path_a, one for path_b
+        expected = {
+            frozenset({"dilemma::d1:path::pa"}),
+            frozenset({"dilemma::d1:path::pb"}),
+        }
+        assert result == expected


### PR DESCRIPTION
## Summary

- Add `graph/algorithms.py` with `compute_active_flags_at_beat(graph, beat_id)` — computes all valid state flag combinations at a beat's DAG position
- Algorithm: reverse BFS from beat → find ancestor commit beats → group by dilemma → Cartesian product with mutual exclusivity
- O(beats x dilemmas) per query, pure function, no side effects

Stacked on #1035. Part of Epic #990 Phase 4.

## Why this matters

This utility is the foundation for:
- POLISH Phase 4b (prose feasibility — which flags are structurally relevant per passage)
- POLISH Phase 7 (arc completeness validation)
- Arc removal (#996) — replaces Arc-based traversal with computed traversals

## Test plan

- [x] No commit ancestors → `{frozenset()}` (4 tests)
- [x] Single dilemma, various positions (3 tests)
- [x] Two dilemmas → cross-product (2 tests)
- [x] Branching DAG: different positions get different flags
- [x] Convergence: shared beat sees both paths → two flag sets
- [x] 11 tests total, all passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)