### PR TITLE
feat(grow): move intersections before interleave, add intersection-aware edges (#1124)

### DIFF
--- a/docs/design/procedures/grow.md
+++ b/docs/design/procedures/grow.md
@@ -126,12 +126,14 @@ If the non-canonical answer is not promoted to a path in SEED, that dilemma has 
 
 ## Algorithm Phases
 
-> **Execution order note:** Phases 4a/4b/4c (gap detection & scene-type
-> tagging) execute **before** Phase 3 (intersection detection).  This
-> ensures each path is fully elaborated with gap beats before cross-path
-> weaving, preventing "conditional prerequisites" where a shared beat
-> depends on a path-specific gap beat.  Phase numbering is preserved for
-> historical continuity; execution order is defined in `_phase_order()`.
+> **Execution order note (#1124):** Phase 3 (intersection detection) executes
+> **before** Phase 1b (interleave) and before Phase 4a/4b/4c (gap detection).
+> Running intersections on a clean beat DAG (no predecessor edges yet) ensures
+> the No-Conditional-Prerequisites Invariant always passes — interleave-created
+> edges cannot invalidate intersection proposals. Phase numbering is preserved
+> for historical continuity; execution order is defined in `_phase_order()`.
+> Actual order: `validate_dag → intersections → interleave_beats → scene_types
+> → narrative_gaps → pacing_gaps → atmospheric → path_arcs → entity_arcs → …`
 > See also: **No-Conditional-Prerequisites Invariant** under Phase 3.
 
 ### Phase 1: Beat Graph Import
@@ -171,7 +173,7 @@ If the non-canonical answer is not promoted to a path in SEED, that dilemma has 
 
 **Purpose:** Find beats from different paths (different dilemmas) that should be one scene.
 
-**Input:** Beat graph with validated DAG, location flexibility from SEED
+**Input:** Beat graph with validated DAG and location flexibility from SEED. No predecessor edges exist yet (interleave has not run).
 
 **Operations:**
 1. Build candidate pool:

--- a/docs/design/procedures/grow.md
+++ b/docs/design/procedures/grow.md
@@ -243,7 +243,7 @@ causes `passage_dag_cycles` failures in validation.
 
 **Purpose:** Find missing beats needed for narrative continuity AND assign scene types for pacing.
 
-**Input:** Beat graph (before intersections — see execution order note above)
+**Input:** Beat graph with intersections applied and predecessor edges from interleave (see execution order note above)
 
 **Operations:**
 

--- a/src/questfoundry/graph/grow_algorithms.py
+++ b/src/questfoundry/graph/grow_algorithms.py
@@ -2483,12 +2483,14 @@ def interleave_cross_path_beats(graph: Graph) -> int:
 
     beat_set = set(beat_nodes.keys())
 
-    # Build intersection-group index (beat → group_id) to avoid creating
+    # Build intersection-group index (beat → set of group_ids) to avoid creating
     # predecessor edges between beats that are co-grouped in an intersection.
     # Such edges would create circular prerequisites on shared beats (#1124).
-    beat_intersection_group: dict[str, str] = {}
+    # A beat can theoretically belong to multiple intersection groups (e.g., grouped
+    # by both location and entity), so we track all groups per beat.
+    beat_intersection_groups: dict[str, set[str]] = {}
     for edge in graph.get_edges(from_id=None, to_id=None, edge_type="intersection"):
-        beat_intersection_group[edge["from"]] = edge["to"]
+        beat_intersection_groups.setdefault(edge["from"], set()).add(edge["to"])
 
     # --- Collect dilemma relationship edges ---
     relationship_edges: list[tuple[str, str, str]] = []  # (dilemma_a, dilemma_b, ordering)
@@ -2519,13 +2521,14 @@ def interleave_cross_path_beats(graph: Graph) -> int:
             return False
         # Skip edges between beats in the same intersection group —
         # such beats co-occur in a single scene and have no ordering (#1124).
-        from_group = beat_intersection_group.get(from_beat)
-        if from_group is not None and from_group == beat_intersection_group.get(to_beat):
+        from_groups = beat_intersection_groups.get(from_beat, set())
+        if from_groups and not from_groups.isdisjoint(beat_intersection_groups.get(to_beat, set())):
+            shared = from_groups & beat_intersection_groups.get(to_beat, set())
             log.debug(
                 "interleave_skipped_same_intersection",
                 from_beat=from_beat,
                 to_beat=to_beat,
-                group=from_group,
+                groups=sorted(shared),
             )
             return False
         if _would_create_cycle(from_beat, to_beat, successors, beat_set):

--- a/src/questfoundry/graph/grow_algorithms.py
+++ b/src/questfoundry/graph/grow_algorithms.py
@@ -2522,13 +2522,14 @@ def interleave_cross_path_beats(graph: Graph) -> int:
         # Skip edges between beats in the same intersection group —
         # such beats co-occur in a single scene and have no ordering (#1124).
         from_groups = beat_intersection_groups.get(from_beat, set())
-        if from_groups and not from_groups.isdisjoint(beat_intersection_groups.get(to_beat, set())):
-            shared = from_groups & beat_intersection_groups.get(to_beat, set())
+        to_groups = beat_intersection_groups.get(to_beat, set())
+        shared_groups = from_groups.intersection(to_groups)
+        if shared_groups:
             log.debug(
                 "interleave_skipped_same_intersection",
                 from_beat=from_beat,
                 to_beat=to_beat,
-                groups=sorted(shared),
+                groups=sorted(shared_groups),
             )
             return False
         if _would_create_cycle(from_beat, to_beat, successors, beat_set):

--- a/src/questfoundry/graph/grow_algorithms.py
+++ b/src/questfoundry/graph/grow_algorithms.py
@@ -2488,9 +2488,9 @@ def interleave_cross_path_beats(graph: Graph) -> int:
     # Such edges would create circular prerequisites on shared beats (#1124).
     # A beat can theoretically belong to multiple intersection groups (e.g., grouped
     # by both location and entity), so we track all groups per beat.
-    beat_intersection_groups: dict[str, set[str]] = {}
+    beat_intersection_groups: defaultdict[str, set[str]] = defaultdict(set)
     for edge in graph.get_edges(from_id=None, to_id=None, edge_type="intersection"):
-        beat_intersection_groups.setdefault(edge["from"], set()).add(edge["to"])
+        beat_intersection_groups[edge["from"]].add(edge["to"])
 
     # --- Collect dilemma relationship edges ---
     relationship_edges: list[tuple[str, str, str]] = []  # (dilemma_a, dilemma_b, ordering)

--- a/src/questfoundry/graph/grow_algorithms.py
+++ b/src/questfoundry/graph/grow_algorithms.py
@@ -2483,6 +2483,13 @@ def interleave_cross_path_beats(graph: Graph) -> int:
 
     beat_set = set(beat_nodes.keys())
 
+    # Build intersection-group index (beat → group_id) to avoid creating
+    # predecessor edges between beats that are co-grouped in an intersection.
+    # Such edges would create circular prerequisites on shared beats (#1124).
+    beat_intersection_group: dict[str, str] = {}
+    for edge in graph.get_edges(from_id=None, to_id=None, edge_type="intersection"):
+        beat_intersection_group[edge["from"]] = edge["to"]
+
     # --- Collect dilemma relationship edges ---
     relationship_edges: list[tuple[str, str, str]] = []  # (dilemma_a, dilemma_b, ordering)
     for ordering in ("concurrent", "wraps", "serial"):
@@ -2509,6 +2516,17 @@ def interleave_cross_path_beats(graph: Graph) -> int:
         if (from_beat, to_beat) in existing_predecessors:
             return False
         if from_beat not in beat_set or to_beat not in beat_set:
+            return False
+        # Skip edges between beats in the same intersection group —
+        # such beats co-occur in a single scene and have no ordering (#1124).
+        from_group = beat_intersection_group.get(from_beat)
+        if from_group is not None and from_group == beat_intersection_group.get(to_beat):
+            log.debug(
+                "interleave_skipped_same_intersection",
+                from_beat=from_beat,
+                to_beat=to_beat,
+                group=from_group,
+            )
             return False
         if _would_create_cycle(from_beat, to_beat, successors, beat_set):
             log.warning(

--- a/src/questfoundry/pipeline/stages/grow/deterministic.py
+++ b/src/questfoundry/pipeline/stages/grow/deterministic.py
@@ -66,9 +66,9 @@ async def phase_validate_dag(graph: Graph, model: BaseChatModel) -> GrowPhaseRes
 
 @grow_phase(
     name="interleave_beats",
-    depends_on=["validate_dag"],
+    depends_on=["intersections"],
     is_deterministic=True,
-    priority=1,
+    priority=2,
 )
 async def phase_interleave_beats(
     graph: Graph,
@@ -80,14 +80,20 @@ async def phase_interleave_beats(
     cross-path ordering rules to create ``predecessor`` edges between beats
     that belong to different dilemmas' paths.
 
+    **Runs after intersections** so it can skip predecessor edges between
+    beats that are already co-grouped in an intersection (#1124). This
+    prevents circular prerequisites on shared beats.
+
     Preconditions:
     - Beat DAG validated (Phase 1 passed).
+    - Intersections applied (Phase 3 complete) — intersection groups exist.
     - Dilemma relationship edges exist (concurrent/wraps/serial between dilemmas).
     - Beats are linked to paths via ``belongs_to`` edges.
 
     Postconditions:
     - Cross-path ``predecessor`` edges created according to relationship type.
     - DAG remains acyclic (cycle-inducing edges are skipped with warnings).
+    - No predecessor edges created between beats in the same intersection group.
 
     Invariants:
     - Deterministic: same graph always produces same edges.

--- a/src/questfoundry/pipeline/stages/grow/llm_phases.py
+++ b/src/questfoundry/pipeline/stages/grow/llm_phases.py
@@ -342,7 +342,7 @@ class _LLMPhaseMixin:
             tokens_used=total_tokens,
         )
 
-    @grow_phase(name="scene_types", depends_on=["validate_dag"], priority=3)
+    @grow_phase(name="scene_types", depends_on=["interleave_beats"], priority=3)
     async def _phase_4a_scene_types(self, graph: Graph, model: BaseChatModel) -> GrowPhaseResult:
         """Phase 4a: Tag beats with scene type classification.
 

--- a/src/questfoundry/pipeline/stages/grow/llm_phases.py
+++ b/src/questfoundry/pipeline/stages/grow/llm_phases.py
@@ -85,7 +85,7 @@ class _LLMPhaseMixin:
     - ``PROLOGUE_ID``
     """
 
-    @grow_phase(name="intersections", depends_on=["path_arcs"], priority=7)
+    @grow_phase(name="intersections", depends_on=["validate_dag"], priority=1)
     async def _phase_3_intersections(self, graph: Graph, model: BaseChatModel) -> GrowPhaseResult:
         """Phase 3: Intersection detection (structural, multi-dilemma).
 
@@ -96,10 +96,16 @@ class _LLMPhaseMixin:
         prose differentiation for same-dilemma convergences is handled
         by Phase 8d (residue beats).
 
+        **Runs before interleave_beats** so that the beat DAG is clean (no
+        predecessor edges yet) when intersection compatibility is checked.
+        This eliminates the conditional-prerequisite rejection problem that
+        occurred when interleave ran first (#1124).
+
         Preconditions:
-        - Path arcs computed (Phase 4e complete).
+        - Beat DAG validated (Phase 1 passed).
         - Beats have belongs_to edges with single-dilemma mapping.
         - Beat nodes have locations, entities for candidate clustering.
+        - No predecessor edges exist yet (interleave has not run).
 
         Postconditions:
         - Accepted intersections marked on beat nodes via apply_intersection_mark.
@@ -336,7 +342,7 @@ class _LLMPhaseMixin:
             tokens_used=total_tokens,
         )
 
-    @grow_phase(name="scene_types", depends_on=["validate_dag"], priority=2)
+    @grow_phase(name="scene_types", depends_on=["validate_dag"], priority=3)
     async def _phase_4a_scene_types(self, graph: Graph, model: BaseChatModel) -> GrowPhaseResult:
         """Phase 4a: Tag beats with scene type classification.
 
@@ -422,7 +428,7 @@ class _LLMPhaseMixin:
             tokens_used=tokens,
         )
 
-    @grow_phase(name="narrative_gaps", depends_on=["scene_types"], priority=3)
+    @grow_phase(name="narrative_gaps", depends_on=["scene_types"], priority=4)
     async def _phase_4b_narrative_gaps(self, graph: Graph, model: BaseChatModel) -> GrowPhaseResult:
         """Phase 4b: Detect narrative gaps in path beat sequences.
 
@@ -527,7 +533,7 @@ class _LLMPhaseMixin:
             tokens_used=tokens,
         )
 
-    @grow_phase(name="pacing_gaps", depends_on=["narrative_gaps"], priority=4)
+    @grow_phase(name="pacing_gaps", depends_on=["narrative_gaps"], priority=5)
     async def _phase_4c_pacing_gaps(self, graph: Graph, model: BaseChatModel) -> GrowPhaseResult:
         """Phase 4c: Detect and fix pacing issues (3+ same scene_type in a row).
 
@@ -673,7 +679,7 @@ class _LLMPhaseMixin:
             tokens_used=tokens,
         )
 
-    @grow_phase(name="atmospheric", depends_on=["pacing_gaps"], priority=5)
+    @grow_phase(name="atmospheric", depends_on=["pacing_gaps"], priority=6)
     async def _phase_4d_atmospheric(self, graph: Graph, model: BaseChatModel) -> GrowPhaseResult:
         """Phase 4d: Atmospheric detail for beats.
 
@@ -753,7 +759,7 @@ class _LLMPhaseMixin:
             tokens_used=tokens,
         )
 
-    @grow_phase(name="path_arcs", depends_on=["atmospheric"], priority=6)
+    @grow_phase(name="path_arcs", depends_on=["atmospheric"], priority=7)
     async def _phase_4e_path_arcs(self, graph: Graph, model: BaseChatModel) -> GrowPhaseResult:
         """Phase 4e: Per-path thematic mini-arcs.
 

--- a/src/questfoundry/pipeline/stages/grow/stage.py
+++ b/src/questfoundry/pipeline/stages/grow/stage.py
@@ -150,15 +150,13 @@ class GrowStage(_LLMHelperMixin, _LLMPhaseMixin):
         level import for deterministic free functions (preserving test
         patchability).
 
-        The registry's declared dependencies encode the invariant that
-        phases 4a-4d run BEFORE intersections (3) so that each path is
-        fully elaborated before cross-path weaving.  Gap detection
-        (4a/4b/4c) prevents "conditional prerequisites" — a shared beat
-        depending on a path-specific gap beat — which would cause silent
-        ``requires`` edge drops during arc enumeration and passage DAG
-        cycles.  Phase 4d (atmospheric) annotates beats with sensory
-        detail and entry states that intersections need for shared beats.
-        See: check_intersection_compatibility() invariant, #357/#358/#359.
+        The registry's declared dependencies encode the invariant (#1124)
+        that intersections (3) runs BEFORE interleave_beats (1b), which
+        runs BEFORE gap-detection phases 4a-4d.  Intersection detection on
+        a clean beat DAG (no predecessor edges yet) guarantees the
+        No-Conditional-Prerequisites Invariant always passes — no
+        interleave-created edges can invalidate intersection proposals.
+        See: check_intersection_compatibility() invariant, #1124.
         """
         import questfoundry.pipeline.stages.grow.stage as _this_module
 

--- a/tests/unit/test_grow_algorithms.py
+++ b/tests/unit/test_grow_algorithms.py
@@ -4601,12 +4601,12 @@ class TestInterleavecrossPathBeats:
     def test_skips_predecessor_between_same_intersection_beats(self) -> None:
         """Beats co-grouped in an intersection must not get predecessor edges (#1124).
 
-        When two beats are in the same intersection group they co-occur in a
-        single scene — ordering them relative to each other is meaningless and
-        would create circular prerequisites if they also have cross-dilemma
-        relationship edges.
+        Uses "wraps" relationship so interleave_cross_path_beats would normally
+        create a predecessor(aq_intro → mt_intro) edge between the intro beats
+        of the two dilemmas. With the intersection group in place that edge must
+        be skipped — the skip logic is actually exercised.
         """
-        graph = _make_two_dilemma_graph_with_relationship("concurrent")
+        graph = _make_two_dilemma_graph_with_relationship("wraps")
 
         # Place mt_intro and aq_intro into the same intersection group
         graph.create_node(

--- a/tests/unit/test_grow_algorithms.py
+++ b/tests/unit/test_grow_algorithms.py
@@ -3561,22 +3561,25 @@ class TestConditionalPrerequisiteInvariant:
         )
         assert errors == []
 
-    def test_phase_order_gaps_before_intersections(self, tmp_path: Path) -> None:
-        """Gap-detection phases must execute before the intersections phase."""
+    def test_phase_order_intersections_before_interleave(self, tmp_path: Path) -> None:
+        """Intersections must execute before interleave_beats (#1124).
+
+        Running intersections on a clean beat DAG (no predecessor edges)
+        ensures the conditional-prerequisites check always passes — no
+        interleave-created edges can invalidate intersection proposals.
+        """
         from questfoundry.pipeline.stages.grow import GrowStage
 
         stage = GrowStage(project_path=tmp_path)
         phase_names = [name for _, name in stage._phase_order()]
 
-        gap_phases = ["scene_types", "narrative_gaps", "pacing_gaps"]
         intersection_idx = phase_names.index("intersections")
+        interleave_idx = phase_names.index("interleave_beats")
 
-        for gap_phase in gap_phases:
-            gap_idx = phase_names.index(gap_phase)
-            assert gap_idx < intersection_idx, (
-                f"Phase '{gap_phase}' (index {gap_idx}) must come before "
-                f"'intersections' (index {intersection_idx})"
-            )
+        assert intersection_idx < interleave_idx, (
+            f"'intersections' (index {intersection_idx}) must come before "
+            f"'interleave_beats' (index {interleave_idx})"
+        )
 
     def test_lifts_orphan_prerequisite(self) -> None:
         """Prerequisite with no belongs_to edges is lifted to all paths."""
@@ -4593,4 +4596,43 @@ class TestInterleavecrossPathBeats:
         }
         assert edges_from_aq_intro == set(), (
             f"Expected no predecessor edges created from same-dilemma hint, got {edges_from_aq_intro}"
+        )
+
+    def test_skips_predecessor_between_same_intersection_beats(self) -> None:
+        """Beats co-grouped in an intersection must not get predecessor edges (#1124).
+
+        When two beats are in the same intersection group they co-occur in a
+        single scene — ordering them relative to each other is meaningless and
+        would create circular prerequisites if they also have cross-dilemma
+        relationship edges.
+        """
+        graph = _make_two_dilemma_graph_with_relationship("concurrent")
+
+        # Place mt_intro and aq_intro into the same intersection group
+        graph.create_node(
+            "intersection_group::mt_intro--aq_intro",
+            {
+                "type": "intersection_group",
+                "raw_id": "mt_intro--aq_intro",
+                "beat_ids": ["beat::mt_intro", "beat::aq_intro"],
+                "shared_entities": [],
+                "rationale": "Both beats open at the same market square.",
+                "resolved_location": "market square",
+            },
+        )
+        graph.add_edge("intersection", "beat::mt_intro", "intersection_group::mt_intro--aq_intro")
+        graph.add_edge("intersection", "beat::aq_intro", "intersection_group::mt_intro--aq_intro")
+
+        edges_before = {(e["from"], e["to"]) for e in graph.get_edges(edge_type="predecessor")}
+        interleave_cross_path_beats(graph)
+        edges_after = {(e["from"], e["to"]) for e in graph.get_edges(edge_type="predecessor")}
+
+        new_edges = edges_after - edges_before
+        # Neither intersection beat should be ordered relative to the other
+        same_intersection_edges = {
+            (f, t) for f, t in new_edges if {f, t} <= {"beat::mt_intro", "beat::aq_intro"}
+        }
+        assert same_intersection_edges == set(), (
+            f"Expected no predecessor edges between co-intersected beats, "
+            f"got {same_intersection_edges}"
         )

--- a/tests/unit/test_grow_registry.py
+++ b/tests/unit/test_grow_registry.py
@@ -230,19 +230,20 @@ class TestGlobalRegistry:
         assert errors == [], f"Registry validation errors: {errors}"
 
     def test_global_registry_execution_order_matches_expected(self) -> None:
-        """Execution order matches the post-#1105 phase structure (15 phases).
+        """Execution order matches the post-#1124 phase structure (15 phases).
 
-        interleave_beats added in #1105; collapse_linear_beats moved to POLISH in #1109.
+        intersections moved before interleave_beats in #1124 so the beat DAG
+        is clean (no predecessor edges) when intersection compatibility runs.
         """
         expected = [
             "validate_dag",
+            "intersections",
             "interleave_beats",
             "scene_types",
             "narrative_gaps",
             "pacing_gaps",
             "atmospheric",
             "path_arcs",
-            "intersections",
             "entity_arcs",
             "enumerate_arcs",
             "divergence",

--- a/tests/unit/test_grow_stage.py
+++ b/tests/unit/test_grow_stage.py
@@ -183,7 +183,7 @@ class TestGrowStageExecute:
 
 class TestGrowStagePhaseOrder:
     def test_phase_order_returns_correct_count(self) -> None:
-        """15 phases after adding interleave_beats (#1105)."""
+        """15 phases; intersections moved before interleave_beats in #1124."""
         stage = GrowStage()
         phases = stage._phase_order()
         assert len(phases) == 15
@@ -193,13 +193,13 @@ class TestGrowStagePhaseOrder:
         names = [name for _, name in stage._phase_order()]
         assert names == [
             "validate_dag",
+            "intersections",
             "interleave_beats",
             "scene_types",
             "narrative_gaps",
             "pacing_gaps",
             "atmospheric",
             "path_arcs",
-            "intersections",
             "entity_arcs",
             "enumerate_arcs",
             "divergence",


### PR DESCRIPTION
## Summary

- Moves `intersections` phase before `interleave_beats` in the GROW execution order
- Running intersections on a clean beat DAG (no predecessor edges) eliminates the conditional-prerequisite rejection problem — `check_intersection_compatibility` always passes
- `interleave_cross_path_beats` now skips predecessor edges between beats sharing an intersection group (using `defaultdict[str, set[str]]` for correct multi-group membership)
- `scene_types` now explicitly `depends_on=["interleave_beats"]` — ordering is structural, not a priority tiebreak
- Stale docstrings in `stage.py` and `grow.md` updated to reflect new invariant

**New execution order**: `validate_dag → intersections → interleave_beats → scene_types → narrative_gaps → pacing_gaps → atmospheric → path_arcs → entity_arcs → …`

## Design Conformance

`architect-reviewer` sign-off on final branch state: **8/8 CONFORMANT, 0 MISSING, 0 DEAD** against `docs/design/procedures/grow.md` Phase 3 and Phase 1b requirements.

| # | Requirement | Status |
|---|---|---|
| 1 | Phase 3 executes before Phase 1b (structural dependency chain) | ✅ CONFORMANT |
| 2 | No-Conditional-Prerequisites Invariant: no predecessor edges during intersection check | ✅ CONFORMANT |
| 3 | interleave-created edges cannot invalidate intersection proposals | ✅ CONFORMANT |
| 4 | Execution order matches design doc: `validate_dag → intersections → interleave_beats → scene_types → …` | ✅ CONFORMANT |
| 5 | Phase 3 input: "No predecessor edges exist yet (interleave has not run)" | ✅ CONFORMANT |
| 6 | interleave skips predecessor edges between beats sharing an intersection group | ✅ CONFORMANT |
| 7 | scene_types depends on interleave_beats (structural, not priority-based) | ✅ CONFORMANT |
| 8 | `_phase_order()` docstring reflects new invariant | ✅ CONFORMANT |

Data flow verified: Phase 3 creates `intersection` edges → `interleave_cross_path_beats` reads them via `beat_intersection_groups` index before adding any predecessor edges. Ordering enforced by `depends_on` chain.

Fixture divergence: none. Test uses `"wraps"` relationship to ensure interleave would normally create `predecessor(aq_intro → mt_intro)`, then verifies the intersection-group skip prevents it.

## Deferred

- `interleave_cycle_skipped` → hard error: tracked in #1129. The `resolve_temporal_hints` phase in #1128 eliminates temporal-hint-caused cycles upstream; remaining cases tracked there.

## Test plan

- [x] `test_phase_order_intersections_before_interleave` — structural ordering enforced via registry
- [x] `test_skips_predecessor_between_same_intersection_beats` — uses `"wraps"` to confirm skip logic is actually exercised
- [x] `test_global_registry_execution_order_matches_expected` — 15-phase order updated
- [x] `test_phase_order_names` — updated to new order
- [x] All 304 unit tests pass

Closes #1124

🤖 Generated with [Claude Code](https://claude.com/claude-code)