### PR TITLE
fix: strip temporal_hint from beat nodes after GROW interleaving (#1106)

### DIFF
--- a/src/questfoundry/graph/grow_algorithms.py
+++ b/src/questfoundry/graph/grow_algorithms.py
@@ -2555,5 +2555,18 @@ def interleave_cross_path_beats(graph: Graph) -> int:
                         for ca in sorted(commits_a):
                             _add_predecessor(ca, cb)
 
-    log.info("interleave_cross_path_beats_complete", edges_created=created)
+    # Strip temporal_hint from all beat nodes — hints have served their purpose
+    # once the DAG encodes the ordering. Setting to None makes json_extract return
+    # SQL NULL, satisfying the spec's "not carried forward" requirement.
+    stripped = 0
+    for beat_id in beat_nodes:
+        if beat_nodes[beat_id].get("temporal_hint") is not None:
+            graph.update_node(beat_id, temporal_hint=None)
+            stripped += 1
+
+    log.info(
+        "interleave_cross_path_beats_complete",
+        edges_created=created,
+        temporal_hints_stripped=stripped,
+    )
     return created

--- a/src/questfoundry/graph/grow_algorithms.py
+++ b/src/questfoundry/graph/grow_algorithms.py
@@ -2361,6 +2361,24 @@ def _would_create_cycle(
     return False
 
 
+def _strip_temporal_hints(graph: Graph, beat_nodes: dict[str, Any]) -> int:
+    """Remove temporal_hint from all beat nodes.
+
+    Hints have served their purpose once the beat DAG encodes the ordering.
+    Sets temporal_hint to None (JSON null) which satisfies the spec's
+    "not carried forward" requirement and the SQL verification query.
+
+    Returns:
+        Count of beats that had a hint stripped.
+    """
+    stripped = 0
+    for beat_id, data in beat_nodes.items():
+        if data.get("temporal_hint") is not None:
+            graph.update_node(beat_id, temporal_hint=None)
+            stripped += 1
+    return stripped
+
+
 def interleave_cross_path_beats(graph: Graph) -> int:
     """Create predecessor edges between beats from different dilemma paths.
 
@@ -2390,6 +2408,7 @@ def interleave_cross_path_beats(graph: Graph) -> int:
 
     dilemma_paths = build_dilemma_paths(graph)
     if len(dilemma_paths) < 2:
+        _strip_temporal_hints(graph, beat_nodes)
         return 0
 
     # path_id → ordered list of beat IDs
@@ -2421,6 +2440,7 @@ def interleave_cross_path_beats(graph: Graph) -> int:
                 relationship_edges.append((a, b, ordering))
 
     if not relationship_edges:
+        _strip_temporal_hints(graph, beat_nodes)
         return 0
 
     created = 0
@@ -2555,18 +2575,9 @@ def interleave_cross_path_beats(graph: Graph) -> int:
                         for ca in sorted(commits_a):
                             _add_predecessor(ca, cb)
 
-    # Strip temporal_hint from all beat nodes — hints have served their purpose
-    # once the DAG encodes the ordering. Setting to None makes json_extract return
-    # SQL NULL, satisfying the spec's "not carried forward" requirement.
-    stripped = 0
-    for beat_id in beat_nodes:
-        if beat_nodes[beat_id].get("temporal_hint") is not None:
-            graph.update_node(beat_id, temporal_hint=None)
-            stripped += 1
-
     log.info(
         "interleave_cross_path_beats_complete",
         edges_created=created,
-        temporal_hints_stripped=stripped,
+        temporal_hints_stripped=_strip_temporal_hints(graph, beat_nodes),
     )
     return created

--- a/tests/unit/test_grow_algorithms.py
+++ b/tests/unit/test_grow_algorithms.py
@@ -4365,6 +4365,56 @@ class TestInterleavecrossPathBeats:
                 f"{beat_id} still has temporal_hint after interleaving: {node.get('temporal_hint')}"
             )
 
+    def test_hints_stripped_on_single_dilemma_early_return(self) -> None:
+        """Hints are stripped even when early-returning due to single-dilemma graph (#1106)."""
+        graph = Graph.empty()
+        graph.create_node("dilemma::solo", {"type": "dilemma", "raw_id": "solo"})
+        graph.create_node(
+            "path::solo_path",
+            {"type": "path", "raw_id": "solo_path", "dilemma_id": "dilemma::solo"},
+        )
+        graph.create_node(
+            "beat::solo_beat",
+            {
+                "type": "beat",
+                "raw_id": "solo_beat",
+                "temporal_hint": {"relative_to": "dilemma::solo", "position": "before_commit"},
+            },
+        )
+        graph.add_edge("belongs_to", "beat::solo_beat", "path::solo_path")
+
+        result = interleave_cross_path_beats(graph)
+        assert result == 0  # No cross-path edges in single-dilemma graph
+        assert graph.get_node("beat::solo_beat").get("temporal_hint") is None
+
+    def test_hints_stripped_on_no_relationship_early_return(self) -> None:
+        """Hints are stripped even when early-returning due to no dilemma relationships (#1106)."""
+        # Two dilemmas but no relationship edges between them
+        graph = Graph.empty()
+        graph.create_node("dilemma::a", {"type": "dilemma", "raw_id": "a"})
+        graph.create_node("dilemma::b", {"type": "dilemma", "raw_id": "b"})
+        graph.create_node(
+            "path::pa",
+            {"type": "path", "raw_id": "pa", "dilemma_id": "dilemma::a", "is_canonical": True},
+        )
+        graph.create_node(
+            "path::pb",
+            {"type": "path", "raw_id": "pb", "dilemma_id": "dilemma::b", "is_canonical": True},
+        )
+        graph.create_node(
+            "beat::beat_a",
+            {
+                "type": "beat",
+                "raw_id": "beat_a",
+                "temporal_hint": {"relative_to": "dilemma::b", "position": "after_introduce"},
+            },
+        )
+        graph.add_edge("belongs_to", "beat::beat_a", "path::pa")
+
+        result = interleave_cross_path_beats(graph)
+        assert result == 0  # No relationship edges
+        assert graph.get_node("beat::beat_a").get("temporal_hint") is None
+
     def test_beat_with_explicit_null_hint_unaffected(self) -> None:
         """A beat with temporal_hint=None before interleaving stays None after (#1106)."""
         graph = _make_two_dilemma_graph_with_relationship("concurrent")

--- a/tests/unit/test_grow_algorithms.py
+++ b/tests/unit/test_grow_algorithms.py
@@ -4358,12 +4358,24 @@ class TestInterleavecrossPathBeats:
 
         interleave_cross_path_beats(graph)
 
-        # All hints stripped after interleaving
-        for beat_id in ["beat::mt_intro", "beat::mt_commit", "beat::aq_intro", "beat::aq_commit"]:
-            node = graph.get_node(beat_id)
+        # All hints stripped after interleaving (check all beats in graph)
+        all_beats = graph.get_nodes_by_type("beat")
+        for beat_id, node in all_beats.items():
             assert node.get("temporal_hint") is None, (
                 f"{beat_id} still has temporal_hint after interleaving: {node.get('temporal_hint')}"
             )
+
+    def test_beat_with_explicit_null_hint_unaffected(self) -> None:
+        """A beat with temporal_hint=None before interleaving stays None after (#1106)."""
+        graph = _make_two_dilemma_graph_with_relationship("concurrent")
+
+        # Explicitly set temporal_hint to None on one beat before interleaving
+        graph.update_node("beat::mt_intro", temporal_hint=None)
+
+        interleave_cross_path_beats(graph)
+
+        # Should still be None (not double-stripped or raised)
+        assert graph.get_node("beat::mt_intro").get("temporal_hint") is None
 
     def test_temporal_hints_influence_beat_ordering(self) -> None:
         """Temporal hints produce predecessor edges that reflect the declared position (#1106).

--- a/tests/unit/test_grow_algorithms.py
+++ b/tests/unit/test_grow_algorithms.py
@@ -4337,3 +4337,60 @@ class TestInterleavecrossPathBeats:
         result = asyncio.run(phase_interleave_beats(graph, mock_model))
         assert result.status == "completed"
         assert "predecessor edges" in result.detail
+
+    def test_temporal_hints_stripped_after_interleaving(self) -> None:
+        """After interleaving, temporal_hint is removed from all beat nodes (#1106)."""
+        graph = _make_two_dilemma_graph_with_relationship("concurrent")
+
+        # Add temporal hints to both beats
+        graph.update_node(
+            "beat::mt_intro",
+            temporal_hint={"relative_to": "dilemma::artifact_quest", "position": "before_commit"},
+        )
+        graph.update_node(
+            "beat::aq_intro",
+            temporal_hint={"relative_to": "dilemma::mentor_trust", "position": "after_introduce"},
+        )
+
+        # Both hints present before interleaving
+        assert graph.get_node("beat::mt_intro").get("temporal_hint") is not None
+        assert graph.get_node("beat::aq_intro").get("temporal_hint") is not None
+
+        interleave_cross_path_beats(graph)
+
+        # All hints stripped after interleaving
+        for beat_id in ["beat::mt_intro", "beat::mt_commit", "beat::aq_intro", "beat::aq_commit"]:
+            node = graph.get_node(beat_id)
+            assert node.get("temporal_hint") is None, (
+                f"{beat_id} still has temporal_hint after interleaving: {node.get('temporal_hint')}"
+            )
+
+    def test_temporal_hints_influence_beat_ordering(self) -> None:
+        """Temporal hints produce predecessor edges that reflect the declared position (#1106).
+
+        beat::aq_intro declares temporal_hint before_commit of dilemma::mentor_trust.
+        This means aq_intro must come before mt_commit.
+        Expected: predecessor(mt_commit, aq_intro) = aq_intro before mt_commit.
+        """
+        from questfoundry.graph.grow_algorithms import validate_beat_dag
+
+        graph = _make_two_dilemma_graph_with_relationship("concurrent")
+
+        # aq_intro wants to appear before mt_commit
+        graph.update_node(
+            "beat::aq_intro",
+            temporal_hint={"relative_to": "dilemma::mentor_trust", "position": "before_commit"},
+        )
+
+        created = interleave_cross_path_beats(graph)
+        assert created > 0, "Expected at least one cross-path predecessor edge"
+
+        # Verify predecessor(mt_commit, aq_intro) was created
+        pred_edges = graph.get_edges(from_id="beat::mt_commit", edge_type="predecessor")
+        prereqs = {e["to"] for e in pred_edges}
+        assert "beat::aq_intro" in prereqs, (
+            f"Expected aq_intro as prerequisite of mt_commit, got prereqs={prereqs}"
+        )
+
+        # DAG must remain valid
+        assert validate_beat_dag(graph) == []


### PR DESCRIPTION
## Summary
- After `interleave_cross_path_beats()` uses temporal hints to create cross-path predecessor edges, it strips `temporal_hint` from all beat nodes via `_strip_temporal_hints()`
- Stripping happens at **every exit path** — including early returns for single-dilemma graphs and no-relationship graphs — per spec requirement that hints are unconditionally not carried forward
- Sets `temporal_hint=None` (JSON null); `json_extract IS NOT NULL` returns 0 ✅

## Tests
- `test_temporal_hints_stripped_after_interleaving`: all beat nodes have `temporal_hint=None` after normal interleaving
- `test_temporal_hints_influence_beat_ordering`: a `before_commit` hint produces the expected `predecessor` edge
- `test_beat_with_explicit_null_hint_unaffected`: beats already null before interleaving stay null
- `test_hints_stripped_on_single_dilemma_early_return`: hints stripped on early return (< 2 dilemmas)
- `test_hints_stripped_on_no_relationship_early_return`: hints stripped on early return (no relationship edges)

## Design Conformance

Architect-reviewer checked against `docs/design/document-3-ontology.md` and `docs/design/how-branching-stories-work.md`.

**Verdict: CONFORMANT** for the stripping feature.

> "The hints are consumed by GROW during interleaving. Once GROW produces the DAG with a total order per arc, the temporal positions are structural facts readable from the ordering — the hints have served their purpose and are not carried forward." — Doc 3, line 258

Stripping at all early-return paths is correct: single-dilemma and no-relationship cases are situations where interleaving is trivially complete; hints have still served their purpose.

**Pre-existing gap** (not introduced by this PR): only `before_commit` and `after_introduce` positions are implemented; `after_commit` and `before_introduce` are silently ignored. Tracked in #1114.

## Verification
```bash
python3 -c "
import sqlite3
conn = sqlite3.connect('projects/test-new/graph.db')
cur = conn.cursor()
cur.execute(\"SELECT COUNT(*) FROM nodes WHERE type='beat' AND json_extract(data, '$.temporal_hint') IS NOT NULL\")
print('Beats with temporal_hint remaining:', cur.fetchone()[0])
"
# Expected: 0
```

Closes #1106

🤖 Generated with [Claude Code](https://claude.com/claude-code)