### PR TITLE
test: prove all four temporal_hint positions handled — closes false positive #1114

### DIFF
--- a/tests/unit/test_grow_algorithms.py
+++ b/tests/unit/test_grow_algorithms.py
@@ -4289,6 +4289,48 @@ class TestInterleavecrossPathBeats:
         # aq_commit requires mt_intro
         assert ("beat::aq_commit", "beat::mt_intro") in pairs
 
+    def test_temporal_hint_after_commit_applied(self) -> None:
+        """Temporal hint 'after_commit' creates edge from this beat to commit beat (#1114)."""
+
+        graph = _make_two_dilemma_graph_with_relationship("concurrent")
+
+        # aq_intro should come after mentor_trust's commit beat
+        graph.update_node(
+            "beat::aq_intro",
+            temporal_hint={
+                "relative_to": "dilemma::mentor_trust",
+                "position": "after_commit",
+            },
+        )
+
+        count = interleave_cross_path_beats(graph)
+        assert count > 0
+        edges = graph.get_edges(edge_type="predecessor")
+        pairs = {(e["from"], e["to"]) for e in edges}
+        # aq_intro requires mt_commit (aq_intro comes after mt_commit)
+        assert ("beat::aq_intro", "beat::mt_commit") in pairs
+
+    def test_temporal_hint_before_introduce_applied(self) -> None:
+        """Temporal hint 'before_introduce' creates edge from intro beat to this beat (#1114)."""
+
+        graph = _make_two_dilemma_graph_with_relationship("concurrent")
+
+        # aq_commit should come before mentor_trust's first (intro) beat
+        graph.update_node(
+            "beat::aq_commit",
+            temporal_hint={
+                "relative_to": "dilemma::mentor_trust",
+                "position": "before_introduce",
+            },
+        )
+
+        count = interleave_cross_path_beats(graph)
+        assert count > 0
+        edges = graph.get_edges(edge_type="predecessor")
+        pairs = {(e["from"], e["to"]) for e in edges}
+        # mt_intro requires aq_commit (aq_commit must precede mt_intro)
+        assert ("beat::mt_intro", "beat::aq_commit") in pairs
+
     def test_no_duplicate_edges_created(self) -> None:
         """Running interleave twice does not create duplicate predecessor edges."""
 


### PR DESCRIPTION
## Summary

Issue #1114 was filed as a false positive by the architect-reviewer during PR #1113's review. The reviewer searched for literal strings `after_commit` and `before_introduce` in the code and found none — but the generic refactoring in #1105 handles all four positions without needing those strings:

```python
is_before = position.startswith("before_")
target_beats = ref_commits if "commit" in position else ref_first
for target in sorted(target_beats):
    from_b, to_b = (target, beat_id) if is_before else (beat_id, target)
```

The logic was already on main when the reviewer ran (PR #1105 merged before #1113 was created). Same false-positive pattern as #1108.

This PR adds the two missing tests to prove the behavior and prevent future false-positive reports.

## Design Conformance

Pure test addition — no pipeline code changed. Not required per CLAUDE.md.

Closes #1114

🤖 Generated with [Claude Code](https://claude.com/claude-code)