### PR TITLE
feat: implement POLISH Phase 5 (LLM enrichment) and Phase 6 (plan application)

### DIFF
--- a/prompts/templates/polish_phase5a_choice_labels.yaml
+++ b/prompts/templates/polish_phase5a_choice_labels.yaml
@@ -1,0 +1,47 @@
+name: polish_phase5a_choice_labels
+description: Generate diegetic choice labels for passage divergence points
+
+system: |
+  You are writing choice labels for a branching story. Each choice is a
+  divergence point where the player picks between paths.
+
+  ## Goals
+  Labels must be:
+  - **Diegetic** — written in the story's voice ("Trust the mentor" not "Choose option A")
+  - **Distinct** — each choice from the same passage must be clearly different
+  - **Concise** — short enough for a button or gamebook instruction (5-12 words)
+
+  ## Story Context
+  {story_context}
+
+  ## Choices to Label
+  {choice_details}
+
+  ## Output Format
+  Return a JSON object with a "choice_labels" array. One entry per choice above.
+
+  Example (do NOT copy these values):
+  {{
+    "choice_labels": [
+      {{
+        "from_passage": "passage::collapse_0",
+        "to_passage": "passage::single_1",
+        "label": "Follow the stranger into the woods"
+      }}
+    ]
+  }}
+
+  ## What NOT to Do
+  - Do NOT use meta-language ("Choose option A", "Select path 2")
+  - Do NOT make labels longer than 15 words
+  - Do NOT skip any choice — provide a label for every choice listed
+  - Do NOT add prose before or after the JSON output
+
+user: |
+  Generate a diegetic label for each of the {choice_count} choices listed above.
+  Each label should feel natural in the story's voice and clearly indicate
+  what the player is choosing.
+
+  REMINDER: Return ONLY valid JSON. Provide exactly one label per choice.
+
+components: []

--- a/prompts/templates/polish_phase5b_residue.yaml
+++ b/prompts/templates/polish_phase5b_residue.yaml
@@ -1,0 +1,46 @@
+name: polish_phase5b_residue
+description: Generate mood-setting content hints for residue beats
+
+system: |
+  You are writing mood-setting prose hints for residue beats. These are
+  brief atmospheric moments that precede shared passages, establishing
+  the emotional tone based on which path the player took.
+
+  ## Goals
+  Content hints must be:
+  - **Brief** — one sentence setting the mood (e.g., "You enter the vault with confidence")
+  - **Path-specific** — reflect the emotional state from the player's choices
+  - **Non-duplicating** — do NOT repeat the shared passage's content
+
+  ## Story Context
+  {story_context}
+
+  ## Residue Beats to Write
+  {residue_details}
+
+  ## Output Format
+  Return a JSON object with a "residue_content" array. One entry per residue above.
+
+  Example (do NOT copy these values):
+  {{
+    "residue_content": [
+      {{
+        "residue_id": "residue::single_2_dilemma__d1_path__brave",
+        "content_hint": "You enter the vault with quiet confidence, the mentor's words still ringing in your ears"
+      }}
+    ]
+  }}
+
+  ## What NOT to Do
+  - Do NOT write full passages — just a mood-setting hint (1-2 sentences max)
+  - Do NOT duplicate content from the target passage
+  - Do NOT skip any residue — provide content for every residue listed
+  - Do NOT add prose before or after the JSON output
+
+user: |
+  Generate a mood-setting content hint for each of the {residue_count} residue beats listed above.
+  Each hint should reflect the emotional tone established by the player's path choices.
+
+  REMINDER: Return ONLY valid JSON. Provide exactly one content hint per residue.
+
+components: []

--- a/prompts/templates/polish_phase5c_false_branches.yaml
+++ b/prompts/templates/polish_phase5c_false_branches.yaml
@@ -1,0 +1,61 @@
+name: polish_phase5c_false_branches
+description: Decide false branch type for linear passage stretches
+
+system: |
+  You are deciding how to add variety to long linear stretches of a
+  branching story. Each candidate is a run of 3+ passages where the
+  player has no choices — you decide whether to add a false branch.
+
+  ## False Branch Types
+  - **skip** — The pacing is fine. No false branch needed.
+  - **diamond** — Split one passage into two alternatives that reconverge.
+    Provide two alternative passage summaries (same story beat, different angle).
+  - **sidetrack** — Add a 1-2 beat detour before rejoining the main path.
+    Provide a detour summary, entity assignments, and choice labels.
+
+  ## Candidate Stretches
+  {candidate_details}
+
+  ## Valid Entity IDs (for sidetrack entity assignments)
+  {valid_entity_ids}
+
+  ## Output Format
+  Return a JSON object with a "decisions" array. One entry per candidate above.
+
+  Example (do NOT copy these values):
+  {{
+    "decisions": [
+      {{
+        "candidate_index": 0,
+        "decision": "diamond",
+        "details": "The discovery scene works well with two perspectives",
+        "diamond_summary_a": "Discover the artifact through careful research",
+        "diamond_summary_b": "Stumble upon the artifact by accident"
+      }},
+      {{
+        "candidate_index": 1,
+        "decision": "sidetrack",
+        "details": "A brief encounter adds character depth",
+        "sidetrack_summary": "A mysterious stranger offers cryptic advice",
+        "sidetrack_entities": ["entity::stranger"],
+        "choice_label_enter": "Approach the stranger",
+        "choice_label_return": "Continue on your way"
+      }}
+    ]
+  }}
+
+  ## What NOT to Do
+  - Do NOT add more than one false branch per candidate
+  - Do NOT skip any candidate — provide a decision for every candidate listed
+  - Do NOT overuse diamond/sidetrack — "skip" is a valid and often best choice
+  - Do NOT add prose before or after the JSON output
+
+user: |
+  Decide whether each of the {candidate_count} candidate stretches needs a false
+  branch for variety. Prefer "skip" unless the stretch genuinely needs more
+  player engagement. Use "diamond" for scenes that work from two angles.
+  Use "sidetrack" for stretches that benefit from a brief detour.
+
+  REMINDER: Return ONLY valid JSON. Provide exactly one decision per candidate.
+
+components: []

--- a/prompts/templates/polish_phase5d_variants.yaml
+++ b/prompts/templates/polish_phase5d_variants.yaml
@@ -1,0 +1,48 @@
+name: polish_phase5d_variants
+description: Generate summaries for variant passages gated by state flags
+
+system: |
+  You are writing summaries for variant passages. Each variant is an
+  alternative version of a base passage, showing the same story moment
+  but with different tone and details reflecting the player's choices.
+
+  ## Goals
+  Variant summaries must:
+  - Cover the **same story beat** as the base passage
+  - Reflect the **emotional state** implied by the active flags
+  - Be **distinct** from other variants of the same base
+  - Be a **brief summary** (1-3 sentences) — not full prose
+
+  ## Story Context
+  {story_context}
+
+  ## Variants to Summarize
+  {variant_details}
+
+  ## Output Format
+  Return a JSON object with a "variant_summaries" array. One entry per variant above.
+
+  Example (do NOT copy these values):
+  {{
+    "variant_summaries": [
+      {{
+        "variant_id": "passage::variant_0",
+        "summary": "The hero enters the throne room confidently, having earned the court's respect through diplomacy"
+      }}
+    ]
+  }}
+
+  ## What NOT to Do
+  - Do NOT write full passage prose — just summaries
+  - Do NOT contradict the base passage's core events
+  - Do NOT skip any variant — provide a summary for every variant listed
+  - Do NOT add prose before or after the JSON output
+
+user: |
+  Generate a summary for each of the {variant_count} variant passages listed above.
+  Each summary should capture how this story moment feels differently based
+  on the player's path choices.
+
+  REMINDER: Return ONLY valid JSON. Provide exactly one summary per variant.
+
+components: []

--- a/src/questfoundry/graph/polish_context.py
+++ b/src/questfoundry/graph/polish_context.py
@@ -251,17 +251,7 @@ def format_choice_label_context(
     for spec in passage_specs:
         passage_lookup[spec["passage_id"]] = spec
 
-    # Build dream context for story tone
-    dream_nodes = graph.get_nodes_by_type("dream_artifact")
-    story_context_parts: list[str] = []
-    for _did, ddata in dream_nodes.items():
-        genre = ddata.get("genre", "")
-        tone = ddata.get("tone", "")
-        if genre:
-            story_context_parts.append(f"Genre: {genre}")
-        if tone:
-            story_context_parts.append(f"Tone: {tone}")
-    story_context = "\n".join(story_context_parts) if story_context_parts else "(no story context)"
+    story_context = _format_story_context(graph)
 
     # Build choice detail lines
     choice_lines: list[str] = []
@@ -308,16 +298,7 @@ def format_residue_content_context(
     for spec in passage_specs:
         passage_lookup[spec["passage_id"]] = spec
 
-    dream_nodes = graph.get_nodes_by_type("dream_artifact")
-    story_context_parts: list[str] = []
-    for _did, ddata in dream_nodes.items():
-        genre = ddata.get("genre", "")
-        tone = ddata.get("tone", "")
-        if genre:
-            story_context_parts.append(f"Genre: {genre}")
-        if tone:
-            story_context_parts.append(f"Tone: {tone}")
-    story_context = "\n".join(story_context_parts) if story_context_parts else "(no story context)"
+    story_context = _format_story_context(graph)
 
     residue_lines: list[str] = []
     for r in residue_specs:
@@ -406,16 +387,7 @@ def format_variant_summary_context(
     for spec in passage_specs:
         passage_lookup[spec["passage_id"]] = spec
 
-    dream_nodes = graph.get_nodes_by_type("dream_artifact")
-    story_context_parts: list[str] = []
-    for _did, ddata in dream_nodes.items():
-        genre = ddata.get("genre", "")
-        tone = ddata.get("tone", "")
-        if genre:
-            story_context_parts.append(f"Genre: {genre}")
-        if tone:
-            story_context_parts.append(f"Tone: {tone}")
-    story_context = "\n".join(story_context_parts) if story_context_parts else "(no story context)"
+    story_context = _format_story_context(graph)
 
     variant_lines: list[str] = []
     for v in variant_specs:
@@ -436,6 +408,20 @@ def format_variant_summary_context(
         "story_context": story_context,
         "variant_count": str(len(variant_specs)),
     }
+
+
+def _format_story_context(graph: Graph) -> str:
+    """Extract genre/tone from dream artifacts as story context string."""
+    dream_nodes = graph.get_nodes_by_type("dream_artifact")
+    parts: list[str] = []
+    for _did, ddata in dream_nodes.items():
+        genre = ddata.get("genre", "")
+        tone = ddata.get("tone", "")
+        if genre:
+            parts.append(f"Genre: {genre}")
+        if tone:
+            parts.append(f"Tone: {tone}")
+    return "\n".join(parts) if parts else "(no story context)"
 
 
 def _format_context_beat(

--- a/src/questfoundry/graph/polish_context.py
+++ b/src/questfoundry/graph/polish_context.py
@@ -231,6 +231,213 @@ def format_entity_arc_context(
     }
 
 
+def format_choice_label_context(
+    graph: Graph,
+    choice_specs: list[dict[str, Any]],
+    passage_specs: list[dict[str, Any]],
+) -> dict[str, str]:
+    """Build context for Phase 5a (choice label generation).
+
+    Args:
+        graph: Graph containing beat DAG.
+        choice_specs: List of choice spec dicts (from_passage, to_passage, grants).
+        passage_specs: List of passage spec dicts (passage_id, summary, beat_ids).
+
+    Returns:
+        Dict with keys: choice_details, story_context, choice_count.
+    """
+    # Build passage lookup
+    passage_lookup: dict[str, dict[str, Any]] = {}
+    for spec in passage_specs:
+        passage_lookup[spec["passage_id"]] = spec
+
+    # Build dream context for story tone
+    dream_nodes = graph.get_nodes_by_type("dream_artifact")
+    story_context_parts: list[str] = []
+    for _did, ddata in dream_nodes.items():
+        genre = ddata.get("genre", "")
+        tone = ddata.get("tone", "")
+        if genre:
+            story_context_parts.append(f"Genre: {genre}")
+        if tone:
+            story_context_parts.append(f"Tone: {tone}")
+    story_context = "\n".join(story_context_parts) if story_context_parts else "(no story context)"
+
+    # Build choice detail lines
+    choice_lines: list[str] = []
+    for i, choice in enumerate(choice_specs):
+        from_id = choice.get("from_passage", "")
+        to_id = choice.get("to_passage", "")
+        grants = choice.get("grants", [])
+
+        from_spec = passage_lookup.get(from_id, {})
+        to_spec = passage_lookup.get(to_id, {})
+
+        from_summary = truncate_summary(from_spec.get("summary", ""), 80)
+        to_summary = truncate_summary(to_spec.get("summary", ""), 80)
+
+        grants_str = f" grants=[{', '.join(grants)}]" if grants else ""
+        choice_lines.append(
+            f"  {i + 1}. From: {from_id} ({from_summary})\n"
+            f"     To: {to_id} ({to_summary}){grants_str}"
+        )
+
+    return {
+        "choice_details": "\n".join(choice_lines),
+        "story_context": story_context,
+        "choice_count": str(len(choice_specs)),
+    }
+
+
+def format_residue_content_context(
+    graph: Graph,
+    residue_specs: list[dict[str, Any]],
+    passage_specs: list[dict[str, Any]],
+) -> dict[str, str]:
+    """Build context for Phase 5b (residue beat content).
+
+    Args:
+        graph: Graph containing beat DAG.
+        residue_specs: List of residue spec dicts.
+        passage_specs: List of passage spec dicts.
+
+    Returns:
+        Dict with keys: residue_details, story_context, residue_count.
+    """
+    passage_lookup: dict[str, dict[str, Any]] = {}
+    for spec in passage_specs:
+        passage_lookup[spec["passage_id"]] = spec
+
+    dream_nodes = graph.get_nodes_by_type("dream_artifact")
+    story_context_parts: list[str] = []
+    for _did, ddata in dream_nodes.items():
+        genre = ddata.get("genre", "")
+        tone = ddata.get("tone", "")
+        if genre:
+            story_context_parts.append(f"Genre: {genre}")
+        if tone:
+            story_context_parts.append(f"Tone: {tone}")
+    story_context = "\n".join(story_context_parts) if story_context_parts else "(no story context)"
+
+    residue_lines: list[str] = []
+    for r in residue_specs:
+        target = r.get("target_passage_id", "")
+        residue_id = r.get("residue_id", "")
+        flag = r.get("flag", "")
+        path_id = r.get("path_id", "")
+
+        target_spec = passage_lookup.get(target, {})
+        target_summary = truncate_summary(target_spec.get("summary", ""), 80)
+
+        residue_lines.append(
+            f"  - {residue_id}: flag={flag} path={path_id}\n"
+            f"    Target passage: {target} ({target_summary})"
+        )
+
+    return {
+        "residue_details": "\n".join(residue_lines),
+        "story_context": story_context,
+        "residue_count": str(len(residue_specs)),
+    }
+
+
+def format_false_branch_context(
+    graph: Graph,
+    candidates: list[dict[str, Any]],
+    passage_specs: list[dict[str, Any]],
+) -> dict[str, str]:
+    """Build context for Phase 5c (false branch decisions).
+
+    Args:
+        graph: Graph containing beat DAG.
+        candidates: List of false branch candidate dicts.
+        passage_specs: List of passage spec dicts.
+
+    Returns:
+        Dict with keys: candidate_details, story_context, candidate_count.
+    """
+    passage_lookup: dict[str, dict[str, Any]] = {}
+    for spec in passage_specs:
+        passage_lookup[spec["passage_id"]] = spec
+
+    entity_nodes = graph.get_nodes_by_type("entity")
+    valid_entity_ids = ", ".join(sorted(entity_nodes.keys()))
+
+    candidate_lines: list[str] = []
+    for i, cand in enumerate(candidates):
+        passage_ids = cand.get("passage_ids", [])
+        context_summary = cand.get("context_summary", "")
+
+        passage_details: list[str] = []
+        for pid in passage_ids:
+            spec = passage_lookup.get(pid, {})
+            summary = truncate_summary(spec.get("summary", ""), 60)
+            passage_details.append(f"    - {pid}: {summary}")
+
+        candidate_lines.append(
+            f"  Candidate {i}:\n"
+            + "\n".join(passage_details)
+            + (f"\n    Context: {context_summary}" if context_summary else "")
+        )
+
+    return {
+        "candidate_details": "\n".join(candidate_lines),
+        "valid_entity_ids": valid_entity_ids,
+        "candidate_count": str(len(candidates)),
+    }
+
+
+def format_variant_summary_context(
+    graph: Graph,
+    variant_specs: list[dict[str, Any]],
+    passage_specs: list[dict[str, Any]],
+) -> dict[str, str]:
+    """Build context for Phase 5d (variant passage summaries).
+
+    Args:
+        graph: Graph containing beat DAG.
+        variant_specs: List of variant spec dicts.
+        passage_specs: List of passage spec dicts.
+
+    Returns:
+        Dict with keys: variant_details, story_context, variant_count.
+    """
+    passage_lookup: dict[str, dict[str, Any]] = {}
+    for spec in passage_specs:
+        passage_lookup[spec["passage_id"]] = spec
+
+    dream_nodes = graph.get_nodes_by_type("dream_artifact")
+    story_context_parts: list[str] = []
+    for _did, ddata in dream_nodes.items():
+        genre = ddata.get("genre", "")
+        tone = ddata.get("tone", "")
+        if genre:
+            story_context_parts.append(f"Genre: {genre}")
+        if tone:
+            story_context_parts.append(f"Tone: {tone}")
+    story_context = "\n".join(story_context_parts) if story_context_parts else "(no story context)"
+
+    variant_lines: list[str] = []
+    for v in variant_specs:
+        variant_id = v.get("variant_id", "")
+        base_id = v.get("base_passage_id", "")
+        requires = v.get("requires", [])
+
+        base_spec = passage_lookup.get(base_id, {})
+        base_summary = truncate_summary(base_spec.get("summary", ""), 80)
+
+        variant_lines.append(
+            f"  - {variant_id}: base={base_id} ({base_summary})\n"
+            f"    requires=[{', '.join(requires)}]"
+        )
+
+    return {
+        "variant_details": "\n".join(variant_lines),
+        "story_context": story_context,
+        "variant_count": str(len(variant_specs)),
+    }
+
+
 def _format_context_beat(
     beat_nodes: dict[str, dict[str, Any]],
     beat_id: str | None,

--- a/src/questfoundry/models/__init__.py
+++ b/src/questfoundry/models/__init__.py
@@ -95,14 +95,18 @@ from questfoundry.models.pipeline import PhaseResult
 from questfoundry.models.polish import (
     ArcPivot,
     CharacterArcMetadata,
+    ChoiceLabelItem,
     ChoiceSpec,
     FalseBranchCandidate,
+    FalseBranchDecisionItem,
     FalseBranchSpec,
     MicroBeatProposal,
     PassageSpec,
     ReorderedSection,
+    ResidueContentItem,
     ResidueSpec,
     VariantSpec,
+    VariantSummaryItem,
 )
 from questfoundry.models.polish import (
     Phase1Output as PolishPhase1Output,
@@ -112,6 +116,18 @@ from questfoundry.models.polish import (
 )
 from questfoundry.models.polish import (
     Phase3Output as PolishPhase3Output,
+)
+from questfoundry.models.polish import (
+    Phase5aOutput as PolishPhase5aOutput,
+)
+from questfoundry.models.polish import (
+    Phase5bOutput as PolishPhase5bOutput,
+)
+from questfoundry.models.polish import (
+    Phase5cOutput as PolishPhase5cOutput,
+)
+from questfoundry.models.polish import (
+    Phase5dOutput as PolishPhase5dOutput,
 )
 from questfoundry.models.seed import (
     Consequence,
@@ -151,6 +167,7 @@ __all__ = [
     "CharacterArcMetadata",
     "Choice",
     "ChoiceLabel",
+    "ChoiceLabelItem",
     "ChoiceSpec",
     "Codeword",
     "CodexEntry",
@@ -184,6 +201,7 @@ __all__ = [
     "EntityVisualWithId",
     "ExpandBlueprint",
     "FalseBranchCandidate",
+    "FalseBranchDecisionItem",
     "FalseBranchSpec",
     "FillExtractOutput",
     "FillPassageOutput",
@@ -224,7 +242,12 @@ __all__ = [
     "PolishPhase1Output",
     "PolishPhase2Output",
     "PolishPhase3Output",
+    "PolishPhase5aOutput",
+    "PolishPhase5bOutput",
+    "PolishPhase5cOutput",
+    "PolishPhase5dOutput",
     "ReorderedSection",
+    "ResidueContentItem",
     "ResidueSpec",
     "ResidueWeight",
     "ReviewFlag",
@@ -237,5 +260,6 @@ __all__ = [
     "TemporalHint",
     "TemporalPosition",
     "VariantSpec",
+    "VariantSummaryItem",
     "VoiceDocument",
 ]

--- a/src/questfoundry/models/polish.py
+++ b/src/questfoundry/models/polish.py
@@ -185,6 +185,9 @@ class ResidueSpec(BaseModel):
     residue_id: str = Field(min_length=1)
     flag: str = Field(min_length=1, description="State flag this residue addresses")
     path_id: str = Field(default="")
+    content_hint: str = Field(
+        default="", description="Mood-setting prose hint (populated by Phase 5)"
+    )
 
 
 class ChoiceSpec(BaseModel):
@@ -225,6 +228,82 @@ class FalseBranchSpec(BaseModel):
         description="skip, diamond, or sidetrack",
     )
     details: str = Field(default="")
+    diamond_summary_a: str = Field(default="", description="First alternative passage (diamond)")
+    diamond_summary_b: str = Field(default="", description="Second alternative passage (diamond)")
+    sidetrack_summary: str = Field(default="", description="Detour beat summary (sidetrack)")
+    sidetrack_entities: list[str] = Field(
+        default_factory=list,
+        description="Entity IDs for sidetrack beat",
+    )
+    choice_label_enter: str = Field(default="", description="Label for entering sidetrack")
+    choice_label_return: str = Field(default="", description="Label for returning from sidetrack")
+
+
+# ---------------------------------------------------------------------------
+# Phase 5: LLM Enrichment — output schemas
+# ---------------------------------------------------------------------------
+
+
+class ChoiceLabelItem(BaseModel):
+    """A single choice label produced by the LLM."""
+
+    from_passage: str = Field(min_length=1)
+    to_passage: str = Field(min_length=1)
+    label: str = Field(min_length=1, description="Diegetic, concise label for this choice")
+
+
+class Phase5aOutput(BaseModel):
+    """Output of Phase 5a: Choice Label Generation."""
+
+    choice_labels: list[ChoiceLabelItem] = Field(default_factory=list)
+
+
+class ResidueContentItem(BaseModel):
+    """Mood-setting prose hint for a residue beat."""
+
+    residue_id: str = Field(min_length=1)
+    content_hint: str = Field(min_length=1, description="Brief mood-setting prose hint")
+
+
+class Phase5bOutput(BaseModel):
+    """Output of Phase 5b: Residue Beat Content."""
+
+    residue_content: list[ResidueContentItem] = Field(default_factory=list)
+
+
+class FalseBranchDecisionItem(BaseModel):
+    """LLM decision for a single false branch candidate."""
+
+    candidate_index: int = Field(ge=0, description="Index into the candidates list")
+    decision: str = Field(min_length=1, description="skip, diamond, or sidetrack")
+    details: str = Field(default="", description="Brief rationale")
+    diamond_summary_a: str = Field(default="")
+    diamond_summary_b: str = Field(default="")
+    sidetrack_summary: str = Field(default="")
+    sidetrack_entities: list[str] = Field(default_factory=list)
+    choice_label_enter: str = Field(default="")
+    choice_label_return: str = Field(default="")
+
+
+class Phase5cOutput(BaseModel):
+    """Output of Phase 5c: False Branch Decisions."""
+
+    decisions: list[FalseBranchDecisionItem] = Field(default_factory=list)
+
+
+class VariantSummaryItem(BaseModel):
+    """Summary for a variant passage."""
+
+    variant_id: str = Field(min_length=1)
+    summary: str = Field(
+        min_length=1, description="Variant passage summary reflecting active flags"
+    )
+
+
+class Phase5dOutput(BaseModel):
+    """Output of Phase 5d: Variant Passage Summaries."""
+
+    variant_summaries: list[VariantSummaryItem] = Field(default_factory=list)
 
 
 # Note: POLISH phases return the shared PhaseResult from models.pipeline.

--- a/src/questfoundry/pipeline/stages/polish/stage.py
+++ b/src/questfoundry/pipeline/stages/polish/stage.py
@@ -29,6 +29,7 @@ from questfoundry.pipeline.stages.polish._helpers import (
     log,
 )
 from questfoundry.pipeline.stages.polish.deterministic import (  # noqa: F401 - register phases
+    phase_plan_application,
     phase_plan_computation,
 )
 from questfoundry.pipeline.stages.polish.llm_helper import _PolishLLMHelperMixin
@@ -89,14 +90,14 @@ class PolishStage(_PolishLLMHelperMixin, _PolishLLMPhaseMixin):
         "beat_reordering": "_phase_1_beat_reordering",
         "pacing": "_phase_2_pacing",
         "character_arcs": "_phase_3_character_arcs",
-        # "llm_enrichment": "_phase_5_llm_enrichment",
+        "llm_enrichment": "_phase_5_llm_enrichment",
     }
 
     # Map from registry phase name → module-level free function.
     # Deterministic phases resolved at call time for test patchability.
     _FREE_PHASES: ClassVar[dict[str, str]] = {
         "plan_computation": "phase_plan_computation",
-        # "plan_application": "phase_plan_application",
+        "plan_application": "phase_plan_application",
         # "validation": "phase_validation",
     }
 

--- a/tests/unit/test_polish_apply.py
+++ b/tests/unit/test_polish_apply.py
@@ -1,0 +1,431 @@
+"""Tests for POLISH Phase 6: atomic plan application.
+
+Tests that the plan application creates correct nodes and edges
+on the graph from passage specs, variant specs, residue specs,
+choice specs, and false branch specs.
+"""
+
+from __future__ import annotations
+
+from questfoundry.graph.graph import Graph
+from questfoundry.models.polish import (
+    ChoiceSpec,
+    FalseBranchSpec,
+    PassageSpec,
+    ResidueSpec,
+    VariantSpec,
+)
+from questfoundry.pipeline.stages.polish.deterministic import (
+    _apply_diamond,
+    _apply_sidetrack,
+    _create_choice_edge,
+    _create_passage_node,
+    _create_residue_beat_and_passage,
+    _create_variant_passage,
+)
+
+
+def _make_beat(graph: Graph, beat_id: str, summary: str = "A beat") -> None:
+    """Helper to create a beat node."""
+    graph.create_node(
+        beat_id,
+        {
+            "type": "beat",
+            "raw_id": beat_id.split("::")[-1],
+            "summary": summary,
+            "dilemma_impacts": [],
+            "entities": [],
+            "scene_type": "scene",
+        },
+    )
+
+
+class TestCreatePassageNode:
+    """Tests for _create_passage_node."""
+
+    def test_creates_passage_with_grouped_in(self) -> None:
+        graph = Graph.empty()
+        _make_beat(graph, "beat::a")
+        _make_beat(graph, "beat::b")
+
+        spec = PassageSpec(
+            passage_id="passage::test",
+            beat_ids=["beat::a", "beat::b"],
+            summary="Test passage",
+            entities=["entity::hero"],
+            grouping_type="collapse",
+        )
+        _create_passage_node(graph, spec)
+
+        passages = graph.get_nodes_by_type("passage")
+        assert "passage::test" in passages
+        assert passages["passage::test"]["summary"] == "Test passage"
+        assert passages["passage::test"]["grouping_type"] == "collapse"
+
+        # Check grouped_in edges
+        edges = graph.get_edges(edge_type="grouped_in")
+        grouped_from = {e["from"] for e in edges}
+        grouped_to = {e["to"] for e in edges}
+        assert "beat::a" in grouped_from
+        assert "beat::b" in grouped_from
+        assert grouped_to == {"passage::test"}
+
+    def test_singleton_passage(self) -> None:
+        graph = Graph.empty()
+        _make_beat(graph, "beat::single")
+
+        spec = PassageSpec(
+            passage_id="passage::s1",
+            beat_ids=["beat::single"],
+            summary="Single beat",
+        )
+        _create_passage_node(graph, spec)
+
+        passages = graph.get_nodes_by_type("passage")
+        assert "passage::s1" in passages
+        edges = graph.get_edges(edge_type="grouped_in")
+        assert len(edges) == 1
+
+
+class TestCreateVariantPassage:
+    """Tests for _create_variant_passage."""
+
+    def test_creates_variant_with_variant_of_edge(self) -> None:
+        graph = Graph.empty()
+        _make_beat(graph, "beat::a")
+
+        # Create base passage first
+        base_spec = PassageSpec(
+            passage_id="passage::base",
+            beat_ids=["beat::a"],
+            summary="Base passage",
+        )
+        _create_passage_node(graph, base_spec)
+
+        # Create variant
+        vspec = VariantSpec(
+            base_passage_id="passage::base",
+            variant_id="passage::variant_0",
+            requires=["flag1"],
+            summary="Variant version",
+        )
+        _create_variant_passage(graph, vspec)
+
+        passages = graph.get_nodes_by_type("passage")
+        assert "passage::variant_0" in passages
+        assert passages["passage::variant_0"]["is_variant"] is True
+        assert passages["passage::variant_0"]["requires"] == ["flag1"]
+
+        # Check variant_of edge
+        edges = graph.get_edges(edge_type="variant_of")
+        assert len(edges) == 1
+        assert edges[0]["from"] == "passage::variant_0"
+        assert edges[0]["to"] == "passage::base"
+
+
+class TestCreateResidueBeatAndPassage:
+    """Tests for _create_residue_beat_and_passage."""
+
+    def test_creates_residue_beat_and_passage(self) -> None:
+        graph = Graph.empty()
+        _make_beat(graph, "beat::target")
+        graph.create_node("path::brave", {"type": "path", "raw_id": "brave"})
+
+        # Create target passage
+        target_spec = PassageSpec(
+            passage_id="passage::target",
+            beat_ids=["beat::target"],
+            summary="Target",
+        )
+        _create_passage_node(graph, target_spec)
+
+        rspec = ResidueSpec(
+            target_passage_id="passage::target",
+            residue_id="residue::r1",
+            flag="dilemma::d1:path::brave",
+            path_id="path::brave",
+            content_hint="You feel confident",
+        )
+        _create_residue_beat_and_passage(graph, rspec)
+
+        # Check residue beat was created
+        beat_nodes = graph.get_nodes_by_type("beat")
+        residue_beat = beat_nodes.get("beat::r1")
+        assert residue_beat is not None
+        assert residue_beat["role"] == "residue_beat"
+        assert residue_beat["summary"] == "You feel confident"
+
+        # Check residue passage was created
+        passages = graph.get_nodes_by_type("passage")
+        residue_passage = passages.get("passage::r1")
+        assert residue_passage is not None
+        assert residue_passage["is_residue"] is True
+        assert residue_passage["requires"] == ["dilemma::d1:path::brave"]
+
+        # Check grouped_in edge
+        grouped_edges = graph.get_edges(edge_type="grouped_in")
+        residue_grouped = [e for e in grouped_edges if e["from"] == "beat::r1"]
+        assert len(residue_grouped) == 1
+        assert residue_grouped[0]["to"] == "passage::r1"
+
+        # Check precedes edge
+        precedes = graph.get_edges(edge_type="precedes")
+        assert len(precedes) == 1
+        assert precedes[0]["from"] == "passage::r1"
+        assert precedes[0]["to"] == "passage::target"
+
+    def test_residue_without_content_hint_uses_default(self) -> None:
+        graph = Graph.empty()
+        _make_beat(graph, "beat::target")
+
+        target_spec = PassageSpec(
+            passage_id="passage::target",
+            beat_ids=["beat::target"],
+            summary="Target",
+        )
+        _create_passage_node(graph, target_spec)
+
+        rspec = ResidueSpec(
+            target_passage_id="passage::target",
+            residue_id="residue::r2",
+            flag="flag1",
+        )
+        _create_residue_beat_and_passage(graph, rspec)
+
+        beat_nodes = graph.get_nodes_by_type("beat")
+        assert "beat::r2" in beat_nodes
+        assert "Residue moment for" in beat_nodes["beat::r2"]["summary"]
+
+
+class TestCreateChoiceEdge:
+    """Tests for _create_choice_edge."""
+
+    def test_creates_choice_edge_with_label(self) -> None:
+        graph = Graph.empty()
+        _make_beat(graph, "beat::a")
+        _make_beat(graph, "beat::b")
+
+        for pid, bid in [("passage::p1", "beat::a"), ("passage::p2", "beat::b")]:
+            _create_passage_node(
+                graph,
+                PassageSpec(passage_id=pid, beat_ids=[bid], summary="s"),
+            )
+
+        cspec = ChoiceSpec(
+            from_passage="passage::p1",
+            to_passage="passage::p2",
+            label="Go north",
+            grants=["flag1"],
+        )
+        _create_choice_edge(graph, cspec)
+
+        edges = graph.get_edges(edge_type="choice")
+        assert len(edges) == 1
+        assert edges[0]["from"] == "passage::p1"
+        assert edges[0]["to"] == "passage::p2"
+
+    def test_choice_edge_without_label(self) -> None:
+        graph = Graph.empty()
+        _make_beat(graph, "beat::a")
+        _make_beat(graph, "beat::b")
+
+        for pid, bid in [("passage::p1", "beat::a"), ("passage::p2", "beat::b")]:
+            _create_passage_node(
+                graph,
+                PassageSpec(passage_id=pid, beat_ids=[bid], summary="s"),
+            )
+
+        cspec = ChoiceSpec(
+            from_passage="passage::p1",
+            to_passage="passage::p2",
+        )
+        _create_choice_edge(graph, cspec)
+
+        edges = graph.get_edges(edge_type="choice")
+        assert len(edges) == 1
+
+
+class TestApplyDiamond:
+    """Tests for _apply_diamond."""
+
+    def test_diamond_creates_alternatives_and_choices(self) -> None:
+        graph = Graph.empty()
+        # Create 3 passages for the candidate stretch
+        for i in range(3):
+            _make_beat(graph, f"beat::b{i}")
+            _create_passage_node(
+                graph,
+                PassageSpec(
+                    passage_id=f"passage::p{i}",
+                    beat_ids=[f"beat::b{i}"],
+                    summary=f"Passage {i}",
+                ),
+            )
+
+        fb_spec = FalseBranchSpec(
+            candidate_passage_ids=["passage::p0", "passage::p1", "passage::p2"],
+            branch_type="diamond",
+            diamond_summary_a="Careful approach",
+            diamond_summary_b="Bold approach",
+        )
+
+        beats, choices = _apply_diamond(graph, fb_spec)
+        assert beats == 0
+        assert choices == 4
+
+        # Check alt passages exist
+        passages = graph.get_nodes_by_type("passage")
+        assert "passage::p1_alt_a" in passages
+        assert "passage::p1_alt_b" in passages
+        assert passages["passage::p1_alt_a"]["is_diamond_alt"] is True
+
+        # Check choice edges exist
+        choice_edges = graph.get_edges(edge_type="choice")
+        assert len(choice_edges) == 4
+
+    def test_diamond_too_few_passages(self) -> None:
+        graph = Graph.empty()
+        fb_spec = FalseBranchSpec(
+            candidate_passage_ids=["p1", "p2"],
+            branch_type="diamond",
+        )
+        beats, choices = _apply_diamond(graph, fb_spec)
+        assert beats == 0
+        assert choices == 0
+
+
+class TestApplySidetrack:
+    """Tests for _apply_sidetrack."""
+
+    def test_sidetrack_creates_detour(self) -> None:
+        graph = Graph.empty()
+        for i in range(3):
+            _make_beat(graph, f"beat::b{i}")
+            _create_passage_node(
+                graph,
+                PassageSpec(
+                    passage_id=f"passage::p{i}",
+                    beat_ids=[f"beat::b{i}"],
+                    summary=f"Passage {i}",
+                ),
+            )
+
+        fb_spec = FalseBranchSpec(
+            candidate_passage_ids=["passage::p0", "passage::p1", "passage::p2"],
+            branch_type="sidetrack",
+            sidetrack_summary="Meet a stranger",
+            sidetrack_entities=["entity::stranger"],
+            choice_label_enter="Approach",
+            choice_label_return="Move on",
+        )
+
+        beats, choices = _apply_sidetrack(graph, fb_spec)
+        assert beats == 1
+        assert choices == 2
+
+        # Check sidetrack beat exists
+        beat_nodes = graph.get_nodes_by_type("beat")
+        sidetrack_beats = {k: v for k, v in beat_nodes.items() if v.get("role") == "sidetrack_beat"}
+        assert len(sidetrack_beats) == 1
+        sb = next(iter(sidetrack_beats.values()))
+        assert sb["summary"] == "Meet a stranger"
+        assert sb["entities"] == ["entity::stranger"]
+
+        # Check sidetrack passage exists
+        passages = graph.get_nodes_by_type("passage")
+        sidetrack_passages = {k: v for k, v in passages.items() if v.get("is_sidetrack")}
+        assert len(sidetrack_passages) == 1
+
+        # Check choice edges
+        choice_edges = graph.get_edges(edge_type="choice")
+        assert len(choice_edges) == 2
+
+    def test_sidetrack_too_few_passages(self) -> None:
+        graph = Graph.empty()
+        fb_spec = FalseBranchSpec(
+            candidate_passage_ids=["p1"],
+            branch_type="sidetrack",
+        )
+        beats, choices = _apply_sidetrack(graph, fb_spec)
+        assert beats == 0
+        assert choices == 0
+
+
+class TestPhase6Integration:
+    """Integration tests combining multiple application steps."""
+
+    def test_full_plan_application(self) -> None:
+        """Apply a complete plan with passages, choices, and a variant."""
+        graph = Graph.empty()
+        graph.create_node("path::pa", {"type": "path", "raw_id": "pa"})
+        graph.create_node("path::pb", {"type": "path", "raw_id": "pb"})
+
+        _make_beat(graph, "beat::start", "Start")
+        _make_beat(graph, "beat::a", "Path A")
+        _make_beat(graph, "beat::b", "Path B")
+
+        # Apply passage specs
+        specs = [
+            PassageSpec(
+                passage_id="passage::start",
+                beat_ids=["beat::start"],
+                summary="Starting point",
+            ),
+            PassageSpec(
+                passage_id="passage::a",
+                beat_ids=["beat::a"],
+                summary="Path A scene",
+            ),
+            PassageSpec(
+                passage_id="passage::b",
+                beat_ids=["beat::b"],
+                summary="Path B scene",
+            ),
+        ]
+        for spec in specs:
+            _create_passage_node(graph, spec)
+
+        # Apply choices
+        choices = [
+            ChoiceSpec(
+                from_passage="passage::start",
+                to_passage="passage::a",
+                label="Take path A",
+            ),
+            ChoiceSpec(
+                from_passage="passage::start",
+                to_passage="passage::b",
+                label="Take path B",
+            ),
+        ]
+        for cspec in choices:
+            _create_choice_edge(graph, cspec)
+
+        # Apply variant
+        vspec = VariantSpec(
+            base_passage_id="passage::a",
+            variant_id="passage::a_v1",
+            requires=["flag1"],
+            summary="Path A variant",
+        )
+        _create_variant_passage(graph, vspec)
+
+        # Verify graph state
+        passages = graph.get_nodes_by_type("passage")
+        assert len(passages) == 4  # 3 base + 1 variant
+
+        choice_edges = graph.get_edges(edge_type="choice")
+        assert len(choice_edges) == 2
+
+        grouped_edges = graph.get_edges(edge_type="grouped_in")
+        assert len(grouped_edges) == 3  # 3 beats grouped into passages
+
+        variant_edges = graph.get_edges(edge_type="variant_of")
+        assert len(variant_edges) == 1
+
+    def test_empty_plan_application(self) -> None:
+        """Applying an empty plan creates nothing."""
+        graph = Graph.empty()
+        # No specs to apply — just verify no crash
+        passages = graph.get_nodes_by_type("passage")
+        assert len(passages) == 0

--- a/tests/unit/test_polish_phase5_context.py
+++ b/tests/unit/test_polish_phase5_context.py
@@ -1,0 +1,144 @@
+"""Tests for POLISH Phase 5 context builders."""
+
+from __future__ import annotations
+
+from questfoundry.graph.graph import Graph
+from questfoundry.graph.polish_context import (
+    format_choice_label_context,
+    format_false_branch_context,
+    format_residue_content_context,
+    format_variant_summary_context,
+)
+
+
+def _make_beat(graph: Graph, beat_id: str, summary: str = "A beat") -> None:
+    """Helper to create a beat node."""
+    graph.create_node(
+        beat_id,
+        {
+            "type": "beat",
+            "raw_id": beat_id.split("::")[-1],
+            "summary": summary,
+            "dilemma_impacts": [],
+            "entities": [],
+            "scene_type": "scene",
+        },
+    )
+
+
+class TestFormatChoiceLabelContext:
+    def test_basic_context(self) -> None:
+        graph = Graph.empty()
+        choice_specs = [
+            {"from_passage": "p1", "to_passage": "p2", "grants": ["flag1"]},
+        ]
+        passage_specs = [
+            {"passage_id": "p1", "summary": "Start", "beat_ids": ["b1"]},
+            {"passage_id": "p2", "summary": "End", "beat_ids": ["b2"]},
+        ]
+
+        ctx = format_choice_label_context(graph, choice_specs, passage_specs)
+        assert "choice_count" in ctx
+        assert ctx["choice_count"] == "1"
+        assert "choice_details" in ctx
+        assert "Start" in ctx["choice_details"]
+        assert "End" in ctx["choice_details"]
+
+    def test_empty_choices(self) -> None:
+        graph = Graph.empty()
+        ctx = format_choice_label_context(graph, [], [])
+        assert ctx["choice_count"] == "0"
+        assert ctx["choice_details"] == ""
+
+    def test_story_context_from_dream(self) -> None:
+        graph = Graph.empty()
+        graph.create_node(
+            "dream_artifact::d1",
+            {"type": "dream_artifact", "raw_id": "d1", "genre": "mystery", "tone": "dark"},
+        )
+        ctx = format_choice_label_context(graph, [], [])
+        assert "mystery" in ctx["story_context"]
+        assert "dark" in ctx["story_context"]
+
+
+class TestFormatResidueContentContext:
+    def test_basic_context(self) -> None:
+        graph = Graph.empty()
+        residue_specs = [
+            {
+                "target_passage_id": "p1",
+                "residue_id": "r1",
+                "flag": "flag1",
+                "path_id": "path::brave",
+            },
+        ]
+        passage_specs = [
+            {"passage_id": "p1", "summary": "Target passage", "beat_ids": ["b1"]},
+        ]
+
+        ctx = format_residue_content_context(graph, residue_specs, passage_specs)
+        assert ctx["residue_count"] == "1"
+        assert "r1" in ctx["residue_details"]
+        assert "Target passage" in ctx["residue_details"]
+
+    def test_empty_residues(self) -> None:
+        graph = Graph.empty()
+        ctx = format_residue_content_context(graph, [], [])
+        assert ctx["residue_count"] == "0"
+
+
+class TestFormatFalseBranchContext:
+    def test_basic_context(self) -> None:
+        graph = Graph.empty()
+        graph.create_node(
+            "entity::hero",
+            {"type": "entity", "raw_id": "hero", "name": "Hero"},
+        )
+
+        candidates = [
+            {
+                "passage_ids": ["p1", "p2", "p3"],
+                "context_summary": "Linear stretch",
+            },
+        ]
+        passage_specs = [
+            {"passage_id": "p1", "summary": "First", "beat_ids": ["b1"]},
+            {"passage_id": "p2", "summary": "Second", "beat_ids": ["b2"]},
+            {"passage_id": "p3", "summary": "Third", "beat_ids": ["b3"]},
+        ]
+
+        ctx = format_false_branch_context(graph, candidates, passage_specs)
+        assert ctx["candidate_count"] == "1"
+        assert "entity::hero" in ctx["valid_entity_ids"]
+        assert "First" in ctx["candidate_details"]
+
+    def test_empty_candidates(self) -> None:
+        graph = Graph.empty()
+        ctx = format_false_branch_context(graph, [], [])
+        assert ctx["candidate_count"] == "0"
+
+
+class TestFormatVariantSummaryContext:
+    def test_basic_context(self) -> None:
+        graph = Graph.empty()
+        variant_specs = [
+            {
+                "variant_id": "v1",
+                "base_passage_id": "p1",
+                "requires": ["flag1"],
+                "summary": "",
+            },
+        ]
+        passage_specs = [
+            {"passage_id": "p1", "summary": "Base passage", "beat_ids": ["b1"]},
+        ]
+
+        ctx = format_variant_summary_context(graph, variant_specs, passage_specs)
+        assert ctx["variant_count"] == "1"
+        assert "Base passage" in ctx["variant_details"]
+        assert "flag1" in ctx["variant_details"]
+
+    def test_empty_variants(self) -> None:
+        graph = Graph.empty()
+        ctx = format_variant_summary_context(graph, [], [])
+        assert ctx["variant_count"] == "0"

--- a/tests/unit/test_polish_phase5_models.py
+++ b/tests/unit/test_polish_phase5_models.py
@@ -1,0 +1,158 @@
+"""Tests for POLISH Phase 5 LLM output models."""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from questfoundry.models.polish import (
+    ChoiceLabelItem,
+    FalseBranchDecisionItem,
+    FalseBranchSpec,
+    Phase5aOutput,
+    Phase5bOutput,
+    Phase5cOutput,
+    Phase5dOutput,
+    ResidueContentItem,
+    ResidueSpec,
+    VariantSummaryItem,
+)
+
+
+class TestChoiceLabelItem:
+    def test_valid(self) -> None:
+        item = ChoiceLabelItem(from_passage="p1", to_passage="p2", label="Trust the mentor")
+        assert item.label == "Trust the mentor"
+
+    def test_empty_label_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            ChoiceLabelItem(from_passage="p1", to_passage="p2", label="")
+
+
+class TestPhase5aOutput:
+    def test_empty_labels(self) -> None:
+        out = Phase5aOutput()
+        assert out.choice_labels == []
+
+    def test_with_labels(self) -> None:
+        out = Phase5aOutput(
+            choice_labels=[
+                ChoiceLabelItem(from_passage="p1", to_passage="p2", label="Go left"),
+                ChoiceLabelItem(from_passage="p1", to_passage="p3", label="Go right"),
+            ]
+        )
+        assert len(out.choice_labels) == 2
+
+
+class TestResidueContentItem:
+    def test_valid(self) -> None:
+        item = ResidueContentItem(residue_id="r1", content_hint="You feel a chill")
+        assert item.content_hint == "You feel a chill"
+
+    def test_empty_hint_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            ResidueContentItem(residue_id="r1", content_hint="")
+
+
+class TestPhase5bOutput:
+    def test_empty(self) -> None:
+        out = Phase5bOutput()
+        assert out.residue_content == []
+
+
+class TestFalseBranchDecisionItem:
+    def test_skip(self) -> None:
+        item = FalseBranchDecisionItem(candidate_index=0, decision="skip")
+        assert item.decision == "skip"
+        assert item.diamond_summary_a == ""
+
+    def test_diamond(self) -> None:
+        item = FalseBranchDecisionItem(
+            candidate_index=1,
+            decision="diamond",
+            diamond_summary_a="Research path",
+            diamond_summary_b="Accident path",
+        )
+        assert item.diamond_summary_a == "Research path"
+
+    def test_sidetrack(self) -> None:
+        item = FalseBranchDecisionItem(
+            candidate_index=2,
+            decision="sidetrack",
+            sidetrack_summary="Meet a stranger",
+            sidetrack_entities=["entity::stranger"],
+            choice_label_enter="Approach",
+            choice_label_return="Move on",
+        )
+        assert item.sidetrack_entities == ["entity::stranger"]
+
+    def test_negative_index_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            FalseBranchDecisionItem(candidate_index=-1, decision="skip")
+
+
+class TestPhase5cOutput:
+    def test_empty(self) -> None:
+        out = Phase5cOutput()
+        assert out.decisions == []
+
+
+class TestVariantSummaryItem:
+    def test_valid(self) -> None:
+        item = VariantSummaryItem(variant_id="v1", summary="Confident entry")
+        assert item.summary == "Confident entry"
+
+
+class TestPhase5dOutput:
+    def test_empty(self) -> None:
+        out = Phase5dOutput()
+        assert out.variant_summaries == []
+
+
+class TestResidueSpecContentHint:
+    """Test the content_hint field added to ResidueSpec."""
+
+    def test_default_empty(self) -> None:
+        spec = ResidueSpec(target_passage_id="p1", residue_id="r1", flag="flag1")
+        assert spec.content_hint == ""
+
+    def test_with_content_hint(self) -> None:
+        spec = ResidueSpec(
+            target_passage_id="p1",
+            residue_id="r1",
+            flag="flag1",
+            content_hint="You enter confidently",
+        )
+        assert spec.content_hint == "You enter confidently"
+
+
+class TestFalseBranchSpecExtended:
+    """Test the extended fields on FalseBranchSpec."""
+
+    def test_default_fields(self) -> None:
+        spec = FalseBranchSpec(
+            candidate_passage_ids=["p1", "p2", "p3"],
+            branch_type="skip",
+        )
+        assert spec.diamond_summary_a == ""
+        assert spec.sidetrack_entities == []
+
+    def test_diamond_fields(self) -> None:
+        spec = FalseBranchSpec(
+            candidate_passage_ids=["p1", "p2", "p3"],
+            branch_type="diamond",
+            diamond_summary_a="Option A",
+            diamond_summary_b="Option B",
+        )
+        assert spec.diamond_summary_a == "Option A"
+
+    def test_sidetrack_fields(self) -> None:
+        spec = FalseBranchSpec(
+            candidate_passage_ids=["p1", "p2", "p3"],
+            branch_type="sidetrack",
+            sidetrack_summary="Detour",
+            sidetrack_entities=["entity::npc"],
+            choice_label_enter="Take detour",
+            choice_label_return="Continue",
+        )
+        assert spec.choice_label_enter == "Take detour"


### PR DESCRIPTION
## Summary

- **Phase 5 (LLM enrichment)**: Enriches the deterministic plan with creative content via 4 focused LLM calls:
  - 5a: Choice label generation (diegetic, distinct, concise labels)
  - 5b: Residue beat content (mood-setting prose hints per path/flag)
  - 5c: False branch decisions (skip/diamond/sidetrack per candidate)
  - 5d: Variant passage summaries (same moment, different tone per flag)
- **Phase 6 (atomic plan application)**: Single-pass application creating all passage nodes, variant passages, residue beats, choice edges, and false branch structures
- Adds `Phase5aOutput`, `Phase5bOutput`, `Phase5cOutput`, `Phase5dOutput` LLM output models
- Extends `FalseBranchSpec` with diamond/sidetrack fields, adds `content_hint` to `ResidueSpec`
- 4 new prompt templates for Phase 5 sub-tasks
- 4 new context builders for Phase 5 prompts

Stacked on PR #1038.

Part of Epic #990, addresses #988.

## Test plan

- [x] 41 new tests (Phase 5 models, Phase 6 application, context builders)
- [x] All 137 POLISH + GROW tests pass
- [x] Registry validates: 6 phases in correct topological order
- [x] mypy + ruff clean
- [ ] Verify Phase 6 creates correct passage nodes with `grouped_in` edges
- [ ] Verify diamond/sidetrack false branches wire correctly
- [ ] Verify variant passages have `variant_of` edges

🤖 Generated with [Claude Code](https://claude.com/claude-code)