### PR TITLE
feat: cross-path beat interleaving (#1105)

### DIFF
--- a/src/questfoundry/graph/grow_algorithms.py
+++ b/src/questfoundry/graph/grow_algorithms.py
@@ -2285,9 +2285,15 @@ def _get_path_beats_ordered(
     beats = path_beats_map.get(path_id, [])
     if not beats:
         return []
-    with contextlib.suppress(ValueError):
+    try:
         return topological_sort_beats(graph, beats)
-    return sorted(beats)  # Fallback to alphabetical on cycle (should not happen)
+    except ValueError:
+        log.warning(
+            "interleave_path_cycle_fallback",
+            path_id=path_id,
+            beats=beats,
+        )
+        return sorted(beats)  # Fallback to alphabetical on cycle (should not happen)
 
 
 def _commits_beats_for_dilemma(
@@ -2508,34 +2514,21 @@ def interleave_cross_path_beats(graph: Graph) -> int:
 
                 # Collect commit/intro beats for the referenced dilemma
                 if relative_to == dilemma_a:
-                    ref_commits = _commits_beats_for_dilemma(all_beats_a, dilemma_a, beat_nodes)
-                    ref_first = [seq[0] for seq in ordered_a if seq]
+                    ref_all, ref_ordered, ref_dil = all_beats_a, ordered_a, dilemma_a
                 elif relative_to == dilemma_b:
-                    ref_commits = _commits_beats_for_dilemma(all_beats_b, dilemma_b, beat_nodes)
-                    ref_first = [seq[0] for seq in ordered_b if seq]
+                    ref_all, ref_ordered, ref_dil = all_beats_b, ordered_b, dilemma_b
                 else:
                     continue
 
-                if position == "before_commit":
-                    # beat_id must come before each commit beat of relative_to
-                    for commit in sorted(ref_commits):
-                        if _add_predecessor(commit, beat_id):
-                            hints_applied += 1
-                elif position == "after_commit":
-                    # beat_id must come after each commit beat of relative_to
-                    for commit in sorted(ref_commits):
-                        if _add_predecessor(beat_id, commit):
-                            hints_applied += 1
-                elif position == "before_introduce":
-                    # beat_id must come before first beats of relative_to
-                    for intro in sorted(ref_first):
-                        if _add_predecessor(intro, beat_id):
-                            hints_applied += 1
-                elif position == "after_introduce":
-                    # beat_id must come after first beats of relative_to
-                    for intro in sorted(ref_first):
-                        if _add_predecessor(beat_id, intro):
-                            hints_applied += 1
+                ref_commits = _commits_beats_for_dilemma(ref_all, ref_dil, beat_nodes)
+                ref_first = [seq[0] for seq in ref_ordered if seq]
+
+                is_before = position.startswith("before_")
+                target_beats = ref_commits if "commit" in position else ref_first
+                for target in sorted(target_beats):
+                    from_b, to_b = (target, beat_id) if is_before else (beat_id, target)
+                    if _add_predecessor(from_b, to_b):
+                        hints_applied += 1
 
             if hints_applied:
                 log.debug(

--- a/src/questfoundry/graph/grow_algorithms.py
+++ b/src/questfoundry/graph/grow_algorithms.py
@@ -2325,7 +2325,7 @@ def _would_create_cycle(
 
     In our DAG: ``predecessor`` edge (X, Y) means X requires Y, i.e. Y comes before X.
     Adding predecessor(new_from, new_to) means new_to → new_from in topological order.
-    A cycle would exist if new_from is already reachable from new_to via existing edges.
+    A cycle would exist if new_to is already reachable from new_from via existing edges.
 
     Args:
         new_from: The beat that would require new_to.
@@ -2336,15 +2336,17 @@ def _would_create_cycle(
     Returns:
         True if adding this edge would create a cycle.
     """
-    # If new_from is reachable forward from new_to, adding new_to as prerequisite
-    # of new_from creates a cycle (new_from → new_to → ... → new_from)
+    # A cycle exists if new_to is already reachable from new_from via successors.
+    # Adding predecessor(new_from, new_to) means new_to executes before new_from.
+    # If new_to is already reachable from new_from (new_from → ... → new_to),
+    # then adding new_to → new_from closes a cycle.
     if new_from not in beat_set or new_to not in beat_set:
         return False
     visited: set[str] = set()
-    queue = [new_to]
+    queue = [new_from]
     while queue:
         node = queue.pop()
-        if node == new_from:
+        if node == new_to:
             return True
         if node in visited:
             continue
@@ -2409,7 +2411,7 @@ def interleave_cross_path_beats(graph: Graph) -> int:
         for edge in graph.get_edges(from_id=None, to_id=None, edge_type=ordering):
             a = edge["from"]
             b = edge["to"]
-            if a in dilemma_paths or b in dilemma_paths:
+            if a in dilemma_paths and b in dilemma_paths:
                 relationship_edges.append((a, b, ordering))
 
     if not relationship_edges:
@@ -2506,12 +2508,10 @@ def interleave_cross_path_beats(graph: Graph) -> int:
 
                 # Collect commit/intro beats for the referenced dilemma
                 if relative_to == dilemma_a:
-                    ref_beats_a = all_beats_a
-                    ref_commits = _commits_beats_for_dilemma(ref_beats_a, dilemma_a, beat_nodes)
+                    ref_commits = _commits_beats_for_dilemma(all_beats_a, dilemma_a, beat_nodes)
                     ref_first = [seq[0] for seq in ordered_a if seq]
                 elif relative_to == dilemma_b:
-                    ref_beats_b = all_beats_b
-                    ref_commits = _commits_beats_for_dilemma(ref_beats_b, dilemma_b, beat_nodes)
+                    ref_commits = _commits_beats_for_dilemma(all_beats_b, dilemma_b, beat_nodes)
                     ref_first = [seq[0] for seq in ordered_b if seq]
                 else:
                     continue

--- a/src/questfoundry/graph/grow_algorithms.py
+++ b/src/questfoundry/graph/grow_algorithms.py
@@ -2260,3 +2260,307 @@ def select_entities_for_arc(
             eligible.add(eid)
 
     return sorted(eligible)
+
+
+# ---------------------------------------------------------------------------
+# Cross-Path Beat Interleaving
+# ---------------------------------------------------------------------------
+
+
+def _get_path_beats_ordered(
+    graph: Graph,
+    path_id: str,
+    path_beats_map: dict[str, list[str]],
+) -> list[str]:
+    """Return beats for a path in topological order.
+
+    Args:
+        graph: The story graph.
+        path_id: Scoped path node ID.
+        path_beats_map: Pre-computed mapping of path_id → list of beat IDs.
+
+    Returns:
+        Beat IDs in topological order (prerequisites first). Empty list if no beats.
+    """
+    beats = path_beats_map.get(path_id, [])
+    if not beats:
+        return []
+    with contextlib.suppress(ValueError):
+        return topological_sort_beats(graph, beats)
+    return sorted(beats)  # Fallback to alphabetical on cycle (should not happen)
+
+
+def _commits_beats_for_dilemma(
+    beats: list[str],
+    dilemma_id: str,
+    beat_nodes: dict[str, Any],
+) -> list[str]:
+    """Return beat IDs that have effect='commits' for the given dilemma.
+
+    Args:
+        beats: Beat IDs to search within.
+        dilemma_id: Scoped dilemma ID to match against impact records.
+        beat_nodes: Pre-fetched beat node data.
+
+    Returns:
+        List of beat IDs with the commits effect for this dilemma.
+    """
+    result = []
+    for bid in beats:
+        data = beat_nodes.get(bid, {})
+        for impact in data.get("dilemma_impacts", []):
+            if impact.get("dilemma_id") == dilemma_id and impact.get("effect") == "commits":
+                result.append(bid)
+                break
+    return result
+
+
+def _would_create_cycle(
+    new_from: str,
+    new_to: str,
+    successors: dict[str, set[str]],
+    beat_set: set[str],
+) -> bool:
+    """Check if adding a predecessor edge (new_from requires new_to) creates a cycle.
+
+    In our DAG: ``predecessor`` edge (X, Y) means X requires Y, i.e. Y comes before X.
+    Adding predecessor(new_from, new_to) means new_to → new_from in topological order.
+    A cycle would exist if new_from is already reachable from new_to via existing edges.
+
+    Args:
+        new_from: The beat that would require new_to.
+        new_to: The beat that would become a prerequisite.
+        successors: Current forward adjacency (prerequisite → dependents).
+        beat_set: All beat IDs in the graph.
+
+    Returns:
+        True if adding this edge would create a cycle.
+    """
+    # If new_from is reachable forward from new_to, adding new_to as prerequisite
+    # of new_from creates a cycle (new_from → new_to → ... → new_from)
+    if new_from not in beat_set or new_to not in beat_set:
+        return False
+    visited: set[str] = set()
+    queue = [new_to]
+    while queue:
+        node = queue.pop()
+        if node == new_from:
+            return True
+        if node in visited:
+            continue
+        visited.add(node)
+        queue.extend(successors.get(node, set()))
+    return False
+
+
+def interleave_cross_path_beats(graph: Graph) -> int:
+    """Create predecessor edges between beats from different dilemma paths.
+
+    Reads dilemma relationship edges (concurrent/wraps/serial) and applies
+    cross-path ordering rules:
+
+    - ``serial`` (A before B): Last beats of every A path must precede first
+      beats of every B path.
+    - ``wraps`` (A wraps B): A's intro beats precede B's intro beats; B's
+      last beats precede A's commit beats.
+    - ``concurrent``: Temporal hints on beats drive specific orderings; without
+      hints, commit beats of one dilemma are ordered before commit beats of the
+      other to ensure pacing.
+
+    Edges that would create a cycle are silently skipped with a warning.
+
+    Args:
+        graph: Graph containing beat, path, and dilemma nodes with relationship edges.
+
+    Returns:
+        Count of new ``predecessor`` edges created.
+    """
+    # --- Build indexes ---
+    beat_nodes = graph.get_nodes_by_type("beat")
+    if not beat_nodes:
+        return 0
+
+    dilemma_paths = build_dilemma_paths(graph)
+    if len(dilemma_paths) < 2:
+        return 0
+
+    # path_id → ordered list of beat IDs
+    path_beats_map: dict[str, list[str]] = defaultdict(list)
+    for edge in graph.get_edges(from_id=None, to_id=None, edge_type="belongs_to"):
+        path_beats_map[edge["to"]].append(edge["from"])
+
+    # Collect existing predecessor edges to avoid duplicates
+    existing_predecessors: set[tuple[str, str]] = set()
+    for edge in graph.get_edges(from_id=None, to_id=None, edge_type="predecessor"):
+        existing_predecessors.add((edge["from"], edge["to"]))
+
+    # Build forward adjacency (prerequisite → dependents) for cycle detection
+    # predecessor(X, Y): Y is prerequisite of X → Y → X in topo order
+    successors: dict[str, set[str]] = {bid: set() for bid in beat_nodes}
+    for from_id, to_id in existing_predecessors:
+        if from_id in successors and to_id in successors:
+            successors[to_id].add(from_id)
+
+    beat_set = set(beat_nodes.keys())
+
+    # --- Collect dilemma relationship edges ---
+    relationship_edges: list[tuple[str, str, str]] = []  # (dilemma_a, dilemma_b, ordering)
+    for ordering in ("concurrent", "wraps", "serial"):
+        for edge in graph.get_edges(from_id=None, to_id=None, edge_type=ordering):
+            a = edge["from"]
+            b = edge["to"]
+            if a in dilemma_paths or b in dilemma_paths:
+                relationship_edges.append((a, b, ordering))
+
+    if not relationship_edges:
+        return 0
+
+    created = 0
+
+    def _add_predecessor(from_beat: str, to_beat: str) -> bool:
+        """Add predecessor(from_beat, to_beat) if valid and not duplicate.
+
+        Returns True if edge was added.
+        """
+        nonlocal created
+        if from_beat == to_beat:
+            return False
+        if (from_beat, to_beat) in existing_predecessors:
+            return False
+        if from_beat not in beat_set or to_beat not in beat_set:
+            return False
+        if _would_create_cycle(from_beat, to_beat, successors, beat_set):
+            log.warning(
+                "interleave_cycle_skipped",
+                from_beat=from_beat,
+                to_beat=to_beat,
+            )
+            return False
+        graph.add_edge("predecessor", from_beat, to_beat)
+        existing_predecessors.add((from_beat, to_beat))
+        successors[to_beat].add(from_beat)
+        created += 1
+        return True
+
+    # --- Process each relationship ---
+    for dilemma_a, dilemma_b, ordering in relationship_edges:
+        paths_a = dilemma_paths.get(dilemma_a, [])
+        paths_b = dilemma_paths.get(dilemma_b, [])
+        if not paths_a or not paths_b:
+            continue
+
+        # Ordered beats per path for both dilemmas
+        ordered_a: list[list[str]] = [
+            _get_path_beats_ordered(graph, p, path_beats_map) for p in paths_a
+        ]
+        ordered_b: list[list[str]] = [
+            _get_path_beats_ordered(graph, p, path_beats_map) for p in paths_b
+        ]
+
+        # Collect all beats belonging exclusively to each dilemma's paths
+        all_beats_a = [b for seq in ordered_a for b in seq]
+        all_beats_b = [b for seq in ordered_b for b in seq]
+
+        if not all_beats_a or not all_beats_b:
+            continue
+
+        if ordering == "serial":
+            # All A beats before all B beats: last A beats → first B beats
+            # "Last" per path is the final element in the ordered sequence
+            last_beats_a = {seq[-1] for seq in ordered_a if seq}
+            first_beats_b = {seq[0] for seq in ordered_b if seq}
+            for last_a in sorted(last_beats_a):
+                for first_b in sorted(first_beats_b):
+                    _add_predecessor(first_b, last_a)
+
+        elif ordering == "wraps":
+            # A wraps B: A's first beats before B's first beats;
+            #            B's last beats before A's commit beats
+            first_beats_a = {seq[0] for seq in ordered_a if seq}
+            first_beats_b = {seq[0] for seq in ordered_b if seq}
+            last_beats_b = {seq[-1] for seq in ordered_b if seq}
+            commits_a = set(_commits_beats_for_dilemma(all_beats_a, dilemma_a, beat_nodes))
+
+            # A's first intro before B's first intro
+            for first_a in sorted(first_beats_a):
+                for first_b in sorted(first_beats_b):
+                    _add_predecessor(first_b, first_a)
+
+            # B's last beat before A's commit beats
+            for last_b in sorted(last_beats_b):
+                for commit_a in sorted(commits_a):
+                    _add_predecessor(commit_a, last_b)
+
+        elif ordering == "concurrent":
+            # Apply temporal hints first
+            hints_applied = 0
+            for beat_id in all_beats_a + all_beats_b:
+                data = beat_nodes.get(beat_id, {})
+                hint = data.get("temporal_hint")
+                if not isinstance(hint, dict):
+                    continue
+                relative_to = hint.get("relative_to", "")
+                position = hint.get("position", "")
+                if not relative_to or not position:
+                    continue
+
+                # Collect commit/intro beats for the referenced dilemma
+                if relative_to == dilemma_a:
+                    ref_beats_a = all_beats_a
+                    ref_commits = _commits_beats_for_dilemma(ref_beats_a, dilemma_a, beat_nodes)
+                    ref_first = [seq[0] for seq in ordered_a if seq]
+                elif relative_to == dilemma_b:
+                    ref_beats_b = all_beats_b
+                    ref_commits = _commits_beats_for_dilemma(ref_beats_b, dilemma_b, beat_nodes)
+                    ref_first = [seq[0] for seq in ordered_b if seq]
+                else:
+                    continue
+
+                if position == "before_commit":
+                    # beat_id must come before each commit beat of relative_to
+                    for commit in sorted(ref_commits):
+                        if _add_predecessor(commit, beat_id):
+                            hints_applied += 1
+                elif position == "after_commit":
+                    # beat_id must come after each commit beat of relative_to
+                    for commit in sorted(ref_commits):
+                        if _add_predecessor(beat_id, commit):
+                            hints_applied += 1
+                elif position == "before_introduce":
+                    # beat_id must come before first beats of relative_to
+                    for intro in sorted(ref_first):
+                        if _add_predecessor(intro, beat_id):
+                            hints_applied += 1
+                elif position == "after_introduce":
+                    # beat_id must come after first beats of relative_to
+                    for intro in sorted(ref_first):
+                        if _add_predecessor(beat_id, intro):
+                            hints_applied += 1
+
+            if hints_applied:
+                log.debug(
+                    "interleave_hints_applied",
+                    dilemma_a=dilemma_a,
+                    dilemma_b=dilemma_b,
+                    count=hints_applied,
+                )
+
+            # Heuristic fallback for concurrent: commits of A before commits of B
+            # (deterministic: use alphabetical dilemma ordering to pick direction)
+            commits_a = set(_commits_beats_for_dilemma(all_beats_a, dilemma_a, beat_nodes))
+            commits_b = set(_commits_beats_for_dilemma(all_beats_b, dilemma_b, beat_nodes))
+            if commits_a and commits_b:
+                # Alphabetically earlier dilemma's commits go first as a stable heuristic
+                if dilemma_a < dilemma_b:
+                    # A commits before B commits
+                    for ca in sorted(commits_a):
+                        for cb in sorted(commits_b):
+                            _add_predecessor(cb, ca)
+                else:
+                    # B commits before A commits
+                    for cb in sorted(commits_b):
+                        for ca in sorted(commits_a):
+                            _add_predecessor(ca, cb)
+
+    log.info("interleave_cross_path_beats_complete", edges_created=created)
+    return created

--- a/src/questfoundry/pipeline/stages/grow/deterministic.py
+++ b/src/questfoundry/pipeline/stages/grow/deterministic.py
@@ -61,10 +61,59 @@ async def phase_validate_dag(graph: Graph, model: BaseChatModel) -> GrowPhaseRes
     return GrowPhaseResult(phase="validate_dag", status="completed")
 
 
+# --- Phase 1b: Interleave Cross-Path Beats ---
+
+
+@grow_phase(
+    name="interleave_beats",
+    depends_on=["validate_dag"],
+    is_deterministic=True,
+    priority=1,
+)
+async def phase_interleave_beats(
+    graph: Graph,
+    model: BaseChatModel,  # noqa: ARG001
+) -> GrowPhaseResult:
+    """Phase 1b: Create predecessor edges between beats from different paths.
+
+    Reads dilemma relationship edges (concurrent/wraps/serial) and applies
+    cross-path ordering rules to create ``predecessor`` edges between beats
+    that belong to different dilemmas' paths.
+
+    Preconditions:
+    - Beat DAG validated (Phase 1 passed).
+    - Dilemma relationship edges exist (concurrent/wraps/serial between dilemmas).
+    - Beats are linked to paths via ``belongs_to`` edges.
+
+    Postconditions:
+    - Cross-path ``predecessor`` edges created according to relationship type.
+    - DAG remains acyclic (cycle-inducing edges are skipped with warnings).
+
+    Invariants:
+    - Deterministic: same graph always produces same edges.
+    - Edges are only added, never removed.
+    - Skips if fewer than 2 dilemmas have paths.
+    """
+    from questfoundry.graph.grow_algorithms import interleave_cross_path_beats
+
+    edges_created = interleave_cross_path_beats(graph)
+
+    return GrowPhaseResult(
+        phase="interleave_beats",
+        status="completed",
+        detail=f"Created {edges_created} cross-path predecessor edges",
+    )
+
+
 # --- Phase 5: Enumerate Arcs ---
 
 
-@grow_phase(name="enumerate_arcs", depends_on=["entity_arcs"], is_deterministic=True, priority=9)
+@grow_phase(
+    name="enumerate_arcs",
+    depends_on=["entity_arcs", "interleave_beats"],
+    is_deterministic=True,
+    priority=9,
+)
 async def phase_enumerate_arcs(
     graph: Graph,
     model: BaseChatModel,  # noqa: ARG001

--- a/tests/unit/test_grow_algorithms.py
+++ b/tests/unit/test_grow_algorithms.py
@@ -14,6 +14,7 @@ from questfoundry.graph.grow_algorithms import (
     compute_shared_beats,
     enumerate_arcs,
     find_convergence_points,
+    interleave_cross_path_beats,
     topological_sort_beats,
     validate_beat_dag,
     validate_commits_beats,
@@ -35,6 +36,7 @@ from questfoundry.pipeline.stages.grow.deterministic import (
     phase_convergence,
     phase_divergence,
     phase_enumerate_arcs,
+    phase_interleave_beats,
     phase_state_flags,
     phase_validate_dag,
 )
@@ -4059,3 +4061,280 @@ class TestBuildArcStateFlags:
         graph = Graph.empty()
         result = build_arc_state_flags(graph, {})
         assert result == {}
+
+
+# ---------------------------------------------------------------------------
+# interleave_cross_path_beats
+# ---------------------------------------------------------------------------
+
+
+def _make_two_dilemma_graph_with_relationship(ordering: str) -> Graph:
+    """Build a two-dilemma graph with a dilemma relationship edge.
+
+    Dilemma A (mentor_trust) and Dilemma B (artifact_quest) are linked by
+    the given ordering edge type. Each dilemma has one canonical path with
+    two beats: an intro beat and a commit beat.
+
+    Beat structure:
+        mt_intro → mt_commit  (mentor_trust path)
+        aq_intro → aq_commit  (artifact_quest path)
+
+    The relationship ordering is applied FROM mentor_trust TO artifact_quest.
+    """
+    graph = Graph.empty()
+
+    # Dilemmas
+    graph.create_node("dilemma::mentor_trust", {"type": "dilemma", "raw_id": "mentor_trust"})
+    graph.create_node("dilemma::artifact_quest", {"type": "dilemma", "raw_id": "artifact_quest"})
+
+    # Paths
+    graph.create_node(
+        "path::mt_path",
+        {
+            "type": "path",
+            "raw_id": "mt_path",
+            "dilemma_id": "dilemma::mentor_trust",
+            "is_canonical": True,
+        },
+    )
+    graph.create_node(
+        "path::aq_path",
+        {
+            "type": "path",
+            "raw_id": "aq_path",
+            "dilemma_id": "dilemma::artifact_quest",
+            "is_canonical": True,
+        },
+    )
+
+    # Beats for mentor_trust path
+    graph.create_node(
+        "beat::mt_intro",
+        {
+            "type": "beat",
+            "raw_id": "mt_intro",
+            "summary": "Mentor path intro.",
+            "dilemma_impacts": [{"dilemma_id": "dilemma::mentor_trust", "effect": "advances"}],
+        },
+    )
+    graph.create_node(
+        "beat::mt_commit",
+        {
+            "type": "beat",
+            "raw_id": "mt_commit",
+            "summary": "Mentor path commit.",
+            "dilemma_impacts": [{"dilemma_id": "dilemma::mentor_trust", "effect": "commits"}],
+        },
+    )
+    graph.add_edge("belongs_to", "beat::mt_intro", "path::mt_path")
+    graph.add_edge("belongs_to", "beat::mt_commit", "path::mt_path")
+    graph.add_edge("predecessor", "beat::mt_commit", "beat::mt_intro")
+
+    # Beats for artifact_quest path
+    graph.create_node(
+        "beat::aq_intro",
+        {
+            "type": "beat",
+            "raw_id": "aq_intro",
+            "summary": "Artifact path intro.",
+            "dilemma_impacts": [{"dilemma_id": "dilemma::artifact_quest", "effect": "advances"}],
+        },
+    )
+    graph.create_node(
+        "beat::aq_commit",
+        {
+            "type": "beat",
+            "raw_id": "aq_commit",
+            "summary": "Artifact path commit.",
+            "dilemma_impacts": [{"dilemma_id": "dilemma::artifact_quest", "effect": "commits"}],
+        },
+    )
+    graph.add_edge("belongs_to", "beat::aq_intro", "path::aq_path")
+    graph.add_edge("belongs_to", "beat::aq_commit", "path::aq_path")
+    graph.add_edge("predecessor", "beat::aq_commit", "beat::aq_intro")
+
+    # Dilemma relationship edge: mentor_trust → artifact_quest
+    graph.add_edge(ordering, "dilemma::mentor_trust", "dilemma::artifact_quest")
+
+    return graph
+
+
+class TestInterleavecrossPathBeats:
+    """Tests for interleave_cross_path_beats."""
+
+    def test_empty_graph_returns_zero(self) -> None:
+        """Returns 0 for a graph with no beats."""
+
+        graph = Graph.empty()
+        assert interleave_cross_path_beats(graph) == 0
+
+    def test_single_dilemma_returns_zero(self) -> None:
+        """Returns 0 when there is only one dilemma (no cross-path edges possible)."""
+
+        graph = make_single_dilemma_graph()
+        result = interleave_cross_path_beats(graph)
+        assert result == 0
+
+    def test_no_relationship_edges_returns_zero(self) -> None:
+        """Returns 0 when two dilemmas exist but have no relationship edges."""
+
+        graph = make_two_dilemma_graph()
+        # No concurrent/wraps/serial edges added — no cross-path edges
+        result = interleave_cross_path_beats(graph)
+        assert result == 0
+
+    def test_serial_creates_last_to_first_edges(self) -> None:
+        """Serial ordering: last A beat → first B beat predecessor edges added."""
+
+        graph = _make_two_dilemma_graph_with_relationship("serial")
+        count = interleave_cross_path_beats(graph)
+
+        assert count > 0
+        # aq_intro must require mt_commit: predecessor(aq_intro, mt_commit)
+        edges = graph.get_edges(edge_type="predecessor")
+        pairs = {(e["from"], e["to"]) for e in edges}
+        assert ("beat::aq_intro", "beat::mt_commit") in pairs
+
+    def test_serial_result_is_acyclic(self) -> None:
+        """After serial interleaving, the beat DAG remains acyclic."""
+        from questfoundry.graph.grow_algorithms import validate_beat_dag
+
+        graph = _make_two_dilemma_graph_with_relationship("serial")
+        interleave_cross_path_beats(graph)
+        errors = validate_beat_dag(graph)
+        assert errors == []
+
+    def test_wraps_creates_intro_and_commit_edges(self) -> None:
+        """Wraps ordering: A's intro before B's intro; B's last before A's commit."""
+
+        graph = _make_two_dilemma_graph_with_relationship("wraps")
+        count = interleave_cross_path_beats(graph)
+
+        assert count > 0
+        edges = graph.get_edges(edge_type="predecessor")
+        pairs = {(e["from"], e["to"]) for e in edges}
+        # A's intro (mt_intro) must come before B's intro (aq_intro)
+        # → predecessor(aq_intro, mt_intro) means aq_intro requires mt_intro
+        assert ("beat::aq_intro", "beat::mt_intro") in pairs
+        # B's last (aq_commit) must come before A's commit (mt_commit)
+        # → predecessor(mt_commit, aq_commit) means mt_commit requires aq_commit
+        assert ("beat::mt_commit", "beat::aq_commit") in pairs
+
+    def test_wraps_result_is_acyclic(self) -> None:
+        """After wraps interleaving, the beat DAG remains acyclic."""
+        from questfoundry.graph.grow_algorithms import validate_beat_dag
+
+        graph = _make_two_dilemma_graph_with_relationship("wraps")
+        interleave_cross_path_beats(graph)
+        errors = validate_beat_dag(graph)
+        assert errors == []
+
+    def test_concurrent_commit_ordering_applied(self) -> None:
+        """Concurrent ordering: commit beats from one dilemma ordered before the other."""
+
+        graph = _make_two_dilemma_graph_with_relationship("concurrent")
+        count = interleave_cross_path_beats(graph)
+
+        # Should create at least one commit ordering edge
+        assert count > 0
+
+    def test_concurrent_result_is_acyclic(self) -> None:
+        """After concurrent interleaving, the beat DAG remains acyclic."""
+        from questfoundry.graph.grow_algorithms import validate_beat_dag
+
+        graph = _make_two_dilemma_graph_with_relationship("concurrent")
+        interleave_cross_path_beats(graph)
+        errors = validate_beat_dag(graph)
+        assert errors == []
+
+    def test_temporal_hint_before_commit_applied(self) -> None:
+        """Temporal hint 'before_commit' creates edge from beat to commit beat."""
+
+        graph = _make_two_dilemma_graph_with_relationship("concurrent")
+
+        # Add temporal hint to aq_intro: should come before mentor_trust's commit
+        graph.update_node(
+            "beat::aq_intro",
+            temporal_hint={
+                "relative_to": "dilemma::mentor_trust",
+                "position": "before_commit",
+            },
+        )
+
+        count = interleave_cross_path_beats(graph)
+        assert count > 0
+        edges = graph.get_edges(edge_type="predecessor")
+        pairs = {(e["from"], e["to"]) for e in edges}
+        # mt_commit requires aq_intro (aq_intro must precede mt_commit)
+        assert ("beat::mt_commit", "beat::aq_intro") in pairs
+
+    def test_temporal_hint_after_introduce_applied(self) -> None:
+        """Temporal hint 'after_introduce' creates edge from intro beat to this beat."""
+
+        graph = _make_two_dilemma_graph_with_relationship("concurrent")
+
+        # aq_commit should come after mentor_trust's first (intro) beat
+        graph.update_node(
+            "beat::aq_commit",
+            temporal_hint={
+                "relative_to": "dilemma::mentor_trust",
+                "position": "after_introduce",
+            },
+        )
+
+        count = interleave_cross_path_beats(graph)
+        assert count > 0
+        edges = graph.get_edges(edge_type="predecessor")
+        pairs = {(e["from"], e["to"]) for e in edges}
+        # aq_commit requires mt_intro
+        assert ("beat::aq_commit", "beat::mt_intro") in pairs
+
+    def test_no_duplicate_edges_created(self) -> None:
+        """Running interleave twice does not create duplicate predecessor edges."""
+
+        graph = _make_two_dilemma_graph_with_relationship("serial")
+        count1 = interleave_cross_path_beats(graph)
+        count2 = interleave_cross_path_beats(graph)
+
+        assert count1 > 0
+        assert count2 == 0  # No new edges on second run
+
+    def test_cycle_inducing_edge_skipped(self) -> None:
+        """Edges that would create a cycle are skipped and DAG stays valid.
+
+        Setup: A concurrent relationship between mentor_trust and artifact_quest.
+        We pre-add predecessor(aq_intro, mt_commit) which means mt_commit must
+        come after aq_intro. The heuristic would want to add predecessor(aq_commit,
+        mt_commit) as well — but since dilemma::artifact_quest > dilemma::mentor_trust
+        alphabetically, heuristic adds predecessor(aq_commit, mt_commit) — aq_commit
+        requires mt_commit. Since mt_commit already requires aq_intro (pre-added),
+        and aq_commit requires aq_intro (within-path), no cycle there.
+
+        Instead, we manually force the cycle-inducing situation by pre-adding
+        predecessor(mt_intro, aq_commit) — mt_intro requires aq_commit, and then
+        concurrent would try to add predecessor(aq_commit, mt_commit). Since
+        mt_commit requires mt_intro (within-path) requires aq_commit (pre-added),
+        adding aq_commit requires mt_commit would cycle. This edge should be skipped.
+        """
+        from questfoundry.graph.grow_algorithms import validate_beat_dag
+
+        graph = _make_two_dilemma_graph_with_relationship("concurrent")
+
+        # Pre-add: mt_intro requires aq_commit
+        # Chain: mt_commit → mt_intro → aq_commit → aq_intro (existing within-path)
+        # If we now try to add: aq_commit requires mt_commit → CYCLE
+        graph.add_edge("predecessor", "beat::mt_intro", "beat::aq_commit")
+
+        interleave_cross_path_beats(graph)
+        errors = validate_beat_dag(graph)
+        assert errors == []
+
+    def test_phase_interleave_beats_completes(self) -> None:
+        """phase_interleave_beats returns completed status."""
+        import asyncio
+
+        graph = _make_two_dilemma_graph_with_relationship("concurrent")
+        mock_model = MagicMock()
+        result = asyncio.run(phase_interleave_beats(graph, mock_model))
+        assert result.status == "completed"
+        assert "predecessor edges" in result.detail

--- a/tests/unit/test_grow_algorithms.py
+++ b/tests/unit/test_grow_algorithms.py
@@ -4302,28 +4302,27 @@ class TestInterleavecrossPathBeats:
     def test_cycle_inducing_edge_skipped(self) -> None:
         """Edges that would create a cycle are skipped and DAG stays valid.
 
-        Setup: A concurrent relationship between mentor_trust and artifact_quest.
-        We pre-add predecessor(aq_intro, mt_commit) which means mt_commit must
-        come after aq_intro. The heuristic would want to add predecessor(aq_commit,
-        mt_commit) as well — but since dilemma::artifact_quest > dilemma::mentor_trust
-        alphabetically, heuristic adds predecessor(aq_commit, mt_commit) — aq_commit
-        requires mt_commit. Since mt_commit already requires aq_intro (pre-added),
-        and aq_commit requires aq_intro (within-path), no cycle there.
+        Alphabetically "dilemma::artifact_quest" < "dilemma::mentor_trust" ('a' < 'm'),
+        so dilemma_a=mentor_trust, dilemma_b=artifact_quest. The heuristic 'else' branch
+        runs: artifact_quest (B) commits before mentor_trust (A).
+        It calls _add_predecessor(mt_commit, aq_commit) = aq_commit before mt_commit in topo.
 
-        Instead, we manually force the cycle-inducing situation by pre-adding
-        predecessor(mt_intro, aq_commit) — mt_intro requires aq_commit, and then
-        concurrent would try to add predecessor(aq_commit, mt_commit). Since
-        mt_commit requires mt_intro (within-path) requires aq_commit (pre-added),
-        adding aq_commit requires mt_commit would cycle. This edge should be skipped.
+        We pre-add predecessor(aq_intro, mt_commit) so that mt_commit executes before
+        aq_intro in topo. Via the within-path edge aq_intro → aq_commit, the topo chain
+        becomes: mt_commit → aq_intro → aq_commit.
+        Now aq_commit IS reachable from mt_commit in the successor graph.
+        _would_create_cycle(mt_commit, aq_commit) correctly detects the cycle and skips
+        the edge, leaving the DAG valid.
         """
         from questfoundry.graph.grow_algorithms import validate_beat_dag
 
         graph = _make_two_dilemma_graph_with_relationship("concurrent")
 
-        # Pre-add: mt_intro requires aq_commit
-        # Chain: mt_commit → mt_intro → aq_commit → aq_intro (existing within-path)
-        # If we now try to add: aq_commit requires mt_commit → CYCLE
-        graph.add_edge("predecessor", "beat::mt_intro", "beat::aq_commit")
+        # Pre-add: aq_intro requires mt_commit (mt_commit before aq_intro in topo).
+        # Creates topo chain: mt_commit → aq_intro → aq_commit (via within-path edge).
+        # Heuristic tries _add_predecessor(mt_commit, aq_commit) = aq_commit before mt_commit.
+        # _would_create_cycle: BFS from mt_commit reaches aq_commit → CYCLE → skipped.
+        graph.add_edge("predecessor", "beat::aq_intro", "beat::mt_commit")
 
         interleave_cross_path_beats(graph)
         errors = validate_beat_dag(graph)

--- a/tests/unit/test_grow_registry.py
+++ b/tests/unit/test_grow_registry.py
@@ -216,11 +216,11 @@ class TestGrowPhaseDecorator:
 class TestGlobalRegistry:
     """Tests for the global registry populated by actual GROW phases."""
 
-    def test_global_registry_has_14_phases(self) -> None:
-        """All GROW phases are registered (14 after #1109 moved collapse_linear_beats to POLISH)."""
+    def test_global_registry_has_15_phases(self) -> None:
+        """All GROW phases are registered (15 after #1105 added interleave_beats)."""
         registry = get_registry()
-        assert len(registry) == 14, (
-            f"Expected 14 phases, got {len(registry)}: {registry.phase_names}"
+        assert len(registry) == 15, (
+            f"Expected 15 phases, got {len(registry)}: {registry.phase_names}"
         )
 
     def test_global_registry_validates(self) -> None:
@@ -230,12 +230,13 @@ class TestGlobalRegistry:
         assert errors == [], f"Registry validation errors: {errors}"
 
     def test_global_registry_execution_order_matches_expected(self) -> None:
-        """Execution order matches the post-#1109 phase structure (14 phases).
+        """Execution order matches the post-#1105 phase structure (15 phases).
 
-        collapse_linear_beats was moved to POLISH in #1109.
+        interleave_beats added in #1105; collapse_linear_beats moved to POLISH in #1109.
         """
         expected = [
             "validate_dag",
+            "interleave_beats",
             "scene_types",
             "narrative_gaps",
             "pacing_gaps",

--- a/tests/unit/test_grow_stage.py
+++ b/tests/unit/test_grow_stage.py
@@ -183,16 +183,17 @@ class TestGrowStageExecute:
 
 class TestGrowStagePhaseOrder:
     def test_phase_order_returns_correct_count(self) -> None:
-        """14 phases after moving collapse_linear_beats to POLISH (#1109)."""
+        """15 phases after adding interleave_beats (#1105)."""
         stage = GrowStage()
         phases = stage._phase_order()
-        assert len(phases) == 14
+        assert len(phases) == 15
 
     def test_phase_order_names(self) -> None:
         stage = GrowStage()
         names = [name for _, name in stage._phase_order()]
         assert names == [
             "validate_dag",
+            "interleave_beats",
             "scene_types",
             "narrative_gaps",
             "pacing_gaps",


### PR DESCRIPTION
## Summary
- Adds `interleave_cross_path_beats()` in `grow_algorithms.py` that creates `predecessor` edges between beats from different paths
- Adds deterministic phase `phase_interleave_beats` registered after `validate_dag`, before arc enumeration
- Updates `enumerate_arcs` to depend on `interleave_beats` so arcs respect cross-path order

## Algorithm

For each pair of dilemmas with a relationship edge:
- **serial**: last beat of A → first beat of B (B's entire path follows A)
- **wraps**: A's intro before B's intro; B's last beat before A's commit beat
- **concurrent**: consume temporal hints (`before_commit`, `after_introduce`, etc.), then apply heuristic to order commit beats

Cycle detection prevents invalid edges: any edge that would create a cycle is logged and skipped.

## Design Conformance
Architect-reviewer finding from GROW review:
- MISSING: Cross-path `predecessor` edges (issue #1105)

This PR implements the missing interleaving, producing non-zero cross-path predecessor edges for stories with dilemma relationships.

## Test plan
- [ ] 14 new tests in `test_grow_algorithms.py` covering serial/wraps/concurrent, temporal hints, cycle detection, no-op cases
- [ ] All 200 grow algorithm tests pass
- [ ] Run GROW reference run and verify cross-path predecessor edges > 0

Closes #1105

🤖 Generated with [Claude Code](https://claude.com/claude-code)