### PR TITLE
fix: DRESS Phase 1 follows appears edges for entity context

### DIFF
--- a/src/questfoundry/graph/dress_context.py
+++ b/src/questfoundry/graph/dress_context.py
@@ -269,7 +269,7 @@ def get_passage_entity_ids(graph: Graph, passage_id: str) -> list[str]:
 
     # Fallback: entities field on passage node
     passage = graph.get_node(passage_id)
-    if not passage:
+    if passage is None:
         return []
     return list(passage.get("entities", []))
 

--- a/tests/unit/test_dress_context.py
+++ b/tests/unit/test_dress_context.py
@@ -188,6 +188,30 @@ class TestFormatEntitiesBatchForCodex:
         assert format_entities_batch_for_codex(dress_graph, []) == ""
 
 
+class TestGetPassageEntityIds:
+    def test_falls_back_to_entities_field(self, dress_graph: Graph) -> None:
+        from questfoundry.graph.dress_context import get_passage_entity_ids
+
+        ids = get_passage_entity_ids(dress_graph, "passage::opening")
+        assert "character::protagonist" in ids
+        assert "location::bridge" in ids
+
+    def test_prefers_appears_edges(self, dress_graph: Graph) -> None:
+        from questfoundry.graph.dress_context import get_passage_entity_ids
+
+        # Add appears edges (entity → passage)
+        dress_graph.add_edge("appears", "character::protagonist", "passage::opening")
+        # Deliberately omit location::bridge edge
+        ids = get_passage_entity_ids(dress_graph, "passage::opening")
+        # Should only return entities with appears edges, ignoring entities field
+        assert ids == ["character::protagonist"]
+
+    def test_nonexistent_passage(self, dress_graph: Graph) -> None:
+        from questfoundry.graph.dress_context import get_passage_entity_ids
+
+        assert get_passage_entity_ids(dress_graph, "passage::nope") == []
+
+
 class TestFormatEntityVisualsForPassage:
     def test_includes_visual_fragments(self, dress_graph: Graph) -> None:
         from questfoundry.graph.dress_context import format_entity_visuals_for_passage
@@ -202,6 +226,29 @@ class TestFormatEntityVisualsForPassage:
         result = format_entity_visuals_for_passage(dress_graph, "passage::opening")
         assert "young woman, short dark hair" in result
         assert "protagonist" in result
+
+    def test_uses_appears_edges(self, dress_graph: Graph) -> None:
+        from questfoundry.graph.dress_context import format_entity_visuals_for_passage
+
+        dress_graph.create_node(
+            "entity_visual::protagonist",
+            {
+                "type": "entity_visual",
+                "reference_prompt_fragment": "young woman, short dark hair",
+            },
+        )
+        dress_graph.create_node(
+            "entity_visual::bridge",
+            {
+                "type": "entity_visual",
+                "reference_prompt_fragment": "crumbling stone arch",
+            },
+        )
+        # Only protagonist has an appears edge
+        dress_graph.add_edge("appears", "character::protagonist", "passage::opening")
+        result = format_entity_visuals_for_passage(dress_graph, "passage::opening")
+        assert "protagonist" in result
+        assert "bridge" not in result
 
     def test_no_visuals(self, dress_graph: Graph) -> None:
         from questfoundry.graph.dress_context import format_entity_visuals_for_passage

--- a/tests/unit/test_dress_context.py
+++ b/tests/unit/test_dress_context.py
@@ -204,7 +204,7 @@ class TestGetPassageEntityIds:
         # Deliberately omit location::bridge edge
         ids = get_passage_entity_ids(dress_graph, "passage::opening")
         # Should only return entities with appears edges, ignoring entities field
-        assert ids == ["character::protagonist"]
+        assert set(ids) == {"character::protagonist"}
 
     def test_nonexistent_passage(self, dress_graph: Graph) -> None:
         from questfoundry.graph.dress_context import get_passage_entity_ids


### PR DESCRIPTION
## Summary
- Add `get_passage_entity_ids()` helper that queries `appears` edges (entity → passage) first, falling back to passage `entities` field
- Update `format_entity_visuals_for_passage()` and `format_all_entity_visuals()` to use edge-aware helper
- Prevents over-injection of entity visuals for passages where entities don't appear

## Context
Audit #1002 finding 1006-D8: The DRESS spec says Phase 1 should "follow Appears edges to find all entities in this passage," but `format_all_entity_visuals()` reads entity IDs from the passage `entities` field globally across the batch.

The new `get_passage_entity_ids()` helper follows the ontology convention: prefer `appears` edges when they exist, fall back to the `entities` field for backward compatibility with graphs that pre-date edge creation.

Closes #1015

## Not included (future PRs)
- Creating `appears` edges in GROW stage (prerequisite for full spec compliance) — tracked by existing graph convergence work

## Test plan
- [x] `test_falls_back_to_entities_field` — field-based path works unchanged
- [x] `test_prefers_appears_edges` — edges take priority over field
- [x] `test_uses_appears_edges` — visual formatting respects edge filtering
- [x] All existing DRESS context tests pass (24/24)

🤖 Generated with [Claude Code](https://claude.com/claude-code)