### PR TITLE
fix: semantic dilemma ordering edges and strengthen relationships prompt

### DIFF
--- a/prompts/templates/serialize_seed_sections.yaml
+++ b/prompts/templates/serialize_seed_sections.yaml
@@ -1000,11 +1000,14 @@ dilemma_analyses_prompt: |
 
 # Section 8: Dilemma Ordering Relationships (post-prune, Doc 3)
 dilemma_relationships_prompt: |
-  You are classifying the temporal ordering between dilemma pairs for a SEED stage.
+  You are classifying the temporal ordering between ALL dilemma pairs for a SEED stage.
 
   Each dilemma pair has a structural relationship that affects how GROW
-  interleaves their beats. MOST pairs are "concurrent" (the default).
-  It is normal and expected to return few or no relationships.
+  interleaves their beats. You MUST classify EVERY pair listed in the Context.
+  `concurrent` is the default when no structural nesting or sequencing exists,
+  but you must still include the pair with `ordering: "concurrent"` — do NOT
+  skip it. An empty list means NOTHING was classified and is only correct when
+  the Context says "fewer than 2 surviving dilemmas."
 
   ## Ordering Types
 
@@ -1013,8 +1016,9 @@ dilemma_relationships_prompt: |
     wraps the mentor's betrayal subplot (B) — the mystery is present from the
     start and resolves at the climax, while the betrayal plays out in the middle."
   - **concurrent**: Neither wraps the other. Both are active simultaneously,
-    interleaving but without nesting. This is the DEFAULT for most pairs.
-    Example: "both the romance and the political intrigue develop in parallel."
+    interleaving but without nesting. Use this when no clear nesting or
+    sequencing exists. Example: "both the romance and the political intrigue
+    develop in parallel."
   - **serial**: A resolves (commits and converges) before B introduces. The
     dilemmas never structurally interact. Example: "the escape subplot resolves
     in Act 1 before the revenge plot begins in Act 2."
@@ -1023,10 +1027,10 @@ dilemma_relationships_prompt: |
   from entity anchoring in the graph. Do NOT classify pairs as shared_entity.
 
   ## What NOT to Do
-  - Do NOT invent relationships for pairs not in the Candidate Pairs list
-  - Do NOT force relationships where none exist — empty list is fine
+  - Do NOT skip any pair — every pair in "All Dilemma Pairs" must appear in output
   - Do NOT use ordering values other than wraps, concurrent, serial
   - Do NOT classify shared characters/locations as ordering — that is derived
+  - Do NOT return an empty array unless the Context says fewer than 2 dilemmas
 
   GOOD: "The central mystery wraps the betrayal subplot — it introduces first
   and resolves last."
@@ -1038,7 +1042,7 @@ dilemma_relationships_prompt: |
   {candidate_pairs_context}
 
   ## Schema
-  Return a JSON object with a "dilemma_relationships" array:
+  Return a JSON object with a "dilemma_relationships" array — one entry per pair:
   ```json
   {{
     "dilemma_relationships": [
@@ -1053,25 +1057,25 @@ dilemma_relationships_prompt: |
   }}
   ```
 
-  If no non-concurrent relationships exist (common), return an empty array:
+  If the Context says "No candidate pairs — fewer than 2 surviving dilemmas", return:
   ```json
   {{
     "dilemma_relationships": []
   }}
   ```
 
-  If the Context says "No candidate pairs", return the empty array above immediately.
-
   ## Rules
-  - ONLY consider pairs from the ### Candidate Pairs list in the Context
+  - Classify EVERY pair from the "All Dilemma Pairs" list in the Context
   - Use canonical ordering: dilemma_a < dilemma_b (alphabetically)
-  - Most stories have 0-2 non-concurrent relationships. Empty list is expected.
+  - `ordering` must be exactly one of: `wraps`, `concurrent`, `serial`
   - `reasoning` must explain the temporal (not thematic) relationship
+  - Output must contain one entry per pair — no pairs may be omitted
 
-  ## REMINDER
-  ONLY use pairs from the Candidate Pairs list. Empty list is normal. Do NOT invent relationships.
+  ## FINAL CHECK
+  Count the pairs listed under "All Dilemma Pairs" in the Context.
+  Your output MUST contain that exact number of entries.
 
   ## Output
-  Return ONLY valid JSON with the "dilemma_relationships" array. An empty array is expected.
+  Return ONLY valid JSON with the "dilemma_relationships" array.
 
 components: []

--- a/src/questfoundry/graph/context.py
+++ b/src/questfoundry/graph/context.py
@@ -1048,11 +1048,11 @@ def format_interaction_candidates_context(
 ) -> str:
     """Format all dilemma pairs for ordering classification (Section 8).
 
-    Builds rich per-dilemma context (question, stakes, answers, convergence
-    point) and enumerates ALL pairs of surviving dilemmas.  Pairs that share
-    central entities are flagged so the LLM has extra signal, but every pair
-    is included because small stories (2-4 dilemmas = 3-6 pairs max) rarely
-    have enough shared-entity pairs to trigger any classification at all.
+    Builds rich per-dilemma context (question, stakes, answers via has_answer
+    edges, convergence point) and enumerates ALL pairs of surviving dilemmas.
+    Pairs that share central entities are flagged so the LLM has extra signal,
+    but every pair is included because small stories (2-4 dilemmas = 3-6 pairs
+    max) rarely have enough shared-entity pairs to trigger any classification.
 
     Args:
         seed_output: Pruned SEED output with surviving dilemmas.
@@ -1069,15 +1069,15 @@ def format_interaction_candidates_context(
 
     sorted_ids = sorted(surviving_ids)
 
-    # Collect per-dilemma data from graph
+    # Collect per-dilemma data and central entities from graph
     dilemma_data: dict[str, dict[str, Any]] = {}
     dilemma_entities: dict[str, set[str]] = {}
     for raw_id in sorted_ids:
         node_id = f"{SCOPE_DILEMMA}::{raw_id}"
         node = graph.get_node(node_id)
         dilemma_data[raw_id] = node if node is not None else {}
-        edges = graph.get_edges(from_id=node_id, edge_type="anchored_to")
-        dilemma_entities[raw_id] = {strip_scope_prefix(e["to"]) for e in edges}
+        anchor_edges = graph.get_edges(from_id=node_id, edge_type="anchored_to")
+        dilemma_entities[raw_id] = {strip_scope_prefix(e["to"]) for e in anchor_edges}
 
     # Build per-dilemma detail blocks
     dilemma_blocks: list[str] = []
@@ -1090,17 +1090,23 @@ def format_interaction_candidates_context(
         why = data.get("why_it_matters", "")
         if why:
             block.append(f"**Stakes:** {why}")
-        # Answers from the dilemma node
-        answers = data.get("answers", [])
-        if answers:
+        # Answers from has_answer edges (not node data — answers are separate nodes)
+        node_id = f"{SCOPE_DILEMMA}::{raw_id}"
+        answer_edges = graph.get_edges(from_id=node_id, edge_type="has_answer")
+        if answer_edges:
             answer_lines = []
-            for ans in answers:
-                label = ans.get("label", ans.get("answer_id", "?"))
+            for ae in answer_edges:
+                ans_node = graph.get_node(ae["to"])
+                if ans_node is None:
+                    continue
+                ans = ans_node
+                label = ans.get("label", ans.get("answer_id", strip_scope_prefix(ae["to"])))
                 consequence = ans.get("consequence", {})
                 desc = consequence.get("description", "") if isinstance(consequence, dict) else ""
                 marker = " (default)" if ans.get("default") else ""
                 answer_lines.append(f"  - `{label}`{marker}" + (f": {desc}" if desc else ""))
-            block.append("**Answers:**\n" + "\n".join(answer_lines))
+            if answer_lines:
+                block.append("**Answers:**\n" + "\n".join(answer_lines))
         conv = data.get("convergence_point", "")
         if conv:
             block.append(f"**Convergence point:** {conv}")
@@ -1132,8 +1138,8 @@ def format_interaction_candidates_context(
         "",
         "You MUST classify ALL pairs below. `concurrent` is the default when no",
         "structural ordering exists, but do NOT skip any pair — an empty list means",
-        "NOTHING was classified, which is only correct if there is exactly one pair",
-        "and it is truly concurrent.",
+        "NOTHING was classified, which is only correct when fewer than 2 surviving",
+        "dilemmas exist.",
         "",
         *pair_lines,
         "",

--- a/src/questfoundry/graph/context.py
+++ b/src/questfoundry/graph/context.py
@@ -1046,61 +1046,94 @@ def format_interaction_candidates_context(
     seed_output: SeedOutput,
     graph: Graph,
 ) -> str:
-    """Format pre-filtered candidate pairs for interaction analysis (Section 8).
+    """Format all dilemma pairs for ordering classification (Section 8).
 
-    Reads ``anchored_to`` edges from brainstorm dilemma nodes in the graph,
-    filters to surviving dilemmas, and computes candidate pairs that share
-    at least one central entity.
+    Builds rich per-dilemma context (question, stakes, answers, convergence
+    point) and enumerates ALL pairs of surviving dilemmas.  Pairs that share
+    central entities are flagged so the LLM has extra signal, but every pair
+    is included because small stories (2-4 dilemmas = 3-6 pairs max) rarely
+    have enough shared-entity pairs to trigger any classification at all.
 
     Args:
         seed_output: Pruned SEED output with surviving dilemmas.
-        graph: Graph containing brainstorm dilemma nodes with anchored_to edges.
+        graph: Graph containing brainstorm dilemma nodes.
 
     Returns:
-        Formatted markdown context with candidate pairs, or a message
-        indicating no candidates if fewer than 2 dilemmas or no shared entities.
+        Formatted markdown context with all pairs and per-dilemma details,
+        or a short message if fewer than 2 dilemmas survive.
     """
     surviving_ids = {strip_scope_prefix(d.dilemma_id) for d in seed_output.dilemmas}
 
     if len(surviving_ids) < 2:
         return "No candidate pairs — fewer than 2 surviving dilemmas. Return an empty list."
 
-    # Read anchored_to edges from graph dilemma nodes
+    sorted_ids = sorted(surviving_ids)
+
+    # Collect per-dilemma data from graph
+    dilemma_data: dict[str, dict[str, Any]] = {}
     dilemma_entities: dict[str, set[str]] = {}
-    for raw_id in sorted(surviving_ids):
+    for raw_id in sorted_ids:
         node_id = f"{SCOPE_DILEMMA}::{raw_id}"
-        if graph.get_node(node_id) is None:
-            continue
+        node = graph.get_node(node_id)
+        dilemma_data[raw_id] = node if node is not None else {}
         edges = graph.get_edges(from_id=node_id, edge_type="anchored_to")
-        # Strip scope prefixes for readability
         dilemma_entities[raw_id] = {strip_scope_prefix(e["to"]) for e in edges}
 
-    # Compute candidate pairs (shared central entities)
-    candidate_pairs: list[tuple[str, str, list[str]]] = []
-    sorted_ids = sorted(dilemma_entities.keys())
+    # Build per-dilemma detail blocks
+    dilemma_blocks: list[str] = []
+    for raw_id in sorted_ids:
+        data = dilemma_data[raw_id]
+        block: list[str] = [f"### `dilemma::{raw_id}`"]
+        question = data.get("question", "")
+        if question:
+            block.append(f"**Question:** {question}")
+        why = data.get("why_it_matters", "")
+        if why:
+            block.append(f"**Stakes:** {why}")
+        # Answers from the dilemma node
+        answers = data.get("answers", [])
+        if answers:
+            answer_lines = []
+            for ans in answers:
+                label = ans.get("label", ans.get("answer_id", "?"))
+                consequence = ans.get("consequence", {})
+                desc = consequence.get("description", "") if isinstance(consequence, dict) else ""
+                marker = " (default)" if ans.get("default") else ""
+                answer_lines.append(f"  - `{label}`{marker}" + (f": {desc}" if desc else ""))
+            block.append("**Answers:**\n" + "\n".join(answer_lines))
+        conv = data.get("convergence_point", "")
+        if conv:
+            block.append(f"**Convergence point:** {conv}")
+        entities = dilemma_entities.get(raw_id, set())
+        if entities:
+            block.append("**Central entities:** " + ", ".join(f"`{e}`" for e in sorted(entities)))
+        dilemma_blocks.append("\n".join(block))
+
+    # Enumerate ALL pairs; flag shared-entity pairs for extra signal
+    pair_lines: list[str] = []
     for i, id_a in enumerate(sorted_ids):
         for id_b in sorted_ids[i + 1 :]:
             shared = dilemma_entities[id_a] & dilemma_entities[id_b]
-            if shared:
-                candidate_pairs.append((id_a, id_b, sorted(shared)))
+            shared_note = (
+                f" — shared entities: {', '.join(f'`{e}`' for e in sorted(shared))}"
+                if shared
+                else ""
+            )
+            pair_lines.append(f"- `dilemma::{id_a}` + `dilemma::{id_b}`{shared_note}")
 
-    if not candidate_pairs:
-        return "No candidate pairs — no dilemmas share central entities. Return an empty list."
-
-    pair_lines = [
-        f"- `dilemma::{a}` + `dilemma::{b}` (shared: {', '.join(entities)})"
-        for a, b, entities in candidate_pairs
-    ]
-
-    valid_ids = [f"`dilemma::{rid}`" for rid in sorted(surviving_ids)]
+    valid_ids = [f"`dilemma::{rid}`" for rid in sorted_ids]
 
     lines = [
-        "## Interaction Candidates",
+        "## Dilemma Details",
         "",
-        "Only consider these pre-filtered pairs (they share central entities).",
-        "Do NOT invent pairs outside this list.",
+        *[line for block in dilemma_blocks for line in block.split("\n")],
         "",
-        "### Candidate Pairs",
+        "## All Dilemma Pairs (classify EVERY pair)",
+        "",
+        "You MUST classify ALL pairs below. `concurrent` is the default when no",
+        "structural ordering exists, but do NOT skip any pair — an empty list means",
+        "NOTHING was classified, which is only correct if there is exactly one pair",
+        "and it is truly concurrent.",
         "",
         *pair_lines,
         "",

--- a/src/questfoundry/graph/mutations.py
+++ b/src/questfoundry/graph/mutations.py
@@ -1926,11 +1926,11 @@ def apply_seed_mutations(graph: Graph, output: dict[str, Any]) -> None:
                 reason="node_missing",
             )
             continue
+        edge_type = relationship.get("ordering", "concurrent")
         graph.add_edge(
-            "dilemma_ordering",
+            edge_type,
             a_node,
             b_node,
-            ordering=relationship.get("ordering", "concurrent"),
             description=relationship.get("description", ""),
         )
 

--- a/tests/unit/test_graph_context.py
+++ b/tests/unit/test_graph_context.py
@@ -1596,7 +1596,7 @@ class TestFormatInteractionCandidatesContext:
         return graph
 
     def test_shared_entity_pair_found(self) -> None:
-        """Two dilemmas sharing an entity produce a candidate pair."""
+        """Two dilemmas sharing an entity produce a pair with shared-entity note."""
         graph = self._graph_with_dilemmas(
             {
                 "alpha": ["entity::hero", "entity::castle"],
@@ -1605,13 +1605,13 @@ class TestFormatInteractionCandidatesContext:
         )
         seed = _seed_output(dilemmas=[_dilemma("alpha"), _dilemma("beta")])
         result = format_interaction_candidates_context(seed, graph)
-        assert "### Candidate Pairs" in result
+        assert "## All Dilemma Pairs" in result
         assert "dilemma::alpha" in result
         assert "dilemma::beta" in result
-        assert "hero" in result
+        assert "hero" in result  # shared entity flagged in pair line
 
-    def test_no_shared_entities_returns_no_candidates(self) -> None:
-        """Disjoint entities produce no-candidates message."""
+    def test_no_shared_entities_still_shows_all_pairs(self) -> None:
+        """Disjoint entities still produce a pair listing — all pairs are always shown."""
         graph = self._graph_with_dilemmas(
             {
                 "alpha": ["entity::hero"],
@@ -1620,7 +1620,9 @@ class TestFormatInteractionCandidatesContext:
         )
         seed = _seed_output(dilemmas=[_dilemma("alpha"), _dilemma("beta")])
         result = format_interaction_candidates_context(seed, graph)
-        assert "No candidate pairs" in result
+        assert "## All Dilemma Pairs" in result
+        assert "dilemma::alpha" in result
+        assert "dilemma::beta" in result
 
     def test_single_dilemma_returns_no_candidates(self) -> None:
         """Fewer than 2 dilemmas cannot have pairs."""

--- a/tests/unit/test_mutations.py
+++ b/tests/unit/test_mutations.py
@@ -4887,13 +4887,15 @@ class TestApplySeedConvergenceAnalysis:
         ]
         apply_seed_mutations(graph, output)
 
+        # Edge type IS the ordering value (semantic edge, not generic dilemma_ordering)
         edges = graph.get_edges(
             from_id="dilemma::stay_or_go",
-            edge_type="dilemma_ordering",
+            edge_type="wraps",
         )
         assert len(edges) == 1
         assert edges[0]["to"] == "dilemma::trust_or_not"
-        assert edges[0]["ordering"] == "wraps"
+        # ordering is encoded in the edge type, not stored as a separate attribute
+        assert "ordering" not in edges[0]
         assert edges[0]["description"] == "Stay/go wraps trust subplot"
 
     def test_ordering_edge_skipped_if_node_missing(self) -> None:


### PR DESCRIPTION
## Problem
Issue #1093: `dilemma_relationships` is DEAD and MISSING — the LLM never populates it due to biased prompt language ("empty list is normal", "0-2 non-concurrent expected"), and when it does the code stores a generic `dilemma_ordering` edge type instead of the semantic type (`wraps`, `concurrent`, `serial`) specified in the design.

## Changes

### Part A — Code: semantic edge types (`mutations.py`)
- `mutations.py` now stores the `ordering` field value directly as the edge type (`wraps`, `concurrent`, `serial`) instead of the fixed string `dilemma_ordering`
- Removes the impedance mismatch between spec and graph; consumers can now query by semantic relationship type

### Part B — Context: full dilemma pair coverage (`context.py`)
- `format_interaction_candidates_context()` now considers ALL dilemma pairs, not just shared-entity pairs
- Injects full dilemma content per pair: question, stakes, answers, and convergence point
- LLM now has enough information to classify every pair correctly

### Part C — Prompt: unbiased classification (`serialize_seed_sections.yaml`)
- Removed bias language ("empty list is normal", "0-2 non-concurrent expected")
- Changed to "classify EVERY pair; `concurrent` is the default but must be emitted explicitly for every pair"
- Ensures the model treats classification as mandatory, not optional

Files: `src/questfoundry/graph/mutations.py`, `src/questfoundry/graph/context.py`, `prompts/templates/serialize_seed_sections.yaml`

## Not Included / Future PRs
- GROW consumers of ordering edges may need updates if they queried by the old `dilemma_ordering` edge type — tracked in a follow-up

## Test Plan
- Run SEED and inspect `graph.db`: verify `dilemma_ordering` edges are replaced by `wraps`/`concurrent`/`serial` typed edges
- Verify via `logs/llm_calls.jsonl`: confirm all dilemma pairs appear in context and the model emits a classification for each

## Risk / Rollback
- Medium risk: edge type rename is a breaking change for any GROW code querying `dilemma_ordering`
- If downstream consumers break: update them to query the semantic type, or add a migration

Closes #1093