### PR TITLE
refactor: remove fallback patterns from get_passage_beats() and get_primary_beat()

### DIFF
--- a/src/questfoundry/graph/context.py
+++ b/src/questfoundry/graph/context.py
@@ -217,9 +217,6 @@ def normalize_scoped_id(raw_id: str, scope: str) -> str:
 def get_passage_beats(graph: Graph, passage_id: str) -> list[str]:
     """Get beat IDs grouped into a passage via ``grouped_in`` edges.
 
-    Falls back to the legacy ``from_beats`` / ``from_beat`` fields when
-    no ``grouped_in`` edges exist (pre-POLISH graphs).
-
     Args:
         graph: The story graph.
         passage_id: Passage node ID to look up.
@@ -228,27 +225,13 @@ def get_passage_beats(graph: Graph, passage_id: str) -> list[str]:
         List of beat IDs (typically single-element, multiple for merged passages).
     """
     edges = graph.get_edges(to_id=passage_id, edge_type="grouped_in")
-    if edges:
-        return sorted(e["from"] for e in edges)
-    # Fallback for GROW-era passages (before POLISH creates grouped_in edges)
-    passage = graph.get_node(passage_id)
-    if not passage:
-        return []
-    from_beats = passage.get("from_beats")
-    if from_beats and isinstance(from_beats, list):
-        return [str(b) for b in from_beats]
-    from_beat = passage.get("from_beat")
-    if from_beat:
-        return [str(from_beat)]
-    return []
+    return sorted(e["from"] for e in edges)
 
 
 def get_primary_beat(graph: Graph, passage_id: str) -> str | None:
     """Get the primary beat ID for a passage.
 
-    Checks the stored ``primary_beat`` field first (set by merged-passage
-    creation to skip gap/bridge beats), then falls back to the first beat
-    from ``get_passage_beats()``.
+    Returns the first beat from the ``grouped_in`` edges.
 
     Args:
         graph: The story graph.
@@ -257,11 +240,6 @@ def get_primary_beat(graph: Graph, passage_id: str) -> str | None:
     Returns:
         Primary beat ID, or None if passage has no beats.
     """
-    passage = graph.get_node(passage_id)
-    if passage:
-        primary = passage.get("primary_beat")
-        if primary:
-            return str(primary)
     beats = get_passage_beats(graph, passage_id)
     return beats[0] if beats else None
 

--- a/src/questfoundry/graph/context.py
+++ b/src/questfoundry/graph/context.py
@@ -222,7 +222,9 @@ def get_passage_beats(graph: Graph, passage_id: str) -> list[str]:
         passage_id: Passage node ID to look up.
 
     Returns:
-        List of beat IDs (typically single-element, multiple for merged passages).
+        Lexicographically sorted list of beat IDs (typically single-element,
+        multiple for merged passages).  Sorted for deterministic ordering;
+        ``get_primary_beat`` returns the first element.
     """
     edges = graph.get_edges(to_id=passage_id, edge_type="grouped_in")
     return sorted(e["from"] for e in edges)

--- a/src/questfoundry/graph/grow_routing.py
+++ b/src/questfoundry/graph/grow_routing.py
@@ -954,6 +954,9 @@ def apply_routing_plan(graph: Graph, plan: RoutingPlan) -> ApplyRoutingResult:
                 node_data = spec.to_node_data()
                 node_data["residue_for"] = op.base_passage_id
                 graph.create_node(spec.variant_id, node_data)
+                # Add grouped_in edge (beat → passage) for get_passage_beats()
+                if spec.from_beat and graph.get_node(spec.from_beat):
+                    graph.add_edge("grouped_in", spec.from_beat, spec.variant_id)
 
         # Step 3: Wire routing choices via split_and_reroute (skip if already wired)
         # Idempotency check: if routing choices already point to the first variant,

--- a/src/questfoundry/graph/grow_validation.py
+++ b/src/questfoundry/graph/grow_validation.py
@@ -17,6 +17,7 @@ from collections import deque
 from typing import TYPE_CHECKING
 
 from questfoundry.graph.context import get_primary_beat, normalize_scoped_id
+from questfoundry.graph.fill_context import is_merged_passage
 from questfoundry.graph.validation_types import ValidationCheck, ValidationReport
 
 if TYPE_CHECKING:
@@ -118,14 +119,13 @@ def build_exempt_passages(graph: Graph, passages: dict[str, dict[str, object]]) 
             exempt_beats.add(bid)
 
     exempt: set[str] = set()
-    for pid, pdata in passages.items():
+    for pid, _pdata in passages.items():
         # Exempt confront/resolve passages
         beat = get_primary_beat(graph, pid)
         if beat and beat in exempt_beats:
             exempt.add(pid)
         # Exempt merged passages (they ARE the result of collapse)
-        from_beats = pdata.get("from_beats")
-        if from_beats and isinstance(from_beats, list) and len(from_beats) > 1:
+        if is_merged_passage(graph, pid):
             exempt.add(pid)
     return exempt
 

--- a/src/questfoundry/pipeline/stages/dress.py
+++ b/src/questfoundry/pipeline/stages/dress.py
@@ -36,7 +36,7 @@ from questfoundry.agents import (
 from questfoundry.agents.serialize import extract_tokens
 from questfoundry.artifacts.validator import get_all_field_paths
 from questfoundry.export.i18n import get_output_language_instruction
-from questfoundry.graph.context import ENTITY_CATEGORIES, strip_scope_prefix
+from questfoundry.graph.context import ENTITY_CATEGORIES, get_primary_beat, strip_scope_prefix
 from questfoundry.graph.dress_context import (
     format_all_entity_visuals,
     format_art_direction_context,
@@ -1554,7 +1554,7 @@ def compute_structural_score(graph: Graph, passage_id: str) -> int:
         return score
 
     # Get beat metadata
-    beat_id = passage.get("from_beat", "")
+    beat_id = get_primary_beat(graph, passage_id) or ""
     beat = graph.get_node(beat_id) if beat_id else None
     scene_type = beat.get("scene_type", "") if beat else ""
 

--- a/tests/unit/test_dress_context.py
+++ b/tests/unit/test_dress_context.py
@@ -69,6 +69,7 @@ def dress_graph() -> Graph:
             "entities": ["character::protagonist", "location::bridge"],
         },
     )
+    g.add_edge("grouped_in", "beat::opening", "passage::opening")
     g.create_node(
         "state_flag::met_aldric",
         {

--- a/tests/unit/test_dress_mutations.py
+++ b/tests/unit/test_dress_mutations.py
@@ -61,6 +61,7 @@ def dress_graph() -> Graph:
             "entities": ["entity::protagonist", "entity::bridge"],
         },
     )
+    g.add_edge("grouped_in", "beat::opening", "passage::opening")
     g.create_node(
         "state_flag::met_aldric",
         {

--- a/tests/unit/test_dress_stage.py
+++ b/tests/unit/test_dress_stage.py
@@ -833,6 +833,11 @@ def scored_graph() -> Graph:
         "passage::side",
         {"type": "passage", "from_beat": "beat::side", "prose": "Meanwhile..."},
     )
+    # grouped_in edges (beat → passage)
+    g.add_edge("grouped_in", "beat::opening", "passage::opening")
+    g.add_edge("grouped_in", "beat::climax", "passage::climax")
+    g.add_edge("grouped_in", "beat::ending", "passage::ending")
+    g.add_edge("grouped_in", "beat::side", "passage::side")
     # Location entity
     g.create_node("entity::castle", {"type": "entity", "entity_type": "location"})
     return g
@@ -1067,14 +1072,18 @@ class TestPhase1Briefs:
             "art_direction::main",
             {"type": "art_direction", "style": "ink", "palette": ["grey"]},
         )
+        # Dilemma/path structure for computed arcs
+        g.create_node(
+            "dilemma::d1",
+            {"type": "dilemma", "raw_id": "d1", "paths": ["sp"]},
+        )
+        g.create_node(
+            "path::sp",
+            {"type": "path", "raw_id": "sp", "dilemma_id": "dilemma::d1", "is_canonical": True},
+        )
         # High-priority passage: spine arc opening + climax = high score
         g.create_node("beat::a", {"type": "beat", "raw_id": "a", "scene_type": "climax"})
-        g.create_node("dilemma::d1", {"type": "dilemma", "raw_id": "d1", "paths": ["t1"]})
-        g.create_node(
-            "path::t1",
-            {"type": "path", "raw_id": "t1", "dilemma_id": "dilemma::d1", "is_canonical": True},
-        )
-        g.add_edge("belongs_to", "beat::a", "path::t1")
+        g.add_edge("belongs_to", "beat::a", "path::sp")
         g.create_node(
             "passage::important",
             {
@@ -1084,6 +1093,7 @@ class TestPhase1Briefs:
                 "from_beat": "beat::a",
             },
         )
+        g.add_edge("grouped_in", "beat::a", "passage::important")
         # Low-priority passage: no beat, no arc = score 0 → priority 0 (or 3 if score=1+)
         g.create_node(
             "passage::filler",

--- a/tests/unit/test_fill_continuity_warning.py
+++ b/tests/unit/test_fill_continuity_warning.py
@@ -42,6 +42,8 @@ def _make_two_passages_graph(*, shared_entity: bool = False) -> tuple[Graph, str
     )
     graph.add_edge("passage_from", "passage::a", "beat::a")
     graph.add_edge("passage_from", "passage::b", "beat::b")
+    graph.add_edge("grouped_in", "beat::a", "passage::a")
+    graph.add_edge("grouped_in", "beat::b", "passage::b")
     return graph, "arc::spine"
 
 

--- a/tests/unit/test_fill_validation.py
+++ b/tests/unit/test_fill_validation.py
@@ -306,6 +306,7 @@ def _make_dilemma_graph(path_a_prose: bool, path_b_prose: bool) -> Graph:
             "prose": "Path one prose." if path_a_prose else None,
         },
     )
+    graph.add_edge("grouped_in", "beat::b1", "passage::b1")
 
     # Beats and passages for path 2
     graph.create_node("beat::b2", {"type": "beat", "raw_id": "b2"})
@@ -319,6 +320,7 @@ def _make_dilemma_graph(path_a_prose: bool, path_b_prose: bool) -> Graph:
             "prose": "Path two prose." if path_b_prose else None,
         },
     )
+    graph.add_edge("grouped_in", "beat::b2", "passage::b2")
 
     return graph
 

--- a/tests/unit/test_grow_algorithms.py
+++ b/tests/unit/test_grow_algorithms.py
@@ -5108,6 +5108,7 @@ class TestCollapseLinearPassages:
                 },
             )
             graph.add_edge("passage_from", f"passage::b{i}", f"beat::b{i}")
+            graph.add_edge("grouped_in", f"beat::b{i}", f"passage::b{i}")
 
         # Create linear choice edges (single outgoing each except last)
         for i in range(chain_length - 1):
@@ -5610,6 +5611,7 @@ class TestSplitEndingFamilies:
                     "summary": f"Passage for {beat_id}",
                 },
             )
+            graph.add_edge("grouped_in", f"beat::{beat_id}", pid)
 
         # Choice edges: opening → commits, commits → finale
         for from_p, to_p, cid in [
@@ -6390,6 +6392,7 @@ class TestHeavyResidueRouting:
                 "summary": "Shared passage",
             },
         )
+        graph.add_edge("grouped_in", "beat::shared", "passage::shared")
         graph.create_node(
             "passage::intro",
             {"type": "passage", "raw_id": "intro"},
@@ -6445,6 +6448,7 @@ class TestHeavyResidueRouting:
                     "residue_for": "passage::shared",
                 },
             )
+            graph.add_edge("grouped_in", "beat::shared", "passage::variant")
             graph.create_node(
                 "choice::routed",
                 {

--- a/tests/unit/test_grow_routing.py
+++ b/tests/unit/test_grow_routing.py
@@ -112,6 +112,18 @@ def _make_routing_graph(
             )
             g.add_edge("tracks", sf_id, cons_id)
 
+    # --- Beats (needed for grouped_in edges and arc sequences) ---
+    g.create_node("beat::start", {"type": "beat", "raw_id": "start", "summary": "Start"})
+    g.create_node("beat::mid_beat", {"type": "beat", "raw_id": "mid_beat", "summary": "Mid"})
+    if shared_terminal:
+        g.create_node("beat::end_beat", {"type": "beat", "raw_id": "end_beat", "summary": "End"})
+    else:
+        for label in ("a", "b"):
+            g.create_node(
+                f"beat::end_beat_{label}",
+                {"type": "beat", "raw_id": f"end_beat_{label}", "summary": f"End {label}"},
+            )
+
     # --- Passages ---
     g.create_node(
         "passage::start",
@@ -130,6 +142,7 @@ def _make_routing_graph(
             "from_beat": "beat::mid_beat",
         },
     )
+    g.add_edge("grouped_in", "beat::mid_beat", "passage::mid")
     if shared_terminal:
         g.create_node(
             "passage::end",
@@ -141,6 +154,7 @@ def _make_routing_graph(
                 "from_beat": "beat::end_beat",
             },
         )
+        g.add_edge("grouped_in", "beat::end_beat", "passage::end")
     else:
         # Separate endings per path of first dilemma
         g.create_node(

--- a/tests/unit/test_inspection.py
+++ b/tests/unit/test_inspection.py
@@ -533,6 +533,13 @@ class TestBranchingQualityScore:
         """Each arc's state flag signature counts as a separate ending variant."""
         graph = Graph.empty()
         spine_beats = [f"beat::s{i}" for i in range(3)]
+        # Create beat nodes (needed for grouped_in edges)
+        for i in range(3):
+            graph.create_node(
+                f"beat::s{i}",
+                {"type": "beat", "raw_id": f"s{i}", "summary": f"Spine beat {i}"},
+            )
+        graph.create_node("beat::b0", {"type": "beat", "raw_id": "b0", "summary": "Branch beat 0"})
         # Two arcs sharing the same ending beat but with different state flag paths
         graph.create_node(
             "arc::spine",
@@ -566,6 +573,7 @@ class TestBranchingQualityScore:
                 "is_ending": True,
             },
         )
+        graph.add_edge("grouped_in", "beat::s2", "passage::ending")
         # Non-ending passage with outgoing choice
         graph.create_node(
             "passage::mid",
@@ -576,6 +584,7 @@ class TestBranchingQualityScore:
                 "summary": "Middle",
             },
         )
+        graph.add_edge("grouped_in", "beat::s0", "passage::mid")
         graph.create_node(
             "choice::mid__ending",
             {
@@ -630,6 +639,12 @@ class TestBranchingQualityScore:
         """Merged passages (primary_beat instead of from_beat) contribute to ending variants."""
         graph = Graph.empty()
         spine_beats = [f"beat::s{i}" for i in range(5)]
+        # Create beat nodes (needed for grouped_in edges)
+        for i in range(5):
+            graph.create_node(
+                f"beat::s{i}",
+                {"type": "beat", "raw_id": f"s{i}", "summary": f"Spine beat {i}"},
+            )
         graph.create_node(
             "arc::spine",
             {
@@ -650,6 +665,9 @@ class TestBranchingQualityScore:
                 "summary": "The end",
             },
         )
+        # Add grouped_in edges for both beats in the merged passage
+        graph.add_edge("grouped_in", "beat::s3", "passage::ending")
+        graph.add_edge("grouped_in", "beat::s4", "passage::ending")
         # Non-ending passage with outgoing choice (so it's NOT a terminal)
         graph.create_node(
             "passage::mid",
@@ -660,6 +678,7 @@ class TestBranchingQualityScore:
                 "summary": "Middle",
             },
         )
+        graph.add_edge("grouped_in", "beat::s2", "passage::mid")
         graph.create_node(
             "choice::mid__ending",
             {


### PR DESCRIPTION
## Summary

- Simplify `get_passage_beats()` to use only `grouped_in` edges (remove `from_beat`/`from_beats` field fallbacks)
- Simplify `get_primary_beat()` to delegate to `get_passage_beats()[0]` (remove `primary_beat` field check)
- Change `is_merged_passage()` signature from `(passage_dict)` to `(graph, passage_id)` using edge count
- Add `grouped_in` edge creation in `grow_algorithms.py` and `grow_routing.py` for merged/variant passages
- Add 7 new tests for `get_passage_beats`/`get_primary_beat` including negative tests
- Add missing `grouped_in` edge for `passage::start` in test_grow_routing.py
- Document lexicographic ordering in `get_passage_beats` docstring

## Test plan

- [x] 203 test_fill_context.py tests pass (7 new)
- [x] 331 test_grow_routing + test_dress_stage + test_fill_context tests pass
- [x] `grep -rn 'from_beat.*fallback\|from_beats.*fallback' src/questfoundry/graph/context.py` returns 0 matches
- [x] `grep -rn 'primary_beat' src/questfoundry/graph/context.py` returns 0 matches
- [x] ruff + mypy clean on all modified files

Closes #1061

🤖 Generated with [Claude Code](https://claude.com/claude-code)