### PR TITLE
refactor: rename Codeword → StateFlag model and node type

### DIFF
--- a/prompts/templates/grow_phase8c_overlays.yaml
+++ b/prompts/templates/grow_phase8c_overlays.yaml
@@ -1,20 +1,20 @@
 name: grow_phase8c_overlays
-description: Create entity overlays conditioned on codewords
+description: Create entity overlays conditioned on state flags
 
 system: |
   You are creating entity overlays -- conditional details that change
   based on which narrative path the player has taken. Overlays activate
-  when specific codewords are granted.
+  when specific state flags are granted.
 
   ## CRITICAL: Every Overlay Needs Details
   The `details` field MUST contain at least one {{key, value}} pair.
-  WRONG: {{"entity_id": "character::hero", "when": ["codeword::cw_trust"], "details": []}}
-  RIGHT: {{"entity_id": "character::hero", "when": ["codeword::cw_trust"], "details": [{{"key": "attitude", "value": "Wary but relieved the alliance held"}}]}}
+  WRONG: {{"entity_id": "character::hero", "when": ["state_flag::cw_trust"], "details": []}}
+  RIGHT: {{"entity_id": "character::hero", "when": ["state_flag::cw_trust"], "details": [{{"key": "attitude", "value": "Wary but relieved the alliance held"}}]}}
 
   ## What is an Entity Overlay?
   An overlay modifies how an entity appears or behaves depending on
   story state. Overlays are cosmetic entity-level changes — they describe
-  how an entity's presentation shifts based on codewords. (Passage-level
+  how an entity's presentation shifts based on state flags. (Passage-level
   prose variants at convergence points are handled by residue beats.)
 
   Examples:
@@ -22,14 +22,14 @@ system: |
   - A location's description changes after a disaster occurs
   - An object becomes unavailable after it is destroyed
 
-  ## Consequences, Codewords, and Their Context
+  ## Consequences, State Flags, and Their Context
   {consequence_context}
 
   ## Entities Available for Overlays
   {entity_context}
 
   ## When to Create an Overlay
-  For EACH codeword above, check these rules against each entity.
+  For EACH state flag above, check these rules against each entity.
   If ANY rule is satisfied, propose an overlay.
 
   1. **Direct mention**: Consequence names an entity → overlay it
@@ -38,7 +38,7 @@ system: |
   4. **Ripple effect**: One step outward — if consequence affects entity A,
      does entity B's relationship to A change? If yes, overlay B
 
-  Central entities per codeword are the strongest candidates.
+  Central entities per state flag are the strongest candidates.
 
   ## Common Mistakes
   - "Ally stays loyal" seems like no change, but it IS a state — the player
@@ -48,8 +48,8 @@ system: |
   - "Benign secret revealed" — still changes what characters know and how they behave.
 
   ## Overlay Structure
-  - Each overlay targets ONE entity, activates on one or more codewords
-  - "when" lists codeword IDs that must ALL be granted
+  - Each overlay targets ONE entity, activates on one or more state flags
+  - "when" lists state flag IDs that must ALL be granted
   - "details" is an array of {{key, value}} describing changes:
     keys like "attitude", "appearance", "description", "access", "status", "mood"
   - Maximum 3 overlays per entity
@@ -57,25 +57,25 @@ system: |
   ## What NOT to Do
   - Do NOT use IDs not listed in the Valid IDs section
   - Do NOT propose overlays with empty details
-  - Do NOT invent entity or codeword IDs
+  - Do NOT invent entity or state flag IDs
   - Do NOT add prose before or after the JSON output
 
   ## Valid IDs
   Valid entity_ids: {valid_entity_ids}
-  Valid codeword_ids (for "when" field): {valid_codeword_ids}
+  Valid state_flag_ids (for "when" field): {valid_state_flag_ids}
 
   ## Output Format
   Return a JSON object with an "overlays" array. Each overlay has:
   - entity_id: the entity being modified (e.g., "character::hero")
-  - when: list of codeword IDs that activate this overlay
+  - when: list of state flag IDs that activate this overlay
   - details: array of {{key, value}} objects describing changes (MUST NOT be empty)
 
   If no overlays exist after checking all rules, return an empty overlays array.
 
 user: |
-  Propose entity overlays based on the consequences and codewords above.
+  Propose entity overlays based on the consequences and state flags above.
 
-  For each codeword, apply the four rules (direct mention, state change,
+  For each state flag, apply the four rules (direct mention, state change,
   atmosphere shift, ripple effect) to every entity.
 
   REMINDER: Every overlay MUST have a non-empty details array.

--- a/prompts/templates/grow_phase8d_residue.yaml
+++ b/prompts/templates/grow_phase8d_residue.yaml
@@ -16,10 +16,10 @@ system: |
   - After a risky shortcut vs. safe route, the shared passage might note
     exhaustion (shortcut) or supplies running low (safe route, took longer)
 
-  Each residue beat produces one variant per path, gated by the codeword
+  Each residue beat produces one variant per path, gated by the state flag
   that tracks which path was taken.
 
-  ## Convergence Points and Available Codewords
+  ## Convergence Points and Available State Flags
   {convergence_context}
 
   ## Passage Summaries
@@ -28,7 +28,7 @@ system: |
   ## Rules
   1. Only propose residue beats for the passages listed above
   2. Each proposal targets ONE passage and ONE dilemma
-  3. Each variant is gated by exactly ONE codeword from the available list
+  3. Each variant is gated by exactly ONE state flag from the available list
   4. The hint field tells the prose writer HOW to differentiate this variant
      (10-200 characters, specific and concrete)
   5. Maximum {max_proposals} proposals total
@@ -47,7 +47,7 @@ system: |
 
   ## Valid IDs
   Valid passage_ids: {valid_passage_ids}
-  Valid codeword_ids (for variant gating): {valid_codeword_ids}
+  Valid state_flag_ids (for variant gating): {valid_state_flag_ids}
   Valid dilemma_ids: {valid_dilemma_ids}
 
   ## Output Format
@@ -56,7 +56,7 @@ system: |
   - dilemma_id: dilemma whose paths are converging at this point
   - rationale: why this passage needs path-specific variants (1 sentence)
   - variants: array of objects, each with:
-    - codeword_id: the codeword that gates this variant
+    - state_flag_id: the state flag that gates this variant
     - hint: specific prose guidance (10-200 chars)
 
   If no passages warrant residue variants, return an empty proposals array.

--- a/prompts/templates/grow_phase9c_hub_spokes.yaml
+++ b/prompts/templates/grow_phase9c_hub_spokes.yaml
@@ -36,13 +36,13 @@ system: |
      based on the prose it writes. This ensures labels match actual content.
   5. If you DO provide labels: 3-6 words, action phrases in imperative form
   6. Forward label: describes continuing the main story (required)
-  7. Spokes may optionally grant codewords when visited. Only use IDs from
-     the Valid Codewords list. Most spokes should NOT grant — only grant when
-     exploring that spoke naturally reveals something tracked by a codeword.
+  7. Spokes may optionally grant state flags when visited. Only use IDs from
+     the Valid State Flags list. Most spokes should NOT grant — only grant when
+     exploring that spoke naturally reveals something tracked by a state flag.
 
   ## What NOT to Do
   - Do NOT use passage IDs not listed in the Valid IDs section
-  - Do NOT use codeword IDs not listed in the Valid Codewords section
+  - Do NOT use state flag IDs not listed in the Valid State Flags section
   - Do NOT make spokes plot-critical (they are OPTIONAL)
   - Do NOT add explanatory prose before or after the JSON output
   - Do NOT propose hubs at ending passages (no outgoing choices)
@@ -51,8 +51,8 @@ system: |
   ## Valid IDs
   Valid passage IDs: {valid_passage_ids}
 
-  ## Valid Codewords
-  Valid codeword IDs: {valid_codeword_ids}
+  ## Valid State Flags
+  Valid state flag IDs: {valid_state_flag_ids}
 
   ## Output Format
   Return a JSON object with a "hubs" array. Each hub has:
@@ -65,7 +65,7 @@ system: |
       - "evocative": Atmospheric — "Trace the faded ink", "Listen to the silence"
       - "character_voice": Internal thought — "That clock... why did it stop?"
       If omitted, defaults to "functional"
-    - grants: (optional) list of codeword IDs this spoke grants when visited (default: empty)
+    - grants: (optional) list of state flag IDs this spoke grants when visited (default: empty)
   - forward_label: choice label for continuing the story (3-6 words)
 
 user: |

--- a/src/questfoundry/cli.py
+++ b/src/questfoundry/cli.py
@@ -88,7 +88,7 @@ DEFAULT_NONINTERACTIVE_SEED_PROMPT = (
 
 DEFAULT_GROW_PROMPT = (
     "Build the complete branching structure from the SEED graph: "
-    "enumerate arcs, create passages, derive choices and codewords."
+    "enumerate arcs, create passages, derive choices and state flags."
 )
 DEFAULT_FILL_PROMPT = (
     "Generate prose for all passages: determine voice document, "
@@ -1116,7 +1116,7 @@ def grow(
     """Run GROW stage - build complete branching structure.
 
     Takes the paths and beats from SEED and builds the full
-    branching story graph: arcs, passages, choices, codewords,
+    branching story graph: arcs, passages, choices, state flags,
     and state overlays.
 
     This stage runs 15 phases (mostly deterministic, some LLM-assisted)

--- a/src/questfoundry/export/context.py
+++ b/src/questfoundry/export/context.py
@@ -83,7 +83,8 @@ def _extract_choices(graph: Graph) -> list[ExportChoice]:
             from_passage=data["from_passage"],
             to_passage=data["to_passage"],
             label=data.get("label", "continue"),
-            requires_codewords=data.get("requires_codewords", []),
+            requires_codewords=data.get("requires_state_flags")
+            or data.get("requires_codewords", []),
             grants=data.get("grants", []),
             is_return=data.get("is_return", False),
         )
@@ -161,7 +162,7 @@ def _project_state_flags_to_codewords(graph: Graph) -> list[ExportCodeword]:
             result.append(
                 ExportCodeword(
                     id=flag_id,
-                    codeword_type=flag_data.get("codeword_type", "granted"),
+                    codeword_type=flag_data.get("flag_type", "granted"),
                     tracks=flag_data.get("tracks"),
                 )
             )

--- a/src/questfoundry/graph/dress_context.py
+++ b/src/questfoundry/graph/dress_context.py
@@ -184,13 +184,13 @@ def format_passage_for_brief(graph: Graph, passage_id: str) -> str:
 
 
 def format_entity_for_codex(graph: Graph, entity_id: str) -> str:
-    """Format entity details + related codewords for codex generation.
+    """Format entity details + related state flags for codex generation.
 
-    Provides the entity's full profile and any codewords that could
+    Provides the entity's full profile and any state flags that could
     gate codex tiers (e.g., meeting a character unlocks deeper lore).
 
     Args:
-        graph: Graph containing entity and codeword nodes.
+        graph: Graph containing entity and state_flag nodes.
         entity_id: Entity node ID (e.g., ``entity::aldric``).
 
     Returns:
@@ -227,14 +227,14 @@ def format_entity_for_codex(graph: Graph, entity_id: str) -> str:
         if features:
             lines.append(f"**Features:** {', '.join(features)}")
 
-    # Related codewords — uses substring matching as a heuristic:
-    # a codeword is "related" if the entity's raw_id appears in the
-    # codeword's trigger text or raw_id (case-insensitive). This is
+    # Related state flags — uses substring matching as a heuristic:
+    # a state flag is "related" if the entity's raw_id appears in the
+    # state flag's trigger text or raw_id (case-insensitive). This is
     # intentionally broad to surface potential codex gates; the LLM
-    # decides which codewords are actually meaningful for gating.
-    codewords = graph.get_nodes_by_type("codeword")
+    # decides which state flags are actually meaningful for gating.
+    state_flags = graph.get_nodes_by_type("state_flag")
     related: list[tuple[str, str]] = []
-    for cw_id, cw_data in codewords.items():
+    for cw_id, cw_data in state_flags.items():
         trigger = cw_data.get("trigger", "")
         cw_raw = cw_data.get("raw_id", strip_scope_prefix(cw_id))
         if raw_id.lower() in trigger.lower() or raw_id.lower() in cw_raw.lower():
@@ -242,7 +242,7 @@ def format_entity_for_codex(graph: Graph, entity_id: str) -> str:
 
     if related:
         lines.append("")
-        lines.append("### Related Codewords (potential codex gates)")
+        lines.append("### Related State Flags (potential codex gates)")
         for cw_raw, trigger in sorted(related):
             if trigger:
                 lines.append(f"- `{cw_raw}`: {trigger}")
@@ -412,7 +412,7 @@ def format_entities_batch_for_codex(graph: Graph, entity_ids: list[str]) -> str:
     """Format a batch of entities for codex generation.
 
     Args:
-        graph: Graph containing entity and codeword nodes.
+        graph: Graph containing entity and state_flag nodes.
         entity_ids: Entity node IDs in this batch.
 
     Returns:

--- a/src/questfoundry/graph/dress_mutations.py
+++ b/src/questfoundry/graph/dress_mutations.py
@@ -238,11 +238,11 @@ def validate_dress_codex_entries(
     Checks:
     - At least one entry exists
     - Entry with rank=1 exists (base tier, always visible)
-    - Codeword IDs in visible_when exist in graph
+    - State flag IDs in visible_when exist in graph
     - Ranks are unique per entity
 
     Args:
-        graph: Story graph for codeword validation.
+        graph: Story graph for state flag validation.
         entity_id: Entity these entries belong to.
         entries: List of CodexEntry dicts.
 
@@ -268,17 +268,17 @@ def validate_dress_codex_entries(
         if count > 1:
             errors.append(f"Entity {entity_id}: duplicate rank={r} ({count} entries)")
 
-    # Validate codeword references
-    codewords = graph.get_nodes_by_type("codeword")
-    codeword_ids = {strip_scope_prefix(cid) for cid in codewords}
+    # Validate state flag references
+    state_flags = graph.get_nodes_by_type("state_flag")
+    state_flag_ids = {strip_scope_prefix(cid) for cid in state_flags}
 
     for entry in entries:
         for cw in entry.get("visible_when", []):
             raw_cw = strip_scope_prefix(cw)
-            if raw_cw not in codeword_ids:
+            if raw_cw not in state_flag_ids:
                 errors.append(
                     f"Entity {entity_id}: codex rank={entry.get('rank')} "
-                    f"references unknown codeword '{cw}'"
+                    f"references unknown state flag '{cw}'"
                 )
 
     return errors

--- a/src/questfoundry/graph/fill_context.py
+++ b/src/questfoundry/graph/fill_context.py
@@ -1683,17 +1683,17 @@ def format_ending_guidance(
 def format_ending_differentiation(graph: Graph, passage_id: str) -> str:
     """Build family-specific narrative context for a synthetic ending passage.
 
-    Traces the passage's ``family_codewords`` back through graph edges to
+    Traces the passage's ``family_state_flags`` back through graph edges to
     collect the consequence descriptions and path themes that distinguish
     this ending from its siblings.  Returns a prompt block that grounds
     the LLM in the specific consequences the reader experienced.
 
     Edge traversal::
 
-        codeword --tracks--> consequence <--has_consequence-- path
+        state_flag --tracks--> consequence <--has_consequence-- path
 
     Args:
-        graph: Story graph with codeword, consequence, and path nodes.
+        graph: Story graph with state_flag, consequence, and path nodes.
         passage_id: Full node ID (e.g. ``passage::ending_climax_0``).
 
     Returns:
@@ -1705,16 +1705,16 @@ def format_ending_differentiation(graph: Graph, passage_id: str) -> str:
     if not passage:
         return ""
 
-    family_codewords = passage.get("family_codewords")
-    if not family_codewords or not passage.get("is_synthetic"):
+    family_flags = passage.get("family_state_flags")
+    if not family_flags or not passage.get("is_synthetic"):
         return ""
 
-    # codeword → consequence (via tracks edges: codeword tracks consequence)
-    # We only need edges for our family codewords.
+    # state_flag → consequence (via tracks edges: state_flag tracks consequence)
+    # We only need edges for our family state flags.
     bullets: list[str] = []
-    for cw_id in sorted(family_codewords):
-        scoped_cw = cw_id if cw_id.startswith("codeword::") else f"codeword::{cw_id}"
-        tracks = graph.get_edges(from_id=scoped_cw, edge_type="tracks")
+    for sf_id in sorted(family_flags):
+        scoped_sf = sf_id if sf_id.startswith("state_flag::") else f"state_flag::{sf_id}"
+        tracks = graph.get_edges(from_id=scoped_sf, edge_type="tracks")
         if not tracks:
             continue
         consequence_id = sorted(tracks, key=lambda e: e["to"])[0]["to"]

--- a/src/questfoundry/graph/grow_validation.py
+++ b/src/questfoundry/graph/grow_validation.py
@@ -655,7 +655,7 @@ _MOVED_TO_POLISH = {
     "check_all_endings_reachable",
     "check_all_passages_reachable",
     "check_arc_divergence",
-    "check_codeword_gate_coverage",
+    "check_state_flag_gate_coverage",
     "check_commits_timing",
     "check_forward_path_reachability",
     "check_gate_co_satisfiability",

--- a/src/questfoundry/graph/grow_validators.py
+++ b/src/questfoundry/graph/grow_validators.py
@@ -104,13 +104,13 @@ def validate_phase4a_output(
 def validate_phase8c_output(
     result: Phase8cOutput,
     valid_entity_ids: set[str],
-    valid_codeword_ids: set[str],
+    valid_state_flag_ids: set[str],
 ) -> list[GrowValidationError]:
     """Validate Phase 8c entity overlay proposals.
 
     Checks:
     - entity_id exists in graph
-    - codeword IDs in 'when' exist
+    - state flag IDs in 'when' exist
     """
     errors: list[GrowValidationError] = []
     for i, overlay in enumerate(result.overlays):
@@ -124,13 +124,13 @@ def validate_phase8c_output(
                 )
             )
         for cw_id in overlay.when:
-            if cw_id not in valid_codeword_ids:
+            if cw_id not in valid_state_flag_ids:
                 errors.append(
                     GrowValidationError(
                         field_path=f"overlays.{i}.when",
-                        issue=f"Codeword ID not found: {cw_id}",
+                        issue=f"State flag ID not found: {cw_id}",
                         provided=cw_id,
-                        available=sorted(valid_codeword_ids)[:10],
+                        available=sorted(valid_state_flag_ids)[:10],
                     )
                 )
     return errors
@@ -139,7 +139,7 @@ def validate_phase8c_output(
 def validate_phase8d_output(
     result: Phase8dOutput,
     valid_passage_ids: set[str],
-    valid_codeword_ids: set[str],
+    valid_state_flag_ids: set[str],
     valid_dilemma_ids: set[str],
 ) -> list[GrowValidationError]:
     """Validate Phase 8d residue beat proposals.
@@ -147,11 +147,11 @@ def validate_phase8d_output(
     Checks:
     - passage_id exists in graph
     - dilemma_id exists in graph
-    - codeword IDs in variants exist
+    - state flag IDs in variants exist
     """
     errors: list[GrowValidationError] = []
     available_passages = sorted(valid_passage_ids)[:10]
-    available_codewords = sorted(valid_codeword_ids)[:10]
+    available_state_flags = sorted(valid_state_flag_ids)[:10]
     available_dilemmas = sorted(valid_dilemma_ids)[:10]
 
     for i, proposal in enumerate(result.proposals):
@@ -174,13 +174,13 @@ def validate_phase8d_output(
                 )
             )
         for j, variant in enumerate(proposal.variants):
-            if variant.codeword_id not in valid_codeword_ids:
+            if variant.state_flag_id not in valid_state_flag_ids:
                 errors.append(
                     GrowValidationError(
-                        field_path=f"proposals.{i}.variants.{j}.codeword_id",
-                        issue=f"Codeword ID not found: {variant.codeword_id}",
-                        provided=variant.codeword_id,
-                        available=available_codewords,
+                        field_path=f"proposals.{i}.variants.{j}.state_flag_id",
+                        issue=f"State flag ID not found: {variant.state_flag_id}",
+                        provided=variant.state_flag_id,
+                        available=available_state_flags,
                     )
                 )
     return errors
@@ -339,14 +339,14 @@ def validate_phase9b_output(
 def validate_phase9c_output(
     result: Phase9cOutput,
     valid_passage_ids: set[str],
-    valid_codeword_ids: set[str] | None = None,
+    valid_state_flag_ids: set[str] | None = None,
 ) -> list[GrowValidationError]:
     """Validate Phase 9c hub-spoke proposals.
 
     Checks:
     - passage_id exists in valid passage IDs (which excludes ending passages,
       ensuring hubs have outgoing choices)
-    - spoke grant IDs reference existing codeword nodes (when valid_codeword_ids
+    - spoke grant IDs reference existing state flag nodes (when valid_state_flag_ids
       is provided)
     """
     errors: list[GrowValidationError] = []
@@ -360,17 +360,17 @@ def validate_phase9c_output(
                     available=sorted(valid_passage_ids)[:10],
                 )
             )
-        if valid_codeword_ids is not None:
+        if valid_state_flag_ids is not None:
             for j, spoke in enumerate(hub.spokes):
                 for k, grant_id in enumerate(spoke.grants):
-                    scoped = normalize_scoped_id(grant_id, "codeword")
-                    if scoped not in valid_codeword_ids:
+                    scoped = normalize_scoped_id(grant_id, "state_flag")
+                    if scoped not in valid_state_flag_ids:
                         errors.append(
                             GrowValidationError(
                                 field_path=f"hubs.{i}.spokes.{j}.grants.{k}",
-                                issue=f"Codeword ID not found: {grant_id}",
+                                issue=f"State flag ID not found: {grant_id}",
                                 provided=grant_id,
-                                available=sorted(valid_codeword_ids)[:10],
+                                available=sorted(valid_state_flag_ids)[:10],
                             )
                         )
     return errors

--- a/src/questfoundry/models/__init__.py
+++ b/src/questfoundry/models/__init__.py
@@ -64,7 +64,6 @@ from questfoundry.models.grow import (
     AtmosphericDetail,
     Choice,
     ChoiceLabel,
-    Codeword,
     EntityArcDescriptor,
     EntityOverlay,
     ForkProposal,
@@ -90,6 +89,7 @@ from questfoundry.models.grow import (
     SceneTypeTag,
     SpokeLabelStyle,
     SpokeProposal,
+    StateFlag,
 )
 from questfoundry.models.pipeline import PhaseResult
 from questfoundry.models.polish import (
@@ -170,7 +170,6 @@ __all__ = [
     "ChoiceLabel",
     "ChoiceLabelItem",
     "ChoiceSpec",
-    "Codeword",
     "CodexEntry",
     "Consequence",
     "ContentNotes",
@@ -259,6 +258,7 @@ __all__ = [
     "SpokeLabelStyle",
     "SpokeLabelUpdate",
     "SpokeProposal",
+    "StateFlag",
     "TemporalHint",
     "TemporalPosition",
     "VariantSpec",

--- a/src/questfoundry/models/seed.py
+++ b/src/questfoundry/models/seed.py
@@ -122,7 +122,7 @@ class Consequence(BaseModel):
     """Narrative consequence of a path choice.
 
     Consequences bridge the gap between "what this path represents" (answer)
-    and "how we track it" (codeword). GROW creates codewords to track when
+    and "how we track it" (state flag). GROW creates state flags to track when
     consequences become active.
 
     Attributes:

--- a/src/questfoundry/pipeline/stages/fill.py
+++ b/src/questfoundry/pipeline/stages/fill.py
@@ -68,7 +68,6 @@ from questfoundry.graph.fill_context import (
     format_vocabulary_note,
     format_voice_context,
     get_arc_passage_order,
-    get_spine_arc_id,
 )
 from questfoundry.graph.graph import Graph
 from questfoundry.graph.snapshots import save_snapshot
@@ -210,25 +209,6 @@ def _resolve_entity_id(graph: Graph, raw_id: str) -> str | None:
     return None
 
 
-def _build_arc_key_to_node_map(graph: Graph) -> dict[str, str]:
-    """Build mapping from computed arc key to stored arc node ID.
-
-    Arc keys are sorted path ``raw_id`` values joined by ``"+"``.
-    """
-    from questfoundry.graph.algorithms import arc_key_for_paths
-
-    path_nodes = graph.get_nodes_by_type("path")
-    arc_nodes = graph.get_nodes_by_type("arc")
-    mapping: dict[str, str] = {}
-    for arc_id, arc_data in arc_nodes.items():
-        path_ids = arc_data.get("paths", [])
-        if not path_ids:
-            continue
-        arc_key = arc_key_for_paths(path_nodes, path_ids)
-        mapping[arc_key] = arc_id
-    return mapping
-
-
 def _find_spine_arc_key(graph: Graph) -> str | None:
     """Compute the spine arc key from graph structure.
 
@@ -262,6 +242,21 @@ def _find_spine_arc_key(graph: Graph) -> str | None:
         all_canonical_pids.extend(dilemma_canonical[_did])
 
     return arc_key_for_paths(path_nodes, all_canonical_pids)
+
+
+def _is_spine_arc(graph: Graph, arc_id: str) -> bool:
+    """Check if an arc (by key or node ID) represents the spine.
+
+    Returns True when all paths in the arc are canonical.
+    Works with both computed arc keys and legacy arc node IDs.
+    """
+    from questfoundry.graph.fill_context import get_arc_paths
+
+    path_ids = get_arc_paths(graph, arc_id)
+    if not path_ids:
+        return False
+    path_nodes = graph.get_nodes_by_type("path")
+    return all(path_nodes.get(pid, {}).get("is_canonical", False) for pid in path_ids)
 
 
 class FillStageError(ValueError):
@@ -925,20 +920,17 @@ class FillStage:
         )
 
     def _get_generation_order(self, graph: Graph) -> list[tuple[str, str]]:
-        """Return passage IDs in generation order with their arc IDs.
+        """Return passage IDs in generation order with their arc keys.
 
         Spine arc passages first, then branch arc passages.
         Passages already filled (have prose) are skipped unless flagged.
 
-        Primary path: uses :func:`compute_passage_traversals` to derive
-        passage ordering from graph structure (no arc node dependency).
-        Falls back to stored arc nodes when computed traversals are empty
-        (legacy graphs, minimal test fixtures).
+        Uses :func:`compute_passage_traversals` to derive passage ordering
+        from graph structure.  Arc IDs are computed arc keys (sorted path
+        raw_ids joined by ``"+"``), not stored arc node IDs.
 
         Returns:
-            List of (passage_id, arc_id) tuples.  The ``arc_id`` is the
-            arc node ID when arc nodes exist, or the computed arc key
-            otherwise.
+            List of (passage_id, arc_key) tuples.
         """
         from questfoundry.graph.algorithms import compute_passage_traversals
 
@@ -948,47 +940,24 @@ class FillStage:
         traversals = compute_passage_traversals(graph)
 
         if traversals:
-            # Build arc_key → arc_node_id mapping for downstream compat
-            arc_key_to_node = _build_arc_key_to_node_map(graph)
-
             # Identify spine: arc whose paths are all canonical
             spine_key = _find_spine_arc_key(graph)
-            spine_arc_id = arc_key_to_node.get(spine_key, spine_key) if spine_key else None
 
             # Spine first
             if spine_key and spine_key in traversals:
                 for pid in traversals[spine_key]:
                     if pid not in seen:
                         seen.add(pid)
-                        order.append((pid, spine_arc_id or spine_key))
+                        order.append((pid, spine_key))
 
             # Branch arcs next (deterministic sort by arc key)
             for arc_key in sorted(traversals):
                 if arc_key == spine_key:
                     continue
-                arc_id = arc_key_to_node.get(arc_key, arc_key)
                 for pid in traversals[arc_key]:
                     if pid not in seen:
                         seen.add(pid)
-                        order.append((pid, arc_id))
-        else:
-            # Fallback: iterate stored arc nodes
-            spine_id = get_spine_arc_id(graph)
-            all_arcs = graph.get_nodes_by_type("arc")
-
-            if spine_id:
-                for pid in get_arc_passage_order(graph, spine_id):
-                    if pid not in seen:
-                        seen.add(pid)
-                        order.append((pid, spine_id))
-
-            for arc_id, _arc_data in all_arcs.items():
-                if arc_id == spine_id:
-                    continue
-                for pid in get_arc_passage_order(graph, arc_id):
-                    if pid not in seen:
-                        seen.add(pid)
-                        order.append((pid, arc_id))
+                        order.append((pid, arc_key))
 
         # Collect synthetic passages (fork-beats, hub-spokes) not in any arc
         default_arc = order[0][1] if order else ""
@@ -1344,10 +1313,9 @@ class FillStage:
 
             # Warn about entity updates on non-spine passages (likely
             # path-dependent details that should be overlays, not base state).
-            arc_data = graph.get_node(arc_id) if arc_id else None
-            is_spine_arc = (arc_data.get("arc_type") == "spine") if arc_data is not None else False
+            is_spine = _is_spine_arc(graph, arc_id) if arc_id else False
 
-            if entity_updates and not is_spine_arc and arc_id is not None:
+            if entity_updates and not is_spine and arc_id is not None:
                 log.warning(
                     "entity_update_non_spine",
                     passage_id=passage_id,
@@ -1691,13 +1659,12 @@ class FillStage:
         from questfoundry.graph.algorithms import compute_passage_traversals
 
         traversals = compute_passage_traversals(graph)
-        arc_key_to_node = _build_arc_key_to_node_map(graph) if traversals else {}
 
         # Pre-compute arc info and passage data for each passage (graph reads only)
         passage_arc_info: dict[str, tuple[str | None, int]] = {}
         passage_data: dict[str, dict[str, Any]] = {}
         for passage_id in flagged_passages:
-            arc_id = self._find_arc_for_passage(graph, passage_id, traversals, arc_key_to_node)
+            arc_id = self._find_arc_for_passage(graph, passage_id, traversals)
             current_idx = 0
             if arc_id:
                 order = get_arc_passage_order(graph, arc_id)
@@ -1906,18 +1873,15 @@ class FillStage:
         graph: Graph,
         passage_id: str,
         traversals: dict[str, list[str]] | None = None,
-        arc_key_to_node: dict[str, str] | None = None,
     ) -> str | None:
         """Find the first arc containing a passage.
 
-        Primary path: checks computed passage traversals.
-        Fallback: reads stored arc node sequences.
+        Checks computed passage traversals and returns the arc key.
 
         Args:
             graph: Graph containing passage/arc data.
             passage_id: The passage to look up.
             traversals: Pre-computed passage traversals (avoids recomputation).
-            arc_key_to_node: Pre-computed arc key → node ID map.
         """
         if traversals is None:
             from questfoundry.graph.algorithms import compute_passage_traversals
@@ -1925,21 +1889,10 @@ class FillStage:
             traversals = compute_passage_traversals(graph)
 
         if traversals:
-            if arc_key_to_node is None:
-                arc_key_to_node = _build_arc_key_to_node_map(graph)
             for arc_key in sorted(traversals):
                 if passage_id in traversals[arc_key]:
-                    return arc_key_to_node.get(arc_key, arc_key)
+                    return arc_key
 
-        # Fallback: stored arc node sequences
-        beat_id = get_primary_beat(graph, passage_id) or ""
-        if not beat_id:
-            return None
-
-        all_arcs = graph.get_nodes_by_type("arc")
-        for arc_id, arc_data in all_arcs.items():
-            if beat_id in arc_data.get("sequence", []):
-                return str(arc_id)
         return None
 
     async def _phase_4_arc_validation(

--- a/src/questfoundry/pipeline/stages/grow/deterministic.py
+++ b/src/questfoundry/pipeline/stages/grow/deterministic.py
@@ -10,11 +10,10 @@ All graph mutations happen in-place on the graph argument.
 from __future__ import annotations
 
 from collections import deque
-from typing import TYPE_CHECKING, Any, Literal
+from typing import TYPE_CHECKING, Any
 
 from questfoundry.graph.context import normalize_scoped_id, strip_scope_prefix
 from questfoundry.graph.graph import Graph  # noqa: TC001 - used at runtime
-from questfoundry.models.grow import Arc as ArcModel
 from questfoundry.models.grow import GrowPhaseResult
 from questfoundry.pipeline.stages.grow._helpers import log
 from questfoundry.pipeline.stages.grow.registry import grow_phase
@@ -25,53 +24,6 @@ if TYPE_CHECKING:
     from questfoundry.pipeline.size import SizeProfile
 
 PROLOGUE_ID = "passage::prologue"
-
-
-def _arcs_from_traversals(graph: Graph) -> tuple[list[ArcModel], str | None]:
-    """Build Arc models from computed traversals (no stored arc nodes needed).
-
-    Uses ``compute_arc_traversals()`` and path metadata to reconstruct
-    the same Arc model objects that ``enumerate_arcs()`` produces.
-
-    Returns:
-        Tuple of (arc_list, spine_arc_id) where spine_arc_id is the raw_id
-        of the spine arc, or None if no spine exists.
-    """
-    from questfoundry.graph.algorithms import compute_arc_traversals
-
-    traversals = compute_arc_traversals(graph)
-    if not traversals:
-        return [], None
-
-    path_nodes = graph.get_nodes_by_type("path")
-    raw_id_to_pid = {
-        pdata.get("raw_id"): pid for pid, pdata in path_nodes.items() if "raw_id" in pdata
-    }
-    arcs: list[ArcModel] = []
-    spine_arc_id: str | None = None
-
-    for arc_key, sequence in traversals.items():
-        raw_ids = arc_key.split("+")
-        path_ids = [raw_id_to_pid[rid] for rid in raw_ids if rid in raw_id_to_pid]
-
-        # Spine arc: all paths are canonical (guard against empty path_ids)
-        is_spine = bool(path_ids) and all(
-            path_nodes.get(pid, {}).get("is_canonical", False) for pid in path_ids
-        )
-        arc_type: Literal["spine", "branch"] = "spine" if is_spine else "branch"
-        if is_spine:
-            spine_arc_id = arc_key
-
-        arcs.append(
-            ArcModel(
-                arc_id=arc_key,
-                arc_type=arc_type,
-                paths=raw_ids,
-                sequence=sequence,
-            )
-        )
-
-    return arcs, spine_arc_id
 
 
 # --- Phase 1: Validate DAG ---
@@ -122,7 +74,7 @@ async def phase_enumerate_arcs(
     *,
     size_profile: SizeProfile | None = None,
 ) -> GrowPhaseResult:
-    """Phase 5: Enumerate arcs from path combinations.
+    """Phase 5: Enumerate arcs from path combinations (validation only).
 
     Preconditions:
     - Beat DAG is valid (Phase 1 passed).
@@ -130,10 +82,11 @@ async def phase_enumerate_arcs(
     - Path and beat nodes exist with belongs_to edges.
 
     Postconditions:
-    - Arc nodes created for each valid path combination.
-    - arc_contains edges link arcs to their beat sequences.
+    - Arc enumeration validated (Cartesian product of paths is tractable).
     - Exactly one spine arc exists (containing all canonical paths).
     - Arc count bounded by 4x size_profile.max_arcs (if provided).
+    - No arc nodes or arc_contains edges are stored — arcs are computed
+      traversals per Document 3 ontology.
 
     Invariants:
     - Deterministic: same graph always produces same arcs.
@@ -176,28 +129,10 @@ async def phase_enumerate_arcs(
             ),
         )
 
-    # Create arc nodes and arc_contains edges
-    for arc in arcs:
-        arc_node_id = f"arc::{arc.arc_id}"
-        graph.create_node(
-            arc_node_id,
-            {
-                "type": "arc",
-                "raw_id": arc.arc_id,
-                "arc_type": arc.arc_type,
-                "paths": arc.paths,
-                "sequence": arc.sequence,
-            },
-        )
-
-        # Add arc_contains edges for each beat in the sequence
-        for beat_id in arc.sequence:
-            graph.add_edge("arc_contains", arc_node_id, beat_id)
-
     return GrowPhaseResult(
         phase="enumerate_arcs",
         status="completed",
-        detail=f"Created {len(arcs)} arcs",
+        detail=f"Validated {len(arcs)} arcs (computed, not stored)",
     )
 
 
@@ -206,36 +141,32 @@ async def phase_enumerate_arcs(
 
 @grow_phase(name="divergence", depends_on=["enumerate_arcs"], is_deterministic=True, priority=10)
 async def phase_divergence(graph: Graph, model: BaseChatModel) -> GrowPhaseResult:  # noqa: ARG001
-    """Phase 6: Compute divergence points between arcs.
+    """Phase 6: Compute divergence points between arcs (validation only).
 
     Preconditions:
     - Arc enumeration complete (Phase 5).
     - At least one spine arc exists for reference.
 
     Postconditions:
-    - Each non-spine arc has diverges_from and diverges_at metadata.
-    - diverges_at edges link arcs to their first diverging beat.
+    - Divergence points computed and validated.
+    - No graph writes — divergence metadata is computed on-the-fly
+      by downstream consumers per Document 3 ontology.
 
     Invariants:
     - Deterministic: divergence points derived from sequence comparison.
     - No-op if only one arc exists (no branching).
     """
-    from questfoundry.graph.grow_algorithms import compute_divergence_points
+    from questfoundry.graph.grow_algorithms import compute_divergence_points, enumerate_arcs
 
-    arcs, spine_arc_id = _arcs_from_traversals(graph)
+    arcs = enumerate_arcs(graph)
     if not arcs:
-        # Fallback: read stored arc nodes for backward compatibility
-        from questfoundry.graph.grow_algorithms import enumerate_arcs
+        return GrowPhaseResult(
+            phase="divergence",
+            status="completed",
+            detail="No arcs to process",
+        )
 
-        arcs = enumerate_arcs(graph)
-        spine_arc_id = next((a.arc_id for a in arcs if a.arc_type == "spine"), None)
-        if not arcs:
-            return GrowPhaseResult(
-                phase="divergence",
-                status="completed",
-                detail="No arcs to process",
-            )
-
+    spine_arc_id = next((a.arc_id for a in arcs if a.arc_type == "spine"), None)
     divergence_map = compute_divergence_points(arcs, spine_arc_id)
 
     if not divergence_map:
@@ -244,19 +175,6 @@ async def phase_divergence(graph: Graph, model: BaseChatModel) -> GrowPhaseResul
             status="completed",
             detail="No divergence points (single arc or no branches)",
         )
-
-    # Update arc nodes and create diverges_at edges
-    for arc_id_raw, info in divergence_map.items():
-        arc_node_id = f"arc::{arc_id_raw}"
-        updates: dict[str, str | None] = {
-            "diverges_from": f"arc::{info.diverges_from}" if info.diverges_from else None,
-            "diverges_at": info.diverges_at,
-        }
-        graph.update_node(arc_node_id, **{k: v for k, v in updates.items() if v is not None})
-
-        # Create diverges_at edge from arc to the divergence beat
-        if info.diverges_at:
-            graph.add_edge("diverges_at", arc_node_id, info.diverges_at)
 
     return GrowPhaseResult(
         phase="divergence",
@@ -270,40 +188,35 @@ async def phase_divergence(graph: Graph, model: BaseChatModel) -> GrowPhaseResul
 
 @grow_phase(name="convergence", depends_on=["divergence"], is_deterministic=True, priority=11)
 async def phase_convergence(graph: Graph, model: BaseChatModel) -> GrowPhaseResult:  # noqa: ARG001
-    """Phase 7: Find convergence points for diverged arcs.
+    """Phase 7: Find convergence points for diverged arcs (validation only).
 
     Preconditions:
     - Divergence points computed (Phase 6 complete).
     - Dilemma nodes have dilemma_role from SEED analysis.
 
     Postconditions:
-    - Arcs with soft/flavor dilemmas get converges_at and converges_to metadata.
-    - converges_at edges link arcs to their convergence beat.
-    - Each arc has dilemma_role and payoff_budget stored.
-    - Hard dilemma arcs have no convergence point.
+    - Convergence points computed and validated.
+    - No graph writes — convergence metadata is computed on-the-fly
+      by downstream consumers per Document 3 ontology.
 
     Invariants:
     - Deterministic: convergence derived from dilemma policies and beat sequences.
-    - dilemma_convergences list stored per arc for multi-dilemma arcs.
     """
     from questfoundry.graph.grow_algorithms import (
         compute_divergence_points,
+        enumerate_arcs,
         find_convergence_points,
     )
 
-    arcs, spine_arc_id = _arcs_from_traversals(graph)
+    arcs = enumerate_arcs(graph)
     if not arcs:
-        # Fallback: read stored arc nodes for backward compatibility
-        from questfoundry.graph.grow_algorithms import enumerate_arcs
+        return GrowPhaseResult(
+            phase="convergence",
+            status="completed",
+            detail="No arcs to process",
+        )
 
-        arcs = enumerate_arcs(graph)
-        spine_arc_id = next((a.arc_id for a in arcs if a.arc_type == "spine"), None)
-        if not arcs:
-            return GrowPhaseResult(
-                phase="convergence",
-                status="completed",
-                detail="No arcs to process",
-            )
+    spine_arc_id = next((a.arc_id for a in arcs if a.arc_type == "spine"), None)
 
     # Compute divergence first (needed for convergence)
     divergence_map = compute_divergence_points(arcs, spine_arc_id)
@@ -316,39 +229,7 @@ async def phase_convergence(graph: Graph, model: BaseChatModel) -> GrowPhaseResu
             detail="No convergence points found",
         )
 
-    # Update arc nodes and create converges_at edges
-    convergence_count = 0
-    for arc_id_raw, info in convergence_map.items():
-        arc_node_id = f"arc::{arc_id_raw}"
-
-        # Always store policy metadata on the arc node
-        update_fields: dict[str, object] = {
-            "dilemma_role": info.dilemma_role,
-            "payoff_budget": info.payoff_budget,
-        }
-        if info.dilemma_convergences:
-            update_fields["dilemma_convergences"] = [
-                {
-                    "dilemma_id": dc.dilemma_id,
-                    "policy": dc.policy,
-                    "budget": dc.budget,
-                    "converges_at": dc.converges_at,
-                }
-                for dc in info.dilemma_convergences
-            ]
-        graph.update_node(arc_node_id, **update_fields)
-
-        if not info.converges_at:
-            continue
-
-        graph.update_node(
-            arc_node_id,
-            converges_to=f"arc::{info.converges_to}" if info.converges_to else None,
-            converges_at=info.converges_at,
-        )
-        graph.add_edge("converges_at", arc_node_id, info.converges_at)
-        convergence_count += 1
-
+    convergence_count = sum(1 for info in convergence_map.values() if info.converges_at)
     return GrowPhaseResult(
         phase="convergence",
         status="completed",
@@ -802,7 +683,7 @@ async def phase_prune(graph: Graph, model: BaseChatModel) -> GrowPhaseResult:  #
     Postconditions:
     - Passages unreachable from the story start are deleted (cascade).
     - When choices exist: BFS via choice_to from prologue or spine start.
-    - When no choices: fallback to arc_contains membership.
+    - When no choices: fallback to computed arc traversal membership.
 
     Invariants:
     - Prologue passage (if synthetic) is always the BFS start.
@@ -855,25 +736,17 @@ def _reachable_via_choices(graph: Graph, passage_nodes: dict[str, dict[str, Any]
         start_passage = PROLOGUE_ID
         log.debug("prune_start_from_prologue", start=PROLOGUE_ID)
     else:
-        # Find spine arc's first passage via computed traversals,
-        # falling back to stored arc nodes for backward compatibility.
-        arcs, _spine_id = _arcs_from_traversals(graph)
+        from questfoundry.graph.grow_algorithms import enumerate_arcs
+
+        arcs = enumerate_arcs(graph)
         start_passage = None
 
         # Find first beat in spine arc's sequence
         spine_sequence: list[str] | None = None
-        if arcs:
-            for arc in arcs:
-                if arc.arc_type == "spine" and arc.sequence:
-                    spine_sequence = arc.sequence
-                    break
-        else:
-            # Fallback: read stored arc nodes directly
-            arc_nodes = graph.get_nodes_by_type("arc")
-            for _arc_id, arc_data in arc_nodes.items():
-                if arc_data.get("arc_type") == "spine":
-                    spine_sequence = arc_data.get("sequence", [])
-                    break
+        for arc in arcs:
+            if arc.arc_type == "spine" and arc.sequence:
+                spine_sequence = arc.sequence
+                break
 
         if spine_sequence:
             first_beat = spine_sequence[0]
@@ -910,10 +783,7 @@ def _reachable_via_choices(graph: Graph, passage_nodes: dict[str, dict[str, Any]
 
 
 def _reachable_via_arcs(graph: Graph, passage_nodes: dict[str, dict[str, Any]]) -> set[str]:
-    """Fallback: passages whose beats are in any arc traversal.
-
-    Prefers computed traversals; falls back to stored arc_contains edges.
-    """
+    """Fallback: passages whose beats are in any arc traversal."""
     from questfoundry.graph.algorithms import compute_arc_traversals
 
     traversals = compute_arc_traversals(graph)
@@ -921,10 +791,6 @@ def _reachable_via_arcs(graph: Graph, passage_nodes: dict[str, dict[str, Any]]) 
 
     if traversals:
         beats_in_arcs.update(*traversals.values())
-    else:
-        # Fallback: stored arc_contains edges
-        arc_contains_edges = graph.get_edges(edge_type="arc_contains")
-        beats_in_arcs = {edge["to"] for edge in arc_contains_edges}
 
     reachable: set[str] = set()
     for passage_id, passage_data in passage_nodes.items():

--- a/src/questfoundry/pipeline/stages/grow/stage.py
+++ b/src/questfoundry/pipeline/stages/grow/stage.py
@@ -356,23 +356,25 @@ class GrowStage(_LLMHelperMixin, _LLMPhaseMixin):
         graph.set_last_stage("grow")
         graph.save(resolved_path / "graph.db")
 
-        # Count created nodes
-        arc_nodes = graph.get_nodes_by_type("arc")
+        # Count created nodes and compute arc count from DAG
+        from questfoundry.graph.grow_algorithms import enumerate_arcs
+
+        arcs = enumerate_arcs(graph)
         passage_nodes = graph.get_nodes_by_type("passage")
         codeword_nodes = graph.get_nodes_by_type("codeword")
         choice_nodes = graph.get_nodes_by_type("choice")
         entity_nodes = graph.get_nodes_by_type("entity")
 
         spine_arc_id = None
-        for arc_id, arc_data in arc_nodes.items():
-            if arc_data.get("arc_type") == "spine":
-                spine_arc_id = arc_id
+        for arc in arcs:
+            if arc.arc_type == "spine":
+                spine_arc_id = f"arc::{arc.arc_id}"
                 break
 
         overlay_count = sum(len(data.get("overlays", [])) for data in entity_nodes.values())
 
         grow_result = GrowResult(
-            arc_count=len(arc_nodes),
+            arc_count=len(arcs),
             passage_count=len(passage_nodes),
             codeword_count=len(codeword_nodes),
             choice_count=len(choice_nodes),

--- a/src/questfoundry/pipeline/stages/grow/stage.py
+++ b/src/questfoundry/pipeline/stages/grow/stage.py
@@ -3,7 +3,7 @@
 The GROW stage builds the complete branching structure from the SEED
 graph. It runs a mix of deterministic and LLM-powered phases that
 enumerate arcs, assess path-agnostic beats, compute
-divergence/convergence points, create passages and codewords, and
+divergence/convergence points, create passages and state flags, and
 prune unreachable nodes.
 
 GROW manages its own graph: it loads, mutates, and saves the graph
@@ -40,7 +40,6 @@ from questfoundry.pipeline.stages.grow._helpers import (
 )
 from questfoundry.pipeline.stages.grow.deterministic import (  # noqa: F401 - register phases
     phase_apply_routing,
-    phase_codewords,
     phase_collapse_linear_beats,
     phase_collapse_passages,
     phase_convergence,
@@ -49,6 +48,7 @@ from questfoundry.pipeline.stages.grow.deterministic import (  # noqa: F401 - re
     phase_mark_endings,
     phase_passages,
     phase_prune,
+    phase_state_flags,
     phase_validate_dag,
     phase_validation,
 )
@@ -151,7 +151,7 @@ class GrowStage(_LLMHelperMixin, _LLMPhaseMixin):
         "convergence": "phase_convergence",
         "collapse_linear_beats": "phase_collapse_linear_beats",
         "passages": "phase_passages",
-        "codewords": "phase_codewords",
+        "state_flags": "phase_state_flags",
         "mark_endings": "phase_mark_endings",
         "apply_routing": "phase_apply_routing",
         "collapse_passages": "phase_collapse_passages",
@@ -361,7 +361,7 @@ class GrowStage(_LLMHelperMixin, _LLMPhaseMixin):
 
         arcs = enumerate_arcs(graph)
         passage_nodes = graph.get_nodes_by_type("passage")
-        codeword_nodes = graph.get_nodes_by_type("codeword")
+        state_flag_nodes = graph.get_nodes_by_type("state_flag")
         choice_nodes = graph.get_nodes_by_type("choice")
         entity_nodes = graph.get_nodes_by_type("entity")
 
@@ -376,7 +376,7 @@ class GrowStage(_LLMHelperMixin, _LLMPhaseMixin):
         grow_result = GrowResult(
             arc_count=len(arcs),
             passage_count=len(passage_nodes),
-            codeword_count=len(codeword_nodes),
+            state_flag_count=len(state_flag_nodes),
             choice_count=len(choice_nodes),
             overlay_count=overlay_count,
             phases_completed=phase_results,
@@ -388,7 +388,7 @@ class GrowStage(_LLMHelperMixin, _LLMPhaseMixin):
             stage="grow",
             arcs=grow_result.arc_count,
             passages=grow_result.passage_count,
-            codewords=grow_result.codeword_count,
+            state_flags=grow_result.state_flag_count,
         )
 
         # GROW manages its own graph; return summary data for validation

--- a/src/questfoundry/visualization.py
+++ b/src/questfoundry/visualization.py
@@ -57,7 +57,7 @@ class VizEdge:
     to_id: str
     label: str = ""
     is_return: bool = False
-    requires_codewords: list[str] = field(default_factory=list)
+    requires_state_flags: list[str] = field(default_factory=list)
     grants: list[str] = field(default_factory=list)
 
 
@@ -108,7 +108,7 @@ def build_story_graph(
             else:
                 passage_to_arc[pid] = arc_id
 
-    # Identify entities with overlays (codeword-dependent content)
+    # Identify entities with overlays (state-flag-dependent content)
     entities = graph.get_nodes_by_type("entity")
     overlay_entity_ids: set[str] = set()
     for eid, edata in entities.items():
@@ -184,7 +184,7 @@ def build_story_graph(
                 to_id=to_p,
                 label=cdata.get("label", ""),
                 is_return=cdata.get("is_return", False),
-                requires_codewords=cdata.get("requires_codewords", []),
+                requires_state_flags=cdata.get("requires_state_flags", []),
                 grants=cdata.get("grants", []),
             )
         )
@@ -239,7 +239,7 @@ def render_dot(sg: StoryGraph, *, no_labels: bool = False) -> str:
             edge_attrs["color"] = '"grey"'
         # Requires (gated) takes precedence over grants (state-changing).
         # Return edges keep their dashed grey style in both renderers.
-        if edge.requires_codewords:
+        if edge.requires_state_flags:
             edge_attrs["color"] = '"orange"'
             edge_attrs["penwidth"] = '"2"'
         elif edge.grants and not edge.is_return:
@@ -308,7 +308,7 @@ def render_mermaid(sg: StoryGraph, *, no_labels: bool = False) -> str:
     grants_indices = [
         i
         for i, e in enumerate(sg.edges)
-        if e.grants and not e.is_return and not e.requires_codewords
+        if e.grants and not e.is_return and not e.requires_state_flags
     ]
     if grants_indices:
         idx_list = ",".join(str(i) for i in grants_indices)

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -1406,7 +1406,7 @@ def test_grow_with_mock_provider(tmp_path: Path) -> None:
         "arc_count": 3,
         "passage_count": 12,
         "choice_count": 8,
-        "codeword_count": 4,
+        "state_flag_count": 4,
         "overlay_count": 2,
         "spine_arc_id": "arc_main",
         "phases_completed": [

--- a/tests/unit/test_dress_context.py
+++ b/tests/unit/test_dress_context.py
@@ -9,7 +9,7 @@ from questfoundry.graph.graph import Graph
 
 @pytest.fixture()
 def dress_graph() -> Graph:
-    """Graph with entities, passages, and codewords for DRESS testing."""
+    """Graph with entities, passages, and state flags for DRESS testing."""
     g = Graph()
     g.create_node(
         "vision::main",
@@ -70,9 +70,9 @@ def dress_graph() -> Graph:
         },
     )
     g.create_node(
-        "codeword::met_aldric",
+        "state_flag::met_aldric",
         {
-            "type": "codeword",
+            "type": "state_flag",
             "raw_id": "met_aldric",
             "trigger": "Player meets aldric at the bridge",
         },
@@ -150,7 +150,7 @@ class TestFormatEntityForCodex:
         assert "character" in result
         assert "court advisor" in result
 
-    def test_includes_related_codewords(self, dress_graph: Graph) -> None:
+    def test_includes_related_state_flags(self, dress_graph: Graph) -> None:
         from questfoundry.graph.dress_context import format_entity_for_codex
 
         result = format_entity_for_codex(dress_graph, "character::aldric")

--- a/tests/unit/test_dress_mutations.py
+++ b/tests/unit/test_dress_mutations.py
@@ -13,7 +13,7 @@ from questfoundry.graph.graph import Graph
 
 @pytest.fixture()
 def dress_graph() -> Graph:
-    """Graph with entities, passages, and codewords for DRESS testing."""
+    """Graph with entities, passages, and state flags for DRESS testing."""
     g = Graph()
     g.create_node(
         "entity::protagonist",
@@ -62,17 +62,17 @@ def dress_graph() -> Graph:
         },
     )
     g.create_node(
-        "codeword::met_aldric",
+        "state_flag::met_aldric",
         {
-            "type": "codeword",
+            "type": "state_flag",
             "raw_id": "met_aldric",
             "trigger": "Player meets aldric at the bridge",
         },
     )
     g.create_node(
-        "codeword::found_tome",
+        "state_flag::found_tome",
         {
-            "type": "codeword",
+            "type": "state_flag",
             "raw_id": "found_tome",
             "trigger": "Player discovers the ancient tome",
         },
@@ -511,7 +511,7 @@ class TestValidateDressCodexEntries:
         )
         assert any("duplicate rank=1" in e for e in errors)
 
-    def test_unknown_codeword(self, dress_graph: Graph) -> None:
+    def test_unknown_state_flag(self, dress_graph: Graph) -> None:
         from questfoundry.graph.dress_mutations import validate_dress_codex_entries
 
         errors = validate_dress_codex_entries(
@@ -522,4 +522,4 @@ class TestValidateDressCodexEntries:
                 {"rank": 2, "visible_when": ["nonexistent_cw"], "content": "gated"},
             ],
         )
-        assert any("unknown codeword" in e for e in errors)
+        assert any("unknown state flag" in e for e in errors)

--- a/tests/unit/test_fill_context.py
+++ b/tests/unit/test_fill_context.py
@@ -73,7 +73,7 @@ def fill_graph() -> Graph:
             "concept": "A young wanderer seeking answers",
             "overlays": [
                 {
-                    "when": ["codeword::betrayal_committed"],
+                    "when": ["state_flag::betrayal_committed"],
                     "details": {"mood": "bitter", "trust": "broken"},
                 }
             ],
@@ -1388,7 +1388,7 @@ class TestEndingDifferentiation:
         )
         assert format_ending_differentiation(g, "passage::finale") == ""
 
-    def test_returns_empty_when_no_family_codewords(self) -> None:
+    def test_returns_empty_when_no_family_state_flags(self) -> None:
         g = Graph.empty()
         g.create_node(
             "passage::ending_climax_0",
@@ -1397,7 +1397,7 @@ class TestEndingDifferentiation:
                 "raw_id": "ending_climax_0",
                 "is_ending": True,
                 "is_synthetic": True,
-                "family_codewords": [],
+                "family_state_flags": [],
             },
         )
         assert format_ending_differentiation(g, "passage::ending_climax_0") == ""
@@ -1407,7 +1407,7 @@ class TestEndingDifferentiation:
         assert format_ending_differentiation(g, "passage::nonexistent") == ""
 
     def test_returns_formatted_consequences(self) -> None:
-        """Synthetic ending with traceable codewords gets narrative context."""
+        """Synthetic ending with traceable state flags gets narrative context."""
         g = Graph.empty()
         # Path node
         g.create_node(
@@ -1428,17 +1428,17 @@ class TestEndingDifferentiation:
                 "description": "The ally stands by the hero in the final battle.",
             },
         )
-        # Codeword node
+        # State flag node
         g.create_node(
-            "codeword::cw_ally",
-            {"type": "codeword", "raw_id": "cw_ally"},
+            "state_flag::sf_ally",
+            {"type": "state_flag", "raw_id": "sf_ally"},
         )
-        # Edges: codeword --tracks--> consequence
-        g.add_edge("tracks", "codeword::cw_ally", "consequence::ally_trusted")
+        # Edges: state_flag --tracks--> consequence
+        g.add_edge("tracks", "state_flag::sf_ally", "consequence::ally_trusted")
         # path --has_consequence--> consequence
         g.add_edge("has_consequence", "path::ally_path", "consequence::ally_trusted")
 
-        # Synthetic ending passage referencing the codeword
+        # Synthetic ending passage referencing the state flag
         g.create_node(
             "passage::ending_climax_0",
             {
@@ -1446,7 +1446,7 @@ class TestEndingDifferentiation:
                 "raw_id": "ending_climax_0",
                 "is_ending": True,
                 "is_synthetic": True,
-                "family_codewords": ["cw_ally"],
+                "family_state_flags": ["sf_ally"],
             },
         )
 
@@ -1472,10 +1472,10 @@ class TestEndingDifferentiation:
             },
         )
         g.create_node(
-            "codeword::cw_shadow",
-            {"type": "codeword", "raw_id": "cw_shadow"},
+            "state_flag::sf_shadow",
+            {"type": "state_flag", "raw_id": "sf_shadow"},
         )
-        g.add_edge("tracks", "codeword::cw_shadow", "consequence::shadow")
+        g.add_edge("tracks", "state_flag::sf_shadow", "consequence::shadow")
         g.add_edge("has_consequence", "path::dark_path", "consequence::shadow")
         g.create_node(
             "passage::ending_0",
@@ -1484,7 +1484,7 @@ class TestEndingDifferentiation:
                 "raw_id": "ending_0",
                 "is_ending": True,
                 "is_synthetic": True,
-                "family_codewords": ["cw_shadow"],
+                "family_state_flags": ["sf_shadow"],
             },
         )
 
@@ -1492,18 +1492,18 @@ class TestEndingDifferentiation:
         assert "dark_path" in result
         assert "Shadows consume" in result
 
-    def test_skips_codewords_without_consequence_description(self) -> None:
-        """Codewords whose consequences lack descriptions are skipped."""
+    def test_skips_state_flags_without_consequence_description(self) -> None:
+        """State flags whose consequences lack descriptions are skipped."""
         g = Graph.empty()
         g.create_node(
             "consequence::empty_cons",
             {"type": "consequence", "raw_id": "empty_cons", "description": ""},
         )
         g.create_node(
-            "codeword::cw_empty",
-            {"type": "codeword", "raw_id": "cw_empty"},
+            "state_flag::sf_empty",
+            {"type": "state_flag", "raw_id": "sf_empty"},
         )
-        g.add_edge("tracks", "codeword::cw_empty", "consequence::empty_cons")
+        g.add_edge("tracks", "state_flag::sf_empty", "consequence::empty_cons")
         g.create_node(
             "passage::ending_1",
             {
@@ -1511,7 +1511,7 @@ class TestEndingDifferentiation:
                 "raw_id": "ending_1",
                 "is_ending": True,
                 "is_synthetic": True,
-                "family_codewords": ["cw_empty"],
+                "family_state_flags": ["sf_empty"],
             },
         )
 

--- a/tests/unit/test_fill_context.py
+++ b/tests/unit/test_fill_context.py
@@ -179,7 +179,49 @@ def fill_graph() -> Graph:
     g.add_edge("passage_from", "passage::p_aftermath", "beat::aftermath")
     g.add_edge("passage_from", "passage::p_branch_reveal", "beat::branch_reveal")
 
-    # Arcs
+    # Dilemma and path nodes (required for computed arc keys)
+    g.create_node(
+        "dilemma::mentor_trust",
+        {"type": "dilemma", "raw_id": "mentor_trust"},
+    )
+    g.create_node(
+        "path::mentor_trust__protector",
+        {
+            "type": "path",
+            "raw_id": "mentor_trust__protector",
+            "dilemma_id": "dilemma::mentor_trust",
+            "is_canonical": True,
+        },
+    )
+    g.create_node(
+        "path::mentor_trust__manipulator",
+        {
+            "type": "path",
+            "raw_id": "mentor_trust__manipulator",
+            "dilemma_id": "dilemma::mentor_trust",
+            "is_canonical": False,
+        },
+    )
+
+    # belongs_to edges: beat → path
+    # opening, explanation, aftermath are shared across both paths
+    g.add_edge("belongs_to", "beat::opening", "path::mentor_trust__protector")
+    g.add_edge("belongs_to", "beat::opening", "path::mentor_trust__manipulator")
+    g.add_edge("belongs_to", "beat::explanation", "path::mentor_trust__protector")
+    g.add_edge("belongs_to", "beat::explanation", "path::mentor_trust__manipulator")
+    g.add_edge("belongs_to", "beat::aftermath", "path::mentor_trust__protector")
+    g.add_edge("belongs_to", "beat::aftermath", "path::mentor_trust__manipulator")
+    # branch_reveal only on manipulator path
+    g.add_edge("belongs_to", "beat::branch_reveal", "path::mentor_trust__manipulator")
+
+    # predecessor edges: child → parent (dependent → prerequisite)
+    g.add_edge("predecessor", "beat::explanation", "beat::opening")
+    g.add_edge("predecessor", "beat::aftermath", "beat::explanation")
+    g.add_edge("predecessor", "beat::branch_reveal", "beat::explanation")
+    # On the manipulator path, branch_reveal comes before aftermath
+    g.add_edge("predecessor", "beat::aftermath", "beat::branch_reveal")
+
+    # Arcs (kept for fallback path and format_grow_summary / format_lookahead_context)
     g.create_node(
         "arc::spine_0_0",
         {
@@ -219,7 +261,7 @@ def fill_graph() -> Graph:
 
 class TestGetSpineArcId:
     def test_finds_spine(self, fill_graph: Graph) -> None:
-        assert get_spine_arc_id(fill_graph) == "arc::spine_0_0"
+        assert get_spine_arc_id(fill_graph) == "mentor_trust__protector"
 
     def test_no_arcs(self) -> None:
         g = Graph.empty()
@@ -233,6 +275,15 @@ class TestGetSpineArcId:
 
 class TestGetArcPassageOrder:
     def test_spine_order(self, fill_graph: Graph) -> None:
+        order = get_arc_passage_order(fill_graph, "mentor_trust__protector")
+        assert order == [
+            "passage::p_opening",
+            "passage::p_explanation",
+            "passage::p_aftermath",
+        ]
+
+    def test_spine_order_via_arc_node(self, fill_graph: Graph) -> None:
+        """Arc node ID resolves to computed traversal via _resolve_arc_key."""
         order = get_arc_passage_order(fill_graph, "arc::spine_0_0")
         assert order == [
             "passage::p_opening",
@@ -241,7 +292,7 @@ class TestGetArcPassageOrder:
         ]
 
     def test_branch_order(self, fill_graph: Graph) -> None:
-        order = get_arc_passage_order(fill_graph, "arc::branch_1_0")
+        order = get_arc_passage_order(fill_graph, "mentor_trust__manipulator")
         assert order == [
             "passage::p_opening",
             "passage::p_explanation",
@@ -363,23 +414,23 @@ class TestFormatPassageContext:
 
 class TestFormatSlidingWindow:
     def test_first_passage_no_window(self, fill_graph: Graph) -> None:
-        result = format_sliding_window(fill_graph, "arc::spine_0_0", 0)
+        result = format_sliding_window(fill_graph, "mentor_trust__protector", 0)
         assert result == "(no previous passages)"
 
     def test_second_passage_has_window(self, fill_graph: Graph) -> None:
-        result = format_sliding_window(fill_graph, "arc::spine_0_0", 1)
+        result = format_sliding_window(fill_graph, "mentor_trust__protector", 1)
         assert "p_opening" in result
         assert "tower stairs" in result
 
     def test_window_size_limits(self, fill_graph: Graph) -> None:
-        result = format_sliding_window(fill_graph, "arc::spine_0_0", 2, window_size=1)
+        result = format_sliding_window(fill_graph, "mentor_trust__protector", 2, window_size=1)
         # Should only include the immediately preceding passage
         assert "p_explanation" in result
         assert "p_opening" not in result
 
     def test_no_prose_skipped(self, fill_graph: Graph) -> None:
         # p_aftermath has no prose — window should skip it
-        result = format_sliding_window(fill_graph, "arc::spine_0_0", 2, window_size=3)
+        result = format_sliding_window(fill_graph, "mentor_trust__protector", 2, window_size=3)
         assert "p_opening" in result
         assert "p_explanation" in result
 
@@ -390,14 +441,18 @@ class TestFormatSlidingWindow:
 
 
 class TestFormatLookaheadContext:
-    def test_convergence_point(self, fill_graph: Graph) -> None:
-        # p_aftermath is convergence point for branch_1_0
-        result = format_lookahead_context(fill_graph, "passage::p_aftermath", "arc::spine_0_0")
-        assert "Convergence" in result
-        assert "branch_1_0" in result
+    def test_convergence_point_no_longer_emitted(self, fill_graph: Graph) -> None:
+        # Convergence context was removed (relied on stored arc nodes).
+        # p_aftermath is on the spine arc, so lookahead returns empty.
+        result = format_lookahead_context(
+            fill_graph, "passage::p_aftermath", "mentor_trust__protector"
+        )
+        assert result == ""
 
     def test_no_lookahead_needed(self, fill_graph: Graph) -> None:
-        result = format_lookahead_context(fill_graph, "passage::p_opening", "arc::spine_0_0")
+        result = format_lookahead_context(
+            fill_graph, "passage::p_opening", "mentor_trust__protector"
+        )
         assert result == ""
 
 
@@ -1469,70 +1524,102 @@ class TestEndingDifferentiation:
 
 
 class TestEchoPrompt:
-    """Tests for thematic echo at convergence points."""
+    """Tests for thematic echo at branch divergence points."""
 
-    def test_convergence_includes_echo(self) -> None:
-        """At convergence, lookahead should include opening passage echo."""
+    def test_divergence_includes_echo(self) -> None:
+        """At branch divergence, lookahead should include opening passage echo."""
         g = Graph()
-        # Spine arc with two beats
+
+        # Dilemma + paths for computed arcs
+        g.create_node("dilemma::d1", {"type": "dilemma", "raw_id": "d1"})
         g.create_node(
-            "arc::spine",
+            "path::canon",
             {
-                "type": "arc",
-                "arc_type": "spine",
-                "sequence": ["beat::b1", "beat::conv"],
+                "type": "path",
+                "raw_id": "canon",
+                "dilemma_id": "dilemma::d1",
+                "is_canonical": True,
             },
         )
-        # Branch arc converging at beat::conv
         g.create_node(
-            "arc::branch",
+            "path::alt",
             {
-                "type": "arc",
-                "arc_type": "branch",
-                "converges_at": "beat::conv",
-                "sequence": ["beat::br1"],
+                "type": "path",
+                "raw_id": "alt",
+                "dilemma_id": "dilemma::d1",
+                "is_canonical": False,
             },
         )
-        g.create_node("beat::b1", {"type": "beat", "summary": "opening"})
-        g.create_node("beat::conv", {"type": "beat", "summary": "convergence"})
-        g.create_node("beat::br1", {"type": "beat", "summary": "branch beat"})
+
+        # Shared beat (on both paths) and branch-only beat
+        g.create_node("beat::b1", {"type": "beat", "raw_id": "b1", "summary": "opening"})
+        g.create_node("beat::br1", {"type": "beat", "raw_id": "br1", "summary": "branch beat"})
+        g.add_edge("belongs_to", "beat::b1", "path::canon")
+        g.add_edge("belongs_to", "beat::b1", "path::alt")
+        g.add_edge("belongs_to", "beat::br1", "path::alt")
+        g.add_edge("predecessor", "beat::br1", "beat::b1")
+
+        # Passages
         g.create_node(
             "passage::p1",
-            {"type": "passage", "from_beat": "beat::b1", "prose": "The rain began to fall."},
+            {
+                "type": "passage",
+                "raw_id": "p1",
+                "from_beat": "beat::b1",
+                "prose": "The rain began to fall.",
+            },
         )
         g.create_node(
-            "passage::conv",
-            {"type": "passage", "from_beat": "beat::conv"},
+            "passage::br1",
+            {"type": "passage", "raw_id": "br1", "from_beat": "beat::br1"},
         )
         g.add_edge("passage_from", "passage::p1", "beat::b1")
-        g.add_edge("passage_from", "passage::conv", "beat::conv")
+        g.add_edge("passage_from", "passage::br1", "beat::br1")
+        g.add_edge("grouped_in", "beat::b1", "passage::p1")
+        g.add_edge("grouped_in", "beat::br1", "passage::br1")
 
-        result = format_lookahead_context(g, "passage::conv", "arc::spine")
+        # The branch arc key is "alt" (single non-canonical path)
+        result = format_lookahead_context(g, "passage::br1", "alt")
         assert "Thematic Echo" in result
         assert "The rain began to fall." in result
 
     def test_no_echo_at_normal_passage(self) -> None:
         """Non-juncture passages should not have echo prompts."""
         g = Graph()
+
+        # Dilemma + path for computed arcs
+        g.create_node("dilemma::d1", {"type": "dilemma", "raw_id": "d1"})
         g.create_node(
-            "arc::spine",
+            "path::canon",
             {
-                "type": "arc",
-                "arc_type": "spine",
-                "sequence": ["beat::b1", "beat::b2"],
+                "type": "path",
+                "raw_id": "canon",
+                "dilemma_id": "dilemma::d1",
+                "is_canonical": True,
             },
         )
-        g.create_node("beat::b1", {"type": "beat"})
-        g.create_node("beat::b2", {"type": "beat"})
+
+        g.create_node("beat::b1", {"type": "beat", "raw_id": "b1"})
+        g.create_node("beat::b2", {"type": "beat", "raw_id": "b2"})
+        g.add_edge("belongs_to", "beat::b1", "path::canon")
+        g.add_edge("belongs_to", "beat::b2", "path::canon")
+        g.add_edge("predecessor", "beat::b2", "beat::b1")
+
         g.create_node(
             "passage::p1",
-            {"type": "passage", "from_beat": "beat::b1", "prose": "Opening."},
+            {"type": "passage", "raw_id": "p1", "from_beat": "beat::b1", "prose": "Opening."},
         )
-        g.create_node("passage::p2", {"type": "passage", "from_beat": "beat::b2"})
+        g.create_node(
+            "passage::p2",
+            {"type": "passage", "raw_id": "p2", "from_beat": "beat::b2"},
+        )
         g.add_edge("passage_from", "passage::p1", "beat::b1")
         g.add_edge("passage_from", "passage::p2", "beat::b2")
+        g.add_edge("grouped_in", "beat::b1", "passage::p1")
+        g.add_edge("grouped_in", "beat::b2", "passage::p2")
 
-        result = format_lookahead_context(g, "passage::p2", "arc::spine")
+        # Spine arc key is "canon"
+        result = format_lookahead_context(g, "passage::p2", "canon")
         assert "Thematic Echo" not in result
 
 

--- a/tests/unit/test_grow_models.py
+++ b/tests/unit/test_grow_models.py
@@ -10,7 +10,6 @@ from questfoundry.models.grow import (
     AtmosphericDetail,
     Choice,
     ChoiceLabel,
-    Codeword,
     EntityArcDescriptor,
     EntityOverlay,
     GapProposal,
@@ -28,6 +27,7 @@ from questfoundry.models.grow import (
     ResidueVariant,
     SceneTypeTag,
     SpokeProposal,
+    StateFlag,
 )
 
 
@@ -125,30 +125,30 @@ class TestPassage:
             Passage(passage_id="p1", from_beat="b1", summary="")
 
 
-class TestCodeword:
-    def test_valid_codeword(self) -> None:
-        cw = Codeword(
-            codeword_id="codeword::mentor_trust_committed",
+class TestStateFlag:
+    def test_valid_state_flag(self) -> None:
+        sf = StateFlag(
+            flag_id="state_flag::mentor_trust_committed",
             tracks="consequence::mentor_trust",
         )
-        assert cw.codeword_id == "codeword::mentor_trust_committed"
-        assert cw.codeword_type == "granted"
+        assert sf.flag_id == "state_flag::mentor_trust_committed"
+        assert sf.flag_type == "granted"
 
     def test_default_type_is_granted(self) -> None:
-        cw = Codeword(codeword_id="cw1", tracks="c1")
-        assert cw.codeword_type == "granted"
+        sf = StateFlag(flag_id="sf1", tracks="c1")
+        assert sf.flag_type == "granted"
 
-    def test_empty_codeword_id_rejected(self) -> None:
-        with pytest.raises(ValidationError, match="codeword_id"):
-            Codeword(codeword_id="", tracks="c1")
+    def test_empty_flag_id_rejected(self) -> None:
+        with pytest.raises(ValidationError, match="flag_id"):
+            StateFlag(flag_id="", tracks="c1")
 
     def test_empty_tracks_rejected(self) -> None:
         with pytest.raises(ValidationError, match="tracks"):
-            Codeword(codeword_id="cw1", tracks="")
+            StateFlag(flag_id="sf1", tracks="")
 
-    def test_invalid_codeword_type_rejected(self) -> None:
-        with pytest.raises(ValidationError, match="codeword_type"):
-            Codeword(codeword_id="cw1", tracks="c1", codeword_type="revoked")  # type: ignore[arg-type]
+    def test_invalid_flag_type_rejected(self) -> None:
+        with pytest.raises(ValidationError, match="flag_type"):
+            StateFlag(flag_id="sf1", tracks="c1", flag_type="revoked")  # type: ignore[arg-type]
 
 
 class TestChoice:
@@ -157,15 +157,15 @@ class TestChoice:
             from_passage="p1",
             to_passage="p2",
             label="Go left",
-            requires_codewords=["cw1"],
-            grants=["cw2"],
+            requires_state_flags=["sf1"],
+            grants=["sf2"],
         )
         assert choice.from_passage == "p1"
-        assert choice.requires_codewords == ["cw1"]
+        assert choice.requires_state_flags == ["sf1"]
 
     def test_empty_requires_grants_allowed(self) -> None:
         choice = Choice(from_passage="p1", to_passage="p2", label="Continue")
-        assert choice.requires_codewords == []
+        assert choice.requires_state_flags == []
         assert choice.grants == []
 
     def test_empty_label_rejected(self) -> None:
@@ -393,7 +393,7 @@ class TestGrowResult:
         result = GrowResult()
         assert result.arc_count == 0
         assert result.passage_count == 0
-        assert result.codeword_count == 0
+        assert result.state_flag_count == 0
         assert result.phases_completed == []
         assert result.spine_arc_id is None
 
@@ -401,7 +401,7 @@ class TestGrowResult:
         result = GrowResult(
             arc_count=4,
             passage_count=8,
-            codeword_count=2,
+            state_flag_count=2,
             phases_completed=[
                 GrowPhaseResult(phase="validate", status="completed"),
                 GrowPhaseResult(phase="arcs", status="completed"),
@@ -428,7 +428,7 @@ class TestGrowResult:
         data = {
             "arc_count": 3,
             "passage_count": 6,
-            "codeword_count": 1,
+            "state_flag_count": 1,
             "phases_completed": [
                 {"phase": "validate", "status": "completed", "detail": ""},
             ],
@@ -650,23 +650,23 @@ class TestResidueVariant:
 
     def test_valid_variant(self) -> None:
         v = ResidueVariant(
-            codeword_id="codeword::fistfight_committed",
+            state_flag_id="state_flag::fistfight_committed",
             hint="mention the scar from the fight",
         )
-        assert v.codeword_id == "codeword::fistfight_committed"
+        assert v.state_flag_id == "state_flag::fistfight_committed"
         assert "scar" in v.hint
 
-    def test_empty_codeword_rejected(self) -> None:
-        with pytest.raises(ValidationError, match="codeword_id"):
-            ResidueVariant(codeword_id="", hint="a valid hint that is long enough")
+    def test_empty_state_flag_rejected(self) -> None:
+        with pytest.raises(ValidationError, match="state_flag_id"):
+            ResidueVariant(state_flag_id="", hint="a valid hint that is long enough")
 
     def test_short_hint_rejected(self) -> None:
         with pytest.raises(ValidationError, match="hint"):
-            ResidueVariant(codeword_id="codeword::x", hint="too short")
+            ResidueVariant(state_flag_id="state_flag::x", hint="too short")
 
     def test_long_hint_rejected(self) -> None:
         with pytest.raises(ValidationError, match="hint"):
-            ResidueVariant(codeword_id="codeword::x", hint="a" * 201)
+            ResidueVariant(state_flag_id="state_flag::x", hint="a" * 201)
 
 
 class TestResidueBeatProposal:
@@ -679,11 +679,11 @@ class TestResidueBeatProposal:
             rationale="The aftermath should acknowledge whether the hero fought or argued",
             variants=[
                 ResidueVariant(
-                    codeword_id="codeword::fistfight_committed",
+                    state_flag_id="state_flag::fistfight_committed",
                     hint="mention the scar from the fight",
                 ),
                 ResidueVariant(
-                    codeword_id="codeword::argue_committed",
+                    state_flag_id="state_flag::argue_committed",
                     hint="mention the lingering tension from the argument",
                 ),
             ],
@@ -699,25 +699,25 @@ class TestResidueBeatProposal:
                 rationale="some rationale here",
                 variants=[
                     ResidueVariant(
-                        codeword_id="codeword::a",
+                        state_flag_id="state_flag::a",
                         hint="only one variant is not enough",
                     )
                 ],
             )
 
-    def test_duplicate_codewords_rejected(self) -> None:
-        with pytest.raises(ValidationError, match=r"codeword_id.*unique"):
+    def test_duplicate_state_flags_rejected(self) -> None:
+        with pytest.raises(ValidationError, match=r"state_flag_id.*unique"):
             ResidueBeatProposal(
                 passage_id="passage::x",
                 dilemma_id="dilemma::y",
                 rationale="rationale for this residue",
                 variants=[
                     ResidueVariant(
-                        codeword_id="codeword::same",
+                        state_flag_id="state_flag::same",
                         hint="first variant hint text here",
                     ),
                     ResidueVariant(
-                        codeword_id="codeword::same",
+                        state_flag_id="state_flag::same",
                         hint="second variant hint text here",
                     ),
                 ],
@@ -730,8 +730,8 @@ class TestResidueBeatProposal:
                 dilemma_id="dilemma::y",
                 rationale="some rationale here",
                 variants=[
-                    ResidueVariant(codeword_id="codeword::a", hint="hint text a long enough"),
-                    ResidueVariant(codeword_id="codeword::b", hint="hint text b long enough"),
+                    ResidueVariant(state_flag_id="state_flag::a", hint="hint text a long enough"),
+                    ResidueVariant(state_flag_id="state_flag::b", hint="hint text b long enough"),
                 ],
             )
 
@@ -752,11 +752,11 @@ class TestPhase8dOutput:
                     rationale="trust aftermath differs by path",
                     variants=[
                         ResidueVariant(
-                            codeword_id="codeword::trust_committed",
+                            state_flag_id="state_flag::trust_committed",
                             hint="hero recalls the leap of faith",
                         ),
                         ResidueVariant(
-                            codeword_id="codeword::distrust_committed",
+                            state_flag_id="state_flag::distrust_committed",
                             hint="hero recalls the cold suspicion",
                         ),
                     ],

--- a/tests/unit/test_grow_registry.py
+++ b/tests/unit/test_grow_registry.py
@@ -245,7 +245,7 @@ class TestGlobalRegistry:
             "convergence",
             "collapse_linear_beats",
             "passages",
-            "codewords",
+            "state_flags",
             "residue_beats",
             "overlays",
             "choices",
@@ -272,8 +272,8 @@ class TestGlobalRegistry:
         assert "prune" in table
 
     def test_apply_routing_has_three_dependencies(self) -> None:
-        """apply_routing depends on mark_endings, codewords, and residue_beats (S3, ADR-017)."""
+        """apply_routing depends on mark_endings, state_flags, and residue_beats (S3, ADR-017)."""
         registry = get_registry()
         meta = registry.get_meta("apply_routing")
         assert meta is not None
-        assert set(meta.depends_on) == {"mark_endings", "codewords", "residue_beats"}
+        assert set(meta.depends_on) == {"mark_endings", "state_flags", "residue_beats"}

--- a/tests/unit/test_grow_stage.py
+++ b/tests/unit/test_grow_stage.py
@@ -60,7 +60,7 @@ class TestGrowStageExecute:
             "arc_count",
             "passage_count",
             "choice_count",
-            "codeword_count",
+            "state_flag_count",
             "overlay_count",
             "spine_arc_id",
             "phases_completed",
@@ -69,7 +69,7 @@ class TestGrowStageExecute:
         assert result_dict["arc_count"] == 0
         assert result_dict["passage_count"] == 0
         assert result_dict["choice_count"] == 0
-        assert result_dict["codeword_count"] == 0
+        assert result_dict["state_flag_count"] == 0
 
     @pytest.mark.asyncio
     async def test_execute_with_project_path_kwarg(
@@ -173,7 +173,7 @@ class TestGrowStageExecute:
             "arc_count",
             "passage_count",
             "choice_count",
-            "codeword_count",
+            "state_flag_count",
             "overlay_count",
             "spine_arc_id",
             "phases_completed",
@@ -205,7 +205,7 @@ class TestGrowStagePhaseOrder:
             "convergence",
             "collapse_linear_beats",
             "passages",
-            "codewords",
+            "state_flags",
             "residue_beats",
             "overlays",
             "choices",
@@ -1358,16 +1358,16 @@ class TestPhase8cOverlays:
             },
         )
         graph.create_node(
-            "codeword::mentor_trusted_committed",
+            "state_flag::mentor_trusted_committed",
             {
-                "type": "codeword",
+                "type": "state_flag",
                 "raw_id": "mentor_trusted_committed",
                 "tracks": "consequence::mentor_trusted",
-                "codeword_type": "granted",
+                "flag_type": "granted",
             },
         )
         graph.add_edge(
-            "tracks", "codeword::mentor_trusted_committed", "consequence::mentor_trusted"
+            "tracks", "state_flag::mentor_trusted_committed", "consequence::mentor_trusted"
         )
 
         stage = GrowStage()
@@ -1375,7 +1375,7 @@ class TestPhase8cOverlays:
             overlays=[
                 OverlayProposal(
                     entity_id="entity::mentor",
-                    when=["codeword::mentor_trusted_committed"],
+                    when=["state_flag::mentor_trusted_committed"],
                     details=[
                         {"key": "attitude", "value": "Warm and supportive"},
                         {"key": "access", "value": "Shares secret knowledge"},
@@ -1399,7 +1399,7 @@ class TestPhase8cOverlays:
         entity_data = graph.get_node("entity::mentor")
         assert entity_data is not None
         assert len(entity_data["overlays"]) == 1
-        assert entity_data["overlays"][0]["when"] == ["codeword::mentor_trusted_committed"]
+        assert entity_data["overlays"][0]["when"] == ["state_flag::mentor_trusted_committed"]
         assert entity_data["overlays"][0]["details"]["attitude"] == "Warm and supportive"
 
     @pytest.mark.asyncio
@@ -1419,12 +1419,12 @@ class TestPhase8cOverlays:
             },
         )
         graph.create_node(
-            "codeword::cw1",
+            "state_flag::cw1",
             {
-                "type": "codeword",
+                "type": "state_flag",
                 "raw_id": "cw1",
                 "tracks": "consequence::c1",
-                "codeword_type": "granted",
+                "flag_type": "granted",
             },
         )
 
@@ -1433,7 +1433,7 @@ class TestPhase8cOverlays:
             overlays=[
                 OverlayProposal(
                     entity_id="entity::nonexistent",
-                    when=["codeword::cw1"],
+                    when=["state_flag::cw1"],
                     details=[{"key": "attitude", "value": "Changed"}],
                 ),
             ]
@@ -1450,8 +1450,8 @@ class TestPhase8cOverlays:
         assert "0" in result.detail
 
     @pytest.mark.asyncio
-    async def test_phase_8c_skips_invalid_codeword(self) -> None:
-        """Phase 8c skips overlays referencing non-existent codewords."""
+    async def test_phase_8c_skips_invalid_state_flag(self) -> None:
+        """Phase 8c skips overlays referencing non-existent state_flags."""
         from questfoundry.graph.graph import Graph
         from questfoundry.models.grow import OverlayProposal, Phase8cOutput
 
@@ -1466,12 +1466,12 @@ class TestPhase8cOverlays:
             },
         )
         graph.create_node(
-            "codeword::cw1",
+            "state_flag::cw1",
             {
-                "type": "codeword",
+                "type": "state_flag",
                 "raw_id": "cw1",
                 "tracks": "consequence::c1",
-                "codeword_type": "granted",
+                "flag_type": "granted",
             },
         )
 
@@ -1480,7 +1480,7 @@ class TestPhase8cOverlays:
             overlays=[
                 OverlayProposal(
                     entity_id="entity::hero",
-                    when=["codeword::nonexistent"],
+                    when=["state_flag::nonexistent"],
                     details=[{"key": "attitude", "value": "Changed"}],
                 ),
             ]
@@ -1502,8 +1502,8 @@ class TestPhase8cOverlays:
     # is no longer reachable since the model won't validate with empty details.
 
     @pytest.mark.asyncio
-    async def test_phase_8c_no_codewords(self) -> None:
-        """Phase 8c returns completed when no codewords exist."""
+    async def test_phase_8c_no_state_flags(self) -> None:
+        """Phase 8c returns completed when no state_flags exist."""
         from questfoundry.graph.graph import Graph
 
         graph = Graph.empty()
@@ -1523,7 +1523,7 @@ class TestPhase8cOverlays:
         result = await stage._phase_8c_overlays(graph, mock_model)
 
         assert result.status == "completed"
-        assert "No codewords or entities" in result.detail
+        assert "No state flags or entities" in result.detail
 
     @pytest.mark.asyncio
     async def test_phase_8c_unprefixed_entity_id(self) -> None:
@@ -1542,12 +1542,12 @@ class TestPhase8cOverlays:
             },
         )
         graph.create_node(
-            "codeword::cw1",
+            "state_flag::cw1",
             {
-                "type": "codeword",
+                "type": "state_flag",
                 "raw_id": "cw1",
                 "tracks": "consequence::c1",
-                "codeword_type": "granted",
+                "flag_type": "granted",
             },
         )
 
@@ -1556,7 +1556,7 @@ class TestPhase8cOverlays:
             overlays=[
                 OverlayProposal(
                     entity_id="mentor",  # No prefix
-                    when=["codeword::cw1"],
+                    when=["state_flag::cw1"],
                     details=[{"key": "attitude", "value": "Friendly"}],
                 ),
             ]
@@ -1578,7 +1578,7 @@ class TestPhase8cOverlays:
 
     @pytest.mark.asyncio
     async def test_phase8c_consequence_context_full_chain(self) -> None:
-        """Enriched context traces codeword → consequence → path → dilemma."""
+        """Enriched context traces state_flag → consequence → path → dilemma."""
         from unittest.mock import patch
 
         from questfoundry.graph.graph import Graph
@@ -1636,12 +1636,12 @@ class TestPhase8cOverlays:
             },
         )
         graph.create_node(
-            "codeword::mentor_trusted_committed",
+            "state_flag::mentor_trusted_committed",
             {
-                "type": "codeword",
+                "type": "state_flag",
                 "raw_id": "mentor_trusted_committed",
                 "tracks": "consequence::mentor_trusted",
-                "codeword_type": "granted",
+                "flag_type": "granted",
             },
         )
 
@@ -1662,7 +1662,7 @@ class TestPhase8cOverlays:
             await stage._phase_8c_overlays(graph, MagicMock())
 
         ctx = captured_context["consequence_context"]
-        assert "codeword::mentor_trusted_committed" in ctx
+        assert "state_flag::mentor_trusted_committed" in ctx
         assert 'Path: path::trust_or_betray__trust ("The Trusting Path")' in ctx
         assert 'Dilemma: "Do you trust or betray the mentor?"' in ctx
         assert "Central entities: mentor, hero" in ctx
@@ -1693,12 +1693,12 @@ class TestPhase8cOverlays:
             },
         )
         graph.create_node(
-            "codeword::hero_saved_committed",
+            "state_flag::hero_saved_committed",
             {
-                "type": "codeword",
+                "type": "state_flag",
                 "raw_id": "hero_saved_committed",
                 "tracks": "consequence::hero_saved",
-                "codeword_type": "granted",
+                "flag_type": "granted",
             },
         )
 
@@ -1719,7 +1719,7 @@ class TestPhase8cOverlays:
             await stage._phase_8c_overlays(graph, MagicMock())
 
         ctx = captured_context["consequence_context"]
-        assert "codeword::hero_saved_committed" in ctx
+        assert "state_flag::hero_saved_committed" in ctx
         assert "Consequence: The hero survives the ordeal" in ctx
         # No path/dilemma lines since path node is missing
         assert "Path:" not in ctx
@@ -1748,12 +1748,12 @@ class TestPhase8cOverlays:
             },
         )
         graph.create_node(
-            "codeword::secret_revealed_committed",
+            "state_flag::secret_revealed_committed",
             {
-                "type": "codeword",
+                "type": "state_flag",
                 "raw_id": "secret_revealed_committed",
                 "tracks": "consequence::secret_revealed",
-                "codeword_type": "granted",
+                "flag_type": "granted",
             },
         )
 
@@ -1794,20 +1794,18 @@ class TestPhase9Choices:
         graph.add_edge("predecessor", "beat::b", "beat::a")
         graph.add_edge("predecessor", "beat::c", "beat::b")
 
-        # Create arc with sequence
+        # Create dilemma + path structure for computed arcs
         graph.create_node(
-            "arc::spine",
-            {
-                "type": "arc",
-                "raw_id": "spine",
-                "arc_type": "spine",
-                "paths": ["t1"],
-                "sequence": ["beat::a", "beat::b", "beat::c"],
-            },
+            "dilemma::d1",
+            {"type": "dilemma", "raw_id": "d1", "paths": ["t1"]},
         )
-        graph.add_edge("arc_contains", "arc::spine", "beat::a")
-        graph.add_edge("arc_contains", "arc::spine", "beat::b")
-        graph.add_edge("arc_contains", "arc::spine", "beat::c")
+        graph.create_node(
+            "path::t1",
+            {"type": "path", "raw_id": "t1", "dilemma_id": "dilemma::d1", "is_canonical": True},
+        )
+        graph.add_edge("belongs_to", "beat::a", "path::t1")
+        graph.add_edge("belongs_to", "beat::b", "path::t1")
+        graph.add_edge("belongs_to", "beat::c", "path::t1")
 
         # Create passages
         for bid in ["a", "b", "c"]:
@@ -1873,18 +1871,17 @@ class TestPhase9Choices:
         graph.create_node("beat::b", {"type": "beat", "raw_id": "b", "summary": "End"})
         graph.add_edge("predecessor", "beat::b", "beat::a")
 
+        # Create dilemma + path structure for computed arcs
         graph.create_node(
-            "arc::spine",
-            {
-                "type": "arc",
-                "raw_id": "spine",
-                "arc_type": "spine",
-                "paths": ["t1"],
-                "sequence": ["beat::a", "beat::b"],
-            },
+            "dilemma::d1",
+            {"type": "dilemma", "raw_id": "d1", "paths": ["t1"]},
         )
-        graph.add_edge("arc_contains", "arc::spine", "beat::a")
-        graph.add_edge("arc_contains", "arc::spine", "beat::b")
+        graph.create_node(
+            "path::t1",
+            {"type": "path", "raw_id": "t1", "dilemma_id": "dilemma::d1", "is_canonical": True},
+        )
+        graph.add_edge("belongs_to", "beat::a", "path::t1")
+        graph.add_edge("belongs_to", "beat::b", "path::t1")
 
         for bid in ["a", "b"]:
             graph.create_node(
@@ -1918,16 +1915,23 @@ class TestPhase9Choices:
         for bid in ["a", "b", "c", "d", "e"]:
             graph.create_node(f"beat::{bid}", {"type": "beat", "raw_id": bid, "summary": bid})
 
+        # predecessor edges for ordering
+        graph.add_edge("predecessor", "beat::b", "beat::a")
+        graph.add_edge("predecessor", "beat::c", "beat::b")
+        graph.add_edge("predecessor", "beat::d", "beat::c")
+        graph.add_edge("predecessor", "beat::e", "beat::d")
+
+        # Create dilemma + path structure for computed arcs
         graph.create_node(
-            "arc::spine",
-            {
-                "type": "arc",
-                "raw_id": "spine",
-                "arc_type": "spine",
-                "paths": ["t1"],
-                "sequence": ["beat::a", "beat::b", "beat::c", "beat::d", "beat::e"],
-            },
+            "dilemma::d1",
+            {"type": "dilemma", "raw_id": "d1", "paths": ["t1"]},
         )
+        graph.create_node(
+            "path::t1",
+            {"type": "path", "raw_id": "t1", "dilemma_id": "dilemma::d1", "is_canonical": True},
+        )
+        for bid in ["a", "b", "c", "d", "e"]:
+            graph.add_edge("belongs_to", f"beat::{bid}", "path::t1")
 
         for bid in ["a", "b", "c", "d", "e"]:
             graph.create_node(
@@ -1969,27 +1973,39 @@ class TestPhase9Choices:
         graph.create_node("beat::b", {"type": "beat", "raw_id": "b", "summary": "Trust mentor"})
         graph.create_node("beat::c", {"type": "beat", "raw_id": "c", "summary": "Reject mentor"})
 
-        # Two arcs diverging at 'a'
+        # predecessor edges for ordering
+        graph.add_edge("predecessor", "beat::b", "beat::a")
+        graph.add_edge("predecessor", "beat::c", "beat::a")
+
+        # Create dilemma + path structure for computed arcs (two paths = divergence)
         graph.create_node(
-            "arc::spine",
+            "dilemma::d1",
+            {"type": "dilemma", "raw_id": "d1", "paths": ["t1_canon", "t1_alt"]},
+        )
+        graph.create_node(
+            "path::t1_canon",
             {
-                "type": "arc",
-                "raw_id": "spine",
-                "arc_type": "spine",
-                "paths": ["t1_canon"],
-                "sequence": ["beat::a", "beat::b"],
+                "type": "path",
+                "raw_id": "t1_canon",
+                "dilemma_id": "dilemma::d1",
+                "is_canonical": True,
             },
         )
         graph.create_node(
-            "arc::branch",
+            "path::t1_alt",
             {
-                "type": "arc",
-                "raw_id": "branch",
-                "arc_type": "branch",
-                "paths": ["t1_alt"],
-                "sequence": ["beat::a", "beat::c"],
+                "type": "path",
+                "raw_id": "t1_alt",
+                "dilemma_id": "dilemma::d1",
+                "is_canonical": False,
             },
         )
+        # beat::a is shared (belongs to both paths)
+        graph.add_edge("belongs_to", "beat::a", "path::t1_canon")
+        graph.add_edge("belongs_to", "beat::a", "path::t1_alt")
+        # beat::b is exclusive to canon, beat::c to alt
+        graph.add_edge("belongs_to", "beat::b", "path::t1_canon")
+        graph.add_edge("belongs_to", "beat::c", "path::t1_alt")
 
         # Create passages
         for bid in ["a", "b", "c"]:
@@ -2084,26 +2100,27 @@ class TestPhase9Choices:
         graph.create_node("beat::b", {"type": "beat", "raw_id": "b", "summary": "Left"})
         graph.create_node("beat::c", {"type": "beat", "raw_id": "c", "summary": "Right"})
 
+        # predecessor edges for ordering
+        graph.add_edge("predecessor", "beat::b", "beat::a")
+        graph.add_edge("predecessor", "beat::c", "beat::a")
+
+        # Create dilemma + path structure for computed arcs (two paths = divergence)
         graph.create_node(
-            "arc::spine",
-            {
-                "type": "arc",
-                "raw_id": "spine",
-                "arc_type": "spine",
-                "paths": ["t1"],
-                "sequence": ["beat::a", "beat::b"],
-            },
+            "dilemma::d1",
+            {"type": "dilemma", "raw_id": "d1", "paths": ["t1", "t2"]},
         )
         graph.create_node(
-            "arc::branch",
-            {
-                "type": "arc",
-                "raw_id": "branch",
-                "arc_type": "branch",
-                "paths": ["t2"],
-                "sequence": ["beat::a", "beat::c"],
-            },
+            "path::t1",
+            {"type": "path", "raw_id": "t1", "dilemma_id": "dilemma::d1", "is_canonical": True},
         )
+        graph.create_node(
+            "path::t2",
+            {"type": "path", "raw_id": "t2", "dilemma_id": "dilemma::d1", "is_canonical": False},
+        )
+        graph.add_edge("belongs_to", "beat::a", "path::t1")
+        graph.add_edge("belongs_to", "beat::a", "path::t2")
+        graph.add_edge("belongs_to", "beat::b", "path::t1")
+        graph.add_edge("belongs_to", "beat::c", "path::t2")
 
         for bid in ["a", "b", "c"]:
             graph.create_node(
@@ -2131,7 +2148,7 @@ class TestPhase9Choices:
         assert labels == {"b", "c"}
 
     @pytest.mark.asyncio
-    async def test_phase_9_grants_codewords_on_choice(self) -> None:
+    async def test_phase_9_grants_state_flags_on_choice(self) -> None:
         """Phase 9 attaches grants from arc beats to choice nodes."""
         from questfoundry.graph.graph import Graph
         from questfoundry.models.grow import ChoiceLabel, Phase9Output
@@ -2141,23 +2158,24 @@ class TestPhase9Choices:
         graph.create_node("beat::b", {"type": "beat", "raw_id": "b", "summary": "Commit"})
         graph.add_edge("predecessor", "beat::b", "beat::a")
 
-        # beat::b grants a codeword
+        # beat::b grants a state_flag
         graph.create_node(
-            "codeword::cw1",
-            {"type": "codeword", "raw_id": "cw1", "tracks": "consequence::c1"},
+            "state_flag::cw1",
+            {"type": "state_flag", "raw_id": "cw1", "tracks": "consequence::c1"},
         )
-        graph.add_edge("grants", "beat::b", "codeword::cw1")
+        graph.add_edge("grants", "beat::b", "state_flag::cw1")
 
+        # Create dilemma + path structure for computed arcs
         graph.create_node(
-            "arc::spine",
-            {
-                "type": "arc",
-                "raw_id": "spine",
-                "arc_type": "spine",
-                "paths": ["t1"],
-                "sequence": ["beat::a", "beat::b"],
-            },
+            "dilemma::d1",
+            {"type": "dilemma", "raw_id": "d1", "paths": ["t1"]},
         )
+        graph.create_node(
+            "path::t1",
+            {"type": "path", "raw_id": "t1", "dilemma_id": "dilemma::d1", "is_canonical": True},
+        )
+        graph.add_edge("belongs_to", "beat::a", "path::t1")
+        graph.add_edge("belongs_to", "beat::b", "path::t1")
 
         for bid in ["a", "b"]:
             graph.create_node(
@@ -2184,7 +2202,7 @@ class TestPhase9Choices:
         choice_nodes = graph.get_nodes_by_type("choice")
         assert len(choice_nodes) == 1
         choice_data = next(iter(choice_nodes.values()))
-        assert "codeword::cw1" in choice_data["grants"]
+        assert "state_flag::cw1" in choice_data["grants"]
 
     @pytest.mark.asyncio
     async def test_phase_9_creates_prologue_for_orphan_starts(self) -> None:
@@ -2218,29 +2236,33 @@ class TestPhase9Choices:
         graph.add_edge("predecessor", "beat::path1_end", "beat::path1_start")
         graph.add_edge("predecessor", "beat::path2_end", "beat::path2_start")
 
-        # Arc 1: path1_start → path1_end
+        # Create dilemma + path structure for computed arcs (two paths, no shared beats)
         graph.create_node(
-            "arc::spine",
+            "dilemma::d1",
+            {"type": "dilemma", "raw_id": "d1", "paths": ["t1_canon", "t1_alt"]},
+        )
+        graph.create_node(
+            "path::t1_canon",
             {
-                "type": "arc",
-                "raw_id": "spine",
-                "arc_type": "spine",
-                "paths": ["t1_canon"],
-                "sequence": ["beat::path1_start", "beat::path1_end"],
+                "type": "path",
+                "raw_id": "t1_canon",
+                "dilemma_id": "dilemma::d1",
+                "is_canonical": True,
             },
         )
-
-        # Arc 2: path2_start → path2_end (different start!)
         graph.create_node(
-            "arc::branch",
+            "path::t1_alt",
             {
-                "type": "arc",
-                "raw_id": "branch",
-                "arc_type": "branch",
-                "paths": ["t1_alt"],
-                "sequence": ["beat::path2_start", "beat::path2_end"],
+                "type": "path",
+                "raw_id": "t1_alt",
+                "dilemma_id": "dilemma::d1",
+                "is_canonical": False,
             },
         )
+        graph.add_edge("belongs_to", "beat::path1_start", "path::t1_canon")
+        graph.add_edge("belongs_to", "beat::path1_end", "path::t1_canon")
+        graph.add_edge("belongs_to", "beat::path2_start", "path::t1_alt")
+        graph.add_edge("belongs_to", "beat::path2_end", "path::t1_alt")
 
         # Create passages for all beats
         for bid in ["path1_start", "path1_end", "path2_start", "path2_end"]:
@@ -2593,14 +2615,14 @@ class TestPhase8cErrorHandling:
         from tests.fixtures.grow_fixtures import make_single_dilemma_graph
 
         graph = make_single_dilemma_graph()
-        # Add codeword and consequence nodes so we pass the early guard
+        # Add state_flag and consequence nodes so we pass the early guard
         graph.create_node(
             "consequence::trust_gain",
             {"type": "consequence", "description": "Trust is gained"},
         )
         graph.create_node(
-            "codeword::cw_trust",
-            {"type": "codeword", "tracks": "consequence::trust_gain", "codeword_type": "granted"},
+            "state_flag::cw_trust",
+            {"type": "state_flag", "tracks": "consequence::trust_gain", "flag_type": "granted"},
         )
 
         stage = GrowStage()
@@ -2625,14 +2647,32 @@ class TestPhase9ErrorHandling:
         from questfoundry.graph.graph import Graph
 
         graph = Graph.empty()
-        # Build a graph with multi-successor passages
+        # Build a graph with multi-successor passages (diverging arcs)
+        for bid in ["a", "b", "c", "d"]:
+            graph.create_node(f"beat::{bid}", {"type": "beat", "raw_id": bid, "summary": bid})
+        graph.add_edge("predecessor", "beat::b", "beat::a")
+        graph.add_edge("predecessor", "beat::c", "beat::b")
+        graph.add_edge("predecessor", "beat::d", "beat::a")
+
+        # Create dilemma + path structure for computed arcs
         graph.create_node(
-            "arc::spine",
-            {"type": "arc", "arc_type": "spine", "sequence": ["beat::a", "beat::b", "beat::c"]},
+            "dilemma::d1",
+            {"type": "dilemma", "raw_id": "d1", "paths": ["t1", "t2"]},
         )
         graph.create_node(
-            "arc::alt", {"type": "arc", "arc_type": "branch", "sequence": ["beat::a", "beat::d"]}
+            "path::t1",
+            {"type": "path", "raw_id": "t1", "dilemma_id": "dilemma::d1", "is_canonical": True},
         )
+        graph.create_node(
+            "path::t2",
+            {"type": "path", "raw_id": "t2", "dilemma_id": "dilemma::d1", "is_canonical": False},
+        )
+        graph.add_edge("belongs_to", "beat::a", "path::t1")
+        graph.add_edge("belongs_to", "beat::a", "path::t2")
+        graph.add_edge("belongs_to", "beat::b", "path::t1")
+        graph.add_edge("belongs_to", "beat::c", "path::t1")
+        graph.add_edge("belongs_to", "beat::d", "path::t2")
+
         graph.create_node(
             "passage::a", {"type": "passage", "from_beat": "beat::a", "summary": "Start"}
         )
@@ -2645,12 +2685,6 @@ class TestPhase9ErrorHandling:
         graph.create_node(
             "passage::d", {"type": "passage", "from_beat": "beat::d", "summary": "Path D"}
         )
-        # Arc contains edges
-        graph.add_edge("arc_contains", "arc::spine", "passage::a")
-        graph.add_edge("arc_contains", "arc::spine", "passage::b")
-        graph.add_edge("arc_contains", "arc::spine", "passage::c")
-        graph.add_edge("arc_contains", "arc::alt", "passage::a")
-        graph.add_edge("arc_contains", "arc::alt", "passage::d")
 
         stage = GrowStage()
         mock_model = MagicMock()
@@ -3042,7 +3076,7 @@ class TestPhase9bForkBeats:
                     "from_passage": f"passage::{pids[i]}",
                     "to_passage": f"passage::{pids[i + 1]}",
                     "label": "continue",
-                    "requires_codewords": [],
+                    "requires_state_flags": [],
                     "grants": [],
                 },
             )
@@ -3137,7 +3171,7 @@ class TestPhase9bForkBeats:
                     "from_passage": f"passage::{pids[i]}",
                     "to_passage": f"passage::{pids[i + 1]}",
                     "label": "continue",
-                    "requires_codewords": [],
+                    "requires_state_flags": [],
                     "grants": [],
                 },
             )
@@ -3176,7 +3210,7 @@ class TestPhase9bForkBeats:
                 {"type": "passage", "raw_id": pid, "summary": f"Passage {pid}"},
             )
 
-        # p1→p2 grants a codeword (simulates commits beat transition)
+        # p1→p2 grants a state_flag (simulates commits beat transition)
         graph.create_node(
             "choice::p1__p2",
             {
@@ -3184,8 +3218,8 @@ class TestPhase9bForkBeats:
                 "from_passage": "passage::p1",
                 "to_passage": "passage::p2",
                 "label": "continue",
-                "requires_codewords": [],
-                "grants": ["codeword::truth_committed"],
+                "requires_state_flags": [],
+                "grants": ["state_flag::truth_committed"],
             },
         )
         graph.add_edge("choice_from", "choice::p1__p2", "passage::p1")
@@ -3198,7 +3232,7 @@ class TestPhase9bForkBeats:
                 "from_passage": "passage::p2",
                 "to_passage": "passage::p3",
                 "label": "continue",
-                "requires_codewords": [],
+                "requires_state_flags": [],
                 "grants": [],
             },
         )
@@ -3232,7 +3266,7 @@ class TestPhase9bForkBeats:
         reconverge_choices = {cid: cdata for cid, cdata in choices.items() if "reconverge" in cid}
         assert len(reconverge_choices) == 2
         for _cid, cdata in reconverge_choices.items():
-            assert cdata["grants"] == ["codeword::truth_committed"]
+            assert cdata["grants"] == ["state_flag::truth_committed"]
 
 
 class TestPhase9cHubSpokes:
@@ -3263,7 +3297,7 @@ class TestPhase9cHubSpokes:
                 "from_passage": "passage::market",
                 "to_passage": "passage::palace",
                 "label": "continue",
-                "requires_codewords": [],
+                "requires_state_flags": [],
                 "grants": [],
             },
         )
@@ -3337,7 +3371,7 @@ class TestPhase9cHubSpokes:
                 "from_passage": "passage::hub",
                 "to_passage": "passage::spoke",
                 "label": "Explore",
-                "requires_codewords": [],
+                "requires_state_flags": [],
                 "grants": [],
             },
         )
@@ -3352,7 +3386,7 @@ class TestPhase9cHubSpokes:
                 "from_passage": "passage::spoke",
                 "to_passage": "passage::hub",
                 "label": "Return",
-                "requires_codewords": [],
+                "requires_state_flags": [],
                 "grants": [],
                 "is_return": True,
             },
@@ -3384,7 +3418,7 @@ class TestPhase9cHubSpokes:
                 "from_passage": "passage::p1",
                 "to_passage": "passage::p2",
                 "label": "continue",
-                "requires_codewords": [],
+                "requires_state_flags": [],
                 "grants": [],
             },
         )
@@ -3407,7 +3441,18 @@ class TestPhase8dResidueBeats:
     """Tests for Phase 8d residue beat insertion."""
 
     def _make_residue_eligible_graph(self) -> Any:
-        """Build a graph with a soft-dilemma convergence eligible for residue variants."""
+        """Build a graph with a soft-dilemma convergence eligible for residue variants.
+
+        Graph structure (computed arcs):
+        - beat::start (shared) -> beat::fight_only (fight) -> beat::aftermath (shared)
+        - beat::start (shared) -> beat::talk_only (talk) -> beat::aftermath (shared)
+
+        enumerate_arcs produces:
+        - spine (fight): [start, fight_only, aftermath]
+        - branch (talk): [start, talk_only, aftermath]
+
+        Convergence: branch diverges at start, converges at aftermath.
+        """
         from questfoundry.graph.graph import Graph
 
         graph = Graph.empty()
@@ -3418,19 +3463,31 @@ class TestPhase8dResidueBeats:
                 "type": "dilemma",
                 "raw_id": "approach",
                 "question": "Fight or negotiate?",
-                "dilemma_type": "soft",
+                "dilemma_role": "soft",
+                "payoff_budget": 0,
+            },
+        )
+        graph.create_node(
+            "path::fight",
+            {
+                "type": "path",
+                "raw_id": "fight",
+                "name": "Fight",
+                "dilemma_id": "dilemma::approach",
+                "is_canonical": True,
+            },
+        )
+        graph.create_node(
+            "path::talk",
+            {
+                "type": "path",
+                "raw_id": "talk",
+                "name": "Negotiate",
+                "dilemma_id": "dilemma::approach",
+                "is_canonical": False,
             },
         )
         for suffix, name in [("fight", "Fight"), ("talk", "Negotiate")]:
-            graph.create_node(
-                f"path::{suffix}",
-                {
-                    "type": "path",
-                    "raw_id": suffix,
-                    "name": name,
-                    "dilemma_id": "dilemma::approach",
-                },
-            )
             graph.create_node(
                 f"consequence::{suffix}_result",
                 {
@@ -3441,19 +3498,48 @@ class TestPhase8dResidueBeats:
             )
             graph.add_edge("has_consequence", f"path::{suffix}", f"consequence::{suffix}_result")
             graph.create_node(
-                f"codeword::{suffix}_committed",
+                f"state_flag::{suffix}_committed",
                 {
-                    "type": "codeword",
+                    "type": "state_flag",
                     "raw_id": f"{suffix}_committed",
                     "tracks": f"consequence::{suffix}_result",
-                    "codeword_type": "granted",
+                    "flag_type": "granted",
                 },
             )
-        # Beat and passage at convergence
+
+        # Beats: shared start, exclusive middle, shared convergence
+        graph.create_node(
+            "beat::start",
+            {"type": "beat", "raw_id": "start", "summary": "The confrontation begins"},
+        )
+        graph.create_node(
+            "beat::fight_only",
+            {"type": "beat", "raw_id": "fight_only", "summary": "Fists fly"},
+        )
+        graph.create_node(
+            "beat::talk_only",
+            {"type": "beat", "raw_id": "talk_only", "summary": "Words are exchanged"},
+        )
         graph.create_node(
             "beat::aftermath",
             {"type": "beat", "raw_id": "aftermath", "summary": "The dust settles"},
         )
+
+        # predecessor edges for ordering
+        graph.add_edge("predecessor", "beat::fight_only", "beat::start")
+        graph.add_edge("predecessor", "beat::talk_only", "beat::start")
+        graph.add_edge("predecessor", "beat::aftermath", "beat::fight_only")
+        graph.add_edge("predecessor", "beat::aftermath", "beat::talk_only")
+
+        # belongs_to edges: shared beats on both paths, exclusive beats on one
+        graph.add_edge("belongs_to", "beat::start", "path::fight")
+        graph.add_edge("belongs_to", "beat::start", "path::talk")
+        graph.add_edge("belongs_to", "beat::fight_only", "path::fight")
+        graph.add_edge("belongs_to", "beat::talk_only", "path::talk")
+        graph.add_edge("belongs_to", "beat::aftermath", "path::fight")
+        graph.add_edge("belongs_to", "beat::aftermath", "path::talk")
+
+        # Passage at convergence
         graph.create_node(
             "passage::aftermath",
             {
@@ -3461,23 +3547,6 @@ class TestPhase8dResidueBeats:
                 "raw_id": "aftermath",
                 "summary": "The dust settles after the confrontation",
                 "from_beat": "beat::aftermath",
-            },
-        )
-        # Arc with convergence metadata
-        graph.create_node(
-            "arc::spine",
-            {
-                "type": "arc",
-                "raw_id": "spine",
-                "arc_type": "spine",
-                "paths": ["path::fight", "path::talk"],
-                "dilemma_convergences": [
-                    {
-                        "dilemma_id": "dilemma::approach",
-                        "policy": "soft",
-                        "converges_at": "beat::aftermath",
-                    },
-                ],
             },
         )
         return graph
@@ -3500,11 +3569,11 @@ class TestPhase8dResidueBeats:
                     rationale="Prose should acknowledge fight vs negotiation",
                     variants=[
                         ResidueVariant(
-                            codeword_id="codeword::fight_committed",
+                            state_flag_id="state_flag::fight_committed",
                             hint="mention bruises from the fistfight",
                         ),
                         ResidueVariant(
-                            codeword_id="codeword::talk_committed",
+                            state_flag_id="state_flag::talk_committed",
                             hint="reference the fragile truce with the guards",
                         ),
                     ],

--- a/tests/unit/test_grow_validation.py
+++ b/tests/unit/test_grow_validation.py
@@ -45,7 +45,7 @@ def _make_linear_passage_graph() -> Graph:
             "from_passage": "passage::p1",
             "to_passage": "passage::p2",
             "label": "continue",
-            "requires_codewords": [],
+            "requires_state_flags": [],
             "grants": [],
         },
     )
@@ -56,7 +56,7 @@ def _make_linear_passage_graph() -> Graph:
             "from_passage": "passage::p2",
             "to_passage": "passage::p3",
             "label": "continue",
-            "requires_codewords": [],
+            "requires_state_flags": [],
             "grants": [],
         },
     )
@@ -136,7 +136,7 @@ class TestSingleStart:
                 "from_passage": "passage::p1",
                 "to_passage": "passage::p2",
                 "label": "go",
-                "requires_codewords": [],
+                "requires_state_flags": [],
                 "grants": [],
             },
         )
@@ -147,7 +147,7 @@ class TestSingleStart:
                 "from_passage": "passage::p2",
                 "to_passage": "passage::p1",
                 "label": "back",
-                "requires_codewords": [],
+                "requires_state_flags": [],
                 "grants": [],
             },
         )
@@ -178,7 +178,7 @@ class TestSingleStart:
                 "from_passage": "passage::p1",
                 "to_passage": "passage::spoke_0",
                 "label": "Look around",
-                "requires_codewords": [],
+                "requires_state_flags": [],
                 "grants": [],
             },
         )
@@ -193,7 +193,7 @@ class TestSingleStart:
                 "to_passage": "passage::p1",
                 "label": "Return",
                 "is_return": True,
-                "requires_codewords": [],
+                "requires_state_flags": [],
                 "grants": [],
             },
         )
@@ -273,7 +273,7 @@ class TestPassageDagCycles:
                 "from_passage": "passage::p1",
                 "to_passage": "passage::p2",
                 "label": "go",
-                "requires_codewords": [],
+                "requires_state_flags": [],
                 "grants": [],
             },
         )
@@ -284,7 +284,7 @@ class TestPassageDagCycles:
                 "from_passage": "passage::p2",
                 "to_passage": "passage::p1",
                 "label": "back",
-                "requires_codewords": [],
+                "requires_state_flags": [],
                 "grants": [],
             },
         )

--- a/tests/unit/test_grow_validation.py
+++ b/tests/unit/test_grow_validation.py
@@ -65,17 +65,33 @@ def _make_linear_passage_graph() -> Graph:
     graph.add_edge("choice_from", "choice::p2__p3", "passage::p2")
     graph.add_edge("choice_to", "choice::p2__p3", "passage::p3")
 
-    # Add a spine arc so validation passes the spine check
+    # Dilemma + path so enumerate_arcs() produces a spine arc
+    graph.create_node("dilemma::d1", {"type": "dilemma", "raw_id": "d1"})
     graph.create_node(
-        "arc::spine",
+        "path::d1__a1",
         {
-            "type": "arc",
-            "raw_id": "spine",
-            "arc_type": "spine",
-            "paths": ["path::d1__a1"],
-            "sequence": ["beat::p1", "beat::p2", "beat::p3"],
+            "type": "path",
+            "raw_id": "d1__a1",
+            "dilemma_id": "dilemma::d1",
+            "is_canonical": True,
         },
     )
+    # Beat nodes belonging to the canonical path (p3 commits the dilemma)
+    for bid in ["p1", "p2"]:
+        graph.create_node(f"beat::{bid}", {"type": "beat", "raw_id": bid})
+        graph.add_edge("belongs_to", f"beat::{bid}", "path::d1__a1")
+    graph.create_node(
+        "beat::p3",
+        {
+            "type": "beat",
+            "raw_id": "p3",
+            "dilemma_impacts": [{"dilemma_id": "dilemma::d1", "effect": "commits"}],
+        },
+    )
+    graph.add_edge("belongs_to", "beat::p3", "path::d1__a1")
+    # Beat ordering: p1 < p2 < p3
+    graph.add_edge("predecessor", "beat::p2", "beat::p1")
+    graph.add_edge("predecessor", "beat::p3", "beat::p2")
 
     return graph
 
@@ -291,19 +307,47 @@ class TestSpineArcExists:
         assert result.name == "spine_arc_exists"
 
     def test_spine_arc_missing(self) -> None:
-        """Fails when no arc has arc_type 'spine'."""
+        """Fails when no computed arc has arc_type 'spine'."""
         graph = Graph.empty()
-        # Add a non-spine arc
+        # Dilemma with two non-canonical paths -> only branch arcs
+        graph.create_node("dilemma::d1", {"type": "dilemma", "raw_id": "d1"})
         graph.create_node(
-            "arc::branch",
-            {"type": "arc", "raw_id": "branch", "arc_type": "branch", "paths": [], "sequence": []},
+            "path::p1",
+            {
+                "type": "path",
+                "raw_id": "p1",
+                "dilemma_id": "dilemma::d1",
+                "is_canonical": False,
+            },
         )
+        graph.create_node(
+            "path::p2",
+            {
+                "type": "path",
+                "raw_id": "p2",
+                "dilemma_id": "dilemma::d1",
+                "is_canonical": False,
+            },
+        )
+        # One beat per path
+        graph.create_node("beat::b1", {"type": "beat", "raw_id": "b1"})
+        graph.add_edge("belongs_to", "beat::b1", "path::p1")
+        graph.create_node("beat::b2", {"type": "beat", "raw_id": "b2"})
+        graph.add_edge("belongs_to", "beat::b2", "path::p2")
+        # Shared beat belonging to both paths
+        graph.create_node("beat::shared", {"type": "beat", "raw_id": "shared"})
+        graph.add_edge("belongs_to", "beat::shared", "path::p1")
+        graph.add_edge("belongs_to", "beat::shared", "path::p2")
+        # Ordering: shared < b1, shared < b2
+        graph.add_edge("predecessor", "beat::b1", "beat::shared")
+        graph.add_edge("predecessor", "beat::b2", "beat::shared")
+
         result = check_spine_arc_exists(graph)
         assert result.severity == "fail"
         assert "No spine arc" in result.message
 
     def test_no_arcs_at_all(self) -> None:
-        """Warns (not fails) when graph has no arc nodes at all."""
+        """Warns (not fails) when graph has no dilemmas/paths to compute arcs."""
         graph = Graph.empty()
         result = check_spine_arc_exists(graph)
         assert result.severity == "warn"
@@ -324,8 +368,13 @@ def _make_compliance_graph(
 ) -> Graph:
     """Build a graph with spine + one branch arc for compliance testing.
 
-    Creates full graph topology: dilemma -> answer -> path -> beat (belongs_to)
-    so the per-dilemma validation can trace beats back to their dilemma.
+    Creates full DAG topology: dilemma -> path -> beat (belongs_to) with
+    predecessor edges so ``enumerate_arcs()`` computes the arcs on-the-fly.
+
+    The graph has one dilemma with two paths (canon + rebel). Beats s0 and s1
+    belong to BOTH paths (shared prefix). After divergence, the spine has beats
+    s2..s5 (canon only) and the branch has b0..b{exclusive_count-1} (rebel only).
+    Optionally, ``shared_after_div`` spine beats also belong to the rebel path.
 
     Args:
         policy: Convergence policy for the dilemma.
@@ -340,7 +389,7 @@ def _make_compliance_graph(
         "dilemma::d1",
         {
             "type": "dilemma",
-            "raw_id": "dilemma::d1",
+            "raw_id": "d1",
             "dilemma_role": policy,
             "payoff_budget": payoff_budget,
         },
@@ -348,53 +397,60 @@ def _make_compliance_graph(
     # Two paths: canon (spine) and rebel (branch)
     graph.create_node(
         "path::canon",
-        {"type": "path", "raw_id": "path::canon", "dilemma_id": "dilemma::d1"},
+        {
+            "type": "path",
+            "raw_id": "canon",
+            "dilemma_id": "dilemma::d1",
+            "is_canonical": True,
+        },
     )
     graph.create_node(
         "path::rebel",
-        {"type": "path", "raw_id": "path::rebel", "dilemma_id": "dilemma::d1"},
+        {
+            "type": "path",
+            "raw_id": "rebel",
+            "dilemma_id": "dilemma::d1",
+            "is_canonical": False,
+        },
     )
 
-    # Spine beats -- all belong to canon path
+    # Spine beats s0..s5 — all belong to canon path
     spine_beats = [f"beat::s{i}" for i in range(6)]
     for bid in spine_beats:
         graph.create_node(bid, {"type": "beat"})
         graph.add_edge("belongs_to", bid, "path::canon")
 
-    graph.create_node(
-        "arc::spine",
-        {
-            "type": "arc",
-            "arc_type": "spine",
-            "sequence": spine_beats,
-            "paths": ["path::canon"],
-        },
-    )
+    # s0 and s1 are shared (belong to both paths — the prefix before divergence)
+    graph.add_edge("belongs_to", "beat::s0", "path::rebel")
+    graph.add_edge("belongs_to", "beat::s1", "path::rebel")
 
-    # Branch: diverges after s1; has exclusive beats, then optionally shares
-    branch_seq = ["beat::s0", "beat::s1"]
+    # Spine beat ordering: s0 < s1 < s2 < s3 < s4 < s5
+    for i in range(1, len(spine_beats)):
+        graph.add_edge("predecessor", spine_beats[i], spine_beats[i - 1])
+
+    # Branch exclusive beats: b0..b{exclusive_count-1}, belong to rebel only
     exclusive_beats = [f"beat::b{i}" for i in range(exclusive_count)]
     for bid in exclusive_beats:
         graph.create_node(bid, {"type": "beat"})
         graph.add_edge("belongs_to", bid, "path::rebel")
-    branch_seq.extend(exclusive_beats)
 
-    # Shared beats after divergence belong to BOTH paths
+    # Exclusive beat ordering: s1 < b0 < b1 < ...
+    if exclusive_beats:
+        graph.add_edge("predecessor", exclusive_beats[0], "beat::s1")
+        for i in range(1, len(exclusive_beats)):
+            graph.add_edge("predecessor", exclusive_beats[i], exclusive_beats[i - 1])
+
+    # Shared beats after divergence: spine beats s2..s{2+shared_after_div-1}
+    # also belong to rebel path
     for i in range(shared_after_div):
         shared_bid = spine_beats[2 + i]
         graph.add_edge("belongs_to", shared_bid, "path::rebel")
-        branch_seq.append(shared_bid)
 
-    graph.create_node(
-        "arc::branch_0",
-        {
-            "type": "arc",
-            "arc_type": "branch",
-            "sequence": branch_seq,
-            "diverges_at": "beat::s1",
-            "paths": ["path::rebel"],
-        },
-    )
+    # Connect shared-after-div beats into the branch ordering so they come
+    # after the exclusive beats in topological sort.
+    if shared_after_div > 0 and exclusive_beats:
+        graph.add_edge("predecessor", spine_beats[2], exclusive_beats[-1])
+
     return graph
 
 
@@ -428,50 +484,81 @@ class TestDilemmaRoleCompliance:
         assert all(r.severity == "pass" for r in results)
 
     def test_no_policy_metadata_skipped(self) -> None:
-        """Arc without dilemma_role field passes silently."""
+        """Dilemma without dilemma_role field passes silently."""
         graph = Graph.empty()
+        # Dilemma with no dilemma_role
+        graph.create_node("dilemma::d1", {"type": "dilemma", "raw_id": "d1"})
         graph.create_node(
-            "arc::spine",
-            {"type": "arc", "arc_type": "spine", "sequence": ["b1", "b2"], "paths": []},
-        )
-        graph.create_node(
-            "arc::branch",
+            "path::canon",
             {
-                "type": "arc",
-                "arc_type": "branch",
-                "sequence": ["b1", "b3"],
-                "diverges_at": "b1",
-                "paths": [],
+                "type": "path",
+                "raw_id": "canon",
+                "dilemma_id": "dilemma::d1",
+                "is_canonical": True,
             },
         )
+        graph.create_node(
+            "path::rebel",
+            {
+                "type": "path",
+                "raw_id": "rebel",
+                "dilemma_id": "dilemma::d1",
+                "is_canonical": False,
+            },
+        )
+        # Shared beat + one exclusive per path
+        graph.create_node("beat::shared", {"type": "beat", "raw_id": "shared"})
+        graph.add_edge("belongs_to", "beat::shared", "path::canon")
+        graph.add_edge("belongs_to", "beat::shared", "path::rebel")
+        graph.create_node("beat::c1", {"type": "beat", "raw_id": "c1"})
+        graph.add_edge("belongs_to", "beat::c1", "path::canon")
+        graph.create_node("beat::r1", {"type": "beat", "raw_id": "r1"})
+        graph.add_edge("belongs_to", "beat::r1", "path::rebel")
+        # Ordering
+        graph.add_edge("predecessor", "beat::c1", "beat::shared")
+        graph.add_edge("predecessor", "beat::r1", "beat::shared")
+
         results = check_dilemma_role_compliance(graph)
         assert all(r.severity == "pass" for r in results)
-        assert "No branch arcs with convergence metadata" in results[0].message
+        assert "No branch arcs with divergence metadata" in results[0].message
 
     def test_diverges_at_end_of_sequence(self) -> None:
-        """diverges_at is the last beat -- no beats after divergence -> passes."""
+        """When sequences share all beats, divergence at end -> passes."""
         graph = Graph.empty()
         graph.create_node(
-            "arc::spine",
+            "dilemma::d1",
             {
-                "type": "arc",
-                "arc_type": "spine",
-                "sequence": ["beat::s0", "beat::s1"],
-                "paths": [],
+                "type": "dilemma",
+                "raw_id": "d1",
+                "dilemma_role": "hard",
+                "payoff_budget": 2,
             },
         )
         graph.create_node(
-            "arc::branch_0",
+            "path::canon",
             {
-                "type": "arc",
-                "arc_type": "branch",
-                "sequence": ["beat::s0", "beat::s1"],
-                "diverges_at": "beat::s1",
-                "dilemma_role": "hard",
-                "payoff_budget": 2,
-                "paths": [],
+                "type": "path",
+                "raw_id": "canon",
+                "dilemma_id": "dilemma::d1",
+                "is_canonical": True,
             },
         )
+        graph.create_node(
+            "path::rebel",
+            {
+                "type": "path",
+                "raw_id": "rebel",
+                "dilemma_id": "dilemma::d1",
+                "is_canonical": False,
+            },
+        )
+        # Both beats belong to both paths -> identical sequences
+        for bid in ["s0", "s1"]:
+            graph.create_node(f"beat::{bid}", {"type": "beat", "raw_id": bid})
+            graph.add_edge("belongs_to", f"beat::{bid}", "path::canon")
+            graph.add_edge("belongs_to", f"beat::{bid}", "path::rebel")
+        graph.add_edge("predecessor", "beat::s1", "beat::s0")
+
         results = check_dilemma_role_compliance(graph)
         assert all(r.severity == "pass" for r in results)
 
@@ -481,159 +568,184 @@ class TestDilemmaRoleCompliance:
         assert results[0].severity == "pass"
 
     def test_hard_policy_per_dilemma_passes(self) -> None:
-        """Multi-dilemma arc: hard dilemma beats are exclusive, soft beats are shared -> passes.
+        """Multi-dilemma arc: hard dilemma beats are exclusive, soft meets budget -> passes.
 
-        Each beat belongs to ONE dilemma's path (like in real graphs).
-        The arc flips both dilemmas but d1-hard's beats are all exclusive.
+        Two dilemmas: d1 (hard) and d2 (soft, budget=1).  A shared opening beat
+        belongs to all paths.  After divergence, each dilemma's rebel path has
+        exclusive beats.  The hard dilemma's beats are NOT in the spine, so the
+        hard policy passes.  The soft dilemma has 1 exclusive beat >= budget 1.
         """
         graph = Graph.empty()
 
         # Dilemma 1: hard policy
         graph.create_node(
             "dilemma::d1",
-            {"type": "dilemma", "dilemma_role": "hard", "payoff_budget": 0},
+            {"type": "dilemma", "raw_id": "d1", "dilemma_role": "hard", "payoff_budget": 0},
         )
         graph.create_node(
             "path::d1_canon",
-            {"type": "path", "raw_id": "path::d1_canon", "dilemma_id": "dilemma::d1"},
+            {
+                "type": "path",
+                "raw_id": "d1_canon",
+                "dilemma_id": "dilemma::d1",
+                "is_canonical": True,
+            },
         )
         graph.create_node(
             "path::d1_rebel",
-            {"type": "path", "raw_id": "path::d1_rebel", "dilemma_id": "dilemma::d1"},
+            {
+                "type": "path",
+                "raw_id": "d1_rebel",
+                "dilemma_id": "dilemma::d1",
+                "is_canonical": False,
+            },
         )
 
         # Dilemma 2: soft policy
         graph.create_node(
             "dilemma::d2",
-            {"type": "dilemma", "dilemma_role": "soft", "payoff_budget": 1},
+            {"type": "dilemma", "raw_id": "d2", "dilemma_role": "soft", "payoff_budget": 1},
         )
         graph.create_node(
             "path::d2_canon",
-            {"type": "path", "raw_id": "path::d2_canon", "dilemma_id": "dilemma::d2"},
+            {
+                "type": "path",
+                "raw_id": "d2_canon",
+                "dilemma_id": "dilemma::d2",
+                "is_canonical": True,
+            },
         )
         graph.create_node(
             "path::d2_rebel",
-            {"type": "path", "raw_id": "path::d2_rebel", "dilemma_id": "dilemma::d2"},
+            {
+                "type": "path",
+                "raw_id": "d2_rebel",
+                "dilemma_id": "dilemma::d2",
+                "is_canonical": False,
+            },
         )
 
-        # Spine beats -- each belongs to ONE dilemma's canon path
-        # d1 canon beats
-        graph.create_node("beat::d1s0", {"type": "beat"})
-        graph.add_edge("belongs_to", "beat::d1s0", "path::d1_canon")
-        graph.create_node("beat::d1s1", {"type": "beat"})
+        # Shared opening beat — belongs to all 4 paths
+        graph.create_node("beat::shared", {"type": "beat", "raw_id": "shared"})
+        graph.add_edge("belongs_to", "beat::shared", "path::d1_canon")
+        graph.add_edge("belongs_to", "beat::shared", "path::d1_rebel")
+        graph.add_edge("belongs_to", "beat::shared", "path::d2_canon")
+        graph.add_edge("belongs_to", "beat::shared", "path::d2_rebel")
+
+        # d1 canon beat (spine only, exclusive to d1_canon)
+        graph.create_node("beat::d1s1", {"type": "beat", "raw_id": "d1s1"})
         graph.add_edge("belongs_to", "beat::d1s1", "path::d1_canon")
-        # d2 canon beats
-        graph.create_node("beat::d2s0", {"type": "beat"})
-        graph.add_edge("belongs_to", "beat::d2s0", "path::d2_canon")
-        graph.create_node("beat::d2s1", {"type": "beat"})
+
+        # d2 canon beat (spine only, exclusive to d2_canon)
+        graph.create_node("beat::d2s1", {"type": "beat", "raw_id": "d2s1"})
         graph.add_edge("belongs_to", "beat::d2s1", "path::d2_canon")
 
-        # Exclusive branch beats for d1_rebel (hard dilemma -- NOT in spine)
-        graph.create_node("beat::h1", {"type": "beat"})
+        # d1 rebel exclusive beats (hard dilemma — NOT in spine)
+        graph.create_node("beat::h1", {"type": "beat", "raw_id": "h1"})
         graph.add_edge("belongs_to", "beat::h1", "path::d1_rebel")
-        graph.create_node("beat::h2", {"type": "beat"})
+        graph.create_node("beat::h2", {"type": "beat", "raw_id": "h2"})
         graph.add_edge("belongs_to", "beat::h2", "path::d1_rebel")
 
-        # Exclusive beat for d2_rebel (soft dilemma -- sufficient for budget=1)
-        graph.create_node("beat::x1", {"type": "beat"})
+        # d2 rebel exclusive beat (soft dilemma — sufficient for budget=1)
+        graph.create_node("beat::x1", {"type": "beat", "raw_id": "x1"})
         graph.add_edge("belongs_to", "beat::x1", "path::d2_rebel")
 
-        spine_beats = ["beat::d1s0", "beat::d1s1", "beat::d2s0", "beat::d2s1"]
-        graph.create_node(
-            "arc::spine",
-            {
-                "type": "arc",
-                "arc_type": "spine",
-                "sequence": spine_beats,
-                "paths": ["path::d1_canon", "path::d2_canon"],
-            },
-        )
-
-        # Branch: flips both dilemmas
-        # d1 canon beats replaced by h1, h2; d2 canon beats partly replaced by x1
-        # d2s1 still appears (shared from spine, but belongs to d2_canon not d2_rebel)
-        graph.create_node(
-            "arc::branch_0",
-            {
-                "type": "arc",
-                "arc_type": "branch",
-                "sequence": [
-                    "beat::d1s0",  # before divergence
-                    "beat::h1",
-                    "beat::h2",  # d1 rebel beats (exclusive)
-                    "beat::x1",  # d2 rebel beat (exclusive)
-                    "beat::d2s1",  # d2 canon beat (shared with spine)
-                ],
-                "diverges_at": "beat::d1s0",
-                "paths": ["path::d1_rebel", "path::d2_rebel"],
-            },
-        )
+        # Beat ordering
+        graph.add_edge("predecessor", "beat::d1s1", "beat::shared")
+        graph.add_edge("predecessor", "beat::d2s1", "beat::shared")
+        graph.add_edge("predecessor", "beat::h1", "beat::shared")
+        graph.add_edge("predecessor", "beat::h2", "beat::h1")
+        graph.add_edge("predecessor", "beat::x1", "beat::shared")
 
         results = check_dilemma_role_compliance(graph)
-        # d1 hard: h1, h2 belong to d1_rebel -> not in spine -> passes
-        # d2 soft: x1 belongs to d2_rebel (exclusive); d2s1 belongs to d2_canon (shared)
-        #          1 exclusive >= budget 1 -> passes
+        # d1 hard: h1, h2 belong to d1_rebel -> not in spine seq -> passes
+        # d2 soft: x1 belongs to d2_rebel (exclusive); 1 >= budget 1 -> passes
         assert all(r.severity == "pass" for r in results)
 
     def test_hard_policy_fails_when_hard_beats_shared(self) -> None:
-        """Multi-dilemma arc: hard dilemma has shared beats after divergence -> fails."""
+        """Multi-dilemma arc: hard dilemma has shared beats after divergence -> fails.
+
+        d1 (hard) has one path flipped.  The rebel path includes a beat (s2)
+        that also belongs to the canon path, making it appear in both the spine
+        and branch sequences.  This violates the hard policy.
+        d2 has only one path (canon), so the branch arc is (d1_rebel + d2_canon).
+        """
         graph = Graph.empty()
 
         # Dilemma 1: hard policy
         graph.create_node(
             "dilemma::d1",
-            {"type": "dilemma", "dilemma_role": "hard", "payoff_budget": 0},
+            {"type": "dilemma", "raw_id": "d1", "dilemma_role": "hard", "payoff_budget": 0},
         )
         graph.create_node(
             "path::d1_canon",
-            {"type": "path", "raw_id": "path::d1_canon", "dilemma_id": "dilemma::d1"},
+            {
+                "type": "path",
+                "raw_id": "d1_canon",
+                "dilemma_id": "dilemma::d1",
+                "is_canonical": True,
+            },
         )
         graph.create_node(
             "path::d1_rebel",
-            {"type": "path", "raw_id": "path::d1_rebel", "dilemma_id": "dilemma::d1"},
+            {
+                "type": "path",
+                "raw_id": "d1_rebel",
+                "dilemma_id": "dilemma::d1",
+                "is_canonical": False,
+            },
         )
 
-        # Dilemma 2: soft (no budget constraint)
+        # Dilemma 2: soft (single path, no budget constraint)
         graph.create_node(
             "dilemma::d2",
-            {"type": "dilemma", "dilemma_role": "soft", "payoff_budget": 0},
+            {"type": "dilemma", "raw_id": "d2", "dilemma_role": "soft", "payoff_budget": 0},
         )
         graph.create_node(
             "path::d2_canon",
-            {"type": "path", "raw_id": "path::d2_canon", "dilemma_id": "dilemma::d2"},
+            {
+                "type": "path",
+                "raw_id": "d2_canon",
+                "dilemma_id": "dilemma::d2",
+                "is_canonical": True,
+            },
         )
 
-        # Spine beats belong to d1_canon and d2_canon
-        spine_beats = ["beat::s0", "beat::s1", "beat::s2", "beat::s3"]
-        for bid in spine_beats:
-            graph.create_node(bid, {"type": "beat"})
-            graph.add_edge("belongs_to", bid, "path::d1_canon")
-            graph.add_edge("belongs_to", bid, "path::d2_canon")
+        # Shared opening beat — belongs to d1_canon, d1_rebel, d2_canon
+        graph.create_node("beat::s0", {"type": "beat", "raw_id": "s0"})
+        graph.add_edge("belongs_to", "beat::s0", "path::d1_canon")
+        graph.add_edge("belongs_to", "beat::s0", "path::d1_rebel")
+        graph.add_edge("belongs_to", "beat::s0", "path::d2_canon")
 
-        # Make s2 also belong to d1_rebel -- this is the hard dilemma beat that IS shared
+        # d1 canon spine beat (exclusive to d1_canon)
+        graph.create_node("beat::s1", {"type": "beat", "raw_id": "s1"})
+        graph.add_edge("belongs_to", "beat::s1", "path::d1_canon")
+
+        # d1 beat that belongs to BOTH d1_canon and d1_rebel — this is the violation
+        graph.create_node("beat::s2", {"type": "beat", "raw_id": "s2"})
+        graph.add_edge("belongs_to", "beat::s2", "path::d1_canon")
         graph.add_edge("belongs_to", "beat::s2", "path::d1_rebel")
 
-        graph.create_node(
-            "arc::spine",
-            {
-                "type": "arc",
-                "arc_type": "spine",
-                "sequence": spine_beats,
-                "paths": ["path::d1_canon", "path::d2_canon"],
-            },
-        )
+        # d2 canon beat
+        graph.create_node("beat::d2s1", {"type": "beat", "raw_id": "d2s1"})
+        graph.add_edge("belongs_to", "beat::d2s1", "path::d2_canon")
 
-        # Branch: flips only d1 (d2 stays canon, so it's NOT in flipped_dilemmas)
-        graph.create_node(
-            "arc::branch_0",
-            {
-                "type": "arc",
-                "arc_type": "branch",
-                "sequence": ["beat::s0", "beat::s1", "beat::s2", "beat::s3"],
-                "diverges_at": "beat::s1",
-                "paths": ["path::d1_rebel", "path::d2_canon"],
-            },
-        )
+        # d1 rebel exclusive beat (so the branch diverges from spine)
+        graph.create_node("beat::r1", {"type": "beat", "raw_id": "r1"})
+        graph.add_edge("belongs_to", "beat::r1", "path::d1_rebel")
+
+        # Beat ordering
+        graph.add_edge("predecessor", "beat::s1", "beat::s0")
+        graph.add_edge("predecessor", "beat::s2", "beat::s1")
+        graph.add_edge("predecessor", "beat::d2s1", "beat::s0")
+        graph.add_edge("predecessor", "beat::r1", "beat::s0")
+        graph.add_edge("predecessor", "beat::s2", "beat::r1")
+
+        # Spine arc (d1_canon + d2_canon): beats = {s0, s1, s2, d2s1}
+        # Branch arc (d1_rebel + d2_canon): beats = {s0, r1, s2, d2s1}
+        # Divergence at s0 (last shared beat before sequences differ):
+        #   spine: [s0, s1, ...], branch: [s0, r1/d2s1, ...]
+        # After divergence, s2 belongs to d1_rebel and IS in spine_seq -> violation
 
         results = check_dilemma_role_compliance(graph)
         assert any(r.severity == "fail" for r in results)
@@ -641,120 +753,96 @@ class TestDilemmaRoleCompliance:
         assert "dilemma::d1" in results[0].message
 
     def test_soft_policy_per_dilemma_passes(self) -> None:
-        """Multi-dilemma arc: soft dilemma has enough exclusive beats -> passes."""
+        """Multi-dilemma arc: soft dilemma has enough exclusive beats -> passes.
+
+        d1 (soft, budget=0) has only a canonical path.  d2 (soft, budget=2) has
+        a canonical and a rebel path.  The branch arc flips only d2.  The rebel
+        path has 2 exclusive beats, meeting the budget.
+        """
         graph = Graph.empty()
 
-        # Dilemma 1: soft (no budget constraint)
+        # Dilemma 1: soft (single path, no budget constraint)
         graph.create_node(
             "dilemma::d1",
-            {"type": "dilemma", "dilemma_role": "soft", "payoff_budget": 0},
+            {"type": "dilemma", "raw_id": "d1", "dilemma_role": "soft", "payoff_budget": 0},
         )
         graph.create_node(
             "path::d1_canon",
-            {"type": "path", "raw_id": "path::d1_canon", "dilemma_id": "dilemma::d1"},
+            {
+                "type": "path",
+                "raw_id": "d1_canon",
+                "dilemma_id": "dilemma::d1",
+                "is_canonical": True,
+            },
         )
 
         # Dilemma 2: soft policy with budget=2
         graph.create_node(
             "dilemma::d2",
-            {"type": "dilemma", "dilemma_role": "soft", "payoff_budget": 2},
+            {"type": "dilemma", "raw_id": "d2", "dilemma_role": "soft", "payoff_budget": 2},
         )
         graph.create_node(
             "path::d2_canon",
-            {"type": "path", "raw_id": "path::d2_canon", "dilemma_id": "dilemma::d2"},
+            {
+                "type": "path",
+                "raw_id": "d2_canon",
+                "dilemma_id": "dilemma::d2",
+                "is_canonical": True,
+            },
         )
         graph.create_node(
             "path::d2_rebel",
-            {"type": "path", "raw_id": "path::d2_rebel", "dilemma_id": "dilemma::d2"},
+            {
+                "type": "path",
+                "raw_id": "d2_rebel",
+                "dilemma_id": "dilemma::d2",
+                "is_canonical": False,
+            },
         )
 
-        # Spine beats
-        spine_beats = ["beat::s0", "beat::s1", "beat::s2", "beat::s3"]
-        for bid in spine_beats:
-            graph.create_node(bid, {"type": "beat"})
-            graph.add_edge("belongs_to", bid, "path::d1_canon")
-            graph.add_edge("belongs_to", bid, "path::d2_canon")
+        # Shared opening beat — belongs to d1_canon, d2_canon, d2_rebel
+        graph.create_node("beat::shared", {"type": "beat", "raw_id": "shared"})
+        graph.add_edge("belongs_to", "beat::shared", "path::d1_canon")
+        graph.add_edge("belongs_to", "beat::shared", "path::d2_canon")
+        graph.add_edge("belongs_to", "beat::shared", "path::d2_rebel")
+
+        # d2 canon beat (spine only)
+        graph.create_node("beat::d2s1", {"type": "beat", "raw_id": "d2s1"})
+        graph.add_edge("belongs_to", "beat::d2s1", "path::d2_canon")
 
         # Two exclusive beats for d2_rebel (meets budget of 2)
-        graph.create_node("beat::x1", {"type": "beat"})
+        graph.create_node("beat::x1", {"type": "beat", "raw_id": "x1"})
         graph.add_edge("belongs_to", "beat::x1", "path::d2_rebel")
-        graph.create_node("beat::x2", {"type": "beat"})
+        graph.create_node("beat::x2", {"type": "beat", "raw_id": "x2"})
         graph.add_edge("belongs_to", "beat::x2", "path::d2_rebel")
 
-        graph.create_node(
-            "arc::spine",
-            {
-                "type": "arc",
-                "arc_type": "spine",
-                "sequence": spine_beats,
-                "paths": ["path::d1_canon", "path::d2_canon"],
-            },
-        )
+        # Beat ordering
+        graph.add_edge("predecessor", "beat::d2s1", "beat::shared")
+        graph.add_edge("predecessor", "beat::x1", "beat::shared")
+        graph.add_edge("predecessor", "beat::x2", "beat::x1")
 
-        # Branch: flips only d2 (d1 stays canon)
-        graph.create_node(
-            "arc::branch_0",
-            {
-                "type": "arc",
-                "arc_type": "branch",
-                "sequence": ["beat::s0", "beat::s1", "beat::x1", "beat::x2", "beat::s2"],
-                "diverges_at": "beat::s1",
-                "paths": ["path::d1_canon", "path::d2_rebel"],
-            },
-        )
+        # Spine (d1_canon + d2_canon): beats = {shared, d2s1}
+        # Branch (d1_canon + d2_rebel): beats = {shared, x1, x2}
+        # Divergence at shared -> after div: spine=[d2s1], branch=[x1, x2]
+        # d2 soft: x1, x2 exclusive (2 >= budget 2) -> passes
 
         results = check_dilemma_role_compliance(graph)
-        # d2 soft: x1, x2 exclusive (2 >= budget 2) -> passes
-        # d1 soft with budget 0: passes trivially
         assert all(r.severity == "pass" for r in results)
 
 
 class TestRunAllChecks:
     def test_run_all_checks_aggregates(self) -> None:
-        """run_all_checks produces a report with mixed pass/warn/fail."""
+        """run_all_checks produces a report combining grow + passage checks."""
         graph = _make_linear_passage_graph()
-        # Add dilemma data so timing checks can run
-        graph.create_node("dilemma::t1", {"type": "dilemma", "raw_id": "t1"})
-        graph.create_node(
-            "path::th1",
-            {"type": "path", "raw_id": "th1", "dilemma_id": "t1", "is_canonical": True},
-        )
-        graph.add_edge("explores", "path::th1", "dilemma::t1")
-        # Beat with commits too early (beat 1 of 3)
-        graph.create_node(
-            "beat::b0",
-            {
-                "type": "beat",
-                "raw_id": "b0",
-                "summary": "Beat 0",
-                "dilemma_impacts": [{"dilemma_id": "dilemma::t1", "effect": "commits"}],
-            },
-        )
-        graph.create_node(
-            "beat::b1",
-            {"type": "beat", "raw_id": "b1", "summary": "Beat 1", "dilemma_impacts": []},
-        )
-        graph.create_node(
-            "beat::b2",
-            {"type": "beat", "raw_id": "b2", "summary": "Beat 2", "dilemma_impacts": []},
-        )
-        graph.add_edge("belongs_to", "beat::b0", "path::th1")
-        graph.add_edge("belongs_to", "beat::b1", "path::th1")
-        graph.add_edge("belongs_to", "beat::b2", "path::th1")
-        graph.add_edge("predecessor", "beat::b1", "beat::b0")
-        graph.add_edge("predecessor", "beat::b2", "beat::b1")
-        # Update existing spine arc to include the test path and its beats
-        graph.update_node(
-            "arc::spine",
-            sequence=["beat::b0", "beat::b1", "beat::b2"],
-            paths=["path::d1__a1", "path::th1"],
-        )
 
         report = run_all_checks(graph)
         assert isinstance(report, ValidationReport)
-        # Should have structural checks + timing warnings
-        assert len(report.checks) >= 6  # At least the 6 structural checks
-        assert report.has_warnings  # commits too early
+        # Should have grow structural checks + passage-layer checks
+        assert len(report.checks) >= 4  # At least the 4 grow checks
+        # Verify both grow and passage checks are present
+        check_names = {c.name for c in report.checks}
+        assert "single_start" in check_names  # from grow checks
+        assert "spine_arc_exists" in check_names  # from grow checks
 
 
 class TestValidationReport:
@@ -830,46 +918,10 @@ class TestPhase10Integration:
         assert "failed" in result.detail
 
     @pytest.mark.asyncio
-    async def test_phase_10_warnings_pass(self) -> None:
-        """Phase 10 passes with warnings when timing issues exist."""
+    async def test_phase_10_all_pass(self) -> None:
+        """Phase 10 passes cleanly when all structural checks pass."""
         graph = _make_linear_passage_graph()
-        # Add dilemma with commits too early
-        graph.create_node("dilemma::t1", {"type": "dilemma", "raw_id": "t1"})
-        graph.create_node(
-            "path::th1",
-            {"type": "path", "raw_id": "th1", "dilemma_id": "t1", "is_canonical": True},
-        )
-        graph.add_edge("explores", "path::th1", "dilemma::t1")
-        graph.create_node(
-            "beat::b0",
-            {
-                "type": "beat",
-                "raw_id": "b0",
-                "summary": "Beat 0",
-                "dilemma_impacts": [{"dilemma_id": "dilemma::t1", "effect": "commits"}],
-            },
-        )
-        graph.create_node(
-            "beat::b1",
-            {"type": "beat", "raw_id": "b1", "summary": "Beat 1", "dilemma_impacts": []},
-        )
-        graph.create_node(
-            "beat::b2",
-            {"type": "beat", "raw_id": "b2", "summary": "Beat 2", "dilemma_impacts": []},
-        )
-        graph.add_edge("belongs_to", "beat::b0", "path::th1")
-        graph.add_edge("belongs_to", "beat::b1", "path::th1")
-        graph.add_edge("belongs_to", "beat::b2", "path::th1")
-        graph.add_edge("predecessor", "beat::b1", "beat::b0")
-        graph.add_edge("predecessor", "beat::b2", "beat::b1")
-        # Update existing spine arc to include the test path and its beats
-        graph.update_node(
-            "arc::spine",
-            sequence=["beat::b0", "beat::b1", "beat::b2"],
-            paths=["path::d1__a1", "path::th1"],
-        )
 
         result = await phase_validation(graph, MagicMock())
-        # Should pass but with warnings
         assert result.status == "completed"
-        assert "warnings" in result.detail
+        assert "passed" in result.detail

--- a/tests/unit/test_grow_validators.py
+++ b/tests/unit/test_grow_validators.py
@@ -166,7 +166,7 @@ class TestValidatePhase8cOutput:
         errors = validate_phase8c_output(
             result,
             valid_entity_ids={"entity::e1"},
-            valid_codeword_ids={"cw::c1"},
+            valid_state_flag_ids={"cw::c1"},
         )
         assert errors == []
 
@@ -183,12 +183,12 @@ class TestValidatePhase8cOutput:
         errors = validate_phase8c_output(
             result,
             valid_entity_ids={"entity::e1"},
-            valid_codeword_ids={"cw::c1"},
+            valid_state_flag_ids={"cw::c1"},
         )
         assert len(errors) == 1
         assert "entity::bad" in errors[0].issue
 
-    def test_invalid_codeword_id(self) -> None:
+    def test_invalid_state_flag_id(self) -> None:
         result = Phase8cOutput(
             overlays=[
                 OverlayProposal(
@@ -201,12 +201,12 @@ class TestValidatePhase8cOutput:
         errors = validate_phase8c_output(
             result,
             valid_entity_ids={"entity::e1"},
-            valid_codeword_ids={"cw::c1"},
+            valid_state_flag_ids={"cw::c1"},
         )
         assert len(errors) == 1
         assert "cw::bad" in errors[0].issue
 
-    def test_multiple_invalid_codewords(self) -> None:
+    def test_multiple_invalid_state_flags(self) -> None:
         result = Phase8cOutput(
             overlays=[
                 OverlayProposal(
@@ -219,7 +219,7 @@ class TestValidatePhase8cOutput:
         errors = validate_phase8c_output(
             result,
             valid_entity_ids={"entity::e1"},
-            valid_codeword_ids={"cw::c1"},
+            valid_state_flag_ids={"cw::c1"},
         )
         assert len(errors) == 2
 
@@ -562,41 +562,41 @@ class TestValidatePhase9cGrants:
         return Phase9cOutput(hubs=[hub])
 
     def test_valid_spoke_grants_pass(self) -> None:
-        result = self._make_phase9c_output(grants=["codeword::cw_mural"])
+        result = self._make_phase9c_output(grants=["state_flag::cw_mural"])
         errors = validate_phase9c_output(
             result,
             valid_passage_ids={"passage::market"},
-            valid_codeword_ids={"codeword::cw_mural"},
+            valid_state_flag_ids={"state_flag::cw_mural"},
         )
         assert not errors
 
     def test_invalid_spoke_grants_rejected(self) -> None:
-        result = self._make_phase9c_output(grants=["codeword::nonexistent"])
+        result = self._make_phase9c_output(grants=["state_flag::nonexistent"])
         errors = validate_phase9c_output(
             result,
             valid_passage_ids={"passage::market"},
-            valid_codeword_ids={"codeword::cw_mural"},
+            valid_state_flag_ids={"state_flag::cw_mural"},
         )
         assert len(errors) == 1
         assert "nonexistent" in errors[0].issue
 
-    def test_no_codeword_validation_when_none(self) -> None:
-        """When valid_codeword_ids is None, grants are not validated."""
-        result = self._make_phase9c_output(grants=["codeword::anything"])
+    def test_no_state_flag_validation_when_none(self) -> None:
+        """When valid_state_flag_ids is None, grants are not validated."""
+        result = self._make_phase9c_output(grants=["state_flag::anything"])
         errors = validate_phase9c_output(
             result,
             valid_passage_ids={"passage::market"},
-            valid_codeword_ids=None,
+            valid_state_flag_ids=None,
         )
         assert not errors
 
     def test_unscoped_grant_id_normalized(self) -> None:
-        """Grant IDs without 'codeword::' prefix are normalized."""
+        """Grant IDs without 'state_flag::' prefix are normalized."""
         result = self._make_phase9c_output(grants=["cw_mural"])
         errors = validate_phase9c_output(
             result,
             valid_passage_ids={"passage::market"},
-            valid_codeword_ids={"codeword::cw_mural"},
+            valid_state_flag_ids={"state_flag::cw_mural"},
         )
         assert not errors
 
@@ -608,10 +608,10 @@ class TestValidatePhase8dOutput:
     def _make_output(
         passage_id: str = "passage::aftermath",
         dilemma_id: str = "dilemma::approach",
-        codeword_ids: list[str] | None = None,
+        state_flag_ids: list[str] | None = None,
     ) -> Phase8dOutput:
-        if codeword_ids is None:
-            codeword_ids = ["codeword::fight_committed", "codeword::talk_committed"]
+        if state_flag_ids is None:
+            state_flag_ids = ["state_flag::fight_committed", "state_flag::talk_committed"]
         return Phase8dOutput(
             proposals=[
                 ResidueBeatProposal(
@@ -619,8 +619,8 @@ class TestValidatePhase8dOutput:
                     dilemma_id=dilemma_id,
                     rationale="Test rationale",
                     variants=[
-                        ResidueVariant(codeword_id=cw, hint=f"hint for {cw} variant prose")
-                        for cw in codeword_ids
+                        ResidueVariant(state_flag_id=sf, hint=f"hint for {sf} variant prose")
+                        for sf in state_flag_ids
                     ],
                 ),
             ]
@@ -631,7 +631,7 @@ class TestValidatePhase8dOutput:
         errors = validate_phase8d_output(
             result,
             valid_passage_ids={"passage::aftermath"},
-            valid_codeword_ids={"codeword::fight_committed", "codeword::talk_committed"},
+            valid_state_flag_ids={"state_flag::fight_committed", "state_flag::talk_committed"},
             valid_dilemma_ids={"dilemma::approach"},
         )
         assert not errors
@@ -641,7 +641,7 @@ class TestValidatePhase8dOutput:
         errors = validate_phase8d_output(
             result,
             valid_passage_ids={"passage::aftermath"},
-            valid_codeword_ids={"codeword::fight_committed", "codeword::talk_committed"},
+            valid_state_flag_ids={"state_flag::fight_committed", "state_flag::talk_committed"},
             valid_dilemma_ids={"dilemma::approach"},
         )
         assert len(errors) == 1
@@ -652,29 +652,31 @@ class TestValidatePhase8dOutput:
         errors = validate_phase8d_output(
             result,
             valid_passage_ids={"passage::aftermath"},
-            valid_codeword_ids={"codeword::fight_committed", "codeword::talk_committed"},
+            valid_state_flag_ids={"state_flag::fight_committed", "state_flag::talk_committed"},
             valid_dilemma_ids={"dilemma::approach"},
         )
         assert len(errors) == 1
         assert "dilemma_id" in errors[0].field_path
 
-    def test_invalid_codeword_id(self) -> None:
-        result = self._make_output(codeword_ids=["codeword::fight_committed", "codeword::fake"])
+    def test_invalid_state_flag_id(self) -> None:
+        result = self._make_output(
+            state_flag_ids=["state_flag::fight_committed", "state_flag::fake"]
+        )
         errors = validate_phase8d_output(
             result,
             valid_passage_ids={"passage::aftermath"},
-            valid_codeword_ids={"codeword::fight_committed", "codeword::talk_committed"},
+            valid_state_flag_ids={"state_flag::fight_committed", "state_flag::talk_committed"},
             valid_dilemma_ids={"dilemma::approach"},
         )
         assert len(errors) == 1
-        assert "codeword_id" in errors[0].field_path
+        assert "state_flag_id" in errors[0].field_path
 
     def test_empty_proposals_no_errors(self) -> None:
         result = Phase8dOutput(proposals=[])
         errors = validate_phase8d_output(
             result,
             valid_passage_ids={"passage::aftermath"},
-            valid_codeword_ids={"codeword::fight_committed"},
+            valid_state_flag_ids={"state_flag::fight_committed"},
             valid_dilemma_ids={"dilemma::approach"},
         )
         assert not errors

--- a/tests/unit/test_inspection.py
+++ b/tests/unit/test_inspection.py
@@ -51,7 +51,7 @@ def _make_full_graph() -> Graph:
             "from_passage": "passage::p0",
             "to_passage": "passage::p1",
             "label": "Enter the forest",
-            "requires_codewords": [],
+            "requires_state_flags": [],
             "grants": [],
         },
     )
@@ -62,7 +62,7 @@ def _make_full_graph() -> Graph:
             "from_passage": "passage::p0",
             "to_passage": "passage::p1",
             "label": "continue",
-            "requires_codewords": [],
+            "requires_state_flags": [],
             "grants": [],
         },
     )
@@ -200,7 +200,7 @@ class TestBranchingStats:
                 "from_passage": "passage::p0",
                 "to_passage": "passage::p1",
                 "label": "Search the room",
-                "requires_codewords": [],
+                "requires_state_flags": [],
                 "grants": [],
             },
         )
@@ -215,7 +215,7 @@ class TestBranchingStats:
                 "from_passage": "passage::p1",
                 "to_passage": "passage::p2",
                 "label": "continue",
-                "requires_codewords": [],
+                "requires_state_flags": [],
                 "grants": [],
             },
         )
@@ -272,7 +272,7 @@ class TestBranchingStats:
                 "from_passage": "passage::p0",
                 "to_passage": "passage::p1",
                 "label": "continue",
-                "requires_codewords": [],
+                "requires_state_flags": [],
                 "grants": [],
             },
         )
@@ -285,7 +285,7 @@ class TestBranchingStats:
                 "from_passage": "passage::p0",
                 "to_passage": "passage::spoke_0",
                 "label": "Look around",
-                "requires_codewords": [],
+                "requires_state_flags": [],
                 "grants": [],
             },
         )
@@ -299,7 +299,7 @@ class TestBranchingStats:
                 "to_passage": "passage::p0",
                 "label": "Return",
                 "is_return": True,
-                "requires_codewords": [],
+                "requires_state_flags": [],
                 "grants": [],
             },
         )
@@ -530,10 +530,10 @@ class TestBranchingQualityScore:
         assert data["branching_quality"] is not None
 
     def test_ending_variants_per_arc(self) -> None:
-        """Each arc's codeword signature counts as a separate ending variant."""
+        """Each arc's state flag signature counts as a separate ending variant."""
         graph = Graph.empty()
         spine_beats = [f"beat::s{i}" for i in range(3)]
-        # Two arcs sharing the same ending beat but with different codeword paths
+        # Two arcs sharing the same ending beat but with different state flag paths
         graph.create_node(
             "arc::spine",
             {
@@ -583,14 +583,14 @@ class TestBranchingQualityScore:
                 "from_passage": "passage::mid",
                 "to_passage": "passage::ending",
                 "label": "Continue",
-                "requires_codewords": [],
+                "requires_state_flags": [],
                 "grants": [],
             },
         )
         graph.add_edge("choice_from", "choice::mid__ending", "passage::mid")
         graph.add_edge("choice_to", "choice::mid__ending", "passage::ending")
 
-        # Give each path a different codeword via consequence
+        # Give each path a different state flag via consequence
         graph.create_node(
             "path::canon",
             {"type": "path", "tier": "major", "description": "Canon"},
@@ -608,22 +608,22 @@ class TestBranchingQualityScore:
             {"type": "consequence", "description": "Rebel wins"},
         )
         graph.create_node(
-            "codeword::canon_flag",
-            {"type": "codeword", "label": "canon_flag"},
+            "state_flag::canon_flag",
+            {"type": "state_flag", "label": "canon_flag"},
         )
         graph.create_node(
-            "codeword::rebel_flag",
-            {"type": "codeword", "label": "rebel_flag"},
+            "state_flag::rebel_flag",
+            {"type": "state_flag", "label": "rebel_flag"},
         )
         graph.add_edge("has_consequence", "path::canon", "consequence::c_canon")
         graph.add_edge("has_consequence", "path::rebel", "consequence::c_rebel")
-        graph.add_edge("tracks", "codeword::canon_flag", "consequence::c_canon")
-        graph.add_edge("tracks", "codeword::rebel_flag", "consequence::c_rebel")
+        graph.add_edge("tracks", "state_flag::canon_flag", "consequence::c_canon")
+        graph.add_edge("tracks", "state_flag::rebel_flag", "consequence::c_rebel")
 
         result = _branching_quality_score(graph, None)
         assert result is not None
         assert result.terminal_count == 1
-        # Two arcs with different codewords → 2 ending variants, not 1
+        # Two arcs with different state flags → 2 ending variants, not 1
         assert result.ending_variants == 2
 
     def test_ending_variants_merged_passage(self) -> None:
@@ -667,7 +667,7 @@ class TestBranchingQualityScore:
                 "from_passage": "passage::mid",
                 "to_passage": "passage::ending",
                 "label": "Finish",
-                "requires_codewords": [],
+                "requires_state_flags": [],
                 "grants": [],
             },
         )
@@ -678,11 +678,11 @@ class TestBranchingQualityScore:
         assert result is not None
         # The ending passage should be detected as a terminal (no outgoing choices)
         assert result.terminal_count == 1
-        # Its primary_beat should map to the spine arc, contributing a codeword signature
+        # Its primary_beat should map to the spine arc, contributing a state flag signature
         assert result.ending_variants >= 1
 
     def test_ending_variants_synthetic_endings(self) -> None:
-        """Synthetic endings (from split_ending_families) use family_codewords directly."""
+        """Synthetic endings (from split_ending_families) use family_state_flags directly."""
         graph = Graph.empty()
         # Need at least one arc for the function to return a result
         graph.create_node(
@@ -694,7 +694,7 @@ class TestBranchingQualityScore:
                 "paths": ["path::canon"],
             },
         )
-        # Two synthetic ending passages with different family_codewords, no from_beat
+        # Two synthetic ending passages with different family_state_flags, no from_beat
         graph.create_node(
             "passage::ending_0",
             {
@@ -703,7 +703,7 @@ class TestBranchingQualityScore:
                 "is_ending": True,
                 "is_synthetic": True,
                 "summary": "Ending A",
-                "family_codewords": ["codeword::trust", "codeword::brave"],
+                "family_state_flags": ["state_flag::trust", "state_flag::brave"],
             },
         )
         graph.create_node(
@@ -714,7 +714,7 @@ class TestBranchingQualityScore:
                 "is_ending": True,
                 "is_synthetic": True,
                 "summary": "Ending B",
-                "family_codewords": ["codeword::betray"],
+                "family_state_flags": ["state_flag::betray"],
             },
         )
         # Wire choices so these are the only terminals

--- a/tests/unit/test_visualization.py
+++ b/tests/unit/test_visualization.py
@@ -431,7 +431,7 @@ def _make_overlay_graph() -> Graph:
             "type": "entity",
             "entity_type": "character",
             "name": "Alice",
-            "overlays": [{"codeword": "saw_truth", "field": "mood", "value": "angry"}],
+            "overlays": [{"state_flag": "saw_truth", "field": "mood", "value": "angry"}],
         },
     )
 
@@ -442,10 +442,10 @@ def _make_overlay_graph() -> Graph:
 
 
 def _make_grants_graph() -> Graph:
-    """Build a graph with a choice that grants codewords."""
+    """Build a graph with a choice that grants state flags."""
     graph = _make_simple_graph()
 
-    # Update existing choice to grant a codeword
+    # Update existing choice to grant a state flag
     graph.update_node("choice::intro_middle", grants=["saw_truth"])
 
     return graph
@@ -494,7 +494,7 @@ class TestOverlayPassages:
                 "type": "entity",
                 "entity_type": "character",
                 "name": "Bob",
-                "overlays": [{"codeword": "met_bob", "field": "mood", "value": "happy"}],
+                "overlays": [{"state_flag": "met_bob", "field": "mood", "value": "happy"}],
             },
         )
         # Passage references entity by raw ID "bob" (not "character::bob")
@@ -567,7 +567,7 @@ class TestGrantsEdges:
         graph = _make_simple_graph()
         graph.update_node(
             "choice::intro_middle",
-            requires_codewords=["has_key"],
+            requires_state_flags=["has_key"],
             grants=["saw_truth"],
         )
         sg = build_story_graph(graph)


### PR DESCRIPTION
## Summary

Closes #1060

- Rename internal `Codeword` model class to `StateFlag` and graph node type from `"codeword"` to `"state_flag"` throughout the pipeline
- State flags are internal routing/overlay markers created by GROW; player-facing "codeword" terminology preserved in SHIP/export
- Update `compute_structural_score()` in dress.py to use `enumerate_arcs()` instead of stored arc nodes (fixes pre-existing bug from #1058)
- Fix 11 pre-existing test failures from stored-arc removal (#1058) by converting test fixtures to computed-arc pattern (dilemma/path/belongs_to)

### Scope (37 files, ~1160 insertions / ~1070 deletions)

**Models**: `Codeword` → `StateFlag`, `codeword_type` → `flag_type`, `codeword_id` → `flag_id`
**Graph nodes**: type `"codeword"` → `"state_flag"`, ID prefix `"state_flag::"`
**GROW**: All phases, algorithms, routing, validation updated
**FILL/DRESS**: Context builders, mutations updated to read `state_flag` nodes
**Prompts**: Templates use `{valid_state_flag_ids}` variable
**Export**: Bridge in `export/context.py` reads `state_flag` nodes, projects to `ExportCodeword` (player-facing)
**Tests**: 15 test files updated; stored-arc fixtures → computed-arc pattern

### Verification

```bash
grep -rn '"type".*"codeword"' src/questfoundry/pipeline/stages/grow/ | wc -l  # 0
grep -rn 'class Codeword' src/questfoundry/models/ | wc -l                    # 0
grep -rn 'class StateFlag' src/questfoundry/models/grow.py | wc -l            # 1
grep -rn 'get_nodes_by_type.*"state_flag"' src/questfoundry/ | wc -l          # 15
```

## Test plan

- [x] All 3306 unit tests pass
- [x] Ruff + mypy clean
- [x] Verification commands confirm old `Codeword` class and `"codeword"` node type removed from active code paths
- [x] Export fallback for legacy `"codeword"` nodes preserved in `export/context.py` (to be addressed in #1061)

🤖 Generated with [Claude Code](https://claude.com/claude-code)