### PR TITLE
refactor: remove arc compat code from FILL stage

### DIFF
--- a/src/questfoundry/pipeline/stages/fill.py
+++ b/src/questfoundry/pipeline/stages/fill.py
@@ -68,7 +68,6 @@ from questfoundry.graph.fill_context import (
     format_vocabulary_note,
     format_voice_context,
     get_arc_passage_order,
-    get_spine_arc_id,
 )
 from questfoundry.graph.graph import Graph
 from questfoundry.graph.snapshots import save_snapshot
@@ -210,25 +209,6 @@ def _resolve_entity_id(graph: Graph, raw_id: str) -> str | None:
     return None
 
 
-def _build_arc_key_to_node_map(graph: Graph) -> dict[str, str]:
-    """Build mapping from computed arc key to stored arc node ID.
-
-    Arc keys are sorted path ``raw_id`` values joined by ``"+"``.
-    """
-    from questfoundry.graph.algorithms import arc_key_for_paths
-
-    path_nodes = graph.get_nodes_by_type("path")
-    arc_nodes = graph.get_nodes_by_type("arc")
-    mapping: dict[str, str] = {}
-    for arc_id, arc_data in arc_nodes.items():
-        path_ids = arc_data.get("paths", [])
-        if not path_ids:
-            continue
-        arc_key = arc_key_for_paths(path_nodes, path_ids)
-        mapping[arc_key] = arc_id
-    return mapping
-
-
 def _find_spine_arc_key(graph: Graph) -> str | None:
     """Compute the spine arc key from graph structure.
 
@@ -262,6 +242,21 @@ def _find_spine_arc_key(graph: Graph) -> str | None:
         all_canonical_pids.extend(dilemma_canonical[_did])
 
     return arc_key_for_paths(path_nodes, all_canonical_pids)
+
+
+def _is_spine_arc(graph: Graph, arc_id: str) -> bool:
+    """Check if an arc (by key or node ID) represents the spine.
+
+    Returns True when all paths in the arc are canonical.
+    Works with both computed arc keys and legacy arc node IDs.
+    """
+    from questfoundry.graph.fill_context import get_arc_paths
+
+    path_ids = get_arc_paths(graph, arc_id)
+    if not path_ids:
+        return False
+    path_nodes = graph.get_nodes_by_type("path")
+    return all(path_nodes.get(pid, {}).get("is_canonical", False) for pid in path_ids)
 
 
 class FillStageError(ValueError):
@@ -925,20 +920,17 @@ class FillStage:
         )
 
     def _get_generation_order(self, graph: Graph) -> list[tuple[str, str]]:
-        """Return passage IDs in generation order with their arc IDs.
+        """Return passage IDs in generation order with their arc keys.
 
         Spine arc passages first, then branch arc passages.
         Passages already filled (have prose) are skipped unless flagged.
 
-        Primary path: uses :func:`compute_passage_traversals` to derive
-        passage ordering from graph structure (no arc node dependency).
-        Falls back to stored arc nodes when computed traversals are empty
-        (legacy graphs, minimal test fixtures).
+        Uses :func:`compute_passage_traversals` to derive passage ordering
+        from graph structure.  Arc IDs are computed arc keys (sorted path
+        raw_ids joined by ``"+"``), not stored arc node IDs.
 
         Returns:
-            List of (passage_id, arc_id) tuples.  The ``arc_id`` is the
-            arc node ID when arc nodes exist, or the computed arc key
-            otherwise.
+            List of (passage_id, arc_key) tuples.
         """
         from questfoundry.graph.algorithms import compute_passage_traversals
 
@@ -948,47 +940,24 @@ class FillStage:
         traversals = compute_passage_traversals(graph)
 
         if traversals:
-            # Build arc_key → arc_node_id mapping for downstream compat
-            arc_key_to_node = _build_arc_key_to_node_map(graph)
-
             # Identify spine: arc whose paths are all canonical
             spine_key = _find_spine_arc_key(graph)
-            spine_arc_id = arc_key_to_node.get(spine_key, spine_key) if spine_key else None
 
             # Spine first
             if spine_key and spine_key in traversals:
                 for pid in traversals[spine_key]:
                     if pid not in seen:
                         seen.add(pid)
-                        order.append((pid, spine_arc_id or spine_key))
+                        order.append((pid, spine_key))
 
             # Branch arcs next (deterministic sort by arc key)
             for arc_key in sorted(traversals):
                 if arc_key == spine_key:
                     continue
-                arc_id = arc_key_to_node.get(arc_key, arc_key)
                 for pid in traversals[arc_key]:
                     if pid not in seen:
                         seen.add(pid)
-                        order.append((pid, arc_id))
-        else:
-            # Fallback: iterate stored arc nodes
-            spine_id = get_spine_arc_id(graph)
-            all_arcs = graph.get_nodes_by_type("arc")
-
-            if spine_id:
-                for pid in get_arc_passage_order(graph, spine_id):
-                    if pid not in seen:
-                        seen.add(pid)
-                        order.append((pid, spine_id))
-
-            for arc_id, _arc_data in all_arcs.items():
-                if arc_id == spine_id:
-                    continue
-                for pid in get_arc_passage_order(graph, arc_id):
-                    if pid not in seen:
-                        seen.add(pid)
-                        order.append((pid, arc_id))
+                        order.append((pid, arc_key))
 
         # Collect synthetic passages (fork-beats, hub-spokes) not in any arc
         default_arc = order[0][1] if order else ""
@@ -1344,10 +1313,9 @@ class FillStage:
 
             # Warn about entity updates on non-spine passages (likely
             # path-dependent details that should be overlays, not base state).
-            arc_data = graph.get_node(arc_id) if arc_id else None
-            is_spine_arc = (arc_data.get("arc_type") == "spine") if arc_data is not None else False
+            is_spine = _is_spine_arc(graph, arc_id) if arc_id else False
 
-            if entity_updates and not is_spine_arc and arc_id is not None:
+            if entity_updates and not is_spine and arc_id is not None:
                 log.warning(
                     "entity_update_non_spine",
                     passage_id=passage_id,
@@ -1691,13 +1659,12 @@ class FillStage:
         from questfoundry.graph.algorithms import compute_passage_traversals
 
         traversals = compute_passage_traversals(graph)
-        arc_key_to_node = _build_arc_key_to_node_map(graph) if traversals else {}
 
         # Pre-compute arc info and passage data for each passage (graph reads only)
         passage_arc_info: dict[str, tuple[str | None, int]] = {}
         passage_data: dict[str, dict[str, Any]] = {}
         for passage_id in flagged_passages:
-            arc_id = self._find_arc_for_passage(graph, passage_id, traversals, arc_key_to_node)
+            arc_id = self._find_arc_for_passage(graph, passage_id, traversals)
             current_idx = 0
             if arc_id:
                 order = get_arc_passage_order(graph, arc_id)
@@ -1906,18 +1873,15 @@ class FillStage:
         graph: Graph,
         passage_id: str,
         traversals: dict[str, list[str]] | None = None,
-        arc_key_to_node: dict[str, str] | None = None,
     ) -> str | None:
         """Find the first arc containing a passage.
 
-        Primary path: checks computed passage traversals.
-        Fallback: reads stored arc node sequences.
+        Checks computed passage traversals and returns the arc key.
 
         Args:
             graph: Graph containing passage/arc data.
             passage_id: The passage to look up.
             traversals: Pre-computed passage traversals (avoids recomputation).
-            arc_key_to_node: Pre-computed arc key → node ID map.
         """
         if traversals is None:
             from questfoundry.graph.algorithms import compute_passage_traversals
@@ -1925,21 +1889,10 @@ class FillStage:
             traversals = compute_passage_traversals(graph)
 
         if traversals:
-            if arc_key_to_node is None:
-                arc_key_to_node = _build_arc_key_to_node_map(graph)
             for arc_key in sorted(traversals):
                 if passage_id in traversals[arc_key]:
-                    return arc_key_to_node.get(arc_key, arc_key)
+                    return arc_key
 
-        # Fallback: stored arc node sequences
-        beat_id = get_primary_beat(graph, passage_id) or ""
-        if not beat_id:
-            return None
-
-        all_arcs = graph.get_nodes_by_type("arc")
-        for arc_id, arc_data in all_arcs.items():
-            if beat_id in arc_data.get("sequence", []):
-                return str(arc_id)
         return None
 
     async def _phase_4_arc_validation(

--- a/tests/unit/test_fill_context.py
+++ b/tests/unit/test_fill_context.py
@@ -179,7 +179,49 @@ def fill_graph() -> Graph:
     g.add_edge("passage_from", "passage::p_aftermath", "beat::aftermath")
     g.add_edge("passage_from", "passage::p_branch_reveal", "beat::branch_reveal")
 
-    # Arcs
+    # Dilemma and path nodes (required for computed arc keys)
+    g.create_node(
+        "dilemma::mentor_trust",
+        {"type": "dilemma", "raw_id": "mentor_trust"},
+    )
+    g.create_node(
+        "path::mentor_trust__protector",
+        {
+            "type": "path",
+            "raw_id": "mentor_trust__protector",
+            "dilemma_id": "dilemma::mentor_trust",
+            "is_canonical": True,
+        },
+    )
+    g.create_node(
+        "path::mentor_trust__manipulator",
+        {
+            "type": "path",
+            "raw_id": "mentor_trust__manipulator",
+            "dilemma_id": "dilemma::mentor_trust",
+            "is_canonical": False,
+        },
+    )
+
+    # belongs_to edges: beat → path
+    # opening, explanation, aftermath are shared across both paths
+    g.add_edge("belongs_to", "beat::opening", "path::mentor_trust__protector")
+    g.add_edge("belongs_to", "beat::opening", "path::mentor_trust__manipulator")
+    g.add_edge("belongs_to", "beat::explanation", "path::mentor_trust__protector")
+    g.add_edge("belongs_to", "beat::explanation", "path::mentor_trust__manipulator")
+    g.add_edge("belongs_to", "beat::aftermath", "path::mentor_trust__protector")
+    g.add_edge("belongs_to", "beat::aftermath", "path::mentor_trust__manipulator")
+    # branch_reveal only on manipulator path
+    g.add_edge("belongs_to", "beat::branch_reveal", "path::mentor_trust__manipulator")
+
+    # predecessor edges: child → parent (dependent → prerequisite)
+    g.add_edge("predecessor", "beat::explanation", "beat::opening")
+    g.add_edge("predecessor", "beat::aftermath", "beat::explanation")
+    g.add_edge("predecessor", "beat::branch_reveal", "beat::explanation")
+    # On the manipulator path, branch_reveal comes before aftermath
+    g.add_edge("predecessor", "beat::aftermath", "beat::branch_reveal")
+
+    # Arcs (kept for fallback path and format_grow_summary / format_lookahead_context)
     g.create_node(
         "arc::spine_0_0",
         {
@@ -219,7 +261,7 @@ def fill_graph() -> Graph:
 
 class TestGetSpineArcId:
     def test_finds_spine(self, fill_graph: Graph) -> None:
-        assert get_spine_arc_id(fill_graph) == "arc::spine_0_0"
+        assert get_spine_arc_id(fill_graph) == "mentor_trust__protector"
 
     def test_no_arcs(self) -> None:
         g = Graph.empty()
@@ -233,6 +275,15 @@ class TestGetSpineArcId:
 
 class TestGetArcPassageOrder:
     def test_spine_order(self, fill_graph: Graph) -> None:
+        order = get_arc_passage_order(fill_graph, "mentor_trust__protector")
+        assert order == [
+            "passage::p_opening",
+            "passage::p_explanation",
+            "passage::p_aftermath",
+        ]
+
+    def test_spine_order_via_arc_node(self, fill_graph: Graph) -> None:
+        """Arc node ID resolves to computed traversal via _resolve_arc_key."""
         order = get_arc_passage_order(fill_graph, "arc::spine_0_0")
         assert order == [
             "passage::p_opening",
@@ -241,7 +292,7 @@ class TestGetArcPassageOrder:
         ]
 
     def test_branch_order(self, fill_graph: Graph) -> None:
-        order = get_arc_passage_order(fill_graph, "arc::branch_1_0")
+        order = get_arc_passage_order(fill_graph, "mentor_trust__manipulator")
         assert order == [
             "passage::p_opening",
             "passage::p_explanation",
@@ -363,23 +414,23 @@ class TestFormatPassageContext:
 
 class TestFormatSlidingWindow:
     def test_first_passage_no_window(self, fill_graph: Graph) -> None:
-        result = format_sliding_window(fill_graph, "arc::spine_0_0", 0)
+        result = format_sliding_window(fill_graph, "mentor_trust__protector", 0)
         assert result == "(no previous passages)"
 
     def test_second_passage_has_window(self, fill_graph: Graph) -> None:
-        result = format_sliding_window(fill_graph, "arc::spine_0_0", 1)
+        result = format_sliding_window(fill_graph, "mentor_trust__protector", 1)
         assert "p_opening" in result
         assert "tower stairs" in result
 
     def test_window_size_limits(self, fill_graph: Graph) -> None:
-        result = format_sliding_window(fill_graph, "arc::spine_0_0", 2, window_size=1)
+        result = format_sliding_window(fill_graph, "mentor_trust__protector", 2, window_size=1)
         # Should only include the immediately preceding passage
         assert "p_explanation" in result
         assert "p_opening" not in result
 
     def test_no_prose_skipped(self, fill_graph: Graph) -> None:
         # p_aftermath has no prose — window should skip it
-        result = format_sliding_window(fill_graph, "arc::spine_0_0", 2, window_size=3)
+        result = format_sliding_window(fill_graph, "mentor_trust__protector", 2, window_size=3)
         assert "p_opening" in result
         assert "p_explanation" in result
 
@@ -390,14 +441,18 @@ class TestFormatSlidingWindow:
 
 
 class TestFormatLookaheadContext:
-    def test_convergence_point(self, fill_graph: Graph) -> None:
-        # p_aftermath is convergence point for branch_1_0
-        result = format_lookahead_context(fill_graph, "passage::p_aftermath", "arc::spine_0_0")
-        assert "Convergence" in result
-        assert "branch_1_0" in result
+    def test_convergence_point_no_longer_emitted(self, fill_graph: Graph) -> None:
+        # Convergence context was removed (relied on stored arc nodes).
+        # p_aftermath is on the spine arc, so lookahead returns empty.
+        result = format_lookahead_context(
+            fill_graph, "passage::p_aftermath", "mentor_trust__protector"
+        )
+        assert result == ""
 
     def test_no_lookahead_needed(self, fill_graph: Graph) -> None:
-        result = format_lookahead_context(fill_graph, "passage::p_opening", "arc::spine_0_0")
+        result = format_lookahead_context(
+            fill_graph, "passage::p_opening", "mentor_trust__protector"
+        )
         assert result == ""
 
 
@@ -1469,70 +1524,102 @@ class TestEndingDifferentiation:
 
 
 class TestEchoPrompt:
-    """Tests for thematic echo at convergence points."""
+    """Tests for thematic echo at branch divergence points."""
 
-    def test_convergence_includes_echo(self) -> None:
-        """At convergence, lookahead should include opening passage echo."""
+    def test_divergence_includes_echo(self) -> None:
+        """At branch divergence, lookahead should include opening passage echo."""
         g = Graph()
-        # Spine arc with two beats
+
+        # Dilemma + paths for computed arcs
+        g.create_node("dilemma::d1", {"type": "dilemma", "raw_id": "d1"})
         g.create_node(
-            "arc::spine",
+            "path::canon",
             {
-                "type": "arc",
-                "arc_type": "spine",
-                "sequence": ["beat::b1", "beat::conv"],
+                "type": "path",
+                "raw_id": "canon",
+                "dilemma_id": "dilemma::d1",
+                "is_canonical": True,
             },
         )
-        # Branch arc converging at beat::conv
         g.create_node(
-            "arc::branch",
+            "path::alt",
             {
-                "type": "arc",
-                "arc_type": "branch",
-                "converges_at": "beat::conv",
-                "sequence": ["beat::br1"],
+                "type": "path",
+                "raw_id": "alt",
+                "dilemma_id": "dilemma::d1",
+                "is_canonical": False,
             },
         )
-        g.create_node("beat::b1", {"type": "beat", "summary": "opening"})
-        g.create_node("beat::conv", {"type": "beat", "summary": "convergence"})
-        g.create_node("beat::br1", {"type": "beat", "summary": "branch beat"})
+
+        # Shared beat (on both paths) and branch-only beat
+        g.create_node("beat::b1", {"type": "beat", "raw_id": "b1", "summary": "opening"})
+        g.create_node("beat::br1", {"type": "beat", "raw_id": "br1", "summary": "branch beat"})
+        g.add_edge("belongs_to", "beat::b1", "path::canon")
+        g.add_edge("belongs_to", "beat::b1", "path::alt")
+        g.add_edge("belongs_to", "beat::br1", "path::alt")
+        g.add_edge("predecessor", "beat::br1", "beat::b1")
+
+        # Passages
         g.create_node(
             "passage::p1",
-            {"type": "passage", "from_beat": "beat::b1", "prose": "The rain began to fall."},
+            {
+                "type": "passage",
+                "raw_id": "p1",
+                "from_beat": "beat::b1",
+                "prose": "The rain began to fall.",
+            },
         )
         g.create_node(
-            "passage::conv",
-            {"type": "passage", "from_beat": "beat::conv"},
+            "passage::br1",
+            {"type": "passage", "raw_id": "br1", "from_beat": "beat::br1"},
         )
         g.add_edge("passage_from", "passage::p1", "beat::b1")
-        g.add_edge("passage_from", "passage::conv", "beat::conv")
+        g.add_edge("passage_from", "passage::br1", "beat::br1")
+        g.add_edge("grouped_in", "beat::b1", "passage::p1")
+        g.add_edge("grouped_in", "beat::br1", "passage::br1")
 
-        result = format_lookahead_context(g, "passage::conv", "arc::spine")
+        # The branch arc key is "alt" (single non-canonical path)
+        result = format_lookahead_context(g, "passage::br1", "alt")
         assert "Thematic Echo" in result
         assert "The rain began to fall." in result
 
     def test_no_echo_at_normal_passage(self) -> None:
         """Non-juncture passages should not have echo prompts."""
         g = Graph()
+
+        # Dilemma + path for computed arcs
+        g.create_node("dilemma::d1", {"type": "dilemma", "raw_id": "d1"})
         g.create_node(
-            "arc::spine",
+            "path::canon",
             {
-                "type": "arc",
-                "arc_type": "spine",
-                "sequence": ["beat::b1", "beat::b2"],
+                "type": "path",
+                "raw_id": "canon",
+                "dilemma_id": "dilemma::d1",
+                "is_canonical": True,
             },
         )
-        g.create_node("beat::b1", {"type": "beat"})
-        g.create_node("beat::b2", {"type": "beat"})
+
+        g.create_node("beat::b1", {"type": "beat", "raw_id": "b1"})
+        g.create_node("beat::b2", {"type": "beat", "raw_id": "b2"})
+        g.add_edge("belongs_to", "beat::b1", "path::canon")
+        g.add_edge("belongs_to", "beat::b2", "path::canon")
+        g.add_edge("predecessor", "beat::b2", "beat::b1")
+
         g.create_node(
             "passage::p1",
-            {"type": "passage", "from_beat": "beat::b1", "prose": "Opening."},
+            {"type": "passage", "raw_id": "p1", "from_beat": "beat::b1", "prose": "Opening."},
         )
-        g.create_node("passage::p2", {"type": "passage", "from_beat": "beat::b2"})
+        g.create_node(
+            "passage::p2",
+            {"type": "passage", "raw_id": "p2", "from_beat": "beat::b2"},
+        )
         g.add_edge("passage_from", "passage::p1", "beat::b1")
         g.add_edge("passage_from", "passage::p2", "beat::b2")
+        g.add_edge("grouped_in", "beat::b1", "passage::p1")
+        g.add_edge("grouped_in", "beat::b2", "passage::p2")
 
-        result = format_lookahead_context(g, "passage::p2", "arc::spine")
+        # Spine arc key is "canon"
+        result = format_lookahead_context(g, "passage::p2", "canon")
         assert "Thematic Echo" not in result
 
 


### PR DESCRIPTION
## Summary

- Remove `_build_arc_key_to_node_map()` and all stored-arc-node reads from FILL stage
- Rewrite `get_spine_arc_id()`, `_is_first_branch_beat()`, `format_lookahead_context()`, and `format_grow_summary()` to derive arc data from computed traversals
- Remove dead convergence context block (relied on stored arc `converges_at` field)
- Add `_is_spine_arc()` helper that derives arc type from path canonical flags

## Test plan

- [x] All 70 `test_fill_stage.py` tests pass
- [x] All 203 `test_fill_context.py` tests pass
- [x] `grep -rn 'get_nodes_by_type.*"arc"' fill.py fill_context.py` returns 0 matches
- [x] ruff + mypy clean on all modified files

Closes #1059

> Stacked on #1070

🤖 Generated with [Claude Code](https://claude.com/claude-code)