### PR TITLE
docs: clarify intentional 2-state-flags-per-dilemma in Phase 8b docstring

### DIFF
--- a/src/questfoundry/pipeline/stages/grow/deterministic.py
+++ b/src/questfoundry/pipeline/stages/grow/deterministic.py
@@ -308,7 +308,7 @@ async def phase_state_flags(graph: Graph, model: BaseChatModel) -> GrowPhaseResu
     for routing (present = path A taken, absent = path B). This phase creates one
     flag per consequence, which yields two flags per dilemma. This is intentional:
     explicit positive flags for each path outcome make overlay conditions clearer
-    (e.g., "hostile_path_committed" rather than "friendly_flag absent") and avoid
+    (e.g., "hostile_committed" rather than "friendly_committed absent") and avoid
     absence-of-flag logic in overlay definitions. SHIP selects which flags become
     player-facing codewords; not every state flag is exported.
     """

--- a/src/questfoundry/pipeline/stages/grow/deterministic.py
+++ b/src/questfoundry/pipeline/stages/grow/deterministic.py
@@ -303,6 +303,14 @@ async def phase_state_flags(graph: Graph, model: BaseChatModel) -> GrowPhaseResu
     Invariants:
     - 1:1 mapping between consequences and state flags.
     - State flag grants derived from beat dilemma_impacts with effect="commits".
+
+    Note on 2-flags-per-dilemma: Doc3 states one flag per soft dilemma suffices
+    for routing (present = path A taken, absent = path B). This phase creates one
+    flag per consequence, which yields two flags per dilemma. This is intentional:
+    explicit positive flags for each path outcome make overlay conditions clearer
+    (e.g., "hostile_path_committed" rather than "friendly_flag absent") and avoid
+    absence-of-flag logic in overlay definitions. SHIP selects which flags become
+    player-facing codewords; not every state flag is exported.
     """
     consequence_nodes = graph.get_nodes_by_type("consequence")
     if not consequence_nodes:


### PR DESCRIPTION
## Summary

Adds a clarifying note to the Phase 8b (`state_flags`) docstring explaining why this phase creates two state flags per dilemma (one per consequence) rather than the one that Doc3 says "suffices."

No code change — documentation only.

## Why

Doc3 states: *"One state flag per soft dilemma suffices for routing: present means path A was taken, absent means path B."*

The architect-reviewer flagged this as PARTIAL in #1117. The deviation is intentional:
- Two explicit positive flags (`hostile_committed`, `friendly_committed`) make overlay conditions clearer than absence-of-flag logic
- Doc3 says "suffices" — it does not prohibit two
- SHIP selects which flags become player-facing codewords; not every state flag is exported

## Design Conformance

Not required — documentation-only change (CLAUDE.md: "When to Skip: Documentation-only changes").

Closes #1118

🤖 Generated with [Claude Code](https://claude.com/claude-code)