### PR TITLE
fix: intersection groups now carry shared_entities, rationale, and null-safe location

### DIFF
--- a/prompts/templates/grow_phase3_intersections.yaml
+++ b/prompts/templates/grow_phase3_intersections.yaml
@@ -36,14 +36,23 @@ system: |
 
   ## Valid IDs
   Valid beat_ids (use ONLY these): {valid_beat_ids}
-  Total candidate groups: {candidate_count}
 
   ## Output Format
   Return a JSON object with an "intersections" array. Each element has:
   - beat_ids: list of 2-3 beat IDs that form the intersection (from DIFFERENT dilemmas)
-  - resolved_location: always a specific location string — NEVER null, never the string "null"
-  - shared_entities: entity IDs shared between the intersecting beats (may be empty)
-  - rationale: one sentence explaining why these beats form a natural scene
+  - resolved_location: the specific location where this scene occurs — MUST be a
+    non-empty string. If the candidate group lists multiple possible locations, pick
+    the one that fits most beats. If location is genuinely unknown, use the most
+    specific location mentioned in any of the beat descriptions (e.g., "the village
+    square" rather than "unknown"). NEVER output null. NEVER output the word "null".
+  - shared_entities: list of entity IDs shared between the intersecting beats — use the
+    full "entity::<name>" format (e.g., "entity::merchant", "entity::artifact"). If no
+    entities are shared, use an empty list []. Do NOT invent entity IDs — use only IDs
+    that appear in the candidate group descriptions above.
+  - rationale: one sentence explaining WHY the beats belong in one scene — mention what
+    narrative or physical element draws them together, not just that they share a location.
+    BAD: "These beats share the market location." GOOD: "Both beats require the merchant's
+    presence, so staging them together avoids a redundant scene."
 
   Example (do not copy these IDs -- use the real IDs from the candidate groups):
   {{
@@ -52,7 +61,13 @@ system: |
         "beat_ids": ["beat::market_encounter", "beat::artifact_reveal"],
         "resolved_location": "the central market",
         "shared_entities": ["entity::merchant", "entity::artifact"],
-        "rationale": "The mentor introduction and artifact discovery both occur at the market."
+        "rationale": "Both beats require the merchant's presence, so staging them together avoids a redundant scene."
+      }},
+      {{
+        "beat_ids": ["beat::council_vote", "beat::spy_report"],
+        "resolved_location": "the council chamber antechamber",
+        "shared_entities": [],
+        "rationale": "The spy delivers news just as the council adjourns, making the antechamber the only staging that keeps both beats from requiring separate scene-setting."
       }}
     ]
   }}
@@ -62,7 +77,14 @@ system: |
 user: |
   Select which candidate groups form natural intersection scenes.
 
-  REMINDER: Return ONLY a valid JSON object. Use ONLY beat IDs from the Valid IDs section. Each beat in at most ONE intersection. Do NOT add prose before or after the JSON. resolved_location MUST be a real location string — NEVER null, never the string "null".
+  REMINDER:
+  - Return ONLY a valid JSON object — no prose before or after.
+  - Use ONLY beat IDs from the Valid IDs section. Do NOT invent IDs.
+  - Each beat may appear in at most ONE intersection.
+  - resolved_location MUST be a non-empty string. If uncertain, pick the best-fit
+    location from the beat descriptions. NEVER output null or the word "null".
+  - shared_entities MUST use "entity::<name>" format or be an empty list [].
+  - rationale MUST explain WHY the beats belong in one scene, not just that they share a location.
   {structural_feedback}
 
 components: []

--- a/prompts/templates/grow_phase3_intersections.yaml
+++ b/prompts/templates/grow_phase3_intersections.yaml
@@ -41,7 +41,8 @@ system: |
   ## Output Format
   Return a JSON object with an "intersections" array. Each element has:
   - beat_ids: list of 2-3 beat IDs that form the intersection (from DIFFERENT dilemmas)
-  - resolved_location: where this combined scene takes place (string or null)
+  - resolved_location: always a specific location string — NEVER null, never the string "null"
+  - shared_entities: entity IDs shared between the intersecting beats (may be empty)
   - rationale: one sentence explaining why these beats form a natural scene
 
   Example (do not copy these IDs -- use the real IDs from the candidate groups):
@@ -50,6 +51,7 @@ system: |
       {{
         "beat_ids": ["beat::market_encounter", "beat::artifact_reveal"],
         "resolved_location": "the central market",
+        "shared_entities": ["entity::merchant", "entity::artifact"],
         "rationale": "The mentor introduction and artifact discovery both occur at the market."
       }}
     ]
@@ -60,7 +62,7 @@ system: |
 user: |
   Select which candidate groups form natural intersection scenes.
 
-  REMINDER: Return ONLY a valid JSON object. Use ONLY beat IDs from the Valid IDs section. Each beat in at most ONE intersection. Do NOT add prose before or after the JSON.
+  REMINDER: Return ONLY a valid JSON object. Use ONLY beat IDs from the Valid IDs section. Each beat in at most ONE intersection. Do NOT add prose before or after the JSON. resolved_location MUST be a real location string — NEVER null, never the string "null".
   {structural_feedback}
 
 components: []

--- a/src/questfoundry/graph/grow_algorithms.py
+++ b/src/questfoundry/graph/grow_algorithms.py
@@ -1917,6 +1917,8 @@ def apply_intersection_mark(
     graph: Graph,
     beat_ids: list[str],
     resolved_location: str | None,
+    shared_entities: list[str] | None = None,
+    rationale: str | None = None,
 ) -> None:
     """Mark beats as co-occurring in an intersection group (Doc 3, Part 4).
 
@@ -1928,6 +1930,8 @@ def apply_intersection_mark(
         graph: Graph to mutate.
         beat_ids: Beat IDs to group into intersection.
         resolved_location: Resolved location, or None.
+        shared_entities: Entity IDs shared between the intersecting beats.
+        rationale: One-sentence explanation of why these beats form a natural scene.
     """
     # Derive a stable group ID from the sorted beat IDs
     sorted_ids = sorted(beat_ids)
@@ -1943,6 +1947,8 @@ def apply_intersection_mark(
         "type": "intersection_group",
         "raw_id": raw_group_id,
         "beat_ids": sorted_ids,
+        "shared_entities": shared_entities or [],
+        "rationale": rationale or "",
     }
     if resolved_location:
         group_data["resolved_location"] = resolved_location

--- a/src/questfoundry/models/grow.py
+++ b/src/questfoundry/models/grow.py
@@ -112,6 +112,7 @@ class IntersectionProposal(BaseModel):
 
     beat_ids: list[str] = Field(min_length=2)
     resolved_location: str | None = None
+    shared_entities: list[str] = Field(default_factory=list)
     rationale: str = Field(min_length=1)
 
 

--- a/src/questfoundry/pipeline/stages/grow/llm_phases.py
+++ b/src/questfoundry/pipeline/stages/grow/llm_phases.py
@@ -215,7 +215,7 @@ class _LLMPhaseMixin:
             applied_count = 0
             skipped_count = 0
             pre_intersection_graph = Graph.from_dict(graph.to_dict())
-            accepted: list[tuple[list[str], str | None]] = []
+            accepted: list[tuple[list[str], str | None, list[str], str]] = []
             structural_errors: list[GrowValidationError] = []
 
             for proposal in result.intersections:
@@ -243,9 +243,14 @@ class _LLMPhaseMixin:
                     continue
 
                 # Resolve location (prefer LLM proposal, fallback to algorithm)
+                # Guard against qwen3:4b returning the literal string "null".
+                raw_loc = proposal.resolved_location
+                llm_location: str | None = (
+                    None if raw_loc in (None, "null", "NULL", "") else raw_loc
+                )
                 location: str | None
-                if proposal.resolved_location:
-                    location = proposal.resolved_location
+                if llm_location:
+                    location = llm_location
                 else:
                     location = resolve_intersection_location(pre_intersection_graph, valid_ids)
                     log.debug(
@@ -254,7 +259,7 @@ class _LLMPhaseMixin:
                         resolved=location,
                     )
 
-                accepted.append((valid_ids, location))
+                accepted.append((valid_ids, location, proposal.shared_entities, proposal.rationale))
                 log.debug(
                     "phase3_intersection_accepted",
                     beat_ids=valid_ids,
@@ -298,8 +303,10 @@ class _LLMPhaseMixin:
                 )
 
         # Apply accepted intersections in a batch to avoid cascade effects.
-        for beat_ids, location in accepted:
-            apply_intersection_mark(graph, beat_ids, location)
+        for beat_ids, location, shared_entities, rationale in accepted:
+            apply_intersection_mark(
+                graph, beat_ids, location, shared_entities=shared_entities, rationale=rationale
+            )
             applied_count += 1
             log.debug(
                 "phase3_intersection_applied",

--- a/src/questfoundry/pipeline/stages/grow/llm_phases.py
+++ b/src/questfoundry/pipeline/stages/grow/llm_phases.py
@@ -176,7 +176,6 @@ class _LLMPhaseMixin:
         context: dict[str, str] = {
             "candidate_groups": candidate_groups_text,
             "valid_beat_ids": ", ".join(sorted(valid_beat_ids)),
-            "candidate_count": str(len(candidates)),
             "structural_feedback": "",
         }
 

--- a/tests/unit/test_grow_algorithms.py
+++ b/tests/unit/test_grow_algorithms.py
@@ -2364,6 +2364,43 @@ class TestApplyKnotMark:
         group = next(iter(group_nodes.values()))
         assert "resolved_location" not in group
 
+    def test_shared_entities_and_rationale_stored_on_group(self) -> None:
+        """shared_entities and rationale are stored on the intersection_group node."""
+        from questfoundry.graph.grow_algorithms import apply_intersection_mark
+        from tests.fixtures.grow_fixtures import make_intersection_candidate_graph
+
+        graph = make_intersection_candidate_graph()
+        apply_intersection_mark(
+            graph,
+            ["beat::mentor_meet", "beat::artifact_discover"],
+            "market",
+            shared_entities=["entity::merchant"],
+            rationale="Both beats involve the merchant at the market.",
+        )
+
+        group_nodes = graph.get_nodes_by_type("intersection_group")
+        assert len(group_nodes) == 1
+        group = next(iter(group_nodes.values()))
+        assert group["shared_entities"] == ["entity::merchant"]
+        assert group["rationale"] == "Both beats involve the merchant at the market."
+
+    def test_shared_entities_defaults_to_empty_list(self) -> None:
+        """When shared_entities is omitted, group stores an empty list."""
+        from questfoundry.graph.grow_algorithms import apply_intersection_mark
+        from tests.fixtures.grow_fixtures import make_intersection_candidate_graph
+
+        graph = make_intersection_candidate_graph()
+        apply_intersection_mark(
+            graph,
+            ["beat::mentor_meet", "beat::artifact_discover"],
+            "market",
+        )
+
+        group_nodes = graph.get_nodes_by_type("intersection_group")
+        group = next(iter(group_nodes.values()))
+        assert group["shared_entities"] == []
+        assert group["rationale"] == ""
+
 
 class TestFormatIntersectionCandidates:
     """Tests for format_intersection_candidates()."""


### PR DESCRIPTION
## Summary

- Adds `shared_entities: list[str]` to `IntersectionProposal` model
- `apply_intersection_mark()` now stores `shared_entities` and `rationale` in the intersection group node
- `llm_phases.py` passes both fields through; adds null-string guard for `resolved_location` (`None`, `"null"`, `"NULL"`, `""` → `None`)
- Prompt overhauled per prompt-engineer review: entity ID format guidance, explicit fallback for ambiguous location, stronger rationale quality constraint, two-entry JSON example, reinforced user-turn sandwich

## Design Conformance

Reviewed by `architect-reviewer` subagent against Document 1, Document 3, and `docs/design/procedures/grow.md`.

| # | Requirement | Status |
|---|---|---|
| 1 | Intersection group carries shared location | CONFORMANT |
| 2 | Intersection group carries shared entities | CONFORMANT |
| 3 | Intersection group carries rationale | CONFORMANT |
| 4 | `resolved_location` null-safe for small models | CONFORMANT |
| 5 | `intersection` edges created to beat nodes | CONFORMANT |
| 6 | `belongs_to` edges unchanged | CONFORMANT |
| 7 | `shared_entities` consumed downstream | **DEAD** (pre-existing) |
| 8 | `rationale` consumed downstream for passage creation | **PARTIAL** (pre-existing) |
| 9 | `resolved_location` always stored on group node | PARTIAL (None allowed) |
| 10 | Prompt requests all four fields | CONFORMANT |

**Pre-existing downstream gaps (not in scope):** POLISH `deterministic.py` passage creation ignores `shared_entities` from the group node (uses `_merge_entities()` from beats instead) and does not use `rationale` for passage spec. These are POLISH consumer issues, not GROW producer issues. Tracked separately.

## Test plan

- [x] 286 unit tests pass
- [x] `TestApplyKnotMark.test_shared_entities_and_rationale_stored_on_group` — new test
- [x] `TestApplyKnotMark.test_shared_entities_defaults_to_empty_list` — new test
- [ ] Verify `shared_entities` and `rationale` populated in `graph.db` intersection group nodes after real run

Closes #1117

🤖 Generated with [Claude Code](https://claude.com/claude-code)