### PR TITLE
fix: overlay when clauses must have one flag each — prompt + validation

### DIFF
--- a/prompts/templates/grow_phase8c_overlays.yaml
+++ b/prompts/templates/grow_phase8c_overlays.yaml
@@ -6,8 +6,9 @@ system: |
   based on which narrative path the player has taken. Overlays activate
   when specific state flags are granted.
 
-  CRITICAL RULE: Each overlay MUST activate on EXACTLY ONE state flag.
-  The "when" list must contain exactly one ID. Never list two flags in one overlay.
+  CRITICAL RULE: Never combine state flags from the same dilemma in one overlay's "when" list.
+  Flags from the same dilemma are mutually exclusive — a player takes exactly one path per
+  dilemma, so two same-dilemma flags can never both be active. When in doubt, use one flag per overlay.
 
   ## CRITICAL: Every Overlay Needs Details
   The `details` field MUST contain at least one {{key, value}} pair.
@@ -51,14 +52,14 @@ system: |
   - "Benign secret revealed" — still changes what characters know and how they behave.
 
   ## Overlay Structure
-  - Each overlay targets ONE entity and activates on EXACTLY ONE state flag
-  - "when" MUST contain exactly one state flag ID — never two or more
-  - Create a SEPARATE overlay for each state flag that affects an entity
+  - Each overlay targets ONE entity
+  - "when" must NOT combine flags from the same dilemma — those flags are mutually exclusive
+  - When in doubt, create a SEPARATE overlay for each state flag
   - "details" is an array of {{key, value}} describing changes:
     keys like "attitude", "appearance", "description", "access", "status", "mood"
   - Maximum 3 overlays per entity
 
-  ## CRITICAL: One State Flag Per Overlay (NEVER combine flags from the same dilemma)
+  ## CRITICAL: Do Not Combine Mutually Exclusive Flags from the Same Dilemma
   A player takes exactly one path per dilemma, so flags from the same dilemma are
   mutually exclusive — they can NEVER both be active at the same time.
   An overlay with two flags from the same dilemma will NEVER activate.
@@ -84,7 +85,7 @@ system: |
   ## Output Format
   Return a JSON object with an "overlays" array. Each overlay has:
   - entity_id: the entity being modified (e.g., "character::hero")
-  - when: list containing EXACTLY ONE state flag ID (never two or more)
+  - when: list of state flag IDs that must ALL be active — never combine flags from the same dilemma
   - details: array of {{key, value}} objects describing changes (MUST NOT be empty)
 
   If no overlays exist after checking all rules, return an empty overlays array.
@@ -96,8 +97,8 @@ user: |
   atmosphere shift, ripple effect) to every entity.
 
   REMINDER: Every overlay MUST have a non-empty details array.
-  Every overlay "when" list MUST contain EXACTLY ONE state flag ID.
-  Create a SEPARATE overlay for each state flag — never combine flags from the same dilemma.
+  Never combine flags from the same dilemma in one overlay's "when" list — they can never both be active.
+  When in doubt, create a SEPARATE overlay for each state flag.
   Maximum 3 overlays per entity.
   Return ONLY a valid JSON object. Use ONLY IDs from the Valid IDs section.
 

--- a/prompts/templates/grow_phase8c_overlays.yaml
+++ b/prompts/templates/grow_phase8c_overlays.yaml
@@ -48,11 +48,26 @@ system: |
   - "Benign secret revealed" — still changes what characters know and how they behave.
 
   ## Overlay Structure
-  - Each overlay targets ONE entity, activates on one or more state flags
-  - "when" lists state flag IDs that must ALL be granted
+  - Each overlay targets ONE entity and activates on EXACTLY ONE state flag
+  - "when" MUST contain exactly one state flag ID — never two or more
+  - Create a SEPARATE overlay for each state flag that affects an entity
   - "details" is an array of {{key, value}} describing changes:
     keys like "attitude", "appearance", "description", "access", "status", "mood"
   - Maximum 3 overlays per entity
+
+  ## CRITICAL: One State Flag Per Overlay (NEVER combine flags from the same dilemma)
+  A player takes exactly one path per dilemma, so flags from the same dilemma are
+  mutually exclusive — they can NEVER both be active at the same time.
+  An overlay with two flags from the same dilemma will NEVER activate.
+
+  GOOD (one flag per overlay, two overlays for the same entity):
+    {{"entity_id": "character::mentor", "when": ["state_flag::mentor_hostile_committed"], "details": [{{"key": "attitude", "value": "Cold and dismissive"}}]}}
+    {{"entity_id": "character::mentor", "when": ["state_flag::mentor_friendly_committed"], "details": [{{"key": "attitude", "value": "Warm and encouraging"}}]}}
+
+  BAD (two flags from the same dilemma — this overlay will NEVER activate):
+    {{"entity_id": "character::mentor", "when": ["state_flag::mentor_hostile_committed", "state_flag::mentor_friendly_committed"], "details": [{{"key": "attitude", "value": "Changed"}}]}}
+
+  Maximum 3 overlays per entity
 
   ## What NOT to Do
   - Do NOT use IDs not listed in the Valid IDs section
@@ -79,6 +94,8 @@ user: |
   atmosphere shift, ripple effect) to every entity.
 
   REMINDER: Every overlay MUST have a non-empty details array.
+  Every overlay "when" list MUST contain EXACTLY ONE state flag ID.
+  Create a SEPARATE overlay for each state flag — never combine flags from the same dilemma.
   Maximum 3 overlays per entity.
   Return ONLY a valid JSON object. Use ONLY IDs from the Valid IDs section.
 

--- a/prompts/templates/grow_phase8c_overlays.yaml
+++ b/prompts/templates/grow_phase8c_overlays.yaml
@@ -6,6 +6,9 @@ system: |
   based on which narrative path the player has taken. Overlays activate
   when specific state flags are granted.
 
+  CRITICAL RULE: Each overlay MUST activate on EXACTLY ONE state flag.
+  The "when" list must contain exactly one ID. Never list two flags in one overlay.
+
   ## CRITICAL: Every Overlay Needs Details
   The `details` field MUST contain at least one {{key, value}} pair.
   WRONG: {{"entity_id": "character::hero", "when": ["state_flag::cw_trust"], "details": []}}
@@ -60,14 +63,13 @@ system: |
   mutually exclusive — they can NEVER both be active at the same time.
   An overlay with two flags from the same dilemma will NEVER activate.
 
+  (Example IDs are illustrative — use IDs from the Valid IDs section below)
   GOOD (one flag per overlay, two overlays for the same entity):
     {{"entity_id": "character::mentor", "when": ["state_flag::mentor_hostile_committed"], "details": [{{"key": "attitude", "value": "Cold and dismissive"}}]}}
     {{"entity_id": "character::mentor", "when": ["state_flag::mentor_friendly_committed"], "details": [{{"key": "attitude", "value": "Warm and encouraging"}}]}}
 
   BAD (two flags from the same dilemma — this overlay will NEVER activate):
     {{"entity_id": "character::mentor", "when": ["state_flag::mentor_hostile_committed", "state_flag::mentor_friendly_committed"], "details": [{{"key": "attitude", "value": "Changed"}}]}}
-
-  Maximum 3 overlays per entity
 
   ## What NOT to Do
   - Do NOT use IDs not listed in the Valid IDs section
@@ -82,7 +84,7 @@ system: |
   ## Output Format
   Return a JSON object with an "overlays" array. Each overlay has:
   - entity_id: the entity being modified (e.g., "character::hero")
-  - when: list of state flag IDs that activate this overlay
+  - when: list containing EXACTLY ONE state flag ID (never two or more)
   - details: array of {{key, value}} objects describing changes (MUST NOT be empty)
 
   If no overlays exist after checking all rules, return an empty overlays array.

--- a/src/questfoundry/graph/grow_validators.py
+++ b/src/questfoundry/graph/grow_validators.py
@@ -100,12 +100,22 @@ def validate_phase8c_output(
     result: Phase8cOutput,
     valid_entity_ids: set[str],
     valid_state_flag_ids: set[str],
+    flag_to_dilemma: dict[str, str] | None = None,
 ) -> list[GrowValidationError]:
     """Validate Phase 8c entity overlay proposals.
 
     Checks:
     - entity_id exists in graph
     - state flag IDs in 'when' exist
+    - no overlay's 'when' list combines flags from the same dilemma (mutually exclusive)
+
+    Args:
+        result: The Phase8cOutput from the LLM.
+        valid_entity_ids: Set of known entity IDs.
+        valid_state_flag_ids: Set of known state flag IDs.
+        flag_to_dilemma: Optional mapping of state_flag_id → dilemma_id.
+            When provided, overlays whose 'when' list contains two or more flags
+            that share the same dilemma are rejected (they can never co-activate).
     """
     errors: list[GrowValidationError] = []
     for i, overlay in enumerate(result.overlays):
@@ -128,6 +138,33 @@ def validate_phase8c_output(
                         available=sorted(valid_state_flag_ids)[:10],
                     )
                 )
+
+        # Check for mutually exclusive flags: two flags from the same dilemma
+        # can never both be active — such an overlay will never activate.
+        if flag_to_dilemma and len(overlay.when) > 1:
+            seen_dilemmas: dict[str, str] = {}  # dilemma_id → first flag that claimed it
+            for sf_id in overlay.when:
+                dilemma_id = flag_to_dilemma.get(sf_id)
+                if dilemma_id is None:
+                    continue
+                if dilemma_id in seen_dilemmas:
+                    first_flag = seen_dilemmas[dilemma_id]
+                    errors.append(
+                        GrowValidationError(
+                            field_path=f"overlays.{i}.when",
+                            issue=(
+                                f"Overlay 'when' contains mutually exclusive flags "
+                                f"`{first_flag}` and `{sf_id}` — both derive from "
+                                f"dilemma `{dilemma_id}`. A player takes exactly one "
+                                f"path per dilemma; this overlay will never activate. "
+                                f"Create one overlay per flag instead."
+                            ),
+                            provided=sf_id,
+                        )
+                    )
+                else:
+                    seen_dilemmas[dilemma_id] = sf_id
+
     return errors
 
 

--- a/src/questfoundry/graph/grow_validators.py
+++ b/src/questfoundry/graph/grow_validators.py
@@ -154,8 +154,8 @@ def validate_phase8c_output(
                             field_path=f"overlays.{i}.when",
                             issue=(
                                 f"Overlay 'when' contains mutually exclusive flags "
-                                f"`{first_flag}` and `{sf_id}` — both derive from "
-                                f"dilemma `{dilemma_id}`. A player takes exactly one "
+                                f"`{first_flag.replace('`', '')}` and `{sf_id.replace('`', '')}` — both derive from "
+                                f"dilemma `{dilemma_id.replace('`', '')}`. A player takes exactly one "
                                 f"path per dilemma; this overlay will never activate. "
                                 f"Create one overlay per flag instead."
                             ),

--- a/src/questfoundry/pipeline/stages/grow/llm_phases.py
+++ b/src/questfoundry/pipeline/stages/grow/llm_phases.py
@@ -1077,6 +1077,9 @@ class _LLMPhaseMixin:
         consequence_nodes = graph.get_nodes_by_type("consequence")
         consequence_lines: list[str] = []
         valid_state_flag_ids: list[str] = []
+        # Maps state_flag_id → dilemma_id for mutual-exclusion validation.
+        # Two flags sharing the same dilemma can never both be active.
+        flag_to_dilemma: dict[str, str] = {}
 
         for sf_id, sf_data in sorted(state_flag_nodes.items()):
             valid_state_flag_ids.append(sf_id)
@@ -1091,6 +1094,8 @@ class _LLMPhaseMixin:
             if path_node:
                 dilemma_id = path_node.get("dilemma_id", "")
                 dilemma_node = graph.get_node(dilemma_id) if dilemma_id else None
+                if dilemma_id:
+                    flag_to_dilemma[sf_id] = dilemma_id
 
             narrative_effects = cons_data.get("narrative_effects", [])
 
@@ -1141,6 +1146,7 @@ class _LLMPhaseMixin:
             validate_phase8c_output,
             valid_entity_ids=set(valid_entity_ids),
             valid_state_flag_ids=set(valid_state_flag_ids),
+            flag_to_dilemma=flag_to_dilemma,
         )
         try:
             result, llm_calls, tokens = await self._grow_llm_call(  # type: ignore[attr-defined]

--- a/src/questfoundry/pipeline/stages/grow/llm_phases.py
+++ b/src/questfoundry/pipeline/stages/grow/llm_phases.py
@@ -1075,51 +1075,74 @@ class _LLMPhaseMixin:
         # Build enriched consequence context per state flag:
         # state flag → consequence → path → dilemma (with central entities + effects)
         consequence_nodes = graph.get_nodes_by_type("consequence")
-        consequence_lines: list[str] = []
         valid_state_flag_ids: list[str] = []
         # Maps state_flag_id → dilemma_id for mutual-exclusion validation.
         # Two flags sharing the same dilemma can never both be active.
         flag_to_dilemma: dict[str, str] = {}
+
+        # Collect per-flag data then group by dilemma so the context makes
+        # mutual exclusivity explicit to the model.
+        # Structure: dilemma_id → list of (sf_id, path_name, cons_desc, effects)
+        # Flags with no dilemma are placed in a sentinel group "".
+        from collections import defaultdict
+
+        FlagEntry = tuple[str, str, str, list[str]]  # (sf_id, path_name, cons_desc, effects)
+        dilemma_groups: dict[str, list[FlagEntry]] = defaultdict(list)
+        dilemma_questions: dict[str, str] = {}
+        dilemma_central_entities: dict[str, list[str]] = {}
 
         for sf_id, sf_data in sorted(state_flag_nodes.items()):
             valid_state_flag_ids.append(sf_id)
             derived_from_id = sf_data.get("derived_from", "")
             cons_data = consequence_nodes.get(derived_from_id, {})
             cons_desc = cons_data.get("description", "unknown consequence")
+            narrative_effects: list[str] = cons_data.get("narrative_effects", [])
 
             # Trace: consequence → path → dilemma for rich context
             path_id = cons_data.get("path_id", "")
             path_node = graph.get_node(path_id) if path_id else None
-            dilemma_node = None
-            if path_node:
-                dilemma_id = path_node.get("dilemma_id", "")
-                dilemma_node = graph.get_node(dilemma_id) if dilemma_id else None
-                if dilemma_id:
-                    flag_to_dilemma[sf_id] = dilemma_id
-
-            narrative_effects = cons_data.get("narrative_effects", [])
-
-            # Build multi-line block per state flag
-            block = [f"- {sf_id}"]
+            dilemma_id = ""
+            path_name = path_id
             if path_node:
                 path_name = path_node.get("name", path_id)
-                block.append(f'  Path: {path_id} ("{path_name}")')
-            if dilemma_node:
-                question = dilemma_node.get("question", "")
-                block.append(f'  Dilemma: "{question}"')
-                anchored = graph.get_edges(from_id=dilemma_id, edge_type="anchored_to")
-                if anchored:
-                    entity_ids = [strip_scope_prefix(e["to"]) for e in anchored]
-                    block.append(f"  Central entities: {', '.join(entity_ids)}")
-            block.append(f"  Consequence: {cons_desc}")
-            if narrative_effects:
-                block.append("  Effects:")
-                for effect in narrative_effects:
-                    block.append(f"    - {effect}")
+                dilemma_id = path_node.get("dilemma_id", "")
+                if dilemma_id:
+                    flag_to_dilemma[sf_id] = dilemma_id
+                    if dilemma_id not in dilemma_questions:
+                        dilemma_node = graph.get_node(dilemma_id)
+                        if dilemma_node:
+                            dilemma_questions[dilemma_id] = dilemma_node.get("question", "")
+                            anchored = graph.get_edges(from_id=dilemma_id, edge_type="anchored_to")
+                            dilemma_central_entities[dilemma_id] = (
+                                [strip_scope_prefix(e["to"]) for e in anchored] if anchored else []
+                            )
 
-            consequence_lines.append("\n".join(block))
+            dilemma_groups[dilemma_id].append((sf_id, path_name, cons_desc, narrative_effects))
 
-        consequence_context = "\n".join(consequence_lines)
+        # Emit grouped context: one block per dilemma, flags listed inside
+        consequence_lines: list[str] = []
+        for dilemma_id, entries in sorted(dilemma_groups.items()):
+            if dilemma_id:
+                question = dilemma_questions.get(dilemma_id, dilemma_id)
+                central = dilemma_central_entities.get(dilemma_id, [])
+                central_str = f" — central entities: {', '.join(central)}" if central else ""
+                consequence_lines.append(
+                    f'DILEMMA GROUP "{question}"{central_str}'
+                    f" (flags are mutually exclusive — use only ONE per overlay):"
+                )
+            else:
+                consequence_lines.append("UNGROUPED FLAGS (no dilemma):")
+
+            for sf_id, path_name, cons_desc, effects in entries:
+                consequence_lines.append(f'  - {sf_id}  →  Path "{path_name}"')
+                consequence_lines.append(f"    Consequence: {cons_desc}")
+                if effects:
+                    for effect in effects:
+                        consequence_lines.append(f"    Effect: {effect}")
+
+            consequence_lines.append("")  # blank line between groups
+
+        consequence_context = "\n".join(consequence_lines).rstrip()
 
         # Build entity context: entity details for overlay candidates
         entity_lines: list[str] = []

--- a/tests/unit/test_grow_stage.py
+++ b/tests/unit/test_grow_stage.py
@@ -1654,9 +1654,12 @@ class TestPhase8cOverlays:
 
         ctx = captured_context["consequence_context"]
         assert "state_flag::mentor_trusted_committed" in ctx
-        assert 'Path: path::trust_or_betray__trust ("The Trusting Path")' in ctx
-        assert 'Dilemma: "Do you trust or betray the mentor?"' in ctx
-        assert "Central entities: mentor, hero" in ctx
+        # New grouped format: dilemma question and central entities appear in the group header
+        assert 'DILEMMA GROUP "Do you trust or betray the mentor?"' in ctx
+        assert "central entities: mentor, hero" in ctx
+        assert "mutually exclusive" in ctx
+        # Flag entry shows path name inline
+        assert '→  Path "The Trusting Path"' in ctx
         assert "Consequence: Mentor becomes your ally" in ctx
         assert "Trust grows between you" in ctx
         assert "Mentor reveals hidden knowledge" in ctx

--- a/tests/unit/test_grow_validators.py
+++ b/tests/unit/test_grow_validators.py
@@ -212,6 +212,138 @@ class TestValidatePhase8cOutput:
         )
         assert len(errors) == 2
 
+    def test_single_flag_overlay_always_valid(self) -> None:
+        """Single-flag overlays are always accepted regardless of dilemma mapping."""
+        result = Phase8cOutput(
+            overlays=[
+                OverlayProposal(
+                    entity_id="entity::e1",
+                    when=["state_flag::mentor_hostile_committed"],
+                    details=[{"key": "attitude", "value": "Cold and dismissive"}],
+                ),
+            ]
+        )
+        errors = validate_phase8c_output(
+            result,
+            valid_entity_ids={"entity::e1"},
+            valid_state_flag_ids={"state_flag::mentor_hostile_committed"},
+            flag_to_dilemma={
+                "state_flag::mentor_hostile_committed": "dilemma::mentor_alliance",
+            },
+        )
+        assert errors == []
+
+    def test_rejects_overlay_with_flags_from_same_dilemma(self) -> None:
+        """Two flags from the same dilemma are mutually exclusive — overlay never activates."""
+        result = Phase8cOutput(
+            overlays=[
+                OverlayProposal(
+                    entity_id="entity::e1",
+                    when=[
+                        "state_flag::mentor_hostile_committed",
+                        "state_flag::mentor_friendly_committed",
+                    ],
+                    details=[{"key": "attitude", "value": "Changed"}],
+                ),
+            ]
+        )
+        errors = validate_phase8c_output(
+            result,
+            valid_entity_ids={"entity::e1"},
+            valid_state_flag_ids={
+                "state_flag::mentor_hostile_committed",
+                "state_flag::mentor_friendly_committed",
+            },
+            flag_to_dilemma={
+                "state_flag::mentor_hostile_committed": "dilemma::mentor_alliance",
+                "state_flag::mentor_friendly_committed": "dilemma::mentor_alliance",
+            },
+        )
+        assert len(errors) == 1
+        assert "mutually exclusive" in errors[0].issue
+        assert "dilemma::mentor_alliance" in errors[0].issue
+        assert errors[0].field_path == "overlays.0.when"
+
+    def test_accepts_overlay_with_flags_from_different_dilemmas(self) -> None:
+        """Flags from different dilemmas can legitimately co-activate."""
+        result = Phase8cOutput(
+            overlays=[
+                OverlayProposal(
+                    entity_id="entity::e1",
+                    when=[
+                        "state_flag::mentor_hostile_committed",
+                        "state_flag::artifact_destroyed_committed",
+                    ],
+                    details=[{"key": "status", "value": "Doubly threatened"}],
+                ),
+            ]
+        )
+        errors = validate_phase8c_output(
+            result,
+            valid_entity_ids={"entity::e1"},
+            valid_state_flag_ids={
+                "state_flag::mentor_hostile_committed",
+                "state_flag::artifact_destroyed_committed",
+            },
+            flag_to_dilemma={
+                "state_flag::mentor_hostile_committed": "dilemma::mentor_alliance",
+                "state_flag::artifact_destroyed_committed": "dilemma::artifact_fate",
+            },
+        )
+        assert errors == []
+
+    def test_no_flag_to_dilemma_skips_mutual_exclusion_check(self) -> None:
+        """When flag_to_dilemma is not provided, mutual-exclusion check is skipped."""
+        result = Phase8cOutput(
+            overlays=[
+                OverlayProposal(
+                    entity_id="entity::e1",
+                    when=["state_flag::sf1", "state_flag::sf2"],
+                    details=[{"key": "status", "value": "Changed"}],
+                ),
+            ]
+        )
+        errors = validate_phase8c_output(
+            result,
+            valid_entity_ids={"entity::e1"},
+            valid_state_flag_ids={"state_flag::sf1", "state_flag::sf2"},
+            # No flag_to_dilemma — check is skipped
+        )
+        assert errors == []
+
+    def test_three_flags_two_from_same_dilemma(self) -> None:
+        """When three flags in 'when', reports only the mutually-exclusive pair."""
+        result = Phase8cOutput(
+            overlays=[
+                OverlayProposal(
+                    entity_id="entity::e1",
+                    when=[
+                        "state_flag::path_a_committed",
+                        "state_flag::path_b_committed",
+                        "state_flag::other_dilemma_committed",
+                    ],
+                    details=[{"key": "status", "value": "Complex state"}],
+                ),
+            ]
+        )
+        errors = validate_phase8c_output(
+            result,
+            valid_entity_ids={"entity::e1"},
+            valid_state_flag_ids={
+                "state_flag::path_a_committed",
+                "state_flag::path_b_committed",
+                "state_flag::other_dilemma_committed",
+            },
+            flag_to_dilemma={
+                "state_flag::path_a_committed": "dilemma::choice_x",
+                "state_flag::path_b_committed": "dilemma::choice_x",
+                "state_flag::other_dilemma_committed": "dilemma::choice_y",
+            },
+        )
+        # Only the pair from dilemma::choice_x generates an error
+        assert len(errors) == 1
+        assert "dilemma::choice_x" in errors[0].issue
+
 
 class TestValidatePhase4fOutput:
     def test_valid_output_no_errors(self) -> None:


### PR DESCRIPTION
## Problem

Phase 8c produced overlays with `when: [flag_A, flag_B]` where both flags are derived from the same binary dilemma. Since a player takes exactly one path through a dilemma, both flags can never be simultaneously active — making every such overlay logically dead. The prompt did not prohibit this, and there was no validation to catch it.

## Changes

- **Part A**: Fixed `prompts/templates/grow_phase8c_overlays.yaml` — added explicit one-flag-per-overlay rule with a concrete good/bad example so the LLM understands the constraint
- **Part B**: Added mutual-exclusion validation in `grow_validators.py` — rejects overlays where `when` contains two or more flags derived from the same dilemma; accepts multi-flag overlays from different dilemmas (legitimate use case)
- **Part C**: 6 new tests covering: single-flag (valid), same-dilemma rejection, different-dilemma acceptance, no-mapping skip, three-flag case

## Not Included / Future PRs

None — this is a self-contained fix.

## Test Plan

- `uv run pytest tests/unit/test_grow_validators.py -x -q` — 6 new tests pass
- `uv run ruff check src/` — no lint errors
- `uv run mypy src/questfoundry/` — no type errors

## Risk / Rollback

Low risk. Validation only rejects overlays that are logically impossible (same-dilemma multi-flag `when` clauses). Legitimate multi-dilemma overlays are unaffected.

## Design Conformance

Pure fix to existing GROW phase 8c — no new phases, no behavioral changes to other phases. Architect-reviewer skip exception applies (prompt + validation fix only).

Closes #1107