### PR TITLE
fix: entity_arcs depends_on interleave_beats, not intersections

### DIFF
--- a/src/questfoundry/pipeline/stages/grow/llm_phases.py
+++ b/src/questfoundry/pipeline/stages/grow/llm_phases.py
@@ -1015,18 +1015,19 @@ class _LLMPhaseMixin:
             tokens_used=total_tokens,
         )
 
-    @grow_phase(name="entity_arcs", depends_on=["intersections"], priority=8)
+    @grow_phase(name="entity_arcs", depends_on=["interleave_beats"], priority=8)
     async def _phase_4f_entity_arcs(self, graph: Graph, model: BaseChatModel) -> GrowPhaseResult:
         """Phase 4f: Per-entity arc trajectories on each path.
 
-        Runs post-intersection so beat topology is final. For each path,
-        selects eligible entities (deterministic), then asks the LLM to
-        generate arc_line and pivot_beat per entity.
+        Runs post-interleave so beat topology (including cross-path predecessor
+        edges) is final. For each path, selects eligible entities
+        (deterministic), then asks the LLM to generate arc_line and pivot_beat
+        per entity.
 
         Preconditions:
-        - Intersections computed (Phase 3 complete), beat topology final.
+        - Interleave complete, predecessor edges exist for path sequencing.
         - Entity nodes have entity_type and concept fields.
-        - Path nodes have beat sequences via belongs_to + requires.
+        - Path nodes have beat sequences via belongs_to + predecessor.
 
         Postconditions:
         - Each path annotated with entity_arcs list.


### PR DESCRIPTION
## Summary

- `entity_arcs` had `depends_on=["intersections"]` but reads `predecessor` edges via `topological_sort_beats`, which are only created by `interleave_beats`
- The phase ran correctly by accident (priority 8 vs 3), not by structural guarantee
- Fix: `depends_on=["interleave_beats"]` + update docstring to reflect the actual precondition

## Design Conformance

Pure registry metadata fix — no behavioral change to pipeline logic. No architect-reviewer gate required.

Closes #1131

🤖 Generated with [Claude Code](https://claude.com/claude-code)