### PR TITLE
fix: rename tracks edge/field to derived_from to match ontology

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -203,5 +203,7 @@ indent-style = "space"
 [dependency-groups]
 dev = [
     "pre-commit>=4.5.1",
+    "pytest>=9.0.2",
+    "pytest-asyncio>=1.3.0",
     "types-pyyaml>=6.0.12.20250915",
 ]

--- a/src/questfoundry/export/base.py
+++ b/src/questfoundry/export/base.py
@@ -51,7 +51,7 @@ class ExportCodeword:
 
     id: str
     codeword_type: str
-    tracks: str | None = None
+    derived_from: str | None = None
 
 
 @dataclass

--- a/src/questfoundry/export/context.py
+++ b/src/questfoundry/export/context.py
@@ -162,7 +162,7 @@ def _project_state_flags_to_codewords(graph: Graph) -> list[ExportCodeword]:
                 ExportCodeword(
                     id=flag_id,
                     codeword_type=flag_data.get("flag_type", "granted"),
-                    tracks=flag_data.get("tracks"),
+                    derived_from=flag_data.get("derived_from"),
                 )
             )
         elif not role:
@@ -194,7 +194,7 @@ def _extract_codewords(graph: Graph) -> list[ExportCodeword]:
         ExportCodeword(
             id=node_id,
             codeword_type=data.get("codeword_type", "granted"),
-            tracks=data.get("tracks"),
+            derived_from=data.get("derived_from"),
         )
         for node_id, data in sorted(nodes.items())
     ]

--- a/src/questfoundry/graph/fill_context.py
+++ b/src/questfoundry/graph/fill_context.py
@@ -1715,10 +1715,10 @@ def format_ending_differentiation(graph: Graph, passage_id: str) -> str:
     bullets: list[str] = []
     for sf_id in sorted(family_flags):
         scoped_sf = sf_id if sf_id.startswith("state_flag::") else f"state_flag::{sf_id}"
-        tracks = graph.get_edges(from_id=scoped_sf, edge_type="tracks")
-        if not tracks:
+        derived_from = graph.get_edges(from_id=scoped_sf, edge_type="derived_from")
+        if not derived_from:
             continue
-        consequence_id = sorted(tracks, key=lambda e: e["to"])[0]["to"]
+        consequence_id = sorted(derived_from, key=lambda e: e["to"])[0]["to"]
         cons_node = graph.get_node(consequence_id)
         if not cons_node:
             continue

--- a/src/questfoundry/graph/grow_algorithms.py
+++ b/src/questfoundry/graph/grow_algorithms.py
@@ -566,8 +566,8 @@ def build_arc_state_flags(
         ):
             included_paths.add(path_id)
 
-    # consequence → state flag (via tracks edges: state_flag tracks consequence)
-    tracks_edges = graph.get_edges(edge_type="tracks")
+    # consequence → state flag (via derived_from edges: state_flag derived_from consequence)
+    tracks_edges = graph.get_edges(edge_type="derived_from")
     consequence_to_state_flag: dict[str, str] = {}
     for edge in tracks_edges:
         consequence_to_state_flag[edge["to"]] = edge["from"]

--- a/src/questfoundry/graph/grow_algorithms.py
+++ b/src/questfoundry/graph/grow_algorithms.py
@@ -567,9 +567,9 @@ def build_arc_state_flags(
             included_paths.add(path_id)
 
     # consequence → state flag (via derived_from edges: state_flag derived_from consequence)
-    tracks_edges = graph.get_edges(edge_type="derived_from")
+    derived_from_edges = graph.get_edges(edge_type="derived_from")
     consequence_to_state_flag: dict[str, str] = {}
-    for edge in tracks_edges:
+    for edge in derived_from_edges:
         consequence_to_state_flag[edge["to"]] = edge["from"]
 
     # path → consequences (via has_consequence edges)

--- a/src/questfoundry/graph/polish_validation.py
+++ b/src/questfoundry/graph/polish_validation.py
@@ -632,7 +632,7 @@ def check_gate_co_satisfiability(graph: Graph) -> ValidationCheck:
     # Build consequence→state_flag lookup
     cons_to_state_flag = {
         edge["to"]: edge["from"]
-        for edge in graph.get_edges(from_id=None, to_id=None, edge_type="tracks")
+        for edge in graph.get_edges(from_id=None, to_id=None, edge_type="derived_from")
     }
 
     # Build path→consequences lookup

--- a/src/questfoundry/inspection.py
+++ b/src/questfoundry/inspection.py
@@ -354,9 +354,9 @@ def _branching_quality_score(
         for beat_id in data.get("sequence", []):
             beat_to_arcs.setdefault(beat_id, []).append(arc_id)
 
-    # Build arc → state flags: arc paths → consequences → state flags via tracks edges
+    # Build arc → state flags: arc paths → consequences → state flags via derived_from edges
     arc_state_flags: dict[str, frozenset[str]] = {}
-    tracks_edges = graph.get_edges(edge_type="tracks")
+    tracks_edges = graph.get_edges(edge_type="derived_from")
     consequence_to_state_flag: dict[str, str] = {}
     for edge in tracks_edges:
         consequence_to_state_flag[edge["to"]] = edge["from"]

--- a/src/questfoundry/inspection.py
+++ b/src/questfoundry/inspection.py
@@ -356,9 +356,9 @@ def _branching_quality_score(
 
     # Build arc → state flags: arc paths → consequences → state flags via derived_from edges
     arc_state_flags: dict[str, frozenset[str]] = {}
-    tracks_edges = graph.get_edges(edge_type="derived_from")
+    derived_from_edges = graph.get_edges(edge_type="derived_from")
     consequence_to_state_flag: dict[str, str] = {}
-    for edge in tracks_edges:
+    for edge in derived_from_edges:
         consequence_to_state_flag[edge["to"]] = edge["from"]
 
     has_consequence_edges = graph.get_edges(edge_type="has_consequence")

--- a/src/questfoundry/models/grow.py
+++ b/src/questfoundry/models/grow.py
@@ -68,7 +68,7 @@ class StateFlag(BaseModel):
     """
 
     flag_id: str = Field(min_length=1)
-    tracks: str = Field(min_length=1)
+    derived_from: str = Field(min_length=1)
     flag_type: Literal["granted"] = "granted"
 
 

--- a/src/questfoundry/pipeline/stages/grow/deterministic.py
+++ b/src/questfoundry/pipeline/stages/grow/deterministic.py
@@ -343,11 +343,11 @@ async def phase_state_flags(graph: Graph, model: BaseChatModel) -> GrowPhaseResu
             {
                 "type": "state_flag",
                 "raw_id": f"{cons_raw}_committed",
-                "tracks": cons_id,
+                "derived_from": cons_id,
                 "flag_type": "granted",
             },
         )
-        graph.add_edge("tracks", flag_id, cons_id)
+        graph.add_edge("derived_from", flag_id, cons_id)
 
         # Find commits beats for this consequence's path
         cons_path_id = cons_data.get("path_id", "")

--- a/src/questfoundry/pipeline/stages/grow/llm_phases.py
+++ b/src/questfoundry/pipeline/stages/grow/llm_phases.py
@@ -1080,7 +1080,7 @@ class _LLMPhaseMixin:
 
         for sf_id, sf_data in sorted(state_flag_nodes.items()):
             valid_state_flag_ids.append(sf_id)
-            tracks_id = sf_data.get("tracks", "")
+            tracks_id = sf_data.get("derived_from", "")
             cons_data = consequence_nodes.get(tracks_id, {})
             cons_desc = cons_data.get("description", "unknown consequence")
 

--- a/src/questfoundry/pipeline/stages/grow/llm_phases.py
+++ b/src/questfoundry/pipeline/stages/grow/llm_phases.py
@@ -1080,8 +1080,8 @@ class _LLMPhaseMixin:
 
         for sf_id, sf_data in sorted(state_flag_nodes.items()):
             valid_state_flag_ids.append(sf_id)
-            tracks_id = sf_data.get("derived_from", "")
-            cons_data = consequence_nodes.get(tracks_id, {})
+            derived_from_id = sf_data.get("derived_from", "")
+            cons_data = consequence_nodes.get(derived_from_id, {})
             cons_desc = cons_data.get("description", "unknown consequence")
 
             # Trace: consequence → path → dilemma for rich context

--- a/tests/unit/test_export_context.py
+++ b/tests/unit/test_export_context.py
@@ -83,7 +83,7 @@ def _graph_with_entities(g: Graph) -> Graph:
             "type": "codeword",
             "raw_id": "entered_castle",
             "codeword_type": "granted",
-            "tracks": "consequence::entered",
+            "derived_from": "consequence::entered",
         },
     )
     return g
@@ -221,7 +221,7 @@ class TestBuildExportContext:
 
         assert len(ctx.codewords) == 1
         assert ctx.codewords[0].id == "codeword::entered_castle"
-        assert ctx.codewords[0].tracks == "consequence::entered"
+        assert ctx.codewords[0].derived_from == "consequence::entered"
 
     def test_dress_nodes_present(self) -> None:
         g = _graph_with_dress(_minimal_graph())
@@ -304,7 +304,7 @@ class TestBuildExportContext:
                 "raw_id": "trusted_mentor",
                 "dilemma_id": "dilemma::trust",
                 "codeword_type": "granted",
-                "tracks": "consequence::trust_given",
+                "derived_from": "consequence::trust_given",
             },
         )
         g.create_node(
@@ -314,14 +314,14 @@ class TestBuildExportContext:
                 "raw_id": "loyal_to_crown",
                 "dilemma_id": "dilemma::loyalty",
                 "codeword_type": "granted",
-                "tracks": "consequence::loyalty",
+                "derived_from": "consequence::loyalty",
             },
         )
         ctx = build_export_context(g, "test")
         # Only soft dilemma flag should be exported
         assert len(ctx.codewords) == 1
         assert ctx.codewords[0].id == "state_flag::trusted_mentor"
-        assert ctx.codewords[0].tracks == "consequence::trust_given"
+        assert ctx.codewords[0].derived_from == "consequence::trust_given"
 
     def test_hard_only_state_flags_yield_no_codewords(self) -> None:
         """Hard-only state flags produce empty codewords, not a legacy fallback."""

--- a/tests/unit/test_fill_context.py
+++ b/tests/unit/test_fill_context.py
@@ -1497,7 +1497,7 @@ class TestEndingDifferentiation:
             {"type": "state_flag", "raw_id": "sf_ally"},
         )
         # Edges: state_flag --tracks--> consequence
-        g.add_edge("tracks", "state_flag::sf_ally", "consequence::ally_trusted")
+        g.add_edge("derived_from", "state_flag::sf_ally", "consequence::ally_trusted")
         # path --has_consequence--> consequence
         g.add_edge("has_consequence", "path::ally_path", "consequence::ally_trusted")
 
@@ -1538,7 +1538,7 @@ class TestEndingDifferentiation:
             "state_flag::sf_shadow",
             {"type": "state_flag", "raw_id": "sf_shadow"},
         )
-        g.add_edge("tracks", "state_flag::sf_shadow", "consequence::shadow")
+        g.add_edge("derived_from", "state_flag::sf_shadow", "consequence::shadow")
         g.add_edge("has_consequence", "path::dark_path", "consequence::shadow")
         g.create_node(
             "passage::ending_0",
@@ -1566,7 +1566,7 @@ class TestEndingDifferentiation:
             "state_flag::sf_empty",
             {"type": "state_flag", "raw_id": "sf_empty"},
         )
-        g.add_edge("tracks", "state_flag::sf_empty", "consequence::empty_cons")
+        g.add_edge("derived_from", "state_flag::sf_empty", "consequence::empty_cons")
         g.create_node(
             "passage::ending_1",
             {

--- a/tests/unit/test_grow_algorithms.py
+++ b/tests/unit/test_grow_algorithms.py
@@ -1942,7 +1942,7 @@ class TestPhase8bIntegration:
         mock_model = MagicMock()
         await phase_state_flags(graph, mock_model)
 
-        tracks_edges = graph.get_edges(from_id=None, to_id=None, edge_type="tracks")
+        tracks_edges = graph.get_edges(from_id=None, to_id=None, edge_type="derived_from")
         state_flag_nodes = graph.get_nodes_by_type("state_flag")
         assert len(tracks_edges) == len(state_flag_nodes)
 
@@ -2771,7 +2771,7 @@ class TestPhaseIntegrationEndToEnd:
         passage_from = saved_graph.get_edges(from_id=None, to_id=None, edge_type="passage_from")
         assert len(passage_from) == 0
 
-        tracks = saved_graph.get_edges(from_id=None, to_id=None, edge_type="tracks")
+        tracks = saved_graph.get_edges(from_id=None, to_id=None, edge_type="derived_from")
         assert len(tracks) == 4
 
         grants = saved_graph.get_edges(from_id=None, to_id=None, edge_type="grants")
@@ -3960,8 +3960,8 @@ class TestBuildArcStateFlags:
             "state_flag::cw2",
             {"type": "state_flag", "raw_id": "cw2"},
         )
-        graph.add_edge("tracks", "state_flag::cw1", "consequence::c1")
-        graph.add_edge("tracks", "state_flag::cw2", "consequence::c2")
+        graph.add_edge("derived_from", "state_flag::cw1", "consequence::c1")
+        graph.add_edge("derived_from", "state_flag::cw2", "consequence::c2")
 
         # Single arc covering both paths
         graph.create_node(
@@ -4035,8 +4035,8 @@ class TestBuildArcStateFlags:
         graph.add_edge("has_consequence", "path::d2__yes", "consequence::c2")
         graph.create_node("state_flag::cw1", {"type": "state_flag", "raw_id": "cw1"})
         graph.create_node("state_flag::cw2", {"type": "state_flag", "raw_id": "cw2"})
-        graph.add_edge("tracks", "state_flag::cw1", "consequence::c1")
-        graph.add_edge("tracks", "state_flag::cw2", "consequence::c2")
+        graph.add_edge("derived_from", "state_flag::cw1", "consequence::c1")
+        graph.add_edge("derived_from", "state_flag::cw2", "consequence::c2")
         graph.create_node(
             "arc::main",
             {

--- a/tests/unit/test_grow_algorithms.py
+++ b/tests/unit/test_grow_algorithms.py
@@ -1942,9 +1942,9 @@ class TestPhase8bIntegration:
         mock_model = MagicMock()
         await phase_state_flags(graph, mock_model)
 
-        tracks_edges = graph.get_edges(from_id=None, to_id=None, edge_type="derived_from")
+        derived_from_edges = graph.get_edges(from_id=None, to_id=None, edge_type="derived_from")
         state_flag_nodes = graph.get_nodes_by_type("state_flag")
-        assert len(tracks_edges) == len(state_flag_nodes)
+        assert len(derived_from_edges) == len(state_flag_nodes)
 
     @pytest.mark.asyncio
     async def test_grants_edges_assigned_to_commits_beats(self) -> None:

--- a/tests/unit/test_grow_models.py
+++ b/tests/unit/test_grow_models.py
@@ -124,26 +124,26 @@ class TestStateFlag:
     def test_valid_state_flag(self) -> None:
         sf = StateFlag(
             flag_id="state_flag::mentor_trust_committed",
-            tracks="consequence::mentor_trust",
+            derived_from="consequence::mentor_trust",
         )
         assert sf.flag_id == "state_flag::mentor_trust_committed"
         assert sf.flag_type == "granted"
 
     def test_default_type_is_granted(self) -> None:
-        sf = StateFlag(flag_id="sf1", tracks="c1")
+        sf = StateFlag(flag_id="sf1", derived_from="c1")
         assert sf.flag_type == "granted"
 
     def test_empty_flag_id_rejected(self) -> None:
         with pytest.raises(ValidationError, match="flag_id"):
-            StateFlag(flag_id="", tracks="c1")
+            StateFlag(flag_id="", derived_from="c1")
 
     def test_empty_tracks_rejected(self) -> None:
-        with pytest.raises(ValidationError, match="tracks"):
-            StateFlag(flag_id="sf1", tracks="")
+        with pytest.raises(ValidationError, match="derived_from"):
+            StateFlag(flag_id="sf1", derived_from="")
 
     def test_invalid_flag_type_rejected(self) -> None:
         with pytest.raises(ValidationError, match="flag_type"):
-            StateFlag(flag_id="sf1", tracks="c1", flag_type="revoked")  # type: ignore[arg-type]
+            StateFlag(flag_id="sf1", derived_from="c1", flag_type="revoked")  # type: ignore[arg-type]
 
 
 class TestChoice:

--- a/tests/unit/test_grow_models.py
+++ b/tests/unit/test_grow_models.py
@@ -137,7 +137,7 @@ class TestStateFlag:
         with pytest.raises(ValidationError, match="flag_id"):
             StateFlag(flag_id="", derived_from="c1")
 
-    def test_empty_tracks_rejected(self) -> None:
+    def test_empty_derived_from_rejected(self) -> None:
         with pytest.raises(ValidationError, match="derived_from"):
             StateFlag(flag_id="sf1", derived_from="")
 

--- a/tests/unit/test_grow_stage.py
+++ b/tests/unit/test_grow_stage.py
@@ -1353,12 +1353,12 @@ class TestPhase8cOverlays:
             {
                 "type": "state_flag",
                 "raw_id": "mentor_trusted_committed",
-                "tracks": "consequence::mentor_trusted",
+                "derived_from": "consequence::mentor_trusted",
                 "flag_type": "granted",
             },
         )
         graph.add_edge(
-            "tracks", "state_flag::mentor_trusted_committed", "consequence::mentor_trusted"
+            "derived_from", "state_flag::mentor_trusted_committed", "consequence::mentor_trusted"
         )
 
         stage = GrowStage()
@@ -1414,7 +1414,7 @@ class TestPhase8cOverlays:
             {
                 "type": "state_flag",
                 "raw_id": "cw1",
-                "tracks": "consequence::c1",
+                "derived_from": "consequence::c1",
                 "flag_type": "granted",
             },
         )
@@ -1461,7 +1461,7 @@ class TestPhase8cOverlays:
             {
                 "type": "state_flag",
                 "raw_id": "cw1",
-                "tracks": "consequence::c1",
+                "derived_from": "consequence::c1",
                 "flag_type": "granted",
             },
         )
@@ -1537,7 +1537,7 @@ class TestPhase8cOverlays:
             {
                 "type": "state_flag",
                 "raw_id": "cw1",
-                "tracks": "consequence::c1",
+                "derived_from": "consequence::c1",
                 "flag_type": "granted",
             },
         )
@@ -1631,7 +1631,7 @@ class TestPhase8cOverlays:
             {
                 "type": "state_flag",
                 "raw_id": "mentor_trusted_committed",
-                "tracks": "consequence::mentor_trusted",
+                "derived_from": "consequence::mentor_trusted",
                 "flag_type": "granted",
             },
         )
@@ -1688,7 +1688,7 @@ class TestPhase8cOverlays:
             {
                 "type": "state_flag",
                 "raw_id": "hero_saved_committed",
-                "tracks": "consequence::hero_saved",
+                "derived_from": "consequence::hero_saved",
                 "flag_type": "granted",
             },
         )
@@ -1743,7 +1743,7 @@ class TestPhase8cOverlays:
             {
                 "type": "state_flag",
                 "raw_id": "secret_revealed_committed",
-                "tracks": "consequence::secret_revealed",
+                "derived_from": "consequence::secret_revealed",
                 "flag_type": "granted",
             },
         )
@@ -2053,7 +2053,11 @@ class TestPhase8cErrorHandling:
         )
         graph.create_node(
             "state_flag::cw_trust",
-            {"type": "state_flag", "tracks": "consequence::trust_gain", "flag_type": "granted"},
+            {
+                "type": "state_flag",
+                "derived_from": "consequence::trust_gain",
+                "flag_type": "granted",
+            },
         )
 
         stage = GrowStage()

--- a/tests/unit/test_inspection.py
+++ b/tests/unit/test_inspection.py
@@ -626,8 +626,8 @@ class TestBranchingQualityScore:
         )
         graph.add_edge("has_consequence", "path::canon", "consequence::c_canon")
         graph.add_edge("has_consequence", "path::rebel", "consequence::c_rebel")
-        graph.add_edge("tracks", "state_flag::canon_flag", "consequence::c_canon")
-        graph.add_edge("tracks", "state_flag::rebel_flag", "consequence::c_rebel")
+        graph.add_edge("derived_from", "state_flag::canon_flag", "consequence::c_canon")
+        graph.add_edge("derived_from", "state_flag::rebel_flag", "consequence::c_rebel")
 
         result = _branching_quality_score(graph, None)
         assert result is not None

--- a/tests/unit/test_polish_passage_validation.py
+++ b/tests/unit/test_polish_passage_validation.py
@@ -216,7 +216,7 @@ def _make_routing_graph(
         graph.create_node(cons_id, {"type": "consequence", "raw_id": p})
         graph.create_node(sf_id, {"type": "state_flag", "raw_id": p})
         graph.add_edge("has_consequence", pid, cons_id)
-        graph.add_edge("tracks", sf_id, cons_id)
+        graph.add_edge("derived_from", sf_id, cons_id)
 
     # Arcs
     for arc_raw, paths in arc_paths.items():
@@ -538,7 +538,7 @@ class TestGateCoSatisfiability:
         graph.create_node("consequence::c1", {"type": "consequence", "raw_id": "c1"})
         graph.add_edge("has_consequence", "path::p1", "consequence::c1")
         graph.create_node("state_flag::cw1", {"type": "state_flag", "raw_id": "cw1"})
-        graph.add_edge("tracks", "state_flag::cw1", "consequence::c1")
+        graph.add_edge("derived_from", "state_flag::cw1", "consequence::c1")
         # Arc containing p1
         graph.create_node(
             "arc::a1",
@@ -571,7 +571,7 @@ class TestGateCoSatisfiability:
             graph.create_node(cons_id, {"type": "consequence", "raw_id": f"{p_id}_c"})
             graph.add_edge("has_consequence", f"path::{p_id}", cons_id)
             graph.create_node(sf_id, {"type": "state_flag", "raw_id": f"{p_id}_cw"})
-            graph.add_edge("tracks", sf_id, cons_id)
+            graph.add_edge("derived_from", sf_id, cons_id)
         # Arc 1 has only p1, Arc 2 has only p2 -- mutually exclusive
         graph.create_node(
             "arc::a1",

--- a/uv.lock
+++ b/uv.lock
@@ -1986,6 +1986,8 @@ viz = [
 [package.dev-dependencies]
 dev = [
     { name = "pre-commit" },
+    { name = "pytest" },
+    { name = "pytest-asyncio" },
     { name = "types-pyyaml" },
 ]
 
@@ -2037,6 +2039,8 @@ provides-extras = ["ollama", "openai", "anthropic", "google", "all-providers", "
 [package.metadata.requires-dev]
 dev = [
     { name = "pre-commit", specifier = ">=4.5.1" },
+    { name = "pytest", specifier = ">=9.0.2" },
+    { name = "pytest-asyncio", specifier = ">=1.3.0" },
     { name = "types-pyyaml", specifier = ">=6.0.12.20250915" },
 ]
 


### PR DESCRIPTION
## Problem

The ontology (`docs/design/00-spec.md`) defines the state_flag → consequence relationship as `derived_from`, but the codebase used `tracks` for both the edge type and the field name on state_flag nodes. This mismatch made the code harder to reason about and violated the principle that code should reflect the ontology directly.

## Changes

- Renames the `tracks` edge type (state_flag → consequence) to `derived_from` across all producers and consumers
- Renames the `tracks` field on state_flag nodes to `derived_from`
- Updates all 9 source files and 7 test files that referenced the old name

**Source files changed:**
- `src/questfoundry/export/base.py`
- `src/questfoundry/export/context.py`
- `src/questfoundry/graph/fill_context.py`
- `src/questfoundry/graph/grow_algorithms.py`
- `src/questfoundry/graph/polish_validation.py`
- `src/questfoundry/inspection.py`
- `src/questfoundry/models/grow.py`
- `src/questfoundry/pipeline/stages/grow/deterministic.py`
- `src/questfoundry/pipeline/stages/grow/llm_phases.py`

**Test files changed:**
- `tests/unit/test_export_context.py`
- `tests/unit/test_fill_context.py`
- `tests/unit/test_grow_algorithms.py`
- `tests/unit/test_grow_models.py`
- `tests/unit/test_grow_stage.py`
- `tests/unit/test_inspection.py`
- `tests/unit/test_polish_passage_validation.py`

## Not Included / Future PRs

No behavior changes — this is a pure rename refactor.

## Test Plan

- All unit tests pass with the renamed edge and field
- `uv run pytest tests/unit/ -x -q`

## Risk / Rollback

Pure rename with no behavioral change. Any existing `graph.db` files created before this change will have `tracks` edges that the new code reads as `derived_from` — projects would need to be re-run from GROW. This is acceptable for the current development stage.

Closes #1095