### PR TITLE
refactor: remove passages, collapse_passages, prune from GROW

### DIFF
--- a/src/questfoundry/pipeline/stages/grow/stage.py
+++ b/src/questfoundry/pipeline/stages/grow/stage.py
@@ -3,8 +3,7 @@
 The GROW stage builds the complete branching structure from the SEED
 graph. It runs a mix of deterministic and LLM-powered phases that
 enumerate arcs, assess path-agnostic beats, compute
-divergence/convergence points, create passages and state flags, and
-prune unreachable nodes.
+divergence/convergence points, and create state flags.
 
 GROW manages its own graph: it loads, mutates, and saves the graph
 within execute(). The orchestrator should skip post-execute
@@ -41,13 +40,10 @@ from questfoundry.pipeline.stages.grow._helpers import (
 from questfoundry.pipeline.stages.grow.deterministic import (  # noqa: F401 - register phases
     phase_apply_routing,
     phase_collapse_linear_beats,
-    phase_collapse_passages,
     phase_convergence,
     phase_divergence,
     phase_enumerate_arcs,
     phase_mark_endings,
-    phase_passages,
-    phase_prune,
     phase_state_flags,
     phase_validate_dag,
     phase_validation,
@@ -150,13 +146,10 @@ class GrowStage(_LLMHelperMixin, _LLMPhaseMixin):
         "divergence": "phase_divergence",
         "convergence": "phase_convergence",
         "collapse_linear_beats": "phase_collapse_linear_beats",
-        "passages": "phase_passages",
         "state_flags": "phase_state_flags",
         "mark_endings": "phase_mark_endings",
         "apply_routing": "phase_apply_routing",
-        "collapse_passages": "phase_collapse_passages",
         "validation": "phase_validation",
-        "prune": "phase_prune",
     }
 
     def _phase_order(self) -> list[tuple[PhaseFunc, str]]:

--- a/tests/unit/test_grow_stage.py
+++ b/tests/unit/test_grow_stage.py
@@ -182,11 +182,11 @@ class TestGrowStageExecute:
 
 
 class TestGrowStagePhaseOrder:
-    def test_phase_order_returns_twenty_five_phases(self) -> None:
-        """S3 collapsed split_endings + heavy_residue_routing into apply_routing; 24 phases remain."""
+    def test_phase_order_returns_correct_count(self) -> None:
+        """21 phases after removing passages, collapse_passages, prune."""
         stage = GrowStage()
         phases = stage._phase_order()
-        assert len(phases) == 24
+        assert len(phases) == 21
 
     def test_phase_order_names(self) -> None:
         stage = GrowStage()
@@ -204,7 +204,6 @@ class TestGrowStagePhaseOrder:
             "divergence",
             "convergence",
             "collapse_linear_beats",
-            "passages",
             "state_flags",
             "residue_beats",
             "overlays",
@@ -213,9 +212,7 @@ class TestGrowStagePhaseOrder:
             "hub_spokes",
             "mark_endings",
             "apply_routing",
-            "collapse_passages",
             "validation",
-            "prune",
         ]
 
 


### PR DESCRIPTION
## Summary
- Remove `phase_passages`, `phase_collapse_passages`, `phase_prune` from GROW deterministic phases
- Rewire `state_flags` dependency from `passages` → `collapse_linear_beats`
- Rewire `validation` dependency from `collapse_passages` → `apply_routing`
- GROW now runs 21 phases (was 24)

Part of epic #1057, milestone 2.

Closes #1062

## Test plan
- [x] Registry DAG validates (21 phases in topological order)
- [x] `tests/unit/test_grow_stage.py` — all 97 tests pass
- [x] mypy + ruff clean on changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)