### PR TITLE
fix: POLISH validation checks (#1156)

### DIFF
--- a/src/questfoundry/graph/polish_validation.py
+++ b/src/questfoundry/graph/polish_validation.py
@@ -235,13 +235,8 @@ def validate_polish_output(graph: Graph) -> list[str]:
     _check_variant_requires_non_empty(passage_nodes, graph, errors)
     _check_no_unresolved_splits(graph, errors)
 
-    endings_check = check_all_endings_reachable(graph)
-    if endings_check.severity == "fail" and "Cannot check" not in endings_check.message:
-        errors.append(endings_check.message)
-
-    gate_check = check_gate_satisfiability(graph)
-    if gate_check.severity == "fail":
-        errors.append(gate_check.message)
+    # TODO: check_all_endings_reachable and check_gate_satisfiability use the old
+    # choice_from/choice_to edge model and are DEAD — see issue #1165 for migration.
 
     return errors
 
@@ -520,29 +515,23 @@ def _check_no_overlapping_requires(
 
 def _check_variant_requires_non_empty(
     passage_nodes: dict[str, Any],
-    graph: Graph,
+    graph: Graph,  # noqa: ARG001
     errors: list[str],
 ) -> None:
-    """Every variant passage must have at least one outgoing choice with non-empty requires."""
-    choice_edges = graph.get_edges(edge_type="choice")
+    """Every variant passage must have a non-empty requires list on the node itself.
 
-    # Build passage -> list of requires lists for outgoing choices
-    outgoing_requires: dict[str, list[list[str]]] = {}
-    for edge in choice_edges:
-        from_id = edge["from"]
-        requires: list[str] = edge.get("requires") or []
-        outgoing_requires.setdefault(from_id, []).append(requires)
-
+    The ``requires`` field is stored directly on the variant passage node by
+    ``_create_variant_passage`` in polish/deterministic.py.  Outgoing choice
+    edges carry their own ``requires`` for gate routing, but the *passage-level*
+    requires controls when FILL should render that variant at all.
+    """
     for passage_id, pdata in passage_nodes.items():
         if not pdata.get("is_variant"):
             continue
-        all_choices = outgoing_requires.get(passage_id, [])
-        # A variant with no outgoing choices is caught by _check_passage_reachability;
-        # here we check that at least one outgoing choice has a non-empty requires.
-        if all_choices and all(not r for r in all_choices):
+        requires: list[str] = pdata.get("requires") or []
+        if not requires:
             errors.append(
-                f"Variant passage {passage_id} has outgoing choices but none have requires — "
-                f"variant cannot be routed"
+                f"Variant passage {passage_id} has empty requires — cannot gate player entry"
             )
 
 

--- a/src/questfoundry/graph/polish_validation.py
+++ b/src/questfoundry/graph/polish_validation.py
@@ -229,6 +229,19 @@ def validate_polish_output(graph: Graph) -> list[str]:
     _check_choice_integrity(graph, errors)
     _check_residue_ordering(graph, errors)
     _check_arc_metadata_edges(graph, errors)
+    _check_arc_completeness(graph, errors)
+    _check_divergences_have_choices(graph, beat_to_passages, errors)
+    _check_no_overlapping_requires(graph, errors)
+    _check_variant_requires_non_empty(passage_nodes, graph, errors)
+    _check_no_unresolved_splits(graph, errors)
+
+    endings_check = check_all_endings_reachable(graph)
+    if endings_check.severity == "fail" and "Cannot check" not in endings_check.message:
+        errors.append(endings_check.message)
+
+    gate_check = check_gate_satisfiability(graph)
+    if gate_check.severity == "fail":
+        errors.append(gate_check.message)
 
     return errors
 
@@ -244,7 +257,7 @@ def _check_beat_grouping(
         if len(passages) == 0:
             # Skip micro/residue/sidetrack beats — they may not exist yet at validation time
             role = beat_nodes[beat_id].get("role", "")
-            if role not in ("micro_beat", "residue_beat", "sidetrack_beat"):
+            if role not in ("micro_beat", "sidetrack_beat"):  # residue_beat no longer exempt
                 errors.append(f"Beat {beat_id} not grouped into any passage")
         elif len(passages) > 1:
             errors.append(f"Beat {beat_id} grouped into {len(passages)} passages: {passages}")
@@ -416,6 +429,160 @@ def _check_residue_ordering(
     for passage_id, pdata in passage_nodes.items():
         if pdata.get("is_residue") and passage_id not in passages_with_precedes:
             errors.append(f"Residue passage {passage_id} has no precedes edge to a target passage")
+
+
+def _check_arc_completeness(
+    graph: Graph,
+    errors: list[str],
+) -> None:
+    """Check arc_traversals in polish_plan for duplicate passage IDs and bad endings."""
+    plan_node = graph.get_node("polish_plan::current") or {}
+    arc_traversals: dict[str, list[str]] = plan_node.get("arc_traversals") or {}
+    for arc_key, passage_ids in arc_traversals.items():
+        if len(passage_ids) != len(set(passage_ids)):
+            errors.append(f"Arc {arc_key} has repeated passage IDs: {passage_ids}")
+        if passage_ids:
+            outgoing = graph.get_edges(edge_type="choice", from_id=passage_ids[-1])
+            if outgoing:
+                errors.append(
+                    f"Arc {arc_key} last passage {passage_ids[-1]} has outgoing choices — not an ending"
+                )
+
+
+def _check_divergences_have_choices(
+    graph: Graph,
+    beat_to_passages: dict[str, list[str]],
+    errors: list[str],
+) -> None:
+    """Beats with 2+ children on different paths must live in a passage with 2+ outgoing choices."""
+    # Find beats that have 2+ outgoing next/branch edges leading to beats on different paths
+    belongs_to_edges = graph.get_edges(edge_type="belongs_to")
+    beat_to_path: dict[str, str] = {}
+    for edge in belongs_to_edges:
+        beat_to_path[edge["from"]] = edge["to"]
+
+    next_edges = graph.get_edges(edge_type="next")
+    branch_edges = graph.get_edges(edge_type="branch")
+    children_by_beat: dict[str, list[str]] = {}
+    for edge in next_edges + branch_edges:
+        children_by_beat.setdefault(edge["from"], []).append(edge["to"])
+
+    # Build passage -> outgoing choice count
+    choice_edges = graph.get_edges(edge_type="choice")
+    passage_outgoing: dict[str, int] = {}
+    for edge in choice_edges:
+        passage_outgoing[edge["from"]] = passage_outgoing.get(edge["from"], 0) + 1
+
+    for beat_id, children in children_by_beat.items():
+        if len(children) < 2:
+            continue
+        # Check if children are on different paths
+        child_paths = {beat_to_path.get(c) for c in children}
+        child_paths.discard(None)
+        if len(child_paths) < 2:
+            continue
+        # This beat is a divergence point — its passage must have 2+ outgoing choices
+        passages = beat_to_passages.get(beat_id, [])
+        for passage_id in passages:
+            if passage_outgoing.get(passage_id, 0) < 2:
+                errors.append(
+                    f"Beat {beat_id} is a divergence point but its passage {passage_id} "
+                    f"has fewer than 2 outgoing choices"
+                )
+
+
+def _check_no_overlapping_requires(
+    graph: Graph,
+    errors: list[str],
+) -> None:
+    """For each passage, no two outgoing choices should have intersecting requires lists."""
+    choice_edges = graph.get_edges(edge_type="choice")
+
+    # Group by source passage
+    choices_by_passage: dict[str, list[list[str]]] = {}
+    for edge in choice_edges:
+        from_id = edge["from"]
+        requires: list[str] = edge.get("requires") or []
+        choices_by_passage.setdefault(from_id, []).append(requires)
+
+    for passage_id, requires_lists in choices_by_passage.items():
+        # Compare all pairs
+        for i in range(len(requires_lists)):
+            for j in range(i + 1, len(requires_lists)):
+                a = set(requires_lists[i])
+                b = set(requires_lists[j])
+                if a and b and a & b:
+                    errors.append(
+                        f"Passage {passage_id} has two choices with overlapping requires: "
+                        f"{sorted(a & b)}"
+                    )
+
+
+def _check_variant_requires_non_empty(
+    passage_nodes: dict[str, Any],
+    graph: Graph,
+    errors: list[str],
+) -> None:
+    """Every variant passage must have at least one outgoing choice with non-empty requires."""
+    choice_edges = graph.get_edges(edge_type="choice")
+
+    # Build passage -> list of requires lists for outgoing choices
+    outgoing_requires: dict[str, list[list[str]]] = {}
+    for edge in choice_edges:
+        from_id = edge["from"]
+        requires: list[str] = edge.get("requires") or []
+        outgoing_requires.setdefault(from_id, []).append(requires)
+
+    for passage_id, pdata in passage_nodes.items():
+        if not pdata.get("is_variant"):
+            continue
+        all_choices = outgoing_requires.get(passage_id, [])
+        # A variant with no outgoing choices is caught by _check_passage_reachability;
+        # here we check that at least one outgoing choice has a non-empty requires.
+        if all_choices and all(not r for r in all_choices):
+            errors.append(
+                f"Variant passage {passage_id} has outgoing choices but none have requires — "
+                f"variant cannot be routed"
+            )
+
+
+def _check_no_unresolved_splits(
+    graph: Graph,
+    errors: list[str],
+) -> None:
+    """Structural split warnings without a corresponding variant passage are errors."""
+    plan_node = graph.get_node("polish_plan::current") or {}
+    warnings: list[str] = plan_node.get("warnings") or []
+
+    passage_nodes = graph.get_nodes_by_type("passage")
+    variant_passage_ids = {pid for pid, pdata in passage_nodes.items() if pdata.get("is_variant")}
+
+    for warning in warnings:
+        if "structural split recommended" not in warning:
+            continue
+        # Warning format: "Passage passage::X has N narratively relevant flags — structural split recommended"
+        # Extract the passage ID from the warning text
+        parts = warning.split()
+        if len(parts) < 2:
+            continue
+        warned_passage_id = parts[1]  # "Passage <id> has ..."
+
+        # Check if any variant passage was created for this base passage
+        has_variant = any(
+            passage_nodes[vid].get("variant_for") == warned_passage_id
+            or passage_nodes[vid].get("base_passage_id") == warned_passage_id
+            for vid in variant_passage_ids
+        )
+        # Also check via variant_of edges
+        if not has_variant:
+            variant_of_edges = graph.get_edges(edge_type="variant_of", to_id=warned_passage_id)
+            has_variant = bool(variant_of_edges)
+
+        if not has_variant:
+            errors.append(
+                f"Passage {warned_passage_id} has a structural split warning but no variant "
+                f"passage was created — split was not resolved"
+            )
 
 
 def _check_arc_metadata_edges(

--- a/src/questfoundry/graph/polish_validation.py
+++ b/src/questfoundry/graph/polish_validation.py
@@ -11,7 +11,8 @@ during POLISH Phase 7 via ``run_passage_checks()``.
 
 from __future__ import annotations
 
-from collections import deque
+import re
+from collections import Counter, deque
 from typing import TYPE_CHECKING, Any
 
 from questfoundry.graph.context import get_primary_beat, normalize_scoped_id
@@ -400,8 +401,6 @@ def _check_choice_integrity(
         from_id = edge["from"]
         choices_by_source.setdefault(from_id, []).append(edge)
 
-    from collections import Counter
-
     for source_id, choices in choices_by_source.items():
         # Check for duplicate labels
         labels: list[str] = [c["label"] for c in choices if c.get("label")]
@@ -501,16 +500,13 @@ def _check_no_overlapping_requires(
         choices_by_passage.setdefault(from_id, []).append(requires)
 
     for passage_id, requires_lists in choices_by_passage.items():
-        # Compare all pairs
-        for i in range(len(requires_lists)):
-            for j in range(i + 1, len(requires_lists)):
-                a = set(requires_lists[i])
-                b = set(requires_lists[j])
-                if a and b and a & b:
-                    errors.append(
-                        f"Passage {passage_id} has two choices with overlapping requires: "
-                        f"{sorted(a & b)}"
-                    )
+        flag_counts = Counter(flag for c in requires_lists for flag in c)
+        overlapping_flags = {f for f, count in flag_counts.items() if count > 1}
+        if overlapping_flags:
+            errors.append(
+                f"Passage {passage_id} has choices with overlapping requires: "
+                f"{sorted(overlapping_flags)}"
+            )
 
 
 def _check_variant_requires_non_empty(
@@ -543,29 +539,19 @@ def _check_no_unresolved_splits(
     plan_node = graph.get_node("polish_plan::current") or {}
     warnings: list[str] = plan_node.get("warnings") or []
 
-    passage_nodes = graph.get_nodes_by_type("passage")
-    variant_passage_ids = {pid for pid, pdata in passage_nodes.items() if pdata.get("is_variant")}
-
     for warning in warnings:
         if "structural split recommended" not in warning:
             continue
         # Warning format: "Passage passage::X has N narratively relevant flags — structural split recommended"
         # Extract the passage ID from the warning text
-        parts = warning.split()
-        if len(parts) < 2:
+        match = re.search(r"Passage (\S+)", warning)
+        if not match:
             continue
-        warned_passage_id = parts[1]  # "Passage <id> has ..."
+        warned_passage_id = match.group(1)
 
-        # Check if any variant passage was created for this base passage
-        has_variant = any(
-            passage_nodes[vid].get("variant_for") == warned_passage_id
-            or passage_nodes[vid].get("base_passage_id") == warned_passage_id
-            for vid in variant_passage_ids
-        )
-        # Also check via variant_of edges
-        if not has_variant:
-            variant_of_edges = graph.get_edges(edge_type="variant_of", to_id=warned_passage_id)
-            has_variant = bool(variant_of_edges)
+        # Check via variant_of edges
+        variant_of_edges = graph.get_edges(edge_type="variant_of", to_id=warned_passage_id)
+        has_variant = bool(variant_of_edges)
 
         if not has_variant:
             errors.append(

--- a/tests/unit/test_polish_validation.py
+++ b/tests/unit/test_polish_validation.py
@@ -406,14 +406,15 @@ class TestVariantRequiresNonEmpty:
     """Tests for _check_variant_requires_non_empty."""
 
     def test_variant_with_empty_requires_errors(self) -> None:
-        """Variant passage with all outgoing choices having empty requires should error."""
+        """Variant passage with empty requires on the node itself should error."""
         graph = _build_valid_graph()
+        # requires=[] (empty) — node-level gate is missing
         _create_variant_passage(
             graph,
             VariantSpec(
                 base_passage_id="passage::start",
                 variant_id="passage::v1",
-                requires=["flagA"],
+                requires=[],
                 summary="Variant",
             ),
         )
@@ -421,14 +422,13 @@ class TestVariantRequiresNonEmpty:
         _create_passage_node(
             graph, PassageSpec(passage_id="passage::dest", beat_ids=["beat::dest"], summary="Dest")
         )
-        # Add outgoing choice from variant with NO requires
         graph.add_edge("choice", "passage::v1", "passage::dest")
 
         errors = validate_polish_output(graph)
-        assert any("passage::v1" in e and "cannot be routed" in e for e in errors)
+        assert any("passage::v1" in e and "cannot gate player entry" in e for e in errors)
 
     def test_variant_with_requires_passes(self) -> None:
-        """Variant passage where at least one choice has requires should pass."""
+        """Variant passage with non-empty requires on the node itself should pass."""
         graph = _build_valid_graph()
         _create_variant_passage(
             graph,
@@ -446,7 +446,7 @@ class TestVariantRequiresNonEmpty:
         graph.add_edge("choice", "passage::v1", "passage::dest", requires=["flagA"])
 
         errors = validate_polish_output(graph)
-        assert not any("cannot be routed" in e for e in errors)
+        assert not any("cannot gate player entry" in e for e in errors)
 
 
 class TestNoUnresolvedSplits:

--- a/tests/unit/test_polish_validation.py
+++ b/tests/unit/test_polish_validation.py
@@ -273,3 +273,224 @@ class TestPolishResult:
         )
         assert result.passage_count == 10
         assert result.false_branch_count == 1
+
+
+class TestResidueExemption:
+    """Residue beats are no longer exempt from grouping checks."""
+
+    def test_residue_beat_not_grouped_errors(self) -> None:
+        """A residue_beat without a grouped_in edge should now produce an error."""
+        graph = Graph.empty()
+        _make_beat(graph, "beat::a", "A beat")
+        _make_beat(graph, "beat::residue", "Residue", role="residue_beat")
+
+        _create_passage_node(
+            graph,
+            PassageSpec(passage_id="passage::pa", beat_ids=["beat::a"], summary="A"),
+        )
+        # beat::residue intentionally not grouped
+
+        errors = validate_polish_output(graph)
+        assert any("beat::residue" in e and "not grouped" in e for e in errors)
+
+    def test_micro_beat_not_grouped_still_exempt(self) -> None:
+        """micro_beat without grouped_in edge should NOT produce an error."""
+        graph = Graph.empty()
+        _make_beat(graph, "beat::a", "A beat")
+        _make_beat(graph, "beat::micro", "Micro", role="micro_beat")
+
+        _create_passage_node(
+            graph,
+            PassageSpec(passage_id="passage::pa", beat_ids=["beat::a"], summary="A"),
+        )
+        # beat::micro intentionally not grouped
+
+        errors = validate_polish_output(graph)
+        assert not any("beat::micro" in e and "not grouped" in e for e in errors)
+
+
+class TestArcCompleteness:
+    """Tests for _check_arc_completeness."""
+
+    def test_repeated_passage_id_errors(self) -> None:
+        """Arc with repeated passage ID should produce an error."""
+        graph = _build_valid_graph()
+        # Store a plan with a repeated passage
+        graph.create_node(
+            "polish_plan::current",
+            {
+                "type": "polish_plan",
+                "arc_traversals": {
+                    "arc1": ["passage::start", "passage::start", "passage::end"],
+                },
+                "warnings": [],
+            },
+        )
+        errors = validate_polish_output(graph)
+        assert any("Arc arc1" in e and "repeated" in e for e in errors)
+
+    def test_last_passage_with_outgoing_choices_errors(self) -> None:
+        """Arc whose last passage has outgoing choices should produce an error."""
+        graph = _build_valid_graph()
+        # passage::start has an outgoing choice to passage::end — make it the last in arc
+        graph.create_node(
+            "polish_plan::current",
+            {
+                "type": "polish_plan",
+                "arc_traversals": {
+                    "arc1": ["passage::start"],  # last passage has outgoing choices
+                },
+                "warnings": [],
+            },
+        )
+        errors = validate_polish_output(graph)
+        assert any("Arc arc1" in e and "outgoing choices" in e for e in errors)
+
+    def test_valid_arc_passes(self) -> None:
+        """Valid arc (no repeated passages, last passage is an ending) passes."""
+        graph = _build_valid_graph()
+        graph.create_node(
+            "polish_plan::current",
+            {
+                "type": "polish_plan",
+                "arc_traversals": {
+                    "arc1": ["passage::start", "passage::end"],
+                },
+                "warnings": [],
+            },
+        )
+        errors = validate_polish_output(graph)
+        assert not any("Arc arc1" in e for e in errors)
+
+
+class TestNoOverlappingRequires:
+    """Tests for _check_no_overlapping_requires."""
+
+    def test_overlapping_requires_errors(self) -> None:
+        """Two choices from same passage with overlapping requires should error."""
+        graph = _build_valid_graph()
+        # Add extra passages to route to
+        _make_beat(graph, "beat::x", "X")
+        _make_beat(graph, "beat::y", "Y")
+        _create_passage_node(
+            graph, PassageSpec(passage_id="passage::x", beat_ids=["beat::x"], summary="X")
+        )
+        _create_passage_node(
+            graph, PassageSpec(passage_id="passage::y", beat_ids=["beat::y"], summary="Y")
+        )
+        graph.add_edge("choice", "passage::end", "passage::x", requires=["flagA", "flagB"])
+        graph.add_edge("choice", "passage::end", "passage::y", requires=["flagB", "flagC"])
+
+        errors = validate_polish_output(graph)
+        assert any("overlapping requires" in e and "passage::end" in e for e in errors)
+
+    def test_non_overlapping_requires_passes(self) -> None:
+        """Two choices with non-overlapping requires should not error."""
+        graph = _build_valid_graph()
+        _make_beat(graph, "beat::x", "X")
+        _make_beat(graph, "beat::y", "Y")
+        _create_passage_node(
+            graph, PassageSpec(passage_id="passage::x", beat_ids=["beat::x"], summary="X")
+        )
+        _create_passage_node(
+            graph, PassageSpec(passage_id="passage::y", beat_ids=["beat::y"], summary="Y")
+        )
+        graph.add_edge("choice", "passage::end", "passage::x", requires=["flagA"])
+        graph.add_edge("choice", "passage::end", "passage::y", requires=["flagB"])
+
+        errors = validate_polish_output(graph)
+        assert not any("overlapping requires" in e for e in errors)
+
+
+class TestVariantRequiresNonEmpty:
+    """Tests for _check_variant_requires_non_empty."""
+
+    def test_variant_with_empty_requires_errors(self) -> None:
+        """Variant passage with all outgoing choices having empty requires should error."""
+        graph = _build_valid_graph()
+        _create_variant_passage(
+            graph,
+            VariantSpec(
+                base_passage_id="passage::start",
+                variant_id="passage::v1",
+                requires=["flagA"],
+                summary="Variant",
+            ),
+        )
+        _make_beat(graph, "beat::dest", "Dest")
+        _create_passage_node(
+            graph, PassageSpec(passage_id="passage::dest", beat_ids=["beat::dest"], summary="Dest")
+        )
+        # Add outgoing choice from variant with NO requires
+        graph.add_edge("choice", "passage::v1", "passage::dest")
+
+        errors = validate_polish_output(graph)
+        assert any("passage::v1" in e and "cannot be routed" in e for e in errors)
+
+    def test_variant_with_requires_passes(self) -> None:
+        """Variant passage where at least one choice has requires should pass."""
+        graph = _build_valid_graph()
+        _create_variant_passage(
+            graph,
+            VariantSpec(
+                base_passage_id="passage::start",
+                variant_id="passage::v1",
+                requires=["flagA"],
+                summary="Variant",
+            ),
+        )
+        _make_beat(graph, "beat::dest", "Dest")
+        _create_passage_node(
+            graph, PassageSpec(passage_id="passage::dest", beat_ids=["beat::dest"], summary="Dest")
+        )
+        graph.add_edge("choice", "passage::v1", "passage::dest", requires=["flagA"])
+
+        errors = validate_polish_output(graph)
+        assert not any("cannot be routed" in e for e in errors)
+
+
+class TestNoUnresolvedSplits:
+    """Tests for _check_no_unresolved_splits."""
+
+    def test_structural_split_warning_without_variant_errors(self) -> None:
+        """A structural split warning without a variant passage should error."""
+        graph = _build_valid_graph()
+        graph.create_node(
+            "polish_plan::current",
+            {
+                "type": "polish_plan",
+                "arc_traversals": {},
+                "warnings": [
+                    "Passage passage::start has 4 narratively relevant flags — structural split recommended"
+                ],
+            },
+        )
+        errors = validate_polish_output(graph)
+        assert any("passage::start" in e and "structural split warning" in e for e in errors)
+
+    def test_structural_split_warning_with_variant_passes(self) -> None:
+        """A structural split warning resolved by a variant passage should pass."""
+        graph = _build_valid_graph()
+        graph.create_node(
+            "polish_plan::current",
+            {
+                "type": "polish_plan",
+                "arc_traversals": {},
+                "warnings": [
+                    "Passage passage::start has 4 narratively relevant flags — structural split recommended"
+                ],
+            },
+        )
+        # Create a variant for passage::start
+        _create_variant_passage(
+            graph,
+            VariantSpec(
+                base_passage_id="passage::start",
+                variant_id="passage::v1",
+                requires=["flagA"],
+                summary="Variant",
+            ),
+        )
+
+        errors = validate_polish_output(graph)
+        assert not any("structural split warning" in e for e in errors)

--- a/tests/unit/test_polish_validation.py
+++ b/tests/unit/test_polish_validation.py
@@ -494,3 +494,98 @@ class TestNoUnresolvedSplits:
 
         errors = validate_polish_output(graph)
         assert not any("structural split warning" in e for e in errors)
+
+
+class TestDivergencesHaveChoices:
+    """Tests for _check_divergences_have_choices."""
+
+    def test_divergence_beat_with_insufficient_choices_errors(self) -> None:
+        """A divergence beat whose passage has only 1 outgoing choice should error."""
+        graph = Graph.empty()
+
+        # Two paths
+        graph.create_node("path::pa", {"type": "path", "raw_id": "pa"})
+        graph.create_node("path::pb", {"type": "path", "raw_id": "pb"})
+
+        # Beats: divergence beat with two children on different paths
+        _make_beat(graph, "beat::div", "Divergence beat")
+        _make_beat(graph, "beat::a", "Path A beat")
+        _make_beat(graph, "beat::b", "Path B beat")
+
+        # belongs_to edges — children on different paths
+        graph.add_edge("belongs_to", "beat::div", "path::pa")
+        graph.add_edge("belongs_to", "beat::a", "path::pa")
+        graph.add_edge("belongs_to", "beat::b", "path::pb")
+
+        # next/branch edges making beat::div a divergence point
+        graph.add_edge("branch", "beat::div", "beat::a")
+        graph.add_edge("branch", "beat::div", "beat::b")
+
+        # Group all beats into passages
+        _create_passage_node(
+            graph,
+            PassageSpec(passage_id="passage::div", beat_ids=["beat::div"], summary="Div"),
+        )
+        _create_passage_node(
+            graph,
+            PassageSpec(passage_id="passage::a", beat_ids=["beat::a"], summary="A"),
+        )
+        _create_passage_node(
+            graph,
+            PassageSpec(passage_id="passage::b", beat_ids=["beat::b"], summary="B"),
+        )
+
+        # Only 1 outgoing choice from divergence passage — not enough
+        _create_choice_edge(
+            graph,
+            ChoiceSpec(from_passage="passage::div", to_passage="passage::a", label="Go A"),
+        )
+
+        errors = validate_polish_output(graph)
+        assert any(
+            "beat::div" in e and "divergence point" in e and "passage::div" in e for e in errors
+        )
+
+    def test_divergence_beat_with_sufficient_choices_passes(self) -> None:
+        """A divergence beat whose passage has 2+ outgoing choices should not error."""
+        graph = Graph.empty()
+
+        graph.create_node("path::pa", {"type": "path", "raw_id": "pa"})
+        graph.create_node("path::pb", {"type": "path", "raw_id": "pb"})
+
+        _make_beat(graph, "beat::div", "Divergence beat")
+        _make_beat(graph, "beat::a", "Path A beat")
+        _make_beat(graph, "beat::b", "Path B beat")
+
+        graph.add_edge("belongs_to", "beat::div", "path::pa")
+        graph.add_edge("belongs_to", "beat::a", "path::pa")
+        graph.add_edge("belongs_to", "beat::b", "path::pb")
+
+        graph.add_edge("branch", "beat::div", "beat::a")
+        graph.add_edge("branch", "beat::div", "beat::b")
+
+        _create_passage_node(
+            graph,
+            PassageSpec(passage_id="passage::div", beat_ids=["beat::div"], summary="Div"),
+        )
+        _create_passage_node(
+            graph,
+            PassageSpec(passage_id="passage::a", beat_ids=["beat::a"], summary="A"),
+        )
+        _create_passage_node(
+            graph,
+            PassageSpec(passage_id="passage::b", beat_ids=["beat::b"], summary="B"),
+        )
+
+        # 2 outgoing choices — sufficient
+        _create_choice_edge(
+            graph,
+            ChoiceSpec(from_passage="passage::div", to_passage="passage::a", label="Go A"),
+        )
+        _create_choice_edge(
+            graph,
+            ChoiceSpec(from_passage="passage::div", to_passage="passage::b", label="Go B"),
+        )
+
+        errors = validate_polish_output(graph)
+        assert not any("divergence point" in e for e in errors)


### PR DESCRIPTION
## Summary

Additional validation checks for the POLISH stage, building on PR #1164 which provides live `arc_traversals` and `requires` data.

**Stacked on**: #1164 (merge that first)

- **Residue beat exemption removed**: residue beats are now required to be grouped into a passage (Phase 6 does group them)
- **`_check_arc_completeness`**: detects repeated passage IDs in arc traversals; last passage with outgoing choices is not an ending
- **`_check_divergences_have_choices`**: divergence beats must have 2+ outgoing choice edges on their passage
- **`_check_no_overlapping_requires`**: no two choices from same passage with intersecting `requires` lists
- **`_check_variant_requires_non_empty`**: variant passages must have non-empty `requires` on passage node
- **`_check_no_unresolved_splits`**: structural split warnings must have matching variant passages

## Design Conformance

Reviewed against `docs/design/procedures/polish.md` §22–29.

| # | Requirement | Status |
|---|---|---|
| Residue beats grouped (no longer exempt) | CONFORMANT |
| Arc completeness (no repeated IDs, proper endings) | CONFORMANT |
| Divergence beats have choice edges | CONFORMANT |
| No overlapping requires | CONFORMANT |
| Variant requires non-empty (reads passage node) | CONFORMANT |
| No unresolved structural splits | CONFORMANT |
| Endings reachable check | DEFERRED — #1165 |
| Gate satisfiability check | DEFERRED — #1165 |

**Note**: `check_all_endings_reachable` and `check_gate_satisfiability` were NOT wired in — they use the old `choice_from`/`choice_to` edge model which the pipeline no longer creates. Wiring them would silently pass everything. Migration tracked in #1165.

## Tests Added

- Residue beat ungrouped → error (micro_beat still exempt)
- Arc with repeated passage IDs → error
- Arc last passage has outgoing choices → error
- Divergence beat without choices on passage → error
- Two choices with overlapping requires → error
- Variant with empty requires on node → error
- Structural split warning without variant → error

Closes #1156