### PR TITLE
fix: restrict FILL entity updates to universal details

### DIFF
--- a/prompts/templates/fill_phase1_extract.yaml
+++ b/prompts/templates/fill_phase1_extract.yaml
@@ -18,6 +18,9 @@ system: |
   - Focus on concrete, observable details: physical appearance, habits, voice
     qualities, distinctive objects, sensory markers
   - Do NOT extract emotional states, plot developments, or abstract qualities
+  - **Only extract UNIVERSAL details** — things true regardless of which path
+    the player takes (e.g., "smokes a pipe", "has a scar"). Do NOT extract
+    path-dependent details (allegiance, knowledge, items gained/lost)
   - If no new entity details were introduced, return an empty list
 
 user: |

--- a/prompts/templates/fill_phase1_prose.yaml
+++ b/prompts/templates/fill_phase1_prose.yaml
@@ -113,6 +113,14 @@ system: |
   voice), list them in entity_updates so they persist for later passages.
   Only update EXISTING entities — do not create new ones.
 
+  **CRITICAL: Only add UNIVERSAL details** — things that are true regardless of
+  which path the player takes. Examples:
+  - GOOD: "smokes a pipe", "has a scar above the left eye", "speaks with a stammer"
+  - BAD: "betrayed the protagonist", "chose to help", "lost their weapon in the fight"
+
+  Path-dependent details (allegiance shifts, knowledge gained, items acquired)
+  belong in entity overlays, not base entity state.
+
   {spoke_context}
 
   ## Output Format

--- a/src/questfoundry/pipeline/stages/fill.py
+++ b/src/questfoundry/pipeline/stages/fill.py
@@ -1340,10 +1340,23 @@ class FillStage:
             else:
                 entity_updates = passage_output.entity_updates
 
+            # Warn about entity updates on non-spine passages (likely
+            # path-dependent details that should be overlays, not base state).
+            arc_data = graph.get_node(arc_id) if arc_id else None
+            is_spine_arc = (arc_data.get("arc_type") == "spine") if arc_data else False
+
             for update in entity_updates:
                 # Resolve entity ID using category prefixes (character::, location::, etc.)
                 entity_id = _resolve_entity_id(graph, update.entity_id)
                 if entity_id:
+                    if not is_spine_arc:
+                        log.warning(
+                            "entity_update_non_spine",
+                            entity_id=update.entity_id,
+                            field=update.field,
+                            passage_id=passage_id,
+                            arc_id=arc_id,
+                        )
                     graph.update_node(
                         entity_id,
                         **{update.field: update.value},

--- a/src/questfoundry/pipeline/stages/fill.py
+++ b/src/questfoundry/pipeline/stages/fill.py
@@ -1343,20 +1343,21 @@ class FillStage:
             # Warn about entity updates on non-spine passages (likely
             # path-dependent details that should be overlays, not base state).
             arc_data = graph.get_node(arc_id) if arc_id else None
-            is_spine_arc = (arc_data.get("arc_type") == "spine") if arc_data else False
+            is_spine_arc = (arc_data.get("arc_type") == "spine") if arc_data is not None else False
+
+            if entity_updates and not is_spine_arc and arc_id is not None:
+                log.warning(
+                    "entity_update_non_spine",
+                    passage_id=passage_id,
+                    arc_id=arc_id,
+                    fields=[u.field for u in entity_updates],
+                    entity_ids=[u.entity_id for u in entity_updates],
+                )
 
             for update in entity_updates:
                 # Resolve entity ID using category prefixes (character::, location::, etc.)
                 entity_id = _resolve_entity_id(graph, update.entity_id)
                 if entity_id:
-                    if not is_spine_arc:
-                        log.warning(
-                            "entity_update_non_spine",
-                            entity_id=update.entity_id,
-                            field=update.field,
-                            passage_id=passage_id,
-                            arc_id=arc_id,
-                        )
                     graph.update_node(
                         entity_id,
                         **{update.field: update.value},


### PR DESCRIPTION
## Summary
- Add explicit prompt instructions restricting entity updates to universal (path-independent) details in both `fill_phase1_prose.yaml` and `fill_phase1_extract.yaml`
- Add runtime `entity_update_non_spine` warning when entity updates occur on non-spine arc passages
- Includes concrete good/bad examples to guide the LLM

## Context
Audit #1002 finding 1005-D9: Entity updates in FILL are applied unconditionally, with no distinction between universal details (appearance, mannerisms) and path-dependent details (allegiance, knowledge). A model writing a branch passage could persist path-specific details as base entity state, corrupting entity representation across all arcs.

Closes #1012

## Stacked on
- #1042 (fix/1018-review-beat-summary)

## Test plan
- [x] Prompt template changes verified via YAML check
- [x] `ruff check` and `mypy` pass
- [x] Warning is log-only (no behavioral change to existing entity update flow)
- Manual testing: Run FILL on a branch arc and verify `entity_update_non_spine` warning appears in debug logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)