### PR TITLE
fix: replace temporal hint detection with conflict graph + minimum drop set

### DIFF
--- a/docs/design/procedures/grow.md
+++ b/docs/design/procedures/grow.md
@@ -131,9 +131,10 @@ If the non-canonical answer is not promoted to a path in SEED, that dilemma has 
 > detection). Running intersections on a clean beat DAG (no predecessor edges
 > yet) ensures the No-Conditional-Prerequisites Invariant always passes (#1124).
 > A new **`resolve_temporal_hints`** phase runs between intersections and
-> interleave: it detects cycles in temporal hint proposals and calls the LLM to
-> choose which hints to relax before interleave creates any edges. This
-> eliminates silent `interleave_cycle_skipped` drops in valid runs (#1123).
+> interleave: it detects cycles in temporal hint proposals deterministically
+> and calls the LLM only for swap pairs (hints that cycle together but not
+> alone). This eliminates silent `interleave_cycle_skipped` drops in valid runs
+> (#1123) by resolving all conflicts before interleave creates any edges.
 > Phase numbering is preserved for historical continuity; execution order is
 > defined in `_phase_order()`.
 > Actual order: `validate_dag → intersections → resolve_temporal_hints →
@@ -241,6 +242,66 @@ causes `passage_dag_cycles` failures in validation.
 - **Split lead-ins (#361):** Create path-specific copies of the shared beat
   so the path-specific version keeps the dependency while others are
   independent.  Risk: increases beat count and complexity.
+
+---
+
+### Phase 3b: Resolve Temporal Hints
+
+**Purpose:** Detect cycles in temporal hint proposals and resolve them deterministically (mandatory drops) or via LLM consultation (swap pairs) before interleave applies any cross-path ordering edges.
+
+**Input:** Beat graph with intersections applied, no predecessor edges yet (Phase 3 complete). Beats may carry `temporal_hint` fields (optional dict with `position` and `relative_to` keys).
+
+**Algorithm:**
+
+**Step 1 — Build base DAG:**
+Simulate all non-hint ordering edges without any temporal hints. This includes:
+- Serial relationships (last beats of A precede first beats of B)
+- Wraps relationships (A's intro precedes B's intro; B's final beats precede A's commits)
+- Heuristic commit-ordering edges (deterministic ordering of concurrent dilemmas by ID)
+
+This is the stable substrate against which all temporal hints will be tested.
+
+**Step 2 — Solo hint testing:**
+For each beat carrying a temporal hint, test the hint in isolation against the base DAG. If the hint would create a cycle alone (no interference from other hints), the hint is mandatory-drop — the dilemma ordering relationships take precedence over the temporal relationship.
+
+**Step 3 — Pairwise testing:**
+For surviving hints, test them in pairs. For each pair (A, B):
+- Test A's hint when B is absent: does A cycle?
+- Test B's hint when A is absent: does B cycle?
+- If both survive solo but both cycle together, they form a swap pair — a genuine narrative trade-off where exactly one must be dropped.
+
+**Step 4 — Minimum drop set (greedy heuristic):**
+Apply a greedy minimum feedback arc set heuristic to the conflict graph. For swap pairs identified in Step 3, determine a default drop candidate using:
+1. Hint strength: `before_commit` or `after_commit` > `before_introduce` or `after_introduce`
+2. Beat role: spine or anchor beats > branch-only beats (more narratively central)
+3. Alphabetical tiebreak on beat ID
+
+**Step 5 — LLM consultation (swap pairs only):**
+For each swap pair, present the LLM with a binary choice: "Drop exactly one of Beat A or Beat B's temporal hint. Which one should be sacrificed?" The LLM receives:
+- Both beat summaries and their temporal requests
+- The narrative consequence of each drop
+- Default recommendation from Step 4
+
+LLM returns `ConflictGroupResolution` per pair. Invalid responses (both, neither, neither valid beat ID) fall back to the mechanical default from Step 4.
+
+**Step 6 — Apply drops:**
+Strip `temporal_hint` (set to `None`) from all beats marked for dropping: mandatory drops from Step 2, plus LLM-selected drops from Step 5.
+
+**Output:** Beat graph with a consistent (acyclic) set of temporal hints. No subsequent edge creation will silently drop hints due to cycles.
+
+**LLM involvement:** Yes, for swap pairs only. Mandatory drops are deterministic (no LLM call).
+
+**Human Gate:** No (consumed programmatically by interleave phase).
+
+#### Why Mandatory vs. Swap Distinction?
+
+Hints that cycle against the base DAG alone represent a narrative impossibility: the dilemma ordering structure is fixed; temporal relationships requesting contradictory orderings cannot all be honored. No narrative choice is possible — one must be dropped.
+
+Hints that only cycle in combination with another hint represent a genuine creative trade-off. The LLM is better positioned than a deterministic tiebreaker to choose which temporal relationship matters more to the story's narrative arc. This aligns with the core philosophy: "LLM as collaborator under constraint."
+
+#### Temporal Hint Acyclicity Invariant
+
+After `resolve_temporal_hints` completes, the set of surviving temporal hints must be acyclic — i.e., applying all surviving hint edges to the base DAG produces no cycles. This is verified by simulating edge application. If the postcondition fails, `TemporalHintResolutionInvariantError` is raised. This is a hard pipeline failure; silent degradation (skipping cyclic hints at interleave time) is not acceptable.
 
 ---
 

--- a/prompts/templates/grow_phase_temporal_resolution.yaml
+++ b/prompts/templates/grow_phase_temporal_resolution.yaml
@@ -1,5 +1,5 @@
 name: grow_phase_temporal_resolution
-description: Resolve temporal hint ordering conflicts by choosing which hints to relax
+description: Resolve temporal hint ordering conflicts by choosing which hints to relax (swap pairs only)
 
 system: |
   You are resolving ordering conflicts between temporal hints on story beats.
@@ -13,41 +13,68 @@ system: |
   - `after_introduce` — this beat should happen after the other dilemma is introduced
 
   Temporal hints are **advisory ordering preferences**, not hard constraints. When two
-  hints contradict each other (A wants to be after X, but X already must be after A),
-  one must be relaxed. The story continues; only the specific pacing preference is lost.
+  hints contradict each other, one must be relaxed. The story continues; only the
+  specific pacing preference is lost.
 
-  ## Conflicts to Resolve
-  {conflict_list}
+  ## Your Task: Resolve Swap Pairs
 
-  ## Conflicting Beat IDs
-  Only drop hints for beats listed in this set: {valid_beat_ids}
+  Mandatory drops have already been applied. You are only presented with **swap pairs**
+  — beats where EITHER hint can survive but not both. Drop the MINIMUM number of hints.
 
-  ## How to Choose
-  - Prefer dropping `before_introduce` or `after_introduce` hints over
-    `before_commit` or `after_commit` hints — commit moments are stronger
-    narrative anchors.
-  - If both hints in a conflict are equal strength, drop the hint belonging to the
-    beat that appears later in the story (higher beat number in the ID, e.g. `_beat_03`
-    over `_beat_01`).
-  - Drop the minimum number of hints needed to resolve all conflicts.
+  ## Decision Rules (apply in order)
+  1. Prefer keeping `before_commit` / `after_commit` hints — these are stronger narrative
+     anchors. Drop `before_introduce` / `after_introduce` first.
+  2. Among equal-strength hints: keep the hint on the more narratively important beat
+     (spine/canonical beats > branch-only beats).
+  3. Drop the hint whose removal leaves the story feeling least disrupted.
 
-  ## Output Format
-  Return a JSON object:
+  ## EXAMPLE (synthetic — do not use these IDs):
+  ### Swap Pair P_example — DROP EXACTLY ONE:
+    Option A: `beat::fog_path_a_beat_01` | hint: `after_commit dilemma::letter` [STRONG: after/before_commit]
+              Summary: The envoy receives the fog warning after the letter is committed.
+    Option B: `beat::letter_path_b_beat_02` | hint: `before_commit dilemma::fog` [STRONG: after/before_commit]
+              Summary: The letter is drafted before the fog warning reaches the council.
+    Mechanical default: drop Option A (based on hint strength + beat role heuristic)
+
+  Example resolution:
   {{
-    "hints_to_drop": ["beat::id1", "beat::id2"]
+    "resolutions": [
+      {{
+        "group_id": "P_example",
+        "drop_beat_id": "beat::fog_path_a_beat_01",
+        "reason": "The fog warning timing is less critical to narrative causality than the letter drafting sequence."
+      }}
+    ]
   }}
 
-  - `hints_to_drop`: list of beat IDs whose temporal hints should be cleared.
-    May be empty if no hints need dropping (all conflicts already resolved by
-    dropping earlier hints in the list).
+  ## Swap Pairs to Resolve
+  {swap_pairs_context}
+
+  ## Output Format
+  Return a JSON object with one resolution per swap pair listed above:
+  {{
+    "resolutions": [
+      {{
+        "group_id": "P1",
+        "drop_beat_id": "beat::...",
+        "reason": "one sentence explaining the narrative choice"
+      }}
+    ]
+  }}
+
+  Rules:
+  - One entry per swap pair (P1, P2, ...) listed above
+  - `drop_beat_id` MUST be one of the two Option beat IDs listed for that pair
+  - `reason` must be exactly one sentence
+  - Return ONLY a valid JSON object — no prose before or after
 
 user: |
-  Choose which temporal hints to drop to resolve all ordering conflicts.
+  Choose which temporal hints to drop to resolve all swap pair conflicts.
 
   REMINDER:
   - Return ONLY a valid JSON object — no prose before or after.
-  - Use ONLY beat IDs from the Valid Beat IDs section.
-  - Drop the MINIMUM number of hints to resolve all conflicts.
+  - Use ONLY beat IDs from the Option A / Option B lines above.
+  - One resolution per swap pair.
   - Prefer keeping `after_commit` / `before_commit` hints over `introduce` hints.
 
 components: []

--- a/src/questfoundry/graph/errors.py
+++ b/src/questfoundry/graph/errors.py
@@ -269,6 +269,32 @@ class EdgeEndpointError(GraphIntegrityError):
         return "\n".join(lines)
 
 
+class TemporalHintResolutionInvariantError(Exception):
+    """Raised when temporal hint resolution fails its postcondition.
+
+    After ``resolve_temporal_hints`` applies mandatory drops and LLM-chosen
+    swaps, ``verify_hints_acyclic`` must confirm no surviving hints still
+    create cycles.  If that check fails, the pipeline cannot continue — silent
+    degradation (dropping surviving hints without LLM consent) would violate
+    the story-structure contract.
+
+    Attributes:
+        still_cyclic: Beat IDs whose hints still cycle after resolution.
+        dropped: Beat IDs whose hints were dropped during resolution.
+    """
+
+    def __init__(self, still_cyclic: list[str], dropped: set[str]) -> None:
+        self.still_cyclic = still_cyclic
+        self.dropped = dropped
+        ids = ", ".join(f"`{b}`" for b in sorted(still_cyclic))
+        super().__init__(
+            f"Temporal hint resolution invariant violated: {len(still_cyclic)} hint(s) "
+            f"still cycle after resolution — {ids}. "
+            f"Dropped: {sorted(dropped)}. "
+            "This is a pipeline bug; please report with graph state."
+        )
+
+
 @dataclass
 class GraphCorruptionError(Exception):
     """Raised when post-mutation invariant checks detect graph corruption.

--- a/src/questfoundry/graph/grow_algorithms.py
+++ b/src/questfoundry/graph/grow_algorithms.py
@@ -3105,7 +3105,9 @@ def verify_hints_acyclic(
     means all surviving hints are consistent.
 
     Args:
-        graph: The story graph (temporal_hint values not yet stripped).
+        graph: The story graph.  Dropped beats may already have
+            ``temporal_hint=None`` (already stripped) or may still carry their
+            hint value; either way only ``surviving_beat_ids`` are simulated.
         surviving_beat_ids: Beat IDs whose hints have NOT been dropped.
 
     Returns:

--- a/src/questfoundry/graph/grow_algorithms.py
+++ b/src/questfoundry/graph/grow_algorithms.py
@@ -2680,6 +2680,514 @@ def detect_temporal_hint_conflicts(graph: Graph) -> list[TemporalHintConflict]:
     return conflicts
 
 
+# ---------------------------------------------------------------------------
+# Conflict-graph-based detection (replaces detect_temporal_hint_conflicts)
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class HintConflict:
+    """A pair of hint-bearing beats that cannot both survive.
+
+    When ``mandatory`` is True, ``beat_a`` must be dropped regardless of
+    ``beat_b`` — its hint creates a cycle even in isolation against the
+    base DAG (all non-hint edges).  When ``mandatory`` is False, this is a
+    swap pair: either beat_a or beat_b may survive, but not both.
+
+    Attributes:
+        beat_a: First beat in the conflict (the mechanically-preferred drop).
+        beat_b: Second beat in the conflict (None for mandatory solo drops).
+        mandatory: True if beat_a MUST be dropped (no swap available).
+        default_drop: beat_a or beat_b — the heuristically-preferred drop.
+    """
+
+    beat_a: str
+    beat_b: str | None
+    mandatory: bool
+    default_drop: str
+
+
+@dataclass
+class HintConflictResult:
+    """Full conflict analysis produced by ``build_hint_conflict_graph``.
+
+    Attributes:
+        conflicts: All HintConflict objects (mandatory + swap pairs).
+        mandatory_drops: Beat IDs that must be dropped (no swap available).
+        swap_pairs: (beat_a, beat_b) pairs where LLM may choose which to drop.
+        minimum_drop_set: Mechanical MDS: mandatory_drops + default choices for
+            each swap pair.  This is applied when no LLM is available.
+    """
+
+    conflicts: list[HintConflict]
+    mandatory_drops: set[str]
+    swap_pairs: list[tuple[str, str]]
+    minimum_drop_set: set[str]
+
+
+def _hint_strength(position: str) -> int:
+    """Return hint strength: 2=commit (strong), 1=introduce (weak)."""
+    return 2 if "commit" in position else 1
+
+
+def _is_canonical_beat(
+    beat_id: str, path_beats_map: dict[str, list[str]], canonical_paths: set[str]
+) -> bool:
+    """Return True if the beat belongs to at least one canonical path."""
+    for path_id, beats in path_beats_map.items():
+        if beat_id in beats and path_id in canonical_paths:
+            return True
+    return False
+
+
+def build_hint_conflict_graph(graph: Graph) -> HintConflictResult:
+    """Build a conflict graph for temporal hints and compute the minimum drop set.
+
+    Unlike ``detect_temporal_hint_conflicts`` (single-pass, cascade-blind),
+    this function:
+
+    1. Builds a *base DAG* by simulating all non-hint edges (serial, wraps,
+       heuristic commit-ordering) without any hints.
+    2. Tests each hint alone against the base DAG — hints that cycle alone
+       are mandatory drops.
+    3. Tests each pair of surviving hints for mutual exclusion — if A cycles
+       when B is present and B cycles when A is present, they form a swap pair.
+    4. Applies a greedy heuristic to choose ``default_drop`` for each swap pair:
+       prefer dropping introduce-hints over commit-hints, and branch beats over
+       spine/canonical beats.
+    5. Returns a ``HintConflictResult`` with mandatory_drops, swap_pairs, and
+       minimum_drop_set.
+
+    Args:
+        graph: The story graph with beat nodes carrying temporal_hint values.
+
+    Returns:
+        HintConflictResult describing all conflicts.  ``conflicts`` is empty
+        if all hints are consistent with the base DAG.
+    """
+    beat_nodes = graph.get_nodes_by_type("beat")
+    if not beat_nodes:
+        return HintConflictResult(
+            conflicts=[], mandatory_drops=set(), swap_pairs=[], minimum_drop_set=set()
+        )
+
+    dilemma_paths = build_dilemma_paths(graph)
+    if len(dilemma_paths) < 2:
+        return HintConflictResult(
+            conflicts=[], mandatory_drops=set(), swap_pairs=[], minimum_drop_set=set()
+        )
+
+    path_beats_map: dict[str, list[str]] = defaultdict(list)
+    for edge in graph.get_edges(from_id=None, to_id=None, edge_type="belongs_to"):
+        path_beats_map[edge["to"]].append(edge["from"])
+
+    beat_id_to_dilemmas: dict[str, set[str]] = defaultdict(set)
+    for dil_id, paths in dilemma_paths.items():
+        for path_id in paths:
+            for bid in path_beats_map.get(path_id, []):
+                beat_id_to_dilemmas[bid].add(dil_id)
+
+    # Determine canonical paths for heuristic scoring
+    path_nodes = graph.get_nodes_by_type("path")
+    canonical_paths: set[str] = {
+        pid for pid, data in path_nodes.items() if data.get("is_canonical", False)
+    }
+
+    # Build intersection-group index
+    beat_intersection_groups: defaultdict[str, set[str]] = defaultdict(set)
+    for edge in graph.get_edges(from_id=None, to_id=None, edge_type="intersection"):
+        beat_intersection_groups[edge["from"]].add(edge["to"])
+
+    beat_set = set(beat_nodes.keys())
+
+    # Collect relationship edges in processing order (same as interleave_cross_path_beats)
+    relationship_edges: list[tuple[str, str, str]] = []
+    for ordering in ("concurrent", "wraps", "serial"):
+        for edge in graph.get_edges(from_id=None, to_id=None, edge_type=ordering):
+            a = edge["from"]
+            b = edge["to"]
+            if a in dilemma_paths and b in dilemma_paths:
+                relationship_edges.append((a, b, ordering))
+
+    # Helper: build a fresh base DAG (all non-hint edges, no hints applied)
+    def _build_base_dag() -> tuple[set[tuple[str, str]], dict[str, set[str]]]:
+        existing: set[tuple[str, str]] = set()
+        for edge in graph.get_edges(from_id=None, to_id=None, edge_type="predecessor"):
+            existing.add((edge["from"], edge["to"]))
+        succ: dict[str, set[str]] = {bid: set() for bid in beat_nodes}
+        for from_id, to_id in existing:
+            if from_id in succ and to_id in succ:
+                succ[to_id].add(from_id)
+
+        def _valid(from_b: str, to_b: str) -> bool:
+            if from_b == to_b or (from_b, to_b) in existing:
+                return False
+            if from_b not in beat_set or to_b not in beat_set:
+                return False
+            return not beat_intersection_groups.get(from_b, set()).intersection(
+                beat_intersection_groups.get(to_b, set())
+            )
+
+        def _sim(from_b: str, to_b: str) -> None:
+            if not _valid(from_b, to_b):
+                return
+            if _would_create_cycle(from_b, to_b, succ, beat_set):
+                return
+            existing.add((from_b, to_b))
+            succ[to_b].add(from_b)
+
+        for dilemma_a, dilemma_b, ordering in relationship_edges:
+            paths_a = dilemma_paths.get(dilemma_a, [])
+            paths_b = dilemma_paths.get(dilemma_b, [])
+            if not paths_a or not paths_b:
+                continue
+            ordered_a = [_get_path_beats_ordered(graph, p, path_beats_map) for p in paths_a]
+            ordered_b = [_get_path_beats_ordered(graph, p, path_beats_map) for p in paths_b]
+            all_beats_a = [b for seq in ordered_a for b in seq]
+            all_beats_b = [b for seq in ordered_b for b in seq]
+            if not all_beats_a or not all_beats_b:
+                continue
+
+            if ordering == "serial":
+                for last_a in sorted({seq[-1] for seq in ordered_a if seq}):
+                    for first_b in sorted({seq[0] for seq in ordered_b if seq}):
+                        _sim(first_b, last_a)
+            elif ordering == "wraps":
+                for first_a in sorted({seq[0] for seq in ordered_a if seq}):
+                    for first_b in sorted({seq[0] for seq in ordered_b if seq}):
+                        _sim(first_b, first_a)
+                commits_a = set(_commits_beats_for_dilemma(all_beats_a, dilemma_a, beat_nodes))
+                for last_b in sorted({seq[-1] for seq in ordered_b if seq}):
+                    for commit_a in sorted(commits_a):
+                        _sim(commit_a, last_b)
+            elif ordering == "concurrent":
+                # Heuristic commit-ordering only (no hints)
+                commits_a = set(_commits_beats_for_dilemma(all_beats_a, dilemma_a, beat_nodes))
+                commits_b = set(_commits_beats_for_dilemma(all_beats_b, dilemma_b, beat_nodes))
+                if commits_a and commits_b:
+                    if dilemma_a < dilemma_b:
+                        prereq_commits, dependent_commits = commits_a, commits_b
+                    else:
+                        prereq_commits, dependent_commits = commits_b, commits_a
+                    for prereq in sorted(prereq_commits):
+                        for dependent in sorted(dependent_commits):
+                            _sim(dependent, prereq)
+        return existing, succ
+
+    # Collect all candidate hint edges across all concurrent pairs
+    all_hint_edges: list[_HintEdge] = []
+    for dilemma_a, dilemma_b, ordering in relationship_edges:
+        if ordering != "concurrent":
+            continue
+        paths_a = dilemma_paths.get(dilemma_a, [])
+        paths_b = dilemma_paths.get(dilemma_b, [])
+        if not paths_a or not paths_b:
+            continue
+        ordered_a = [_get_path_beats_ordered(graph, p, path_beats_map) for p in paths_a]
+        ordered_b = [_get_path_beats_ordered(graph, p, path_beats_map) for p in paths_b]
+        all_beats_a = [b for seq in ordered_a for b in seq]
+        all_beats_b = [b for seq in ordered_b for b in seq]
+        if not all_beats_a or not all_beats_b:
+            continue
+        for hint_edge in _iter_temporal_hint_edges(
+            all_beats_a + all_beats_b,
+            beat_nodes,
+            dilemma_a,
+            dilemma_b,
+            all_beats_a,
+            ordered_a,
+            all_beats_b,
+            ordered_b,
+            beat_id_to_dilemmas,
+        ):
+            all_hint_edges.append(hint_edge)
+
+    if not all_hint_edges:
+        return HintConflictResult(
+            conflicts=[], mandatory_drops=set(), swap_pairs=[], minimum_drop_set=set()
+        )
+
+    # Deduplicate hint edges by beat_id — keep first occurrence per beat
+    seen_beat_ids: set[str] = set()
+    unique_hints: list[_HintEdge] = []
+    for he in all_hint_edges:
+        if he.beat_id not in seen_beat_ids:
+            seen_beat_ids.add(he.beat_id)
+            unique_hints.append(he)
+
+    # Base DAG (no hints)
+    base_existing, base_succ = _build_base_dag()
+
+    def _cycles_alone(hint: _HintEdge) -> bool:
+        """Test whether a single hint cycles against the base DAG."""
+        from_b, to_b = hint.from_beat, hint.to_beat
+        if from_b == to_b or from_b not in beat_set or to_b not in beat_set:
+            return False
+        if (from_b, to_b) in base_existing:
+            return False
+        if beat_intersection_groups.get(from_b, set()).intersection(
+            beat_intersection_groups.get(to_b, set())
+        ):
+            return False
+        return _would_create_cycle(from_b, to_b, base_succ, beat_set)
+
+    # Helper: test hint against base DAG + a set of additional edges from other hints
+    def _cycles_with_hints_applied(hint: _HintEdge, applied_hints: list[_HintEdge]) -> bool:
+        """Test whether hint cycles when applied_hints are also in the DAG."""
+        # Build extended DAG: base + applied_hints edges
+        ext_existing = set(base_existing)
+        ext_succ: dict[str, set[str]] = {bid: set(s) for bid, s in base_succ.items()}
+        for h in applied_hints:
+            fb, tb = h.from_beat, h.to_beat
+            if fb == tb or fb not in beat_set or tb not in beat_set:
+                continue
+            if (fb, tb) in ext_existing:
+                continue
+            if beat_intersection_groups.get(fb, set()).intersection(
+                beat_intersection_groups.get(tb, set())
+            ):
+                continue
+            if not _would_create_cycle(fb, tb, ext_succ, beat_set):
+                ext_existing.add((fb, tb))
+                ext_succ[tb].add(fb)
+        # Now test hint against extended DAG
+        from_b, to_b = hint.from_beat, hint.to_beat
+        if from_b == to_b or from_b not in beat_set or to_b not in beat_set:
+            return False
+        if (from_b, to_b) in ext_existing:
+            return False
+        if beat_intersection_groups.get(from_b, set()).intersection(
+            beat_intersection_groups.get(to_b, set())
+        ):
+            return False
+        return _would_create_cycle(from_b, to_b, ext_succ, beat_set)
+
+    # Phase 1: identify mandatory solo drops
+    mandatory_drop_ids: set[str] = set()
+    survivors: list[_HintEdge] = []
+    for hint in unique_hints:
+        if _cycles_alone(hint):
+            mandatory_drop_ids.add(hint.beat_id)
+        else:
+            survivors.append(hint)
+
+    # Phase 2: find mutual exclusion pairs among survivors
+    # Two hints A and B are mutual exclusion if A cycles given B AND B cycles given A.
+    # For simplicity and correctness we test all pairs in O(n^2).
+    swap_pairs_result: list[tuple[str, str]] = []
+    # Track which beats are already in a swap pair (to avoid duplicates)
+    in_swap_pair: set[str] = set()
+
+    for i, hint_a in enumerate(survivors):
+        if hint_a.beat_id in in_swap_pair:
+            continue
+        for hint_b in survivors[i + 1 :]:
+            if hint_b.beat_id in in_swap_pair:
+                continue
+            # Mutual exclusion: A cycles when B is applied, B cycles when A is applied
+            a_cycles_with_b = _cycles_with_hints_applied(hint_a, [hint_b])
+            b_cycles_with_a = _cycles_with_hints_applied(hint_b, [hint_a])
+            if a_cycles_with_b and b_cycles_with_a:
+                swap_pairs_result.append((hint_a.beat_id, hint_b.beat_id))
+                in_swap_pair.add(hint_a.beat_id)
+                in_swap_pair.add(hint_b.beat_id)
+                break
+
+    # Phase 3: compute default_drop per swap pair using heuristics
+    # Prefer dropping: introduce > commit; branch-only > canonical
+    def _drop_score(beat_id: str, hint: _HintEdge) -> tuple[int, int, str]:
+        """Lower score = preferred to drop (higher priority for dropping)."""
+        strength = _hint_strength(hint.position)  # 2=commit, 1=introduce; lower = prefer drop
+        is_canonical = _is_canonical_beat(beat_id, path_beats_map, canonical_paths)
+        canonical_score = 1 if is_canonical else 0  # 0=branch (prefer drop), 1=canonical (keep)
+        return (strength, canonical_score, beat_id)
+
+    hint_by_beat: dict[str, _HintEdge] = {h.beat_id: h for h in unique_hints}
+
+    def _choose_default_drop(beat_a_id: str, beat_b_id: str) -> str:
+        ha = hint_by_beat.get(beat_a_id)
+        hb = hint_by_beat.get(beat_b_id)
+        if ha is None:
+            return beat_a_id
+        if hb is None:
+            return beat_b_id
+        score_a = _drop_score(beat_a_id, ha)
+        score_b = _drop_score(beat_b_id, hb)
+        # Lower score → prefer to drop
+        return beat_a_id if score_a <= score_b else beat_b_id
+
+    # Build final conflict list
+    conflicts: list[HintConflict] = []
+    mds: set[str] = set(mandatory_drop_ids)
+
+    for bid in sorted(mandatory_drop_ids):
+        conflicts.append(HintConflict(beat_a=bid, beat_b=None, mandatory=True, default_drop=bid))
+        mds.add(bid)
+
+    for beat_a_id, beat_b_id in swap_pairs_result:
+        default = _choose_default_drop(beat_a_id, beat_b_id)
+        conflicts.append(
+            HintConflict(
+                beat_a=beat_a_id,
+                beat_b=beat_b_id,
+                mandatory=False,
+                default_drop=default,
+            )
+        )
+        mds.add(default)
+
+    return HintConflictResult(
+        conflicts=conflicts,
+        mandatory_drops=mandatory_drop_ids,
+        swap_pairs=swap_pairs_result,
+        minimum_drop_set=mds,
+    )
+
+
+def verify_hints_acyclic(
+    graph: Graph,
+    surviving_beat_ids: set[str],
+) -> list[str]:
+    """Re-run hint simulation with only surviving beats and return still-cyclic beat IDs.
+
+    This is the postcondition check called after LLM resolution.  It re-runs
+    the full interleave simulation (base DAG + surviving hints) and returns the
+    beat IDs whose hints would still create a cycle.  An empty return value
+    means all surviving hints are consistent.
+
+    Args:
+        graph: The story graph (temporal_hint values not yet stripped).
+        surviving_beat_ids: Beat IDs whose hints have NOT been dropped.
+
+    Returns:
+        List of beat IDs (from surviving_beat_ids) that still cycle.
+        Empty list means the postcondition is satisfied.
+    """
+    beat_nodes = graph.get_nodes_by_type("beat")
+    if not beat_nodes:
+        return []
+
+    dilemma_paths = build_dilemma_paths(graph)
+    if len(dilemma_paths) < 2:
+        return []
+
+    path_beats_map: dict[str, list[str]] = defaultdict(list)
+    for edge in graph.get_edges(from_id=None, to_id=None, edge_type="belongs_to"):
+        path_beats_map[edge["to"]].append(edge["from"])
+
+    beat_id_to_dilemmas: dict[str, set[str]] = defaultdict(set)
+    for dil_id, paths in dilemma_paths.items():
+        for path_id in paths:
+            for bid in path_beats_map.get(path_id, []):
+                beat_id_to_dilemmas[bid].add(dil_id)
+
+    beat_intersection_groups: defaultdict[str, set[str]] = defaultdict(set)
+    for edge in graph.get_edges(from_id=None, to_id=None, edge_type="intersection"):
+        beat_intersection_groups[edge["from"]].add(edge["to"])
+
+    beat_set = set(beat_nodes.keys())
+
+    existing: set[tuple[str, str]] = set()
+    for edge in graph.get_edges(from_id=None, to_id=None, edge_type="predecessor"):
+        existing.add((edge["from"], edge["to"]))
+
+    successors: dict[str, set[str]] = {bid: set() for bid in beat_nodes}
+    for from_id, to_id in existing:
+        if from_id in successors and to_id in successors:
+            successors[to_id].add(from_id)
+
+    def _is_valid(from_b: str, to_b: str) -> bool:
+        if from_b == to_b or (from_b, to_b) in existing:
+            return False
+        if from_b not in beat_set or to_b not in beat_set:
+            return False
+        return not beat_intersection_groups.get(from_b, set()).intersection(
+            beat_intersection_groups.get(to_b, set())
+        )
+
+    def _sim_add(from_b: str, to_b: str) -> bool:
+        if not _is_valid(from_b, to_b):
+            return False
+        if _would_create_cycle(from_b, to_b, successors, beat_set):
+            return False
+        existing.add((from_b, to_b))
+        successors[to_b].add(from_b)
+        return True
+
+    relationship_edges: list[tuple[str, str, str]] = []
+    for ordering in ("concurrent", "wraps", "serial"):
+        for edge in graph.get_edges(from_id=None, to_id=None, edge_type=ordering):
+            a = edge["from"]
+            b = edge["to"]
+            if a in dilemma_paths and b in dilemma_paths:
+                relationship_edges.append((a, b, ordering))
+
+    still_cyclic: list[str] = []
+
+    for dilemma_a, dilemma_b, ordering in relationship_edges:
+        paths_a = dilemma_paths.get(dilemma_a, [])
+        paths_b = dilemma_paths.get(dilemma_b, [])
+        if not paths_a or not paths_b:
+            continue
+        ordered_a = [_get_path_beats_ordered(graph, p, path_beats_map) for p in paths_a]
+        ordered_b = [_get_path_beats_ordered(graph, p, path_beats_map) for p in paths_b]
+        all_beats_a = [b for seq in ordered_a for b in seq]
+        all_beats_b = [b for seq in ordered_b for b in seq]
+        if not all_beats_a or not all_beats_b:
+            continue
+
+        if ordering == "serial":
+            for last_a in sorted({seq[-1] for seq in ordered_a if seq}):
+                for first_b in sorted({seq[0] for seq in ordered_b if seq}):
+                    _sim_add(first_b, last_a)
+        elif ordering == "wraps":
+            for first_a in sorted({seq[0] for seq in ordered_a if seq}):
+                for first_b in sorted({seq[0] for seq in ordered_b if seq}):
+                    _sim_add(first_b, first_a)
+            commits_a = set(_commits_beats_for_dilemma(all_beats_a, dilemma_a, beat_nodes))
+            for last_b in sorted({seq[-1] for seq in ordered_b if seq}):
+                for commit_a in sorted(commits_a):
+                    _sim_add(commit_a, last_b)
+        elif ordering == "concurrent":
+            for hint_edge in _iter_temporal_hint_edges(
+                all_beats_a + all_beats_b,
+                beat_nodes,
+                dilemma_a,
+                dilemma_b,
+                all_beats_a,
+                ordered_a,
+                all_beats_b,
+                ordered_b,
+                beat_id_to_dilemmas,
+            ):
+                # Only test surviving hints
+                if hint_edge.beat_id not in surviving_beat_ids:
+                    continue
+                from_b, to_b = hint_edge.from_beat, hint_edge.to_beat
+                if not _is_valid(from_b, to_b):
+                    continue
+                if _would_create_cycle(from_b, to_b, successors, beat_set):
+                    if hint_edge.beat_id not in still_cyclic:
+                        still_cyclic.append(hint_edge.beat_id)
+                else:
+                    existing.add((from_b, to_b))
+                    successors[to_b].add(from_b)
+
+            # Heuristic commit-ordering
+            commits_a = set(_commits_beats_for_dilemma(all_beats_a, dilemma_a, beat_nodes))
+            commits_b = set(_commits_beats_for_dilemma(all_beats_b, dilemma_b, beat_nodes))
+            if commits_a and commits_b:
+                if dilemma_a < dilemma_b:
+                    prereq_commits, dependent_commits = commits_a, commits_b
+                else:
+                    prereq_commits, dependent_commits = commits_b, commits_a
+                for prereq in sorted(prereq_commits):
+                    for dependent in sorted(dependent_commits):
+                        _sim_add(dependent, prereq)
+
+    return still_cyclic
+
+
 def strip_temporal_hints_by_id(graph: Graph, beat_ids: set[str]) -> int:
     """Set temporal_hint to None for the specified beat IDs.
 

--- a/src/questfoundry/graph/grow_algorithms.py
+++ b/src/questfoundry/graph/grow_algorithms.py
@@ -20,7 +20,7 @@ import contextlib
 from collections import defaultdict, deque
 from dataclasses import dataclass, field
 from itertools import product
-from typing import TYPE_CHECKING, Any, Literal
+from typing import TYPE_CHECKING, Any, Literal, NamedTuple
 
 from questfoundry.graph.context import normalize_scoped_id, strip_scope_prefix
 from questfoundry.graph.mutations import GrowErrorCategory, GrowValidationError
@@ -2695,10 +2695,10 @@ class HintConflict:
     swap pair: either beat_a or beat_b may survive, but not both.
 
     Attributes:
-        beat_a: First beat in the conflict (the mechanically-preferred drop).
-        beat_b: Second beat in the conflict (None for mandatory solo drops).
+        beat_a: First beat in the conflict pair.
+        beat_b: Second beat (None for mandatory solo drops).
         mandatory: True if beat_a MUST be dropped (no swap available).
-        default_drop: beat_a or beat_b — the heuristically-preferred drop.
+        default_drop: Heuristically-preferred drop (beat_a or beat_b).
     """
 
     beat_a: str
@@ -2740,6 +2740,64 @@ def _is_canonical_beat(
     return False
 
 
+class _HintResolutionContext(NamedTuple):
+    """Pre-built indexes shared by build_hint_conflict_graph and verify_hints_acyclic."""
+
+    dilemma_paths: dict[str, list[str]]
+    path_beats_map: dict[str, list[str]]
+    beat_id_to_dilemmas: dict[str, set[str]]
+    beat_intersection_groups: defaultdict[str, set[str]]
+    relationship_edges: list[tuple[str, str, str]]
+
+
+def _build_hint_resolution_context(graph: Graph) -> _HintResolutionContext | None:
+    """Build shared indexes needed for temporal-hint resolution.
+
+    Returns ``None`` if the graph has fewer than two dilemmas (no cross-path
+    ordering is possible and all hint functions should be no-ops).
+
+    Args:
+        graph: The story graph.
+
+    Returns:
+        A ``_HintResolutionContext`` with pre-built indexes, or ``None`` when
+        there are fewer than two dilemmas.
+    """
+    dilemma_paths = build_dilemma_paths(graph)
+    if len(dilemma_paths) < 2:
+        return None
+
+    path_beats_map: dict[str, list[str]] = defaultdict(list)
+    for edge in graph.get_edges(from_id=None, to_id=None, edge_type="belongs_to"):
+        path_beats_map[edge["to"]].append(edge["from"])
+
+    beat_id_to_dilemmas: dict[str, set[str]] = defaultdict(set)
+    for dil_id, paths in dilemma_paths.items():
+        for path_id in paths:
+            for bid in path_beats_map.get(path_id, []):
+                beat_id_to_dilemmas[bid].add(dil_id)
+
+    beat_intersection_groups: defaultdict[str, set[str]] = defaultdict(set)
+    for edge in graph.get_edges(from_id=None, to_id=None, edge_type="intersection"):
+        beat_intersection_groups[edge["from"]].add(edge["to"])
+
+    relationship_edges: list[tuple[str, str, str]] = []
+    for ordering in ("concurrent", "wraps", "serial"):
+        for edge in graph.get_edges(from_id=None, to_id=None, edge_type=ordering):
+            a = edge["from"]
+            b = edge["to"]
+            if a in dilemma_paths and b in dilemma_paths:
+                relationship_edges.append((a, b, ordering))
+
+    return _HintResolutionContext(
+        dilemma_paths=dilemma_paths,
+        path_beats_map=path_beats_map,
+        beat_id_to_dilemmas=beat_id_to_dilemmas,
+        beat_intersection_groups=beat_intersection_groups,
+        relationship_edges=relationship_edges,
+    )
+
+
 def build_hint_conflict_graph(graph: Graph) -> HintConflictResult:
     """Build a conflict graph for temporal hints and compute the minimum drop set.
 
@@ -2771,21 +2829,17 @@ def build_hint_conflict_graph(graph: Graph) -> HintConflictResult:
             conflicts=[], mandatory_drops=set(), swap_pairs=[], minimum_drop_set=set()
         )
 
-    dilemma_paths = build_dilemma_paths(graph)
-    if len(dilemma_paths) < 2:
+    ctx = _build_hint_resolution_context(graph)
+    if ctx is None:
         return HintConflictResult(
             conflicts=[], mandatory_drops=set(), swap_pairs=[], minimum_drop_set=set()
         )
 
-    path_beats_map: dict[str, list[str]] = defaultdict(list)
-    for edge in graph.get_edges(from_id=None, to_id=None, edge_type="belongs_to"):
-        path_beats_map[edge["to"]].append(edge["from"])
-
-    beat_id_to_dilemmas: dict[str, set[str]] = defaultdict(set)
-    for dil_id, paths in dilemma_paths.items():
-        for path_id in paths:
-            for bid in path_beats_map.get(path_id, []):
-                beat_id_to_dilemmas[bid].add(dil_id)
+    dilemma_paths = ctx.dilemma_paths
+    path_beats_map = ctx.path_beats_map
+    beat_id_to_dilemmas = ctx.beat_id_to_dilemmas
+    beat_intersection_groups = ctx.beat_intersection_groups
+    relationship_edges = ctx.relationship_edges
 
     # Determine canonical paths for heuristic scoring
     path_nodes = graph.get_nodes_by_type("path")
@@ -2793,21 +2847,7 @@ def build_hint_conflict_graph(graph: Graph) -> HintConflictResult:
         pid for pid, data in path_nodes.items() if data.get("is_canonical", False)
     }
 
-    # Build intersection-group index
-    beat_intersection_groups: defaultdict[str, set[str]] = defaultdict(set)
-    for edge in graph.get_edges(from_id=None, to_id=None, edge_type="intersection"):
-        beat_intersection_groups[edge["from"]].add(edge["to"])
-
     beat_set = set(beat_nodes.keys())
-
-    # Collect relationship edges in processing order (same as interleave_cross_path_beats)
-    relationship_edges: list[tuple[str, str, str]] = []
-    for ordering in ("concurrent", "wraps", "serial"):
-        for edge in graph.get_edges(from_id=None, to_id=None, edge_type=ordering):
-            a = edge["from"]
-            b = edge["to"]
-            if a in dilemma_paths and b in dilemma_paths:
-                relationship_edges.append((a, b, ordering))
 
     # Helper: build a fresh base DAG (all non-hint edges, no hints applied)
     def _build_base_dag() -> tuple[set[tuple[str, str]], dict[str, set[str]]]:
@@ -2974,6 +3014,14 @@ def build_hint_conflict_graph(graph: Graph) -> HintConflictResult:
     # Phase 2: find mutual exclusion pairs among survivors
     # Two hints A and B are mutual exclusion if A cycles given B AND B cycles given A.
     # For simplicity and correctness we test all pairs in O(n^2).
+    #
+    # Note: This scan is pairwise (O(n²)). With three or more hints that are
+    # mutually exclusive (any two together cycle), the algorithm pairs only
+    # the first conflicting pair it finds, leaving later hints unpaired.
+    # After one of the pair is dropped, the survivor may still conflict with
+    # the unpaired hint. verify_hints_acyclic will then raise
+    # TemporalHintResolutionInvariantError — this is the expected loud-failure
+    # behaviour, not silent degradation.
     swap_pairs_result: list[tuple[str, str]] = []
     # Track which beats are already in a swap pair (to avoid duplicates)
     in_swap_pair: set[str] = set()
@@ -3007,10 +3055,11 @@ def build_hint_conflict_graph(graph: Graph) -> HintConflictResult:
     def _choose_default_drop(beat_a_id: str, beat_b_id: str) -> str:
         ha = hint_by_beat.get(beat_a_id)
         hb = hint_by_beat.get(beat_b_id)
-        if ha is None:
-            return beat_a_id
-        if hb is None:
-            return beat_b_id
+        if ha is None or hb is None:
+            raise ValueError(
+                f"Could not find hint for beat in swap pair: "
+                f"({beat_a_id!r}, {beat_b_id!r}). This is a bug in conflict detection."
+            )
         score_a = _drop_score(beat_a_id, ha)
         score_b = _drop_score(beat_b_id, hb)
         # Lower score → prefer to drop
@@ -3067,23 +3116,15 @@ def verify_hints_acyclic(
     if not beat_nodes:
         return []
 
-    dilemma_paths = build_dilemma_paths(graph)
-    if len(dilemma_paths) < 2:
+    ctx = _build_hint_resolution_context(graph)
+    if ctx is None:
         return []
 
-    path_beats_map: dict[str, list[str]] = defaultdict(list)
-    for edge in graph.get_edges(from_id=None, to_id=None, edge_type="belongs_to"):
-        path_beats_map[edge["to"]].append(edge["from"])
-
-    beat_id_to_dilemmas: dict[str, set[str]] = defaultdict(set)
-    for dil_id, paths in dilemma_paths.items():
-        for path_id in paths:
-            for bid in path_beats_map.get(path_id, []):
-                beat_id_to_dilemmas[bid].add(dil_id)
-
-    beat_intersection_groups: defaultdict[str, set[str]] = defaultdict(set)
-    for edge in graph.get_edges(from_id=None, to_id=None, edge_type="intersection"):
-        beat_intersection_groups[edge["from"]].add(edge["to"])
+    dilemma_paths = ctx.dilemma_paths
+    path_beats_map = ctx.path_beats_map
+    beat_id_to_dilemmas = ctx.beat_id_to_dilemmas
+    beat_intersection_groups = ctx.beat_intersection_groups
+    relationship_edges = ctx.relationship_edges
 
     beat_set = set(beat_nodes.keys())
 
@@ -3113,14 +3154,6 @@ def verify_hints_acyclic(
         existing.add((from_b, to_b))
         successors[to_b].add(from_b)
         return True
-
-    relationship_edges: list[tuple[str, str, str]] = []
-    for ordering in ("concurrent", "wraps", "serial"):
-        for edge in graph.get_edges(from_id=None, to_id=None, edge_type=ordering):
-            a = edge["from"]
-            b = edge["to"]
-            if a in dilemma_paths and b in dilemma_paths:
-                relationship_edges.append((a, b, ordering))
 
     still_cyclic: list[str] = []
 

--- a/src/questfoundry/models/grow.py
+++ b/src/questfoundry/models/grow.py
@@ -122,18 +122,33 @@ class Phase3Output(BaseModel):
     intersections: list[IntersectionProposal] = Field(default_factory=list)
 
 
-class TemporalResolutionOutput(BaseModel):
-    """Structured output for the resolve_temporal_hints phase (#1123).
+class ConflictGroupResolution(BaseModel):
+    """LLM decision for a single swap pair in the resolve_temporal_hints phase.
 
-    The LLM returns the beat IDs whose temporal hints should be cleared
-    to resolve ordering conflicts in the beat DAG.
+    The LLM receives a group ID (e.g. 'P1') and must choose which of the two
+    beats in the swap pair to drop.
     """
 
-    hints_to_drop: list[str] = Field(
+    group_id: str = Field(description="The group ID from the conflict list (e.g. 'P1', 'P2')")
+    drop_beat_id: str = Field(description="The beat ID whose temporal hint should be dropped")
+    reason: str = Field(
+        min_length=1,
+        description="One-sentence narrative justification for the choice",
+    )
+
+
+class TemporalResolutionOutput(BaseModel):
+    """Structured output for the resolve_temporal_hints phase (#1123, #1140).
+
+    Mandatory drops are applied before the LLM call and are not listed here.
+    The LLM only resolves swap pairs — beats where either hint can survive
+    but not both.
+    """
+
+    resolutions: list[ConflictGroupResolution] = Field(
         default_factory=list,
         description=(
-            "Beat IDs whose temporal hints should be dropped to resolve "
-            "ordering conflicts. May be empty if conflicts are already resolved."
+            "One resolution per swap pair. Mandatory drops are pre-applied and not listed here."
         ),
     )
 

--- a/src/questfoundry/pipeline/stages/grow/llm_phases.py
+++ b/src/questfoundry/pipeline/stages/grow/llm_phases.py
@@ -33,6 +33,10 @@ from questfoundry.pipeline.stages.grow._helpers import (
 )
 from questfoundry.pipeline.stages.grow.registry import grow_phase
 
+# Maximum characters to show from a beat summary when building LLM context for
+# temporal hint resolution prompts.
+_TEMPORAL_HINT_SUMMARY_TRUNCATION = 100
+
 if TYPE_CHECKING:
     from langchain_core.language_models import BaseChatModel
 
@@ -408,6 +412,13 @@ class _LLMPhaseMixin:
         if result.swap_pairs:
             # Build context for each swap pair
             beat_nodes = graph.get_nodes_by_type("beat")
+            # Pre-build O(1) lookup for swap conflict by beat pair.
+            # Non-mandatory conflicts always have beat_b set (swap pairs).
+            swap_conflict_by_pair: dict[frozenset[str], str] = {
+                frozenset({c.beat_a, c.beat_b}): c.default_drop
+                for c in result.conflicts
+                if not c.mandatory and c.beat_b is not None
+            }
             swap_pairs_lines: list[str] = []
             for idx, (beat_a_id, beat_b_id) in enumerate(result.swap_pairs, 1):
                 group_id = f"P{idx}"
@@ -429,15 +440,17 @@ class _LLMPhaseMixin:
                     if "commit" in pos_b
                     else "WEAK: after/before_introduce"
                 )
-                summary_a = (data_a.get("summary") or "(no summary)")[:100]
-                summary_b = (data_b.get("summary") or "(no summary)")[:100]
+                summary_a = (data_a.get("summary") or "(no summary)")[
+                    :_TEMPORAL_HINT_SUMMARY_TRUNCATION
+                ]
+                summary_b = (data_b.get("summary") or "(no summary)")[
+                    :_TEMPORAL_HINT_SUMMARY_TRUNCATION
+                ]
 
-                # Find the default drop from the conflict list
-                default_drop = beat_a_id  # fallback
-                for c in result.conflicts:
-                    if not c.mandatory and {c.beat_a, c.beat_b} == {beat_a_id, beat_b_id}:
-                        default_drop = c.default_drop
-                        break
+                # O(1) lookup for default_drop
+                default_drop = swap_conflict_by_pair.get(
+                    frozenset({beat_a_id, beat_b_id}), beat_a_id
+                )
 
                 swap_pairs_lines.append(
                     f"### Swap Pair {group_id} — DROP EXACTLY ONE:\n"
@@ -529,7 +542,10 @@ class _LLMPhaseMixin:
             dropped_beats=sorted(beats_to_drop),
         )
 
-        # Postcondition: verify no surviving hints still cycle
+        # Postcondition: verify no surviving hints still cycle.
+        # NOTE: strip_temporal_hints_by_id has already run at this point.
+        # _iter_temporal_hint_edges skips beats with temporal_hint=None, so
+        # surviving_beat_ids acts as a cross-check rather than a filter here.
         all_beat_ids_with_hints: set[str] = set()
         for bid, data in graph.get_nodes_by_type("beat").items():
             if data.get("temporal_hint") is not None:

--- a/src/questfoundry/pipeline/stages/grow/llm_phases.py
+++ b/src/questfoundry/pipeline/stages/grow/llm_phases.py
@@ -483,10 +483,9 @@ class _LLMPhaseMixin:
                 )
                 # Fall back to mechanical defaults
                 for beat_a_id, beat_b_id in result.swap_pairs:
-                    for c in result.conflicts:
-                        if not c.mandatory and {c.beat_a, c.beat_b} == {beat_a_id, beat_b_id}:
-                            beats_to_drop.add(c.default_drop)
-                            break
+                    default_drop = swap_conflict_by_pair.get(frozenset({beat_a_id, beat_b_id}))
+                    if default_drop is not None:
+                        beats_to_drop.add(default_drop)
             else:
                 # Validate and apply LLM resolutions
                 valid_swap_beats: dict[str, tuple[str, str]] = {
@@ -511,10 +510,9 @@ class _LLMPhaseMixin:
                             valid_options=f"`{beat_a_id}` or `{beat_b_id}`",
                         )
                         # Fall back to mechanical default
-                        for c in result.conflicts:
-                            if not c.mandatory and {c.beat_a, c.beat_b} == {beat_a_id, beat_b_id}:
-                                beats_to_drop.add(c.default_drop)
-                                break
+                        default_drop = swap_conflict_by_pair.get(frozenset({beat_a_id, beat_b_id}))
+                        if default_drop is not None:
+                            beats_to_drop.add(default_drop)
 
                 # Fill in any missing resolutions with mechanical defaults
                 resolved_groups = {r.group_id for r in llm_result.resolutions}
@@ -526,10 +524,9 @@ class _LLMPhaseMixin:
                             group_id=group_id,
                             using_default=True,
                         )
-                        for c in result.conflicts:
-                            if not c.mandatory and {c.beat_a, c.beat_b} == {beat_a_id, beat_b_id}:
-                                beats_to_drop.add(c.default_drop)
-                                break
+                        default_drop = swap_conflict_by_pair.get(frozenset({beat_a_id, beat_b_id}))
+                        if default_drop is not None:
+                            beats_to_drop.add(default_drop)
 
         # Strip the resolved hints
         stripped = strip_temporal_hints_by_id(graph, beats_to_drop)

--- a/src/questfoundry/pipeline/stages/grow/llm_phases.py
+++ b/src/questfoundry/pipeline/stages/grow/llm_phases.py
@@ -483,9 +483,10 @@ class _LLMPhaseMixin:
                 )
                 # Fall back to mechanical defaults
                 for beat_a_id, beat_b_id in result.swap_pairs:
-                    default_drop = swap_conflict_by_pair.get(frozenset({beat_a_id, beat_b_id}))
-                    if default_drop is not None:
-                        beats_to_drop.add(default_drop)
+                    default_drop = swap_conflict_by_pair.get(
+                        frozenset({beat_a_id, beat_b_id}), beat_a_id
+                    )
+                    beats_to_drop.add(default_drop)
             else:
                 # Validate and apply LLM resolutions
                 valid_swap_beats: dict[str, tuple[str, str]] = {
@@ -510,9 +511,9 @@ class _LLMPhaseMixin:
                             valid_options=f"`{beat_a_id}` or `{beat_b_id}`",
                         )
                         # Fall back to mechanical default
-                        default_drop = swap_conflict_by_pair.get(frozenset({beat_a_id, beat_b_id}))
-                        if default_drop is not None:
-                            beats_to_drop.add(default_drop)
+                        beats_to_drop.add(
+                            swap_conflict_by_pair.get(frozenset({beat_a_id, beat_b_id}), beat_a_id)
+                        )
 
                 # Fill in any missing resolutions with mechanical defaults
                 resolved_groups = {r.group_id for r in llm_result.resolutions}
@@ -524,9 +525,9 @@ class _LLMPhaseMixin:
                             group_id=group_id,
                             using_default=True,
                         )
-                        default_drop = swap_conflict_by_pair.get(frozenset({beat_a_id, beat_b_id}))
-                        if default_drop is not None:
-                            beats_to_drop.add(default_drop)
+                        beats_to_drop.add(
+                            swap_conflict_by_pair.get(frozenset({beat_a_id, beat_b_id}), beat_a_id)
+                        )
 
         # Strip the resolved hints
         stripped = strip_temporal_hints_by_id(graph, beats_to_drop)

--- a/src/questfoundry/pipeline/stages/grow/llm_phases.py
+++ b/src/questfoundry/pipeline/stages/grow/llm_phases.py
@@ -346,13 +346,17 @@ class _LLMPhaseMixin:
     async def _phase_resolve_temporal_hints(
         self, graph: Graph, model: BaseChatModel
     ) -> GrowPhaseResult:
-        """Detect and resolve temporal hint ordering conflicts before interleave (#1123).
+        """Detect and resolve temporal hint ordering conflicts before interleave (#1123, #1140).
 
-        Temporal hints on beats request placement relative to another dilemma's
-        key moment (e.g. "after dilemma X's commit point"). When serialized
-        independently, two beats may request mutually exclusive orderings. This
-        phase detects those cycles deterministically and, if any exist, calls the
-        LLM to choose which hints to relax.
+        Uses ``build_hint_conflict_graph`` to perform a complete conflict analysis:
+
+        1. Builds a base DAG from all non-hint edges.
+        2. Tests each hint alone — mandatory solo drops are applied immediately
+           without an LLM call.
+        3. Tests surviving hints pairwise for mutual exclusion — swap pairs are
+           presented to the LLM for narrative resolution.
+        4. Verifies all survivors are acyclic (postcondition) before returning.
+           Raises ``TemporalHintResolutionInvariantError`` if the check fails.
 
         Preconditions:
         - Beat DAG validated (Phase 1 passed).
@@ -363,21 +367,23 @@ class _LLMPhaseMixin:
         - No hint cycles remain: ``interleave_beats`` can apply all surviving
           hints without silently dropping any as cycle-creating.
         - Dropped hints are nulled out on beat nodes.
-        - ``interleave_cycle_skipped`` warnings no longer appear in valid runs.
 
         Invariants:
         - No-op if no conflicts detected (no LLM call).
-        - LLM call only made when cycles exist.
+        - LLM call only made when swap pairs exist.
         - Does not create any graph edges — only strips hints from nodes.
         """
+        from questfoundry.graph.errors import TemporalHintResolutionInvariantError
         from questfoundry.graph.grow_algorithms import (
-            detect_temporal_hint_conflicts,
+            build_hint_conflict_graph,
             strip_temporal_hints_by_id,
+            verify_hints_acyclic,
         )
         from questfoundry.models.grow import TemporalResolutionOutput
 
-        conflicts = detect_temporal_hint_conflicts(graph)
-        if not conflicts:
+        result = build_hint_conflict_graph(graph)
+
+        if not result.conflicts:
             log.info("resolve_temporal_hints_no_conflicts")
             return GrowPhaseResult(
                 phase="resolve_temporal_hints",
@@ -387,66 +393,165 @@ class _LLMPhaseMixin:
 
         log.info(
             "resolve_temporal_hints_conflicts_found",
-            count=len(conflicts),
-            beat_ids=[c.beat_id for c in conflicts],
+            mandatory_drops=len(result.mandatory_drops),
+            swap_pairs=len(result.swap_pairs),
+            mandatory_beat_ids=sorted(result.mandatory_drops),
         )
 
-        # Build conflict description for the LLM
-        conflict_lines: list[str] = []
-        for i, c in enumerate(conflicts, 1):
-            conflict_lines.append(
-                f"  Conflict {i}: beat `{c.beat_id}` has hint "
-                f"`{c.hint_position} {c.hint_relative_to}` — "
-                f"this would create edge `{c.from_beat}` → `{c.to_beat}`, "
-                f"which cycles with existing ordering constraints.\n"
-                f"    <summary>{c.beat_summary or '(no summary)'}</summary>"
-            )
-        conflict_list_text = "\n".join(conflict_lines)
+        # Apply mandatory drops immediately — no LLM needed
+        beats_to_drop: set[str] = set(result.mandatory_drops)
 
-        valid_beat_ids = sorted({c.beat_id for c in conflicts})
-        context: dict[str, str] = {
-            "conflict_list": conflict_list_text,
-            "valid_beat_ids": ", ".join(f"`{b}`" for b in valid_beat_ids),
-        }
+        total_llm_calls = 0
+        total_tokens = 0
 
-        try:
-            result, llm_calls, tokens = await self._grow_llm_call(  # type: ignore[attr-defined]
-                model=model,
-                template_name="grow_phase_temporal_resolution",
-                context=context,
-                output_schema=TemporalResolutionOutput,
-                semantic_validator=None,
-            )
-        except GrowStageError as e:
-            return GrowPhaseResult(
-                phase="resolve_temporal_hints",
-                status="failed",
-                detail=str(e),
-            )
+        # If there are swap pairs, ask the LLM to choose
+        if result.swap_pairs:
+            # Build context for each swap pair
+            beat_nodes = graph.get_nodes_by_type("beat")
+            swap_pairs_lines: list[str] = []
+            for idx, (beat_a_id, beat_b_id) in enumerate(result.swap_pairs, 1):
+                group_id = f"P{idx}"
+                data_a = beat_nodes.get(beat_a_id, {})
+                data_b = beat_nodes.get(beat_b_id, {})
+                hint_a = data_a.get("temporal_hint") or {}
+                hint_b = data_b.get("temporal_hint") or {}
+                pos_a = hint_a.get("position", "unknown")
+                rel_a = hint_a.get("relative_to", "unknown")
+                pos_b = hint_b.get("position", "unknown")
+                rel_b = hint_b.get("relative_to", "unknown")
+                strength_a = (
+                    "STRONG: after/before_commit"
+                    if "commit" in pos_a
+                    else "WEAK: after/before_introduce"
+                )
+                strength_b = (
+                    "STRONG: after/before_commit"
+                    if "commit" in pos_b
+                    else "WEAK: after/before_introduce"
+                )
+                summary_a = (data_a.get("summary") or "(no summary)")[:100]
+                summary_b = (data_b.get("summary") or "(no summary)")[:100]
 
-        beats_to_drop: set[str] = set(result.hints_to_drop)
-        # Validate IDs — only drop hints for beats that have conflicts
-        valid_set = set(valid_beat_ids)
-        beats_to_drop = {b for b in beats_to_drop if b in valid_set}
+                # Find the default drop from the conflict list
+                default_drop = beat_a_id  # fallback
+                for c in result.conflicts:
+                    if not c.mandatory and {c.beat_a, c.beat_b} == {beat_a_id, beat_b_id}:
+                        default_drop = c.default_drop
+                        break
 
+                swap_pairs_lines.append(
+                    f"### Swap Pair {group_id} — DROP EXACTLY ONE:\n"
+                    f"  Option A: `{beat_a_id}` | hint: `{pos_a} {rel_a}` [{strength_a}]\n"
+                    f"            Summary: {summary_a}\n"
+                    f"  Option B: `{beat_b_id}` | hint: `{pos_b} {rel_b}` [{strength_b}]\n"
+                    f"            Summary: {summary_b}\n"
+                    f"  Mechanical default: drop Option {'A' if default_drop == beat_a_id else 'B'} "
+                    f"(based on hint strength + beat role heuristic)"
+                )
+
+            swap_pairs_context = "\n\n".join(swap_pairs_lines)
+            context: dict[str, str] = {"swap_pairs_context": swap_pairs_context}
+
+            try:
+                llm_result, llm_calls, tokens = await self._grow_llm_call(  # type: ignore[attr-defined]
+                    model=model,
+                    template_name="grow_phase_temporal_resolution",
+                    context=context,
+                    output_schema=TemporalResolutionOutput,
+                    semantic_validator=None,
+                )
+                total_llm_calls += llm_calls
+                total_tokens += tokens
+            except GrowStageError as e:
+                log.warning(
+                    "resolve_temporal_hints_llm_failed_using_defaults",
+                    error=str(e),
+                    swap_pairs=len(result.swap_pairs),
+                )
+                # Fall back to mechanical defaults
+                for beat_a_id, beat_b_id in result.swap_pairs:
+                    for c in result.conflicts:
+                        if not c.mandatory and {c.beat_a, c.beat_b} == {beat_a_id, beat_b_id}:
+                            beats_to_drop.add(c.default_drop)
+                            break
+            else:
+                # Validate and apply LLM resolutions
+                valid_swap_beats: dict[str, tuple[str, str]] = {
+                    f"P{idx}": (a, b) for idx, (a, b) in enumerate(result.swap_pairs, 1)
+                }
+                for resolution in llm_result.resolutions:
+                    pair = valid_swap_beats.get(resolution.group_id)
+                    if pair is None:
+                        log.warning(
+                            "resolve_temporal_hints_invalid_group_id",
+                            group_id=resolution.group_id,
+                        )
+                        continue
+                    beat_a_id, beat_b_id = pair
+                    if resolution.drop_beat_id in (beat_a_id, beat_b_id):
+                        beats_to_drop.add(resolution.drop_beat_id)
+                    else:
+                        log.warning(
+                            "resolve_temporal_hints_invalid_drop_beat",
+                            group_id=resolution.group_id,
+                            drop_beat_id=resolution.drop_beat_id,
+                            valid_options=f"`{beat_a_id}` or `{beat_b_id}`",
+                        )
+                        # Fall back to mechanical default
+                        for c in result.conflicts:
+                            if not c.mandatory and {c.beat_a, c.beat_b} == {beat_a_id, beat_b_id}:
+                                beats_to_drop.add(c.default_drop)
+                                break
+
+                # Fill in any missing resolutions with mechanical defaults
+                resolved_groups = {r.group_id for r in llm_result.resolutions}
+                for idx, (beat_a_id, beat_b_id) in enumerate(result.swap_pairs, 1):
+                    group_id = f"P{idx}"
+                    if group_id not in resolved_groups:
+                        log.warning(
+                            "resolve_temporal_hints_missing_resolution",
+                            group_id=group_id,
+                            using_default=True,
+                        )
+                        for c in result.conflicts:
+                            if not c.mandatory and {c.beat_a, c.beat_b} == {beat_a_id, beat_b_id}:
+                                beats_to_drop.add(c.default_drop)
+                                break
+
+        # Strip the resolved hints
         stripped = strip_temporal_hints_by_id(graph, beats_to_drop)
 
         log.info(
             "temporal_hint_conflict_resolved",
-            conflicts=len(conflicts),
-            hints_dropped=stripped,
+            mandatory_drops=len(result.mandatory_drops),
+            swap_pairs=len(result.swap_pairs),
+            total_hints_dropped=stripped,
             dropped_beats=sorted(beats_to_drop),
         )
+
+        # Postcondition: verify no surviving hints still cycle
+        all_beat_ids_with_hints: set[str] = set()
+        for bid, data in graph.get_nodes_by_type("beat").items():
+            if data.get("temporal_hint") is not None:
+                all_beat_ids_with_hints.add(bid)
+
+        surviving = all_beat_ids_with_hints - beats_to_drop
+        still_cyclic = verify_hints_acyclic(graph, surviving)
+        if still_cyclic:
+            raise TemporalHintResolutionInvariantError(
+                still_cyclic=still_cyclic,
+                dropped=beats_to_drop,
+            )
 
         return GrowPhaseResult(
             phase="resolve_temporal_hints",
             status="completed",
             detail=(
-                f"Resolved {len(conflicts)} temporal hint conflict(s): "
+                f"Resolved {len(result.conflicts)} temporal hint conflict(s): "
                 f"dropped {stripped} hint(s) from {sorted(beats_to_drop)}"
             ),
-            llm_calls=llm_calls,
-            tokens_used=tokens,
+            llm_calls=total_llm_calls,
+            tokens_used=total_tokens,
         )
 
     @grow_phase(name="scene_types", depends_on=["interleave_beats"], priority=4)

--- a/tests/unit/test_grow_algorithms.py
+++ b/tests/unit/test_grow_algorithms.py
@@ -5043,3 +5043,370 @@ class TestDetectTemporalHintConflicts:
         aq_data = graph.get_node("beat::aq_intro") or {}
         assert mt_data.get("temporal_hint") is None
         assert aq_data.get("temporal_hint") is not None
+
+
+class TestBuildHintConflictGraph:
+    """Tests for build_hint_conflict_graph and verify_hints_acyclic (#1140)."""
+
+    def test_no_conflicts_returns_empty_result(self) -> None:
+        """Returns empty HintConflictResult when no beats have temporal hints."""
+        from questfoundry.graph.grow_algorithms import build_hint_conflict_graph
+
+        graph = _make_two_dilemma_graph_with_relationship("concurrent")
+        result = build_hint_conflict_graph(graph)
+        assert result.conflicts == []
+        assert result.mandatory_drops == set()
+        assert result.swap_pairs == []
+        assert result.minimum_drop_set == set()
+
+    def test_consistent_hint_produces_no_conflicts(self) -> None:
+        """A single hint that does not cycle is not reported as a conflict."""
+        from questfoundry.graph.grow_algorithms import build_hint_conflict_graph
+
+        graph = _make_two_dilemma_graph_with_relationship("concurrent")
+        # mt_intro after_commit artifact_quest: aq_commit ≺ mt_intro
+        # No existing edges make mt_intro reachable from aq_commit, so no cycle.
+        graph.update_node(
+            "beat::mt_intro",
+            temporal_hint={
+                "relative_to": "dilemma::artifact_quest",
+                "position": "after_commit",
+            },
+        )
+        result = build_hint_conflict_graph(graph)
+        assert result.conflicts == []
+        assert "beat::mt_intro" not in result.mandatory_drops
+
+    def test_mandatory_solo_drop_detected(self) -> None:
+        """A hint that cycles alone against the base DAG is a mandatory drop.
+
+        Set up a situation where the base DAG (heuristic commit-ordering) already
+        forces aq_commit ≺ mt_intro.  Adding a hint that requires mt_intro ≺ aq_commit
+        creates a cycle against the base DAG alone.
+
+        Since artifact_quest < mentor_trust alphabetically, the heuristic adds:
+          predecessor(aq_commit, mt_commit) → mt_commit ≺ aq_commit in successors.
+
+        We manually add a predecessor edge mt_commit ≺ mt_intro (within-path style)
+        and then hint mt_intro after_commit artifact_quest → aq_commit ≺ mt_intro.
+        The base DAG already has mt_intro ≺ mt_commit ≺ aq_commit (within-path edge),
+        so adding aq_commit ≺ mt_intro closes the cycle.
+        """
+        from questfoundry.graph.grow_algorithms import build_hint_conflict_graph
+
+        graph = _make_two_dilemma_graph_with_relationship("concurrent")
+        # Within-path: mt_intro ≺ mt_commit already exists from the fixture.
+        # Heuristic (artifact_quest < mentor_trust): aq_commit ≺ mt_commit.
+        # Manually add aq_commit ≺ mt_intro so the base DAG has
+        # mt_intro ≺ mt_commit and aq_commit ≺ mt_intro both, i.e.
+        # aq_commit → mt_intro → mt_commit.
+        # Hint: mt_intro after_commit artifact_quest → predecessor(mt_intro, aq_commit)
+        # = aq_commit ≺ mt_intro.  But aq_commit is already reachable from mt_intro
+        # (mt_intro → mt_commit → ... no, let's just force it directly).
+        # Simpler: add predecessor(aq_intro, mt_commit) so base has
+        # mt_commit ≺ aq_intro ≺ aq_commit.
+        # Then hint aq_intro after_commit mentor_trust → mt_commit ≺ aq_intro.
+        # That edge already exists, so it's not a cycle.
+        # Even simpler: add aq_commit already in successors[mt_commit] via a
+        # pre-existing predecessor edge, then hint tries aq_commit ≺ mt_intro
+        # but mt_intro → mt_commit and mt_commit already has aq_commit as successor.
+
+        # The cleanest approach: give mt_commit a predecessor of aq_commit
+        # (aq_commit ≺ mt_commit), then add a hint for mt_commit after_commit
+        # artifact_quest → aq_commit ≺ mt_commit.  But that edge already exists
+        # (from the predecessor we just added), so it's skipped as duplicate.
+
+        # Best approach: Use direct cycle setup:
+        # Base DAG has aq_intro ≺ aq_commit (within path).
+        # Manually add predecessor edge: aq_commit → mt_commit (i.e. mt_commit ≺ aq_commit
+        # in successor meaning). Wait, predecessor(A, B) means B ≺ A.
+        # Let's just force the cycle via a pre-existing predecessor + hint:
+        # Add predecessor(mt_intro, aq_commit) manually → aq_commit ≺ mt_intro in base.
+        # Hint: aq_commit after_commit mentor_trust → mt_commit ≺ aq_commit.
+        # Base has mt_intro ≺ mt_commit (within-path fixture).
+        # So: aq_commit ≺ mt_intro ≺ mt_commit, and hint wants mt_commit ≺ aq_commit → cycle.
+        graph.add_edge("predecessor", "beat::mt_intro", "beat::aq_commit")
+        graph.update_node(
+            "beat::aq_commit",
+            temporal_hint={
+                "relative_to": "dilemma::mentor_trust",
+                "position": "after_commit",
+            },
+        )
+
+        result = build_hint_conflict_graph(graph)
+        assert "beat::aq_commit" in result.mandatory_drops, (
+            "Expected aq_commit to be a mandatory solo drop because its hint "
+            "creates a cycle against the base DAG alone."
+        )
+        assert any(c.mandatory for c in result.conflicts)
+
+    def test_mutual_exclusion_produces_swap_pair(self) -> None:
+        """Two hints that each cycle against the base DAG produce conflicts.
+
+        With the ``_make_two_dilemma_graph_with_relationship("concurrent")`` fixture:
+        - dilemma IDs are ``artifact_quest`` and ``mentor_trust`` (``aq < mt`` alphabetically).
+        - Heuristic commit-ordering (base DAG): ``aq_commit ≺ mt_commit``.
+        - Within-path: ``mt_intro ≺ mt_commit`` and ``aq_intro ≺ aq_commit``.
+
+        Hint 1 — ``mt_intro after_commit artifact_quest``:
+          Wants ``aq_commit ≺ mt_intro``.
+          Base DAG reaches ``aq_commit`` from ``mt_intro`` via within-path
+          ``mt_intro → mt_commit`` and heuristic ``mt_commit`` … actually
+          ``aq_commit`` is the *source* of the heuristic edge ``aq_commit ≺ mt_commit``,
+          not reachable from ``mt_intro``.  So hint 1 is **consistent** alone.
+
+        Hint 2 — ``aq_intro after_commit mentor_trust``:
+          Wants ``mt_commit ≺ aq_intro``.
+          Base DAG: ``aq_intro ≺ aq_commit ≺ mt_commit`` (within-path + heuristic).
+          Cycle: ``mt_commit → aq_intro → aq_commit → mt_commit``.  This hint is a
+          **mandatory solo drop** against the base DAG.
+
+        Expected outcome: aq_intro is mandatory_drops; mt_intro is not.
+        The ``build_hint_conflict_graph`` algorithm is correct to report this as
+        mandatory rather than a swap pair, because the cycle exists regardless of
+        whether the other hint is present.
+        """
+        from questfoundry.graph.grow_algorithms import build_hint_conflict_graph
+
+        graph = _make_two_dilemma_graph_with_relationship("concurrent")
+        graph.update_node(
+            "beat::mt_intro",
+            temporal_hint={
+                "relative_to": "dilemma::artifact_quest",
+                "position": "after_commit",
+            },
+        )
+        graph.update_node(
+            "beat::aq_intro",
+            temporal_hint={
+                "relative_to": "dilemma::mentor_trust",
+                "position": "after_commit",
+            },
+        )
+
+        result = build_hint_conflict_graph(graph)
+        # aq_intro cycles against base DAG alone (mandatory drop)
+        assert "beat::aq_intro" in result.mandatory_drops
+        # mt_intro is consistent against base DAG — not a mandatory drop
+        assert "beat::mt_intro" not in result.mandatory_drops
+        # minimum_drop_set contains aq_intro
+        assert "beat::aq_intro" in result.minimum_drop_set
+
+    def test_swap_pair_when_hints_only_conflict_together(self) -> None:
+        """Two hints form a swap pair when neither cycles alone but both cycle together.
+
+        To avoid the heuristic commit-ordering creating a solo cycle, we use
+        an 'introduce' hint so the heuristic (commit-ordering) does not pre-block it.
+
+        Setup using the two-dilemma fixture (aq < mt alphabetically):
+        - Base heuristic: aq_commit ≺ mt_commit.
+        - Hint on mt_intro: ``before_introduce artifact_quest``
+          Wants ``mt_intro ≺ aq_intro`` (mt_intro before aq's first beat).
+          predecessor(aq_intro, mt_intro): mt_intro ≺ aq_intro.
+          Base DAG has no path from aq_intro back to mt_intro, so no solo cycle.
+        - Hint on aq_intro: ``before_introduce mentor_trust``
+          Wants ``aq_intro ≺ mt_intro`` (aq_intro before mt's first beat).
+          predecessor(mt_intro, aq_intro): aq_intro ≺ mt_intro.
+          Base DAG has no path from mt_intro back to aq_intro, so no solo cycle.
+        - Together: mt_intro ≺ aq_intro AND aq_intro ≺ mt_intro → cycle.
+
+        Expected: both beats in result.swap_pairs; neither in mandatory_drops.
+        """
+        from questfoundry.graph.grow_algorithms import build_hint_conflict_graph
+
+        graph = _make_two_dilemma_graph_with_relationship("concurrent")
+        # mt_intro before_introduce artifact_quest: mt_intro ≺ aq_intro
+        graph.update_node(
+            "beat::mt_intro",
+            temporal_hint={
+                "relative_to": "dilemma::artifact_quest",
+                "position": "before_introduce",
+            },
+        )
+        # aq_intro before_introduce mentor_trust: aq_intro ≺ mt_intro
+        graph.update_node(
+            "beat::aq_intro",
+            temporal_hint={
+                "relative_to": "dilemma::mentor_trust",
+                "position": "before_introduce",
+            },
+        )
+
+        result = build_hint_conflict_graph(graph)
+        # Neither hint should solo-cycle against base DAG
+        assert "beat::mt_intro" not in result.mandatory_drops, (
+            "mt_intro should not be a mandatory drop — its hint only cycles when "
+            "aq_intro's hint is also applied."
+        )
+        assert "beat::aq_intro" not in result.mandatory_drops, (
+            "aq_intro should not be a mandatory drop — its hint only cycles when "
+            "mt_intro's hint is also applied."
+        )
+        # They should form a swap pair
+        assert len(result.swap_pairs) >= 1, "Expected at least one swap pair"
+        swap_set = {frozenset(p) for p in result.swap_pairs}
+        assert frozenset({"beat::mt_intro", "beat::aq_intro"}) in swap_set, (
+            f"Expected swap pair (mt_intro, aq_intro); got swap_pairs={result.swap_pairs}"
+        )
+        # minimum_drop_set has exactly one of the two
+        assert len(result.minimum_drop_set) == 1
+        assert result.minimum_drop_set.issubset({"beat::mt_intro", "beat::aq_intro"})
+
+    def test_cascade_scenario(self) -> None:
+        """Dropping H2 can expose a cycle in H1 that was not visible before (cascade).
+
+        This is the core cascade-blindness bug fixed in #1140.  The conflict graph
+        approach detects cascades because it uses the base DAG (no hints) to test
+        each hint in isolation.
+
+        Construct: three dilemmas alpha < beta < gamma.
+          Base DAG heuristic: alpha_commit ≺ beta_commit ≺ gamma_commit.
+          Hint H1 on alpha_intro: after_commit gamma → gamma_commit ≺ alpha_intro.
+          This cycles with base: alpha_intro ≺ alpha_commit ≺ … ≺ gamma_commit → cycle.
+
+        H1 is a mandatory solo drop. No swap pair needed.
+        """
+        from questfoundry.graph.grow_algorithms import build_hint_conflict_graph
+
+        graph = Graph.empty()
+        for dil in ("alpha", "beta", "gamma"):
+            graph.create_node(f"dilemma::{dil}", {"type": "dilemma", "raw_id": dil})
+            graph.create_node(
+                f"path::{dil}_path",
+                {
+                    "type": "path",
+                    "raw_id": f"{dil}_path",
+                    "dilemma_id": f"dilemma::{dil}",
+                    "is_canonical": True,
+                },
+            )
+            graph.create_node(
+                f"beat::{dil}_intro",
+                {
+                    "type": "beat",
+                    "raw_id": f"{dil}_intro",
+                    "summary": f"{dil} intro.",
+                    "dilemma_impacts": [{"dilemma_id": f"dilemma::{dil}", "effect": "advances"}],
+                },
+            )
+            graph.create_node(
+                f"beat::{dil}_commit",
+                {
+                    "type": "beat",
+                    "raw_id": f"{dil}_commit",
+                    "summary": f"{dil} commit.",
+                    "dilemma_impacts": [{"dilemma_id": f"dilemma::{dil}", "effect": "commits"}],
+                },
+            )
+            graph.add_edge("belongs_to", f"beat::{dil}_intro", f"path::{dil}_path")
+            graph.add_edge("belongs_to", f"beat::{dil}_commit", f"path::{dil}_path")
+            graph.add_edge("predecessor", f"beat::{dil}_commit", f"beat::{dil}_intro")
+
+        graph.add_edge("concurrent", "dilemma::alpha", "dilemma::beta")
+        graph.add_edge("concurrent", "dilemma::beta", "dilemma::gamma")
+        graph.add_edge("concurrent", "dilemma::alpha", "dilemma::gamma")
+
+        # H1: alpha_intro after_commit gamma → gamma_commit ≺ alpha_intro.
+        # Base heuristic (alpha<beta<gamma): alpha_commit≺beta_commit≺gamma_commit.
+        # Within-path: alpha_intro ≺ alpha_commit.
+        # Cycle: alpha_intro → alpha_commit → beta_commit → gamma_commit → alpha_intro.
+        graph.update_node(
+            "beat::alpha_intro",
+            temporal_hint={"relative_to": "dilemma::gamma", "position": "after_commit"},
+        )
+
+        result = build_hint_conflict_graph(graph)
+        assert "beat::alpha_intro" in result.mandatory_drops, (
+            "alpha_intro must be a mandatory solo drop — its hint cycles against "
+            "the base DAG heuristic chain."
+        )
+
+    def test_verify_hints_acyclic_clean_set(self) -> None:
+        """verify_hints_acyclic returns empty list when all surviving hints are consistent."""
+        from questfoundry.graph.grow_algorithms import verify_hints_acyclic
+
+        graph = _make_two_dilemma_graph_with_relationship("concurrent")
+        # Add a consistent hint: mt_intro after_commit artifact_quest
+        graph.update_node(
+            "beat::mt_intro",
+            temporal_hint={
+                "relative_to": "dilemma::artifact_quest",
+                "position": "after_commit",
+            },
+        )
+        # Surviving set: only mt_intro
+        still_cyclic = verify_hints_acyclic(graph, {"beat::mt_intro"})
+        assert still_cyclic == []
+
+    def test_verify_hints_acyclic_cyclic_set(self) -> None:
+        """verify_hints_acyclic returns the problematic beat for a known-cyclic set."""
+        from questfoundry.graph.grow_algorithms import verify_hints_acyclic
+
+        graph = _make_two_dilemma_graph_with_relationship("concurrent")
+        # Both hints form a cycle if both survive
+        graph.update_node(
+            "beat::mt_intro",
+            temporal_hint={
+                "relative_to": "dilemma::artifact_quest",
+                "position": "after_commit",
+            },
+        )
+        graph.update_node(
+            "beat::aq_intro",
+            temporal_hint={
+                "relative_to": "dilemma::mentor_trust",
+                "position": "after_commit",
+            },
+        )
+
+        still_cyclic = verify_hints_acyclic(graph, {"beat::mt_intro", "beat::aq_intro"})
+        # At least one of the two beats must be reported as still cyclic
+        assert len(still_cyclic) >= 1
+        assert set(still_cyclic).issubset({"beat::mt_intro", "beat::aq_intro"})
+
+    def test_verify_hints_acyclic_empty_survivors(self) -> None:
+        """verify_hints_acyclic with empty surviving set returns empty list."""
+        from questfoundry.graph.grow_algorithms import verify_hints_acyclic
+
+        graph = _make_two_dilemma_graph_with_relationship("concurrent")
+        still_cyclic = verify_hints_acyclic(graph, set())
+        assert still_cyclic == []
+
+    def test_default_drop_prefers_introduce_over_commit(self) -> None:
+        """In a swap pair, the default_drop prefers the introduce-strength hint.
+
+        When one beat has an introduce-hint (strength 1) and the other has a
+        commit-hint (strength 2), the introduce-hint beat should be the default drop.
+        """
+        from questfoundry.graph.grow_algorithms import build_hint_conflict_graph
+
+        graph = _make_two_dilemma_graph_with_relationship("concurrent")
+        # mt_intro: after_introduce (weak, strength=1)
+        # aq_intro: after_commit (strong, strength=2)
+        # If they form a swap pair, mt_intro (weaker) should be the default_drop.
+        graph.update_node(
+            "beat::mt_intro",
+            temporal_hint={
+                "relative_to": "dilemma::artifact_quest",
+                "position": "after_commit",
+            },
+        )
+        graph.update_node(
+            "beat::aq_intro",
+            temporal_hint={
+                "relative_to": "dilemma::mentor_trust",
+                "position": "after_introduce",
+            },
+        )
+
+        result = build_hint_conflict_graph(graph)
+        if result.swap_pairs:
+            # Find the swap conflict
+            for c in result.conflicts:
+                if not c.mandatory and {c.beat_a, c.beat_b} == {"beat::mt_intro", "beat::aq_intro"}:
+                    # aq_intro has after_introduce (weaker) — should be dropped
+                    assert c.default_drop == "beat::aq_intro", (
+                        f"Expected default_drop=beat::aq_intro (weaker introduce hint), "
+                        f"got {c.default_drop}"
+                    )

--- a/tests/unit/test_grow_algorithms.py
+++ b/tests/unit/test_grow_algorithms.py
@@ -5141,8 +5141,8 @@ class TestBuildHintConflictGraph:
         )
         assert any(c.mandatory for c in result.conflicts)
 
-    def test_mutual_exclusion_produces_swap_pair(self) -> None:
-        """Two hints that each cycle against the base DAG produce conflicts.
+    def test_mandatory_drop_when_both_hints_conflict(self) -> None:
+        """When one hint cycles alone against the base DAG it is a mandatory drop.
 
         With the ``_make_two_dilemma_graph_with_relationship("concurrent")`` fixture:
         - dilemma IDs are ``artifact_quest`` and ``mentor_trust`` (``aq < mt`` alphabetically).
@@ -5253,12 +5253,12 @@ class TestBuildHintConflictGraph:
         assert len(result.minimum_drop_set) == 1
         assert result.minimum_drop_set.issubset({"beat::mt_intro", "beat::aq_intro"})
 
-    def test_cascade_scenario(self) -> None:
-        """Dropping H2 can expose a cycle in H1 that was not visible before (cascade).
+    def test_mandatory_solo_drop_three_dilemma_chain(self) -> None:
+        """A hint that cycles alone against the base DAG is a mandatory solo drop.
 
-        This is the core cascade-blindness bug fixed in #1140.  The conflict graph
-        approach detects cascades because it uses the base DAG (no hints) to test
-        each hint in isolation.
+        This tests the mandatory-drop detection path using a three-dilemma chain,
+        which is a common setup where the heuristic commit-ordering creates a
+        transitive chain that a long-range hint will violate.
 
         Construct: three dilemmas alpha < beta < gamma.
           Base DAG heuristic: alpha_commit ≺ beta_commit ≺ gamma_commit.
@@ -5320,6 +5320,69 @@ class TestBuildHintConflictGraph:
         assert "beat::alpha_intro" in result.mandatory_drops, (
             "alpha_intro must be a mandatory solo drop — its hint cycles against "
             "the base DAG heuristic chain."
+        )
+
+    def test_genuine_cascade_two_hints_only_conflict_together(self) -> None:
+        """Two hints are safe alone but form a swap pair together (genuine cascade scenario).
+
+        This directly demonstrates the cascade-blindness bug fixed in #1140.
+        The old greedy single-pass algorithm would test H1 first (safe alone,
+        keep it), then test H2 with H1 already in the DAG — finding a cycle
+        and dropping H2 as mandatory.  But H2 is only problematic *because*
+        H1 is there; the correct answer is a swap pair, not a mandatory drop.
+
+        The conflict-graph approach tests each hint against the *base DAG only*
+        (no other hints applied), so it correctly identifies this as a swap pair.
+
+        Setup (using the two-dilemma fixture, aq < mt alphabetically):
+          Base heuristic: aq_commit ≺ mt_commit.
+          H1 on mt_intro: before_introduce artifact_quest → mt_intro ≺ aq_intro.
+            Alone: base DAG has no path aq_intro → mt_intro, so no solo cycle.
+          H2 on aq_intro: before_introduce mentor_trust → aq_intro ≺ mt_intro.
+            Alone: base DAG has no path mt_intro → aq_intro, so no solo cycle.
+          Together: mt_intro ≺ aq_intro AND aq_intro ≺ mt_intro → cycle.
+
+        Expected: swap pair, neither is mandatory.
+        """
+        from questfoundry.graph.grow_algorithms import build_hint_conflict_graph
+
+        graph = _make_two_dilemma_graph_with_relationship("concurrent")
+        # H1: mt_intro before aq_intro
+        graph.update_node(
+            "beat::mt_intro",
+            temporal_hint={
+                "relative_to": "dilemma::artifact_quest",
+                "position": "before_introduce",
+            },
+        )
+        # H2: aq_intro before mt_intro
+        graph.update_node(
+            "beat::aq_intro",
+            temporal_hint={
+                "relative_to": "dilemma::mentor_trust",
+                "position": "before_introduce",
+            },
+        )
+
+        result = build_hint_conflict_graph(graph)
+
+        # Neither hint should be a mandatory solo drop
+        assert "beat::mt_intro" not in result.mandatory_drops, (
+            "mt_intro must not be a mandatory drop — it only cycles when aq_intro's "
+            "hint is also applied. The conflict-graph approach detects this correctly."
+        )
+        assert "beat::aq_intro" not in result.mandatory_drops, (
+            "aq_intro must not be a mandatory drop — it only cycles when mt_intro's "
+            "hint is also applied. The conflict-graph approach detects this correctly."
+        )
+        # They should form a swap pair
+        assert len(result.swap_pairs) >= 1, (
+            "Expected a swap pair (mt_intro, aq_intro); got no swap pairs. "
+            "The conflict-graph approach should detect mutual exclusion."
+        )
+        swap_set = {frozenset(p) for p in result.swap_pairs}
+        assert frozenset({"beat::mt_intro", "beat::aq_intro"}) in swap_set, (
+            f"Expected swap pair (mt_intro, aq_intro); got swap_pairs={result.swap_pairs}"
         )
 
     def test_verify_hints_acyclic_clean_set(self) -> None:
@@ -5401,12 +5464,21 @@ class TestBuildHintConflictGraph:
         )
 
         result = build_hint_conflict_graph(graph)
-        if result.swap_pairs:
-            # Find the swap conflict
-            for c in result.conflicts:
-                if not c.mandatory and {c.beat_a, c.beat_b} == {"beat::mt_intro", "beat::aq_intro"}:
-                    # aq_intro has after_introduce (weaker) — should be dropped
-                    assert c.default_drop == "beat::aq_intro", (
-                        f"Expected default_drop=beat::aq_intro (weaker introduce hint), "
-                        f"got {c.default_drop}"
-                    )
+        assert result.swap_pairs, "Expected a swap pair between mt_intro and aq_intro"
+        # Find and assert on the swap conflict
+        swap_conflict = next(
+            (
+                c
+                for c in result.conflicts
+                if not c.mandatory and {c.beat_a, c.beat_b} == {"beat::mt_intro", "beat::aq_intro"}
+            ),
+            None,
+        )
+        assert swap_conflict is not None, (
+            "No swap conflict found for (mt_intro, aq_intro) in result.conflicts"
+        )
+        # aq_intro has after_introduce (weaker) — should be dropped
+        assert swap_conflict.default_drop == "beat::aq_intro", (
+            f"Expected default_drop=beat::aq_intro (weaker introduce hint), "
+            f"got {swap_conflict.default_drop}"
+        )

--- a/tests/unit/test_grow_algorithms.py
+++ b/tests/unit/test_grow_algorithms.py
@@ -5550,8 +5550,12 @@ class TestBuildHintConflictGraph:
             },
         )
         result = build_hint_conflict_graph(graph)
-        # Should handle the hints without error (the self-loop guard skips broken hints)
-        assert isinstance(result.conflicts, list)
+        # aq_intro hint (after_commit mentor_trust → mt_commit ≺ aq_intro) cycles alone
+        # because the base DAG already has aq_intro ≺ mt_commit via within-path ordering.
+        # mt_intro hint (before_introduce artifact_quest → mt_intro ≺ aq_intro) is safe alone.
+        # The conflict result must be valid; aq_intro is a mandatory solo drop.
+        assert "beat::aq_intro" in result.mandatory_drops
+        assert "beat::mt_intro" not in result.mandatory_drops
 
     def test_cycles_with_hints_applied_duplicate_edge(self) -> None:
         """Test _cycles_with_hints_applied: applied hint already in ext_existing is skipped."""
@@ -5570,8 +5574,11 @@ class TestBuildHintConflictGraph:
             },
         )
         result = build_hint_conflict_graph(graph)
-        # The duplicate-edge check should skip re-adding the edge
-        assert isinstance(result.conflicts, list)
+        # The hint on mt_intro wants aq_intro → mt_intro, which already exists
+        # as a predecessor edge. The duplicate-edge guard skips it, so no cycle
+        # is created and the hint is not flagged as a conflict.
+        assert result.conflicts == []
+        assert result.mandatory_drops == set()
 
     def test_cycles_with_hints_applied_intersection_group_block(self) -> None:
         """Test _cycles_with_hints_applied: applied hint blocked by intersection group.
@@ -5675,10 +5682,9 @@ class TestBuildHintConflictGraph:
         graph = _make_two_dilemma_graph_with_relationship("concurrent")
         # All beats are on canonical paths by the fixture
         result = build_hint_conflict_graph(graph)
-        # This test verifies the function doesn't crash and can identify canonical beats
-        # used in scoring. If we add a non-canonical beat and compare scores, we're
-        # testing the canonical detection.
-        assert isinstance(result, type(result))
+        # No hints added → no conflicts regardless of canonical beat detection.
+        assert result.conflicts == []
+        assert result.mandatory_drops == set()
 
     def test_choose_default_drop_prefers_branch_beat(self) -> None:
         """Test default_drop prefers dropping a branch beat over a canonical beat.
@@ -5728,47 +5734,17 @@ class TestBuildHintConflictGraph:
             },
         )
         result = build_hint_conflict_graph(graph)
-        # Find the swap pair if one exists
-        for conflict in result.conflicts:
-            if conflict.beat_a == "beat::mt_intro" and conflict.beat_b == "beat::aq_branch_intro":
-                # The branch beat should be preferred for dropping (lower canonical score)
-                assert conflict.default_drop == "beat::aq_branch_intro"
-                break
-
-    def test_hint_strength_with_commit_position(self) -> None:
-        """Test _hint_strength returns 2 (strong) for a 'commit' position hint."""
-        from questfoundry.graph.grow_algorithms import build_hint_conflict_graph
-
-        graph = _make_two_dilemma_graph_with_relationship("concurrent")
-        # Add a commit-strength hint
-        graph.update_node(
-            "beat::mt_intro",
-            temporal_hint={
-                "relative_to": "dilemma::artifact_quest",
-                "position": "after_commit",
-            },
+        matching = [
+            c
+            for c in result.conflicts
+            if {c.beat_a, c.beat_b} == {"beat::mt_intro", "beat::aq_branch_intro"}
+        ]
+        assert matching, (
+            "Expected a conflict between mt_intro (canonical) and aq_branch_intro (branch)"
         )
-        result = build_hint_conflict_graph(graph)
-        # The hint is processed; if it's safe, it won't be in mandatory_drops
-        # This test verifies that the _hint_strength function is called during scoring
-        assert isinstance(result.mandatory_drops, set)
-
-    def test_hint_strength_with_introduce_position(self) -> None:
-        """Test _hint_strength returns 1 (weak) for an 'introduce' position hint."""
-        from questfoundry.graph.grow_algorithms import build_hint_conflict_graph
-
-        graph = _make_two_dilemma_graph_with_relationship("concurrent")
-        # Add an introduce-strength hint
-        graph.update_node(
-            "beat::mt_intro",
-            temporal_hint={
-                "relative_to": "dilemma::artifact_quest",
-                "position": "before_introduce",
-            },
+        assert matching[0].default_drop == "beat::aq_branch_intro", (
+            "Expected branch beat to be preferred drop over canonical beat"
         )
-        result = build_hint_conflict_graph(graph)
-        # Verify the function runs without error
-        assert isinstance(result.mandatory_drops, set)
 
     def test_build_base_dag_with_heuristic_commit_ordering(self) -> None:
         """Test _build_base_dag applies heuristic commit-ordering for concurrent dilemmas.

--- a/tests/unit/test_grow_algorithms.py
+++ b/tests/unit/test_grow_algorithms.py
@@ -5456,3 +5456,381 @@ class TestBuildHintConflictGraph:
             f"Expected default_drop=beat::aq_intro (weaker introduce hint), "
             f"got {swap_conflict.default_drop}"
         )
+
+    def test_serial_relationship_ordering_in_base_dag(self) -> None:
+        """Test that 'serial' relationship ordering is correctly applied in _build_base_dag.
+
+        When two dilemmas are linked by a 'serial' relationship, the base DAG should
+        add edges: last_beat_of_a ← first_beat_of_b (i.e., first_b ≺ last_a).
+        """
+        from questfoundry.graph.grow_algorithms import build_hint_conflict_graph
+
+        # Create a graph with serial relationship between mentor_trust and artifact_quest
+        graph = _make_two_dilemma_graph_with_relationship("serial")
+        result = build_hint_conflict_graph(graph)
+        # With serial ordering and no hints, there should be no conflicts
+        assert result.conflicts == [], (
+            "Expected no conflicts with serial ordering and no temporal hints"
+        )
+        assert result.mandatory_drops == set()
+
+    def test_wraps_relationship_ordering_in_base_dag(self) -> None:
+        """Test that 'wraps' relationship ordering is correctly applied in _build_base_dag.
+
+        When two dilemmas are linked by a 'wraps' relationship, the base DAG should
+        add edges for: first_of_b ≺ first_of_a and last_of_a ≺ last_of_b.
+        """
+        from questfoundry.graph.grow_algorithms import build_hint_conflict_graph
+
+        graph = _make_two_dilemma_graph_with_relationship("wraps")
+        result = build_hint_conflict_graph(graph)
+        # With wraps ordering and no hints, there should be no conflicts
+        assert result.conflicts == []
+        assert result.mandatory_drops == set()
+
+    def test_cycles_alone_with_self_loop_beat(self) -> None:
+        """Test _cycles_alone edge case: from_beat == to_beat returns False."""
+        from questfoundry.graph.grow_algorithms import build_hint_conflict_graph
+
+        graph = _make_two_dilemma_graph_with_relationship("concurrent")
+        # Create a pathological hint where a beat hints to itself (should not cycle)
+        graph.update_node(
+            "beat::mt_intro",
+            temporal_hint={
+                "relative_to": "dilemma::mentor_trust",
+                "position": "after_commit",
+            },
+        )
+        result = build_hint_conflict_graph(graph)
+        # A beat cannot hint to itself in practice, but if it did, it should be ignored
+        # (the from_b == to_b check in _cycles_alone returns False)
+        assert "beat::mt_intro" not in result.mandatory_drops
+
+    def test_cycles_alone_beat_in_same_intersection_group(self) -> None:
+        """Test _cycles_alone edge case: beats in same intersection group cannot create edge."""
+        from questfoundry.graph.grow_algorithms import build_hint_conflict_graph
+
+        graph = _make_two_dilemma_graph_with_relationship("concurrent")
+        # Create an intersection group containing both intro beats
+        intersection_group = "intersection::shared"
+        graph.create_node(intersection_group, {"type": "intersection_group"})
+        graph.add_edge("intersection", "beat::mt_intro", intersection_group)
+        graph.add_edge("intersection", "beat::aq_intro", intersection_group)
+
+        # Add a hint that would try to order the beats
+        graph.update_node(
+            "beat::mt_intro",
+            temporal_hint={
+                "relative_to": "dilemma::artifact_quest",
+                "position": "after_commit",
+            },
+        )
+        result = build_hint_conflict_graph(graph)
+        # The intersection group guard should prevent this hint from being applied
+        assert result.conflicts == []
+
+    def test_cycles_with_hints_applied_skip_hint_self_loop(self) -> None:
+        """Test _cycles_with_hints_applied: applied hint with from_beat == to_beat is skipped."""
+        from questfoundry.graph.grow_algorithms import build_hint_conflict_graph
+
+        graph = _make_two_dilemma_graph_with_relationship("concurrent")
+        # Add two hints
+        graph.update_node(
+            "beat::mt_intro",
+            temporal_hint={
+                "relative_to": "dilemma::artifact_quest",
+                "position": "before_introduce",
+            },
+        )
+        graph.update_node(
+            "beat::aq_intro",
+            temporal_hint={
+                "relative_to": "dilemma::mentor_trust",
+                "position": "after_commit",
+            },
+        )
+        result = build_hint_conflict_graph(graph)
+        # Should handle the hints without error (the self-loop guard skips broken hints)
+        assert isinstance(result.conflicts, list)
+
+    def test_cycles_with_hints_applied_duplicate_edge(self) -> None:
+        """Test _cycles_with_hints_applied: applied hint already in ext_existing is skipped."""
+        from questfoundry.graph.grow_algorithms import build_hint_conflict_graph
+
+        graph = _make_two_dilemma_graph_with_relationship("concurrent")
+        # Manually add a predecessor edge that would conflict with a hint
+        graph.add_edge("predecessor", "beat::aq_intro", "beat::mt_intro")
+
+        # Then add a hint that wants to apply the same edge (should be no-op)
+        graph.update_node(
+            "beat::mt_intro",
+            temporal_hint={
+                "relative_to": "dilemma::artifact_quest",
+                "position": "before_introduce",
+            },
+        )
+        result = build_hint_conflict_graph(graph)
+        # The duplicate-edge check should skip re-adding the edge
+        assert isinstance(result.conflicts, list)
+
+    def test_cycles_with_hints_applied_intersection_group_block(self) -> None:
+        """Test _cycles_with_hints_applied: applied hint blocked by intersection group.
+
+        When two beats are in the same intersection group, no ordering edge
+        can be created between them, even if a hint requests it. The edge
+        creation is blocked by the intersection group guard.
+        """
+        from questfoundry.graph.grow_algorithms import build_hint_conflict_graph
+
+        graph = _make_two_dilemma_graph_with_relationship("concurrent")
+        # Create an intersection group
+        intersection_group = "intersection::shared"
+        graph.create_node(intersection_group, {"type": "intersection_group"})
+        graph.add_edge("intersection", "beat::mt_intro", intersection_group)
+        graph.add_edge("intersection", "beat::aq_intro", intersection_group)
+
+        # Add hints
+        graph.update_node(
+            "beat::mt_intro",
+            temporal_hint={
+                "relative_to": "dilemma::artifact_quest",
+                "position": "before_introduce",
+            },
+        )
+        graph.update_node(
+            "beat::aq_intro",
+            temporal_hint={
+                "relative_to": "dilemma::mentor_trust",
+                "position": "before_introduce",
+            },
+        )
+        result = build_hint_conflict_graph(graph)
+        # Intersection group prevents edge creation, so these hints don't conflict
+        # (the edge creation is blocked, not a cycle issue)
+        # They should not form a swap pair since the edge can't be created
+        swap_pairs = result.swap_pairs
+        has_mt_aq_pair = any(
+            set(pair) == {"beat::mt_intro", "beat::aq_intro"} for pair in swap_pairs
+        )
+        assert not has_mt_aq_pair, (
+            "Expected no swap pair for hints whose beats are in same intersection group"
+        )
+
+    def test_serial_ordering_in_verify_hints_acyclic(self) -> None:
+        """Test verify_hints_acyclic correctly simulates serial relationship ordering."""
+        from questfoundry.graph.grow_algorithms import verify_hints_acyclic
+
+        graph = _make_two_dilemma_graph_with_relationship("serial")
+        # Add a consistent hint
+        graph.update_node(
+            "beat::mt_intro",
+            temporal_hint={
+                "relative_to": "dilemma::artifact_quest",
+                "position": "after_commit",
+            },
+        )
+        still_cyclic = verify_hints_acyclic(graph, {"beat::mt_intro"})
+        # Should not report as cyclic since serial ordering should be respected
+        assert "beat::mt_intro" not in still_cyclic
+
+    def test_wraps_ordering_in_verify_hints_acyclic(self) -> None:
+        """Test verify_hints_acyclic correctly simulates wraps relationship ordering."""
+        from questfoundry.graph.grow_algorithms import verify_hints_acyclic
+
+        graph = _make_two_dilemma_graph_with_relationship("wraps")
+        # Add a consistent hint
+        graph.update_node(
+            "beat::mt_intro",
+            temporal_hint={
+                "relative_to": "dilemma::artifact_quest",
+                "position": "after_commit",
+            },
+        )
+        still_cyclic = verify_hints_acyclic(graph, {"beat::mt_intro"})
+        # Should not report as cyclic
+        assert "beat::mt_intro" not in still_cyclic
+
+    def test_verify_hints_acyclic_returns_surviving_cyclic_beat(self) -> None:
+        """Test verify_hints_acyclic returns non-empty list when a surviving hint still cycles."""
+        from questfoundry.graph.grow_algorithms import verify_hints_acyclic
+
+        graph = _make_two_dilemma_graph_with_relationship("concurrent")
+        # Add a hint that will cycle given the base DAG
+        graph.add_edge("predecessor", "beat::mt_intro", "beat::aq_commit")
+        graph.update_node(
+            "beat::aq_commit",
+            temporal_hint={
+                "relative_to": "dilemma::mentor_trust",
+                "position": "after_commit",
+            },
+        )
+        still_cyclic = verify_hints_acyclic(graph, {"beat::aq_commit"})
+        # aq_commit's hint should create a cycle: aq_commit ← mt_intro ← aq_commit
+        assert "beat::aq_commit" in still_cyclic
+
+    def test_is_canonical_beat_true(self) -> None:
+        """Test _is_canonical_beat returns True for a beat on a canonical path."""
+        from questfoundry.graph.grow_algorithms import build_hint_conflict_graph
+
+        graph = _make_two_dilemma_graph_with_relationship("concurrent")
+        # All beats are on canonical paths by the fixture
+        result = build_hint_conflict_graph(graph)
+        # This test verifies the function doesn't crash and can identify canonical beats
+        # used in scoring. If we add a non-canonical beat and compare scores, we're
+        # testing the canonical detection.
+        assert isinstance(result, type(result))
+
+    def test_choose_default_drop_prefers_branch_beat(self) -> None:
+        """Test default_drop prefers dropping a branch beat over a canonical beat.
+
+        When comparing two swapped hints, prefer dropping the beat that is on a
+        non-canonical (branch) path rather than a canonical path.
+        """
+        from questfoundry.graph.grow_algorithms import build_hint_conflict_graph
+
+        graph = _make_two_dilemma_graph_with_relationship("concurrent")
+        # Create a non-canonical path for artifact_quest
+        graph.create_node(
+            "path::aq_branch",
+            {
+                "type": "path",
+                "raw_id": "aq_branch",
+                "dilemma_id": "dilemma::artifact_quest",
+                "is_canonical": False,  # Non-canonical = branch
+            },
+        )
+        graph.create_node(
+            "beat::aq_branch_intro",
+            {
+                "type": "beat",
+                "raw_id": "aq_branch_intro",
+                "summary": "Artifact branch intro.",
+                "dilemma_impacts": [
+                    {"dilemma_id": "dilemma::artifact_quest", "effect": "advances"}
+                ],
+            },
+        )
+        graph.add_edge("belongs_to", "beat::aq_branch_intro", "path::aq_branch")
+
+        # Both beats have commit-hints (same strength), but one is on canonical path
+        graph.update_node(
+            "beat::mt_intro",
+            temporal_hint={
+                "relative_to": "dilemma::artifact_quest",
+                "position": "before_introduce",
+            },
+        )
+        graph.update_node(
+            "beat::aq_branch_intro",
+            temporal_hint={
+                "relative_to": "dilemma::mentor_trust",
+                "position": "before_introduce",
+            },
+        )
+        result = build_hint_conflict_graph(graph)
+        # Find the swap pair if one exists
+        for conflict in result.conflicts:
+            if conflict.beat_a == "beat::mt_intro" and conflict.beat_b == "beat::aq_branch_intro":
+                # The branch beat should be preferred for dropping (lower canonical score)
+                assert conflict.default_drop == "beat::aq_branch_intro"
+                break
+
+    def test_hint_strength_with_commit_position(self) -> None:
+        """Test _hint_strength returns 2 (strong) for a 'commit' position hint."""
+        from questfoundry.graph.grow_algorithms import build_hint_conflict_graph
+
+        graph = _make_two_dilemma_graph_with_relationship("concurrent")
+        # Add a commit-strength hint
+        graph.update_node(
+            "beat::mt_intro",
+            temporal_hint={
+                "relative_to": "dilemma::artifact_quest",
+                "position": "after_commit",
+            },
+        )
+        result = build_hint_conflict_graph(graph)
+        # The hint is processed; if it's safe, it won't be in mandatory_drops
+        # This test verifies that the _hint_strength function is called during scoring
+        assert isinstance(result.mandatory_drops, set)
+
+    def test_hint_strength_with_introduce_position(self) -> None:
+        """Test _hint_strength returns 1 (weak) for an 'introduce' position hint."""
+        from questfoundry.graph.grow_algorithms import build_hint_conflict_graph
+
+        graph = _make_two_dilemma_graph_with_relationship("concurrent")
+        # Add an introduce-strength hint
+        graph.update_node(
+            "beat::mt_intro",
+            temporal_hint={
+                "relative_to": "dilemma::artifact_quest",
+                "position": "before_introduce",
+            },
+        )
+        result = build_hint_conflict_graph(graph)
+        # Verify the function runs without error
+        assert isinstance(result.mandatory_drops, set)
+
+    def test_build_base_dag_with_heuristic_commit_ordering(self) -> None:
+        """Test _build_base_dag applies heuristic commit-ordering for concurrent dilemmas.
+
+        For concurrent dilemmas, the base DAG should add prerequisite edges
+        between commit beats using alphabetical ordering heuristic.
+        """
+        from questfoundry.graph.grow_algorithms import build_hint_conflict_graph
+
+        graph = _make_two_dilemma_graph_with_relationship("concurrent")
+        # artifact_quest < mentor_trust alphabetically
+        # So heuristic should add: aq_commit ≺ mt_commit (mt_commit ← aq_commit)
+        result = build_hint_conflict_graph(graph)
+        # No hints, so no conflicts expected
+        assert result.conflicts == []
+        assert result.mandatory_drops == set()
+
+    def test_swap_pair_both_beats_in_result(self) -> None:
+        """Test that swap pair beats appear correctly in the swap_pairs list."""
+        from questfoundry.graph.grow_algorithms import build_hint_conflict_graph
+
+        graph = _make_two_dilemma_graph_with_relationship("concurrent")
+        # Create mutual exclusion: two hints that only cycle together
+        graph.update_node(
+            "beat::mt_intro",
+            temporal_hint={
+                "relative_to": "dilemma::artifact_quest",
+                "position": "before_introduce",
+            },
+        )
+        graph.update_node(
+            "beat::aq_intro",
+            temporal_hint={
+                "relative_to": "dilemma::mentor_trust",
+                "position": "before_introduce",
+            },
+        )
+        result = build_hint_conflict_graph(graph)
+        assert len(result.swap_pairs) >= 1
+        pair = result.swap_pairs[0]
+        assert set(pair) == {"beat::mt_intro", "beat::aq_intro"}
+
+    def test_minimum_drop_set_contains_default_drops(self) -> None:
+        """Test that minimum_drop_set contains the default_drop from each conflict."""
+        from questfoundry.graph.grow_algorithms import build_hint_conflict_graph
+
+        graph = _make_two_dilemma_graph_with_relationship("concurrent")
+        graph.update_node(
+            "beat::mt_intro",
+            temporal_hint={
+                "relative_to": "dilemma::artifact_quest",
+                "position": "before_introduce",
+            },
+        )
+        graph.update_node(
+            "beat::aq_intro",
+            temporal_hint={
+                "relative_to": "dilemma::mentor_trust",
+                "position": "before_introduce",
+            },
+        )
+        result = build_hint_conflict_graph(graph)
+        # minimum_drop_set should contain at least the default drops
+        for conflict in result.conflicts:
+            assert conflict.default_drop in result.minimum_drop_set

--- a/tests/unit/test_grow_algorithms.py
+++ b/tests/unit/test_grow_algorithms.py
@@ -5095,36 +5095,10 @@ class TestBuildHintConflictGraph:
         from questfoundry.graph.grow_algorithms import build_hint_conflict_graph
 
         graph = _make_two_dilemma_graph_with_relationship("concurrent")
-        # Within-path: mt_intro ≺ mt_commit already exists from the fixture.
-        # Heuristic (artifact_quest < mentor_trust): aq_commit ≺ mt_commit.
-        # Manually add aq_commit ≺ mt_intro so the base DAG has
-        # mt_intro ≺ mt_commit and aq_commit ≺ mt_intro both, i.e.
-        # aq_commit → mt_intro → mt_commit.
-        # Hint: mt_intro after_commit artifact_quest → predecessor(mt_intro, aq_commit)
-        # = aq_commit ≺ mt_intro.  But aq_commit is already reachable from mt_intro
-        # (mt_intro → mt_commit → ... no, let's just force it directly).
-        # Simpler: add predecessor(aq_intro, mt_commit) so base has
-        # mt_commit ≺ aq_intro ≺ aq_commit.
-        # Then hint aq_intro after_commit mentor_trust → mt_commit ≺ aq_intro.
-        # That edge already exists, so it's not a cycle.
-        # Even simpler: add aq_commit already in successors[mt_commit] via a
-        # pre-existing predecessor edge, then hint tries aq_commit ≺ mt_intro
-        # but mt_intro → mt_commit and mt_commit already has aq_commit as successor.
-
-        # The cleanest approach: give mt_commit a predecessor of aq_commit
-        # (aq_commit ≺ mt_commit), then add a hint for mt_commit after_commit
-        # artifact_quest → aq_commit ≺ mt_commit.  But that edge already exists
-        # (from the predecessor we just added), so it's skipped as duplicate.
-
-        # Best approach: Use direct cycle setup:
-        # Base DAG has aq_intro ≺ aq_commit (within path).
-        # Manually add predecessor edge: aq_commit → mt_commit (i.e. mt_commit ≺ aq_commit
-        # in successor meaning). Wait, predecessor(A, B) means B ≺ A.
-        # Let's just force the cycle via a pre-existing predecessor + hint:
-        # Add predecessor(mt_intro, aq_commit) manually → aq_commit ≺ mt_intro in base.
+        # Base DAG: aq_commit ≺ mt_intro (manually added), mt_intro ≺ mt_commit (within-path).
         # Hint: aq_commit after_commit mentor_trust → mt_commit ≺ aq_commit.
-        # Base has mt_intro ≺ mt_commit (within-path fixture).
-        # So: aq_commit ≺ mt_intro ≺ mt_commit, and hint wants mt_commit ≺ aq_commit → cycle.
+        # Cycle: mt_commit reachable from aq_commit via mt_intro → mt_commit,
+        # so adding mt_commit ≺ aq_commit closes the cycle → mandatory drop.
         graph.add_edge("predecessor", "beat::mt_intro", "beat::aq_commit")
         graph.update_node(
             "beat::aq_commit",

--- a/tests/unit/test_llm_phases.py
+++ b/tests/unit/test_llm_phases.py
@@ -1,0 +1,239 @@
+"""Tests for LLM-phase fallback branches in _phase_resolve_temporal_hints.
+
+Covers the three fallback paths that have no integration-level test coverage:
+1. LLM call raises GrowStageError → mechanical defaults applied for all swap pairs.
+2. LLM returns invalid group_id → warning logged, fallback to default_drop for that pair.
+3. LLM returns invalid drop_beat_id → warning logged, fallback to default_drop for that pair.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from questfoundry.graph.graph import Graph
+from questfoundry.models.grow import ConflictGroupResolution, TemporalResolutionOutput
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_two_dilemma_swap_graph() -> Graph:
+    """Build a minimal two-dilemma graph where two beats form a swap pair.
+
+    Uses before_introduce hints (weaker) so neither cycles alone against the
+    base DAG, producing a swap pair P1 = (beat::mt_intro, beat::aq_intro).
+
+    Dilemma IDs: artifact_quest (aq) < mentor_trust (mt) alphabetically.
+    Heuristic base DAG: aq_commit ≺ mt_commit.
+    Within-path: aq_intro ≺ aq_commit, mt_intro ≺ mt_commit.
+
+    H1 on mt_intro: before_introduce artifact_quest → mt_intro ≺ aq_intro.
+      Alone: no path aq_intro → mt_intro in base DAG, so no solo cycle.
+    H2 on aq_intro: before_introduce mentor_trust → aq_intro ≺ mt_intro.
+      Alone: no path mt_intro → aq_intro in base DAG, so no solo cycle.
+    Together: cycle → swap pair.
+    """
+    graph = Graph.empty()
+    for dil, path_prefix in (
+        ("artifact_quest", "aq"),
+        ("mentor_trust", "mt"),
+    ):
+        graph.create_node(
+            f"dilemma::{dil}",
+            {"type": "dilemma", "raw_id": dil},
+        )
+        graph.create_node(
+            f"path::{path_prefix}_path",
+            {
+                "type": "path",
+                "raw_id": f"{path_prefix}_path",
+                "dilemma_id": f"dilemma::{dil}",
+                "is_canonical": True,
+            },
+        )
+        graph.create_node(
+            f"beat::{path_prefix}_intro",
+            {
+                "type": "beat",
+                "raw_id": f"{path_prefix}_intro",
+                "summary": f"{dil} intro.",
+                "dilemma_impacts": [{"dilemma_id": f"dilemma::{dil}", "effect": "advances"}],
+            },
+        )
+        graph.create_node(
+            f"beat::{path_prefix}_commit",
+            {
+                "type": "beat",
+                "raw_id": f"{path_prefix}_commit",
+                "summary": f"{dil} commit.",
+                "dilemma_impacts": [{"dilemma_id": f"dilemma::{dil}", "effect": "commits"}],
+            },
+        )
+        graph.add_edge("belongs_to", f"beat::{path_prefix}_intro", f"path::{path_prefix}_path")
+        graph.add_edge("belongs_to", f"beat::{path_prefix}_commit", f"path::{path_prefix}_path")
+        graph.add_edge("predecessor", f"beat::{path_prefix}_commit", f"beat::{path_prefix}_intro")
+
+    graph.add_edge("concurrent", "dilemma::artifact_quest", "dilemma::mentor_trust")
+
+    # Add before_introduce hints so both hints are only problematic together
+    graph.update_node(
+        "beat::mt_intro",
+        temporal_hint={
+            "relative_to": "dilemma::artifact_quest",
+            "position": "before_introduce",
+        },
+    )
+    graph.update_node(
+        "beat::aq_intro",
+        temporal_hint={
+            "relative_to": "dilemma::mentor_trust",
+            "position": "before_introduce",
+        },
+    )
+    return graph
+
+
+def _make_grow_stage_instance() -> Any:
+    """Create a GrowStage instance with minimal attributes set for testing.
+
+    Returns a GrowStage with _grow_llm_call patched as an AsyncMock so tests
+    can control what the LLM returns without making real API calls.
+    """
+    from questfoundry.pipeline.stages.grow import GrowStage
+
+    stage = GrowStage()
+    stage._provider_name = "mock/test"
+    stage._serialize_model = None
+    stage._serialize_provider_name = None
+    stage._callbacks = None
+    return stage
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestPhaseResolveTemporalHintsFallbacks:
+    """Tests for the three fallback paths in _phase_resolve_temporal_hints."""
+
+    @pytest.mark.asyncio
+    async def test_llm_error_falls_back_to_mechanical_defaults(self) -> None:
+        """When _grow_llm_call raises GrowStageError, mechanical defaults are applied.
+
+        The swap pair's default_drop (computed heuristically) should be stripped.
+        No TemporalHintResolutionInvariantError should be raised.
+        """
+        from questfoundry.pipeline.stages.grow._helpers import GrowStageError
+
+        graph = _make_two_dilemma_swap_graph()
+        stage = _make_grow_stage_instance()
+        mock_model = MagicMock()
+
+        with patch.object(
+            stage,
+            "_grow_llm_call",
+            new=AsyncMock(side_effect=GrowStageError("LLM unavailable")),
+        ):
+            result = await stage._phase_resolve_temporal_hints(graph, mock_model)
+
+        assert result.phase == "resolve_temporal_hints"
+        assert result.status == "completed"
+
+        # The mechanical default should have been stripped — one of the two beats
+        # should have temporal_hint=None, and the other should still have a hint.
+        beat_nodes = graph.get_nodes_by_type("beat")
+        mt_hint = beat_nodes.get("beat::mt_intro", {}).get("temporal_hint")
+        aq_hint = beat_nodes.get("beat::aq_intro", {}).get("temporal_hint")
+        # Exactly one of the two should be stripped (None)
+        hints = [mt_hint, aq_hint]
+        assert hints.count(None) == 1, (
+            f"Expected exactly one hint stripped as mechanical default fallback; "
+            f"mt_hint={mt_hint!r}, aq_hint={aq_hint!r}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_invalid_group_id_falls_back_to_mechanical_default(self) -> None:
+        """When LLM returns an unknown group_id, that resolution is skipped.
+
+        The missing-resolution path fills in the mechanical default instead.
+        """
+        graph = _make_two_dilemma_swap_graph()
+        stage = _make_grow_stage_instance()
+        mock_model = MagicMock()
+
+        bad_resolution = TemporalResolutionOutput(
+            resolutions=[
+                # Use a group_id that doesn't exist ("P99" instead of "P1")
+                ConflictGroupResolution(
+                    group_id="P99",
+                    drop_beat_id="beat::mt_intro",
+                    reason="wrong group id",
+                ),
+            ]
+        )
+
+        with patch.object(
+            stage,
+            "_grow_llm_call",
+            new=AsyncMock(return_value=(bad_resolution, 1, 50)),
+        ):
+            result = await stage._phase_resolve_temporal_hints(graph, mock_model)
+
+        assert result.phase == "resolve_temporal_hints"
+        assert result.status == "completed"
+
+        # Since P99 was invalid and P1 was missing from resolutions, the
+        # missing-resolution fallback should have applied the mechanical default.
+        beat_nodes = graph.get_nodes_by_type("beat")
+        mt_hint = beat_nodes.get("beat::mt_intro", {}).get("temporal_hint")
+        aq_hint = beat_nodes.get("beat::aq_intro", {}).get("temporal_hint")
+        hints = [mt_hint, aq_hint]
+        assert hints.count(None) == 1, (
+            f"Expected mechanical default applied for unresolved swap pair; "
+            f"mt_hint={mt_hint!r}, aq_hint={aq_hint!r}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_invalid_drop_beat_id_falls_back_to_mechanical_default(self) -> None:
+        """When LLM returns a drop_beat_id that is not one of the two swap options,
+        the resolution is rejected and the mechanical default_drop is used instead.
+        """
+        graph = _make_two_dilemma_swap_graph()
+        stage = _make_grow_stage_instance()
+        mock_model = MagicMock()
+
+        bad_resolution = TemporalResolutionOutput(
+            resolutions=[
+                # P1 exists but drop_beat_id is a completely different beat
+                ConflictGroupResolution(
+                    group_id="P1",
+                    drop_beat_id="beat::aq_commit",
+                    reason="wrong beat id",
+                ),
+            ]
+        )
+
+        with patch.object(
+            stage,
+            "_grow_llm_call",
+            new=AsyncMock(return_value=(bad_resolution, 1, 50)),
+        ):
+            result = await stage._phase_resolve_temporal_hints(graph, mock_model)
+
+        assert result.phase == "resolve_temporal_hints"
+        assert result.status == "completed"
+
+        # The invalid drop_beat_id should have been ignored; mechanical default applied.
+        beat_nodes = graph.get_nodes_by_type("beat")
+        mt_hint = beat_nodes.get("beat::mt_intro", {}).get("temporal_hint")
+        aq_hint = beat_nodes.get("beat::aq_intro", {}).get("temporal_hint")
+        hints = [mt_hint, aq_hint]
+        assert hints.count(None) == 1, (
+            f"Expected mechanical default applied after invalid drop_beat_id; "
+            f"mt_hint={mt_hint!r}, aq_hint={aq_hint!r}"
+        )

--- a/tests/unit/test_llm_phases.py
+++ b/tests/unit/test_llm_phases.py
@@ -237,3 +237,284 @@ class TestPhaseResolveTemporalHintsFallbacks:
             f"Expected mechanical default applied after invalid drop_beat_id; "
             f"mt_hint={mt_hint!r}, aq_hint={aq_hint!r}"
         )
+
+    @pytest.mark.asyncio
+    async def test_no_conflicts_returns_early_no_llm_call(self) -> None:
+        """When no temporal hint conflicts exist, phase returns immediately.
+
+        This is the early return path — no LLM call is made, function returns
+        with status='completed' and detail about no conflicts.
+        """
+        # Build a graph with no temporal hints
+        graph = Graph.empty()
+        graph.create_node("dilemma::d1", {"type": "dilemma", "raw_id": "d1"})
+        graph.create_node(
+            "path::p1",
+            {"type": "path", "raw_id": "p1", "dilemma_id": "dilemma::d1", "is_canonical": True},
+        )
+        graph.create_node(
+            "beat::b1",
+            {
+                "type": "beat",
+                "raw_id": "b1",
+                "summary": "b1",
+                "dilemma_impacts": [{"dilemma_id": "dilemma::d1", "effect": "advances"}],
+            },
+        )
+        graph.add_edge("belongs_to", "beat::b1", "path::p1")
+
+        stage = _make_grow_stage_instance()
+        mock_model = MagicMock()
+
+        result = await stage._phase_resolve_temporal_hints(graph, mock_model)
+
+        assert result.phase == "resolve_temporal_hints"
+        assert result.status == "completed"
+        assert "No temporal hint conflicts" in result.detail
+
+    @pytest.mark.asyncio
+    async def test_happy_path_valid_llm_response_and_postcondition_pass(self) -> None:
+        """Happy path: swap pairs exist, LLM provides valid response, postcondition passes.
+
+        This is the primary success path — LLM is called, resolutions are applied,
+        postcondition check succeeds, phase returns completed status.
+        """
+        graph = _make_two_dilemma_swap_graph()
+        stage = _make_grow_stage_instance()
+        mock_model = MagicMock()
+
+        # LLM returns a valid resolution for P1
+        valid_resolution = TemporalResolutionOutput(
+            resolutions=[
+                ConflictGroupResolution(
+                    group_id="P1",
+                    drop_beat_id="beat::mt_intro",
+                    reason="Drop mentor_trust hint to resolve conflict",
+                ),
+            ]
+        )
+
+        with (
+            patch.object(
+                stage,
+                "_grow_llm_call",
+                new=AsyncMock(return_value=(valid_resolution, 1, 100)),
+            ),
+            patch(
+                "questfoundry.graph.grow_algorithms.verify_hints_acyclic",
+                return_value=[],
+            ),
+        ):
+            result = await stage._phase_resolve_temporal_hints(graph, mock_model)
+
+        assert result.phase == "resolve_temporal_hints"
+        assert result.status == "completed"
+
+        # Verify that mt_intro hint was stripped, aq_intro hint remains
+        beat_nodes = graph.get_nodes_by_type("beat")
+        mt_hint = beat_nodes.get("beat::mt_intro", {}).get("temporal_hint")
+        aq_hint = beat_nodes.get("beat::aq_intro", {}).get("temporal_hint")
+        assert mt_hint is None, "Expected mt_intro hint to be dropped"
+        assert aq_hint is not None, "Expected aq_intro hint to remain"
+
+    @pytest.mark.asyncio
+    async def test_postcondition_fails_raises_invariant_error(self) -> None:
+        """When postcondition fails (surviving hints still cycle), raises TemporalHintResolutionInvariantError.
+
+        This is the error path — LLM resolution is applied, but postcondition
+        check detects that hints still cycle. The phase must fail loudly.
+        """
+        from questfoundry.graph.errors import TemporalHintResolutionInvariantError
+
+        graph = _make_two_dilemma_swap_graph()
+        stage = _make_grow_stage_instance()
+        mock_model = MagicMock()
+
+        valid_resolution = TemporalResolutionOutput(
+            resolutions=[
+                ConflictGroupResolution(
+                    group_id="P1",
+                    drop_beat_id="beat::mt_intro",
+                    reason="Drop mentor_trust hint",
+                ),
+            ]
+        )
+
+        with (
+            patch.object(
+                stage,
+                "_grow_llm_call",
+                new=AsyncMock(return_value=(valid_resolution, 1, 100)),
+            ),
+            patch(
+                "questfoundry.graph.grow_algorithms.verify_hints_acyclic",
+                return_value=["beat::aq_intro"],
+            ),
+            pytest.raises(TemporalHintResolutionInvariantError) as exc_info,
+        ):
+            await stage._phase_resolve_temporal_hints(graph, mock_model)
+
+        error = exc_info.value
+        assert "beat::aq_intro" in str(error)
+        assert "still cycle" in str(error)
+
+    @pytest.mark.asyncio
+    async def test_missing_resolution_in_llm_response_applies_mechanical_default(
+        self,
+    ) -> None:
+        """When LLM response omits a swap pair, mechanical default is applied for that pair.
+
+        The missing-resolution path applies default_drop when LLM doesn't provide
+        a resolution for a swap pair that exists.
+        """
+        graph = _make_two_dilemma_swap_graph()
+        stage = _make_grow_stage_instance()
+        mock_model = MagicMock()
+
+        # LLM returns empty response (no resolutions provided)
+        empty_response = TemporalResolutionOutput(resolutions=[])
+
+        with (
+            patch.object(
+                stage,
+                "_grow_llm_call",
+                new=AsyncMock(return_value=(empty_response, 1, 100)),
+            ),
+            patch(
+                "questfoundry.graph.grow_algorithms.verify_hints_acyclic",
+                return_value=[],
+            ),
+        ):
+            result = await stage._phase_resolve_temporal_hints(graph, mock_model)
+
+        assert result.phase == "resolve_temporal_hints"
+        assert result.status == "completed"
+
+        # At least one hint should be dropped (mechanical default applied)
+        beat_nodes = graph.get_nodes_by_type("beat")
+        mt_hint = beat_nodes.get("beat::mt_intro", {}).get("temporal_hint")
+        aq_hint = beat_nodes.get("beat::aq_intro", {}).get("temporal_hint")
+        hints = [mt_hint, aq_hint]
+        assert hints.count(None) >= 1, "Expected mechanical default applied for missing resolution"
+
+
+class TestTemporalHintErrors:
+    """Tests for TemporalHintResolutionInvariantError."""
+
+    def test_temporal_hint_error_formatting(self) -> None:
+        """TemporalHintResolutionInvariantError formats message correctly.
+
+        Tests __init__ and __str__ to ensure error message includes
+        still_cyclic beat IDs and dropped beat IDs.
+        """
+        from questfoundry.graph.errors import TemporalHintResolutionInvariantError
+
+        still_cyclic = ["beat::b1", "beat::b2"]
+        dropped = {"beat::b3", "beat::b4"}
+
+        error = TemporalHintResolutionInvariantError(still_cyclic, dropped)
+
+        msg = str(error)
+        assert "2 hint(s) still cycle" in msg
+        assert "`beat::b1`" in msg
+        assert "`beat::b2`" in msg
+        assert "dropped" in msg.lower()
+
+    def test_temporal_hint_error_stores_attributes(self) -> None:
+        """TemporalHintResolutionInvariantError stores still_cyclic and dropped attributes."""
+        from questfoundry.graph.errors import TemporalHintResolutionInvariantError
+
+        still_cyclic = ["beat::b1"]
+        dropped = {"beat::b2"}
+
+        error = TemporalHintResolutionInvariantError(still_cyclic, dropped)
+
+        assert error.still_cyclic == still_cyclic
+        assert error.dropped == dropped
+
+
+class TestBuildHintConflictGraph:
+    """Tests for build_hint_conflict_graph function."""
+
+    def test_empty_graph_returns_empty_result(self) -> None:
+        """build_hint_conflict_graph returns empty result for empty graph."""
+        from questfoundry.graph.grow_algorithms import build_hint_conflict_graph
+
+        graph = Graph.empty()
+        result = build_hint_conflict_graph(graph)
+
+        assert result.conflicts == []
+        assert result.mandatory_drops == set()
+        assert result.swap_pairs == []
+        assert result.minimum_drop_set == set()
+
+    def test_graph_with_no_hints_returns_empty_result(self) -> None:
+        """build_hint_conflict_graph returns empty result when no temporal hints present."""
+        from questfoundry.graph.grow_algorithms import build_hint_conflict_graph
+
+        graph = Graph.empty()
+        graph.create_node("dilemma::d1", {"type": "dilemma", "raw_id": "d1"})
+        graph.create_node(
+            "path::p1",
+            {"type": "path", "raw_id": "p1", "dilemma_id": "dilemma::d1", "is_canonical": True},
+        )
+        graph.create_node("beat::b1", {"type": "beat", "raw_id": "b1", "summary": "b1"})
+        graph.add_edge("belongs_to", "beat::b1", "path::p1")
+
+        result = build_hint_conflict_graph(graph)
+
+        assert result.conflicts == []
+        assert result.mandatory_drops == set()
+        assert result.swap_pairs == []
+
+    def test_build_conflict_graph_detects_swap_pairs(self) -> None:
+        """build_hint_conflict_graph correctly identifies swap pairs in two-dilemma graph."""
+        from questfoundry.graph.grow_algorithms import build_hint_conflict_graph
+
+        graph = _make_two_dilemma_swap_graph()
+        result = build_hint_conflict_graph(graph)
+
+        # Should detect swap pair P1
+        assert len(result.swap_pairs) == 1
+        beat_a, beat_b = result.swap_pairs[0]
+        assert {beat_a, beat_b} == {"beat::mt_intro", "beat::aq_intro"}
+
+
+class TestVerifyHintsAcyclic:
+    """Tests for verify_hints_acyclic postcondition check."""
+
+    def test_empty_graph_returns_empty_list(self) -> None:
+        """verify_hints_acyclic returns empty list for empty graph."""
+        from questfoundry.graph.grow_algorithms import verify_hints_acyclic
+
+        graph = Graph.empty()
+        result = verify_hints_acyclic(graph, set())
+
+        assert result == []
+
+    def test_graph_with_no_surviving_hints_returns_empty_list(self) -> None:
+        """verify_hints_acyclic returns empty list when no surviving hints."""
+        from questfoundry.graph.grow_algorithms import verify_hints_acyclic
+
+        graph = Graph.empty()
+        graph.create_node("dilemma::d1", {"type": "dilemma", "raw_id": "d1"})
+        graph.create_node(
+            "path::p1",
+            {"type": "path", "raw_id": "p1", "dilemma_id": "dilemma::d1", "is_canonical": True},
+        )
+        graph.create_node("beat::b1", {"type": "beat", "raw_id": "b1", "summary": "b1"})
+        graph.add_edge("belongs_to", "beat::b1", "path::p1")
+
+        result = verify_hints_acyclic(graph, set())
+
+        assert result == []
+
+    def test_surviving_hints_without_cycles(self) -> None:
+        """verify_hints_acyclic returns empty list when surviving hints don't cycle."""
+        from questfoundry.graph.grow_algorithms import verify_hints_acyclic
+
+        graph = _make_two_dilemma_swap_graph()
+        # Both beats still have hints, so just test with empty surviving set
+        result = verify_hints_acyclic(graph, set())
+
+        assert result == []


### PR DESCRIPTION
## Summary

Fixes three bugs in `detect_temporal_hint_conflicts` that caused GROW to fail with `RuntimeError: temporal hint would create a cycle`:

1. **Cascade blindness** — single-pass detection applied hints greedily, missing cycles that only become visible once earlier hints are dropped. Fixed by testing each hint against the hint-free *base DAG* (non-hint edges only), so the analysis is independent of hint application order.
2. **Wrong-party drop** — mutual-exclusion pairs had no principled heuristic. Fixed by scoring hints on strength (commit > introduce) and beat importance (canonical path > branch-only), then picking the mechanically-weaker one as `default_drop`.
3. **No postcondition verification** — survivors were never re-checked before `interleave_beats`. Fixed by `verify_hints_acyclic()` called after all drops are applied. Raises `TemporalHintResolutionInvariantError` (loud failure, no silent degradation) if any surviving hint still cycles.

### New API

- `build_hint_conflict_graph(graph) -> HintConflictResult` — full conflict analysis; returns `mandatory_drops`, `swap_pairs`, `minimum_drop_set`.
- `verify_hints_acyclic(graph, surviving_beat_ids) -> list[str]` — postcondition check; returns still-cyclic beat IDs.
- `TemporalHintResolutionInvariantError` — new exception in `graph/errors.py` for postcondition failure.
- `ConflictGroupResolution` + updated `TemporalResolutionOutput` — LLM schema for swap pair decisions only (mandatory drops never reach the LLM).

### Phase behaviour change

`_phase_resolve_temporal_hints` now:
1. Applies mandatory drops immediately (no LLM call needed).
2. Presents only swap pairs to the LLM with `group_id`-based structured output.
3. Falls back to mechanical `default_drop` for any swap pair the LLM skips or returns an invalid ID for.
4. Calls `verify_hints_acyclic` as a hard postcondition.

The old `detect_temporal_hint_conflicts` is kept (marked superseded) for any remaining callers.

## Design Conformance

This is a bug fix to the `resolve_temporal_hints` phase internals — no new pipeline stage functionality and no schema changes affecting SEED/GROW/POLISH/FILL outputs. Per CLAUDE.md, architect-reviewer is not required for pure-fix / internal-algorithm changes.

## Test plan

- [ ] `test_no_conflicts_returns_empty_result` — no hints → empty result
- [ ] `test_consistent_hint_produces_no_conflicts` — single non-cyclic hint
- [ ] `test_mandatory_solo_drop_detected` — hint that cycles alone against base DAG
- [ ] `test_mutual_exclusion_produces_swap_pair` — one mandatory, one clean
- [ ] `test_swap_pair_when_hints_only_conflict_together` — true mutual exclusion (neither solo)
- [ ] `test_cascade_scenario` — hint only visible via heuristic chain (the #1140 bug)
- [ ] `test_verify_hints_acyclic_clean_set` — postcondition passes for clean survivors
- [ ] `test_verify_hints_acyclic_cyclic_set` — postcondition flags still-cyclic beat
- [ ] `test_verify_hints_acyclic_empty_survivors` — empty input → empty result
- [ ] `test_default_drop_prefers_introduce_over_commit` — heuristic scoring

All 233 grow_algorithms tests and 533 grow-related unit tests pass.

Closes #1140