### PR TITLE
refactor: FILL traversal uses compute_passage_traversals()

### DIFF
--- a/src/questfoundry/graph/algorithms.py
+++ b/src/questfoundry/graph/algorithms.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 from collections import defaultdict
 from itertools import product
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from questfoundry.graph.context import normalize_scoped_id
 from questfoundry.observability.logging import get_logger
@@ -131,6 +131,28 @@ def compute_active_flags_at_beat(graph: Graph, beat_id: str) -> set[frozenset[st
         result.add(frozenset(combo))
 
     return result
+
+
+def arc_key_for_paths(
+    path_nodes: dict[str, dict[str, Any]],
+    path_ids: list[str],
+) -> str:
+    """Build a canonical arc key from path node IDs.
+
+    Arc keys are sorted path ``raw_id`` values joined by ``"+"``.
+    This is the shared formula used by :func:`compute_arc_traversals`,
+    ``_build_arc_key_to_node_map``, ``_find_spine_arc_key``, and
+    ``_resolve_arc_key``.
+
+    Args:
+        path_nodes: Mapping of path node ID → path data (must contain ``raw_id``).
+        path_ids: List of path node IDs to include in the key.
+
+    Returns:
+        Arc key string (e.g. ``"alpha+beta"``).
+    """
+    raw_ids = sorted(str(path_nodes.get(pid, {}).get("raw_id", pid)) for pid in path_ids)
+    return "+".join(raw_ids)
 
 
 def compute_arc_traversals(graph: Graph) -> dict[str, list[str]]:

--- a/src/questfoundry/graph/fill_context.py
+++ b/src/questfoundry/graph/fill_context.py
@@ -139,17 +139,40 @@ def get_spine_arc_id(graph: Graph) -> str | None:
 def get_arc_passage_order(graph: Graph, arc_id: str) -> list[str]:
     """Get passage IDs in traversal order for an arc.
 
-    Follows the arc's beat sequence and maps each beat to its passage
-    via ``passage_from`` edges.
+    Primary path: computes the traversal from graph structure (paths,
+    beats, ``grouped_in`` / ``passage_from`` edges) via
+    :func:`~questfoundry.graph.algorithms.compute_passage_traversals`,
+    matching the ``arc_id`` to a computed arc key through the arc node's
+    ``paths`` field.
+
+    Fallback: reads the arc node's ``sequence`` field directly and maps
+    beats to passages via ``passage_from`` edges.  This handles legacy
+    graphs and minimal test fixtures that lack full dilemma/path nodes.
 
     Args:
         graph: Graph containing arc, beat, and passage nodes.
-        arc_id: The arc node ID (e.g., ``arc::spine_0_0``).
+        arc_id: The arc node ID (e.g., ``arc::spine_0_0``) or a computed
+            arc key (e.g., ``"path_a+path_b"``).
 
     Returns:
         Ordered list of passage node IDs. Beats without passages are
         silently skipped.
     """
+    from questfoundry.graph.algorithms import compute_passage_traversals
+
+    traversals = compute_passage_traversals(graph)
+
+    if traversals:
+        # Direct arc key lookup (caller may pass a computed arc key)
+        if arc_id in traversals:
+            return traversals[arc_id]
+
+        # Map arc node ID → arc key via the arc node's paths field
+        arc_key = _resolve_arc_key(graph, arc_id)
+        if arc_key and arc_key in traversals:
+            return traversals[arc_key]
+
+    # Fallback: read arc node sequence + beat→passage mapping
     arc_node = graph.get_node(arc_id)
     if not arc_node:
         return []
@@ -158,18 +181,44 @@ def get_arc_passage_order(graph: Graph, arc_id: str) -> list[str]:
     if not sequence:
         return []
 
-    # Build beat→passage lookup from passage_from edges
     beat_to_passage: dict[str, str] = {}
-    for edge in graph.get_edges(edge_type="passage_from"):
-        beat_to_passage[edge["to"]] = edge["from"]
+    for edge in graph.get_edges(edge_type="grouped_in"):
+        beat_to_passage[edge["from"]] = edge["to"]
+    if not beat_to_passage:
+        for edge in graph.get_edges(edge_type="passage_from"):
+            beat_to_passage[edge["to"]] = edge["from"]
 
-    passages = []
+    passages: list[str] = []
+    seen: set[str] = set()
     for beat_id in sequence:
         passage_id = beat_to_passage.get(beat_id)
-        if passage_id:
+        if passage_id and passage_id not in seen:
+            seen.add(passage_id)
             passages.append(passage_id)
 
     return passages
+
+
+def _resolve_arc_key(graph: Graph, arc_id: str) -> str | None:
+    """Map an arc node ID to its computed arc key.
+
+    Reads the arc node's ``paths`` list and derives the arc key
+    (sorted path ``raw_id`` values joined by ``"+"``) to match keys
+    produced by :func:`compute_arc_traversals`.
+
+    Returns:
+        Arc key string, or None if the arc node doesn't exist or has
+        no paths.
+    """
+    arc_node = graph.get_node(arc_id)
+    if not arc_node:
+        return None
+    path_ids = arc_node.get("paths", [])
+    if not path_ids:
+        return None
+    path_nodes = graph.get_nodes_by_type("path")
+    raw_ids = sorted(path_nodes.get(pid, {}).get("raw_id", pid) for pid in path_ids)
+    return "+".join(raw_ids)
 
 
 def format_story_identity(graph: Graph) -> str:

--- a/src/questfoundry/graph/fill_context.py
+++ b/src/questfoundry/graph/fill_context.py
@@ -181,20 +181,20 @@ def get_arc_passage_order(graph: Graph, arc_id: str) -> list[str]:
     if not sequence:
         return []
 
-    beat_to_passage: dict[str, str] = {}
+    beat_to_passages: dict[str, list[str]] = {}
     for edge in graph.get_edges(edge_type="grouped_in"):
-        beat_to_passage[edge["from"]] = edge["to"]
-    if not beat_to_passage:
+        beat_to_passages.setdefault(edge["from"], []).append(edge["to"])
+    if not beat_to_passages:
         for edge in graph.get_edges(edge_type="passage_from"):
-            beat_to_passage[edge["to"]] = edge["from"]
+            beat_to_passages.setdefault(edge["to"], []).append(edge["from"])
 
     passages: list[str] = []
     seen: set[str] = set()
     for beat_id in sequence:
-        passage_id = beat_to_passage.get(beat_id)
-        if passage_id and passage_id not in seen:
-            seen.add(passage_id)
-            passages.append(passage_id)
+        for passage_id in sorted(beat_to_passages.get(beat_id, [])):
+            if passage_id not in seen:
+                seen.add(passage_id)
+                passages.append(passage_id)
 
     return passages
 

--- a/src/questfoundry/pipeline/stages/fill.py
+++ b/src/questfoundry/pipeline/stages/fill.py
@@ -256,7 +256,7 @@ def _find_spine_arc_key(graph: Graph) -> str | None:
     raw_ids: list[str] = []
     for _did in sorted(dilemma_canonical):
         pids = dilemma_canonical[_did]
-        raw_ids.extend(sorted(path_nodes[pid].get("raw_id", pid) for pid in pids))
+        raw_ids.extend(path_nodes[pid].get("raw_id", pid) for pid in pids)
 
     return "+".join(sorted(raw_ids))
 
@@ -1801,8 +1801,8 @@ class FillStage:
         traversals = compute_passage_traversals(graph)
         if traversals:
             arc_key_to_node = _build_arc_key_to_node_map(graph)
-            for arc_key, passages in traversals.items():
-                if passage_id in passages:
+            for arc_key in sorted(traversals):
+                if passage_id in traversals[arc_key]:
                     return arc_key_to_node.get(arc_key, arc_key)
 
         # Fallback: stored arc node sequences

--- a/tests/unit/test_algorithms.py
+++ b/tests/unit/test_algorithms.py
@@ -909,3 +909,24 @@ class TestComputePassageTraversalsFallback:
 
         result = compute_passage_traversals(graph)
         assert result == {"alpha": ["passage::p1", "passage::p2"]}
+
+    def test_grouped_in_takes_precedence(self) -> None:
+        """When both grouped_in and passage_from edges exist, grouped_in wins."""
+        graph = Graph.empty()
+        _make_dilemma(graph, "dilemma::d1")
+        _make_path(graph, "path::alpha", "dilemma::d1")
+
+        _make_beat(graph, "beat::b1", "Start", [])
+        _add_belongs_to(graph, "beat::b1", "path::alpha")
+
+        _make_passage(graph, "passage::p1", "beat::b1")
+        _make_passage(graph, "passage::p_legacy", "beat::b1")
+
+        # grouped_in links beat::b1 → passage::p1
+        _add_grouped_in(graph, "beat::b1", "passage::p1")
+        # passage_from links passage::p_legacy → beat::b1 (legacy)
+        _add_passage_from(graph, "passage::p_legacy", "beat::b1")
+
+        result = compute_passage_traversals(graph)
+        # Should use grouped_in only, ignoring passage_from
+        assert result == {"alpha": ["passage::p1"]}


### PR DESCRIPTION
## Summary

- Add `compute_passage_traversals()` to `graph/algorithms.py` — maps arc keys to passage lists using `compute_arc_traversals()` + `grouped_in` edges (with `passage_from` fallback)
- Rewrite `get_arc_passage_order()` in `fill_context.py` to use computed traversals as primary path, resolving arc node IDs to arc keys via `_resolve_arc_key()` helper
- Rewrite `_get_generation_order()` and `_find_arc_for_passage()` in `fill.py` to use `compute_passage_traversals()` with spine-first ordering, falling back to stored arc nodes for legacy graphs
- Add `_build_arc_key_to_node_map()` and `_find_spine_arc_key()` module-level helpers for arc key ↔ node ID mapping

## Test plan

- [x] `test_algorithms.py`: 7 new tests for `compute_passage_traversals()` (grouped_in, passage_from fallback, dedup, shared passages)
- [x] `test_fill_context.py`: 1 new test verifying `get_arc_passage_order()` uses computed traversals when full graph structure exists
- [x] All existing tests pass (fallback path exercised by minimal test fixtures)
- [x] `ruff check` + `mypy` clean

Closes #993

🤖 Generated with [Claude Code](https://claude.com/claude-code)