### PR TITLE
refactor: GROW phases use compute_arc_traversals()

### DIFF
--- a/src/questfoundry/pipeline/stages/grow/deterministic.py
+++ b/src/questfoundry/pipeline/stages/grow/deterministic.py
@@ -10,7 +10,7 @@ All graph mutations happen in-place on the graph argument.
 from __future__ import annotations
 
 from collections import deque
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Literal
 
 from questfoundry.graph.context import normalize_scoped_id, strip_scope_prefix
 from questfoundry.graph.graph import Graph  # noqa: TC001 - used at runtime
@@ -24,6 +24,55 @@ if TYPE_CHECKING:
     from questfoundry.pipeline.size import SizeProfile
 
 PROLOGUE_ID = "passage::prologue"
+
+
+def _arcs_from_traversals(graph: Graph) -> tuple[list[Any], str | None]:
+    """Build Arc models from computed traversals (no stored arc nodes needed).
+
+    Uses ``compute_arc_traversals()`` and path metadata to reconstruct
+    the same Arc model objects that ``enumerate_arcs()`` produces.
+
+    Returns:
+        Tuple of (arc_list, spine_arc_id) where spine_arc_id is the raw_id
+        of the spine arc, or None if no spine exists.
+    """
+    from questfoundry.graph.algorithms import compute_arc_traversals
+    from questfoundry.models.grow import Arc as ArcModel
+
+    traversals = compute_arc_traversals(graph)
+    if not traversals:
+        return [], None
+
+    path_nodes = graph.get_nodes_by_type("path")
+    arcs: list[ArcModel] = []
+    spine_arc_id: str | None = None
+
+    for arc_key, sequence in traversals.items():
+        # Determine path IDs from arc key (raw_ids joined by "+")
+        raw_ids = arc_key.split("+")
+        path_ids = []
+        for raw_id in raw_ids:
+            for pid, pdata in path_nodes.items():
+                if pdata.get("raw_id") == raw_id:
+                    path_ids.append(pid)
+                    break
+
+        # Spine arc: all paths are canonical
+        is_spine = all(path_nodes.get(pid, {}).get("is_canonical", False) for pid in path_ids)
+        arc_type: Literal["spine", "branch"] = "spine" if is_spine else "branch"
+        if is_spine:
+            spine_arc_id = arc_key
+
+        arcs.append(
+            ArcModel(
+                arc_id=arc_key,
+                arc_type=arc_type,
+                paths=path_ids,
+                sequence=sequence,
+            )
+        )
+
+    return arcs, spine_arc_id
 
 
 # --- Phase 1: Validate DAG ---
@@ -161,7 +210,7 @@ async def phase_divergence(graph: Graph, model: BaseChatModel) -> GrowPhaseResul
     """Phase 6: Compute divergence points between arcs.
 
     Preconditions:
-    - Arc nodes exist with sequence and paths metadata (Phase 5 complete).
+    - Arc enumeration complete (Phase 5).
     - At least one spine arc exists for reference.
 
     Postconditions:
@@ -173,29 +222,14 @@ async def phase_divergence(graph: Graph, model: BaseChatModel) -> GrowPhaseResul
     - No-op if only one arc exists (no branching).
     """
     from questfoundry.graph.grow_algorithms import compute_divergence_points
-    from questfoundry.models.grow import Arc as ArcModel
 
-    # Reconstruct Arc models from graph nodes
-    arc_nodes = graph.get_nodes_by_type("arc")
-    if not arc_nodes:
+    arcs, spine_arc_id = _arcs_from_traversals(graph)
+    if not arcs:
         return GrowPhaseResult(
             phase="divergence",
             status="completed",
             detail="No arcs to process",
         )
-
-    arcs: list[ArcModel] = []
-    spine_arc_id: str | None = None
-    for _arc_id, arc_data in arc_nodes.items():
-        arc = ArcModel(
-            arc_id=arc_data["raw_id"],
-            arc_type=arc_data["arc_type"],
-            paths=arc_data.get("paths", []),
-            sequence=arc_data.get("sequence", []),
-        )
-        arcs.append(arc)
-        if arc.arc_type == "spine":
-            spine_arc_id = arc.arc_id
 
     divergence_map = compute_divergence_points(arcs, spine_arc_id)
 
@@ -235,7 +269,6 @@ async def phase_convergence(graph: Graph, model: BaseChatModel) -> GrowPhaseResu
 
     Preconditions:
     - Divergence points computed (Phase 6 complete).
-    - Arc nodes have sequence, paths, and diverges_at metadata.
     - Dilemma nodes have dilemma_role from SEED analysis.
 
     Postconditions:
@@ -252,29 +285,14 @@ async def phase_convergence(graph: Graph, model: BaseChatModel) -> GrowPhaseResu
         compute_divergence_points,
         find_convergence_points,
     )
-    from questfoundry.models.grow import Arc as ArcModel
 
-    arc_nodes = graph.get_nodes_by_type("arc")
-    if not arc_nodes:
+    arcs, spine_arc_id = _arcs_from_traversals(graph)
+    if not arcs:
         return GrowPhaseResult(
             phase="convergence",
             status="completed",
             detail="No arcs to process",
         )
-
-    # Reconstruct Arc models from graph nodes
-    arcs: list[ArcModel] = []
-    spine_arc_id: str | None = None
-    for _arc_id, arc_data in arc_nodes.items():
-        arc = ArcModel(
-            arc_id=arc_data["raw_id"],
-            arc_type=arc_data["arc_type"],
-            paths=arc_data.get("paths", []),
-            sequence=arc_data.get("sequence", []),
-        )
-        arcs.append(arc)
-        if arc.arc_type == "spine":
-            spine_arc_id = arc.arc_id
 
     # Compute divergence first (needed for convergence)
     divergence_map = compute_divergence_points(arcs, spine_arc_id)
@@ -826,21 +844,33 @@ def _reachable_via_choices(graph: Graph, passage_nodes: dict[str, dict[str, Any]
         start_passage = PROLOGUE_ID
         log.debug("prune_start_from_prologue", start=PROLOGUE_ID)
     else:
-        # Find spine arc's first passage
-        arc_nodes = graph.get_nodes_by_type("arc")
+        # Find spine arc's first passage via computed traversals,
+        # falling back to stored arc nodes for backward compatibility.
+        arcs, _spine_id = _arcs_from_traversals(graph)
         start_passage = None
 
-        for _arc_id, arc_data in arc_nodes.items():
-            if arc_data.get("arc_type") == "spine":
-                sequence = arc_data.get("sequence", [])
-                if sequence:
-                    # First beat -> its passage
-                    first_beat = sequence[0]
+        if not arcs:
+            # Fallback: read stored arc nodes
+            arc_nodes = graph.get_nodes_by_type("arc")
+            for _arc_id, arc_data in arc_nodes.items():
+                if arc_data.get("arc_type") == "spine":
+                    sequence = arc_data.get("sequence", [])
+                    if sequence:
+                        first_beat = sequence[0]
+                        for p_id, p_data in passage_nodes.items():
+                            if p_data.get("from_beat") == first_beat:
+                                start_passage = p_id
+                                break
+                    break
+        else:
+            for arc in arcs:
+                if arc.arc_type == "spine" and arc.sequence:
+                    first_beat = arc.sequence[0]
                     for p_id, p_data in passage_nodes.items():
                         if p_data.get("from_beat") == first_beat:
                             start_passage = p_id
                             break
-                break
+                    break
 
     if not start_passage:
         log.warning("phase9_no_spine_arc", detail="Cannot BFS without spine; all passages kept")
@@ -870,9 +900,22 @@ def _reachable_via_choices(graph: Graph, passage_nodes: dict[str, dict[str, Any]
 
 
 def _reachable_via_arcs(graph: Graph, passage_nodes: dict[str, dict[str, Any]]) -> set[str]:
-    """Fallback: passages whose beats are in any arc."""
-    arc_contains_edges = graph.get_edges(from_id=None, to_id=None, edge_type="arc_contains")
-    beats_in_arcs: set[str] = {edge["to"] for edge in arc_contains_edges}
+    """Fallback: passages whose beats are in any arc traversal.
+
+    Prefers computed traversals; falls back to stored arc_contains edges.
+    """
+    from questfoundry.graph.algorithms import compute_arc_traversals
+
+    traversals = compute_arc_traversals(graph)
+    beats_in_arcs: set[str] = set()
+
+    if traversals:
+        for sequence in traversals.values():
+            beats_in_arcs.update(sequence)
+    else:
+        # Fallback: stored arc_contains edges
+        arc_contains_edges = graph.get_edges(edge_type="arc_contains")
+        beats_in_arcs = {edge["to"] for edge in arc_contains_edges}
 
     reachable: set[str] = set()
     for passage_id, passage_data in passage_nodes.items():


### PR DESCRIPTION
## Summary
- Add `_arcs_from_traversals()` helper that converts computed arc traversals into Arc model objects
- Refactor `phase_divergence`, `phase_convergence`, `_reachable_via_choices`, and `_reachable_via_arcs` to use computed traversals instead of stored arc nodes
- Falls back to stored arc nodes when computed traversals are empty (backward compatibility)

Closes #998

## Test plan
- [x] All 271 tests in `test_grow_algorithms.py` pass
- [x] `ruff check` clean
- [x] `mypy` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)