### PR TITLE
refactor: rename Codeword → StateFlag model and node type

### DIFF
--- a/prompts/templates/grow_phase8c_overlays.yaml
+++ b/prompts/templates/grow_phase8c_overlays.yaml
@@ -1,20 +1,20 @@
 name: grow_phase8c_overlays
-description: Create entity overlays conditioned on codewords
+description: Create entity overlays conditioned on state flags
 
 system: |
   You are creating entity overlays -- conditional details that change
   based on which narrative path the player has taken. Overlays activate
-  when specific codewords are granted.
+  when specific state flags are granted.
 
   ## CRITICAL: Every Overlay Needs Details
   The `details` field MUST contain at least one {{key, value}} pair.
-  WRONG: {{"entity_id": "character::hero", "when": ["codeword::cw_trust"], "details": []}}
-  RIGHT: {{"entity_id": "character::hero", "when": ["codeword::cw_trust"], "details": [{{"key": "attitude", "value": "Wary but relieved the alliance held"}}]}}
+  WRONG: {{"entity_id": "character::hero", "when": ["state_flag::cw_trust"], "details": []}}
+  RIGHT: {{"entity_id": "character::hero", "when": ["state_flag::cw_trust"], "details": [{{"key": "attitude", "value": "Wary but relieved the alliance held"}}]}}
 
   ## What is an Entity Overlay?
   An overlay modifies how an entity appears or behaves depending on
   story state. Overlays are cosmetic entity-level changes — they describe
-  how an entity's presentation shifts based on codewords. (Passage-level
+  how an entity's presentation shifts based on state flags. (Passage-level
   prose variants at convergence points are handled by residue beats.)
 
   Examples:
@@ -22,14 +22,14 @@ system: |
   - A location's description changes after a disaster occurs
   - An object becomes unavailable after it is destroyed
 
-  ## Consequences, Codewords, and Their Context
+  ## Consequences, State Flags, and Their Context
   {consequence_context}
 
   ## Entities Available for Overlays
   {entity_context}
 
   ## When to Create an Overlay
-  For EACH codeword above, check these rules against each entity.
+  For EACH state flag above, check these rules against each entity.
   If ANY rule is satisfied, propose an overlay.
 
   1. **Direct mention**: Consequence names an entity → overlay it
@@ -38,7 +38,7 @@ system: |
   4. **Ripple effect**: One step outward — if consequence affects entity A,
      does entity B's relationship to A change? If yes, overlay B
 
-  Central entities per codeword are the strongest candidates.
+  Central entities per state flag are the strongest candidates.
 
   ## Common Mistakes
   - "Ally stays loyal" seems like no change, but it IS a state — the player
@@ -48,8 +48,8 @@ system: |
   - "Benign secret revealed" — still changes what characters know and how they behave.
 
   ## Overlay Structure
-  - Each overlay targets ONE entity, activates on one or more codewords
-  - "when" lists codeword IDs that must ALL be granted
+  - Each overlay targets ONE entity, activates on one or more state flags
+  - "when" lists state flag IDs that must ALL be granted
   - "details" is an array of {{key, value}} describing changes:
     keys like "attitude", "appearance", "description", "access", "status", "mood"
   - Maximum 3 overlays per entity
@@ -57,25 +57,25 @@ system: |
   ## What NOT to Do
   - Do NOT use IDs not listed in the Valid IDs section
   - Do NOT propose overlays with empty details
-  - Do NOT invent entity or codeword IDs
+  - Do NOT invent entity or state flag IDs
   - Do NOT add prose before or after the JSON output
 
   ## Valid IDs
   Valid entity_ids: {valid_entity_ids}
-  Valid codeword_ids (for "when" field): {valid_codeword_ids}
+  Valid state_flag_ids (for "when" field): {valid_state_flag_ids}
 
   ## Output Format
   Return a JSON object with an "overlays" array. Each overlay has:
   - entity_id: the entity being modified (e.g., "character::hero")
-  - when: list of codeword IDs that activate this overlay
+  - when: list of state flag IDs that activate this overlay
   - details: array of {{key, value}} objects describing changes (MUST NOT be empty)
 
   If no overlays exist after checking all rules, return an empty overlays array.
 
 user: |
-  Propose entity overlays based on the consequences and codewords above.
+  Propose entity overlays based on the consequences and state flags above.
 
-  For each codeword, apply the four rules (direct mention, state change,
+  For each state flag, apply the four rules (direct mention, state change,
   atmosphere shift, ripple effect) to every entity.
 
   REMINDER: Every overlay MUST have a non-empty details array.

--- a/prompts/templates/grow_phase8d_residue.yaml
+++ b/prompts/templates/grow_phase8d_residue.yaml
@@ -16,10 +16,10 @@ system: |
   - After a risky shortcut vs. safe route, the shared passage might note
     exhaustion (shortcut) or supplies running low (safe route, took longer)
 
-  Each residue beat produces one variant per path, gated by the codeword
+  Each residue beat produces one variant per path, gated by the state flag
   that tracks which path was taken.
 
-  ## Convergence Points and Available Codewords
+  ## Convergence Points and Available State Flags
   {convergence_context}
 
   ## Passage Summaries
@@ -28,7 +28,7 @@ system: |
   ## Rules
   1. Only propose residue beats for the passages listed above
   2. Each proposal targets ONE passage and ONE dilemma
-  3. Each variant is gated by exactly ONE codeword from the available list
+  3. Each variant is gated by exactly ONE state flag from the available list
   4. The hint field tells the prose writer HOW to differentiate this variant
      (10-200 characters, specific and concrete)
   5. Maximum {max_proposals} proposals total
@@ -47,7 +47,7 @@ system: |
 
   ## Valid IDs
   Valid passage_ids: {valid_passage_ids}
-  Valid codeword_ids (for variant gating): {valid_codeword_ids}
+  Valid state_flag_ids (for variant gating): {valid_state_flag_ids}
   Valid dilemma_ids: {valid_dilemma_ids}
 
   ## Output Format
@@ -56,7 +56,7 @@ system: |
   - dilemma_id: dilemma whose paths are converging at this point
   - rationale: why this passage needs path-specific variants (1 sentence)
   - variants: array of objects, each with:
-    - codeword_id: the codeword that gates this variant
+    - state_flag_id: the state flag that gates this variant
     - hint: specific prose guidance (10-200 chars)
 
   If no passages warrant residue variants, return an empty proposals array.

--- a/prompts/templates/grow_phase9c_hub_spokes.yaml
+++ b/prompts/templates/grow_phase9c_hub_spokes.yaml
@@ -36,13 +36,13 @@ system: |
      based on the prose it writes. This ensures labels match actual content.
   5. If you DO provide labels: 3-6 words, action phrases in imperative form
   6. Forward label: describes continuing the main story (required)
-  7. Spokes may optionally grant codewords when visited. Only use IDs from
-     the Valid Codewords list. Most spokes should NOT grant — only grant when
-     exploring that spoke naturally reveals something tracked by a codeword.
+  7. Spokes may optionally grant state flags when visited. Only use IDs from
+     the Valid State Flags list. Most spokes should NOT grant — only grant when
+     exploring that spoke naturally reveals something tracked by a state flag.
 
   ## What NOT to Do
   - Do NOT use passage IDs not listed in the Valid IDs section
-  - Do NOT use codeword IDs not listed in the Valid Codewords section
+  - Do NOT use state flag IDs not listed in the Valid State Flags section
   - Do NOT make spokes plot-critical (they are OPTIONAL)
   - Do NOT add explanatory prose before or after the JSON output
   - Do NOT propose hubs at ending passages (no outgoing choices)
@@ -51,8 +51,8 @@ system: |
   ## Valid IDs
   Valid passage IDs: {valid_passage_ids}
 
-  ## Valid Codewords
-  Valid codeword IDs: {valid_codeword_ids}
+  ## Valid State Flags
+  Valid state flag IDs: {valid_state_flag_ids}
 
   ## Output Format
   Return a JSON object with a "hubs" array. Each hub has:
@@ -65,7 +65,7 @@ system: |
       - "evocative": Atmospheric — "Trace the faded ink", "Listen to the silence"
       - "character_voice": Internal thought — "That clock... why did it stop?"
       If omitted, defaults to "functional"
-    - grants: (optional) list of codeword IDs this spoke grants when visited (default: empty)
+    - grants: (optional) list of state flag IDs this spoke grants when visited (default: empty)
   - forward_label: choice label for continuing the story (3-6 words)
 
 user: |

--- a/src/questfoundry/cli.py
+++ b/src/questfoundry/cli.py
@@ -88,7 +88,7 @@ DEFAULT_NONINTERACTIVE_SEED_PROMPT = (
 
 DEFAULT_GROW_PROMPT = (
     "Build the complete branching structure from the SEED graph: "
-    "enumerate arcs, create passages, derive choices and codewords."
+    "enumerate arcs, create passages, derive choices and state flags."
 )
 DEFAULT_FILL_PROMPT = (
     "Generate prose for all passages: determine voice document, "
@@ -1116,7 +1116,7 @@ def grow(
     """Run GROW stage - build complete branching structure.
 
     Takes the paths and beats from SEED and builds the full
-    branching story graph: arcs, passages, choices, codewords,
+    branching story graph: arcs, passages, choices, state flags,
     and state overlays.
 
     This stage runs 15 phases (mostly deterministic, some LLM-assisted)

--- a/src/questfoundry/export/context.py
+++ b/src/questfoundry/export/context.py
@@ -83,7 +83,8 @@ def _extract_choices(graph: Graph) -> list[ExportChoice]:
             from_passage=data["from_passage"],
             to_passage=data["to_passage"],
             label=data.get("label", "continue"),
-            requires_codewords=data.get("requires_codewords", []),
+            requires_codewords=data.get("requires_state_flags")
+            or data.get("requires_codewords", []),
             grants=data.get("grants", []),
             is_return=data.get("is_return", False),
         )
@@ -161,7 +162,7 @@ def _project_state_flags_to_codewords(graph: Graph) -> list[ExportCodeword]:
             result.append(
                 ExportCodeword(
                     id=flag_id,
-                    codeword_type=flag_data.get("codeword_type", "granted"),
+                    codeword_type=flag_data.get("flag_type", "granted"),
                     tracks=flag_data.get("tracks"),
                 )
             )

--- a/src/questfoundry/export/context.py
+++ b/src/questfoundry/export/context.py
@@ -83,8 +83,7 @@ def _extract_choices(graph: Graph) -> list[ExportChoice]:
             from_passage=data["from_passage"],
             to_passage=data["to_passage"],
             label=data.get("label", "continue"),
-            requires_codewords=data.get("requires_state_flags")
-            or data.get("requires_codewords", []),
+            requires_codewords=data.get("requires_state_flags", data.get("requires_codewords", [])),
             grants=data.get("grants", []),
             is_return=data.get("is_return", False),
         )

--- a/src/questfoundry/graph/dress_context.py
+++ b/src/questfoundry/graph/dress_context.py
@@ -234,20 +234,20 @@ def format_entity_for_codex(graph: Graph, entity_id: str) -> str:
     # decides which state flags are actually meaningful for gating.
     state_flags = graph.get_nodes_by_type("state_flag")
     related: list[tuple[str, str]] = []
-    for cw_id, cw_data in state_flags.items():
-        trigger = cw_data.get("trigger", "")
-        cw_raw = cw_data.get("raw_id", strip_scope_prefix(cw_id))
-        if raw_id.lower() in trigger.lower() or raw_id.lower() in cw_raw.lower():
-            related.append((cw_raw, trigger))
+    for sf_id, sf_data in state_flags.items():
+        trigger = sf_data.get("trigger", "")
+        sf_raw = sf_data.get("raw_id", strip_scope_prefix(sf_id))
+        if raw_id.lower() in trigger.lower() or raw_id.lower() in sf_raw.lower():
+            related.append((sf_raw, trigger))
 
     if related:
         lines.append("")
         lines.append("### Related State Flags (potential codex gates)")
-        for cw_raw, trigger in sorted(related):
+        for sf_raw, trigger in sorted(related):
             if trigger:
-                lines.append(f"- `{cw_raw}`: {trigger}")
+                lines.append(f"- `{sf_raw}`: {trigger}")
             else:
-                lines.append(f"- `{cw_raw}`")
+                lines.append(f"- `{sf_raw}`")
 
     return "\n".join(lines).strip()
 

--- a/src/questfoundry/graph/dress_context.py
+++ b/src/questfoundry/graph/dress_context.py
@@ -184,13 +184,13 @@ def format_passage_for_brief(graph: Graph, passage_id: str) -> str:
 
 
 def format_entity_for_codex(graph: Graph, entity_id: str) -> str:
-    """Format entity details + related codewords for codex generation.
+    """Format entity details + related state flags for codex generation.
 
-    Provides the entity's full profile and any codewords that could
+    Provides the entity's full profile and any state flags that could
     gate codex tiers (e.g., meeting a character unlocks deeper lore).
 
     Args:
-        graph: Graph containing entity and codeword nodes.
+        graph: Graph containing entity and state_flag nodes.
         entity_id: Entity node ID (e.g., ``entity::aldric``).
 
     Returns:
@@ -227,14 +227,14 @@ def format_entity_for_codex(graph: Graph, entity_id: str) -> str:
         if features:
             lines.append(f"**Features:** {', '.join(features)}")
 
-    # Related codewords — uses substring matching as a heuristic:
-    # a codeword is "related" if the entity's raw_id appears in the
-    # codeword's trigger text or raw_id (case-insensitive). This is
+    # Related state flags — uses substring matching as a heuristic:
+    # a state flag is "related" if the entity's raw_id appears in the
+    # state flag's trigger text or raw_id (case-insensitive). This is
     # intentionally broad to surface potential codex gates; the LLM
-    # decides which codewords are actually meaningful for gating.
-    codewords = graph.get_nodes_by_type("codeword")
+    # decides which state flags are actually meaningful for gating.
+    state_flags = graph.get_nodes_by_type("state_flag")
     related: list[tuple[str, str]] = []
-    for cw_id, cw_data in codewords.items():
+    for cw_id, cw_data in state_flags.items():
         trigger = cw_data.get("trigger", "")
         cw_raw = cw_data.get("raw_id", strip_scope_prefix(cw_id))
         if raw_id.lower() in trigger.lower() or raw_id.lower() in cw_raw.lower():
@@ -242,7 +242,7 @@ def format_entity_for_codex(graph: Graph, entity_id: str) -> str:
 
     if related:
         lines.append("")
-        lines.append("### Related Codewords (potential codex gates)")
+        lines.append("### Related State Flags (potential codex gates)")
         for cw_raw, trigger in sorted(related):
             if trigger:
                 lines.append(f"- `{cw_raw}`: {trigger}")
@@ -412,7 +412,7 @@ def format_entities_batch_for_codex(graph: Graph, entity_ids: list[str]) -> str:
     """Format a batch of entities for codex generation.
 
     Args:
-        graph: Graph containing entity and codeword nodes.
+        graph: Graph containing entity and state_flag nodes.
         entity_ids: Entity node IDs in this batch.
 
     Returns:

--- a/src/questfoundry/graph/dress_mutations.py
+++ b/src/questfoundry/graph/dress_mutations.py
@@ -238,11 +238,11 @@ def validate_dress_codex_entries(
     Checks:
     - At least one entry exists
     - Entry with rank=1 exists (base tier, always visible)
-    - Codeword IDs in visible_when exist in graph
+    - State flag IDs in visible_when exist in graph
     - Ranks are unique per entity
 
     Args:
-        graph: Story graph for codeword validation.
+        graph: Story graph for state flag validation.
         entity_id: Entity these entries belong to.
         entries: List of CodexEntry dicts.
 
@@ -268,17 +268,17 @@ def validate_dress_codex_entries(
         if count > 1:
             errors.append(f"Entity {entity_id}: duplicate rank={r} ({count} entries)")
 
-    # Validate codeword references
-    codewords = graph.get_nodes_by_type("codeword")
-    codeword_ids = {strip_scope_prefix(cid) for cid in codewords}
+    # Validate state flag references
+    state_flags = graph.get_nodes_by_type("state_flag")
+    state_flag_ids = {strip_scope_prefix(cid) for cid in state_flags}
 
     for entry in entries:
         for cw in entry.get("visible_when", []):
             raw_cw = strip_scope_prefix(cw)
-            if raw_cw not in codeword_ids:
+            if raw_cw not in state_flag_ids:
                 errors.append(
                     f"Entity {entity_id}: codex rank={entry.get('rank')} "
-                    f"references unknown codeword '{cw}'"
+                    f"references unknown state flag '{cw}'"
                 )
 
     return errors

--- a/src/questfoundry/graph/fill_context.py
+++ b/src/questfoundry/graph/fill_context.py
@@ -1685,17 +1685,17 @@ def format_ending_guidance(
 def format_ending_differentiation(graph: Graph, passage_id: str) -> str:
     """Build family-specific narrative context for a synthetic ending passage.
 
-    Traces the passage's ``family_codewords`` back through graph edges to
+    Traces the passage's ``family_state_flags`` back through graph edges to
     collect the consequence descriptions and path themes that distinguish
     this ending from its siblings.  Returns a prompt block that grounds
     the LLM in the specific consequences the reader experienced.
 
     Edge traversal::
 
-        codeword --tracks--> consequence <--has_consequence-- path
+        state_flag --tracks--> consequence <--has_consequence-- path
 
     Args:
-        graph: Story graph with codeword, consequence, and path nodes.
+        graph: Story graph with state_flag, consequence, and path nodes.
         passage_id: Full node ID (e.g. ``passage::ending_climax_0``).
 
     Returns:
@@ -1707,16 +1707,16 @@ def format_ending_differentiation(graph: Graph, passage_id: str) -> str:
     if not passage:
         return ""
 
-    family_codewords = passage.get("family_codewords")
-    if not family_codewords or not passage.get("is_synthetic"):
+    family_flags = passage.get("family_state_flags")
+    if not family_flags or not passage.get("is_synthetic"):
         return ""
 
-    # codeword → consequence (via tracks edges: codeword tracks consequence)
-    # We only need edges for our family codewords.
+    # state_flag → consequence (via tracks edges: state_flag tracks consequence)
+    # We only need edges for our family state flags.
     bullets: list[str] = []
-    for cw_id in sorted(family_codewords):
-        scoped_cw = cw_id if cw_id.startswith("codeword::") else f"codeword::{cw_id}"
-        tracks = graph.get_edges(from_id=scoped_cw, edge_type="tracks")
+    for sf_id in sorted(family_flags):
+        scoped_sf = sf_id if sf_id.startswith("state_flag::") else f"state_flag::{sf_id}"
+        tracks = graph.get_edges(from_id=scoped_sf, edge_type="tracks")
         if not tracks:
             continue
         consequence_id = sorted(tracks, key=lambda e: e["to"])[0]["to"]

--- a/src/questfoundry/graph/grow_algorithms.py
+++ b/src/questfoundry/graph/grow_algorithms.py
@@ -712,16 +712,16 @@ def _collect_family_tones(
 def split_ending_families(graph: Graph) -> EndingSplitResult:
     """Split shared terminal passages into per-arc-family ending passages.
 
-    When multiple arcs with different codeword signatures share the same
+    When multiple arcs with different state flag signatures share the same
     terminal passage, this function creates distinct ending passages gated
-    by distinguishing codewords.  Each arc family gets its own ending
+    by distinguishing state flags.  Each arc family gets its own ending
     passage so that FILL can write unique prose per family.
 
-    Must run AFTER mark_terminal_passages (Phase 9c2) and AFTER codewords
+    Must run AFTER mark_terminal_passages (Phase 9c2) and AFTER state flags
     have been created (Phase 8b).
 
     Args:
-        graph: Story graph with passages, arcs, and codewords.
+        graph: Story graph with passages, arcs, and state flags.
 
     Returns:
         EndingSplitResult with counts.
@@ -736,8 +736,8 @@ def split_ending_families(graph: Graph) -> EndingSplitResult:
     if not terminal_ids:
         return EndingSplitResult(0, 0, 0)
 
-    # Build arc → codeword signature mapping
-    arc_codewords = _build_arc_codewords(graph, arc_nodes)
+    # Build arc → state flag signature mapping
+    arc_state_flags = _build_arc_state_flags(graph, arc_nodes)
 
     # Build beat → covering arcs mapping
     beat_to_arcs: dict[str, list[str]] = {}
@@ -758,10 +758,10 @@ def split_ending_families(graph: Graph) -> EndingSplitResult:
             already_unique += 1
             continue
 
-        # Group arcs by codeword signature
+        # Group arcs by state flag signature
         sig_to_arcs: dict[frozenset[str], list[str]] = {}
         for arc_id in covering_arcs:
-            sig = arc_codewords.get(arc_id, frozenset())
+            sig = arc_state_flags.get(arc_id, frozenset())
             sig_to_arcs.setdefault(sig, []).append(arc_id)
 
         if len(sig_to_arcs) <= 1:
@@ -776,12 +776,12 @@ def split_ending_families(graph: Graph) -> EndingSplitResult:
         for i, (sig, family_arcs) in enumerate(
             sorted(sig_to_arcs.items(), key=lambda x: sorted(x[0]))
         ):
-            # Distinguishing codewords: in this family but not in ALL other families
+            # Distinguishing state flags: in this family but not in ALL other families
             other_sigs_intersection = _intersect_all([s for s in all_sigs if s != sig])
             distinguishing = sorted(sig - other_sigs_intersection)
 
             if not distinguishing:
-                # Degenerate: families share all codewords but have different
+                # Degenerate: families share all state flags but have different
                 # signatures — shouldn't occur, indicates upstream issue
                 log.warning(
                     "degenerate_ending_split",
@@ -804,7 +804,7 @@ def split_ending_families(graph: Graph) -> EndingSplitResult:
                 "is_ending": True,
                 "is_synthetic": True,
                 "summary": summary,
-                "family_codewords": distinguishing,
+                "family_state_flags": distinguishing,
                 "family_arc_count": len(family_arcs),
                 "residue_for": terminal_id,
             }
@@ -838,26 +838,26 @@ def split_ending_families(graph: Graph) -> EndingSplitResult:
     )
 
 
-def build_arc_codewords(
+def build_arc_state_flags(
     graph: Graph,
     arc_nodes: dict[str, dict[str, Any]],
     scope: Literal["ending", "routing", "all"] = "ending",
 ) -> dict[str, frozenset[str]]:
-    """Build mapping from arc node ID to its codeword signature.
+    """Build mapping from arc node ID to its state flag signature.
 
     Args:
         graph: The story graph.
         arc_nodes: Arc node data from ``graph.get_nodes_by_type("arc")``.
-        scope: Which codewords to include:
+        scope: Which state flags to include:
 
-            - ``"ending"`` — only codewords from ``ending_salience == "high"``
+            - ``"ending"`` — only state flags from ``ending_salience == "high"``
               dilemmas (for ``split_ending_families``).
-            - ``"routing"`` — codewords from dilemmas with any active routing
+            - ``"routing"`` — state flags from dilemmas with any active routing
               need (``ending_salience == "high"`` OR
               ``residue_weight == "heavy"``), for routing validation.
-            - ``"all"`` — all codewords, unfiltered.
+            - ``"all"`` — all state flags, unfiltered.
 
-    Traces: arc → paths → consequences → codewords via graph edges,
+    Traces: arc → paths → consequences → state flags via graph edges,
     filtered by: path → dilemma → ending_salience / residue_weight.
     """
     # Build path → dilemma lookup, filtered by scope
@@ -880,11 +880,11 @@ def build_arc_codewords(
         ):
             included_paths.add(path_id)
 
-    # consequence → codeword (via tracks edges: codeword tracks consequence)
+    # consequence → state flag (via tracks edges: state_flag tracks consequence)
     tracks_edges = graph.get_edges(edge_type="tracks")
-    consequence_to_codeword: dict[str, str] = {}
+    consequence_to_state_flag: dict[str, str] = {}
     for edge in tracks_edges:
-        consequence_to_codeword[edge["to"]] = edge["from"]
+        consequence_to_state_flag[edge["to"]] = edge["from"]
 
     # path → consequences (via has_consequence edges)
     has_consequence_edges = graph.get_edges(edge_type="has_consequence")
@@ -894,21 +894,21 @@ def build_arc_codewords(
 
     result: dict[str, frozenset[str]] = {}
     for arc_id, data in arc_nodes.items():
-        cws: set[str] = set()
+        sfs: set[str] = set()
         for path_raw in data.get("paths", []):
             path_id = normalize_scoped_id(path_raw, "path")
             if path_id not in included_paths:
                 continue
             for cons_id in path_consequences.get(path_id, []):
-                if cw := consequence_to_codeword.get(cons_id):
-                    cws.add(cw)
-        result[arc_id] = frozenset(cws)
+                if sf := consequence_to_state_flag.get(cons_id):
+                    sfs.add(sf)
+        result[arc_id] = frozenset(sfs)
 
     return result
 
 
 # Backward-compatible alias for internal callers
-_build_arc_codewords = build_arc_codewords
+_build_arc_state_flags = build_arc_state_flags
 
 
 def _intersect_all(sets: list[frozenset[str]]) -> frozenset[str]:
@@ -927,11 +927,11 @@ class VariantSpec:
 
     Attributes:
         passage_id: Target variant passage (must already exist in graph).
-        requires_codewords: Codewords gating this variant route.
+        requires_state_flags: State flags gating this variant route.
     """
 
     passage_id: str
-    requires_codewords: list[str]
+    requires_state_flags: list[str]
 
 
 def split_and_reroute(
@@ -955,7 +955,7 @@ def split_and_reroute(
     Args:
         graph: Story graph with passage and choice nodes.
         base_passage_id: The shared passage to replace with variants.
-        variants: List of variant specs (passage + codeword gates).
+        variants: List of variant specs (passage + state flag gates).
         keep_fallback: If True, keep original incoming choices as ungated
             fallback routes to base_passage_id.  If False (default),
             remove original incoming choices.
@@ -1000,7 +1000,7 @@ def split_and_reroute(
                     "type": "choice",
                     "from_passage": source_passage,
                     "to_passage": variant.passage_id,
-                    "requires_codewords": list(variant.requires_codewords),
+                    "requires_state_flags": list(variant.requires_state_flags),
                     "grants": list(original_choice.get("grants", [])),
                     "label": original_choice.get("label"),
                     "is_routing": True,
@@ -1920,7 +1920,7 @@ class ResidueCandidate:
     dilemma_id: str
     dilemma_role: str  # "soft"
     residue_weight: str  # "heavy" or "light" (cosmetic filtered out)
-    codeword_ids: list[str]  # Available codewords for gating variants
+    state_flag_ids: list[str]  # Available state flags for gating variants
     dilemma_question: str  # For LLM context
 
 
@@ -1959,20 +1959,20 @@ def find_residue_candidates(graph: Graph) -> list[ResidueCandidate]:
         if from_beat:
             beat_to_passage[from_beat] = pid
 
-    # Build path → codeword mapping (path's consequence → codeword)
-    path_codewords: dict[str, list[str]] = {}
-    codeword_nodes = graph.get_nodes_by_type("codeword")
+    # Build path → state flag mapping (path's consequence → state flag)
+    path_state_flags: dict[str, list[str]] = {}
+    state_flag_nodes = graph.get_nodes_by_type("state_flag")
     has_consequence_edges = graph.get_edges(edge_type="has_consequence")
     # Map consequence → path
     cons_to_path: dict[str, str] = {}
     for edge in has_consequence_edges:
         cons_to_path[edge["to"]] = edge["from"]
-    # Map path → codewords via consequence
-    for cw_id, cw_data in codeword_nodes.items():
-        tracks = cw_data.get("tracks", "")
+    # Map path → state flags via consequence
+    for sf_id, sf_data in state_flag_nodes.items():
+        tracks = sf_data.get("tracks", "")
         path_id = cons_to_path.get(tracks)
         if path_id:
-            path_codewords.setdefault(path_id, []).append(cw_id)
+            path_state_flags.setdefault(path_id, []).append(sf_id)
 
     # Build dilemma → paths mapping
     dilemma_paths_map = build_dilemma_paths(graph)
@@ -2009,13 +2009,13 @@ def find_residue_candidates(graph: Graph) -> list[ResidueCandidate]:
                 continue
             seen.add(key)
 
-            # Collect codewords for this dilemma's paths
+            # Collect state flags for this dilemma's paths
             paths = dilemma_paths_map.get(dc.dilemma_id, [])
-            cw_ids: list[str] = []
+            sf_ids: list[str] = []
             for path_id in paths:
-                cw_ids.extend(path_codewords.get(path_id, []))
+                sf_ids.extend(path_state_flags.get(path_id, []))
 
-            if len(cw_ids) < 2:
+            if len(sf_ids) < 2:
                 continue  # Need at least 2 variants
 
             # Get dilemma question for LLM context
@@ -2027,7 +2027,7 @@ def find_residue_candidates(graph: Graph) -> list[ResidueCandidate]:
                     dilemma_id=dc.dilemma_id,
                     dilemma_role=dc.policy,
                     residue_weight=residue_weight,
-                    codeword_ids=sorted(cw_ids),
+                    state_flag_ids=sorted(sf_ids),
                     dilemma_question=question,
                 )
             )
@@ -2051,24 +2051,24 @@ def create_residue_passages(
     """Create variant passages from accepted residue proposals.
 
     For each proposal:
-    1. Create variant passages (passage::{base}__via_{codeword_suffix})
+    1. Create variant passages (passage::{base}__via_{state_flag_suffix})
     2. Mark variants with is_residue=True and residue metadata
     3. Wire variants via split_and_reroute (incoming-edge rewriting)
 
-    The base passage is kept as fallback for arcs whose codewords don't
+    The base passage is kept as fallback for arcs whose state flags don't
     match any variant (keep_fallback=True).
 
     Args:
-        graph: Story graph with passages and codewords.
+        graph: Story graph with passages and state flags.
         proposals: List of dicts with keys: passage_id, dilemma_id,
-            variants (list of {codeword_id, hint}).
+            variants (list of {state_flag_id, hint}).
 
     Returns:
         ResidueCreationResult with counts.
     """
     passage_nodes = graph.get_nodes_by_type("passage")
-    codeword_nodes = graph.get_nodes_by_type("codeword")
-    valid_codewords = set(codeword_nodes.keys())
+    state_flag_nodes = graph.get_nodes_by_type("state_flag")
+    valid_state_flags = set(state_flag_nodes.keys())
 
     variants_created = 0
     applied = 0
@@ -2091,15 +2091,15 @@ def create_residue_passages(
             skipped += 1
             continue
 
-        # Validate all codewords exist
+        # Validate all state flags exist
         all_valid = True
         for variant in variants:
-            cw_id = variant.get("codeword_id", "")
-            if cw_id not in valid_codewords:
+            sf_id = variant.get("state_flag_id", "")
+            if sf_id not in valid_state_flags:
                 log.warning(
-                    "residue_invalid_codeword",
+                    "residue_invalid_state_flag",
                     passage_id=passage_id,
-                    codeword_id=cw_id,
+                    state_flag_id=sf_id,
                 )
                 all_valid = False
                 break
@@ -2110,15 +2110,15 @@ def create_residue_passages(
         # Create variant passages and collect specs for routing
         variant_specs: list[VariantSpec] = []
         for variant in variants:
-            cw_id = variant.get("codeword_id", "")
+            sf_id = variant.get("state_flag_id", "")
             hint = variant.get("hint", "")
-            cw_suffix = strip_scope_prefix(cw_id).removesuffix("_committed")
+            sf_suffix = strip_scope_prefix(sf_id).removesuffix("_committed")
 
-            variant_pid = f"passage::{raw_id}__via_{cw_suffix}"
+            variant_pid = f"passage::{raw_id}__via_{sf_suffix}"
             # Ensure unique ID
             counter = 1
             while graph.get_node(variant_pid):
-                variant_pid = f"passage::{raw_id}__via_{cw_suffix}_{counter}"
+                variant_pid = f"passage::{raw_id}__via_{sf_suffix}_{counter}"
                 counter += 1
 
             graph.create_node(
@@ -2132,16 +2132,16 @@ def create_residue_passages(
                     "is_residue": True,
                     "is_synthetic": True,
                     "residue_for": passage_id,
-                    "residue_codeword": cw_id,
+                    "residue_state_flag": sf_id,
                     "residue_hint": hint,
                     "residue_dilemma": dilemma_id,
                 },
             )
-            variant_specs.append(VariantSpec(variant_pid, [cw_id]))
+            variant_specs.append(VariantSpec(variant_pid, [sf_id]))
             variants_created += 1
 
         # Wire variants via incoming-edge rewriting; base passage is kept
-        # as fallback for arcs whose codewords don't match any variant
+        # as fallback for arcs whose state flags don't match any variant
         split_and_reroute(graph, passage_id, variant_specs, keep_fallback=True)
         applied += 1
 
@@ -2174,7 +2174,7 @@ class HeavyDivergenceTarget:
     dilemma_id: str
     residue_weight: str
     ending_salience: str
-    path_codewords: dict[str, str]  # path_id → codeword_id
+    path_state_flags: dict[str, str]  # path_id → state_flag_id
 
 
 def find_heavy_divergence_targets(graph: Graph) -> list[HeavyDivergenceTarget]:
@@ -2197,7 +2197,7 @@ def find_heavy_divergence_targets(graph: Graph) -> list[HeavyDivergenceTarget]:
     passage_nodes = graph.get_nodes_by_type("passage")
     dilemma_nodes = graph.get_nodes_by_type("dilemma")
     path_nodes = graph.get_nodes_by_type("path")
-    codeword_nodes = graph.get_nodes_by_type("codeword")
+    state_flag_nodes = graph.get_nodes_by_type("state_flag")
 
     if not arc_nodes or not passage_nodes or not dilemma_nodes:
         return []
@@ -2219,26 +2219,26 @@ def find_heavy_divergence_targets(graph: Graph) -> list[HeavyDivergenceTarget]:
                 dilemma_id = normalize_scoped_id(raw_did, "dilemma")
                 arc_dilemma_paths.setdefault(arc_id, set()).add((dilemma_id, path_id))
 
-    # Path → codeword mapping (via consequence → codeword.tracks)
-    path_to_codeword: dict[str, str] = {}
+    # Path → state flag mapping (via consequence → state_flag.tracks)
+    path_to_state_flag: dict[str, str] = {}
     has_consequence_edges = graph.get_edges(edge_type="has_consequence")
     cons_to_path: dict[str, str] = {}
     for edge in has_consequence_edges:
         cons_to_path[edge["to"]] = edge["from"]
-    for cw_id, cw_data in codeword_nodes.items():
-        tracks = cw_data.get("tracks", "")
+    for sf_id, sf_data in state_flag_nodes.items():
+        tracks = sf_data.get("tracks", "")
         path_id_for_tracks = cons_to_path.get(tracks)
         if not path_id_for_tracks:
             continue
-        # Invariant: each path should have a single committed codeword.
-        if path_id_for_tracks in path_to_codeword:
+        # Invariant: each path should have a single committed state flag.
+        if path_id_for_tracks in path_to_state_flag:
             log.warning(
-                "path_codeword_duplicate",
+                "path_state_flag_duplicate",
                 path_id=path_id_for_tracks,
-                codeword_id=cw_id,
+                state_flag_id=sf_id,
             )
             continue
-        path_to_codeword[path_id_for_tracks] = cw_id
+        path_to_state_flag[path_id_for_tracks] = sf_id
 
     # Already-routed passages — identified by variant passages that
     # reference them via ``residue_for`` metadata.  We do NOT use
@@ -2301,15 +2301,15 @@ def find_heavy_divergence_targets(graph: Graph) -> list[HeavyDivergenceTarget]:
             if len(paths_for_dilemma) < 2:
                 continue  # Arcs agree — no divergence
 
-            # Build path → codeword mapping for the diverging paths
-            pcw: dict[str, str] = {}
+            # Build path → state flag mapping for the diverging paths
+            psf: dict[str, str] = {}
             for p_id in sorted(paths_for_dilemma):
-                cw = path_to_codeword.get(p_id)
-                if cw:
-                    pcw[p_id] = cw
+                sf = path_to_state_flag.get(p_id)
+                if sf:
+                    psf[p_id] = sf
 
-            if len(pcw) < 2:
-                continue  # Need at least 2 gatable codewords
+            if len(psf) < 2:
+                continue  # Need at least 2 gatable state flags
 
             # Detect multi-dilemma routing for the same passage.
             existing_dilemmas = [k[1] for k in seen if k[0] == pid]
@@ -2328,7 +2328,7 @@ def find_heavy_divergence_targets(graph: Graph) -> list[HeavyDivergenceTarget]:
                     dilemma_id=dilemma_id,
                     residue_weight=weight,
                     ending_salience=salience,
-                    path_codewords=pcw,
+                    path_state_flags=psf,
                 )
             )
 
@@ -2388,13 +2388,13 @@ def wire_heavy_residue_routing(graph: Graph) -> HeavyRoutingResult:
 
         # Create one variant passage per diverging path
         variant_specs: list[VariantSpec] = []
-        for _path_id, cw_id in sorted(target.path_codewords.items()):
-            cw_suffix = strip_scope_prefix(cw_id).removesuffix("_committed")
-            variant_pid = f"passage::{raw_id}__heavy_{cw_suffix}"
+        for _path_id, sf_id in sorted(target.path_state_flags.items()):
+            sf_suffix = strip_scope_prefix(sf_id).removesuffix("_committed")
+            variant_pid = f"passage::{raw_id}__heavy_{sf_suffix}"
             # Ensure unique ID
             counter = 1
             while graph.get_node(variant_pid):
-                variant_pid = f"passage::{raw_id}__heavy_{cw_suffix}_{counter}"
+                variant_pid = f"passage::{raw_id}__heavy_{sf_suffix}_{counter}"
                 counter += 1
 
             graph.create_node(
@@ -2408,11 +2408,11 @@ def wire_heavy_residue_routing(graph: Graph) -> HeavyRoutingResult:
                     "is_residue": True,
                     "is_synthetic": True,
                     "residue_for": target.passage_id,
-                    "residue_codeword": cw_id,
+                    "residue_state_flag": sf_id,
                     "residue_dilemma": target.dilemma_id,
                 },
             )
-            variant_specs.append(VariantSpec(variant_pid, [cw_id]))
+            variant_specs.append(VariantSpec(variant_pid, [sf_id]))
             variants_created += 1
 
         if not variant_specs:
@@ -2469,20 +2469,20 @@ def compute_all_choice_requires(
     graph: Graph,
     passage_arcs: dict[str, set[str]],
 ) -> dict[str, list[str]]:
-    """Compute codeword ``requires`` for hard-policy branch entry passages.
+    """Compute state flag ``requires`` for hard-policy branch entry passages.
 
     For each passage that appears exclusively in hard-policy branch arcs
-    (not on the spine), collects codewords from **branch-exclusive** paths —
-    paths on the branch arc that are NOT on the spine.  These codewords
+    (not on the spine), collects state flags from **branch-exclusive** paths —
+    paths on the branch arc that are NOT on the spine.  These state flags
     identify the specific off-spine choices the player made, so the gate
     is satisfiable by any player on that arc.
 
     When a passage appears on multiple hard arcs, the requires are the
-    **intersection** of each arc's branch-exclusive codewords — ensuring
+    **intersection** of each arc's branch-exclusive state flags — ensuring
     any player on any qualifying arc can satisfy the gate.
 
     Returns:
-        Mapping of ``passage_id`` → list of required codeword IDs.
+        Mapping of ``passage_id`` → list of required state flag IDs.
         Empty dict if no spine arc exists or no hard-policy branches.
     """
     arcs = enumerate_arcs(graph)
@@ -2510,8 +2510,8 @@ def compute_all_choice_requires(
     for arc_id_raw, conv_info in convergence_map.items():
         arc_dilemma_role[f"arc::{arc_id_raw}"] = conv_info.dilemma_role
 
-    # 2. Build consequence→codeword lookup (reverse of tracks edges)
-    cons_to_codeword = {
+    # 2. Build consequence→state flag lookup (reverse of tracks edges)
+    cons_to_state_flag = {
         edge["to"]: edge["from"]
         for edge in graph.get_edges(from_id=None, to_id=None, edge_type="tracks")
     }
@@ -2523,16 +2523,16 @@ def compute_all_choice_requires(
         path_consequences.setdefault(edge["from"], []).append(edge["to"])
 
     # 4. For each passage exclusive to hard-policy branches, collect
-    #    codewords from branch-exclusive paths (off-spine choices).
+    #    state flags from branch-exclusive paths (off-spine choices).
     requires: dict[str, list[str]] = {}
     for passage_id, arc_ids in passage_arcs.items():
         # Skip passages reachable via the spine — no gating needed
         if any((a := arc_by_id.get(aid)) is not None and a.arc_type == "spine" for aid in arc_ids):
             continue
 
-        # Collect per-arc codeword sets; intersection gives codewords
+        # Collect per-arc state flag sets; intersection gives state flags
         # that ANY player on a qualifying arc will have.
-        arc_codeword_sets: list[set[str]] = []
+        arc_state_flag_sets: list[set[str]] = []
         for aid in sorted(arc_ids):
             arc_obj = arc_by_id.get(aid)
             if arc_obj is None or arc_dilemma_role.get(aid) != "hard":
@@ -2542,20 +2542,20 @@ def compute_all_choice_requires(
             branch_paths = {normalize_scoped_id(p, "path") for p in arc_obj.paths}
             branch_exclusive = branch_paths - spine_paths
 
-            arc_codewords: set[str] = set()
+            arc_state_flags: set[str] = set()
             for path_id in sorted(branch_exclusive):
                 for cons_id in path_consequences.get(path_id, []):
-                    cw = cons_to_codeword.get(cons_id)
-                    if cw:
-                        arc_codewords.add(cw)
+                    sf = cons_to_state_flag.get(cons_id)
+                    if sf:
+                        arc_state_flags.add(sf)
 
-            if arc_codewords:
-                arc_codeword_sets.append(arc_codewords)
+            if arc_state_flags:
+                arc_state_flag_sets.append(arc_state_flags)
 
-        if arc_codeword_sets:
-            codewords = set.intersection(*arc_codeword_sets)
-            if codewords:
-                requires[passage_id] = sorted(codewords)
+        if arc_state_flag_sets:
+            state_flags = set.intersection(*arc_state_flag_sets)
+            if state_flags:
+                requires[passage_id] = sorted(state_flags)
 
     return requires
 
@@ -3631,7 +3631,7 @@ def find_passage_successors(graph: Graph) -> dict[str, list[PassageSuccessor]]:
         if from_beat:
             beat_to_passage[from_beat] = p_id
 
-    # Collect grants edges: beat → codeword
+    # Collect grants edges: beat → state_flag
     grants_edges = graph.get_edges(from_id=None, to_id=None, edge_type="grants")
     beat_grants: dict[str, list[str]] = {}
     for edge in grants_edges:
@@ -3667,10 +3667,10 @@ def find_passage_successors(graph: Graph) -> dict[str, list[PassageSuccessor]]:
                 continue
             seen_targets[p_id].add(next_p)
 
-            # Grants: codewords from beats between this passage's beat and the
+            # Grants: state flags from beats between this passage's beat and the
             # next passage's beat (inclusive). This reflects state changes that
             # happen when the player takes this choice, without leaking future
-            # arc codewords.
+            # arc state flags.
             arc_grants: list[str] = []
             for beat_id in sequence[beat_idx + 1 : next_beat_idx + 1]:
                 arc_grants.extend(beat_grants.get(beat_id, []))

--- a/src/questfoundry/graph/grow_validation.py
+++ b/src/questfoundry/graph/grow_validation.py
@@ -655,7 +655,7 @@ _MOVED_TO_POLISH = {
     "check_all_endings_reachable",
     "check_all_passages_reachable",
     "check_arc_divergence",
-    "check_codeword_gate_coverage",
+    "check_state_flag_gate_coverage",
     "check_commits_timing",
     "check_forward_path_reachability",
     "check_gate_co_satisfiability",

--- a/src/questfoundry/graph/grow_validators.py
+++ b/src/questfoundry/graph/grow_validators.py
@@ -104,13 +104,13 @@ def validate_phase4a_output(
 def validate_phase8c_output(
     result: Phase8cOutput,
     valid_entity_ids: set[str],
-    valid_codeword_ids: set[str],
+    valid_state_flag_ids: set[str],
 ) -> list[GrowValidationError]:
     """Validate Phase 8c entity overlay proposals.
 
     Checks:
     - entity_id exists in graph
-    - codeword IDs in 'when' exist
+    - state flag IDs in 'when' exist
     """
     errors: list[GrowValidationError] = []
     for i, overlay in enumerate(result.overlays):
@@ -124,13 +124,13 @@ def validate_phase8c_output(
                 )
             )
         for cw_id in overlay.when:
-            if cw_id not in valid_codeword_ids:
+            if cw_id not in valid_state_flag_ids:
                 errors.append(
                     GrowValidationError(
                         field_path=f"overlays.{i}.when",
-                        issue=f"Codeword ID not found: {cw_id}",
+                        issue=f"State flag ID not found: {cw_id}",
                         provided=cw_id,
-                        available=sorted(valid_codeword_ids)[:10],
+                        available=sorted(valid_state_flag_ids)[:10],
                     )
                 )
     return errors
@@ -139,7 +139,7 @@ def validate_phase8c_output(
 def validate_phase8d_output(
     result: Phase8dOutput,
     valid_passage_ids: set[str],
-    valid_codeword_ids: set[str],
+    valid_state_flag_ids: set[str],
     valid_dilemma_ids: set[str],
 ) -> list[GrowValidationError]:
     """Validate Phase 8d residue beat proposals.
@@ -147,11 +147,11 @@ def validate_phase8d_output(
     Checks:
     - passage_id exists in graph
     - dilemma_id exists in graph
-    - codeword IDs in variants exist
+    - state flag IDs in variants exist
     """
     errors: list[GrowValidationError] = []
     available_passages = sorted(valid_passage_ids)[:10]
-    available_codewords = sorted(valid_codeword_ids)[:10]
+    available_state_flags = sorted(valid_state_flag_ids)[:10]
     available_dilemmas = sorted(valid_dilemma_ids)[:10]
 
     for i, proposal in enumerate(result.proposals):
@@ -174,13 +174,13 @@ def validate_phase8d_output(
                 )
             )
         for j, variant in enumerate(proposal.variants):
-            if variant.codeword_id not in valid_codeword_ids:
+            if variant.state_flag_id not in valid_state_flag_ids:
                 errors.append(
                     GrowValidationError(
-                        field_path=f"proposals.{i}.variants.{j}.codeword_id",
-                        issue=f"Codeword ID not found: {variant.codeword_id}",
-                        provided=variant.codeword_id,
-                        available=available_codewords,
+                        field_path=f"proposals.{i}.variants.{j}.state_flag_id",
+                        issue=f"State flag ID not found: {variant.state_flag_id}",
+                        provided=variant.state_flag_id,
+                        available=available_state_flags,
                     )
                 )
     return errors
@@ -339,14 +339,14 @@ def validate_phase9b_output(
 def validate_phase9c_output(
     result: Phase9cOutput,
     valid_passage_ids: set[str],
-    valid_codeword_ids: set[str] | None = None,
+    valid_state_flag_ids: set[str] | None = None,
 ) -> list[GrowValidationError]:
     """Validate Phase 9c hub-spoke proposals.
 
     Checks:
     - passage_id exists in valid passage IDs (which excludes ending passages,
       ensuring hubs have outgoing choices)
-    - spoke grant IDs reference existing codeword nodes (when valid_codeword_ids
+    - spoke grant IDs reference existing state flag nodes (when valid_state_flag_ids
       is provided)
     """
     errors: list[GrowValidationError] = []
@@ -360,17 +360,17 @@ def validate_phase9c_output(
                     available=sorted(valid_passage_ids)[:10],
                 )
             )
-        if valid_codeword_ids is not None:
+        if valid_state_flag_ids is not None:
             for j, spoke in enumerate(hub.spokes):
                 for k, grant_id in enumerate(spoke.grants):
-                    scoped = normalize_scoped_id(grant_id, "codeword")
-                    if scoped not in valid_codeword_ids:
+                    scoped = normalize_scoped_id(grant_id, "state_flag")
+                    if scoped not in valid_state_flag_ids:
                         errors.append(
                             GrowValidationError(
                                 field_path=f"hubs.{i}.spokes.{j}.grants.{k}",
-                                issue=f"Codeword ID not found: {grant_id}",
+                                issue=f"State flag ID not found: {grant_id}",
                                 provided=grant_id,
-                                available=sorted(valid_codeword_ids)[:10],
+                                available=sorted(valid_state_flag_ids)[:10],
                             )
                         )
     return errors

--- a/src/questfoundry/graph/grow_validators.py
+++ b/src/questfoundry/graph/grow_validators.py
@@ -123,13 +123,13 @@ def validate_phase8c_output(
                     available=sorted(valid_entity_ids)[:10],
                 )
             )
-        for cw_id in overlay.when:
-            if cw_id not in valid_state_flag_ids:
+        for sf_id in overlay.when:
+            if sf_id not in valid_state_flag_ids:
                 errors.append(
                     GrowValidationError(
                         field_path=f"overlays.{i}.when",
-                        issue=f"State flag ID not found: {cw_id}",
-                        provided=cw_id,
+                        issue=f"State flag ID not found: {sf_id}",
+                        provided=sf_id,
                         available=sorted(valid_state_flag_ids)[:10],
                     )
                 )

--- a/src/questfoundry/models/__init__.py
+++ b/src/questfoundry/models/__init__.py
@@ -64,7 +64,6 @@ from questfoundry.models.grow import (
     AtmosphericDetail,
     Choice,
     ChoiceLabel,
-    Codeword,
     EntityArcDescriptor,
     EntityOverlay,
     ForkProposal,
@@ -90,6 +89,7 @@ from questfoundry.models.grow import (
     SceneTypeTag,
     SpokeLabelStyle,
     SpokeProposal,
+    StateFlag,
 )
 from questfoundry.models.pipeline import PhaseResult
 from questfoundry.models.polish import (
@@ -170,7 +170,6 @@ __all__ = [
     "ChoiceLabel",
     "ChoiceLabelItem",
     "ChoiceSpec",
-    "Codeword",
     "CodexEntry",
     "Consequence",
     "ContentNotes",
@@ -259,6 +258,7 @@ __all__ = [
     "SpokeLabelStyle",
     "SpokeLabelUpdate",
     "SpokeProposal",
+    "StateFlag",
     "TemporalHint",
     "TemporalPosition",
     "VariantSpec",

--- a/src/questfoundry/models/seed.py
+++ b/src/questfoundry/models/seed.py
@@ -122,7 +122,7 @@ class Consequence(BaseModel):
     """Narrative consequence of a path choice.
 
     Consequences bridge the gap between "what this path represents" (answer)
-    and "how we track it" (codeword). GROW creates codewords to track when
+    and "how we track it" (state flag). GROW creates state flags to track when
     consequences become active.
 
     Attributes:

--- a/src/questfoundry/pipeline/stages/dress.py
+++ b/src/questfoundry/pipeline/stages/dress.py
@@ -864,7 +864,7 @@ class DressStage:
                 "vision_context": vision_ctx or "No creative vision available.",
                 "entities_batch": entities_batch,
                 "entity_count": str(len(chunk)),
-                "codewords": state_flag_list or "No state flags defined.",
+                "codewords": state_flag_list or "No codewords defined.",
                 "output_language_instruction": self._lang_instruction,
             }
             output, llm_calls, tokens = await self._dress_llm_call(

--- a/src/questfoundry/pipeline/stages/dress.py
+++ b/src/questfoundry/pipeline/stages/dress.py
@@ -53,6 +53,7 @@ from questfoundry.graph.dress_mutations import (
 )
 from questfoundry.graph.fill_context import format_dream_vision
 from questfoundry.graph.graph import Graph
+from questfoundry.graph.grow_algorithms import enumerate_arcs
 from questfoundry.graph.snapshots import save_snapshot
 from questfoundry.models.dress import (
     BatchedBriefOutput,
@@ -827,7 +828,7 @@ class DressStage:
         """Phase 2: Generate codex entries for entities.
 
         Batches entities (default 4 per LLM call) to reduce repeated
-        context injection. Shared vision and codewords go in the system
+        context injection. Shared vision and state flags go in the system
         message; per-batch entity details in the user message.
         """
         if self._skip_codex:
@@ -839,10 +840,10 @@ class DressStage:
             return DressPhaseResult(phase="codex", status="completed", detail="no entities")
 
         vision_ctx = format_dream_vision(graph)
-        codewords = graph.get_nodes_by_type("codeword")
-        codeword_list = "\n".join(
-            f"- `{cw_data.get('raw_id', cw_id)}`: {cw_data.get('trigger', '')}"
-            for cw_id, cw_data in codewords.items()
+        state_flags = graph.get_nodes_by_type("state_flag")
+        state_flag_list = "\n".join(
+            f"- `{sf_data.get('raw_id', sf_id)}`: {sf_data.get('trigger', '')}"
+            for sf_id, sf_data in state_flags.items()
         )
 
         codex_created = 0
@@ -863,7 +864,7 @@ class DressStage:
                 "vision_context": vision_ctx or "No creative vision available.",
                 "entities_batch": entities_batch,
                 "entity_count": str(len(chunk)),
-                "codewords": codeword_list or "No codewords defined.",
+                "codewords": state_flag_list or "No state flags defined.",
                 "output_language_instruction": self._lang_instruction,
             }
             output, llm_calls, tokens = await self._dress_llm_call(
@@ -1564,8 +1565,6 @@ def compute_structural_score(graph: Graph, passage_id: str) -> int:
         score -= 1
 
     # Check arc position using computed arcs
-    from questfoundry.graph.grow_algorithms import enumerate_arcs
-
     arcs = enumerate_arcs(graph)
 
     for arc in arcs:

--- a/src/questfoundry/pipeline/stages/grow/stage.py
+++ b/src/questfoundry/pipeline/stages/grow/stage.py
@@ -3,7 +3,7 @@
 The GROW stage builds the complete branching structure from the SEED
 graph. It runs a mix of deterministic and LLM-powered phases that
 enumerate arcs, assess path-agnostic beats, compute
-divergence/convergence points, create passages and codewords, and
+divergence/convergence points, create passages and state flags, and
 prune unreachable nodes.
 
 GROW manages its own graph: it loads, mutates, and saves the graph
@@ -40,7 +40,6 @@ from questfoundry.pipeline.stages.grow._helpers import (
 )
 from questfoundry.pipeline.stages.grow.deterministic import (  # noqa: F401 - register phases
     phase_apply_routing,
-    phase_codewords,
     phase_collapse_linear_beats,
     phase_collapse_passages,
     phase_convergence,
@@ -49,6 +48,7 @@ from questfoundry.pipeline.stages.grow.deterministic import (  # noqa: F401 - re
     phase_mark_endings,
     phase_passages,
     phase_prune,
+    phase_state_flags,
     phase_validate_dag,
     phase_validation,
 )
@@ -151,7 +151,7 @@ class GrowStage(_LLMHelperMixin, _LLMPhaseMixin):
         "convergence": "phase_convergence",
         "collapse_linear_beats": "phase_collapse_linear_beats",
         "passages": "phase_passages",
-        "codewords": "phase_codewords",
+        "state_flags": "phase_state_flags",
         "mark_endings": "phase_mark_endings",
         "apply_routing": "phase_apply_routing",
         "collapse_passages": "phase_collapse_passages",
@@ -361,7 +361,7 @@ class GrowStage(_LLMHelperMixin, _LLMPhaseMixin):
 
         arcs = enumerate_arcs(graph)
         passage_nodes = graph.get_nodes_by_type("passage")
-        codeword_nodes = graph.get_nodes_by_type("codeword")
+        state_flag_nodes = graph.get_nodes_by_type("state_flag")
         choice_nodes = graph.get_nodes_by_type("choice")
         entity_nodes = graph.get_nodes_by_type("entity")
 
@@ -376,7 +376,7 @@ class GrowStage(_LLMHelperMixin, _LLMPhaseMixin):
         grow_result = GrowResult(
             arc_count=len(arcs),
             passage_count=len(passage_nodes),
-            codeword_count=len(codeword_nodes),
+            state_flag_count=len(state_flag_nodes),
             choice_count=len(choice_nodes),
             overlay_count=overlay_count,
             phases_completed=phase_results,
@@ -388,7 +388,7 @@ class GrowStage(_LLMHelperMixin, _LLMPhaseMixin):
             stage="grow",
             arcs=grow_result.arc_count,
             passages=grow_result.passage_count,
-            codewords=grow_result.codeword_count,
+            state_flags=grow_result.state_flag_count,
         )
 
         # GROW manages its own graph; return summary data for validation

--- a/src/questfoundry/visualization.py
+++ b/src/questfoundry/visualization.py
@@ -57,7 +57,7 @@ class VizEdge:
     to_id: str
     label: str = ""
     is_return: bool = False
-    requires_codewords: list[str] = field(default_factory=list)
+    requires_state_flags: list[str] = field(default_factory=list)
     grants: list[str] = field(default_factory=list)
 
 
@@ -108,7 +108,7 @@ def build_story_graph(
             else:
                 passage_to_arc[pid] = arc_id
 
-    # Identify entities with overlays (codeword-dependent content)
+    # Identify entities with overlays (state-flag-dependent content)
     entities = graph.get_nodes_by_type("entity")
     overlay_entity_ids: set[str] = set()
     for eid, edata in entities.items():
@@ -184,7 +184,7 @@ def build_story_graph(
                 to_id=to_p,
                 label=cdata.get("label", ""),
                 is_return=cdata.get("is_return", False),
-                requires_codewords=cdata.get("requires_codewords", []),
+                requires_state_flags=cdata.get("requires_state_flags", []),
                 grants=cdata.get("grants", []),
             )
         )
@@ -239,7 +239,7 @@ def render_dot(sg: StoryGraph, *, no_labels: bool = False) -> str:
             edge_attrs["color"] = '"grey"'
         # Requires (gated) takes precedence over grants (state-changing).
         # Return edges keep their dashed grey style in both renderers.
-        if edge.requires_codewords:
+        if edge.requires_state_flags:
             edge_attrs["color"] = '"orange"'
             edge_attrs["penwidth"] = '"2"'
         elif edge.grants and not edge.is_return:
@@ -308,7 +308,7 @@ def render_mermaid(sg: StoryGraph, *, no_labels: bool = False) -> str:
     grants_indices = [
         i
         for i, e in enumerate(sg.edges)
-        if e.grants and not e.is_return and not e.requires_codewords
+        if e.grants and not e.is_return and not e.requires_state_flags
     ]
     if grants_indices:
         idx_list = ",".join(str(i) for i in grants_indices)

--- a/tests/integration/test_grow_e2e.py
+++ b/tests/integration/test_grow_e2e.py
@@ -174,7 +174,7 @@ class TestGrowFullPipeline:
             "arc_count",
             "passage_count",
             "choice_count",
-            "codeword_count",
+            "state_flag_count",
             "overlay_count",
             "spine_arc_id",
             "phases_completed",
@@ -192,9 +192,9 @@ class TestGrowFullPipeline:
         choice edges exist; base passage count after consolidation is the minimum)."""
         assert pipeline_result["result_dict"]["passage_count"] >= 7
 
-    def test_codewords_derived(self, pipeline_result: dict[str, Any]) -> None:
-        """Verify codewords are created from consequences (4 consequences)."""
-        assert pipeline_result["result_dict"]["codeword_count"] == 4
+    def test_state_flags_derived(self, pipeline_result: dict[str, Any]) -> None:
+        """Verify state flags are created from consequences (4 consequences)."""
+        assert pipeline_result["result_dict"]["state_flag_count"] == 4
 
     def test_choices_created(self, pipeline_result: dict[str, Any]) -> None:
         """Verify choices are created at divergence points."""
@@ -211,7 +211,7 @@ class TestGrowFullPipeline:
         expected_keys = {
             "arc_count",
             "passage_count",
-            "codeword_count",
+            "state_flag_count",
             "choice_count",
             "overlay_count",
         }

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -1406,7 +1406,7 @@ def test_grow_with_mock_provider(tmp_path: Path) -> None:
         "arc_count": 3,
         "passage_count": 12,
         "choice_count": 8,
-        "codeword_count": 4,
+        "state_flag_count": 4,
         "overlay_count": 2,
         "spine_arc_id": "arc_main",
         "phases_completed": [

--- a/tests/unit/test_dress_context.py
+++ b/tests/unit/test_dress_context.py
@@ -9,7 +9,7 @@ from questfoundry.graph.graph import Graph
 
 @pytest.fixture()
 def dress_graph() -> Graph:
-    """Graph with entities, passages, and codewords for DRESS testing."""
+    """Graph with entities, passages, and state flags for DRESS testing."""
     g = Graph()
     g.create_node(
         "vision::main",
@@ -70,9 +70,9 @@ def dress_graph() -> Graph:
         },
     )
     g.create_node(
-        "codeword::met_aldric",
+        "state_flag::met_aldric",
         {
-            "type": "codeword",
+            "type": "state_flag",
             "raw_id": "met_aldric",
             "trigger": "Player meets aldric at the bridge",
         },
@@ -150,7 +150,7 @@ class TestFormatEntityForCodex:
         assert "character" in result
         assert "court advisor" in result
 
-    def test_includes_related_codewords(self, dress_graph: Graph) -> None:
+    def test_includes_related_state_flags(self, dress_graph: Graph) -> None:
         from questfoundry.graph.dress_context import format_entity_for_codex
 
         result = format_entity_for_codex(dress_graph, "character::aldric")

--- a/tests/unit/test_dress_mutations.py
+++ b/tests/unit/test_dress_mutations.py
@@ -13,7 +13,7 @@ from questfoundry.graph.graph import Graph
 
 @pytest.fixture()
 def dress_graph() -> Graph:
-    """Graph with entities, passages, and codewords for DRESS testing."""
+    """Graph with entities, passages, and state flags for DRESS testing."""
     g = Graph()
     g.create_node(
         "entity::protagonist",
@@ -62,17 +62,17 @@ def dress_graph() -> Graph:
         },
     )
     g.create_node(
-        "codeword::met_aldric",
+        "state_flag::met_aldric",
         {
-            "type": "codeword",
+            "type": "state_flag",
             "raw_id": "met_aldric",
             "trigger": "Player meets aldric at the bridge",
         },
     )
     g.create_node(
-        "codeword::found_tome",
+        "state_flag::found_tome",
         {
-            "type": "codeword",
+            "type": "state_flag",
             "raw_id": "found_tome",
             "trigger": "Player discovers the ancient tome",
         },
@@ -511,7 +511,7 @@ class TestValidateDressCodexEntries:
         )
         assert any("duplicate rank=1" in e for e in errors)
 
-    def test_unknown_codeword(self, dress_graph: Graph) -> None:
+    def test_unknown_state_flag(self, dress_graph: Graph) -> None:
         from questfoundry.graph.dress_mutations import validate_dress_codex_entries
 
         errors = validate_dress_codex_entries(
@@ -522,4 +522,4 @@ class TestValidateDressCodexEntries:
                 {"rank": 2, "visible_when": ["nonexistent_cw"], "content": "gated"},
             ],
         )
-        assert any("unknown codeword" in e for e in errors)
+        assert any("unknown state flag" in e for e in errors)

--- a/tests/unit/test_dress_stage.py
+++ b/tests/unit/test_dress_stage.py
@@ -1241,8 +1241,8 @@ class TestPhase2Codex:
             },
         )
         g.create_node(
-            "codeword::met_aldric",
-            {"type": "codeword", "raw_id": "met_aldric", "trigger": "Meets aldric"},
+            "state_flag::met_aldric",
+            {"type": "state_flag", "raw_id": "met_aldric", "trigger": "Meets aldric"},
         )
 
         stage = DressStage()
@@ -1378,7 +1378,7 @@ class TestPhase2Codex:
             "entity::protagonist",
             {"type": "entity", "raw_id": "protagonist", "entity_type": "character"},
         )
-        # No codewords defined — met_aldric in visible_when will trigger warning
+        # No state flags defined — met_aldric in visible_when will trigger warning
 
         stage = DressStage()
         mock_output = _make_codex_output("entity::protagonist")

--- a/tests/unit/test_fill_context.py
+++ b/tests/unit/test_fill_context.py
@@ -73,7 +73,7 @@ def fill_graph() -> Graph:
             "concept": "A young wanderer seeking answers",
             "overlays": [
                 {
-                    "when": ["codeword::betrayal_committed"],
+                    "when": ["state_flag::betrayal_committed"],
                     "details": {"mood": "bitter", "trust": "broken"},
                 }
             ],
@@ -1388,7 +1388,7 @@ class TestEndingDifferentiation:
         )
         assert format_ending_differentiation(g, "passage::finale") == ""
 
-    def test_returns_empty_when_no_family_codewords(self) -> None:
+    def test_returns_empty_when_no_family_state_flags(self) -> None:
         g = Graph.empty()
         g.create_node(
             "passage::ending_climax_0",
@@ -1397,7 +1397,7 @@ class TestEndingDifferentiation:
                 "raw_id": "ending_climax_0",
                 "is_ending": True,
                 "is_synthetic": True,
-                "family_codewords": [],
+                "family_state_flags": [],
             },
         )
         assert format_ending_differentiation(g, "passage::ending_climax_0") == ""
@@ -1407,7 +1407,7 @@ class TestEndingDifferentiation:
         assert format_ending_differentiation(g, "passage::nonexistent") == ""
 
     def test_returns_formatted_consequences(self) -> None:
-        """Synthetic ending with traceable codewords gets narrative context."""
+        """Synthetic ending with traceable state flags gets narrative context."""
         g = Graph.empty()
         # Path node
         g.create_node(
@@ -1428,17 +1428,17 @@ class TestEndingDifferentiation:
                 "description": "The ally stands by the hero in the final battle.",
             },
         )
-        # Codeword node
+        # State flag node
         g.create_node(
-            "codeword::cw_ally",
-            {"type": "codeword", "raw_id": "cw_ally"},
+            "state_flag::sf_ally",
+            {"type": "state_flag", "raw_id": "sf_ally"},
         )
-        # Edges: codeword --tracks--> consequence
-        g.add_edge("tracks", "codeword::cw_ally", "consequence::ally_trusted")
+        # Edges: state_flag --tracks--> consequence
+        g.add_edge("tracks", "state_flag::sf_ally", "consequence::ally_trusted")
         # path --has_consequence--> consequence
         g.add_edge("has_consequence", "path::ally_path", "consequence::ally_trusted")
 
-        # Synthetic ending passage referencing the codeword
+        # Synthetic ending passage referencing the state flag
         g.create_node(
             "passage::ending_climax_0",
             {
@@ -1446,7 +1446,7 @@ class TestEndingDifferentiation:
                 "raw_id": "ending_climax_0",
                 "is_ending": True,
                 "is_synthetic": True,
-                "family_codewords": ["cw_ally"],
+                "family_state_flags": ["sf_ally"],
             },
         )
 
@@ -1472,10 +1472,10 @@ class TestEndingDifferentiation:
             },
         )
         g.create_node(
-            "codeword::cw_shadow",
-            {"type": "codeword", "raw_id": "cw_shadow"},
+            "state_flag::sf_shadow",
+            {"type": "state_flag", "raw_id": "sf_shadow"},
         )
-        g.add_edge("tracks", "codeword::cw_shadow", "consequence::shadow")
+        g.add_edge("tracks", "state_flag::sf_shadow", "consequence::shadow")
         g.add_edge("has_consequence", "path::dark_path", "consequence::shadow")
         g.create_node(
             "passage::ending_0",
@@ -1484,7 +1484,7 @@ class TestEndingDifferentiation:
                 "raw_id": "ending_0",
                 "is_ending": True,
                 "is_synthetic": True,
-                "family_codewords": ["cw_shadow"],
+                "family_state_flags": ["sf_shadow"],
             },
         )
 
@@ -1492,18 +1492,18 @@ class TestEndingDifferentiation:
         assert "dark_path" in result
         assert "Shadows consume" in result
 
-    def test_skips_codewords_without_consequence_description(self) -> None:
-        """Codewords whose consequences lack descriptions are skipped."""
+    def test_skips_state_flags_without_consequence_description(self) -> None:
+        """State flags whose consequences lack descriptions are skipped."""
         g = Graph.empty()
         g.create_node(
             "consequence::empty_cons",
             {"type": "consequence", "raw_id": "empty_cons", "description": ""},
         )
         g.create_node(
-            "codeword::cw_empty",
-            {"type": "codeword", "raw_id": "cw_empty"},
+            "state_flag::sf_empty",
+            {"type": "state_flag", "raw_id": "sf_empty"},
         )
-        g.add_edge("tracks", "codeword::cw_empty", "consequence::empty_cons")
+        g.add_edge("tracks", "state_flag::sf_empty", "consequence::empty_cons")
         g.create_node(
             "passage::ending_1",
             {
@@ -1511,7 +1511,7 @@ class TestEndingDifferentiation:
                 "raw_id": "ending_1",
                 "is_ending": True,
                 "is_synthetic": True,
-                "family_codewords": ["cw_empty"],
+                "family_state_flags": ["sf_empty"],
             },
         )
 

--- a/tests/unit/test_grow_models.py
+++ b/tests/unit/test_grow_models.py
@@ -10,7 +10,6 @@ from questfoundry.models.grow import (
     AtmosphericDetail,
     Choice,
     ChoiceLabel,
-    Codeword,
     EntityArcDescriptor,
     EntityOverlay,
     GapProposal,
@@ -28,6 +27,7 @@ from questfoundry.models.grow import (
     ResidueVariant,
     SceneTypeTag,
     SpokeProposal,
+    StateFlag,
 )
 
 
@@ -125,30 +125,30 @@ class TestPassage:
             Passage(passage_id="p1", from_beat="b1", summary="")
 
 
-class TestCodeword:
-    def test_valid_codeword(self) -> None:
-        cw = Codeword(
-            codeword_id="codeword::mentor_trust_committed",
+class TestStateFlag:
+    def test_valid_state_flag(self) -> None:
+        sf = StateFlag(
+            flag_id="state_flag::mentor_trust_committed",
             tracks="consequence::mentor_trust",
         )
-        assert cw.codeword_id == "codeword::mentor_trust_committed"
-        assert cw.codeword_type == "granted"
+        assert sf.flag_id == "state_flag::mentor_trust_committed"
+        assert sf.flag_type == "granted"
 
     def test_default_type_is_granted(self) -> None:
-        cw = Codeword(codeword_id="cw1", tracks="c1")
-        assert cw.codeword_type == "granted"
+        sf = StateFlag(flag_id="sf1", tracks="c1")
+        assert sf.flag_type == "granted"
 
-    def test_empty_codeword_id_rejected(self) -> None:
-        with pytest.raises(ValidationError, match="codeword_id"):
-            Codeword(codeword_id="", tracks="c1")
+    def test_empty_flag_id_rejected(self) -> None:
+        with pytest.raises(ValidationError, match="flag_id"):
+            StateFlag(flag_id="", tracks="c1")
 
     def test_empty_tracks_rejected(self) -> None:
         with pytest.raises(ValidationError, match="tracks"):
-            Codeword(codeword_id="cw1", tracks="")
+            StateFlag(flag_id="sf1", tracks="")
 
-    def test_invalid_codeword_type_rejected(self) -> None:
-        with pytest.raises(ValidationError, match="codeword_type"):
-            Codeword(codeword_id="cw1", tracks="c1", codeword_type="revoked")  # type: ignore[arg-type]
+    def test_invalid_flag_type_rejected(self) -> None:
+        with pytest.raises(ValidationError, match="flag_type"):
+            StateFlag(flag_id="sf1", tracks="c1", flag_type="revoked")  # type: ignore[arg-type]
 
 
 class TestChoice:
@@ -157,15 +157,15 @@ class TestChoice:
             from_passage="p1",
             to_passage="p2",
             label="Go left",
-            requires_codewords=["cw1"],
-            grants=["cw2"],
+            requires_state_flags=["sf1"],
+            grants=["sf2"],
         )
         assert choice.from_passage == "p1"
-        assert choice.requires_codewords == ["cw1"]
+        assert choice.requires_state_flags == ["sf1"]
 
     def test_empty_requires_grants_allowed(self) -> None:
         choice = Choice(from_passage="p1", to_passage="p2", label="Continue")
-        assert choice.requires_codewords == []
+        assert choice.requires_state_flags == []
         assert choice.grants == []
 
     def test_empty_label_rejected(self) -> None:
@@ -393,7 +393,7 @@ class TestGrowResult:
         result = GrowResult()
         assert result.arc_count == 0
         assert result.passage_count == 0
-        assert result.codeword_count == 0
+        assert result.state_flag_count == 0
         assert result.phases_completed == []
         assert result.spine_arc_id is None
 
@@ -401,7 +401,7 @@ class TestGrowResult:
         result = GrowResult(
             arc_count=4,
             passage_count=8,
-            codeword_count=2,
+            state_flag_count=2,
             phases_completed=[
                 GrowPhaseResult(phase="validate", status="completed"),
                 GrowPhaseResult(phase="arcs", status="completed"),
@@ -428,7 +428,7 @@ class TestGrowResult:
         data = {
             "arc_count": 3,
             "passage_count": 6,
-            "codeword_count": 1,
+            "state_flag_count": 1,
             "phases_completed": [
                 {"phase": "validate", "status": "completed", "detail": ""},
             ],
@@ -650,23 +650,23 @@ class TestResidueVariant:
 
     def test_valid_variant(self) -> None:
         v = ResidueVariant(
-            codeword_id="codeword::fistfight_committed",
+            state_flag_id="state_flag::fistfight_committed",
             hint="mention the scar from the fight",
         )
-        assert v.codeword_id == "codeword::fistfight_committed"
+        assert v.state_flag_id == "state_flag::fistfight_committed"
         assert "scar" in v.hint
 
-    def test_empty_codeword_rejected(self) -> None:
-        with pytest.raises(ValidationError, match="codeword_id"):
-            ResidueVariant(codeword_id="", hint="a valid hint that is long enough")
+    def test_empty_state_flag_rejected(self) -> None:
+        with pytest.raises(ValidationError, match="state_flag_id"):
+            ResidueVariant(state_flag_id="", hint="a valid hint that is long enough")
 
     def test_short_hint_rejected(self) -> None:
         with pytest.raises(ValidationError, match="hint"):
-            ResidueVariant(codeword_id="codeword::x", hint="too short")
+            ResidueVariant(state_flag_id="state_flag::x", hint="too short")
 
     def test_long_hint_rejected(self) -> None:
         with pytest.raises(ValidationError, match="hint"):
-            ResidueVariant(codeword_id="codeword::x", hint="a" * 201)
+            ResidueVariant(state_flag_id="state_flag::x", hint="a" * 201)
 
 
 class TestResidueBeatProposal:
@@ -679,11 +679,11 @@ class TestResidueBeatProposal:
             rationale="The aftermath should acknowledge whether the hero fought or argued",
             variants=[
                 ResidueVariant(
-                    codeword_id="codeword::fistfight_committed",
+                    state_flag_id="state_flag::fistfight_committed",
                     hint="mention the scar from the fight",
                 ),
                 ResidueVariant(
-                    codeword_id="codeword::argue_committed",
+                    state_flag_id="state_flag::argue_committed",
                     hint="mention the lingering tension from the argument",
                 ),
             ],
@@ -699,25 +699,25 @@ class TestResidueBeatProposal:
                 rationale="some rationale here",
                 variants=[
                     ResidueVariant(
-                        codeword_id="codeword::a",
+                        state_flag_id="state_flag::a",
                         hint="only one variant is not enough",
                     )
                 ],
             )
 
-    def test_duplicate_codewords_rejected(self) -> None:
-        with pytest.raises(ValidationError, match=r"codeword_id.*unique"):
+    def test_duplicate_state_flags_rejected(self) -> None:
+        with pytest.raises(ValidationError, match=r"state_flag_id.*unique"):
             ResidueBeatProposal(
                 passage_id="passage::x",
                 dilemma_id="dilemma::y",
                 rationale="rationale for this residue",
                 variants=[
                     ResidueVariant(
-                        codeword_id="codeword::same",
+                        state_flag_id="state_flag::same",
                         hint="first variant hint text here",
                     ),
                     ResidueVariant(
-                        codeword_id="codeword::same",
+                        state_flag_id="state_flag::same",
                         hint="second variant hint text here",
                     ),
                 ],
@@ -730,8 +730,8 @@ class TestResidueBeatProposal:
                 dilemma_id="dilemma::y",
                 rationale="some rationale here",
                 variants=[
-                    ResidueVariant(codeword_id="codeword::a", hint="hint text a long enough"),
-                    ResidueVariant(codeword_id="codeword::b", hint="hint text b long enough"),
+                    ResidueVariant(state_flag_id="state_flag::a", hint="hint text a long enough"),
+                    ResidueVariant(state_flag_id="state_flag::b", hint="hint text b long enough"),
                 ],
             )
 
@@ -752,11 +752,11 @@ class TestPhase8dOutput:
                     rationale="trust aftermath differs by path",
                     variants=[
                         ResidueVariant(
-                            codeword_id="codeword::trust_committed",
+                            state_flag_id="state_flag::trust_committed",
                             hint="hero recalls the leap of faith",
                         ),
                         ResidueVariant(
-                            codeword_id="codeword::distrust_committed",
+                            state_flag_id="state_flag::distrust_committed",
                             hint="hero recalls the cold suspicion",
                         ),
                     ],

--- a/tests/unit/test_grow_registry.py
+++ b/tests/unit/test_grow_registry.py
@@ -245,7 +245,7 @@ class TestGlobalRegistry:
             "convergence",
             "collapse_linear_beats",
             "passages",
-            "codewords",
+            "state_flags",
             "residue_beats",
             "overlays",
             "choices",
@@ -272,8 +272,8 @@ class TestGlobalRegistry:
         assert "prune" in table
 
     def test_apply_routing_has_three_dependencies(self) -> None:
-        """apply_routing depends on mark_endings, codewords, and residue_beats (S3, ADR-017)."""
+        """apply_routing depends on mark_endings, state_flags, and residue_beats (S3, ADR-017)."""
         registry = get_registry()
         meta = registry.get_meta("apply_routing")
         assert meta is not None
-        assert set(meta.depends_on) == {"mark_endings", "codewords", "residue_beats"}
+        assert set(meta.depends_on) == {"mark_endings", "state_flags", "residue_beats"}

--- a/tests/unit/test_grow_stage.py
+++ b/tests/unit/test_grow_stage.py
@@ -60,7 +60,7 @@ class TestGrowStageExecute:
             "arc_count",
             "passage_count",
             "choice_count",
-            "codeword_count",
+            "state_flag_count",
             "overlay_count",
             "spine_arc_id",
             "phases_completed",
@@ -69,7 +69,7 @@ class TestGrowStageExecute:
         assert result_dict["arc_count"] == 0
         assert result_dict["passage_count"] == 0
         assert result_dict["choice_count"] == 0
-        assert result_dict["codeword_count"] == 0
+        assert result_dict["state_flag_count"] == 0
 
     @pytest.mark.asyncio
     async def test_execute_with_project_path_kwarg(
@@ -173,7 +173,7 @@ class TestGrowStageExecute:
             "arc_count",
             "passage_count",
             "choice_count",
-            "codeword_count",
+            "state_flag_count",
             "overlay_count",
             "spine_arc_id",
             "phases_completed",
@@ -205,7 +205,7 @@ class TestGrowStagePhaseOrder:
             "convergence",
             "collapse_linear_beats",
             "passages",
-            "codewords",
+            "state_flags",
             "residue_beats",
             "overlays",
             "choices",
@@ -1358,16 +1358,16 @@ class TestPhase8cOverlays:
             },
         )
         graph.create_node(
-            "codeword::mentor_trusted_committed",
+            "state_flag::mentor_trusted_committed",
             {
-                "type": "codeword",
+                "type": "state_flag",
                 "raw_id": "mentor_trusted_committed",
                 "tracks": "consequence::mentor_trusted",
-                "codeword_type": "granted",
+                "flag_type": "granted",
             },
         )
         graph.add_edge(
-            "tracks", "codeword::mentor_trusted_committed", "consequence::mentor_trusted"
+            "tracks", "state_flag::mentor_trusted_committed", "consequence::mentor_trusted"
         )
 
         stage = GrowStage()
@@ -1375,7 +1375,7 @@ class TestPhase8cOverlays:
             overlays=[
                 OverlayProposal(
                     entity_id="entity::mentor",
-                    when=["codeword::mentor_trusted_committed"],
+                    when=["state_flag::mentor_trusted_committed"],
                     details=[
                         {"key": "attitude", "value": "Warm and supportive"},
                         {"key": "access", "value": "Shares secret knowledge"},
@@ -1399,7 +1399,7 @@ class TestPhase8cOverlays:
         entity_data = graph.get_node("entity::mentor")
         assert entity_data is not None
         assert len(entity_data["overlays"]) == 1
-        assert entity_data["overlays"][0]["when"] == ["codeword::mentor_trusted_committed"]
+        assert entity_data["overlays"][0]["when"] == ["state_flag::mentor_trusted_committed"]
         assert entity_data["overlays"][0]["details"]["attitude"] == "Warm and supportive"
 
     @pytest.mark.asyncio
@@ -1419,12 +1419,12 @@ class TestPhase8cOverlays:
             },
         )
         graph.create_node(
-            "codeword::cw1",
+            "state_flag::cw1",
             {
-                "type": "codeword",
+                "type": "state_flag",
                 "raw_id": "cw1",
                 "tracks": "consequence::c1",
-                "codeword_type": "granted",
+                "flag_type": "granted",
             },
         )
 
@@ -1433,7 +1433,7 @@ class TestPhase8cOverlays:
             overlays=[
                 OverlayProposal(
                     entity_id="entity::nonexistent",
-                    when=["codeword::cw1"],
+                    when=["state_flag::cw1"],
                     details=[{"key": "attitude", "value": "Changed"}],
                 ),
             ]
@@ -1450,8 +1450,8 @@ class TestPhase8cOverlays:
         assert "0" in result.detail
 
     @pytest.mark.asyncio
-    async def test_phase_8c_skips_invalid_codeword(self) -> None:
-        """Phase 8c skips overlays referencing non-existent codewords."""
+    async def test_phase_8c_skips_invalid_state_flag(self) -> None:
+        """Phase 8c skips overlays referencing non-existent state_flags."""
         from questfoundry.graph.graph import Graph
         from questfoundry.models.grow import OverlayProposal, Phase8cOutput
 
@@ -1466,12 +1466,12 @@ class TestPhase8cOverlays:
             },
         )
         graph.create_node(
-            "codeword::cw1",
+            "state_flag::cw1",
             {
-                "type": "codeword",
+                "type": "state_flag",
                 "raw_id": "cw1",
                 "tracks": "consequence::c1",
-                "codeword_type": "granted",
+                "flag_type": "granted",
             },
         )
 
@@ -1480,7 +1480,7 @@ class TestPhase8cOverlays:
             overlays=[
                 OverlayProposal(
                     entity_id="entity::hero",
-                    when=["codeword::nonexistent"],
+                    when=["state_flag::nonexistent"],
                     details=[{"key": "attitude", "value": "Changed"}],
                 ),
             ]
@@ -1502,8 +1502,8 @@ class TestPhase8cOverlays:
     # is no longer reachable since the model won't validate with empty details.
 
     @pytest.mark.asyncio
-    async def test_phase_8c_no_codewords(self) -> None:
-        """Phase 8c returns completed when no codewords exist."""
+    async def test_phase_8c_no_state_flags(self) -> None:
+        """Phase 8c returns completed when no state_flags exist."""
         from questfoundry.graph.graph import Graph
 
         graph = Graph.empty()
@@ -1523,7 +1523,7 @@ class TestPhase8cOverlays:
         result = await stage._phase_8c_overlays(graph, mock_model)
 
         assert result.status == "completed"
-        assert "No codewords or entities" in result.detail
+        assert "No state flags or entities" in result.detail
 
     @pytest.mark.asyncio
     async def test_phase_8c_unprefixed_entity_id(self) -> None:
@@ -1542,12 +1542,12 @@ class TestPhase8cOverlays:
             },
         )
         graph.create_node(
-            "codeword::cw1",
+            "state_flag::cw1",
             {
-                "type": "codeword",
+                "type": "state_flag",
                 "raw_id": "cw1",
                 "tracks": "consequence::c1",
-                "codeword_type": "granted",
+                "flag_type": "granted",
             },
         )
 
@@ -1556,7 +1556,7 @@ class TestPhase8cOverlays:
             overlays=[
                 OverlayProposal(
                     entity_id="mentor",  # No prefix
-                    when=["codeword::cw1"],
+                    when=["state_flag::cw1"],
                     details=[{"key": "attitude", "value": "Friendly"}],
                 ),
             ]
@@ -1578,7 +1578,7 @@ class TestPhase8cOverlays:
 
     @pytest.mark.asyncio
     async def test_phase8c_consequence_context_full_chain(self) -> None:
-        """Enriched context traces codeword → consequence → path → dilemma."""
+        """Enriched context traces state_flag → consequence → path → dilemma."""
         from unittest.mock import patch
 
         from questfoundry.graph.graph import Graph
@@ -1636,12 +1636,12 @@ class TestPhase8cOverlays:
             },
         )
         graph.create_node(
-            "codeword::mentor_trusted_committed",
+            "state_flag::mentor_trusted_committed",
             {
-                "type": "codeword",
+                "type": "state_flag",
                 "raw_id": "mentor_trusted_committed",
                 "tracks": "consequence::mentor_trusted",
-                "codeword_type": "granted",
+                "flag_type": "granted",
             },
         )
 
@@ -1662,7 +1662,7 @@ class TestPhase8cOverlays:
             await stage._phase_8c_overlays(graph, MagicMock())
 
         ctx = captured_context["consequence_context"]
-        assert "codeword::mentor_trusted_committed" in ctx
+        assert "state_flag::mentor_trusted_committed" in ctx
         assert 'Path: path::trust_or_betray__trust ("The Trusting Path")' in ctx
         assert 'Dilemma: "Do you trust or betray the mentor?"' in ctx
         assert "Central entities: mentor, hero" in ctx
@@ -1693,12 +1693,12 @@ class TestPhase8cOverlays:
             },
         )
         graph.create_node(
-            "codeword::hero_saved_committed",
+            "state_flag::hero_saved_committed",
             {
-                "type": "codeword",
+                "type": "state_flag",
                 "raw_id": "hero_saved_committed",
                 "tracks": "consequence::hero_saved",
-                "codeword_type": "granted",
+                "flag_type": "granted",
             },
         )
 
@@ -1719,7 +1719,7 @@ class TestPhase8cOverlays:
             await stage._phase_8c_overlays(graph, MagicMock())
 
         ctx = captured_context["consequence_context"]
-        assert "codeword::hero_saved_committed" in ctx
+        assert "state_flag::hero_saved_committed" in ctx
         assert "Consequence: The hero survives the ordeal" in ctx
         # No path/dilemma lines since path node is missing
         assert "Path:" not in ctx
@@ -1748,12 +1748,12 @@ class TestPhase8cOverlays:
             },
         )
         graph.create_node(
-            "codeword::secret_revealed_committed",
+            "state_flag::secret_revealed_committed",
             {
-                "type": "codeword",
+                "type": "state_flag",
                 "raw_id": "secret_revealed_committed",
                 "tracks": "consequence::secret_revealed",
-                "codeword_type": "granted",
+                "flag_type": "granted",
             },
         )
 
@@ -2134,7 +2134,7 @@ class TestPhase9Choices:
         assert labels == {"b", "c"}
 
     @pytest.mark.asyncio
-    async def test_phase_9_grants_codewords_on_choice(self) -> None:
+    async def test_phase_9_grants_state_flags_on_choice(self) -> None:
         """Phase 9 attaches grants from arc beats to choice nodes."""
         from questfoundry.graph.graph import Graph
         from questfoundry.models.grow import ChoiceLabel, Phase9Output
@@ -2144,12 +2144,12 @@ class TestPhase9Choices:
         graph.create_node("beat::b", {"type": "beat", "raw_id": "b", "summary": "Commit"})
         graph.add_edge("predecessor", "beat::b", "beat::a")
 
-        # beat::b grants a codeword
+        # beat::b grants a state_flag
         graph.create_node(
-            "codeword::cw1",
-            {"type": "codeword", "raw_id": "cw1", "tracks": "consequence::c1"},
+            "state_flag::cw1",
+            {"type": "state_flag", "raw_id": "cw1", "tracks": "consequence::c1"},
         )
-        graph.add_edge("grants", "beat::b", "codeword::cw1")
+        graph.add_edge("grants", "beat::b", "state_flag::cw1")
 
         # Computed-arc pattern: dilemma + path + belongs_to
         graph.create_node("dilemma::d1", {"type": "dilemma", "raw_id": "d1", "paths": ["t1"]})
@@ -2185,7 +2185,7 @@ class TestPhase9Choices:
         choice_nodes = graph.get_nodes_by_type("choice")
         assert len(choice_nodes) == 1
         choice_data = next(iter(choice_nodes.values()))
-        assert "codeword::cw1" in choice_data["grants"]
+        assert "state_flag::cw1" in choice_data["grants"]
 
     @pytest.mark.asyncio
     async def test_phase_9_creates_prologue_for_orphan_starts(self) -> None:
@@ -2598,14 +2598,14 @@ class TestPhase8cErrorHandling:
         from tests.fixtures.grow_fixtures import make_single_dilemma_graph
 
         graph = make_single_dilemma_graph()
-        # Add codeword and consequence nodes so we pass the early guard
+        # Add state_flag and consequence nodes so we pass the early guard
         graph.create_node(
             "consequence::trust_gain",
             {"type": "consequence", "description": "Trust is gained"},
         )
         graph.create_node(
-            "codeword::cw_trust",
-            {"type": "codeword", "tracks": "consequence::trust_gain", "codeword_type": "granted"},
+            "state_flag::cw_trust",
+            {"type": "state_flag", "tracks": "consequence::trust_gain", "flag_type": "granted"},
         )
 
         stage = GrowStage()
@@ -3066,7 +3066,7 @@ class TestPhase9bForkBeats:
                     "from_passage": f"passage::{pids[i]}",
                     "to_passage": f"passage::{pids[i + 1]}",
                     "label": "continue",
-                    "requires_codewords": [],
+                    "requires_state_flags": [],
                     "grants": [],
                 },
             )
@@ -3161,7 +3161,7 @@ class TestPhase9bForkBeats:
                     "from_passage": f"passage::{pids[i]}",
                     "to_passage": f"passage::{pids[i + 1]}",
                     "label": "continue",
-                    "requires_codewords": [],
+                    "requires_state_flags": [],
                     "grants": [],
                 },
             )
@@ -3200,7 +3200,7 @@ class TestPhase9bForkBeats:
                 {"type": "passage", "raw_id": pid, "summary": f"Passage {pid}"},
             )
 
-        # p1→p2 grants a codeword (simulates commits beat transition)
+        # p1→p2 grants a state_flag (simulates commits beat transition)
         graph.create_node(
             "choice::p1__p2",
             {
@@ -3208,8 +3208,8 @@ class TestPhase9bForkBeats:
                 "from_passage": "passage::p1",
                 "to_passage": "passage::p2",
                 "label": "continue",
-                "requires_codewords": [],
-                "grants": ["codeword::truth_committed"],
+                "requires_state_flags": [],
+                "grants": ["state_flag::truth_committed"],
             },
         )
         graph.add_edge("choice_from", "choice::p1__p2", "passage::p1")
@@ -3222,7 +3222,7 @@ class TestPhase9bForkBeats:
                 "from_passage": "passage::p2",
                 "to_passage": "passage::p3",
                 "label": "continue",
-                "requires_codewords": [],
+                "requires_state_flags": [],
                 "grants": [],
             },
         )
@@ -3256,7 +3256,7 @@ class TestPhase9bForkBeats:
         reconverge_choices = {cid: cdata for cid, cdata in choices.items() if "reconverge" in cid}
         assert len(reconverge_choices) == 2
         for _cid, cdata in reconverge_choices.items():
-            assert cdata["grants"] == ["codeword::truth_committed"]
+            assert cdata["grants"] == ["state_flag::truth_committed"]
 
 
 class TestPhase9cHubSpokes:
@@ -3287,7 +3287,7 @@ class TestPhase9cHubSpokes:
                 "from_passage": "passage::market",
                 "to_passage": "passage::palace",
                 "label": "continue",
-                "requires_codewords": [],
+                "requires_state_flags": [],
                 "grants": [],
             },
         )
@@ -3361,7 +3361,7 @@ class TestPhase9cHubSpokes:
                 "from_passage": "passage::hub",
                 "to_passage": "passage::spoke",
                 "label": "Explore",
-                "requires_codewords": [],
+                "requires_state_flags": [],
                 "grants": [],
             },
         )
@@ -3376,7 +3376,7 @@ class TestPhase9cHubSpokes:
                 "from_passage": "passage::spoke",
                 "to_passage": "passage::hub",
                 "label": "Return",
-                "requires_codewords": [],
+                "requires_state_flags": [],
                 "grants": [],
                 "is_return": True,
             },
@@ -3408,7 +3408,7 @@ class TestPhase9cHubSpokes:
                 "from_passage": "passage::p1",
                 "to_passage": "passage::p2",
                 "label": "continue",
-                "requires_codewords": [],
+                "requires_state_flags": [],
                 "grants": [],
             },
         )
@@ -3431,7 +3431,18 @@ class TestPhase8dResidueBeats:
     """Tests for Phase 8d residue beat insertion."""
 
     def _make_residue_eligible_graph(self) -> Any:
-        """Build a graph with a soft-dilemma convergence eligible for residue variants."""
+        """Build a graph with a soft-dilemma convergence eligible for residue variants.
+
+        Graph structure (computed arcs):
+        - beat::start (shared) -> beat::fight_only (fight) -> beat::aftermath (shared)
+        - beat::start (shared) -> beat::talk_only (talk) -> beat::aftermath (shared)
+
+        enumerate_arcs produces:
+        - spine (fight): [start, fight_only, aftermath]
+        - branch (talk): [start, talk_only, aftermath]
+
+        Convergence: branch diverges at start, converges at aftermath.
+        """
         from questfoundry.graph.graph import Graph
 
         graph = Graph.empty()
@@ -3477,12 +3488,12 @@ class TestPhase8dResidueBeats:
             )
             graph.add_edge("has_consequence", f"path::{suffix}", f"consequence::{suffix}_result")
             graph.create_node(
-                f"codeword::{suffix}_committed",
+                f"state_flag::{suffix}_committed",
                 {
-                    "type": "codeword",
+                    "type": "state_flag",
                     "raw_id": f"{suffix}_committed",
                     "tracks": f"consequence::{suffix}_result",
-                    "codeword_type": "granted",
+                    "flag_type": "granted",
                 },
             )
 
@@ -3548,11 +3559,11 @@ class TestPhase8dResidueBeats:
                     rationale="Prose should acknowledge fight vs negotiation",
                     variants=[
                         ResidueVariant(
-                            codeword_id="codeword::fight_committed",
+                            state_flag_id="state_flag::fight_committed",
                             hint="mention bruises from the fistfight",
                         ),
                         ResidueVariant(
-                            codeword_id="codeword::talk_committed",
+                            state_flag_id="state_flag::talk_committed",
                             hint="reference the fragile truce with the guards",
                         ),
                     ],

--- a/tests/unit/test_grow_validation.py
+++ b/tests/unit/test_grow_validation.py
@@ -45,7 +45,7 @@ def _make_linear_passage_graph() -> Graph:
             "from_passage": "passage::p1",
             "to_passage": "passage::p2",
             "label": "continue",
-            "requires_codewords": [],
+            "requires_state_flags": [],
             "grants": [],
         },
     )
@@ -56,7 +56,7 @@ def _make_linear_passage_graph() -> Graph:
             "from_passage": "passage::p2",
             "to_passage": "passage::p3",
             "label": "continue",
-            "requires_codewords": [],
+            "requires_state_flags": [],
             "grants": [],
         },
     )
@@ -136,7 +136,7 @@ class TestSingleStart:
                 "from_passage": "passage::p1",
                 "to_passage": "passage::p2",
                 "label": "go",
-                "requires_codewords": [],
+                "requires_state_flags": [],
                 "grants": [],
             },
         )
@@ -147,7 +147,7 @@ class TestSingleStart:
                 "from_passage": "passage::p2",
                 "to_passage": "passage::p1",
                 "label": "back",
-                "requires_codewords": [],
+                "requires_state_flags": [],
                 "grants": [],
             },
         )
@@ -178,7 +178,7 @@ class TestSingleStart:
                 "from_passage": "passage::p1",
                 "to_passage": "passage::spoke_0",
                 "label": "Look around",
-                "requires_codewords": [],
+                "requires_state_flags": [],
                 "grants": [],
             },
         )
@@ -193,7 +193,7 @@ class TestSingleStart:
                 "to_passage": "passage::p1",
                 "label": "Return",
                 "is_return": True,
-                "requires_codewords": [],
+                "requires_state_flags": [],
                 "grants": [],
             },
         )
@@ -273,7 +273,7 @@ class TestPassageDagCycles:
                 "from_passage": "passage::p1",
                 "to_passage": "passage::p2",
                 "label": "go",
-                "requires_codewords": [],
+                "requires_state_flags": [],
                 "grants": [],
             },
         )
@@ -284,7 +284,7 @@ class TestPassageDagCycles:
                 "from_passage": "passage::p2",
                 "to_passage": "passage::p1",
                 "label": "back",
-                "requires_codewords": [],
+                "requires_state_flags": [],
                 "grants": [],
             },
         )

--- a/tests/unit/test_grow_validators.py
+++ b/tests/unit/test_grow_validators.py
@@ -166,7 +166,7 @@ class TestValidatePhase8cOutput:
         errors = validate_phase8c_output(
             result,
             valid_entity_ids={"entity::e1"},
-            valid_codeword_ids={"cw::c1"},
+            valid_state_flag_ids={"cw::c1"},
         )
         assert errors == []
 
@@ -183,12 +183,12 @@ class TestValidatePhase8cOutput:
         errors = validate_phase8c_output(
             result,
             valid_entity_ids={"entity::e1"},
-            valid_codeword_ids={"cw::c1"},
+            valid_state_flag_ids={"cw::c1"},
         )
         assert len(errors) == 1
         assert "entity::bad" in errors[0].issue
 
-    def test_invalid_codeword_id(self) -> None:
+    def test_invalid_state_flag_id(self) -> None:
         result = Phase8cOutput(
             overlays=[
                 OverlayProposal(
@@ -201,12 +201,12 @@ class TestValidatePhase8cOutput:
         errors = validate_phase8c_output(
             result,
             valid_entity_ids={"entity::e1"},
-            valid_codeword_ids={"cw::c1"},
+            valid_state_flag_ids={"cw::c1"},
         )
         assert len(errors) == 1
         assert "cw::bad" in errors[0].issue
 
-    def test_multiple_invalid_codewords(self) -> None:
+    def test_multiple_invalid_state_flags(self) -> None:
         result = Phase8cOutput(
             overlays=[
                 OverlayProposal(
@@ -219,7 +219,7 @@ class TestValidatePhase8cOutput:
         errors = validate_phase8c_output(
             result,
             valid_entity_ids={"entity::e1"},
-            valid_codeword_ids={"cw::c1"},
+            valid_state_flag_ids={"cw::c1"},
         )
         assert len(errors) == 2
 
@@ -562,41 +562,41 @@ class TestValidatePhase9cGrants:
         return Phase9cOutput(hubs=[hub])
 
     def test_valid_spoke_grants_pass(self) -> None:
-        result = self._make_phase9c_output(grants=["codeword::cw_mural"])
+        result = self._make_phase9c_output(grants=["state_flag::cw_mural"])
         errors = validate_phase9c_output(
             result,
             valid_passage_ids={"passage::market"},
-            valid_codeword_ids={"codeword::cw_mural"},
+            valid_state_flag_ids={"state_flag::cw_mural"},
         )
         assert not errors
 
     def test_invalid_spoke_grants_rejected(self) -> None:
-        result = self._make_phase9c_output(grants=["codeword::nonexistent"])
+        result = self._make_phase9c_output(grants=["state_flag::nonexistent"])
         errors = validate_phase9c_output(
             result,
             valid_passage_ids={"passage::market"},
-            valid_codeword_ids={"codeword::cw_mural"},
+            valid_state_flag_ids={"state_flag::cw_mural"},
         )
         assert len(errors) == 1
         assert "nonexistent" in errors[0].issue
 
-    def test_no_codeword_validation_when_none(self) -> None:
-        """When valid_codeword_ids is None, grants are not validated."""
-        result = self._make_phase9c_output(grants=["codeword::anything"])
+    def test_no_state_flag_validation_when_none(self) -> None:
+        """When valid_state_flag_ids is None, grants are not validated."""
+        result = self._make_phase9c_output(grants=["state_flag::anything"])
         errors = validate_phase9c_output(
             result,
             valid_passage_ids={"passage::market"},
-            valid_codeword_ids=None,
+            valid_state_flag_ids=None,
         )
         assert not errors
 
     def test_unscoped_grant_id_normalized(self) -> None:
-        """Grant IDs without 'codeword::' prefix are normalized."""
+        """Grant IDs without 'state_flag::' prefix are normalized."""
         result = self._make_phase9c_output(grants=["cw_mural"])
         errors = validate_phase9c_output(
             result,
             valid_passage_ids={"passage::market"},
-            valid_codeword_ids={"codeword::cw_mural"},
+            valid_state_flag_ids={"state_flag::cw_mural"},
         )
         assert not errors
 
@@ -608,10 +608,10 @@ class TestValidatePhase8dOutput:
     def _make_output(
         passage_id: str = "passage::aftermath",
         dilemma_id: str = "dilemma::approach",
-        codeword_ids: list[str] | None = None,
+        state_flag_ids: list[str] | None = None,
     ) -> Phase8dOutput:
-        if codeword_ids is None:
-            codeword_ids = ["codeword::fight_committed", "codeword::talk_committed"]
+        if state_flag_ids is None:
+            state_flag_ids = ["state_flag::fight_committed", "state_flag::talk_committed"]
         return Phase8dOutput(
             proposals=[
                 ResidueBeatProposal(
@@ -619,8 +619,8 @@ class TestValidatePhase8dOutput:
                     dilemma_id=dilemma_id,
                     rationale="Test rationale",
                     variants=[
-                        ResidueVariant(codeword_id=cw, hint=f"hint for {cw} variant prose")
-                        for cw in codeword_ids
+                        ResidueVariant(state_flag_id=sf, hint=f"hint for {sf} variant prose")
+                        for sf in state_flag_ids
                     ],
                 ),
             ]
@@ -631,7 +631,7 @@ class TestValidatePhase8dOutput:
         errors = validate_phase8d_output(
             result,
             valid_passage_ids={"passage::aftermath"},
-            valid_codeword_ids={"codeword::fight_committed", "codeword::talk_committed"},
+            valid_state_flag_ids={"state_flag::fight_committed", "state_flag::talk_committed"},
             valid_dilemma_ids={"dilemma::approach"},
         )
         assert not errors
@@ -641,7 +641,7 @@ class TestValidatePhase8dOutput:
         errors = validate_phase8d_output(
             result,
             valid_passage_ids={"passage::aftermath"},
-            valid_codeword_ids={"codeword::fight_committed", "codeword::talk_committed"},
+            valid_state_flag_ids={"state_flag::fight_committed", "state_flag::talk_committed"},
             valid_dilemma_ids={"dilemma::approach"},
         )
         assert len(errors) == 1
@@ -652,29 +652,31 @@ class TestValidatePhase8dOutput:
         errors = validate_phase8d_output(
             result,
             valid_passage_ids={"passage::aftermath"},
-            valid_codeword_ids={"codeword::fight_committed", "codeword::talk_committed"},
+            valid_state_flag_ids={"state_flag::fight_committed", "state_flag::talk_committed"},
             valid_dilemma_ids={"dilemma::approach"},
         )
         assert len(errors) == 1
         assert "dilemma_id" in errors[0].field_path
 
-    def test_invalid_codeword_id(self) -> None:
-        result = self._make_output(codeword_ids=["codeword::fight_committed", "codeword::fake"])
+    def test_invalid_state_flag_id(self) -> None:
+        result = self._make_output(
+            state_flag_ids=["state_flag::fight_committed", "state_flag::fake"]
+        )
         errors = validate_phase8d_output(
             result,
             valid_passage_ids={"passage::aftermath"},
-            valid_codeword_ids={"codeword::fight_committed", "codeword::talk_committed"},
+            valid_state_flag_ids={"state_flag::fight_committed", "state_flag::talk_committed"},
             valid_dilemma_ids={"dilemma::approach"},
         )
         assert len(errors) == 1
-        assert "codeword_id" in errors[0].field_path
+        assert "state_flag_id" in errors[0].field_path
 
     def test_empty_proposals_no_errors(self) -> None:
         result = Phase8dOutput(proposals=[])
         errors = validate_phase8d_output(
             result,
             valid_passage_ids={"passage::aftermath"},
-            valid_codeword_ids={"codeword::fight_committed"},
+            valid_state_flag_ids={"state_flag::fight_committed"},
             valid_dilemma_ids={"dilemma::approach"},
         )
         assert not errors

--- a/tests/unit/test_inspection.py
+++ b/tests/unit/test_inspection.py
@@ -51,7 +51,7 @@ def _make_full_graph() -> Graph:
             "from_passage": "passage::p0",
             "to_passage": "passage::p1",
             "label": "Enter the forest",
-            "requires_codewords": [],
+            "requires_state_flags": [],
             "grants": [],
         },
     )
@@ -62,7 +62,7 @@ def _make_full_graph() -> Graph:
             "from_passage": "passage::p0",
             "to_passage": "passage::p1",
             "label": "continue",
-            "requires_codewords": [],
+            "requires_state_flags": [],
             "grants": [],
         },
     )
@@ -200,7 +200,7 @@ class TestBranchingStats:
                 "from_passage": "passage::p0",
                 "to_passage": "passage::p1",
                 "label": "Search the room",
-                "requires_codewords": [],
+                "requires_state_flags": [],
                 "grants": [],
             },
         )
@@ -215,7 +215,7 @@ class TestBranchingStats:
                 "from_passage": "passage::p1",
                 "to_passage": "passage::p2",
                 "label": "continue",
-                "requires_codewords": [],
+                "requires_state_flags": [],
                 "grants": [],
             },
         )
@@ -272,7 +272,7 @@ class TestBranchingStats:
                 "from_passage": "passage::p0",
                 "to_passage": "passage::p1",
                 "label": "continue",
-                "requires_codewords": [],
+                "requires_state_flags": [],
                 "grants": [],
             },
         )
@@ -285,7 +285,7 @@ class TestBranchingStats:
                 "from_passage": "passage::p0",
                 "to_passage": "passage::spoke_0",
                 "label": "Look around",
-                "requires_codewords": [],
+                "requires_state_flags": [],
                 "grants": [],
             },
         )
@@ -299,7 +299,7 @@ class TestBranchingStats:
                 "to_passage": "passage::p0",
                 "label": "Return",
                 "is_return": True,
-                "requires_codewords": [],
+                "requires_state_flags": [],
                 "grants": [],
             },
         )
@@ -530,10 +530,10 @@ class TestBranchingQualityScore:
         assert data["branching_quality"] is not None
 
     def test_ending_variants_per_arc(self) -> None:
-        """Each arc's codeword signature counts as a separate ending variant."""
+        """Each arc's state flag signature counts as a separate ending variant."""
         graph = Graph.empty()
         spine_beats = [f"beat::s{i}" for i in range(3)]
-        # Two arcs sharing the same ending beat but with different codeword paths
+        # Two arcs sharing the same ending beat but with different state flag paths
         graph.create_node(
             "arc::spine",
             {
@@ -583,14 +583,14 @@ class TestBranchingQualityScore:
                 "from_passage": "passage::mid",
                 "to_passage": "passage::ending",
                 "label": "Continue",
-                "requires_codewords": [],
+                "requires_state_flags": [],
                 "grants": [],
             },
         )
         graph.add_edge("choice_from", "choice::mid__ending", "passage::mid")
         graph.add_edge("choice_to", "choice::mid__ending", "passage::ending")
 
-        # Give each path a different codeword via consequence
+        # Give each path a different state flag via consequence
         graph.create_node(
             "path::canon",
             {"type": "path", "tier": "major", "description": "Canon"},
@@ -608,22 +608,22 @@ class TestBranchingQualityScore:
             {"type": "consequence", "description": "Rebel wins"},
         )
         graph.create_node(
-            "codeword::canon_flag",
-            {"type": "codeword", "label": "canon_flag"},
+            "state_flag::canon_flag",
+            {"type": "state_flag", "label": "canon_flag"},
         )
         graph.create_node(
-            "codeword::rebel_flag",
-            {"type": "codeword", "label": "rebel_flag"},
+            "state_flag::rebel_flag",
+            {"type": "state_flag", "label": "rebel_flag"},
         )
         graph.add_edge("has_consequence", "path::canon", "consequence::c_canon")
         graph.add_edge("has_consequence", "path::rebel", "consequence::c_rebel")
-        graph.add_edge("tracks", "codeword::canon_flag", "consequence::c_canon")
-        graph.add_edge("tracks", "codeword::rebel_flag", "consequence::c_rebel")
+        graph.add_edge("tracks", "state_flag::canon_flag", "consequence::c_canon")
+        graph.add_edge("tracks", "state_flag::rebel_flag", "consequence::c_rebel")
 
         result = _branching_quality_score(graph, None)
         assert result is not None
         assert result.terminal_count == 1
-        # Two arcs with different codewords → 2 ending variants, not 1
+        # Two arcs with different state flags → 2 ending variants, not 1
         assert result.ending_variants == 2
 
     def test_ending_variants_merged_passage(self) -> None:
@@ -667,7 +667,7 @@ class TestBranchingQualityScore:
                 "from_passage": "passage::mid",
                 "to_passage": "passage::ending",
                 "label": "Finish",
-                "requires_codewords": [],
+                "requires_state_flags": [],
                 "grants": [],
             },
         )
@@ -678,11 +678,11 @@ class TestBranchingQualityScore:
         assert result is not None
         # The ending passage should be detected as a terminal (no outgoing choices)
         assert result.terminal_count == 1
-        # Its primary_beat should map to the spine arc, contributing a codeword signature
+        # Its primary_beat should map to the spine arc, contributing a state flag signature
         assert result.ending_variants >= 1
 
     def test_ending_variants_synthetic_endings(self) -> None:
-        """Synthetic endings (from split_ending_families) use family_codewords directly."""
+        """Synthetic endings (from split_ending_families) use family_state_flags directly."""
         graph = Graph.empty()
         # Need at least one arc for the function to return a result
         graph.create_node(
@@ -694,7 +694,7 @@ class TestBranchingQualityScore:
                 "paths": ["path::canon"],
             },
         )
-        # Two synthetic ending passages with different family_codewords, no from_beat
+        # Two synthetic ending passages with different family_state_flags, no from_beat
         graph.create_node(
             "passage::ending_0",
             {
@@ -703,7 +703,7 @@ class TestBranchingQualityScore:
                 "is_ending": True,
                 "is_synthetic": True,
                 "summary": "Ending A",
-                "family_codewords": ["codeword::trust", "codeword::brave"],
+                "family_state_flags": ["state_flag::trust", "state_flag::brave"],
             },
         )
         graph.create_node(
@@ -714,7 +714,7 @@ class TestBranchingQualityScore:
                 "is_ending": True,
                 "is_synthetic": True,
                 "summary": "Ending B",
-                "family_codewords": ["codeword::betray"],
+                "family_state_flags": ["state_flag::betray"],
             },
         )
         # Wire choices so these are the only terminals

--- a/tests/unit/test_visualization.py
+++ b/tests/unit/test_visualization.py
@@ -431,7 +431,7 @@ def _make_overlay_graph() -> Graph:
             "type": "entity",
             "entity_type": "character",
             "name": "Alice",
-            "overlays": [{"codeword": "saw_truth", "field": "mood", "value": "angry"}],
+            "overlays": [{"state_flag": "saw_truth", "field": "mood", "value": "angry"}],
         },
     )
 
@@ -442,10 +442,10 @@ def _make_overlay_graph() -> Graph:
 
 
 def _make_grants_graph() -> Graph:
-    """Build a graph with a choice that grants codewords."""
+    """Build a graph with a choice that grants state flags."""
     graph = _make_simple_graph()
 
-    # Update existing choice to grant a codeword
+    # Update existing choice to grant a state flag
     graph.update_node("choice::intro_middle", grants=["saw_truth"])
 
     return graph
@@ -494,7 +494,7 @@ class TestOverlayPassages:
                 "type": "entity",
                 "entity_type": "character",
                 "name": "Bob",
-                "overlays": [{"codeword": "met_bob", "field": "mood", "value": "happy"}],
+                "overlays": [{"state_flag": "met_bob", "field": "mood", "value": "happy"}],
             },
         )
         # Passage references entity by raw ID "bob" (not "character::bob")
@@ -567,7 +567,7 @@ class TestGrantsEdges:
         graph = _make_simple_graph()
         graph.update_node(
             "choice::intro_middle",
-            requires_codewords=["has_key"],
+            requires_state_flags=["has_key"],
             grants=["saw_truth"],
         )
         sg = build_story_graph(graph)


### PR DESCRIPTION
## Summary

- Rename `Codeword` Pydantic model → `StateFlag` throughout codebase
- Rename graph node type `codeword` → `state_flag`
- Update all prompt templates, context builders, validators, and tests
- Fix falsy empty list bug in `export/context.py` requires_state_flags fallback
- Fix player-facing prompt text: "No state flags defined" → "No codewords defined"

The external-facing terminology remains "codeword" (in SHIP/export and prompt templates visible to players). The internal model and graph node type is now `state_flag` to match the ontology.

## Test plan

- [x] 97 test_grow_stage.py tests pass
- [x] 350 test_dress_context + test_dress_stage + test_grow_validators + test_fill_context tests pass
- [x] ruff + mypy clean on all modified files
- [x] `grep -rn 'class Codeword' src/` returns 0 matches
- [x] `grep -rn "get_nodes_by_type.*codeword" src/` returns 0 matches

Closes #1060

🤖 Generated with [Claude Code](https://claude.com/claude-code)