### PR TITLE
fix: include beat summary in FILL review context

### DIFF
--- a/src/questfoundry/graph/fill_context.py
+++ b/src/questfoundry/graph/fill_context.py
@@ -2122,7 +2122,16 @@ def format_passages_batch(
         beat = graph.get_node(beat_id) if beat_id else None
         scene_type = beat.get("scene_type", "unknown") if beat else "unknown"
 
+        # Beat summary for summary_deviation review criterion
+        beat_summary = ""
+        if beat:
+            beat_summary = beat.get("summary", "")
+        if not beat_summary:
+            beat_summary = pnode.get("summary", "")
+
         lines.append(f"### {raw_id} (scene_type: {scene_type})")
+        if beat_summary:
+            lines.append(f"**Beat summary:** {beat_summary}")
         lines.append(prose if prose else "(no prose)")
         lines.append("")
 

--- a/tests/unit/test_fill_context.py
+++ b/tests/unit/test_fill_context.py
@@ -555,6 +555,28 @@ class TestFormatPassagesBatch:
         assert "tower stairs" in result
         assert "scene_type: scene" in result
 
+    def test_includes_beat_summary(self, fill_graph: Graph) -> None:
+        result = format_passages_batch(
+            fill_graph,
+            ["passage::p_opening"],
+        )
+        assert "**Beat summary:**" in result
+        assert "Kay enters the tower and meets the mentor" in result
+
+    def test_beat_summary_falls_back_to_passage(self, fill_graph: Graph) -> None:
+        # Create passage with no beat link but with its own summary
+        fill_graph.create_node(
+            "passage::p_orphan",
+            {
+                "type": "passage",
+                "raw_id": "p_orphan",
+                "summary": "Orphan passage summary",
+                "prose": "Some prose.",
+            },
+        )
+        result = format_passages_batch(fill_graph, ["passage::p_orphan"])
+        assert "**Beat summary:** Orphan passage summary" in result
+
     def test_empty_batch(self, fill_graph: Graph) -> None:
         result = format_passages_batch(fill_graph, [])
         assert result == ""
@@ -562,6 +584,8 @@ class TestFormatPassagesBatch:
     def test_passage_without_prose(self, fill_graph: Graph) -> None:
         result = format_passages_batch(fill_graph, ["passage::p_aftermath"])
         assert "(no prose)" in result
+        # Should still include beat summary even without prose
+        assert "Kay reflects on choices made" in result
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_fill_context.py
+++ b/tests/unit/test_fill_context.py
@@ -94,7 +94,7 @@ def fill_graph() -> Graph:
         {
             "type": "beat",
             "raw_id": "opening",
-            "summary": "Kay enters the tower and meets the mentor",
+            "summary": "Kay ascends the crumbling staircase to confront the mentor",
             "scene_type": "scene",
             "entities": ["entity::kay", "entity::mentor"],
         },
@@ -561,7 +561,7 @@ class TestFormatPassagesBatch:
             ["passage::p_opening"],
         )
         assert "**Beat summary:**" in result
-        assert "Kay enters the tower and meets the mentor" in result
+        assert "Kay ascends the crumbling staircase to confront the mentor" in result
 
     def test_beat_summary_falls_back_to_passage(self, fill_graph: Graph) -> None:
         # Create passage with no beat link but with its own summary


### PR DESCRIPTION
## Summary
- Add beat summary to `format_passages_batch()` output so the reviewer LLM can evaluate the `summary_deviation` criterion
- Falls back to passage's own `summary` field when beat node is unavailable
- Adds tests for beat summary inclusion and fallback behavior

## Context
Audit #1002 finding 1005-D14: The review prompt includes `summary_deviation` as a criterion, but `format_passages_batch()` only provides `raw_id`, `prose`, and `scene_type` — not the beat summary. The reviewer cannot detect deviation without seeing what the beat was supposed to accomplish.

Closes #1018

## Test plan
- [x] `test_includes_beat_summary` — verifies beat summary appears in output
- [x] `test_beat_summary_falls_back_to_passage` — verifies fallback when no beat linked
- [x] `test_passage_without_prose` — verifies beat summary still shown when prose is absent
- [x] Existing tests still pass unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)