### PR TITLE
fix: remove beat_id dedup in hint conflict graph for multi-path dilemmas

### DIFF
--- a/src/questfoundry/graph/grow_algorithms.py
+++ b/src/questfoundry/graph/grow_algorithms.py
@@ -3101,6 +3101,16 @@ def build_hint_conflict_graph(graph: Graph) -> HintConflictResult:
     # Flatten surviving beats back into an edge list for simulation.
     # All edges for each surviving beat are included so that
     # _simulate_hints_sequential sees the full set of edges a beat would add.
+    #
+    # Known limitation: the simulation is edge-atomic, not beat-atomic.
+    # When a beat has N edges and edge 1 is safe but edge 2 cycles,
+    # _simulate_hints_sequential commits edge 1 before rejecting edge 2.
+    # Edge 1 then remains in the working DAG for that simulation pass and may
+    # cause a false conflict for a subsequent beat.  This is benign: each
+    # _sim_survivors call starts a fresh copy of the base DAG, so the false
+    # conflict disappears on the next MDS iteration after the beat is dropped.
+    # Strict beat-atomic semantics would require pre-checking all edges of a
+    # beat before committing any, but are not needed for correctness here.
     survivors: list[_HintEdge] = [edge for bid in surviving_beat_ids for edge in hints_by_beat[bid]]
 
     # Phase 2: greedy MDS loop — detect transitive multi-hint cycles.
@@ -3146,8 +3156,10 @@ def build_hint_conflict_graph(graph: Graph) -> HintConflictResult:
         rejected_edges = _simulate_hints_sequential(
             active, base_existing, base_succ, beat_set, beat_intersection_groups
         )
-        # Deduplicate by beat_id: one representative per rejected beat.
-        # A multi-edge beat may appear multiple times; return only the first.
+        # Deduplicate by beat_id: one representative _HintEdge per rejected beat.
+        # A multi-edge beat may appear multiple times (edge-atomic simulation commits
+        # edge 1 before rejecting edge 2, so edge 1 may cause a false conflict for
+        # a subsequent beat; MDS re-runs clean this up on the next iteration).
         seen: set[str] = set()
         unique_rejected: list[_HintEdge] = []
         for h in rejected_edges:
@@ -3369,12 +3381,8 @@ def verify_hints_acyclic(
     rejected = _simulate_hints_sequential(
         surviving_hint_edges, base_existing, base_succ, beat_set, beat_intersection_groups
     )
-    seen: set[str] = set()
-    result: list[str] = []
-    for h in rejected:
-        if h.beat_id not in seen:
-            seen.add(h.beat_id)
-            result.append(h.beat_id)
+    # dict.fromkeys preserves insertion order and deduplicates beat IDs in one pass.
+    result: list[str] = list(dict.fromkeys(h.beat_id for h in rejected))
     return result
 
 

--- a/src/questfoundry/graph/grow_algorithms.py
+++ b/src/questfoundry/graph/grow_algorithms.py
@@ -3054,37 +3054,54 @@ def build_hint_conflict_graph(graph: Graph) -> HintConflictResult:
             conflicts=[], mandatory_drops=set(), swap_pairs=[], minimum_drop_set=set()
         )
 
-    # Deduplicate hint edges by beat_id — keep first occurrence per beat
-    seen_beat_ids: set[str] = set()
-    unique_hints: list[_HintEdge] = []
+    # Group ALL hint edges by beat_id.  A beat with a hint targeting a
+    # dilemma with N paths produces N edges.  Evaluation is per-beat-id:
+    # a beat's hint survives only if ALL its edges are acyclic (atomic
+    # semantics — the hint either applies fully or not at all).
+    hints_by_beat: dict[str, list[_HintEdge]] = {}
     for he in all_hint_edges:
-        if he.beat_id not in seen_beat_ids:
-            seen_beat_ids.add(he.beat_id)
-            unique_hints.append(he)
+        hints_by_beat.setdefault(he.beat_id, []).append(he)
+
+    # Keep one representative _HintEdge per beat for scoring/conflict APIs
+    # that need a single hint object.  All edges for a beat share the same
+    # position/strength (they come from the same temporal_hint field).
+    hint_by_beat: dict[str, _HintEdge] = {bid: edges[0] for bid, edges in hints_by_beat.items()}
 
     # base_existing and base_succ are already built above via _build_hint_base_dag()
 
-    def _cycles_alone(hint: _HintEdge) -> bool:
-        """Test whether a single hint cycles against the base DAG."""
-        from_b, to_b = hint.from_beat, hint.to_beat
-        if from_b == to_b or from_b not in beat_set or to_b not in beat_set:
-            return False
-        if (from_b, to_b) in base_existing:
-            return False
-        if beat_intersection_groups.get(from_b, set()).intersection(
-            beat_intersection_groups.get(to_b, set())
-        ):
-            return False
-        return _would_create_cycle(from_b, to_b, base_succ, beat_set)
+    def _beat_cycles_alone(beat_id: str) -> bool:
+        """Test whether ANY edge of a beat's hint cycles against the base DAG.
 
-    # Phase 1: identify mandatory solo drops
+        A beat is a mandatory drop if even one of its edges would create a cycle
+        against the base DAG in isolation (before considering other hints).
+        """
+        for edge in hints_by_beat[beat_id]:
+            from_b, to_b = edge.from_beat, edge.to_beat
+            if from_b == to_b or from_b not in beat_set or to_b not in beat_set:
+                continue
+            if (from_b, to_b) in base_existing:
+                continue
+            if beat_intersection_groups.get(from_b, set()).intersection(
+                beat_intersection_groups.get(to_b, set())
+            ):
+                continue
+            if _would_create_cycle(from_b, to_b, base_succ, beat_set):
+                return True
+        return False
+
+    # Phase 1: identify mandatory solo drops — beats where ANY edge cycles alone.
     mandatory_drop_ids: set[str] = set()
-    survivors: list[_HintEdge] = []
-    for hint in unique_hints:
-        if _cycles_alone(hint):
-            mandatory_drop_ids.add(hint.beat_id)
+    surviving_beat_ids: list[str] = []
+    for beat_id in hints_by_beat:
+        if _beat_cycles_alone(beat_id):
+            mandatory_drop_ids.add(beat_id)
         else:
-            survivors.append(hint)
+            surviving_beat_ids.append(beat_id)
+
+    # Flatten surviving beats back into an edge list for simulation.
+    # All edges for each surviving beat are included so that
+    # _simulate_hints_sequential sees the full set of edges a beat would add.
+    survivors: list[_HintEdge] = [edge for bid in surviving_beat_ids for edge in hints_by_beat[bid]]
 
     # Phase 2: greedy MDS loop — detect transitive multi-hint cycles.
     #
@@ -3093,7 +3110,6 @@ def build_hint_conflict_graph(graph: Graph) -> HintConflictResult:
     # all three together cycle).  The sequential simulation in
     # _simulate_hints_sequential uses the same base DAG as _build_base_dag(),
     # so detection and postcondition check (verify_hints_acyclic) are consistent.
-    hint_by_beat: dict[str, _HintEdge] = {h.beat_id: h for h in unique_hints}
 
     # Scoring heuristic — prefer dropping: introduce over commit; branch over canonical
     def _drop_score(beat_id: str, hint: _HintEdge) -> tuple[int, int, str]:
@@ -3119,14 +3135,26 @@ def build_hint_conflict_graph(graph: Graph) -> HintConflictResult:
     # Run the greedy MDS loop.  conflict_set starts as the hints rejected by
     # the sequential simulation of all survivors (those not already in
     # mandatory_drop_ids from Phase 1).
+    #
+    # _sim_survivors returns unique-by-beat_id rejected hints (one per beat)
+    # so the MDS loop operates on beats, not individual edges.
     swap_pairs_result: list[tuple[str, str]] = []
 
     def _sim_survivors(excluded_beat_ids: set[str]) -> list[_HintEdge]:
-        """Simulate survivors minus the excluded beats; return rejected hints."""
+        """Simulate survivors minus the excluded beats; return rejected hints (one per beat_id)."""
         active = [h for h in survivors if h.beat_id not in excluded_beat_ids]
-        return _simulate_hints_sequential(
+        rejected_edges = _simulate_hints_sequential(
             active, base_existing, base_succ, beat_set, beat_intersection_groups
         )
+        # Deduplicate by beat_id: one representative per rejected beat.
+        # A multi-edge beat may appear multiple times; return only the first.
+        seen: set[str] = set()
+        unique_rejected: list[_HintEdge] = []
+        for h in rejected_edges:
+            if h.beat_id not in seen:
+                seen.add(h.beat_id)
+                unique_rejected.append(h)
+        return unique_rejected
 
     greedy_excluded: set[str] = set()
     conflict_set = _sim_survivors(greedy_excluded)
@@ -3301,9 +3329,11 @@ def verify_hints_acyclic(
         path_beats_map,
     )
 
-    # Collect all surviving hint edges across all concurrent pairs
+    # Collect all surviving hint edges across all concurrent pairs.
+    # A beat targeting a dilemma with N paths produces N edges; keep ALL of
+    # them so the simulation tests the full set of edges each hint would add
+    # (matching the per-edge evaluation used by build_hint_conflict_graph).
     surviving_hint_edges: list[_HintEdge] = []
-    seen_beat_ids: set[str] = set()
     for dilemma_a, dilemma_b, ordering in relationship_edges:
         if ordering != "concurrent":
             continue
@@ -3330,17 +3360,22 @@ def verify_hints_acyclic(
         ):
             if hint_edge.beat_id not in surviving_beat_ids:
                 continue
-            # Deduplicate by beat_id (keep first occurrence, matching build_hint_conflict_graph)
-            if hint_edge.beat_id not in seen_beat_ids:
-                seen_beat_ids.add(hint_edge.beat_id)
-                surviving_hint_edges.append(hint_edge)
+            surviving_hint_edges.append(hint_edge)
 
     # Run the same sequential simulation as build_hint_conflict_graph uses.
-    # Rejected hints are still-cyclic.
+    # Rejected hints are still-cyclic.  Deduplicate by beat_id: a multi-edge
+    # beat may appear multiple times in the rejected list (one per rejected
+    # edge), but callers need one entry per beat.
     rejected = _simulate_hints_sequential(
         surviving_hint_edges, base_existing, base_succ, beat_set, beat_intersection_groups
     )
-    return [h.beat_id for h in rejected]
+    seen: set[str] = set()
+    result: list[str] = []
+    for h in rejected:
+        if h.beat_id not in seen:
+            seen.add(h.beat_id)
+            result.append(h.beat_id)
+    return result
 
 
 def strip_temporal_hints_by_id(graph: Graph, beat_ids: set[str]) -> int:

--- a/tests/unit/test_grow_algorithms.py
+++ b/tests/unit/test_grow_algorithms.py
@@ -7052,3 +7052,179 @@ class TestBuildHintConflictGraph:
         assert still_cyclic == [], (
             f"verify_hints_acyclic must return [] after MDS; got {still_cyclic}"
         )
+
+    # ------------------------------------------------------------------ #
+    # Regression: multi-path hint dedup bug (#1149)                       #
+    # ------------------------------------------------------------------ #
+
+    def test_multi_path_hint_second_edge_cycle_detected(self) -> None:
+        """Regression test for #1149: beat_id dedup in build_hint_conflict_graph
+        dropped edges 2..N for hints targeting a multi-path dilemma.
+
+        Setup
+        -----
+        - Dilemma ``alpha`` (1 path): a_intro → a_commit
+        - Dilemma ``beta``  (2 paths):
+            - path1: b1_intro → b1_commit
+            - path2: b2_intro → b2_commit
+        - concurrent relationship: alpha ↔ beta
+        - Manual graph edge: ``predecessor(a_commit, b2_commit)``
+          (a_commit requires b2_commit → b2_commit ≺ a_commit)
+          This makes succ[b2_commit] = {a_commit} in the base DAG.
+
+        Hint on ``a_commit``: ``before_commit dilemma::beta``
+        generates TWO edges (one per path's commit beat):
+          Edge 1: predecessor(b1_commit, a_commit) — b1_commit ≺ a_commit
+                  Safe alone: b1_commit has no succ leading to a_commit.
+          Edge 2: predecessor(b2_commit, a_commit) — b2_commit ≺ a_commit
+                  Cyclic alone: base succ[b2_commit] = {a_commit}, so
+                  _would_create_cycle(b2_commit, a_commit) = True.
+
+        Old behaviour (bug): dedup kept only Edge 1 (safe) → hint passed.
+        New behaviour (fix): both edges evaluated → Edge 2 cycles → mandatory drop.
+        """
+        from questfoundry.graph.grow_algorithms import (
+            build_hint_conflict_graph,
+            verify_hints_acyclic,
+        )
+
+        graph = Graph.empty()
+
+        # Dilemmas
+        graph.create_node("dilemma::alpha", {"type": "dilemma", "raw_id": "alpha"})
+        graph.create_node("dilemma::beta", {"type": "dilemma", "raw_id": "beta"})
+
+        # alpha: 1 path with 2 beats
+        graph.create_node(
+            "path::alpha_path",
+            {
+                "type": "path",
+                "raw_id": "alpha_path",
+                "dilemma_id": "dilemma::alpha",
+                "is_canonical": True,
+            },
+        )
+        graph.create_node(
+            "beat::a_intro",
+            {
+                "type": "beat",
+                "raw_id": "a_intro",
+                "summary": "Alpha intro.",
+                "dilemma_impacts": [{"dilemma_id": "dilemma::alpha", "effect": "advances"}],
+            },
+        )
+        graph.create_node(
+            "beat::a_commit",
+            {
+                "type": "beat",
+                "raw_id": "a_commit",
+                "summary": "Alpha commit.",
+                "dilemma_impacts": [{"dilemma_id": "dilemma::alpha", "effect": "commits"}],
+            },
+        )
+        graph.add_edge("belongs_to", "beat::a_intro", "path::alpha_path")
+        graph.add_edge("belongs_to", "beat::a_commit", "path::alpha_path")
+        graph.add_edge("predecessor", "beat::a_commit", "beat::a_intro")
+
+        # beta: 2 paths
+        graph.create_node(
+            "path::beta_path1",
+            {
+                "type": "path",
+                "raw_id": "beta_path1",
+                "dilemma_id": "dilemma::beta",
+                "is_canonical": True,
+            },
+        )
+        graph.create_node(
+            "path::beta_path2",
+            {
+                "type": "path",
+                "raw_id": "beta_path2",
+                "dilemma_id": "dilemma::beta",
+                "is_canonical": False,
+            },
+        )
+        graph.create_node(
+            "beat::b1_intro",
+            {
+                "type": "beat",
+                "raw_id": "b1_intro",
+                "summary": "Beta path1 intro.",
+                "dilemma_impacts": [{"dilemma_id": "dilemma::beta", "effect": "advances"}],
+            },
+        )
+        graph.create_node(
+            "beat::b1_commit",
+            {
+                "type": "beat",
+                "raw_id": "b1_commit",
+                "summary": "Beta path1 commit.",
+                "dilemma_impacts": [{"dilemma_id": "dilemma::beta", "effect": "commits"}],
+            },
+        )
+        graph.create_node(
+            "beat::b2_intro",
+            {
+                "type": "beat",
+                "raw_id": "b2_intro",
+                "summary": "Beta path2 intro.",
+                "dilemma_impacts": [{"dilemma_id": "dilemma::beta", "effect": "advances"}],
+            },
+        )
+        graph.create_node(
+            "beat::b2_commit",
+            {
+                "type": "beat",
+                "raw_id": "b2_commit",
+                "summary": "Beta path2 commit.",
+                "dilemma_impacts": [{"dilemma_id": "dilemma::beta", "effect": "commits"}],
+            },
+        )
+        graph.add_edge("belongs_to", "beat::b1_intro", "path::beta_path1")
+        graph.add_edge("belongs_to", "beat::b1_commit", "path::beta_path1")
+        graph.add_edge("predecessor", "beat::b1_commit", "beat::b1_intro")
+
+        graph.add_edge("belongs_to", "beat::b2_intro", "path::beta_path2")
+        graph.add_edge("belongs_to", "beat::b2_commit", "path::beta_path2")
+        graph.add_edge("predecessor", "beat::b2_commit", "beat::b2_intro")
+
+        # Relationship: alpha concurrent with beta
+        graph.add_edge("concurrent", "dilemma::alpha", "dilemma::beta")
+
+        # The crucial setup edge: a_commit requires b2_commit (b2_commit ≺ a_commit).
+        # This makes b2_commit → a_commit in the base succ graph.
+        # The heuristic alpha_commit ≺ b2_commit would cycle against this and is
+        # therefore skipped by _build_hint_base_dag, leaving succ[b2_commit]={a_commit}.
+        graph.add_edge("predecessor", "beat::a_commit", "beat::b2_commit")
+
+        # Add the temporal hint on a_commit: "before_commit dilemma::beta"
+        # This targets the commit beats of both beta paths → 2 edges:
+        #   Edge 1: predecessor(b1_commit, a_commit) — b1_commit ≺ a_commit [SAFE]
+        #   Edge 2: predecessor(b2_commit, a_commit) — b2_commit ≺ a_commit [CYCLES]
+        graph.update_node(
+            "beat::a_commit",
+            temporal_hint={
+                "relative_to": "dilemma::beta",
+                "position": "before_commit",
+            },
+        )
+
+        result = build_hint_conflict_graph(graph)
+
+        assert "beat::a_commit" in result.mandatory_drops, (
+            "beat::a_commit must be a mandatory drop: its hint generates 2 edges "
+            "(one per beta path), and Edge 2 (b2_commit ≺ a_commit) cycles against "
+            "the base DAG (b2_commit already has a_commit as a successor). "
+            "The old code (dedup by beat_id) only tested Edge 1 (safe) and "
+            "incorrectly passed the hint."
+        )
+
+        # After applying the minimum drop set (dropping a_commit's hint),
+        # verify_hints_acyclic must confirm no cycles remain.
+        all_hint_beats = {"beat::a_commit"}
+        survivors = all_hint_beats - result.minimum_drop_set
+        still_cyclic = verify_hints_acyclic(graph, survivors)
+        assert still_cyclic == [], (
+            f"verify_hints_acyclic must return [] after MDS; got {still_cyclic}"
+        )


### PR DESCRIPTION
## Problem

`build_hint_conflict_graph` deduplicated hint edges by `beat_id`, keeping only the first `_HintEdge` per beat. A hint targeting a dilemma with N paths generates N edges (one per path's commit/intro beat). Deduplication discarded edges 2..N, so cycle detection only tested edge 1. If edge 1 was safe but edge 2 created a cycle, the hint passed detection and later caused a `RuntimeError` in `interleave_cross_path_beats`.

## Changes

- Remove `seen_beat_ids` dedup in `build_hint_conflict_graph`; group all edges by `beat_id` in `hints_by_beat`. A beat is a mandatory drop if ANY of its edges cycles against the base DAG (`_beat_cycles_alone` replaces `_cycles_alone`).
- `_sim_survivors` flattens all edges for active beats and deduplicates the *rejected* list by `beat_id` so the MDS loop operates on beats (not edges).
- Remove `seen_beat_ids` dedup in `verify_hints_acyclic`; use `dict.fromkeys` to deduplicate the rejection result by `beat_id` before returning.
- `hint_by_beat` now stores one representative edge per beat (for scoring) since all edges of a beat share the same position/strength.
- Document edge-atomic vs beat-atomic simulation limitation in comments.

## Test Plan

- Regression test added in `tests/unit/test_grow_algorithms.py`: 2-path beta dilemma where edge 1 (`b1_commit`) is safe but edge 2 (`b2_commit`) cycles alone against the base DAG. Old code passed the hint; new code correctly marks it as a mandatory drop.
- Run: `uv run pytest tests/unit/test_grow_algorithms.py -x -q` → 262 passed

## Design Conformance

**N/A — this is a bug fix to existing cycle detection/verification logic, not a new pipeline stage feature.** No specification requirements added or changed; the conformance checklist does not apply.

The architect-reviewer pre-PR gate was run and confirmed all 6 acceptance criteria from issue #1149 are CONFORMANT (0 MISSING, 0 DEAD).

| # | Requirement | Status |
|---|---|---|
| 1 | `build_hint_conflict_graph` evaluates ALL edges per beat | CONFORMANT |
| 2 | `verify_hints_acyclic` applies same per-edge evaluation | CONFORMANT |
| 3 | `hint_by_beat` scoring dict corrected for multi-edge hints | CONFORMANT |
| 4 | `interleave_cross_path_beats` not changed | CONFORMANT |
| 5 | Regression test with 2-path target dilemma | CONFORMANT |
| 6 | `seen_beat_ids` dedup gone from detection/postcondition | CONFORMANT |

## Not Included / Future PRs

None — self-contained bug fix.

Closes #1149