### PR TITLE
fix: remove consequence_ids from path nodes, use has_consequence edges

### DIFF
--- a/src/questfoundry/graph/mutations.py
+++ b/src/questfoundry/graph/mutations.py
@@ -1776,7 +1776,6 @@ def apply_seed_mutations(graph: Graph, output: dict[str, Any]) -> None:
             "unexplored_answer_ids": prefixed_unexplored,
             "path_importance": path.get("path_importance"),
             "description": path.get("description"),
-            "consequence_ids": path.get("consequence_ids", []),
             "is_canonical": is_canonical,  # True if exploring default answer (for spine arc)
         }
         path_data = _clean_dict(path_data)

--- a/src/questfoundry/models/seed.py
+++ b/src/questfoundry/models/seed.py
@@ -159,7 +159,6 @@ class Path(BaseModel):
         unexplored_answer_ids: IDs of unexplored answers (context for FILL).
         path_importance: Major paths interweave; minor paths support.
         description: What this path is about.
-        consequence_ids: IDs of consequences for this path.
     """
 
     path_id: str = Field(
@@ -178,10 +177,6 @@ class Path(BaseModel):
         description="Path importance: major (interweaves) or minor (supports)"
     )
     description: str = Field(min_length=1, description="What this path is about")
-    consequence_ids: list[str] = Field(
-        default_factory=list,
-        description="Consequence IDs for this path (references consequence_id)",
-    )
     pov_character: str | None = Field(
         default=None,
         description="Entity ID of the POV character for this path (overrides global protagonist)",

--- a/tests/unit/test_graph_context.py
+++ b/tests/unit/test_graph_context.py
@@ -1352,7 +1352,6 @@ def _path(
     dilemma_id: str,
     answer_id: str,
     description: str | None = None,
-    consequence_ids: list[str] | None = None,
 ) -> Path:
     return Path(
         path_id=path_id,
@@ -1361,7 +1360,6 @@ def _path(
         answer_id=answer_id,
         path_importance="major",
         description=description or f"Explores {answer_id}",
-        consequence_ids=consequence_ids or [],
     )
 
 
@@ -1496,13 +1494,11 @@ class TestFormatDilemmaAnalysisContext:
                     "path::key_destroy_or_keep__destroy",
                     "key_destroy_or_keep",
                     "destroy",
-                    consequence_ids=["cons::destroy_result"],
                 ),
                 _path(
                     "path::key_destroy_or_keep__keep",
                     "key_destroy_or_keep",
                     "keep",
-                    consequence_ids=["cons::keep_result"],
                 ),
             ],
             consequences=[
@@ -1534,7 +1530,6 @@ class TestFormatDilemmaAnalysisContext:
                     "path::d1__a",
                     "d1",
                     "a",
-                    consequence_ids=["cons::empty_fx"],
                 ),
             ],
             consequences=[

--- a/tests/unit/test_mutations.py
+++ b/tests/unit/test_mutations.py
@@ -1018,7 +1018,6 @@ class TestSeedMutations:
                     "dilemma_id": "mentor_trust",  # Raw dilemma ID from LLM
                     "answer_id": "protector",  # Local alt ID, not full path
                     "description": "Exploring mentor relationship",
-                    "consequence_ids": ["consequence_trust"],
                 }
             ],
             "initial_beats": [
@@ -1096,7 +1095,6 @@ class TestSeedMutations:
                     "dilemma_id": "mentor_trust",
                     "answer_id": "protector",  # Canonical
                     "description": "The mentor genuinely protects",
-                    "consequence_ids": [],
                 },
                 {
                     "path_id": "mentor_manipulates",
@@ -1104,7 +1102,6 @@ class TestSeedMutations:
                     "dilemma_id": "mentor_trust",
                     "answer_id": "manipulator",  # Non-canonical
                     "description": "The mentor is manipulating",
-                    "consequence_ids": [],
                 },
             ],
             "initial_beats": [

--- a/tests/unit/test_serialize.py
+++ b/tests/unit/test_serialize.py
@@ -720,7 +720,6 @@ class TestSerializeResult:
             "description": "D",
             "unexplored_answer_ids": [],
             "path_importance": "major",
-            "consequence_ids": [],
         }
 
         warning_errors = [
@@ -778,7 +777,6 @@ class TestSerializeResult:
             "description": "D",
             "unexplored_answer_ids": [],
             "path_importance": "major",
-            "consequence_ids": [],
         }
 
         mixed_errors = [
@@ -870,7 +868,6 @@ class TestSerializeSeedAsFunction:
             "description": "A test path",
             "unexplored_answer_ids": [],
             "path_importance": "major",
-            "consequence_ids": [],
         }
 
         with (
@@ -1342,7 +1339,6 @@ class TestBeatRetryAndContextRefresh:
             "unexplored_answer_ids": [],
             "path_importance": "major",
             "description": "desc",
-            "consequence_ids": [],
         }
 
         with (
@@ -1396,7 +1392,6 @@ class TestBeatRetryAndContextRefresh:
             "unexplored_answer_ids": [],
             "path_importance": "major",
             "description": "desc",
-            "consequence_ids": [],
         }
 
         # Path serialization error (semantic)
@@ -1513,7 +1508,6 @@ class TestBeatRetryAndContextRefresh:
             "unexplored_answer_ids": [],
             "path_importance": "major",
             "description": "desc",
-            "consequence_ids": [],
         }
 
         validation_call_count = [0]


### PR DESCRIPTION
## Problem

The `Path` model and path node data stored a redundant `consequence_ids` field alongside the `has_consequence` edges in the graph. This created a dual source of truth: consequences were reachable both via graph traversal (`has_consequence` edges) and via the stored field on the path node. The `has_consequence` edges are the canonical representation per the ontology.

## Changes

- Removed `consequence_ids` field from the `Path` model in `src/questfoundry/models/seed.py`
- Removed `consequence_ids` from path node data written in `src/questfoundry/graph/mutations.py`
- Updated `src/questfoundry/graph/context.py` to look up consequences by matching `path_id` from `seed_output.consequences` directly instead of reading `consequence_ids` from the stored node
- Removed corresponding test assertions that verified the now-deleted field

## Not Included / Future PRs

None — this is a self-contained removal.

## Verification

```bash
grep -rn "consequence_ids" src/questfoundry/
```

Returns 0 matches — the field is fully removed from the codebase.

## Test Plan

- `uv run pytest tests/unit/test_mutations.py tests/unit/test_graph_context.py tests/unit/test_serialize.py -x -q`
- All tests pass with the updated assertions

## Risk / Rollback

Low risk — removes a redundant stored field. All consequence lookups now go through `seed_output.consequences` matching on `path_id`, which is the canonical source. No external consumers of `consequence_ids` exist in this codebase.

Closes #1097