### PR TITLE
feat: SHIP state-flag-to-codeword projection

### DIFF
--- a/src/questfoundry/export/context.py
+++ b/src/questfoundry/export/context.py
@@ -127,8 +127,66 @@ def _extract_entities(graph: Graph) -> list[ExportEntity]:
     ]
 
 
+def _project_state_flags_to_codewords(graph: Graph) -> list[ExportCodeword]:
+    """Project state flags to player-facing codewords based on dilemma role.
+
+    Per Document 3 ontology: soft dilemma state flags become codewords
+    (the player carries state across convergence points). Hard dilemma
+    state flags remain internal routing machinery and are not exported.
+
+    Args:
+        graph: Graph containing state_flag and dilemma nodes.
+
+    Returns:
+        Projected codewords for export (only soft dilemma flags).
+    """
+    state_flags = graph.get_nodes_by_type("state_flag")
+    if not state_flags:
+        return []
+
+    # Build dilemma role lookup
+    dilemmas = graph.get_nodes_by_type("dilemma")
+    dilemma_roles: dict[str, str] = {}
+    for did, ddata in dilemmas.items():
+        role = ddata.get("dilemma_role", "")
+        if role:
+            dilemma_roles[did] = role
+
+    result: list[ExportCodeword] = []
+    for flag_id, flag_data in sorted(state_flags.items()):
+        dilemma_ref = flag_data.get("dilemma_id") or flag_data.get("dilemma", "")
+        role = dilemma_roles.get(str(dilemma_ref), "")
+
+        if role == "soft":
+            result.append(
+                ExportCodeword(
+                    id=flag_id,
+                    codeword_type=flag_data.get("codeword_type", "granted"),
+                    tracks=flag_data.get("tracks"),
+                )
+            )
+        elif not role:
+            log.warning(
+                "state_flag_no_dilemma_role",
+                flag_id=flag_id,
+                dilemma_ref=dilemma_ref,
+            )
+
+    return result
+
+
 def _extract_codewords(graph: Graph) -> list[ExportCodeword]:
-    """Extract codeword nodes."""
+    """Extract player-facing codewords via state flag projection.
+
+    Prefers state_flag nodes with dilemma-role-based projection.
+    Falls back to legacy codeword nodes for backward compatibility.
+    """
+    # Try projection from state_flag nodes first
+    projected = _project_state_flags_to_codewords(graph)
+    if projected:
+        return projected
+
+    # Fallback: legacy codeword nodes (pre-projection graphs)
     nodes = graph.get_nodes_by_type("codeword")
     return [
         ExportCodeword(

--- a/tests/unit/test_export_context.py
+++ b/tests/unit/test_export_context.py
@@ -323,6 +323,25 @@ class TestBuildExportContext:
         assert ctx.codewords[0].id == "state_flag::trusted_mentor"
         assert ctx.codewords[0].tracks == "consequence::trust_given"
 
+    def test_hard_only_state_flags_yield_no_codewords(self) -> None:
+        """Hard-only state flags produce empty codewords, not a legacy fallback."""
+        g = _minimal_graph()
+        g.create_node(
+            "dilemma::routing",
+            {"type": "dilemma", "raw_id": "routing", "dilemma_role": "hard"},
+        )
+        g.create_node(
+            "state_flag::branch_taken",
+            {
+                "type": "state_flag",
+                "raw_id": "branch_taken",
+                "dilemma_id": "dilemma::routing",
+                "codeword_type": "granted",
+            },
+        )
+        ctx = build_export_context(g, "test")
+        assert ctx.codewords == []
+
     def test_legacy_codeword_fallback(self) -> None:
         """When no state_flag nodes exist, legacy codeword nodes are used."""
         g = _graph_with_entities(_minimal_graph())

--- a/tests/unit/test_export_context.py
+++ b/tests/unit/test_export_context.py
@@ -284,6 +284,52 @@ class TestBuildExportContext:
 
         assert ctx.cover is None
 
+    def test_state_flag_projection_soft_only(self) -> None:
+        """Soft dilemma state flags are projected as codewords; hard ones are not."""
+        g = _minimal_graph()
+        # Dilemmas
+        g.create_node(
+            "dilemma::trust",
+            {"type": "dilemma", "raw_id": "trust", "dilemma_role": "soft"},
+        )
+        g.create_node(
+            "dilemma::loyalty",
+            {"type": "dilemma", "raw_id": "loyalty", "dilemma_role": "hard"},
+        )
+        # State flags
+        g.create_node(
+            "state_flag::trusted_mentor",
+            {
+                "type": "state_flag",
+                "raw_id": "trusted_mentor",
+                "dilemma_id": "dilemma::trust",
+                "codeword_type": "granted",
+                "tracks": "consequence::trust_given",
+            },
+        )
+        g.create_node(
+            "state_flag::loyal_to_crown",
+            {
+                "type": "state_flag",
+                "raw_id": "loyal_to_crown",
+                "dilemma_id": "dilemma::loyalty",
+                "codeword_type": "granted",
+                "tracks": "consequence::loyalty",
+            },
+        )
+        ctx = build_export_context(g, "test")
+        # Only soft dilemma flag should be exported
+        assert len(ctx.codewords) == 1
+        assert ctx.codewords[0].id == "state_flag::trusted_mentor"
+        assert ctx.codewords[0].tracks == "consequence::trust_given"
+
+    def test_legacy_codeword_fallback(self) -> None:
+        """When no state_flag nodes exist, legacy codeword nodes are used."""
+        g = _graph_with_entities(_minimal_graph())
+        ctx = build_export_context(g, "test")
+        assert len(ctx.codewords) == 1
+        assert ctx.codewords[0].id == "codeword::entered_castle"
+
     def test_language_default_english(self) -> None:
         g = _minimal_graph()
         ctx = build_export_context(g, "test")


### PR DESCRIPTION
## Summary
- Add `_project_state_flags_to_codewords()` that filters state flags by dilemma role: soft → export as codeword, hard → skip (internal routing only)
- Update `_extract_codewords()` to try projection first, fall back to legacy `codeword` nodes
- Adds tests for soft-only projection and legacy fallback

## Context
Document 3 specifies that SHIP decides which state flags become player-visible codewords. Soft dilemma flags carry state across convergence points (the player needs to remember choices). Hard dilemma flags are routing machinery (the gamebook structure handles it via page separation).

Closes #994

## Stacked on
- #1046 (feat/1014-sample-gate)
- #1043 (fix/1015-appears-edges)

## Test plan
- [x] `test_state_flag_projection_soft_only` — only soft dilemma flags exported
- [x] `test_legacy_codeword_fallback` — old graphs still work
- [x] All export context tests pass (16/16)
- [x] `ruff check` and `mypy` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)