### PR TITLE
feat: add compute_arc_traversals() utility (#996)

### DIFF
--- a/src/questfoundry/graph/algorithms.py
+++ b/src/questfoundry/graph/algorithms.py
@@ -7,6 +7,7 @@ replace Arc-dependent computations and can be used by both GROW
 
 from __future__ import annotations
 
+from collections import defaultdict
 from itertools import product
 from typing import TYPE_CHECKING
 
@@ -123,5 +124,145 @@ def compute_active_flags_at_beat(graph: Graph, beat_id: str) -> set[frozenset[st
     result: set[frozenset[str]] = set()
     for combo in product(*per_dilemma_options):
         result.add(frozenset(combo))
+
+    return result
+
+
+def compute_arc_traversals(graph: Graph) -> dict[str, list[str]]:
+    """Compute arc traversals from graph structure without stored Arc nodes.
+
+    Replicates the logic of ``enumerate_arcs()`` in ``grow_algorithms.py``
+    but as a pure read-only computation. For each Cartesian product
+    combination of paths across dilemmas, collects all beats belonging
+    to those paths and topologically sorts them.
+
+    The arc key is the sorted path raw_ids joined by ``"+"``, matching
+    the ``arc_id`` convention used by stored Arc nodes.
+
+    Algorithm:
+        1. Build dilemma → paths mapping from path node ``dilemma_id``.
+        2. Build path → beat set mapping from ``belongs_to`` edges.
+        3. Compute Cartesian product of paths (one per dilemma).
+        4. For each combination, union the beat sets and topologically sort.
+
+    Args:
+        graph: Graph containing dilemma, path, and beat nodes with
+            ``belongs_to`` and ``predecessor`` edges.
+
+    Returns:
+        Dict mapping arc key (``"path_a+path_b"``) to topologically sorted
+        list of beat IDs. Returns empty dict if no dilemmas or paths exist.
+    """
+    path_nodes = graph.get_nodes_by_type("path")
+    dilemma_nodes = graph.get_nodes_by_type("dilemma")
+
+    if not dilemma_nodes or not path_nodes:
+        return {}
+
+    # Step 1: Build dilemma → paths mapping
+    dilemma_paths: dict[str, list[str]] = defaultdict(list)
+    for path_id, path_data in path_nodes.items():
+        dilemma_id = path_data.get("dilemma_id")
+        if dilemma_id:
+            # Normalize: ensure "dilemma::" prefix
+            prefixed = (
+                dilemma_id if dilemma_id.startswith("dilemma::") else f"dilemma::{dilemma_id}"
+            )
+            if prefixed in dilemma_nodes:
+                dilemma_paths[prefixed].append(path_id)
+
+    if not dilemma_paths or any(not pl for pl in dilemma_paths.values()):
+        return {}
+
+    # Sort paths within each dilemma for determinism
+    for paths in dilemma_paths.values():
+        paths.sort()
+
+    sorted_dilemmas = sorted(dilemma_paths.keys())
+    path_lists = [dilemma_paths[did] for did in sorted_dilemmas]
+
+    # Step 2: Build path → beat set mapping via belongs_to edges
+    path_beat_sets: dict[str, set[str]] = defaultdict(set)
+    belongs_to_edges = graph.get_edges(edge_type="belongs_to")
+    beat_nodes = graph.get_nodes_by_type("beat")
+    for edge in belongs_to_edges:
+        beat_id = edge["from"]
+        path_id = edge["to"]
+        if beat_id in beat_nodes and path_id in path_nodes:
+            path_beat_sets[path_id].add(beat_id)
+
+    # Step 3: Build predecessor adjacency for topological sort
+    # successors_all: parent → [children] (prerequisite → dependents)
+    predecessor_edges = graph.get_edges(edge_type="predecessor")
+    successors_all: dict[str, list[str]] = {bid: [] for bid in beat_nodes}
+    for edge in predecessor_edges:
+        from_id = edge["from"]  # dependent (child)
+        to_id = edge["to"]  # prerequisite (parent)
+        if from_id in beat_nodes and to_id in beat_nodes:
+            successors_all[to_id].append(from_id)
+
+    # Step 4: Cartesian product of paths, build traversals
+    result: dict[str, list[str]] = {}
+    for combo in product(*path_lists):
+        path_combo = list(combo)
+        path_raw_ids = sorted(path_nodes[pid].get("raw_id", pid) for pid in path_combo)
+        arc_key = "+".join(path_raw_ids)
+
+        # Collect beats from all selected paths
+        beat_set: set[str] = set()
+        for pid in path_combo:
+            beat_set.update(path_beat_sets.get(pid, set()))
+
+        # Topological sort within the beat subset
+        sequence = _topological_sort_subset(beat_set, successors_all)
+        result[arc_key] = sequence
+
+    return result
+
+
+def _topological_sort_subset(
+    beat_set: set[str],
+    successors_all: dict[str, list[str]],
+) -> list[str]:
+    """Topologically sort a subset of beats using Kahn's algorithm.
+
+    Uses alphabetical tie-breaking for determinism. Falls back to
+    sorted order if a cycle is detected.
+
+    Args:
+        beat_set: Set of beat IDs to sort.
+        successors_all: Successor adjacency for all beats in the full graph.
+
+    Returns:
+        Topologically sorted list of beat IDs.
+    """
+    if not beat_set:
+        return []
+
+    # Build in-degree restricted to the subset
+    in_degree: dict[str, int] = dict.fromkeys(beat_set, 0)
+    for bid in beat_set:
+        for succ in successors_all.get(bid, []):
+            if succ in beat_set:
+                in_degree[succ] = in_degree.get(succ, 0) + 1
+
+    queue = sorted(bid for bid, deg in in_degree.items() if deg == 0)
+    result: list[str] = []
+
+    while queue:
+        node = queue.pop(0)
+        result.append(node)
+        new_ready: list[str] = []
+        for succ in successors_all.get(node, []):
+            if succ in beat_set:
+                in_degree[succ] -= 1
+                if in_degree[succ] == 0:
+                    new_ready.append(succ)
+        # Insert in sorted order for determinism
+        queue = sorted(queue + new_ready)
+
+    if len(result) != len(beat_set):
+        # Fallback for cycles: sorted order
+        return sorted(beat_set)
 
     return result

--- a/tests/unit/test_algorithms.py
+++ b/tests/unit/test_algorithms.py
@@ -716,3 +716,25 @@ class TestComputeArcTraversalsDilemmaIdNormalization:
 
         result = compute_arc_traversals(graph)
         assert result == {"p1": ["beat::b1"]}
+
+
+class TestComputeArcTraversalsCycleFallback:
+    """Tests for cycle detection fallback in _topological_sort_subset."""
+
+    def test_cyclic_predecessors_falls_back_to_sorted(self) -> None:
+        """When beats form a cycle, falls back to sorted order."""
+        graph = Graph.empty()
+        _make_dilemma(graph, "dilemma::d1")
+        _make_path(graph, "path::p1", "d1")
+        _make_beat(graph, "beat::a", "Beat A", [])
+        _make_beat(graph, "beat::b", "Beat B", [])
+        _add_belongs_to(graph, "beat::a", "path::p1")
+        _add_belongs_to(graph, "beat::b", "path::p1")
+
+        # Create a cycle: a → b → a
+        graph.add_edge("predecessor", "beat::a", "beat::b")
+        graph.add_edge("predecessor", "beat::b", "beat::a")
+
+        result = compute_arc_traversals(graph)
+        # Cycle fallback returns sorted order
+        assert result == {"p1": ["beat::a", "beat::b"]}


### PR DESCRIPTION
## Summary
- Adds `compute_arc_traversals()` pure function to `graph/algorithms.py` that computes arc traversals from graph structure without stored Arc nodes
- Takes Cartesian product of paths across dilemmas, collects beats per combination, and topologically sorts them using Kahn's algorithm with alphabetical tie-breaking
- Handles `dilemma_id` normalization (with and without `dilemma::` prefix)
- Adds `_topological_sort_subset()` private helper for deterministic subset sorting

## Test plan
- [x] Empty graph returns empty dict
- [x] No dilemmas / no paths returns empty dict
- [x] Single dilemma, single path → one traversal
- [x] Single dilemma, single path chain → correct topological order
- [x] Single dilemma, two paths → two traversals with correct exclusive beats
- [x] Two dilemmas × 2 paths = 4 traversals (Cartesian product)
- [x] Shared beats appear in all traversals
- [x] Exclusive beats only in their respective traversals
- [x] Topological order preserved (start before exclusive before end)
- [x] Three paths → three traversals
- [x] `dilemma_id` normalization (with/without prefix)
- [x] All 25 algorithm tests pass, 153 POLISH tests pass (no regression)

Closes #996

🤖 Generated with [Claude Code](https://claude.com/claude-code)