### PR TITLE
feat: size-aware beat counts in SEED serialize phase

### DIFF
--- a/prompts/templates/serialize_seed_sections.yaml
+++ b/prompts/templates/serialize_seed_sections.yaml
@@ -374,7 +374,7 @@ beats_prompt: |
   You are generating INITIAL BEATS for a SEED stage.
 
   ## Generation Requirements (CRITICAL)
-  Generate 2-4 initial beats PER PATH. If there are 3 paths, expect 6-12 beats total.
+  Generate {size_beats_per_path} initial beats PER PATH.
   Beats must use ONLY valid IDs from the manifest - no invented or derived IDs.
 
   ## CRITICAL: ID CONSTRAINTS (read first!)
@@ -438,7 +438,7 @@ beats_prompt: |
   - effect must be exactly "advances", "reveals", "commits", or "complicates"
   - All ID fields must use the correct type (see FIELD → ID TYPE MAPPING below)
   - location can be null; location_alternatives can be empty array
-  - Generate 2-4 beats for EACH path in the VALID PATH IDs list
+  - Generate {size_beats_per_path} beats for EACH path in the VALID PATH IDs list
   - dilemma_impacts MUST use dilemma IDs from the Dilemma IDs list — NOT entity names
   - temporal_hint is OPTIONAL — only include it when a beat's placement relative to
     ANOTHER dilemma matters. Most beats don't need one. When used:
@@ -509,7 +509,7 @@ beats_prompt: |
 
   If you receive validation feedback about invalid IDs, DO NOT reduce your beat count.
   Fix ONLY the invalid ID references using the table above.
-  Your beat count should stay at 2-4 beats per path.
+  Your beat count should stay at {size_beats_per_path} beats per path.
 
   ## What NOT to Do
   - Do NOT use entity IDs as dilemma_ids (entity IDs lack `_or_`)
@@ -591,7 +591,7 @@ per_path_beats_prompt: |
   4. Include at least one beat with `effect: "commits"` for `{dilemma_id}`
 
   ## Schema
-  Return a JSON object with an "initial_beats" array of 2-4 beats:
+  Return a JSON object with an "initial_beats" array of {size_beats_per_path} beats:
   ```json
   {{
     "initial_beats": [
@@ -621,7 +621,7 @@ per_path_beats_prompt: |
   Valid positions: `before_commit`, `after_commit`, `before_introduce`, `after_introduce`
 
   ## Rules
-  - Generate exactly 2-4 beats for path `{path_id}`
+  - Generate exactly {size_beats_per_path} beats for path `{path_id}`
   - Beat IDs MUST start with `{path_name}_beat_` (e.g., `{path_name}_beat_01`)
   - EVERY beat must have `path_id: "{path_id}"`
   - EVERY beat must have at least one dilemma_impact for `{dilemma_id}`
@@ -663,7 +663,7 @@ per_path_beats_prompt: |
   If you see a dilemma ID in your `path_id` value, YOU MADE A MISTAKE. Fix it.
 
   ## Output
-  Return ONLY valid JSON with the "initial_beats" array (2-4 beats).
+  Return ONLY valid JSON with the "initial_beats" array ({size_beats_per_path} beats).
 
 # Section 7: Dilemma Convergence Analysis (post-prune)
 dilemma_analyses_prompt: |

--- a/src/questfoundry/agents/serialize.py
+++ b/src/questfoundry/agents/serialize.py
@@ -40,6 +40,7 @@ from questfoundry.observability.tracing import (
     trace_context,
     traceable,
 )
+from questfoundry.pipeline.size import size_template_vars
 from questfoundry.providers.structured_output import (
     StructuredOutputStrategy,
     unwrap_structured_result,
@@ -1683,10 +1684,8 @@ async def serialize_seed_as_function(
     prompts = dict(_load_seed_section_prompts())  # Copy — cached original is immutable
 
     # Inject size-aware beat count range into beat prompts
-    from questfoundry.pipeline.size import size_template_vars
-
     size_vars = size_template_vars(size_profile)
-    beats_range = size_vars.get("size_beats_per_path", "2-4")
+    beats_range = size_vars["size_beats_per_path"]
     for key in ("beats", "per_path_beats"):
         if key in prompts:
             prompts[key] = prompts[key].replace("{size_beats_per_path}", beats_range)

--- a/src/questfoundry/models/seed.py
+++ b/src/questfoundry/models/seed.py
@@ -654,8 +654,8 @@ class PathBeatsSection(BaseModel):
 
     initial_beats: list[InitialBeat] = Field(
         min_length=2,
-        max_length=4,
-        description="2-4 initial beats for this specific path",
+        max_length=6,
+        description="2-6 initial beats for this specific path (range set by size preset)",
     )
 
     @model_validator(mode="after")

--- a/src/questfoundry/pipeline/stages/seed.py
+++ b/src/questfoundry/pipeline/stages/seed.py
@@ -391,6 +391,7 @@ class SeedStage:
                 callbacks=callbacks,
                 graph=graph,  # Enables semantic validation
                 on_phase_progress=on_phase_progress,
+                size_profile=size_profile,
             )
             # Iterative serialization makes one call per section plus potential retries
             # (actual count depends on serialize_seed_as_function implementation)

--- a/tests/unit/test_seed_models.py
+++ b/tests/unit/test_seed_models.py
@@ -237,6 +237,32 @@ class TestPathBeatsSectionDedup:
                 ]
             )
 
+    def test_five_beats_accepted_for_long_preset(self) -> None:
+        """PathBeatsSection allows up to 6 beats for long presets (3-5 range)."""
+        beats = [
+            {
+                "beat_id": f"beat_{i}",
+                "summary": f"Beat {i}",
+                "path_id": "path::trust_or_betray__trust",
+            }
+            for i in range(5)
+        ]
+        section = PathBeatsSection(initial_beats=beats)
+        assert len(section.initial_beats) == 5
+
+    def test_seven_beats_rejected(self) -> None:
+        """PathBeatsSection rejects more than 6 beats."""
+        beats = [
+            {
+                "beat_id": f"beat_{i}",
+                "summary": f"Beat {i}",
+                "path_id": "path::trust_or_betray__trust",
+            }
+            for i in range(7)
+        ]
+        with pytest.raises(ValidationError):
+            PathBeatsSection(initial_beats=beats)
+
 
 # ---------------------------------------------------------------------------
 # Branching contract models (#741)

--- a/tests/unit/test_seed_stage.py
+++ b/tests/unit/test_seed_stage.py
@@ -871,8 +871,8 @@ class TestPathBeatsSectionValidation:
                 ]
             )
 
-    def test_five_beats_rejected(self) -> None:
-        """More than 4 beats is rejected by Pydantic max_length."""
+    def test_seven_beats_rejected(self) -> None:
+        """More than 6 beats is rejected by Pydantic max_length."""
         from pydantic import ValidationError
 
         from questfoundry.models.seed import InitialBeat, PathBeatsSection
@@ -883,7 +883,7 @@ class TestPathBeatsSectionValidation:
                 summary=f"Beat {i}",
                 paths=["path_a"],
             )
-            for i in range(5)
+            for i in range(7)
         ]
         with pytest.raises(ValidationError, match="initial_beats"):
             PathBeatsSection(initial_beats=beats)


### PR DESCRIPTION
## Summary

- **PathBeatsSection.max_length**: Raised from 4 to 6 to accommodate long presets (3-5 beats per path)
- **Dynamic beat ranges**: Replaced all hardcoded "2-4" in beat prompts with `{size_beats_per_path}` template variable, rendered from the active size profile
- **serialize_seed_as_function()**: Added `size_profile` parameter; copies cached prompts dict before mutating (lru_cache safety)
- **SeedStage.execute()**: Passes `size_profile` through to serialize function

Stacked on #1055.

## Changes

| File | Change |
|------|--------|
| `src/questfoundry/models/seed.py` | `PathBeatsSection.max_length` 4→6 |
| `prompts/templates/serialize_seed_sections.yaml` | 6 occurrences of "2-4" → `{size_beats_per_path}` in beat prompts |
| `src/questfoundry/agents/serialize.py` | Add `size_profile` param, copy+render beat prompts |
| `src/questfoundry/pipeline/stages/seed.py` | Pass `size_profile` to `serialize_seed_as_function()` |
| `tests/unit/test_seed_models.py` | 5 beats accepted, 7 beats rejected |
| `tests/unit/test_seed_stage.py` | Update test: 7 beats rejected (was 5) |
| `tests/unit/test_serialize.py` | Test size_profile renders into beat prompts, default uses standard range |

## Test plan

- [x] `uv run pytest tests/unit/test_seed_models.py tests/unit/test_serialize.py tests/unit/test_seed_stage.py -x -q` — 217 passed
- [ ] Re-run pipeline with `--size long` to confirm 3-5 beats per path
- [ ] Verify `logs/llm_calls.jsonl` shows correct beat range in prompts

🤖 Generated with [Claude Code](https://claude.com/claude-code)