### PR TITLE
feat: implement POLISH Phases 1-3 (LLM-assisted pre-freeze)

### DIFF
--- a/prompts/templates/polish_phase1_reorder.yaml
+++ b/prompts/templates/polish_phase1_reorder.yaml
@@ -1,0 +1,61 @@
+name: polish_phase1_reorder
+description: Propose reorderings for linear beat sections to improve narrative flow
+
+system: |
+  You are reordering beats within a linear section of a story graph.
+  The branching structure is frozen — you can only reorder beats within
+  the section, never add, remove, or move beats across sections.
+
+  ## Goals
+  Optimize the order for:
+  - **Scene-sequel rhythm**: Action beats followed by reflection beats
+  - **Entity continuity**: Avoid jarring character jumps between consecutive beats
+  - **Emotional arc**: Build tension, provide release, create momentum
+
+  ## Constraints (MUST obey)
+  - The reordered list MUST contain exactly the same beat IDs as the input
+  - Commit beats MUST come AFTER any advance/reveal beats for the same dilemma
+  - Do NOT add or remove any beats
+
+  ## Section to Reorder
+  Section ID: {section_id}
+
+  ### Context (preceding/following beats — NOT part of this section)
+  {before_context}
+  {after_context}
+
+  ### Beats in Current Order
+  {beat_details}
+
+  ## Valid IDs
+  Valid beat_ids (use ONLY these, in any order): {valid_beat_ids}
+  Total beats in section: {beat_count}
+
+  ## Output Format
+  Return a JSON object with a "reordered_sections" array.
+  If the current order is already good, return an empty array.
+
+  Example (do NOT copy these IDs):
+  {{
+    "reordered_sections": [
+      {{
+        "section_id": "section_0",
+        "beat_ids": ["beat::reflect", "beat::discover", "beat::confront"],
+        "rationale": "Moved reflection before discovery to build anticipation"
+      }}
+    ]
+  }}
+
+  ## What NOT to Do
+  - Do NOT use IDs not listed in the Valid IDs section
+  - Do NOT add or remove beats from the list
+  - Do NOT add prose before or after the JSON output
+  - Do NOT reorder if the current order already flows well — return empty array
+
+user: |
+  Analyze the beat sequence and propose a reordering if it would improve
+  narrative flow. If the current order is good, return an empty reordered_sections array.
+
+  REMINDER: Return ONLY valid JSON. Use ONLY the beat IDs listed above.
+
+components: []

--- a/prompts/templates/polish_phase2_pacing.yaml
+++ b/prompts/templates/polish_phase2_pacing.yaml
@@ -1,0 +1,61 @@
+name: polish_phase2_pacing
+description: Propose micro-beat insertions to fix pacing issues
+
+system: |
+  You are a pacing consultant for a branching story. The story has
+  pacing issues — stretches of beats that need breathing room.
+
+  ## What Are Micro-beats?
+  Brief transition moments that don't advance the plot:
+  - "A moment of silence falls over the study"
+  - "You pause to gather your thoughts before continuing"
+  - "The sound of distant thunder rolls across the valley"
+
+  Micro-beats:
+  - Are one sentence long
+  - Reference entities from surrounding beats (subset, not new ones)
+  - Do NOT advance, reveal, commit, or complicate any dilemma
+  - Provide emotional breathing room between major scenes
+
+  ## Pacing Issues Detected
+  {pacing_issues}
+
+  ## Guidelines
+  - For "consecutive_scene": Insert a reflection/transition micro-beat
+  - For "consecutive_sequel": Insert an action/event micro-beat
+  - For "no_sequel_after_commit": Insert a processing/reaction micro-beat
+  - Not every flag needs a micro-beat — skip if the pacing feels natural
+  - Maximum 1 micro-beat per pacing issue
+
+  ## Valid Entity IDs
+  Valid entity_ids (use ONLY these): {valid_entity_ids}
+  Total entities: {entity_count}
+
+  ## Output Format
+  Return a JSON object with a "micro_beats" array.
+  If no micro-beats are needed, return an empty array.
+
+  Example (do NOT copy these IDs):
+  {{
+    "micro_beats": [
+      {{
+        "after_beat_id": "beat::tense_confrontation",
+        "summary": "A heavy silence settles over the room as both parties consider what was said",
+        "entity_ids": ["entity::mentor", "entity::protagonist"]
+      }}
+    ]
+  }}
+
+  ## What NOT to Do
+  - Do NOT create micro-beats that advance any dilemma
+  - Do NOT use entity IDs not listed in the Valid Entity IDs section
+  - Do NOT insert more than one micro-beat per pacing issue
+  - Do NOT add prose before or after the JSON output
+
+user: |
+  Review the pacing issues and propose micro-beat insertions where needed.
+  If no micro-beats are needed, return an empty micro_beats array.
+
+  REMINDER: Return ONLY valid JSON. Use ONLY the entity IDs listed above.
+
+components: []

--- a/prompts/templates/polish_phase3_arcs.yaml
+++ b/prompts/templates/polish_phase3_arcs.yaml
@@ -1,0 +1,79 @@
+name: polish_phase3_arcs
+description: Synthesize character arc metadata for an entity
+
+system: |
+  You are synthesizing a character arc description for one entity in a
+  branching story. This metadata will guide prose writers to maintain
+  character consistency across scenes.
+
+  ## Entity
+  ID: {entity_id}
+  Name: {entity_name}
+  Description: {entity_description}
+  Central to dilemmas: {anchored_dilemmas}
+
+  ## Entity Overlays (how the entity changes based on player choices)
+  {overlay_data}
+
+  ## Beats Featuring This Entity (in story order)
+  {beat_appearances}
+
+  ## Paths in This Story
+  {path_ids}
+
+  ## Arc Structure
+  For this entity, describe:
+  1. **Start**: How the entity is introduced — first impression, initial role
+  2. **Pivots**: Key moments where the entity's trajectory changes.
+     Each pivot is path-specific (the entity may change differently on
+     different paths). Use the beat IDs and path IDs from above.
+  3. **End per path**: Where the entity ends up on each path. One entry
+     per path where the entity appears.
+
+  ## Valid IDs
+  Valid path_ids: {valid_path_ids}
+  Valid beat_ids (for pivots): {valid_beat_ids}
+
+  ## Output Format
+  Return a JSON object with a "character_arcs" array containing exactly
+  one arc for entity {entity_id}.
+
+  Example (do NOT copy these IDs):
+  {{
+    "character_arcs": [
+      {{
+        "entity_id": "entity::mentor",
+        "start": "The mentor appears as a calm authority figure, offering guidance",
+        "pivots": [
+          {{
+            "path_id": "path::trust",
+            "beat_id": "beat::mentor_reveal",
+            "description": "The mentor reveals hidden knowledge, deepening the bond"
+          }},
+          {{
+            "path_id": "path::doubt",
+            "beat_id": "beat::mentor_secret",
+            "description": "The protagonist discovers the mentor has been hiding something"
+          }}
+        ],
+        "end_per_path": {{
+          "path::trust": "The mentor becomes a true ally, having earned full trust",
+          "path::doubt": "The mentor is estranged, their motives forever uncertain"
+        }}
+      }}
+    ]
+  }}
+
+  ## What NOT to Do
+  - Do NOT use IDs not listed in the Valid IDs sections
+  - Do NOT return arcs for entities other than {entity_id}
+  - Do NOT write novel-length descriptions — keep each field to 1-2 sentences
+  - Do NOT add prose before or after the JSON output
+
+user: |
+  Synthesize the character arc for {entity_name} ({entity_id}).
+  Consider how this entity changes across the story's paths.
+
+  REMINDER: Return ONLY valid JSON with one arc for this entity.
+
+components: []

--- a/src/questfoundry/graph/polish_context.py
+++ b/src/questfoundry/graph/polish_context.py
@@ -62,7 +62,10 @@ def format_linear_section_context(
 
         entity_str = ""
         if entities:
-            entity_str = f" entities=[{', '.join(entities[:5])}]"
+            # Truncate to 5 entities per beat to keep context compact
+            display = entities[:5]
+            suffix = f" +{len(entities) - 5}" if len(entities) > 5 else ""
+            entity_str = f" entities=[{', '.join(display)}{suffix}]"
 
         line = f"  {i + 1}. {bid}: [{scene_type}] {summary}{impact_str}{entity_str}"
         beat_items.append(ContextItem(id=bid, text=line))
@@ -175,8 +178,9 @@ def format_entity_arc_context(
         data = beat_nodes.get(bid, {})
         summary = truncate_summary(data.get("summary", ""), 100)
         scene_type = data.get("scene_type", "unknown")
-        path_id = beat_to_path.get(bid, "unknown")
-        paths_seen.add(path_id)
+        path_id = beat_to_path.get(bid)
+        if path_id:
+            paths_seen.add(path_id)
 
         impacts = data.get("dilemma_impacts", [])
         impact_str = ""
@@ -184,7 +188,8 @@ def format_entity_arc_context(
             effects = [imp.get("effect", "?") for imp in impacts]
             impact_str = f" dilemma_effects=[{', '.join(effects)}]"
 
-        line = f"  - {bid} (path: {path_id}) [{scene_type}]: {summary}{impact_str}"
+        path_label = path_id or "unknown"
+        line = f"  - {bid} (path: {path_label}) [{scene_type}]: {summary}{impact_str}"
         beat_items.append(ContextItem(id=bid, text=line))
 
     if config:

--- a/src/questfoundry/graph/polish_context.py
+++ b/src/questfoundry/graph/polish_context.py
@@ -1,0 +1,240 @@
+"""Context builders for POLISH LLM phases.
+
+Each function builds a context dict for injection into a prompt template.
+The context is a flat dict of string values (or lists) that map to
+{placeholders} in the YAML template.
+
+These are pure functions operating on graph data — no side effects.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from questfoundry.graph.context_compact import (
+    ContextItem,
+    compact_items,
+    truncate_summary,
+)
+
+if TYPE_CHECKING:
+    from questfoundry.graph.context_compact import CompactContextConfig
+    from questfoundry.graph.graph import Graph
+
+
+def format_linear_section_context(
+    graph: Graph,
+    section_id: str,
+    beat_ids: list[str],
+    before_beat: str | None,
+    after_beat: str | None,
+    config: CompactContextConfig | None = None,
+) -> dict[str, str]:
+    """Build context for Phase 1 (beat reordering) for one linear section.
+
+    Args:
+        graph: Graph containing beat DAG.
+        section_id: Identifier for this linear section.
+        beat_ids: Beat IDs in current order within the section.
+        before_beat: Beat immediately before this section (for context), or None.
+        after_beat: Beat immediately after this section (for context), or None.
+        config: Optional compaction config.
+
+    Returns:
+        Dict with keys: section_id, beat_details, before_context,
+        after_context, valid_beat_ids, beat_count.
+    """
+    beat_nodes = graph.get_nodes_by_type("beat")
+
+    # Build detailed beat lines
+    beat_items: list[ContextItem] = []
+    for i, bid in enumerate(beat_ids):
+        data = beat_nodes.get(bid, {})
+        summary = truncate_summary(data.get("summary", ""), 120)
+        scene_type = data.get("scene_type", "unknown")
+        impacts = data.get("dilemma_impacts", [])
+        entities = data.get("entities", [])
+
+        impact_str = ""
+        if impacts:
+            effects = [f"{imp.get('effect', '?')}({imp.get('dilemma_id', '?')})" for imp in impacts]
+            impact_str = f" impacts=[{', '.join(effects)}]"
+
+        entity_str = ""
+        if entities:
+            entity_str = f" entities=[{', '.join(entities[:5])}]"
+
+        line = f"  {i + 1}. {bid}: [{scene_type}] {summary}{impact_str}{entity_str}"
+        beat_items.append(ContextItem(id=bid, text=line))
+
+    if config:
+        beat_details = compact_items(beat_items, config)
+    else:
+        beat_details = "\n".join(item.text for item in beat_items)
+
+    # Context beats (before/after the section)
+    before_context = _format_context_beat(beat_nodes, before_beat, "preceding")
+    after_context = _format_context_beat(beat_nodes, after_beat, "following")
+
+    return {
+        "section_id": section_id,
+        "beat_details": beat_details,
+        "before_context": before_context,
+        "after_context": after_context,
+        "valid_beat_ids": ", ".join(beat_ids),
+        "beat_count": str(len(beat_ids)),
+    }
+
+
+def format_pacing_context(
+    graph: Graph,
+    pacing_flags: list[dict[str, Any]],
+    config: CompactContextConfig | None = None,  # noqa: ARG001
+) -> dict[str, str]:
+    """Build context for Phase 2 (pacing & micro-beat injection).
+
+    Args:
+        graph: Graph containing beat DAG.
+        pacing_flags: List of dicts with keys: issue_type, beat_ids, path_id.
+        config: Optional compaction config.
+
+    Returns:
+        Dict with keys: pacing_issues, valid_entity_ids, entity_count.
+    """
+    beat_nodes = graph.get_nodes_by_type("beat")
+    entity_nodes = graph.get_nodes_by_type("entity")
+
+    # Format each pacing flag
+    issue_lines: list[str] = []
+    for flag in pacing_flags:
+        issue_type = flag.get("issue_type", "unknown")
+        beat_ids = flag.get("beat_ids", [])
+        path_id = flag.get("path_id", "")
+
+        issue_lines.append(f"\n### Pacing Issue: {issue_type}")
+        if path_id:
+            issue_lines.append(f"Path: {path_id}")
+
+        for bid in beat_ids:
+            data = beat_nodes.get(bid, {})
+            summary = truncate_summary(data.get("summary", ""), 100)
+            scene_type = data.get("scene_type", "unknown")
+            entities = data.get("entities", [])
+            entity_str = f" entities=[{', '.join(entities[:3])}]" if entities else ""
+            issue_lines.append(f"  - {bid}: [{scene_type}] {summary}{entity_str}")
+
+    pacing_issues = "\n".join(issue_lines) if issue_lines else "No pacing issues detected."
+
+    # Valid entity IDs for micro-beat entity references
+    valid_entity_ids = ", ".join(sorted(entity_nodes.keys()))
+
+    return {
+        "pacing_issues": pacing_issues,
+        "valid_entity_ids": valid_entity_ids,
+        "entity_count": str(len(entity_nodes)),
+    }
+
+
+def format_entity_arc_context(
+    graph: Graph,
+    entity_id: str,
+    beat_appearances: list[str],
+    config: CompactContextConfig | None = None,
+) -> dict[str, str]:
+    """Build context for Phase 3 (character arc synthesis) for one entity.
+
+    Args:
+        graph: Graph containing beat DAG and entity data.
+        entity_id: The entity to build arc context for.
+        beat_appearances: Beat IDs where this entity appears, in topological order.
+        config: Optional compaction config.
+
+    Returns:
+        Dict with keys: entity_id, entity_name, entity_description,
+        beat_appearances, path_ids, valid_path_ids, valid_beat_ids.
+    """
+    beat_nodes = graph.get_nodes_by_type("beat")
+    entity_nodes = graph.get_nodes_by_type("entity")
+    path_nodes = graph.get_nodes_by_type("path")
+
+    # Entity info
+    entity_data = entity_nodes.get(entity_id, {})
+    entity_name = entity_data.get("name", entity_id)
+    entity_description = entity_data.get("description", "")
+
+    # Build beat appearance lines with path context
+    belongs_to_edges = graph.get_edges(edge_type="belongs_to")
+    beat_to_path: dict[str, str] = {}
+    for edge in belongs_to_edges:
+        if edge["from"] in beat_nodes:
+            beat_to_path[edge["from"]] = edge["to"]
+
+    beat_items: list[ContextItem] = []
+    paths_seen: set[str] = set()
+    for bid in beat_appearances:
+        data = beat_nodes.get(bid, {})
+        summary = truncate_summary(data.get("summary", ""), 100)
+        scene_type = data.get("scene_type", "unknown")
+        path_id = beat_to_path.get(bid, "unknown")
+        paths_seen.add(path_id)
+
+        impacts = data.get("dilemma_impacts", [])
+        impact_str = ""
+        if impacts:
+            effects = [imp.get("effect", "?") for imp in impacts]
+            impact_str = f" dilemma_effects=[{', '.join(effects)}]"
+
+        line = f"  - {bid} (path: {path_id}) [{scene_type}]: {summary}{impact_str}"
+        beat_items.append(ContextItem(id=bid, text=line))
+
+    if config:
+        beat_text = compact_items(beat_items, config)
+    else:
+        beat_text = "\n".join(item.text for item in beat_items)
+
+    # Overlay data (how entity changes based on state flags)
+    overlay_nodes = graph.get_nodes_by_type("entity_overlay")
+    overlay_lines: list[str] = []
+    for _oid, odata in overlay_nodes.items():
+        if odata.get("entity_id") == entity_id:
+            flag = odata.get("activation_flag", "")
+            desc = odata.get("description", "")
+            if flag and desc:
+                overlay_lines.append(f"  - When {flag}: {truncate_summary(desc, 80)}")
+
+    overlay_text = "\n".join(overlay_lines) if overlay_lines else "  (no overlays)"
+
+    # Anchored-to edges (dilemmas this entity is central to)
+    anchored_edges = graph.get_edges(edge_type="anchored_to")
+    anchored_dilemmas: list[str] = []
+    for edge in anchored_edges:
+        if edge["from"] == entity_id:
+            anchored_dilemmas.append(edge["to"])
+
+    anchored_text = ", ".join(anchored_dilemmas) if anchored_dilemmas else "(none)"
+
+    return {
+        "entity_id": entity_id,
+        "entity_name": entity_name,
+        "entity_description": truncate_summary(entity_description, 200),
+        "beat_appearances": beat_text,
+        "overlay_data": overlay_text,
+        "anchored_dilemmas": anchored_text,
+        "path_ids": ", ".join(sorted(paths_seen)),
+        "valid_path_ids": ", ".join(sorted(path_nodes.keys())),
+        "valid_beat_ids": ", ".join(sorted(beat_appearances)),
+    }
+
+
+def _format_context_beat(
+    beat_nodes: dict[str, dict[str, Any]],
+    beat_id: str | None,
+    label: str,
+) -> str:
+    """Format a single beat as context (preceding/following a section)."""
+    if beat_id is None:
+        return f"  ({label}: start/end of path)"
+    data = beat_nodes.get(beat_id, {})
+    summary = truncate_summary(data.get("summary", ""), 80)
+    scene_type = data.get("scene_type", "unknown")
+    return f"  {label}: {beat_id} [{scene_type}] {summary}"

--- a/src/questfoundry/models/__init__.py
+++ b/src/questfoundry/models/__init__.py
@@ -96,7 +96,6 @@ from questfoundry.models.polish import (
     ArcPivot,
     CharacterArcMetadata,
     MicroBeatProposal,
-    PolishPhaseResult,
     ReorderedSection,
 )
 from questfoundry.models.polish import (
@@ -215,7 +214,6 @@ __all__ = [
     "PolishPhase1Output",
     "PolishPhase2Output",
     "PolishPhase3Output",
-    "PolishPhaseResult",
     "ReorderedSection",
     "ResidueWeight",
     "ReviewFlag",

--- a/src/questfoundry/models/__init__.py
+++ b/src/questfoundry/models/__init__.py
@@ -92,6 +92,22 @@ from questfoundry.models.grow import (
     SpokeProposal,
 )
 from questfoundry.models.pipeline import PhaseResult
+from questfoundry.models.polish import (
+    ArcPivot,
+    CharacterArcMetadata,
+    MicroBeatProposal,
+    PolishPhaseResult,
+    ReorderedSection,
+)
+from questfoundry.models.polish import (
+    Phase1Output as PolishPhase1Output,
+)
+from questfoundry.models.polish import (
+    Phase2Output as PolishPhase2Output,
+)
+from questfoundry.models.polish import (
+    Phase3Output as PolishPhase3Output,
+)
 from questfoundry.models.seed import (
     Consequence,
     DilemmaAnalysis,
@@ -118,6 +134,7 @@ from questfoundry.models.seed import (
 __all__ = [
     "Answer",
     "Arc",
+    "ArcPivot",
     "ArtDirection",
     "AtmosphericDetail",
     "BatchedBriefItem",
@@ -126,6 +143,7 @@ __all__ = [
     "BatchedCodexOutput",
     "BatchedExpandOutput",
     "BrainstormOutput",
+    "CharacterArcMetadata",
     "Choice",
     "ChoiceLabel",
     "Codeword",
@@ -176,6 +194,7 @@ __all__ = [
     "IllustrationCategory",
     "InitialBeat",
     "IntersectionProposal",
+    "MicroBeatProposal",
     "OverlayDetailItem",
     "OverlayProposal",
     "Passage",
@@ -193,6 +212,11 @@ __all__ = [
     "Phase9bOutput",
     "Phase9cOutput",
     "PhaseResult",
+    "PolishPhase1Output",
+    "PolishPhase2Output",
+    "PolishPhase3Output",
+    "PolishPhaseResult",
+    "ReorderedSection",
     "ResidueWeight",
     "ReviewFlag",
     "SceneTypeTag",

--- a/src/questfoundry/models/polish.py
+++ b/src/questfoundry/models/polish.py
@@ -136,19 +136,6 @@ class Phase3Output(BaseModel):
     character_arcs: list[CharacterArcMetadata] = Field(default_factory=list)
 
 
-# ---------------------------------------------------------------------------
-# Stage result
-# ---------------------------------------------------------------------------
-
-
-class PolishPhaseResult(BaseModel):
-    """Result of a single POLISH phase execution.
-
-    Extends the base PhaseResult with POLISH-specific detail.
-    """
-
-    phase: str = Field(min_length=1)
-    status: str = "completed"
-    detail: str = ""
-    llm_calls: int = 0
-    tokens_used: int = 0
+# Note: POLISH phases return the shared PhaseResult from models.pipeline.
+# Stage-specific result models (PolishResult) are added in later PRs
+# when passage/choice counts are available.

--- a/src/questfoundry/models/polish.py
+++ b/src/questfoundry/models/polish.py
@@ -1,0 +1,154 @@
+"""POLISH stage models.
+
+These models define LLM output schemas for POLISH's three pre-freeze
+phases (beat reordering, pacing, character arc synthesis) and the
+stage result container.
+
+Node types created by POLISH:
+- micro_beat: Brief transition beats inserted for pacing (Phase 2)
+- character_arc_metadata: Arc data for entities (Phase 3)
+
+See docs/design/procedures/polish.md for algorithm details.
+
+Terminology (v5):
+- passage: A rendered scene grouping one or more beats
+- variant: An alternative passage gated by state flags
+- residue beat: A mood-setting beat preceding shared passages
+"""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, Field
+
+# ---------------------------------------------------------------------------
+# Phase 1: Beat Reordering — LLM output schema
+# ---------------------------------------------------------------------------
+
+
+class ReorderedSection(BaseModel):
+    """A reordered linear section of the beat DAG.
+
+    The LLM proposes a new order for beats within a linear section,
+    optimizing for scene-sequel rhythm, entity continuity, and
+    emotional arc.
+    """
+
+    section_id: str = Field(min_length=1, description="Identifier for the linear section")
+    beat_ids: list[str] = Field(
+        min_length=1,
+        description="Beat IDs in proposed new order (must be same set as input)",
+    )
+    rationale: str = Field(
+        min_length=1,
+        description="Brief explanation of why this order is better",
+    )
+
+
+class Phase1Output(BaseModel):
+    """Output of Phase 1: Beat Reordering.
+
+    Contains reordered sections. Sections not listed are kept in
+    original order.
+    """
+
+    reordered_sections: list[ReorderedSection] = Field(default_factory=list)
+
+
+# ---------------------------------------------------------------------------
+# Phase 2: Pacing & Micro-beat Injection — LLM output schema
+# ---------------------------------------------------------------------------
+
+
+class MicroBeatProposal(BaseModel):
+    """A micro-beat proposed for insertion to improve pacing.
+
+    Micro-beats are brief transitions that don't advance any dilemma.
+    They provide breathing room between major scenes.
+    """
+
+    after_beat_id: str = Field(
+        min_length=1,
+        description="Insert after this beat in the DAG",
+    )
+    summary: str = Field(
+        min_length=1,
+        description="One-sentence summary of the micro-beat",
+    )
+    entity_ids: list[str] = Field(
+        default_factory=list,
+        description="Entity IDs referenced in this micro-beat (subset of surrounding beats)",
+    )
+
+
+class Phase2Output(BaseModel):
+    """Output of Phase 2: Pacing & Micro-beat Injection.
+
+    Contains micro-beat proposals. Empty list means no pacing issues found.
+    """
+
+    micro_beats: list[MicroBeatProposal] = Field(default_factory=list)
+
+
+# ---------------------------------------------------------------------------
+# Phase 3: Character Arc Synthesis — LLM output schema
+# ---------------------------------------------------------------------------
+
+
+class ArcPivot(BaseModel):
+    """A key moment where an entity's trajectory changes."""
+
+    path_id: str = Field(min_length=1, description="Path where this pivot occurs")
+    beat_id: str = Field(min_length=1, description="Beat where the pivot happens")
+    description: str = Field(
+        min_length=1,
+        description="What changes at this moment for this entity",
+    )
+
+
+class CharacterArcMetadata(BaseModel):
+    """Arc description for a single entity across the story.
+
+    Consumed by FILL when writing prose to ensure character
+    consistency across passages.
+    """
+
+    entity_id: str = Field(min_length=1, description="Entity this arc describes")
+    start: str = Field(
+        min_length=1,
+        description="How the entity is introduced",
+    )
+    pivots: list[ArcPivot] = Field(
+        default_factory=list,
+        description="Key trajectory changes per path",
+    )
+    end_per_path: dict[str, str] = Field(
+        default_factory=dict,
+        description="Where the entity ends up on each path (path_id → description)",
+    )
+
+
+class Phase3Output(BaseModel):
+    """Output of Phase 3: Character Arc Synthesis.
+
+    Contains arc metadata for entities appearing in 2+ beats.
+    """
+
+    character_arcs: list[CharacterArcMetadata] = Field(default_factory=list)
+
+
+# ---------------------------------------------------------------------------
+# Stage result
+# ---------------------------------------------------------------------------
+
+
+class PolishPhaseResult(BaseModel):
+    """Result of a single POLISH phase execution.
+
+    Extends the base PhaseResult with POLISH-specific detail.
+    """
+
+    phase: str = Field(min_length=1)
+    status: str = "completed"
+    detail: str = ""
+    llm_calls: int = 0
+    tokens_used: int = 0

--- a/src/questfoundry/pipeline/stages/polish/llm_helper.py
+++ b/src/questfoundry/pipeline/stages/polish/llm_helper.py
@@ -1,0 +1,188 @@
+"""LLM call helper for the POLISH stage.
+
+Provides _PolishLLMHelperMixin with _polish_llm_call(), adapting the
+proven GROW pattern (template loading → context injection → structured
+output → validation retry) for POLISH's phases.
+
+PolishStage inherits this mixin so all LLM phase methods can call
+``self._polish_llm_call(...)`` directly.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, TypeVar
+
+from langchain_core.messages import HumanMessage, SystemMessage
+from pydantic import BaseModel, ValidationError
+
+from questfoundry.agents.serialize import extract_tokens
+from questfoundry.artifacts.validator import get_all_field_paths
+from questfoundry.observability.tracing import traceable
+from questfoundry.pipeline.stages.polish._helpers import (
+    PolishStageError,
+    log,
+)
+from questfoundry.prompts.compiler import safe_format
+from questfoundry.providers.structured_output import (
+    unwrap_structured_result,
+    with_structured_output,
+)
+
+if TYPE_CHECKING:
+    from langchain_core.language_models import BaseChatModel
+
+T = TypeVar("T", bound=BaseModel)
+
+
+def _get_prompts_path() -> Path:
+    """Get the prompts directory path.
+
+    Returns prompts from package first, then falls back to project root.
+    """
+    pkg_path = Path(__file__).parents[5] / "prompts"
+    if pkg_path.exists():
+        return pkg_path
+    return Path.cwd() / "prompts"
+
+
+class _PolishLLMHelperMixin:
+    """Mixin providing LLM call wrapper for POLISH phases.
+
+    Expects the host class to set the following attributes in ``__init__``
+    or ``execute()``:
+
+    - ``_serialize_model``
+    - ``_serialize_provider_name``
+    - ``_provider_name``
+    - ``_callbacks``
+    """
+
+    @traceable(name="POLISH LLM Call", run_type="llm", tags=["stage:polish"])
+    async def _polish_llm_call(
+        self,
+        model: BaseChatModel,
+        template_name: str,
+        context: dict[str, Any],
+        output_schema: type[T],
+        max_retries: int = 3,
+    ) -> tuple[T, int, int]:
+        """Call LLM with structured output and retry on validation failure.
+
+        Loads prompt template, injects context, calls model.with_structured_output(),
+        validates with Pydantic, retries with error feedback on failure.
+
+        Args:
+            model: LangChain chat model.
+            template_name: Name of the prompt template (without .yaml).
+            context: Variables to inject into the prompt template.
+            output_schema: Pydantic model class for structured output.
+            max_retries: Maximum retry attempts on validation failure.
+
+        Returns:
+            Tuple of (validated_result, llm_calls, tokens_used).
+
+        Raises:
+            PolishStageError: After max_retries exhausted.
+        """
+        from questfoundry.observability.tracing import build_runnable_config
+        from questfoundry.prompts.loader import PromptLoader
+
+        loader = PromptLoader(_get_prompts_path())
+        template = loader.load(template_name)
+
+        # Build messages from template with context injection
+        system_text = safe_format(template.system, context) if context else template.system
+        user_text = (
+            safe_format(template.user, context) if template.user and context else template.user
+        )
+
+        effective_model = self._serialize_model or model  # type: ignore[attr-defined]
+        effective_provider = self._serialize_provider_name or self._provider_name  # type: ignore[attr-defined]
+        structured_model = with_structured_output(
+            effective_model, output_schema, provider_name=effective_provider
+        )
+
+        messages: list[SystemMessage | HumanMessage] = [SystemMessage(content=system_text)]
+        if user_text:
+            messages.append(HumanMessage(content=user_text))
+
+        # Build config with callbacks for LLM call logging
+        config = build_runnable_config(
+            run_name=f"polish_{template_name}",
+            metadata={"stage": "polish", "phase": template_name},
+            callbacks=self._callbacks,  # type: ignore[attr-defined]
+        )
+
+        llm_calls = 0
+        total_tokens = 0
+        base_messages = list(messages)
+
+        for attempt in range(max_retries):
+            log.debug(
+                "polish_llm_call",
+                template=template_name,
+                attempt=attempt + 1,
+                max_retries=max_retries,
+            )
+
+            try:
+                raw_result = await structured_model.ainvoke(messages, config=config)
+                llm_calls += 1
+                total_tokens += extract_tokens(raw_result)
+
+                result = unwrap_structured_result(raw_result)
+                validated = (
+                    result
+                    if isinstance(result, output_schema)
+                    else output_schema.model_validate(result)
+                )
+                log.debug("polish_llm_validation_pass", template=template_name)
+
+                return validated, llm_calls, total_tokens
+
+            except (ValidationError, TypeError) as e:
+                log.warning(
+                    "polish_llm_validation_fail",
+                    template=template_name,
+                    attempt=attempt + 1,
+                    error=str(e),
+                )
+
+                if attempt < max_retries - 1:
+                    error_msg = _build_error_feedback(e, output_schema)
+                    messages = list(base_messages)
+                    messages.append(HumanMessage(content=error_msg))
+
+        raise PolishStageError(
+            f"LLM call for {template_name} failed after {max_retries} attempts. "
+            f"Could not produce valid {output_schema.__name__} output."
+        )
+
+
+def _build_error_feedback(error: Exception, output_schema: type[BaseModel]) -> str:
+    """Build structured error feedback for LLM retry.
+
+    Converts validation errors into field-level feedback the LLM can
+    act on, including the list of required fields.
+
+    Args:
+        error: The validation or type error from parsing.
+        output_schema: The Pydantic model class expected.
+
+    Returns:
+        Formatted error feedback string for the LLM.
+    """
+    if isinstance(error, ValidationError):
+        lines: list[str] = []
+        for e in error.errors():
+            loc = ".".join(str(p) for p in e["loc"]) or "(root)"
+            lines.append(f"  - {loc}: {e['msg']}")
+        required_fields = ", ".join(sorted(get_all_field_paths(output_schema)))
+        return (
+            "Validation errors in your response:\n"
+            + "\n".join(lines)
+            + f"\n\nRequired fields: {required_fields}"
+            + "\nEnsure all IDs are from the Valid IDs list."
+        )
+    return f"Error: {error}\n\nPlease produce valid output matching the expected schema."

--- a/src/questfoundry/pipeline/stages/polish/llm_phases.py
+++ b/src/questfoundry/pipeline/stages/polish/llm_phases.py
@@ -1,0 +1,711 @@
+"""LLM-powered phase implementations for the POLISH stage.
+
+Contains _PolishLLMPhaseMixin with Phases 1-3: beat reordering,
+pacing/micro-beat injection, and character arc synthesis.
+
+PolishStage inherits this mixin so ``execute()`` can delegate to
+``self._phase_1_beat_reordering()``, etc.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from questfoundry.graph.polish_context import (
+    format_entity_arc_context,
+    format_linear_section_context,
+    format_pacing_context,
+)
+from questfoundry.models.pipeline import PhaseResult
+from questfoundry.models.polish import (
+    Phase1Output,
+    Phase2Output,
+    Phase3Output,
+)
+from questfoundry.pipeline.stages.polish._helpers import log
+from questfoundry.pipeline.stages.polish.registry import polish_phase
+
+if TYPE_CHECKING:
+    from langchain_core.language_models import BaseChatModel
+
+    from questfoundry.graph.graph import Graph
+
+
+class _PolishLLMPhaseMixin:
+    """Mixin providing LLM-powered POLISH phases (1, 2, 3).
+
+    Expects the host class to provide (via ``_PolishLLMHelperMixin``):
+
+    - ``_polish_llm_call()``
+    """
+
+    @polish_phase(name="beat_reordering", depends_on=[], priority=0)
+    async def _phase_1_beat_reordering(self, graph: Graph, model: BaseChatModel) -> PhaseResult:
+        """Phase 1: Beat Reordering.
+
+        Within linear sections of the beat DAG (3+ beats, single
+        predecessor and single successor per beat), proposes reorderings
+        for better narrative flow.
+
+        Postconditions:
+        - Predecessor edges updated within reordered sections.
+        - Sections with invalid proposals keep original order.
+        """
+        beat_nodes = graph.get_nodes_by_type("beat")
+        predecessor_edges = graph.get_edges(edge_type="predecessor")
+
+        sections = _find_linear_sections(beat_nodes, predecessor_edges)
+
+        if not sections:
+            log.info("phase1_no_sections", detail="No linear sections with 3+ beats found")
+            return PhaseResult(
+                phase="beat_reordering",
+                status="skipped",
+                detail="No linear sections with 3+ beats found",
+            )
+
+        total_llm_calls = 0
+        total_tokens = 0
+        reordered_count = 0
+        warnings: list[str] = []
+
+        for section in sections:
+            section_id = section["section_id"]
+            beat_ids = section["beat_ids"]
+            before_beat = section.get("before_beat")
+            after_beat = section.get("after_beat")
+
+            context = format_linear_section_context(
+                graph, section_id, beat_ids, before_beat, after_beat
+            )
+
+            result, llm_calls, tokens = await self._polish_llm_call(  # type: ignore[attr-defined]
+                model=model,
+                template_name="polish_phase1_reorder",
+                context=context,
+                output_schema=Phase1Output,
+            )
+            total_llm_calls += llm_calls
+            total_tokens += tokens
+
+            # Find the matching section in the output
+            matched = None
+            for rs in result.reordered_sections:
+                if rs.section_id == section_id:
+                    matched = rs
+                    break
+
+            if matched is None:
+                # LLM didn't propose a reordering for this section — keep original
+                continue
+
+            # Validate: must contain exactly the same beats
+            if set(matched.beat_ids) != set(beat_ids):
+                warnings.append(
+                    f"Section {section_id}: reordering rejected — "
+                    f"beat set mismatch (expected {len(beat_ids)}, got {len(matched.beat_ids)})"
+                )
+                log.warning(
+                    "phase1_set_mismatch",
+                    section=section_id,
+                    expected=len(beat_ids),
+                    got=len(matched.beat_ids),
+                )
+                continue
+
+            # Validate: commit beats must not precede their dilemma's advance/reveal beats
+            if not _validate_reorder_constraints(graph, beat_ids, matched.beat_ids):
+                warnings.append(
+                    f"Section {section_id}: reordering rejected — "
+                    f"hard constraint violation (commit before advance/reveal)"
+                )
+                log.warning("phase1_constraint_violation", section=section_id)
+                continue
+
+            # Apply: update predecessor edges within the section
+            _apply_reorder(graph, beat_ids, matched.beat_ids, before_beat, after_beat)
+            reordered_count += 1
+            log.debug(
+                "phase1_section_reordered",
+                section=section_id,
+                rationale=matched.rationale[:80],
+            )
+
+        detail = f"Reordered {reordered_count}/{len(sections)} sections"
+        if warnings:
+            detail += f"; {len(warnings)} warning(s)"
+
+        return PhaseResult(
+            phase="beat_reordering",
+            status="completed",
+            detail=detail,
+            llm_calls=total_llm_calls,
+            tokens_used=total_tokens,
+        )
+
+    @polish_phase(name="pacing", depends_on=["beat_reordering"], priority=1)
+    async def _phase_2_pacing(self, graph: Graph, model: BaseChatModel) -> PhaseResult:
+        """Phase 2: Pacing & Micro-beat Injection.
+
+        Detects pacing issues (3+ scene/sequel in a row, no sequel after
+        commit) and proposes micro-beat insertions to smooth the rhythm.
+
+        Postconditions:
+        - Micro-beat nodes created with role="micro_beat".
+        - Predecessor edges updated to include micro-beats in DAG.
+        """
+        beat_nodes = graph.get_nodes_by_type("beat")
+        predecessor_edges = graph.get_edges(edge_type="predecessor")
+
+        pacing_flags = _detect_pacing_flags(beat_nodes, predecessor_edges, graph)
+
+        if not pacing_flags:
+            log.info("phase2_no_flags", detail="No pacing issues detected")
+            return PhaseResult(
+                phase="pacing",
+                status="skipped",
+                detail="No pacing issues detected",
+            )
+
+        context = format_pacing_context(graph, pacing_flags)
+
+        result, llm_calls, tokens = await self._polish_llm_call(  # type: ignore[attr-defined]
+            model=model,
+            template_name="polish_phase2_pacing",
+            context=context,
+            output_schema=Phase2Output,
+        )
+
+        # Apply micro-beats
+        inserted = 0
+        for mb in result.micro_beats:
+            if mb.after_beat_id not in beat_nodes:
+                log.warning(
+                    "phase2_invalid_after_beat",
+                    after_beat_id=mb.after_beat_id,
+                )
+                continue
+
+            micro_beat_id = f"beat::micro_{inserted}_{mb.after_beat_id.split('::')[-1]}"
+            _insert_micro_beat(graph, micro_beat_id, mb.after_beat_id, mb.summary, mb.entity_ids)
+            inserted += 1
+
+        return PhaseResult(
+            phase="pacing",
+            status="completed",
+            detail=f"Inserted {inserted} micro-beat(s) from {len(pacing_flags)} pacing flag(s)",
+            llm_calls=llm_calls,
+            tokens_used=tokens,
+        )
+
+    @polish_phase(name="character_arcs", depends_on=["pacing"], priority=2)
+    async def _phase_3_character_arcs(self, graph: Graph, model: BaseChatModel) -> PhaseResult:
+        """Phase 3: Character Arc Synthesis.
+
+        For entities appearing in 2+ beats, synthesizes arc descriptions
+        (start, pivots, end per path) for FILL's prose consistency.
+
+        Postconditions:
+        - CharacterArcMetadata nodes created for arc-worthy entities.
+        """
+        beat_nodes = graph.get_nodes_by_type("beat")
+        entity_nodes = graph.get_nodes_by_type("entity")
+
+        # Find entities appearing in 2+ beats
+        entity_beats = _collect_entity_appearances(beat_nodes, graph)
+        arc_worthy = {
+            eid: beats
+            for eid, beats in entity_beats.items()
+            if len(beats) >= 2 and eid in entity_nodes
+        }
+
+        if not arc_worthy:
+            log.info("phase3_no_entities", detail="No entities with 2+ beat appearances")
+            return PhaseResult(
+                phase="character_arcs",
+                status="skipped",
+                detail="No entities with 2+ beat appearances",
+            )
+
+        total_llm_calls = 0
+        total_tokens = 0
+        arcs_created = 0
+
+        # Process entities in batches via a single LLM call per entity
+        for entity_id, beat_appearances in sorted(arc_worthy.items()):
+            context = format_entity_arc_context(graph, entity_id, beat_appearances)
+
+            result, llm_calls, tokens = await self._polish_llm_call(  # type: ignore[attr-defined]
+                model=model,
+                template_name="polish_phase3_arcs",
+                context=context,
+                output_schema=Phase3Output,
+            )
+            total_llm_calls += llm_calls
+            total_tokens += tokens
+
+            # Store arc metadata
+            for arc in result.character_arcs:
+                if arc.entity_id != entity_id:
+                    log.warning(
+                        "phase3_entity_mismatch",
+                        expected=entity_id,
+                        got=arc.entity_id,
+                    )
+                    continue
+
+                arc_node_id = f"character_arc_metadata::{entity_id.split('::')[-1]}"
+                graph.create_node(
+                    arc_node_id,
+                    {
+                        "type": "character_arc_metadata",
+                        "raw_id": entity_id.split("::")[-1],
+                        "entity_id": entity_id,
+                        "start": arc.start,
+                        "pivots": [p.model_dump() for p in arc.pivots],
+                        "end_per_path": arc.end_per_path,
+                    },
+                )
+                arcs_created += 1
+
+        return PhaseResult(
+            phase="character_arcs",
+            status="completed",
+            detail=f"Created {arcs_created} character arc(s) from {len(arc_worthy)} entities",
+            llm_calls=total_llm_calls,
+            tokens_used=total_tokens,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Phase 1 helpers
+# ---------------------------------------------------------------------------
+
+
+def _find_linear_sections(
+    beat_nodes: dict[str, dict[str, Any]],
+    predecessor_edges: list[dict[str, str]],
+) -> list[dict[str, Any]]:
+    """Find maximal linear sections in the beat DAG.
+
+    A linear section is a chain of beats where each has exactly one
+    predecessor and one successor (within the section). Only returns
+    sections with 3+ beats.
+
+    Returns:
+        List of dicts with keys: section_id, beat_ids, before_beat, after_beat.
+    """
+    # Build adjacency
+    children: dict[str, list[str]] = {bid: [] for bid in beat_nodes}
+    parents: dict[str, list[str]] = {bid: [] for bid in beat_nodes}
+
+    for edge in predecessor_edges:
+        from_id = edge["from"]
+        to_id = edge["to"]
+        if from_id in beat_nodes and to_id in beat_nodes:
+            parents[from_id].append(to_id)
+            children[to_id].append(from_id)
+
+    # Find linear chains: start from beats with != 1 parent or with a parent
+    # that has != 1 child (i.e., boundary beats)
+    visited: set[str] = set()
+    sections: list[dict[str, Any]] = []
+    section_counter = 0
+
+    for bid in sorted(beat_nodes.keys()):
+        if bid in visited:
+            continue
+
+        # Check if this is a potential chain start:
+        # - Has exactly 1 child
+        # - Has != 1 parent OR parent has != 1 child (i.e., is a boundary)
+        p = parents[bid]
+        c = children[bid]
+
+        is_chain_start = len(c) == 1 and (len(p) != 1 or (p and len(children[p[0]]) != 1))
+        # Also start from root beats (no parents)
+        if not is_chain_start and len(p) != 0:
+            continue
+
+        # Walk the chain
+        chain = [bid]
+        current = bid
+        while True:
+            c = children[current]
+            if len(c) != 1:
+                break
+            next_beat = c[0]
+            if len(parents[next_beat]) != 1:
+                break
+            chain.append(next_beat)
+            current = next_beat
+
+        for b in chain:
+            visited.add(b)
+
+        if len(chain) < 3:
+            continue
+
+        before_beat = parents[chain[0]][0] if parents[chain[0]] else None
+        after_beat = children[chain[-1]][0] if children[chain[-1]] else None
+
+        sections.append(
+            {
+                "section_id": f"section_{section_counter}",
+                "beat_ids": chain,
+                "before_beat": before_beat,
+                "after_beat": after_beat,
+            }
+        )
+        section_counter += 1
+
+    return sections
+
+
+def _validate_reorder_constraints(
+    graph: Graph,
+    original_order: list[str],  # noqa: ARG001
+    proposed_order: list[str],
+) -> bool:
+    """Validate that a reordering preserves hard constraints.
+
+    Commit beats must come after their dilemma's advance/reveal beats
+    within the same section.
+
+    Returns:
+        True if the reordering is valid.
+    """
+    beat_nodes = graph.get_nodes_by_type("beat")
+
+    # Map dilemma_id → list of (beat_id, effect) in proposed order
+    dilemma_beats: dict[str, list[tuple[str, str]]] = {}
+    for bid in proposed_order:
+        data = beat_nodes.get(bid, {})
+        for impact in data.get("dilemma_impacts", []):
+            dilemma_id = impact.get("dilemma_id", "")
+            effect = impact.get("effect", "")
+            if dilemma_id and effect:
+                dilemma_beats.setdefault(dilemma_id, []).append((bid, effect))
+
+    # For each dilemma, commits must not precede advances/reveals
+    for _dilemma_id, beats in dilemma_beats.items():
+        commit_indices = []
+        advance_reveal_indices = []
+        for i, (_bid, effect) in enumerate(beats):
+            if effect == "commits":
+                commit_indices.append(i)
+            elif effect in ("advances", "reveals"):
+                advance_reveal_indices.append(i)
+
+        if commit_indices and advance_reveal_indices:
+            earliest_commit = min(commit_indices)
+            latest_advance_reveal = max(advance_reveal_indices)
+            if earliest_commit < latest_advance_reveal:
+                return False
+
+    return True
+
+
+def _apply_reorder(
+    graph: Graph,
+    original_order: list[str],
+    new_order: list[str],
+    before_beat: str | None,
+    after_beat: str | None,
+) -> None:
+    """Apply a reordering by updating predecessor edges within the section.
+
+    Removes old predecessor edges between section beats and creates
+    new ones reflecting the proposed order.
+    """
+    # Remove old internal predecessor edges
+    for i in range(1, len(original_order)):
+        graph.remove_edge("predecessor", original_order[i], original_order[i - 1])
+
+    # Remove edges connecting section to before/after
+    if before_beat:
+        graph.remove_edge("predecessor", original_order[0], before_beat)
+    if after_beat:
+        graph.remove_edge("predecessor", after_beat, original_order[-1])
+
+    # Add new internal edges
+    for i in range(1, len(new_order)):
+        graph.add_edge("predecessor", new_order[i], new_order[i - 1])
+
+    # Reconnect to before/after
+    if before_beat:
+        graph.add_edge("predecessor", new_order[0], before_beat)
+    if after_beat:
+        graph.add_edge("predecessor", after_beat, new_order[-1])
+
+
+# ---------------------------------------------------------------------------
+# Phase 2 helpers
+# ---------------------------------------------------------------------------
+
+
+def _detect_pacing_flags(
+    beat_nodes: dict[str, dict[str, Any]],
+    predecessor_edges: list[dict[str, str]],
+    graph: Graph,
+) -> list[dict[str, Any]]:
+    """Detect pacing issues in the beat DAG.
+
+    Flags:
+    - 3+ scene beats in a row without a sequel/reflection
+    - 3+ sequel beats in a row without an action/scene
+    - No sequel after a commits beat
+
+    Returns:
+        List of dicts with keys: issue_type, beat_ids, path_id.
+    """
+    # Build adjacency for path-local walks
+    belongs_to_edges = graph.get_edges(edge_type="belongs_to")
+    beat_to_path: dict[str, str] = {}
+    for edge in belongs_to_edges:
+        if edge["from"] in beat_nodes:
+            beat_to_path[edge["from"]] = edge["to"]
+
+    children: dict[str, list[str]] = {bid: [] for bid in beat_nodes}
+    parents: dict[str, list[str]] = {bid: [] for bid in beat_nodes}
+    for edge in predecessor_edges:
+        from_id = edge["from"]
+        to_id = edge["to"]
+        if from_id in beat_nodes and to_id in beat_nodes:
+            parents[from_id].append(to_id)
+            children[to_id].append(from_id)
+
+    flags: list[dict[str, Any]] = []
+
+    # Walk linear chains and detect patterns
+    visited: set[str] = set()
+    for bid in sorted(beat_nodes.keys()):
+        if bid in visited or parents[bid]:
+            continue
+
+        # Walk from roots
+        chain = _walk_linear_chain(bid, children, parents)
+        for b in chain:
+            visited.add(b)
+
+        # Check for consecutive scene/sequel runs
+        _check_consecutive_runs(chain, beat_nodes, beat_to_path, flags)
+
+        # Check for missing sequel after commits
+        _check_post_commit_sequel(chain, beat_nodes, beat_to_path, flags)
+
+    return flags
+
+
+def _walk_linear_chain(
+    start: str,
+    children: dict[str, list[str]],
+    parents: dict[str, list[str]],
+) -> list[str]:
+    """Walk a linear chain from start, following single-child links."""
+    chain = [start]
+    current = start
+    while True:
+        c = children[current]
+        if len(c) != 1:
+            break
+        next_beat = c[0]
+        if len(parents[next_beat]) != 1:
+            break
+        chain.append(next_beat)
+        current = next_beat
+    return chain
+
+
+def _check_consecutive_runs(
+    chain: list[str],
+    beat_nodes: dict[str, dict[str, Any]],
+    beat_to_path: dict[str, str],
+    flags: list[dict[str, Any]],
+) -> None:
+    """Check for 3+ consecutive same-type beats in a chain."""
+    if len(chain) < 3:
+        return
+
+    run_type: str | None = None
+    run_beats: list[str] = []
+
+    for bid in chain:
+        scene_type = beat_nodes.get(bid, {}).get("scene_type", "unknown")
+
+        if scene_type == run_type:
+            run_beats.append(bid)
+        else:
+            if len(run_beats) >= 3 and run_type in ("scene", "sequel"):
+                flags.append(
+                    {
+                        "issue_type": f"consecutive_{run_type}",
+                        "beat_ids": list(run_beats),
+                        "path_id": beat_to_path.get(run_beats[0], ""),
+                    }
+                )
+            run_type = scene_type
+            run_beats = [bid]
+
+    # Check final run
+    if len(run_beats) >= 3 and run_type in ("scene", "sequel"):
+        flags.append(
+            {
+                "issue_type": f"consecutive_{run_type}",
+                "beat_ids": list(run_beats),
+                "path_id": beat_to_path.get(run_beats[0], ""),
+            }
+        )
+
+
+def _check_post_commit_sequel(
+    chain: list[str],
+    beat_nodes: dict[str, dict[str, Any]],
+    beat_to_path: dict[str, str],
+    flags: list[dict[str, Any]],
+) -> None:
+    """Check for missing sequel beats after commit beats."""
+    for i, bid in enumerate(chain):
+        data = beat_nodes.get(bid, {})
+        impacts = data.get("dilemma_impacts", [])
+
+        is_commit = any(imp.get("effect") == "commits" for imp in impacts)
+        if not is_commit:
+            continue
+
+        # Check if next beat is a sequel
+        if i + 1 < len(chain):
+            next_data = beat_nodes.get(chain[i + 1], {})
+            next_type = next_data.get("scene_type", "unknown")
+            if next_type != "sequel":
+                flags.append(
+                    {
+                        "issue_type": "no_sequel_after_commit",
+                        "beat_ids": chain[max(0, i - 1) : i + 3],
+                        "path_id": beat_to_path.get(bid, ""),
+                    }
+                )
+
+
+def _insert_micro_beat(
+    graph: Graph,
+    micro_beat_id: str,
+    after_beat_id: str,
+    summary: str,
+    entity_ids: list[str],
+) -> None:
+    """Insert a micro-beat node after the specified beat in the DAG.
+
+    Updates predecessor edges to splice the micro-beat into the chain.
+    """
+    beat_nodes = graph.get_nodes_by_type("beat")
+
+    # Determine path from the after_beat
+    belongs_to_edges = graph.get_edges(edge_type="belongs_to")
+    path_id = None
+    for edge in belongs_to_edges:
+        if edge["from"] == after_beat_id:
+            path_id = edge["to"]
+            break
+
+    # Create the micro-beat node
+    graph.create_node(
+        micro_beat_id,
+        {
+            "type": "beat",
+            "raw_id": micro_beat_id.split("::")[-1],
+            "summary": summary,
+            "role": "micro_beat",
+            "scene_type": "micro_beat",
+            "dilemma_impacts": [],
+            "entities": entity_ids,
+        },
+    )
+
+    # Add belongs_to edge
+    if path_id:
+        graph.add_edge("belongs_to", micro_beat_id, path_id)
+
+    # Find children of after_beat that are on the same path (linear successors)
+    predecessor_edges = graph.get_edges(edge_type="predecessor")
+    successors = []
+    for edge in predecessor_edges:
+        if edge["to"] == after_beat_id and edge["from"] in beat_nodes:
+            successors.append(edge["from"])
+
+    # Splice: micro-beat becomes predecessor of after_beat's successors
+    # and after_beat becomes predecessor of micro-beat
+    graph.add_edge("predecessor", micro_beat_id, after_beat_id)
+
+    # For linear chains, reconnect the first successor
+    if len(successors) == 1:
+        graph.remove_edge("predecessor", successors[0], after_beat_id)
+        graph.add_edge("predecessor", successors[0], micro_beat_id)
+
+
+# ---------------------------------------------------------------------------
+# Phase 3 helpers
+# ---------------------------------------------------------------------------
+
+
+def _collect_entity_appearances(
+    beat_nodes: dict[str, dict[str, Any]],
+    graph: Graph,
+) -> dict[str, list[str]]:
+    """Collect which beats each entity appears in, in topological order.
+
+    Returns:
+        Dict mapping entity_id → list of beat_ids (topologically sorted).
+    """
+    # Build topological order
+    predecessor_edges = graph.get_edges(edge_type="predecessor")
+    topo_order = _topological_sort(beat_nodes, predecessor_edges)
+
+    entity_beats: dict[str, list[str]] = {}
+    for bid in topo_order:
+        data = beat_nodes.get(bid, {})
+        entities = data.get("entities", [])
+        for eid in entities:
+            entity_beats.setdefault(eid, []).append(bid)
+
+    # Also check anchored_to edges for entities central to dilemmas
+    anchored_edges = graph.get_edges(edge_type="anchored_to")
+    for edge in anchored_edges:
+        entity_id = edge["from"]
+        # Entity is central to a dilemma, ensure it's in our map
+        if entity_id not in entity_beats:
+            entity_beats[entity_id] = []
+
+    return entity_beats
+
+
+def _topological_sort(
+    beat_nodes: dict[str, dict[str, Any]],
+    predecessor_edges: list[dict[str, str]],
+) -> list[str]:
+    """Kahn's algorithm for topological sort of beat DAG.
+
+    Returns beat IDs in topological order (parents before children).
+    """
+    in_degree: dict[str, int] = dict.fromkeys(beat_nodes, 0)
+    adj: dict[str, list[str]] = {bid: [] for bid in beat_nodes}
+
+    for edge in predecessor_edges:
+        from_id = edge["from"]
+        to_id = edge["to"]
+        if from_id in beat_nodes and to_id in beat_nodes:
+            in_degree[from_id] += 1
+            adj[to_id].append(from_id)
+
+    queue = sorted(bid for bid, deg in in_degree.items() if deg == 0)
+    result: list[str] = []
+
+    while queue:
+        node = queue.pop(0)
+        result.append(node)
+        for neighbor in sorted(adj[node]):
+            in_degree[neighbor] -= 1
+            if in_degree[neighbor] == 0:
+                queue.append(neighbor)
+
+    return result

--- a/src/questfoundry/pipeline/stages/polish/stage.py
+++ b/src/questfoundry/pipeline/stages/polish/stage.py
@@ -28,6 +28,8 @@ from questfoundry.pipeline.stages.polish._helpers import (
     PolishStageError,
     log,
 )
+from questfoundry.pipeline.stages.polish.llm_helper import _PolishLLMHelperMixin
+from questfoundry.pipeline.stages.polish.llm_phases import _PolishLLMPhaseMixin
 from questfoundry.pipeline.stages.polish.registry import get_polish_registry
 
 if TYPE_CHECKING:
@@ -46,7 +48,7 @@ if TYPE_CHECKING:
 PhaseFunc = Callable[["Graph", "BaseChatModel"], Awaitable[PhaseResult]]
 
 
-class PolishStage:
+class PolishStage(_PolishLLMHelperMixin, _PolishLLMPhaseMixin):
     """POLISH stage: transforms beat DAG into prose-ready passage graph.
 
     Executes phases sequentially with gate hooks between phases for
@@ -81,10 +83,9 @@ class PolishStage:
     # Map from registry phase name → self method name.
     # LLM phases that need binding to ``self`` at call time.
     _METHOD_PHASES: ClassVar[dict[str, str]] = {
-        # Will be populated as phases are implemented:
-        # "beat_reordering": "_phase_1_beat_reordering",
-        # "pacing": "_phase_2_pacing",
-        # "character_arcs": "_phase_3_character_arcs",
+        "beat_reordering": "_phase_1_beat_reordering",
+        "pacing": "_phase_2_pacing",
+        "character_arcs": "_phase_3_character_arcs",
         # "llm_enrichment": "_phase_5_llm_enrichment",
     }
 

--- a/tests/unit/test_polish_context.py
+++ b/tests/unit/test_polish_context.py
@@ -1,0 +1,181 @@
+"""Tests for POLISH context builders."""
+
+from __future__ import annotations
+
+from questfoundry.graph.graph import Graph
+from questfoundry.graph.polish_context import (
+    format_entity_arc_context,
+    format_linear_section_context,
+    format_pacing_context,
+)
+
+
+def _make_beat(graph: Graph, beat_id: str, summary: str, **kwargs: object) -> None:
+    """Helper to create a beat node with optional extras."""
+    data = {
+        "type": "beat",
+        "raw_id": beat_id.split("::")[-1],
+        "summary": summary,
+        "dilemma_impacts": [],
+        "entities": [],
+        "scene_type": "scene",
+    }
+    data.update(kwargs)
+    graph.create_node(beat_id, data)
+
+
+class TestFormatLinearSectionContext:
+    """Tests for Phase 1 context builder."""
+
+    def test_basic_section(self) -> None:
+        graph = Graph.empty()
+        graph.create_node("path::p1", {"type": "path", "raw_id": "p1"})
+        _make_beat(graph, "beat::a", "First action")
+        _make_beat(graph, "beat::b", "Second action")
+        _make_beat(graph, "beat::c", "Third action")
+
+        ctx = format_linear_section_context(
+            graph, "section_0", ["beat::a", "beat::b", "beat::c"], None, None
+        )
+
+        assert ctx["section_id"] == "section_0"
+        assert "beat::a" in ctx["beat_details"]
+        assert "beat::b" in ctx["beat_details"]
+        assert "beat::c" in ctx["beat_details"]
+        assert ctx["beat_count"] == "3"
+        assert ctx["valid_beat_ids"] == "beat::a, beat::b, beat::c"
+
+    def test_with_context_beats(self) -> None:
+        graph = Graph.empty()
+        _make_beat(graph, "beat::before", "Before section", scene_type="sequel")
+        _make_beat(graph, "beat::a", "Section beat")
+        _make_beat(graph, "beat::after", "After section")
+
+        ctx = format_linear_section_context(graph, "s0", ["beat::a"], "beat::before", "beat::after")
+
+        assert "preceding" in ctx["before_context"]
+        assert "beat::before" in ctx["before_context"]
+        assert "following" in ctx["after_context"]
+        assert "beat::after" in ctx["after_context"]
+
+    def test_no_context_beats(self) -> None:
+        graph = Graph.empty()
+        _make_beat(graph, "beat::a", "Only beat")
+
+        ctx = format_linear_section_context(graph, "s0", ["beat::a"], None, None)
+
+        assert "start/end" in ctx["before_context"]
+        assert "start/end" in ctx["after_context"]
+
+    def test_dilemma_impacts_shown(self) -> None:
+        graph = Graph.empty()
+        _make_beat(
+            graph,
+            "beat::commit",
+            "Commit beat",
+            dilemma_impacts=[{"dilemma_id": "dilemma::d1", "effect": "commits"}],
+        )
+
+        ctx = format_linear_section_context(graph, "s0", ["beat::commit"], None, None)
+
+        assert "commits" in ctx["beat_details"]
+        assert "dilemma::d1" in ctx["beat_details"]
+
+
+class TestFormatPacingContext:
+    """Tests for Phase 2 context builder."""
+
+    def test_with_pacing_flags(self) -> None:
+        graph = Graph.empty()
+        _make_beat(graph, "beat::a", "Action 1", scene_type="scene")
+        _make_beat(graph, "beat::b", "Action 2", scene_type="scene")
+        _make_beat(graph, "beat::c", "Action 3", scene_type="scene")
+        graph.create_node("entity::hero", {"type": "entity", "raw_id": "hero", "name": "Hero"})
+
+        flags = [
+            {
+                "issue_type": "consecutive_scene",
+                "beat_ids": ["beat::a", "beat::b", "beat::c"],
+                "path_id": "path::p1",
+            }
+        ]
+
+        ctx = format_pacing_context(graph, flags)
+
+        assert "consecutive_scene" in ctx["pacing_issues"]
+        assert "beat::a" in ctx["pacing_issues"]
+        assert "entity::hero" in ctx["valid_entity_ids"]
+        assert ctx["entity_count"] == "1"
+
+    def test_no_flags(self) -> None:
+        graph = Graph.empty()
+        ctx = format_pacing_context(graph, [])
+        assert "No pacing issues" in ctx["pacing_issues"]
+
+
+class TestFormatEntityArcContext:
+    """Tests for Phase 3 context builder."""
+
+    def test_basic_entity_context(self) -> None:
+        graph = Graph.empty()
+        graph.create_node("path::brave", {"type": "path", "raw_id": "brave"})
+        graph.create_node(
+            "entity::mentor",
+            {
+                "type": "entity",
+                "raw_id": "mentor",
+                "name": "The Mentor",
+                "description": "A wise guide",
+            },
+        )
+
+        _make_beat(
+            graph, "beat::intro", "Mentor introduces themselves", entities=["entity::mentor"]
+        )
+        _make_beat(graph, "beat::reveal", "Mentor reveals a secret", entities=["entity::mentor"])
+
+        graph.add_edge("belongs_to", "beat::intro", "path::brave")
+        graph.add_edge("belongs_to", "beat::reveal", "path::brave")
+        graph.add_edge("predecessor", "beat::reveal", "beat::intro")
+
+        ctx = format_entity_arc_context(graph, "entity::mentor", ["beat::intro", "beat::reveal"])
+
+        assert ctx["entity_id"] == "entity::mentor"
+        assert ctx["entity_name"] == "The Mentor"
+        assert "wise guide" in ctx["entity_description"]
+        assert "beat::intro" in ctx["beat_appearances"]
+        assert "beat::reveal" in ctx["beat_appearances"]
+        assert "path::brave" in ctx["path_ids"]
+
+    def test_entity_with_overlays(self) -> None:
+        graph = Graph.empty()
+        graph.create_node("path::p1", {"type": "path", "raw_id": "p1"})
+        graph.create_node("entity::npc", {"type": "entity", "raw_id": "npc", "name": "NPC"})
+        graph.create_node(
+            "overlay::npc_angry",
+            {
+                "type": "entity_overlay",
+                "raw_id": "npc_angry",
+                "entity_id": "entity::npc",
+                "activation_flag": "dilemma::d1:path::p1",
+                "description": "The NPC becomes hostile",
+            },
+        )
+
+        _make_beat(graph, "beat::b1", "Meet NPC", entities=["entity::npc"])
+        graph.add_edge("belongs_to", "beat::b1", "path::p1")
+
+        ctx = format_entity_arc_context(graph, "entity::npc", ["beat::b1"])
+
+        assert "hostile" in ctx["overlay_data"]
+        assert "dilemma::d1:path::p1" in ctx["overlay_data"]
+
+    def test_entity_not_found(self) -> None:
+        """Missing entity returns empty fields gracefully."""
+        graph = Graph.empty()
+        _make_beat(graph, "beat::b1", "Some beat")
+
+        ctx = format_entity_arc_context(graph, "entity::missing", ["beat::b1"])
+
+        assert ctx["entity_id"] == "entity::missing"
+        assert ctx["entity_name"] == "entity::missing"

--- a/tests/unit/test_polish_models.py
+++ b/tests/unit/test_polish_models.py
@@ -1,0 +1,169 @@
+"""Tests for POLISH stage Pydantic models."""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from questfoundry.models.polish import (
+    ArcPivot,
+    CharacterArcMetadata,
+    MicroBeatProposal,
+    Phase1Output,
+    Phase2Output,
+    Phase3Output,
+    PolishPhaseResult,
+    ReorderedSection,
+)
+
+
+class TestReorderedSection:
+    """Tests for Phase 1 output model."""
+
+    def test_valid_section(self) -> None:
+        section = ReorderedSection(
+            section_id="section_0",
+            beat_ids=["beat::a", "beat::b", "beat::c"],
+            rationale="Better scene-sequel rhythm",
+        )
+        assert section.section_id == "section_0"
+        assert len(section.beat_ids) == 3
+
+    def test_empty_section_id_fails(self) -> None:
+        with pytest.raises(ValidationError):
+            ReorderedSection(section_id="", beat_ids=["beat::a"], rationale="test")
+
+    def test_empty_beat_ids_fails(self) -> None:
+        with pytest.raises(ValidationError):
+            ReorderedSection(section_id="s1", beat_ids=[], rationale="test")
+
+    def test_empty_rationale_fails(self) -> None:
+        with pytest.raises(ValidationError):
+            ReorderedSection(section_id="s1", beat_ids=["beat::a"], rationale="")
+
+
+class TestPhase1Output:
+    """Tests for Phase 1 output container."""
+
+    def test_empty_reorderings(self) -> None:
+        output = Phase1Output(reordered_sections=[])
+        assert output.reordered_sections == []
+
+    def test_with_sections(self) -> None:
+        output = Phase1Output(
+            reordered_sections=[
+                ReorderedSection(
+                    section_id="s0",
+                    beat_ids=["beat::a", "beat::b"],
+                    rationale="test",
+                )
+            ]
+        )
+        assert len(output.reordered_sections) == 1
+
+    def test_defaults_to_empty(self) -> None:
+        output = Phase1Output()
+        assert output.reordered_sections == []
+
+
+class TestMicroBeatProposal:
+    """Tests for Phase 2 output model."""
+
+    def test_valid_micro_beat(self) -> None:
+        mb = MicroBeatProposal(
+            after_beat_id="beat::conflict",
+            summary="A moment of quiet settles over the room",
+            entity_ids=["entity::mentor"],
+        )
+        assert mb.after_beat_id == "beat::conflict"
+        assert len(mb.entity_ids) == 1
+
+    def test_empty_summary_fails(self) -> None:
+        with pytest.raises(ValidationError):
+            MicroBeatProposal(after_beat_id="beat::a", summary="")
+
+    def test_no_entities_ok(self) -> None:
+        mb = MicroBeatProposal(
+            after_beat_id="beat::a",
+            summary="Wind whistles through the corridor",
+        )
+        assert mb.entity_ids == []
+
+
+class TestPhase2Output:
+    """Tests for Phase 2 output container."""
+
+    def test_empty_micro_beats(self) -> None:
+        output = Phase2Output(micro_beats=[])
+        assert output.micro_beats == []
+
+    def test_defaults_to_empty(self) -> None:
+        output = Phase2Output()
+        assert output.micro_beats == []
+
+
+class TestCharacterArcMetadata:
+    """Tests for Phase 3 output model."""
+
+    def test_full_arc(self) -> None:
+        arc = CharacterArcMetadata(
+            entity_id="entity::mentor",
+            start="The mentor appears as a calm authority figure",
+            pivots=[
+                ArcPivot(
+                    path_id="path::trust",
+                    beat_id="beat::reveal",
+                    description="The mentor reveals hidden knowledge",
+                ),
+            ],
+            end_per_path={
+                "path::trust": "The mentor becomes a true ally",
+                "path::doubt": "The mentor is estranged",
+            },
+        )
+        assert arc.entity_id == "entity::mentor"
+        assert len(arc.pivots) == 1
+        assert len(arc.end_per_path) == 2
+
+    def test_empty_entity_id_fails(self) -> None:
+        with pytest.raises(ValidationError):
+            CharacterArcMetadata(
+                entity_id="",
+                start="test",
+            )
+
+    def test_no_pivots_ok(self) -> None:
+        arc = CharacterArcMetadata(
+            entity_id="entity::npc",
+            start="A background character",
+        )
+        assert arc.pivots == []
+        assert arc.end_per_path == {}
+
+
+class TestPhase3Output:
+    """Tests for Phase 3 output container."""
+
+    def test_defaults_to_empty(self) -> None:
+        output = Phase3Output()
+        assert output.character_arcs == []
+
+
+class TestPolishPhaseResult:
+    """Tests for the phase result container."""
+
+    def test_default_values(self) -> None:
+        result = PolishPhaseResult(phase="test")
+        assert result.status == "completed"
+        assert result.llm_calls == 0
+        assert result.tokens_used == 0
+
+    def test_custom_values(self) -> None:
+        result = PolishPhaseResult(
+            phase="beat_reordering",
+            status="completed",
+            detail="Reordered 3/5 sections",
+            llm_calls=5,
+            tokens_used=12000,
+        )
+        assert result.llm_calls == 5

--- a/tests/unit/test_polish_phases.py
+++ b/tests/unit/test_polish_phases.py
@@ -299,6 +299,20 @@ class TestPostCommitSequel:
         _check_post_commit_sequel(["a", "b"], beat_nodes, {}, flags)
         assert len(flags) == 1
 
+    def test_commit_at_end_of_chain_flagged(self) -> None:
+        """Commit as the last beat in a chain triggers no-sequel flag."""
+        beat_nodes = {
+            "a": {"dilemma_impacts": [], "scene_type": "scene"},
+            "b": {
+                "dilemma_impacts": [{"effect": "commits"}],
+                "scene_type": "scene",
+            },
+        }
+        flags: list = []
+        _check_post_commit_sequel(["a", "b"], beat_nodes, {}, flags)
+        assert len(flags) == 1
+        assert flags[0]["issue_type"] == "no_sequel_after_commit"
+
 
 class TestTopologicalSort:
     """Tests for _topological_sort."""

--- a/tests/unit/test_polish_phases.py
+++ b/tests/unit/test_polish_phases.py
@@ -1,0 +1,355 @@
+"""Tests for POLISH LLM phase helpers (deterministic logic).
+
+Tests the pure functions that support Phases 1-3, not the LLM calls
+themselves. LLM integration is tested separately.
+"""
+
+from __future__ import annotations
+
+from questfoundry.graph.graph import Graph
+from questfoundry.pipeline.stages.polish.llm_phases import (
+    _check_consecutive_runs,
+    _check_post_commit_sequel,
+    _collect_entity_appearances,
+    _detect_pacing_flags,
+    _find_linear_sections,
+    _topological_sort,
+    _validate_reorder_constraints,
+)
+
+
+def _make_beat(graph: Graph, beat_id: str, summary: str, **kwargs: object) -> None:
+    """Helper to create a beat node."""
+    data = {
+        "type": "beat",
+        "raw_id": beat_id.split("::")[-1],
+        "summary": summary,
+        "dilemma_impacts": [],
+        "entities": [],
+        "scene_type": "scene",
+    }
+    data.update(kwargs)
+    graph.create_node(beat_id, data)
+
+
+def _add_predecessor(graph: Graph, child: str, parent: str) -> None:
+    """Helper to create a predecessor edge."""
+    graph.add_edge("predecessor", child, parent)
+
+
+class TestFindLinearSections:
+    """Tests for _find_linear_sections."""
+
+    def test_simple_chain(self) -> None:
+        """Linear chain of 4 beats → one section."""
+        graph = Graph.empty()
+        for i in range(4):
+            _make_beat(graph, f"beat::b{i}", f"Beat {i}")
+        for i in range(1, 4):
+            _add_predecessor(graph, f"beat::b{i}", f"beat::b{i - 1}")
+
+        beat_nodes = graph.get_nodes_by_type("beat")
+        edges = graph.get_edges(edge_type="predecessor")
+
+        sections = _find_linear_sections(beat_nodes, edges)
+        assert len(sections) == 1
+        assert len(sections[0]["beat_ids"]) == 4
+
+    def test_short_chain_excluded(self) -> None:
+        """Chain of 2 beats is too short → no sections."""
+        graph = Graph.empty()
+        _make_beat(graph, "beat::a", "A")
+        _make_beat(graph, "beat::b", "B")
+        _add_predecessor(graph, "beat::b", "beat::a")
+
+        beat_nodes = graph.get_nodes_by_type("beat")
+        edges = graph.get_edges(edge_type="predecessor")
+
+        sections = _find_linear_sections(beat_nodes, edges)
+        assert len(sections) == 0
+
+    def test_branching_splits_sections(self) -> None:
+        """Branch point splits the DAG into separate sections.
+
+        Structure: a → b → c (one parent)
+                   a → d → e → f (branch)
+        """
+        graph = Graph.empty()
+        for name in ["a", "b", "c", "d", "e", "f"]:
+            _make_beat(graph, f"beat::{name}", f"Beat {name}")
+
+        _add_predecessor(graph, "beat::b", "beat::a")
+        _add_predecessor(graph, "beat::c", "beat::b")
+        _add_predecessor(graph, "beat::d", "beat::a")
+        _add_predecessor(graph, "beat::e", "beat::d")
+        _add_predecessor(graph, "beat::f", "beat::e")
+
+        beat_nodes = graph.get_nodes_by_type("beat")
+        edges = graph.get_edges(edge_type="predecessor")
+
+        sections = _find_linear_sections(beat_nodes, edges)
+        # The branch from a splits — d→e→f forms a linear section of 3
+        # a→b→c doesn't form a section because a has 2 children (b, d)
+        section_lengths = sorted(len(s["beat_ids"]) for s in sections)
+        assert 3 in section_lengths
+
+    def test_before_after_context(self) -> None:
+        """Section tracks before/after beats for context."""
+        graph = Graph.empty()
+        for i in range(5):
+            _make_beat(graph, f"beat::b{i}", f"Beat {i}")
+        for i in range(1, 5):
+            _add_predecessor(graph, f"beat::b{i}", f"beat::b{i - 1}")
+
+        beat_nodes = graph.get_nodes_by_type("beat")
+        edges = graph.get_edges(edge_type="predecessor")
+
+        sections = _find_linear_sections(beat_nodes, edges)
+        assert len(sections) == 1
+        # First beat has no predecessor, last beat has no successor
+        assert sections[0]["before_beat"] is None
+        assert sections[0]["after_beat"] is None
+
+    def test_no_beats(self) -> None:
+        """Empty graph → no sections."""
+        sections = _find_linear_sections({}, [])
+        assert sections == []
+
+
+class TestValidateReorderConstraints:
+    """Tests for _validate_reorder_constraints."""
+
+    def test_valid_reorder(self) -> None:
+        """Reorder that preserves constraints passes."""
+        graph = Graph.empty()
+        _make_beat(graph, "beat::a", "Setup")
+        _make_beat(
+            graph,
+            "beat::b",
+            "Advance",
+            dilemma_impacts=[{"dilemma_id": "d1", "effect": "advances"}],
+        )
+        _make_beat(
+            graph,
+            "beat::c",
+            "Commit",
+            dilemma_impacts=[{"dilemma_id": "d1", "effect": "commits"}],
+        )
+
+        # Original: a, b, c. Proposed: a, b, c (same — valid)
+        assert _validate_reorder_constraints(
+            graph, ["beat::a", "beat::b", "beat::c"], ["beat::a", "beat::b", "beat::c"]
+        )
+
+    def test_commit_before_advance_rejected(self) -> None:
+        """Reorder putting commit before advance fails."""
+        graph = Graph.empty()
+        _make_beat(
+            graph,
+            "beat::advance",
+            "Advance",
+            dilemma_impacts=[{"dilemma_id": "d1", "effect": "advances"}],
+        )
+        _make_beat(
+            graph,
+            "beat::commit",
+            "Commit",
+            dilemma_impacts=[{"dilemma_id": "d1", "effect": "commits"}],
+        )
+        _make_beat(graph, "beat::other", "Other")
+
+        # Proposed: commit before advance — should fail
+        assert not _validate_reorder_constraints(
+            graph,
+            ["beat::advance", "beat::commit", "beat::other"],
+            ["beat::commit", "beat::advance", "beat::other"],
+        )
+
+    def test_no_dilemma_impacts_always_valid(self) -> None:
+        """Beats without dilemma impacts can be freely reordered."""
+        graph = Graph.empty()
+        _make_beat(graph, "beat::a", "A")
+        _make_beat(graph, "beat::b", "B")
+        _make_beat(graph, "beat::c", "C")
+
+        assert _validate_reorder_constraints(
+            graph, ["beat::a", "beat::b", "beat::c"], ["beat::c", "beat::a", "beat::b"]
+        )
+
+
+class TestDetectPacingFlags:
+    """Tests for _detect_pacing_flags."""
+
+    def test_three_consecutive_scenes(self) -> None:
+        """Three scene beats in a row triggers a flag."""
+        graph = Graph.empty()
+        graph.create_node("path::p1", {"type": "path", "raw_id": "p1"})
+        for i in range(3):
+            _make_beat(graph, f"beat::s{i}", f"Scene {i}", scene_type="scene")
+            graph.add_edge("belongs_to", f"beat::s{i}", "path::p1")
+        _add_predecessor(graph, "beat::s1", "beat::s0")
+        _add_predecessor(graph, "beat::s2", "beat::s1")
+
+        edges = graph.get_edges(edge_type="predecessor")
+        beat_nodes = graph.get_nodes_by_type("beat")
+
+        flags = _detect_pacing_flags(beat_nodes, edges, graph)
+        assert len(flags) >= 1
+        assert any(f["issue_type"] == "consecutive_scene" for f in flags)
+
+    def test_mixed_types_no_flag(self) -> None:
+        """Alternating scene/sequel doesn't trigger flags."""
+        graph = Graph.empty()
+        graph.create_node("path::p1", {"type": "path", "raw_id": "p1"})
+
+        types = ["scene", "sequel", "scene"]
+        for i, st in enumerate(types):
+            _make_beat(graph, f"beat::b{i}", f"Beat {i}", scene_type=st)
+            graph.add_edge("belongs_to", f"beat::b{i}", "path::p1")
+        _add_predecessor(graph, "beat::b1", "beat::b0")
+        _add_predecessor(graph, "beat::b2", "beat::b1")
+
+        edges = graph.get_edges(edge_type="predecessor")
+        beat_nodes = graph.get_nodes_by_type("beat")
+
+        flags = _detect_pacing_flags(beat_nodes, edges, graph)
+        # No consecutive runs of 3+
+        consecutive_flags = [f for f in flags if "consecutive" in f["issue_type"]]
+        assert len(consecutive_flags) == 0
+
+    def test_no_sequel_after_commit(self) -> None:
+        """Commit beat followed by non-sequel triggers a flag."""
+        graph = Graph.empty()
+        graph.create_node("path::p1", {"type": "path", "raw_id": "p1"})
+
+        _make_beat(
+            graph,
+            "beat::commit",
+            "Commit",
+            scene_type="scene",
+            dilemma_impacts=[{"dilemma_id": "d1", "effect": "commits"}],
+        )
+        _make_beat(graph, "beat::action", "Action", scene_type="scene")
+        graph.add_edge("belongs_to", "beat::commit", "path::p1")
+        graph.add_edge("belongs_to", "beat::action", "path::p1")
+        _add_predecessor(graph, "beat::action", "beat::commit")
+
+        edges = graph.get_edges(edge_type="predecessor")
+        beat_nodes = graph.get_nodes_by_type("beat")
+
+        flags = _detect_pacing_flags(beat_nodes, edges, graph)
+        assert any(f["issue_type"] == "no_sequel_after_commit" for f in flags)
+
+
+class TestConsecutiveRuns:
+    """Tests for _check_consecutive_runs helper."""
+
+    def test_detects_scene_run(self) -> None:
+        beat_nodes = {
+            "a": {"scene_type": "scene"},
+            "b": {"scene_type": "scene"},
+            "c": {"scene_type": "scene"},
+        }
+        flags: list = []
+        _check_consecutive_runs(["a", "b", "c"], beat_nodes, {}, flags)
+        assert len(flags) == 1
+        assert flags[0]["issue_type"] == "consecutive_scene"
+
+    def test_detects_sequel_run(self) -> None:
+        beat_nodes = {
+            "a": {"scene_type": "sequel"},
+            "b": {"scene_type": "sequel"},
+            "c": {"scene_type": "sequel"},
+        }
+        flags: list = []
+        _check_consecutive_runs(["a", "b", "c"], beat_nodes, {}, flags)
+        assert len(flags) == 1
+        assert flags[0]["issue_type"] == "consecutive_sequel"
+
+    def test_short_chain_ignored(self) -> None:
+        flags: list = []
+        _check_consecutive_runs(["a", "b"], {"a": {}, "b": {}}, {}, flags)
+        assert len(flags) == 0
+
+
+class TestPostCommitSequel:
+    """Tests for _check_post_commit_sequel helper."""
+
+    def test_commit_followed_by_sequel_ok(self) -> None:
+        beat_nodes = {
+            "a": {
+                "dilemma_impacts": [{"effect": "commits"}],
+                "scene_type": "scene",
+            },
+            "b": {"dilemma_impacts": [], "scene_type": "sequel"},
+        }
+        flags: list = []
+        _check_post_commit_sequel(["a", "b"], beat_nodes, {}, flags)
+        assert len(flags) == 0
+
+    def test_commit_followed_by_scene_flagged(self) -> None:
+        beat_nodes = {
+            "a": {
+                "dilemma_impacts": [{"effect": "commits"}],
+                "scene_type": "scene",
+            },
+            "b": {"dilemma_impacts": [], "scene_type": "scene"},
+        }
+        flags: list = []
+        _check_post_commit_sequel(["a", "b"], beat_nodes, {}, flags)
+        assert len(flags) == 1
+
+
+class TestTopologicalSort:
+    """Tests for _topological_sort."""
+
+    def test_linear_chain(self) -> None:
+        beat_nodes = {"a": {}, "b": {}, "c": {}}
+        edges = [
+            {"from": "b", "to": "a", "type": "predecessor"},
+            {"from": "c", "to": "b", "type": "predecessor"},
+        ]
+        result = _topological_sort(beat_nodes, edges)
+        assert result == ["a", "b", "c"]
+
+    def test_single_node(self) -> None:
+        result = _topological_sort({"x": {}}, [])
+        assert result == ["x"]
+
+    def test_diamond(self) -> None:
+        """Diamond DAG: a → b, a → c, b → d, c → d."""
+        beat_nodes = {"a": {}, "b": {}, "c": {}, "d": {}}
+        edges = [
+            {"from": "b", "to": "a", "type": "predecessor"},
+            {"from": "c", "to": "a", "type": "predecessor"},
+            {"from": "d", "to": "b", "type": "predecessor"},
+            {"from": "d", "to": "c", "type": "predecessor"},
+        ]
+        result = _topological_sort(beat_nodes, edges)
+        assert result[0] == "a"
+        assert result[-1] == "d"
+        assert result.index("b") < result.index("d")
+        assert result.index("c") < result.index("d")
+
+
+class TestCollectEntityAppearances:
+    """Tests for _collect_entity_appearances."""
+
+    def test_entities_collected_in_order(self) -> None:
+        graph = Graph.empty()
+        _make_beat(graph, "beat::a", "First", entities=["entity::hero"])
+        _make_beat(graph, "beat::b", "Second", entities=["entity::hero", "entity::npc"])
+        _make_beat(graph, "beat::c", "Third", entities=["entity::npc"])
+        _add_predecessor(graph, "beat::b", "beat::a")
+        _add_predecessor(graph, "beat::c", "beat::b")
+
+        beat_nodes = graph.get_nodes_by_type("beat")
+        result = _collect_entity_appearances(beat_nodes, graph)
+
+        assert result["entity::hero"] == ["beat::a", "beat::b"]
+        assert result["entity::npc"] == ["beat::b", "beat::c"]
+
+    def test_empty_graph(self) -> None:
+        graph = Graph.empty()
+        result = _collect_entity_appearances({}, graph)
+        assert result == {}


### PR DESCRIPTION
## Summary

- Add beat reordering (Phase 1), pacing/micro-beat injection (Phase 2), and character arc synthesis (Phase 3) — the three LLM-assisted phases that run before the beat DAG is frozen
- Create `models/polish.py` with Pydantic output schemas (`Phase1Output`, `Phase2Output`, `Phase3Output`, `CharacterArcMetadata`)
- Create `graph/polish_context.py` with context builders for LLM prompts
- Create `polish/llm_helper.py` with `_PolishLLMHelperMixin` adapting GROW's proven template → structured output → retry pattern
- Create `polish/llm_phases.py` with phase methods and deterministic helpers (linear section finding, pacing detection, reorder validation, topological sort)
- Add 3 prompt templates (`polish_phase1_reorder`, `polish_phase2_pacing`, `polish_phase3_arcs`)
- Wire phases into `PolishStage` via `_METHOD_PHASES` map and mixin inheritance

Stacked on #1036 (compute_active_flags_at_beat utility).

## Test plan

- [x] 48 new tests covering models, context builders, and all deterministic helpers
- [x] All 92 POLISH tests pass (existing + new)
- [x] GROW registry tests pass (no regression)
- [x] `ruff check` clean, `mypy` clean, `ruff format` clean
- [x] Registry validates: 3 phases registered in correct execution order

## Not Included / Future PRs

- POLISH Phases 4-7 (deterministic plan, enrichment, application, validation) — #988, #989
- GROW validation split — #999
- Arc removal — #996

🤖 Generated with [Claude Code](https://claude.com/claude-code)