### PR TITLE
fix: gap beats now carry dilemma_impacts (GROW phase 4b/4c)

### DIFF
--- a/prompts/templates/grow_phase4b_narrative_gaps.yaml
+++ b/prompts/templates/grow_phase4b_narrative_gaps.yaml
@@ -30,6 +30,12 @@ system: |
   4. Gap beats should be concise transitions, not major story events
   5. Maximum 2 gap beats per path
 
+  ## Path → Dilemma mapping (use these dilemma_id values)
+  {path_dilemma_map}
+
+  ## Valid dilemma IDs
+  {valid_dilemma_ids}
+
   ## Path Sequences (in execution order)
   {path_sequences}
 
@@ -51,6 +57,13 @@ system: |
   - before_beat: the LATER beat (or null for end of path)
   - summary: concise description of the gap beat (1 sentence)
   - scene_type: scene | sequel | micro_beat (default: sequel)
+  - dilemma_impacts: list of how this beat affects dilemmas (may be empty)
+    Each item: {{"dilemma_id": "<id>", "effect": "<advances|reveals|commits|complicates>", "note": "<explanation>"}}
+    Effect values:
+      advances    = moves the dilemma closer to resolution (tension builds)
+      reveals     = discloses new information about the dilemma
+      commits     = a character makes an irreversible choice about the dilemma
+      complicates = adds a new obstacle or contradiction to the dilemma
 
   If no gaps are needed, return an empty gaps array.
 
@@ -62,7 +75,10 @@ system: |
         "after_beat": "beat::setup_01",
         "before_beat": "beat::climax_01",
         "summary": "Hero reflects on the stakes before the confrontation",
-        "scene_type": "sequel"
+        "scene_type": "sequel",
+        "dilemma_impacts": [
+          {{"dilemma_id": "dilemma::trust_or_betray", "effect": "advances", "note": "Hero weighs loyalty against self-interest before the confrontation forces a choice"}}
+        ]
       }}
     ]
   }}
@@ -72,6 +88,7 @@ user: |
 
   REMINDER: Return ONLY a valid JSON object. Use ONLY IDs from the Valid IDs section.
   REMINDER: after_beat is the EARLIER beat, before_beat is the LATER beat. Do NOT reverse them.
+  REMINDER: Include dilemma_impacts for each gap beat using ONLY valid dilemma_ids listed above. Valid effect values: advances, reveals, commits, complicates.
   Maximum 2 gap beats per path.
 
 components: []

--- a/prompts/templates/grow_phase4c_pacing_gaps.yaml
+++ b/prompts/templates/grow_phase4c_pacing_gaps.yaml
@@ -30,6 +30,12 @@ system: |
   5. Place where it makes the most narrative sense
   6. One correction beat per issue is usually sufficient
 
+  ## Path → Dilemma mapping (use these dilemma_id values)
+  {path_dilemma_map}
+
+  ## Valid dilemma IDs
+  {valid_dilemma_ids}
+
   ## Full Path Sequences (numbered in story order)
   {path_sequences}
 
@@ -55,13 +61,37 @@ system: |
   - before_beat: the LATER beat
   - summary: concise description of the correction beat (1 sentence)
   - scene_type: scene | sequel | micro_beat (must differ from issue type)
+  - dilemma_impacts: list of how this beat affects dilemmas (may be empty)
+    Each item: {{"dilemma_id": "<id>", "effect": "<advances|reveals|commits|complicates>", "note": "<explanation>"}}
+    Effect values:
+      advances    = moves the dilemma closer to resolution (tension builds)
+      reveals     = discloses new information about the dilemma
+      commits     = a character makes an irreversible choice about the dilemma
+      complicates = adds a new obstacle or contradiction to the dilemma
 
   If the issues are acceptable, return an empty gaps array.
+
+  Example (do not copy these IDs):
+  {{
+    "gaps": [
+      {{
+        "path_id": "path::dilemma__answer",
+        "after_beat": "beat::scene_01",
+        "before_beat": "beat::scene_02",
+        "summary": "A moment of doubt interrupts the relentless forward march",
+        "scene_type": "sequel",
+        "dilemma_impacts": [
+          {{"dilemma_id": "dilemma::trust_or_betray", "effect": "complicates", "note": "New evidence emerges that makes the protagonist's choice harder"}}
+        ]
+      }}
+    ]
+  }}
 
 user: |
   Propose correction beats to fix the pacing issues described above.
 
   REMINDER: Return ONLY a valid JSON object. Use ONLY IDs from the Valid IDs section.
   REMINDER: after_beat is the EARLIER beat, before_beat is the LATER beat. Do NOT reverse them.
+  REMINDER: Include dilemma_impacts for each gap beat using ONLY valid dilemma_ids listed above. Valid effect values: advances, reveals, commits, complicates.
 
 components: []

--- a/src/questfoundry/graph/grow_algorithms.py
+++ b/src/questfoundry/graph/grow_algorithms.py
@@ -2057,6 +2057,7 @@ def insert_gap_beat(
     before_beat: str | None,
     summary: str,
     scene_type: str,
+    dilemma_impacts: list[dict[str, Any]] | None = None,
 ) -> str:
     """Insert a new gap beat into the graph between existing beats.
 
@@ -2074,6 +2075,7 @@ def insert_gap_beat(
         before_beat: Beat that should come after the new beat (or None for end).
         summary: Summary text for the new beat.
         scene_type: Scene type tag for the new beat.
+        dilemma_impacts: List of dilemma impact dicts (dilemma_id, effect, note).
 
     Returns:
         The new beat's node ID.
@@ -2130,6 +2132,7 @@ def insert_gap_beat(
             "transition_style": transition_style,
             "bridges_from": after_beat,
             "bridges_to": before_beat,
+            "dilemma_impacts": dilemma_impacts or [],
         },
     )
 

--- a/src/questfoundry/graph/grow_validators.py
+++ b/src/questfoundry/graph/grow_validators.py
@@ -15,6 +15,7 @@ from typing import TYPE_CHECKING
 from questfoundry.graph.mutations import GrowValidationError
 
 if TYPE_CHECKING:
+    from questfoundry.graph.graph import Graph
     from questfoundry.models.grow import (
         Phase3Output,
         Phase4aOutput,
@@ -172,11 +173,14 @@ def validate_phase4_output(
     result: Phase4bOutput,
     valid_path_ids: set[str],
     valid_beat_ids: set[str],
+    graph: Graph | None = None,
 ) -> list[GrowValidationError]:
     """Validate Phase 4b/4c gap proposals.
 
     Accepts unprefixed IDs if the prefixed version exists in valid IDs.
     """
+    valid_dilemma_ids: set[str] = set(graph.get_nodes_by_type("dilemma").keys()) if graph else set()
+
     errors: list[GrowValidationError] = []
     for i, gap in enumerate(result.gaps):
         path_id = gap.path_id
@@ -206,6 +210,23 @@ def validate_phase4_output(
                             issue=f"Beat ID not found: {beat_id}",
                             provided=beat_id,
                             available=sorted(valid_beat_ids)[:10],
+                        )
+                    )
+        for j, impact in enumerate(gap.dilemma_impacts or []):
+            dilemma_id = impact.dilemma_id
+            if dilemma_id not in valid_dilemma_ids:
+                prefixed = (
+                    f"dilemma::{dilemma_id}"
+                    if not dilemma_id.startswith("dilemma::")
+                    else dilemma_id
+                )
+                if prefixed not in valid_dilemma_ids:
+                    errors.append(
+                        GrowValidationError(
+                            field_path=f"gaps.{i}.dilemma_impacts.{j}.dilemma_id",
+                            issue=f"Dilemma ID not found: {dilemma_id}",
+                            provided=dilemma_id,
+                            available=sorted(valid_dilemma_ids)[:10],
                         )
                     )
     return errors

--- a/src/questfoundry/models/grow.py
+++ b/src/questfoundry/models/grow.py
@@ -23,6 +23,7 @@ from typing import Literal
 from pydantic import BaseModel, Field, model_validator
 
 from questfoundry.models.pipeline import PhaseResult
+from questfoundry.models.seed import DilemmaImpact  # noqa: TC001
 
 # ---------------------------------------------------------------------------
 # Graph node types
@@ -248,6 +249,7 @@ class GapProposal(BaseModel):
     )
     summary: str = Field(min_length=1)
     scene_type: Literal["scene", "sequel", "micro_beat"] = "sequel"
+    dilemma_impacts: list[DilemmaImpact] = Field(default_factory=list)
 
 
 class Phase4bOutput(BaseModel):

--- a/src/questfoundry/pipeline/stages/grow/llm_helper.py
+++ b/src/questfoundry/pipeline/stages/grow/llm_helper.py
@@ -339,6 +339,7 @@ class _LLMHelperMixin:
                 before_beat=before_beat,
                 summary=gap.summary,
                 scene_type=gap.scene_type,
+                dilemma_impacts=[i.model_dump() for i in gap.dilemma_impacts],
             )
             report.inserted += 1
         return report

--- a/src/questfoundry/pipeline/stages/grow/llm_phases.py
+++ b/src/questfoundry/pipeline/stages/grow/llm_phases.py
@@ -441,10 +441,26 @@ class _LLMPhaseMixin:
                 detail="No paths with 2+ beats to check",
             )
 
+        dilemma_nodes = graph.get_nodes_by_type("dilemma")
+        valid_dilemma_ids = sorted(dilemma_nodes.keys())
+        path_dilemma_lines = []
+        for pid in sorted(path_nodes.keys()):
+            pdata = path_nodes[pid]
+            dilemma_id = pdata.get("dilemma_id", "")
+            if dilemma_id and not dilemma_id.startswith("dilemma::"):
+                dilemma_id = f"dilemma::{dilemma_id}"
+            question = ""
+            if dilemma_id and dilemma_id in dilemma_nodes:
+                question = dilemma_nodes[dilemma_id].get("question", "")
+            suffix = f' ("{question}")' if question else ""
+            path_dilemma_lines.append(f"  {pid} → {dilemma_id or '(none)'}{suffix}")
+
         context = {
             "path_sequences": "\n\n".join(path_sequences),
             "valid_path_ids": ", ".join(sorted(path_nodes.keys())),
             "valid_beat_ids": ", ".join(sorted(valid_beat_ids)),
+            "path_dilemma_map": "\n".join(path_dilemma_lines) or "(no paths with dilemmas)",
+            "valid_dilemma_ids": ", ".join(valid_dilemma_ids) or "(none)",
         }
 
         from questfoundry.graph.grow_validators import validate_phase4_output
@@ -566,12 +582,28 @@ class _LLMPhaseMixin:
                 f"'{issue.scene_type}' beats:\n" + "\n".join(issue_beats)
             )
 
+        dilemma_nodes_4c = graph.get_nodes_by_type("dilemma")
+        valid_dilemma_ids_4c = sorted(dilemma_nodes_4c.keys())
+        path_dilemma_lines_4c = []
+        for pid in sorted(path_nodes.keys()):
+            pdata = path_nodes[pid]
+            dilemma_id = pdata.get("dilemma_id", "")
+            if dilemma_id and not dilemma_id.startswith("dilemma::"):
+                dilemma_id = f"dilemma::{dilemma_id}"
+            question = ""
+            if dilemma_id and dilemma_id in dilemma_nodes_4c:
+                question = dilemma_nodes_4c[dilemma_id].get("question", "")
+            suffix = f' ("{question}")' if question else ""
+            path_dilemma_lines_4c.append(f"  {pid} → {dilemma_id or '(none)'}{suffix}")
+
         context = {
             "path_sequences": "\n\n".join(path_sequences),
             "pacing_issues": "\n\n".join(issue_descriptions),
             "valid_path_ids": ", ".join(sorted(path_nodes.keys())),
             "valid_beat_ids": ", ".join(sorted(valid_beat_ids)),
             "issue_count": str(len(issues)),
+            "path_dilemma_map": "\n".join(path_dilemma_lines_4c) or "(no paths with dilemmas)",
+            "valid_dilemma_ids": ", ".join(valid_dilemma_ids_4c) or "(none)",
         }
 
         from questfoundry.graph.grow_validators import validate_phase4_output

--- a/src/questfoundry/pipeline/stages/grow/llm_phases.py
+++ b/src/questfoundry/pipeline/stages/grow/llm_phases.py
@@ -39,6 +39,38 @@ if TYPE_CHECKING:
     from questfoundry.graph.mutations import GrowValidationError
 
 
+def _build_path_dilemma_context(
+    graph: Graph,
+    path_nodes: dict[str, Any],
+) -> tuple[str, str]:
+    """Build path-to-dilemma mapping text and valid dilemma ID text for LLM context.
+
+    Args:
+        graph: The graph store to query for dilemma nodes.
+        path_nodes: Dict of path_id → path data.
+
+    Returns:
+        A tuple of (path_dilemma_map_text, valid_dilemma_ids_text) ready for
+        injection into a prompt context dict.
+    """
+    dilemma_nodes = graph.get_nodes_by_type("dilemma")
+    valid_dilemma_ids = sorted(dilemma_nodes.keys())
+    path_dilemma_lines = []
+    for pid in sorted(path_nodes.keys()):
+        pdata = path_nodes[pid]
+        dilemma_id = pdata.get("dilemma_id", "")
+        if dilemma_id and not dilemma_id.startswith("dilemma::"):
+            dilemma_id = f"dilemma::{dilemma_id}"
+        question = ""
+        if dilemma_id and dilemma_id in dilemma_nodes:
+            question = dilemma_nodes[dilemma_id].get("question", "")
+        suffix = f' ("{question}")' if question else ""
+        path_dilemma_lines.append(f"  {pid} → {dilemma_id or '(none)'}{suffix}")
+    path_dilemma_map_text = "\n".join(path_dilemma_lines) or "(no paths with dilemmas)"
+    valid_dilemma_ids_text = ", ".join(valid_dilemma_ids) or "(none)"
+    return path_dilemma_map_text, valid_dilemma_ids_text
+
+
 class _LLMPhaseMixin:
     """Mixin providing LLM-powered GROW phases (3, 4a-4f, 8c).
 
@@ -441,26 +473,16 @@ class _LLMPhaseMixin:
                 detail="No paths with 2+ beats to check",
             )
 
-        dilemma_nodes = graph.get_nodes_by_type("dilemma")
-        valid_dilemma_ids = sorted(dilemma_nodes.keys())
-        path_dilemma_lines = []
-        for pid in sorted(path_nodes.keys()):
-            pdata = path_nodes[pid]
-            dilemma_id = pdata.get("dilemma_id", "")
-            if dilemma_id and not dilemma_id.startswith("dilemma::"):
-                dilemma_id = f"dilemma::{dilemma_id}"
-            question = ""
-            if dilemma_id and dilemma_id in dilemma_nodes:
-                question = dilemma_nodes[dilemma_id].get("question", "")
-            suffix = f' ("{question}")' if question else ""
-            path_dilemma_lines.append(f"  {pid} → {dilemma_id or '(none)'}{suffix}")
+        path_dilemma_map_text, valid_dilemma_ids_text = _build_path_dilemma_context(
+            graph, path_nodes
+        )
 
         context = {
             "path_sequences": "\n\n".join(path_sequences),
             "valid_path_ids": ", ".join(sorted(path_nodes.keys())),
             "valid_beat_ids": ", ".join(sorted(valid_beat_ids)),
-            "path_dilemma_map": "\n".join(path_dilemma_lines) or "(no paths with dilemmas)",
-            "valid_dilemma_ids": ", ".join(valid_dilemma_ids) or "(none)",
+            "path_dilemma_map": path_dilemma_map_text,
+            "valid_dilemma_ids": valid_dilemma_ids_text,
         }
 
         from questfoundry.graph.grow_validators import validate_phase4_output
@@ -469,6 +491,7 @@ class _LLMPhaseMixin:
             validate_phase4_output,
             valid_path_ids=set(path_nodes.keys()),
             valid_beat_ids=valid_beat_ids,
+            graph=graph,
         )
         try:
             result, llm_calls, tokens = await self._grow_llm_call(  # type: ignore[attr-defined]
@@ -582,19 +605,9 @@ class _LLMPhaseMixin:
                 f"'{issue.scene_type}' beats:\n" + "\n".join(issue_beats)
             )
 
-        dilemma_nodes_4c = graph.get_nodes_by_type("dilemma")
-        valid_dilemma_ids_4c = sorted(dilemma_nodes_4c.keys())
-        path_dilemma_lines_4c = []
-        for pid in sorted(path_nodes.keys()):
-            pdata = path_nodes[pid]
-            dilemma_id = pdata.get("dilemma_id", "")
-            if dilemma_id and not dilemma_id.startswith("dilemma::"):
-                dilemma_id = f"dilemma::{dilemma_id}"
-            question = ""
-            if dilemma_id and dilemma_id in dilemma_nodes_4c:
-                question = dilemma_nodes_4c[dilemma_id].get("question", "")
-            suffix = f' ("{question}")' if question else ""
-            path_dilemma_lines_4c.append(f"  {pid} → {dilemma_id or '(none)'}{suffix}")
+        path_dilemma_map_text_4c, valid_dilemma_ids_text_4c = _build_path_dilemma_context(
+            graph, path_nodes
+        )
 
         context = {
             "path_sequences": "\n\n".join(path_sequences),
@@ -602,8 +615,8 @@ class _LLMPhaseMixin:
             "valid_path_ids": ", ".join(sorted(path_nodes.keys())),
             "valid_beat_ids": ", ".join(sorted(valid_beat_ids)),
             "issue_count": str(len(issues)),
-            "path_dilemma_map": "\n".join(path_dilemma_lines_4c) or "(no paths with dilemmas)",
-            "valid_dilemma_ids": ", ".join(valid_dilemma_ids_4c) or "(none)",
+            "path_dilemma_map": path_dilemma_map_text_4c,
+            "valid_dilemma_ids": valid_dilemma_ids_text_4c,
         }
 
         from questfoundry.graph.grow_validators import validate_phase4_output
@@ -612,6 +625,7 @@ class _LLMPhaseMixin:
             validate_phase4_output,
             valid_path_ids=set(path_nodes.keys()),
             valid_beat_ids=valid_beat_ids,
+            graph=graph,
         )
         try:
             result, llm_calls, tokens = await self._grow_llm_call(  # type: ignore[attr-defined]

--- a/tests/unit/test_grow_algorithms.py
+++ b/tests/unit/test_grow_algorithms.py
@@ -3306,6 +3306,31 @@ class TestInsertGapBeat:
         assert node["bridges_to"] == "beat::b"
         assert node["transition_style"] == "smooth"  # Default when context missing
 
+    def test_stores_dilemma_impacts(self) -> None:
+        """Gap beat stores dilemma_impacts list on the node."""
+        from questfoundry.graph.grow_algorithms import insert_gap_beat
+
+        graph = Graph.empty()
+        graph.create_node("path::t1", {"type": "path", "raw_id": "t1"})
+        graph.create_node("beat::a", {"type": "beat", "raw_id": "a", "summary": "A"})
+        graph.add_edge("belongs_to", "beat::a", "path::t1")
+
+        dilemma_impacts = [
+            {"dilemma_id": "dilemma::rescue", "effect": "advances", "note": "moves plot"}
+        ]
+        beat_id = insert_gap_beat(
+            graph,
+            path_id="path::t1",
+            after_beat="beat::a",
+            before_beat=None,
+            summary="Gap with dilemma impact",
+            scene_type="scene",
+            dilemma_impacts=dilemma_impacts,
+        )
+
+        node = graph.get_node(beat_id)
+        assert node["dilemma_impacts"] == dilemma_impacts
+
 
 class TestCollapseLinearBeats:
     def test_collapse_linear_chain(self) -> None:


### PR DESCRIPTION
## Summary

- Adds `dilemma_impacts` field to `GapProposal` Pydantic model (phase 4b/4c gap beat proposals)
- Updates `insert_gap_beat()` to persist `dilemma_impacts` on the gap beat node
- Injects `path_dilemma_map` (path → dilemma question) and `valid_dilemma_ids` context into phase 4b/4c prompts via extracted `_build_path_dilemma_context()` helper
- Adds `dilemma_impacts` to both prompt schemas with concrete JSON examples and sandwich reinforcement
- Corrects effect values: `advances|reveals|commits|complicates` (was `raises|explores|commits|resolves`)
- Adds output validation of `dilemma_impacts[].dilemma_id` in `validate_phase4_output()`

## Design Conformance

Reviewed by `architect-reviewer` subagent against Document 1, Document 3, and `docs/design/procedures/grow.md`.

| # | Requirement | Status |
|---|---|---|
| 1 | Every beat carries `dilemma_impacts` | CONFORMANT |
| 2 | `DilemmaImpact` schema: `dilemma_id`, `effect` (advances\|reveals\|commits\|complicates), `note` | CONFORMANT |
| 3 | Gap beats (4b narrative gaps) MUST have `dilemma_impacts` | CONFORMANT |
| 4 | Gap beats (4c pacing gaps) MUST have `dilemma_impacts` | CONFORMANT |
| 5 | Prompt MUST provide valid dilemma IDs to the LLM | CONFORMANT |
| 6 | Output validation of `dilemma_impacts[].dilemma_id` | CONFORMANT (fixed in review) |
| 7 | `dilemma_impacts` consumed by downstream stages | CONFORMANT |
| 8 | Empty `dilemma_impacts` list allowed | CONFORMANT |

**Pre-existing PARTIAL (not in scope):** `DilemmaImpact` model missing `path_id` for `commits` effect. Filed as separate issue.

**Data flow verified:** LLM → `GapProposal.dilemma_impacts` → `insert_gap_beat()` → beat node → consumers in `grow_algorithms.py`, `polish_validation.py`, `fill_context.py`.

## Test plan

- [x] `uv run pytest tests/unit/test_grow_algorithms.py tests/unit/test_grow_stage.py -x -q` — pass
- [x] All 284 unit tests pass
- [x] New test: `TestInsertGapBeat.test_stores_dilemma_impacts` verifies persistence
- [ ] Verify `dilemma_impacts` populated in `graph.db` gap beat nodes after real run

Closes #1116

🤖 Generated with [Claude Code](https://claude.com/claude-code)