### PR TITLE
feat: POLISH Phase 5e (ambiguous feasibility LLM escalation) and Phase 5f (transition guidance)

### DIFF
--- a/prompts/templates/polish_phase5e_feasibility.yaml
+++ b/prompts/templates/polish_phase5e_feasibility.yaml
@@ -1,0 +1,57 @@
+name: polish_phase5e_feasibility
+description: Resolve ambiguous prose feasibility cases where flags have mixed residue weights
+
+system: |
+  You are resolving ambiguous passage feasibility cases. Each case is a passage
+  that has state flags from dilemmas with MIXED residue weights — some heavy
+  (requiring separate prose), some light (requiring a mood-setting beat).
+
+  ## Your Task
+  For each flag listed in each case, decide one of three treatments:
+  - **variant**: The flag changes the scene significantly — separate prose is needed
+  - **residue**: The flag adds mood only — a brief beat before the shared passage is enough
+  - **irrelevant**: The flag has no meaningful effect on this passage
+
+  ## Decision Criteria
+  - **weight=heavy** means the flag dramatically changes character actions or events → lean toward "variant"
+  - **weight=light** means the flag is tonal or atmospheric → lean toward "residue"
+  - Choose "irrelevant" when the flag's dilemma has no entities in this passage (the subplot doesn't touch this scene)
+  - Override the weight hint if the passage context clearly warrants a different judgment
+
+  ## Cases to Resolve
+  {case_details}
+
+  ## What NOT to Do
+  - Do NOT skip any flag — provide a decision for every flag in every case
+  - Do NOT use any decision value other than "variant", "residue", or "irrelevant"
+  - Do NOT add prose before or after the JSON output
+
+  ## Output Format
+  Return a JSON object with a "feasibility_decisions" array. One entry per flag per case.
+  "flag_index" is the 0-based position of the flag within the case's flags list (matching the [0], [1]... labels above).
+
+  Example (do NOT copy these values):
+  {{
+    "feasibility_decisions": [
+      {{
+        "passage_id": "passage::intersection_0",
+        "flag_index": 0,
+        "decision": "variant"
+      }},
+      {{
+        "passage_id": "passage::intersection_0",
+        "flag_index": 1,
+        "decision": "residue"
+      }}
+    ]
+  }}
+
+user: |
+  Resolve the feasibility decision for each flag in each of the {case_count} ambiguous
+  passage(s) above. Decide "variant", "residue", or "irrelevant" for each flag.
+
+  REMINDER: Return ONLY valid JSON. Provide one decision per flag (flag_index matches the
+  [0], [1]... labels in the case details above). Decision must be "variant", "residue",
+  or "irrelevant".
+
+components: []

--- a/prompts/templates/polish_phase5f_transitions.yaml
+++ b/prompts/templates/polish_phase5f_transitions.yaml
@@ -1,0 +1,63 @@
+name: polish_phase5f_transitions
+description: Generate transition guidance for collapsed passages covering multiple beats
+
+system: |
+  You are writing transition instructions for collapsed passages. A collapsed passage
+  groups multiple consecutive beats into one scene. The FILL writer needs brief
+  guidance on how to bridge from one beat to the next within the scene.
+
+  ## Your Task
+  For each collapsed passage, write one transition instruction per beat BOUNDARY.
+  If a passage has N beats, provide exactly N-1 transition instructions.
+
+  A transition instruction is a short directive (one or two clauses, 10-20 words) that
+  tells the FILL writer how to move the narrative from the end of one beat into
+  the start of the next.
+
+  ## Good Transition Examples
+  - "As the argument fades, the protagonist notices something across the room."
+  - "Time passes; when they meet again, the mood has shifted."
+  - "The discovery prompts an immediate decision."
+  - "Without a word, they move on to the next task."
+
+  ## Bad Transition Examples
+  - "Transition smoothly." (too vague — no narrative direction)
+  - "Write a transition here." (meta-instruction, not a directive)
+  - "The argument ends and the protagonist discovers something." (restates beats instead of bridging them)
+
+  ## What NOT to Do
+  - Do NOT write full prose — only brief transition directives
+  - Do NOT provide more or fewer transitions than beat boundaries
+  - Do NOT restate what happened in the beat — bridge to the next beat
+  - Do NOT skip any collapsed passage
+  - Do NOT add prose before or after the JSON output
+
+  ## Collapsed Passages to Process
+  {collapsed_passage_details}
+
+  ## Output Format
+  Return a JSON object with a "transition_guidance" array. One entry per collapsed passage.
+  Each "transitions" list must have exactly as many entries as beat boundaries listed above.
+
+  Example (do NOT copy these values):
+  {{
+    "transition_guidance": [
+      {{
+        "passage_id": "passage::collapse_0",
+        "transitions": [
+          "The silence stretches until the protagonist turns away.",
+          "Moments later, the situation demands a response."
+        ]
+      }}
+    ]
+  }}
+
+user: |
+  Generate transition guidance for each of the {collapsed_count} collapsed passage(s)
+  above. Each passage lists how many boundaries it has — provide exactly that many
+  transition instructions, no more, no fewer.
+
+  REMINDER: Return ONLY valid JSON. Each "transitions" list length must equal the
+  boundary count shown for that passage.
+
+components: []

--- a/src/questfoundry/graph/polish_context.py
+++ b/src/questfoundry/graph/polish_context.py
@@ -20,6 +20,7 @@ from questfoundry.graph.context_compact import (
 if TYPE_CHECKING:
     from questfoundry.graph.context_compact import CompactContextConfig
     from questfoundry.graph.graph import Graph
+    from questfoundry.models.polish import AmbiguousFeasibilityCase
 
 
 def format_linear_section_context(
@@ -409,6 +410,125 @@ def format_variant_summary_context(
         "variant_details": "\n".join(variant_lines),
         "story_context": story_context,
         "variant_count": str(len(variant_specs)),
+    }
+
+
+def format_ambiguous_feasibility_context(
+    graph: Graph,
+    ambiguous_cases: list[AmbiguousFeasibilityCase],
+    passage_specs: list[dict[str, Any]],
+) -> dict[str, str]:
+    """Build context for Phase 5e (ambiguous feasibility resolution).
+
+    Args:
+        graph: Graph containing dilemma data.
+        ambiguous_cases: Passages with mixed-weight flags needing LLM judgment.
+        passage_specs: All passage specs for summary lookup.
+
+    Returns:
+        Dict with keys: case_details, case_count.
+    """
+    dilemma_nodes = graph.get_nodes_by_type("dilemma")
+
+    passage_lookup: dict[str, dict[str, Any]] = {p["passage_id"]: p for p in passage_specs}
+
+    case_lines: list[str] = []
+    for case in ambiguous_cases:
+        passage_spec = passage_lookup.get(case.passage_id, {})
+        summary = truncate_summary(case.passage_summary or passage_spec.get("summary", ""), 100)
+        entities_str = ", ".join(f"`{e}`" for e in case.entities[:6]) if case.entities else "(none)"
+
+        flag_lines: list[str] = []
+        for i, flag in enumerate(case.flags):
+            # Flag format: "{dilemma_id}:{path_id}" e.g. "dilemma::d1:path::brave"
+            colon_before_path = flag.find(":path::")
+            if colon_before_path != -1:
+                dilemma_id = flag[:colon_before_path]
+            else:
+                dilemma_id = flag.split(":")[0] if ":" in flag else ""
+            dilemma_data = dilemma_nodes.get(dilemma_id, {})
+            dilemma_name = dilemma_data.get("name", dilemma_id)
+            weight = dilemma_data.get("residue_weight", "light")
+            question = dilemma_data.get("question", "")
+            # Pull consequence from the matched answer if available
+            consequence = ""
+            for answer in dilemma_data.get("answers") or []:
+                ans_path = answer.get("path_id", "")
+                if ans_path and flag.endswith(ans_path):
+                    consequence = (answer.get("consequence") or {}).get("description", "")
+                    break
+            extra_lines: list[str] = []
+            if question:
+                extra_lines.append(f"      question: {question}")
+            if consequence:
+                extra_lines.append(f"      consequence: {consequence}")
+            flag_line = f"    [{i}] flag=`{flag}` dilemma=`{dilemma_name}` weight={weight}"
+            if extra_lines:
+                flag_line += "\n" + "\n".join(extra_lines)
+            flag_lines.append(flag_line)
+
+        flags_str = "\n".join(flag_lines)
+        case_lines.append(
+            f"  passage_id: {case.passage_id}\n"
+            f"  summary: {summary}\n"
+            f"  entities: {entities_str}\n"
+            f"  flags:\n{flags_str}"
+        )
+
+    return {
+        "case_details": "\n\n".join(case_lines) if case_lines else "(no cases)",
+        "case_count": str(len(ambiguous_cases)),
+    }
+
+
+def format_transition_guidance_context(
+    graph: Graph,
+    passage_specs: list[dict[str, Any]],
+) -> dict[str, str]:
+    """Build context for Phase 5f (transition guidance for collapsed passages).
+
+    Accepts all passage specs and filters to collapsed passages with 2+ beats.
+
+    Args:
+        graph: Graph containing beat data.
+        passage_specs: All passage specs from Phase 4a.
+
+    Returns:
+        Dict with keys: collapsed_passage_details, collapsed_count.
+    """
+    beat_nodes = graph.get_nodes_by_type("beat")
+
+    collapsed = [
+        p
+        for p in passage_specs
+        if p.get("grouping_type") == "collapse" and len(p.get("beat_ids", [])) >= 2
+    ]
+
+    passage_lines: list[str] = []
+    for spec in collapsed:
+        passage_id = spec["passage_id"]
+        beat_ids = spec.get("beat_ids", [])
+        entities_str = ", ".join(f"`{e}`" for e in spec.get("entities", [])[:5]) or "(none)"
+
+        beat_lines: list[str] = []
+        for i, bid in enumerate(beat_ids):
+            data = beat_nodes.get(bid, {})
+            summary = truncate_summary(data.get("summary", ""), 90)
+            scene_type = data.get("scene_type", "")
+            scene_tag = f"[{scene_type}] " if scene_type else ""
+            beat_lines.append(f"    Beat {i + 1}: {bid} {scene_tag}— {summary}")
+
+        boundary_count = len(beat_ids) - 1
+        beats_str = "\n".join(beat_lines)
+        passage_lines.append(
+            f"  passage_id: {passage_id}\n"
+            f"  entities: {entities_str}\n"
+            f"  beats ({len(beat_ids)} total, {boundary_count} boundary/ies):\n{beats_str}"
+        )
+
+    return {
+        "collapsed_passage_details": "\n\n".join(passage_lines) if passage_lines else "(none)",
+        "collapsed_count": str(len(collapsed)),
     }
 
 

--- a/src/questfoundry/graph/polish_context.py
+++ b/src/questfoundry/graph/polish_context.py
@@ -23,6 +23,30 @@ if TYPE_CHECKING:
     from questfoundry.models.polish import AmbiguousFeasibilityCase
 
 
+# ---------------------------------------------------------------------------
+# Shared flag parsing helper
+# ---------------------------------------------------------------------------
+
+
+def _parse_flag_dilemma_id(flag: str) -> str:
+    """Extract the dilemma ID from a feasibility flag string.
+
+    Flag format is either:
+    - ``"{dilemma_id}:path::{path_raw}"`` (new format)
+    - ``"{dilemma_id}:{path_id}"`` (old short format)
+
+    Args:
+        flag: Raw flag string from an overlay ``when`` list.
+
+    Returns:
+        The dilemma ID portion, or empty string if not parseable.
+    """
+    colon_before_path = flag.find(":path::")
+    if colon_before_path != -1:
+        return flag[:colon_before_path]
+    return flag.split(":")[0] if ":" in flag else ""
+
+
 def format_linear_section_context(
     graph: Graph,
     section_id: str,
@@ -440,12 +464,7 @@ def format_ambiguous_feasibility_context(
 
         flag_lines: list[str] = []
         for i, flag in enumerate(case.flags):
-            # Flag format: "{dilemma_id}:{path_id}" e.g. "dilemma::d1:path::brave"
-            colon_before_path = flag.find(":path::")
-            if colon_before_path != -1:
-                dilemma_id = flag[:colon_before_path]
-            else:
-                dilemma_id = flag.split(":")[0] if ":" in flag else ""
+            dilemma_id = _parse_flag_dilemma_id(flag)
             dilemma_data = dilemma_nodes.get(dilemma_id, {})
             dilemma_name = dilemma_data.get("name", dilemma_id)
             weight = dilemma_data.get("residue_weight", "light")

--- a/src/questfoundry/models/polish.py
+++ b/src/questfoundry/models/polish.py
@@ -156,6 +156,10 @@ class PassageSpec(BaseModel):
         default="singleton",
         description="How beats were grouped: intersection, collapse, or singleton",
     )
+    transition_guidance: list[str] = Field(
+        default_factory=list,
+        description="Transition instructions between beats (N-1 for N beats; Phase 5f)",
+    )
 
 
 class VariantSpec(BaseModel):
@@ -304,6 +308,61 @@ class Phase5dOutput(BaseModel):
     """Output of Phase 5d: Variant Passage Summaries."""
 
     variant_summaries: list[VariantSummaryItem] = Field(default_factory=list)
+
+
+# ---------------------------------------------------------------------------
+# Phase 5e: Ambiguous Feasibility — LLM output schema
+# ---------------------------------------------------------------------------
+
+
+class AmbiguousFeasibilityCase(BaseModel):
+    """One passage with ambiguous feasibility flags for LLM review.
+
+    Ambiguous means 2+ relevant flags with mixed residue weights
+    (at least one heavy AND at least one light dilemma).
+    """
+
+    passage_id: str = Field(min_length=1)
+    passage_summary: str = Field(default="")
+    entities: list[str] = Field(default_factory=list)
+    flags: list[str] = Field(
+        min_length=1, description="Flag IDs that are ambiguous (mixed weights)"
+    )
+
+
+class FeasibilityDecisionItem(BaseModel):
+    """LLM decision for one flag in an ambiguous passage."""
+
+    passage_id: str = Field(min_length=1)
+    flag_index: int = Field(ge=0, description="Index into the case's flags list")
+    decision: str = Field(description='"variant" | "residue" | "irrelevant"')
+
+
+class Phase5eOutput(BaseModel):
+    """Output of Phase 5e: Ambiguous Feasibility Resolution."""
+
+    feasibility_decisions: list[FeasibilityDecisionItem] = Field(default_factory=list)
+
+
+# ---------------------------------------------------------------------------
+# Phase 5f: Transition Guidance — LLM output schema
+# ---------------------------------------------------------------------------
+
+
+class TransitionGuidanceItem(BaseModel):
+    """Transition guidance for a collapsed passage."""
+
+    passage_id: str = Field(min_length=1)
+    transitions: list[str] = Field(
+        min_length=1,
+        description="One transition instruction per beat boundary (N-1 for N beats)",
+    )
+
+
+class Phase5fOutput(BaseModel):
+    """Output of Phase 5f: Transition Guidance for Collapsed Passages."""
+
+    transition_guidance: list[TransitionGuidanceItem] = Field(default_factory=list)
 
 
 # ---------------------------------------------------------------------------

--- a/src/questfoundry/pipeline/stages/polish/deterministic.py
+++ b/src/questfoundry/pipeline/stages/polish/deterministic.py
@@ -18,6 +18,7 @@ from typing import TYPE_CHECKING, Any
 from questfoundry.graph.algorithms import compute_active_flags_at_beat, compute_passage_traversals
 from questfoundry.models.pipeline import PhaseResult
 from questfoundry.models.polish import (
+    AmbiguousFeasibilityCase,
     ChoiceSpec,
     FalseBranchCandidate,
     FalseBranchSpec,
@@ -54,6 +55,7 @@ class PolishPlan:
     false_branch_candidates: list[FalseBranchCandidate] = field(default_factory=list)
     false_branch_specs: list[FalseBranchSpec] = field(default_factory=list)  # Phase 5
     feasibility_annotations: dict[str, list[str]] = field(default_factory=dict)
+    ambiguous_specs: list[AmbiguousFeasibilityCase] = field(default_factory=list)  # Phase 5e
     arc_traversals: dict[str, list[str]] = field(default_factory=dict)
     warnings: list[str] = field(default_factory=list)
 
@@ -137,12 +139,14 @@ async def phase_plan_computation(
     plan.feasibility_annotations = feasibility["annotations"]
     plan.variant_specs = feasibility["variant_specs"]
     plan.residue_specs = feasibility["residue_specs"]
+    plan.ambiguous_specs = feasibility["ambiguous_specs"]
     plan.warnings.extend(feasibility.get("warnings", []))
     log.debug(
         "phase4b_complete",
         variants=len(plan.variant_specs),
         residues=len(plan.residue_specs),
         annotated=len(plan.feasibility_annotations),
+        ambiguous=len(plan.ambiguous_specs),
     )
 
     # 4c: Choice edge derivation
@@ -311,11 +315,12 @@ def compute_prose_feasibility(
     """Determine feasibility category for each passage.
 
     Returns:
-        Dict with keys: annotations, variant_specs, residue_specs, warnings.
+        Dict with keys: annotations, variant_specs, residue_specs, warnings, ambiguous_specs.
     """
     annotations: dict[str, list[str]] = {}
     variant_specs: list[VariantSpec] = []
     residue_specs: list[ResidueSpec] = []
+    ambiguous_specs: list[AmbiguousFeasibilityCase] = []
     warnings: list[str] = []
 
     # Build overlay data: flag → affected entities
@@ -383,18 +388,37 @@ def compute_prose_feasibility(
             )
             continue
 
-        # Check for heavy residue (→ variant) vs light (→ residue beat)
-        has_heavy = False
+        # Categorize flags by residue weight
+        heavy_flags: list[str] = []
+        light_flags: list[str] = []
         for flag in relevant_flags:
-            # Flag format: "dilemma_id:path_id" — extract dilemma
-            dilemma_id = flag.split(":")[0] if ":" in flag else ""
+            # Flag format: "{dilemma_id}:{path_id}" e.g. "dilemma::d1:path::brave"
+            # Extract dilemma_id: find the colon that separates dilemma from path.
+            # Both parts use "::" internally, so the separator is the ":" right
+            # before "path::" (or the first ":" if the old short format is used).
+            colon_before_path = flag.find(":path::")
+            if colon_before_path != -1:
+                dilemma_id = flag[:colon_before_path]
+            else:
+                dilemma_id = flag.split(":")[0] if ":" in flag else ""
             weight = dilemma_residue.get(dilemma_id, "light")
             if weight in ("heavy", "hard"):
-                has_heavy = True
-                break
+                heavy_flags.append(flag)
+            else:
+                light_flags.append(flag)
 
-        if has_heavy:
-            # Variant: create variant passages
+        # Ambiguous: 2+ relevant flags with MIXED weights (some heavy AND some light)
+        if len(relevant_flags) >= 2 and heavy_flags and light_flags:
+            ambiguous_specs.append(
+                AmbiguousFeasibilityCase(
+                    passage_id=spec.passage_id,
+                    passage_summary=spec.summary,
+                    entities=spec.entities,
+                    flags=relevant_flags,
+                )
+            )
+        elif heavy_flags:
+            # All relevant flags are heavy → deterministically variant
             for flag in relevant_flags:
                 variant_specs.append(
                     VariantSpec(
@@ -406,7 +430,7 @@ def compute_prose_feasibility(
                 )
                 variant_counter += 1
         else:
-            # Residue: create residue beats
+            # All relevant flags are light → deterministically residue
             for flag in relevant_flags:
                 path_id = flag.split(":")[-1] if ":" in flag else ""
                 residue_specs.append(
@@ -422,6 +446,7 @@ def compute_prose_feasibility(
         "annotations": annotations,
         "variant_specs": variant_specs,
         "residue_specs": residue_specs,
+        "ambiguous_specs": ambiguous_specs,
         "warnings": warnings,
     }
 
@@ -631,6 +656,7 @@ def _store_plan(graph: Graph, plan: PolishPlan) -> None:
             "choice_specs": [s.model_dump() for s in plan.choice_specs],
             "false_branch_candidates": [c.model_dump() for c in plan.false_branch_candidates],
             "feasibility_annotations": plan.feasibility_annotations,
+            "ambiguous_specs": [s.model_dump() for s in plan.ambiguous_specs],
             "arc_traversals": plan.arc_traversals,
         },
     )
@@ -773,6 +799,7 @@ def _create_passage_node(graph: Graph, spec: PassageSpec) -> None:
             "summary": spec.summary,
             "entities": spec.entities,
             "grouping_type": spec.grouping_type,
+            "transition_guidance": spec.transition_guidance,
         },
     )
 

--- a/src/questfoundry/pipeline/stages/polish/deterministic.py
+++ b/src/questfoundry/pipeline/stages/polish/deterministic.py
@@ -36,6 +36,30 @@ if TYPE_CHECKING:
 
 
 # ---------------------------------------------------------------------------
+# Shared flag parsing helper
+# ---------------------------------------------------------------------------
+
+
+def _parse_flag_dilemma_id(flag: str) -> str:
+    """Extract the dilemma ID from a feasibility flag string.
+
+    Flag format is either:
+    - ``"{dilemma_id}:path::{path_raw}"`` (new format)
+    - ``"{dilemma_id}:{path_id}"`` (old short format)
+
+    Args:
+        flag: Raw flag string from an overlay ``when`` list.
+
+    Returns:
+        The dilemma ID portion, or empty string if not parseable.
+    """
+    colon_before_path = flag.find(":path::")
+    if colon_before_path != -1:
+        return flag[:colon_before_path]
+    return flag.split(":")[0] if ":" in flag else ""
+
+
+# ---------------------------------------------------------------------------
 # PolishPlan dataclass
 # ---------------------------------------------------------------------------
 
@@ -396,11 +420,7 @@ def compute_prose_feasibility(
             # Extract dilemma_id: find the colon that separates dilemma from path.
             # Both parts use "::" internally, so the separator is the ":" right
             # before "path::" (or the first ":" if the old short format is used).
-            colon_before_path = flag.find(":path::")
-            if colon_before_path != -1:
-                dilemma_id = flag[:colon_before_path]
-            else:
-                dilemma_id = flag.split(":")[0] if ":" in flag else ""
+            dilemma_id = _parse_flag_dilemma_id(flag)
             weight = dilemma_residue.get(dilemma_id, "light")
             if weight in ("heavy", "hard"):
                 heavy_flags.append(flag)

--- a/src/questfoundry/pipeline/stages/polish/llm_phases.py
+++ b/src/questfoundry/pipeline/stages/polish/llm_phases.py
@@ -13,16 +13,19 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any
 
 from questfoundry.graph.polish_context import (
+    format_ambiguous_feasibility_context,
     format_choice_label_context,
     format_entity_arc_context,
     format_false_branch_context,
     format_linear_section_context,
     format_pacing_context,
     format_residue_content_context,
+    format_transition_guidance_context,
     format_variant_summary_context,
 )
 from questfoundry.models.pipeline import PhaseResult
 from questfoundry.models.polish import (
+    AmbiguousFeasibilityCase,
     FalseBranchSpec,
     Phase1Output,
     Phase2Output,
@@ -31,6 +34,10 @@ from questfoundry.models.polish import (
     Phase5bOutput,
     Phase5cOutput,
     Phase5dOutput,
+    Phase5eOutput,
+    Phase5fOutput,
+    ResidueSpec,
+    VariantSpec,
 )
 from questfoundry.pipeline.stages.polish._helpers import log
 from questfoundry.pipeline.stages.polish.deterministic import _load_plan_data
@@ -433,6 +440,132 @@ class _PolishLLMPhaseMixin:
             enrichment_parts.append(f"{len(result_d.variant_summaries)} variant summaries")
             log.debug("phase5d_complete", summaries=len(result_d.variant_summaries))
 
+        # 5e: Resolve ambiguous feasibility cases
+        ambiguous_specs_raw = plan_data.get("ambiguous_specs", [])
+        if ambiguous_specs_raw:
+            ambiguous_cases = [AmbiguousFeasibilityCase(**a) for a in ambiguous_specs_raw]
+            context = format_ambiguous_feasibility_context(graph, ambiguous_cases, passage_specs)
+            result_e, llm_calls, tokens = await self._polish_llm_call(  # type: ignore[attr-defined]
+                model=model,
+                template_name="polish_phase5e_feasibility",
+                context=context,
+                output_schema=Phase5eOutput,
+            )
+            total_llm_calls += llm_calls
+            total_tokens += tokens
+
+            # Build lookup for fast access
+            case_lookup: dict[str, AmbiguousFeasibilityCase] = {
+                c.passage_id: c for c in ambiguous_cases
+            }
+
+            resolved_count = 0
+            for decision in result_e.feasibility_decisions:
+                passage_id = decision.passage_id
+                flag_index = decision.flag_index
+                case = case_lookup.get(passage_id)
+                if case is None:
+                    log.warning("phase5e_unknown_passage", passage_id=passage_id)
+                    continue
+                if flag_index < 0 or flag_index >= len(case.flags):
+                    log.warning(
+                        "phase5e_invalid_flag_index",
+                        passage_id=passage_id,
+                        flag_index=flag_index,
+                        flags_count=len(case.flags),
+                    )
+                    continue
+
+                flag = case.flags[flag_index]
+                d = decision.decision
+
+                if d == "variant":
+                    variant_counter = len(variant_specs)
+                    variant_specs.append(
+                        VariantSpec(
+                            base_passage_id=passage_id,
+                            variant_id=f"passage::variant_{variant_counter}",
+                            requires=[flag],
+                            summary="",
+                        ).model_dump()
+                    )
+                elif d == "residue":
+                    path_id = flag.split(":")[-1] if ":" in flag else ""
+                    passage_raw = passage_id.split("::")[-1]
+                    residue_specs.append(
+                        ResidueSpec(
+                            target_passage_id=passage_id,
+                            residue_id=f"residue::{passage_raw}_{flag.replace(':', '_')}",
+                            flag=flag,
+                            path_id=path_id,
+                        ).model_dump()
+                    )
+                elif d == "irrelevant":
+                    # Append to feasibility_annotations
+                    ann_key = passage_id
+                    existing = plan_data.get("feasibility_annotations", {})
+                    existing.setdefault(ann_key, []).append(flag)
+                else:
+                    log.warning("phase5e_unknown_decision", decision=d, passage_id=passage_id)
+                    continue
+
+                resolved_count += 1
+
+            enrichment_parts.append(f"{resolved_count} ambiguous cases resolved")
+            log.debug("phase5e_complete", resolved=resolved_count)
+        else:
+            enrichment_parts.append("0 ambiguous cases resolved")
+            log.info("phase5e_skipped", status="skipped", detail="No ambiguous feasibility cases")
+
+        # 5f: Transition guidance for collapsed passages
+        collapsed_specs = [
+            p
+            for p in passage_specs
+            if p.get("grouping_type") == "collapse" and len(p.get("beat_ids", [])) >= 2
+        ]
+        if collapsed_specs:
+            context = format_transition_guidance_context(graph, passage_specs)
+            result_f, llm_calls, tokens = await self._polish_llm_call(  # type: ignore[attr-defined]
+                model=model,
+                template_name="polish_phase5f_transitions",
+                context=context,
+                output_schema=Phase5fOutput,
+            )
+            total_llm_calls += llm_calls
+            total_tokens += tokens
+
+            passage_lookup: dict[str, dict[str, Any]] = {p["passage_id"]: p for p in passage_specs}
+            guides_applied = 0
+            for item in result_f.transition_guidance:
+                spec = passage_lookup.get(item.passage_id)
+                if spec is None:
+                    log.warning(
+                        "phase5f_unknown_passage",
+                        passage_id=item.passage_id,
+                    )
+                    continue
+                expected = len(spec.get("beat_ids", [])) - 1
+                if len(item.transitions) != expected:
+                    log.warning(
+                        "phase5f_transition_count_mismatch",
+                        passage_id=item.passage_id,
+                        expected=expected,
+                        got=len(item.transitions),
+                    )
+                    continue
+                spec["transition_guidance"] = item.transitions
+                guides_applied += 1
+
+            enrichment_parts.append(f"{guides_applied} transition guides generated")
+            log.debug("phase5f_complete", guides=guides_applied)
+        else:
+            enrichment_parts.append("0 transition guides generated")
+            log.info(
+                "phase5f_skipped",
+                status="skipped",
+                detail="No collapsed passages with 2+ beats",
+            )
+
         # Store enriched plan back to graph
         _update_plan_data(
             graph,
@@ -440,6 +573,8 @@ class _PolishLLMPhaseMixin:
             residue_specs=residue_specs,
             false_branch_specs=false_branch_specs,
             variant_specs=variant_specs,
+            ambiguous_specs=[],  # Resolved — clear from plan
+            passage_specs=passage_specs,
         )
 
         detail = "; ".join(enrichment_parts) if enrichment_parts else "No enrichment needed"
@@ -465,15 +600,21 @@ def _update_plan_data(
     residue_specs: list[dict[str, Any]],
     false_branch_specs: list[dict[str, Any]],
     variant_specs: list[dict[str, Any]],
+    ambiguous_specs: list[dict[str, Any]] | None = None,
+    passage_specs: list[dict[str, Any]] | None = None,
 ) -> None:
     """Update the plan node with enriched data from Phase 5."""
-    graph.update_node(
-        "polish_plan::current",
-        choice_specs=choice_specs,
-        residue_specs=residue_specs,
-        false_branch_specs=false_branch_specs,
-        variant_specs=variant_specs,
-    )
+    updates: dict[str, Any] = {
+        "choice_specs": choice_specs,
+        "residue_specs": residue_specs,
+        "false_branch_specs": false_branch_specs,
+        "variant_specs": variant_specs,
+    }
+    if ambiguous_specs is not None:
+        updates["ambiguous_specs"] = ambiguous_specs
+    if passage_specs is not None:
+        updates["passage_specs"] = passage_specs
+    graph.update_node("polish_plan::current", **updates)
 
 
 # ---------------------------------------------------------------------------

--- a/src/questfoundry/pipeline/stages/polish/llm_phases.py
+++ b/src/questfoundry/pipeline/stages/polish/llm_phases.py
@@ -575,6 +575,7 @@ class _PolishLLMPhaseMixin:
             variant_specs=variant_specs,
             ambiguous_specs=[],  # Resolved — clear from plan
             passage_specs=passage_specs,
+            feasibility_annotations=plan_data.get("feasibility_annotations", {}),
         )
 
         detail = "; ".join(enrichment_parts) if enrichment_parts else "No enrichment needed"
@@ -602,6 +603,7 @@ def _update_plan_data(
     variant_specs: list[dict[str, Any]],
     ambiguous_specs: list[dict[str, Any]] | None = None,
     passage_specs: list[dict[str, Any]] | None = None,
+    feasibility_annotations: dict[str, list[str]] | None = None,
 ) -> None:
     """Update the plan node with enriched data from Phase 5."""
     updates: dict[str, Any] = {
@@ -614,6 +616,8 @@ def _update_plan_data(
         updates["ambiguous_specs"] = ambiguous_specs
     if passage_specs is not None:
         updates["passage_specs"] = passage_specs
+    if feasibility_annotations is not None:
+        updates["feasibility_annotations"] = feasibility_annotations
     graph.update_node("polish_plan::current", **updates)
 
 

--- a/tests/unit/test_polish_deterministic.py
+++ b/tests/unit/test_polish_deterministic.py
@@ -658,3 +658,264 @@ class TestChoiceSpecRequires:
         assert any(len(c.requires) > 0 for c in intersection_choices), (
             "Expected at least one intersection choice to have a non-empty requires list"
         )
+
+
+# ---------------------------------------------------------------------------
+# Tests for Issue #1157: Ambiguous feasibility detection in Phase 4b
+# ---------------------------------------------------------------------------
+
+
+class TestAmbiguousFeasibilityDetection:
+    """Phase 4b must detect ambiguous cases (mixed residue weights) and store them."""
+
+    def _make_commit_beat(
+        self,
+        graph: Graph,
+        beat_id: str,
+        path_id: str,
+        dilemma_id: str,
+    ) -> None:
+        graph.create_node(
+            beat_id,
+            {
+                "type": "beat",
+                "raw_id": beat_id.split("::")[-1],
+                "summary": f"Commit on {path_id}",
+                "dilemma_impacts": [{"dilemma_id": dilemma_id, "effect": "commits"}],
+                "entities": [],
+                "scene_type": "scene",
+            },
+        )
+        graph.add_edge("belongs_to", beat_id, path_id)
+
+    def test_mixed_weights_produces_ambiguous_spec(self) -> None:
+        """Passage with one heavy flag and one light flag → ambiguous_specs, NOT in variant or residue."""
+        graph = Graph.empty()
+
+        # Two dilemmas — one heavy, one light
+        graph.create_node(
+            "dilemma::heavy",
+            {
+                "type": "dilemma",
+                "raw_id": "heavy",
+                "residue_weight": "heavy",
+            },
+        )
+        graph.create_node(
+            "dilemma::light",
+            {
+                "type": "dilemma",
+                "raw_id": "light",
+                "residue_weight": "light",
+            },
+        )
+
+        # Two paths
+        graph.create_node("path::ph", {"type": "path", "raw_id": "ph"})
+        graph.create_node("path::pl", {"type": "path", "raw_id": "pl"})
+
+        # Entity that appears in the passage
+        graph.create_node(
+            "entity::hero",
+            {
+                "type": "entity",
+                "raw_id": "hero",
+                "overlays": [
+                    {"when": ["dilemma::heavy:path::ph"], "details": {"mood": "grim"}},
+                    {"when": ["dilemma::light:path::pl"], "details": {"mood": "relieved"}},
+                ],
+            },
+        )
+
+        # Commit beats (ancestors of the target passage).
+        # Both need to be in the ancestor chain so both flags are active at beat::target.
+        # Chain: commit_h → commit_l → target
+        self._make_commit_beat(graph, "beat::commit_h", "path::ph", "dilemma::heavy")
+        self._make_commit_beat(graph, "beat::commit_l", "path::pl", "dilemma::light")
+        _add_predecessor(graph, "beat::commit_l", "beat::commit_h")
+
+        # Target beat referencing entity::hero
+        _make_beat(
+            graph,
+            "beat::target",
+            "Target beat with hero",
+            entities=["entity::hero"],
+        )
+        graph.add_edge("belongs_to", "beat::target", "path::ph")
+        _add_predecessor(graph, "beat::target", "beat::commit_l")
+
+        spec = PassageSpec(
+            passage_id="passage::test_mixed",
+            beat_ids=["beat::target"],
+            summary="test",
+            entities=["entity::hero"],
+        )
+
+        result = compute_prose_feasibility(graph, [spec])
+
+        # Mixed weights → goes to ambiguous, NOT variant or residue
+        assert len(result["ambiguous_specs"]) == 1
+        assert result["ambiguous_specs"][0].passage_id == "passage::test_mixed"
+        assert len(result["variant_specs"]) == 0
+        assert len(result["residue_specs"]) == 0
+
+    def test_all_heavy_flags_not_ambiguous(self) -> None:
+        """2+ flags all heavy → deterministic variant, NOT ambiguous."""
+        graph = Graph.empty()
+
+        graph.create_node(
+            "dilemma::d1",
+            {"type": "dilemma", "raw_id": "d1", "residue_weight": "heavy"},
+        )
+        graph.create_node(
+            "dilemma::d2",
+            {"type": "dilemma", "raw_id": "d2", "residue_weight": "hard"},
+        )
+        graph.create_node("path::p1", {"type": "path", "raw_id": "p1"})
+        graph.create_node("path::p2", {"type": "path", "raw_id": "p2"})
+
+        graph.create_node(
+            "entity::hero",
+            {
+                "type": "entity",
+                "raw_id": "hero",
+                "overlays": [
+                    {"when": ["dilemma::d1:path::p1"], "details": {"mood": "dark"}},
+                    {"when": ["dilemma::d2:path::p2"], "details": {"mood": "grim"}},
+                ],
+            },
+        )
+
+        self._make_commit_beat(graph, "beat::c1", "path::p1", "dilemma::d1")
+        self._make_commit_beat(graph, "beat::c2", "path::p2", "dilemma::d2")
+
+        _make_beat(graph, "beat::target", "Target", entities=["entity::hero"])
+        graph.add_edge("belongs_to", "beat::target", "path::p1")
+        _add_predecessor(graph, "beat::target", "beat::c1")
+
+        spec = PassageSpec(
+            passage_id="passage::all_heavy",
+            beat_ids=["beat::target"],
+            summary="heavy test",
+            entities=["entity::hero"],
+        )
+
+        result = compute_prose_feasibility(graph, [spec])
+        assert len(result["ambiguous_specs"]) == 0
+        assert len(result["variant_specs"]) > 0
+        assert len(result["residue_specs"]) == 0
+
+    def test_single_relevant_flag_always_deterministic(self) -> None:
+        """Exactly 1 relevant flag → never ambiguous (deterministic assignment)."""
+        graph = Graph.empty()
+
+        graph.create_node(
+            "dilemma::d1",
+            {"type": "dilemma", "raw_id": "d1", "residue_weight": "heavy"},
+        )
+        graph.create_node("path::p1", {"type": "path", "raw_id": "p1"})
+
+        graph.create_node(
+            "entity::hero",
+            {
+                "type": "entity",
+                "raw_id": "hero",
+                "overlays": [
+                    {"when": ["dilemma::d1:path::p1"], "details": {"mood": "dark"}},
+                ],
+            },
+        )
+
+        self._make_commit_beat(graph, "beat::c1", "path::p1", "dilemma::d1")
+        _make_beat(graph, "beat::target", "Target", entities=["entity::hero"])
+        graph.add_edge("belongs_to", "beat::target", "path::p1")
+        _add_predecessor(graph, "beat::target", "beat::c1")
+
+        spec = PassageSpec(
+            passage_id="passage::single_flag",
+            beat_ids=["beat::target"],
+            summary="single flag test",
+            entities=["entity::hero"],
+        )
+
+        result = compute_prose_feasibility(graph, [spec])
+        assert len(result["ambiguous_specs"]) == 0
+        assert len(result["variant_specs"]) == 1  # heavy → variant
+
+
+# ---------------------------------------------------------------------------
+# Tests for Issue #1158: transition_guidance stored on passage node in Phase 6
+# ---------------------------------------------------------------------------
+
+
+class TestTransitionGuidanceInGraph:
+    """After Phase 6, passage nodes created from collapsed specs must have transition_guidance."""
+
+    def test_transition_guidance_stored_on_passage_node(self) -> None:
+        """Phase 6 stores transition_guidance from PassageSpec onto the passage graph node."""
+        import asyncio
+
+        from questfoundry.pipeline.stages.polish.deterministic import phase_plan_application
+
+        graph = Graph.empty()
+
+        # Build a minimal plan node directly (bypass phase 4) with a collapsed passage
+        # that has transition_guidance set (simulating what phase 5f would produce).
+        from questfoundry.models.polish import PassageSpec as _PassageSpec
+
+        spec = _PassageSpec(
+            passage_id="passage::collapse_0",
+            beat_ids=["beat::a", "beat::b", "beat::c"],
+            summary="Three beats collapsed",
+            entities=[],
+            grouping_type="collapse",
+            transition_guidance=["Move from action to reflection.", "Time passes quietly."],
+        )
+
+        graph.create_node(
+            "polish_plan::current",
+            {
+                "type": "polish_plan",
+                "raw_id": "current",
+                "passage_count": 1,
+                "variant_count": 0,
+                "residue_count": 0,
+                "choice_count": 0,
+                "candidate_count": 0,
+                "warnings": [],
+                "passage_specs": [spec.model_dump()],
+                "variant_specs": [],
+                "residue_specs": [],
+                "choice_specs": [],
+                "false_branch_candidates": [],
+                "false_branch_specs": [],
+                "feasibility_annotations": {},
+                "ambiguous_specs": [],
+                "arc_traversals": {},
+            },
+        )
+
+        # Create beat nodes so grouped_in edges don't fail
+        for bid in ["beat::a", "beat::b", "beat::c"]:
+            graph.create_node(
+                bid,
+                {
+                    "type": "beat",
+                    "raw_id": bid.split("::")[-1],
+                    "summary": f"Beat {bid}",
+                    "dilemma_impacts": [],
+                    "entities": [],
+                    "scene_type": "scene",
+                },
+            )
+
+        result = asyncio.run(phase_plan_application(graph, None))  # type: ignore[arg-type]
+        assert result.status == "completed"
+
+        passage_nodes = graph.get_nodes_by_type("passage")
+        passage = passage_nodes.get("passage::collapse_0")
+        assert passage is not None
+        assert passage.get("transition_guidance") == [
+            "Move from action to reflection.",
+            "Time passes quietly.",
+        ]

--- a/tests/unit/test_polish_deterministic.py
+++ b/tests/unit/test_polish_deterministic.py
@@ -788,6 +788,8 @@ class TestAmbiguousFeasibilityDetection:
 
         self._make_commit_beat(graph, "beat::c1", "path::p1", "dilemma::d1")
         self._make_commit_beat(graph, "beat::c2", "path::p2", "dilemma::d2")
+        # Chain: c2 → c1 → target so both flags are ancestors of beat::target
+        _add_predecessor(graph, "beat::c1", "beat::c2")
 
         _make_beat(graph, "beat::target", "Target", entities=["entity::hero"])
         graph.add_edge("belongs_to", "beat::target", "path::p1")
@@ -802,7 +804,7 @@ class TestAmbiguousFeasibilityDetection:
 
         result = compute_prose_feasibility(graph, [spec])
         assert len(result["ambiguous_specs"]) == 0
-        assert len(result["variant_specs"]) > 0
+        assert len(result["variant_specs"]) == 2  # one per heavy flag
         assert len(result["residue_specs"]) == 0
 
     def test_single_relevant_flag_always_deterministic(self) -> None:

--- a/tests/unit/test_polish_phases.py
+++ b/tests/unit/test_polish_phases.py
@@ -434,3 +434,304 @@ class TestPhase3ArcMetadataEdge:
         edges = graph.get_edges(from_id="entity::hero", edge_type="has_arc_metadata")
         assert len(edges) == 1
         assert edges[0]["to"] == arc_node_id
+
+
+# ---------------------------------------------------------------------------
+# Tests for Issue #1157: Phase 5e — ambiguous feasibility resolution
+# ---------------------------------------------------------------------------
+
+
+class TestPhase5eAmbiguousFeasibility:
+    """Phase 5e must resolve ambiguous cases via LLM and apply decisions to plan."""
+
+    def _build_plan_with_ambiguous(self, graph: Graph) -> None:
+        """Build a minimal polish_plan node with one ambiguous feasibility case."""
+        from questfoundry.models.polish import AmbiguousFeasibilityCase, PassageSpec
+
+        passage = PassageSpec(
+            passage_id="passage::ambig_0",
+            beat_ids=["beat::a"],
+            summary="Ambiguous passage",
+            entities=["entity::hero"],
+            grouping_type="singleton",
+        )
+        ambiguous = AmbiguousFeasibilityCase(
+            passage_id="passage::ambig_0",
+            passage_summary="Ambiguous passage",
+            entities=["entity::hero"],
+            flags=["dilemma::heavy:path::ph"],
+        )
+
+        graph.create_node(
+            "polish_plan::current",
+            {
+                "type": "polish_plan",
+                "raw_id": "current",
+                "passage_count": 1,
+                "variant_count": 0,
+                "residue_count": 0,
+                "choice_count": 0,
+                "candidate_count": 0,
+                "warnings": [],
+                "passage_specs": [passage.model_dump()],
+                "variant_specs": [],
+                "residue_specs": [],
+                "choice_specs": [],
+                "false_branch_candidates": [],
+                "false_branch_specs": [],
+                "feasibility_annotations": {},
+                "ambiguous_specs": [ambiguous.model_dump()],
+                "arc_traversals": {},
+            },
+        )
+
+    def test_variant_decision_adds_variant_spec(self) -> None:
+        """LLM decision 'variant' → new VariantSpec appended to plan."""
+        from questfoundry.models.polish import FeasibilityDecisionItem, Phase5eOutput
+
+        graph = Graph.empty()
+        self._build_plan_with_ambiguous(graph)
+
+        llm_output = Phase5eOutput(
+            feasibility_decisions=[
+                FeasibilityDecisionItem(
+                    passage_id="passage::ambig_0",
+                    flag_index=0,
+                    decision="variant",
+                )
+            ]
+        )
+
+        host = _FakePolishLLMHost(llm_output)
+        result = asyncio.run(host._phase_5_llm_enrichment(graph, MagicMock()))  # type: ignore[arg-type]
+
+        assert result.status == "completed"
+
+        # Plan node should have a variant_spec for the resolved case
+        plan_nodes = graph.get_nodes_by_type("polish_plan")
+        plan_data = plan_nodes.get("polish_plan::current", {})
+        variant_specs = plan_data.get("variant_specs", [])
+        assert len(variant_specs) == 1
+        assert variant_specs[0]["base_passage_id"] == "passage::ambig_0"
+        assert variant_specs[0]["requires"] == ["dilemma::heavy:path::ph"]
+
+    def test_residue_decision_adds_residue_spec(self) -> None:
+        """LLM decision 'residue' → new ResidueSpec appended to plan."""
+        from questfoundry.models.polish import FeasibilityDecisionItem, Phase5eOutput
+
+        graph = Graph.empty()
+        self._build_plan_with_ambiguous(graph)
+
+        llm_output = Phase5eOutput(
+            feasibility_decisions=[
+                FeasibilityDecisionItem(
+                    passage_id="passage::ambig_0",
+                    flag_index=0,
+                    decision="residue",
+                )
+            ]
+        )
+
+        host = _FakePolishLLMHost(llm_output)
+        result = asyncio.run(host._phase_5_llm_enrichment(graph, MagicMock()))  # type: ignore[arg-type]
+
+        assert result.status == "completed"
+
+        plan_nodes = graph.get_nodes_by_type("polish_plan")
+        plan_data = plan_nodes.get("polish_plan::current", {})
+        residue_specs = plan_data.get("residue_specs", [])
+        assert len(residue_specs) == 1
+        assert residue_specs[0]["target_passage_id"] == "passage::ambig_0"
+        assert residue_specs[0]["flag"] == "dilemma::heavy:path::ph"
+
+    def test_skipped_when_no_ambiguous_cases(self) -> None:
+        """Phase 5e is skipped when ambiguous_specs is empty."""
+        from questfoundry.models.polish import Phase5eOutput
+
+        graph = Graph.empty()
+        graph.create_node(
+            "polish_plan::current",
+            {
+                "type": "polish_plan",
+                "raw_id": "current",
+                "passage_count": 0,
+                "variant_count": 0,
+                "residue_count": 0,
+                "choice_count": 0,
+                "candidate_count": 0,
+                "warnings": [],
+                "passage_specs": [],
+                "variant_specs": [],
+                "residue_specs": [],
+                "choice_specs": [],
+                "false_branch_candidates": [],
+                "false_branch_specs": [],
+                "feasibility_annotations": {},
+                "ambiguous_specs": [],
+                "arc_traversals": {},
+            },
+        )
+
+        host = _FakePolishLLMHost(Phase5eOutput())
+        result = asyncio.run(host._phase_5_llm_enrichment(graph, MagicMock()))  # type: ignore[arg-type]
+
+        assert result.status == "completed"
+        assert "0 ambiguous cases resolved" in result.detail
+
+
+# ---------------------------------------------------------------------------
+# Tests for Issue #1158: Phase 5f — transition guidance for collapsed passages
+# ---------------------------------------------------------------------------
+
+
+class TestPhase5fTransitionGuidance:
+    """Phase 5f must generate and apply transition guidance for collapsed passages."""
+
+    def _build_plan_with_collapsed(self, graph: Graph) -> None:
+        """Build a minimal polish_plan node with one collapsed passage (3 beats)."""
+        from questfoundry.models.polish import PassageSpec
+
+        passage = PassageSpec(
+            passage_id="passage::collapse_0",
+            beat_ids=["beat::a", "beat::b", "beat::c"],
+            summary="Three beats in one scene",
+            entities=["entity::hero"],
+            grouping_type="collapse",
+        )
+
+        graph.create_node(
+            "polish_plan::current",
+            {
+                "type": "polish_plan",
+                "raw_id": "current",
+                "passage_count": 1,
+                "variant_count": 0,
+                "residue_count": 0,
+                "choice_count": 0,
+                "candidate_count": 0,
+                "warnings": [],
+                "passage_specs": [passage.model_dump()],
+                "variant_specs": [],
+                "residue_specs": [],
+                "choice_specs": [],
+                "false_branch_candidates": [],
+                "false_branch_specs": [],
+                "feasibility_annotations": {},
+                "ambiguous_specs": [],
+                "arc_traversals": {},
+            },
+        )
+
+        for bid in ["beat::a", "beat::b", "beat::c"]:
+            graph.create_node(
+                bid,
+                {
+                    "type": "beat",
+                    "raw_id": bid.split("::")[-1],
+                    "summary": f"Beat {bid}",
+                    "dilemma_impacts": [],
+                    "entities": [],
+                    "scene_type": "scene",
+                },
+            )
+
+    def test_transition_guidance_applied_to_passage_spec(self) -> None:
+        """LLM returns 2 transitions for 3-beat collapsed passage → spec updated."""
+        from questfoundry.models.polish import Phase5fOutput, TransitionGuidanceItem
+
+        graph = Graph.empty()
+        self._build_plan_with_collapsed(graph)
+
+        llm_output = Phase5fOutput(
+            transition_guidance=[
+                TransitionGuidanceItem(
+                    passage_id="passage::collapse_0",
+                    transitions=[
+                        "As the dust settles, a new threat emerges.",
+                        "Time passes; the hero steels their resolve.",
+                    ],
+                )
+            ]
+        )
+
+        host = _FakePolishLLMHost(llm_output)
+        result = asyncio.run(host._phase_5_llm_enrichment(graph, MagicMock()))  # type: ignore[arg-type]
+
+        assert result.status == "completed"
+        assert "transition guides generated" in result.detail
+
+        # Passage spec in plan should have transition_guidance
+        plan_nodes = graph.get_nodes_by_type("polish_plan")
+        plan_data = plan_nodes.get("polish_plan::current", {})
+        passage_specs = plan_data.get("passage_specs", [])
+        assert len(passage_specs) == 1
+        assert passage_specs[0]["transition_guidance"] == [
+            "As the dust settles, a new threat emerges.",
+            "Time passes; the hero steels their resolve.",
+        ]
+
+    def test_wrong_transition_count_skipped(self) -> None:
+        """If transitions count != beat_count - 1, the spec is skipped with a warning."""
+        from questfoundry.models.polish import Phase5fOutput, TransitionGuidanceItem
+
+        graph = Graph.empty()
+        self._build_plan_with_collapsed(graph)
+
+        # Wrong count: 3 beats → need 2 transitions, but LLM returns 3
+        llm_output = Phase5fOutput(
+            transition_guidance=[
+                TransitionGuidanceItem(
+                    passage_id="passage::collapse_0",
+                    transitions=["T1.", "T2.", "T3."],  # too many
+                )
+            ]
+        )
+
+        host = _FakePolishLLMHost(llm_output)
+        result = asyncio.run(host._phase_5_llm_enrichment(graph, MagicMock()))  # type: ignore[arg-type]
+
+        assert result.status == "completed"
+        # Guide not applied — count says 0
+        assert "0 transition guides generated" in result.detail
+
+    def test_skipped_when_no_collapsed_passages(self) -> None:
+        """Phase 5f is skipped when no collapsed passages with 2+ beats exist."""
+        from questfoundry.models.polish import PassageSpec, Phase5fOutput
+
+        graph = Graph.empty()
+
+        singleton = PassageSpec(
+            passage_id="passage::single_0",
+            beat_ids=["beat::x"],
+            summary="singleton",
+            entities=[],
+            grouping_type="singleton",
+        )
+        graph.create_node(
+            "polish_plan::current",
+            {
+                "type": "polish_plan",
+                "raw_id": "current",
+                "passage_count": 1,
+                "variant_count": 0,
+                "residue_count": 0,
+                "choice_count": 0,
+                "candidate_count": 0,
+                "warnings": [],
+                "passage_specs": [singleton.model_dump()],
+                "variant_specs": [],
+                "residue_specs": [],
+                "choice_specs": [],
+                "false_branch_candidates": [],
+                "false_branch_specs": [],
+                "feasibility_annotations": {},
+                "ambiguous_specs": [],
+                "arc_traversals": {},
+            },
+        )
+
+        host = _FakePolishLLMHost(Phase5fOutput())
+        result = asyncio.run(host._phase_5_llm_enrichment(graph, MagicMock()))  # type: ignore[arg-type]
+
+        assert result.status == "completed"
+        assert "0 transition guides generated" in result.detail

--- a/tests/unit/test_polish_phases.py
+++ b/tests/unit/test_polish_phases.py
@@ -544,6 +544,39 @@ class TestPhase5eAmbiguousFeasibility:
         assert residue_specs[0]["target_passage_id"] == "passage::ambig_0"
         assert residue_specs[0]["flag"] == "dilemma::heavy:path::ph"
 
+    def test_irrelevant_decision_updates_feasibility_annotations(self) -> None:
+        """LLM decision 'irrelevant' → flag recorded in feasibility_annotations, not variant/residue."""
+        from questfoundry.models.polish import FeasibilityDecisionItem, Phase5eOutput
+
+        graph = Graph.empty()
+        self._build_plan_with_ambiguous(graph)
+
+        llm_output = Phase5eOutput(
+            feasibility_decisions=[
+                FeasibilityDecisionItem(
+                    passage_id="passage::ambig_0",
+                    flag_index=0,
+                    decision="irrelevant",
+                )
+            ]
+        )
+
+        host = _FakePolishLLMHost(llm_output)
+        result = asyncio.run(host._phase_5_llm_enrichment(graph, MagicMock()))  # type: ignore[arg-type]
+
+        assert result.status == "completed"
+
+        plan_nodes = graph.get_nodes_by_type("polish_plan")
+        plan_data = plan_nodes.get("polish_plan::current", {})
+
+        # Flag recorded in feasibility_annotations for the passage
+        annotations = plan_data.get("feasibility_annotations", {})
+        assert "passage::ambig_0" in annotations
+        assert "dilemma::heavy:path::ph" in annotations["passage::ambig_0"]
+
+        # Nothing added to variant or residue specs
+        assert len(plan_data.get("variant_specs", [])) == 0
+
     def test_skipped_when_no_ambiguous_cases(self) -> None:
         """Phase 5e is skipped when ambiguous_specs is empty."""
         from questfoundry.models.polish import Phase5eOutput


### PR DESCRIPTION
## Summary

Implements two missing POLISH stage phases identified in the March 5 conformance report.

### Phase 5e — LLM escalation for ambiguous feasibility cases (#1157)

Phase 4b now detects ambiguous passages: 2+ relevant state flags with **mixed** residue weights (some heavy, some light). Previously these were heuristically classified via `has_heavy`; now they are stored as `AmbiguousFeasibilityCase` objects and escalated to a single batched LLM call in Phase 5e. The LLM decides per flag: `variant`, `residue`, or `irrelevant`. Each decision is merged into the existing `variant_specs`, `residue_specs`, or `feasibility_annotations`.

### Phase 5f — Transition guidance for collapsed passages (#1158)

Collapsed passages (`grouping_type="collapse"`, 2+ beats) now receive LLM-generated bridging directives between each beat boundary (N beats → N-1 transitions). Phase 5f runs after 5e as a single batched call over all collapsed passages. Phase 6 writes `transition_guidance` to the passage node in the graph so FILL can read it at prose generation time.

## Changes

| File | Change |
|---|---|
| `models/polish.py` | `AmbiguousFeasibilityCase`, `FeasibilityDecisionItem`, `Phase5eOutput`, `TransitionGuidanceItem`, `Phase5fOutput`; `PassageSpec.transition_guidance` field |
| `deterministic.py` | `PolishPlan.ambiguous_specs`; mixed-weight detection in `compute_prose_feasibility`; `_create_passage_node` writes `transition_guidance` |
| `llm_phases.py` | Phase 5e and 5f sub-steps in `_phase_5_llm_enrichment`; extended `_update_plan_data` |
| `polish_context.py` | `format_ambiguous_feasibility_context` (with dilemma question/consequence); `format_transition_guidance_context` (with scene_type on beat lines) |
| `polish_phase5e_feasibility.yaml` | Sandwich pattern; weight-to-decision criteria; `flag_index` explanation |
| `polish_phase5f_transitions.yaml` | Sandwich pattern (Output Format last); good/bad examples; boundary-count directive |
| `test_polish_deterministic.py` | `TestAmbiguousFeasibilityDetection`, `TestTransitionGuidanceInGraph` |
| `test_polish_phases.py` | `TestPhase5eAmbiguousFeasibility`, `TestPhase5fTransitionGuidance` |

## Design Conformance

Reviewed by `@architect-reviewer` against `docs/design/procedures/polish.md` and `docs/analysis/polish-conformance-report-2026-03-05.md`.

| # | Requirement | Status |
|---|---|---|
| 1 | `PolishPlan.ambiguous_specs` field | CONFORMANT |
| 2 | Phase 4b emits ambiguous cases (mixed weights) instead of classifying heuristically | CONFORMANT |
| 3 | Phase 5e exists, runs after 5d, skipped if empty | CONFORMANT |
| 4 | `polish_phase5e_feasibility.yaml` with sandwich pattern | CONFORMANT |
| 5 | Phase 5e decisions applied (variant/residue/irrelevant) | CONFORMANT |
| 6 | Test: mixed-weight flags → ambiguous case emitted | CONFORMANT |
| 7 | Test: Phase 5e "variant" decision → variant_specs | CONFORMANT |
| 8 | `PassageSpec.transition_guidance` field | CONFORMANT |
| 9 | Phase 5f exists, runs after 5e, single batched call | CONFORMANT |
| 10 | Phase 5f skipped if no collapsed passages | CONFORMANT |
| 11 | `polish_phase5f_transitions.yaml` with sandwich pattern + good/bad examples | CONFORMANT |
| 12 | Phase 6 writes `transition_guidance` to passage node | CONFORMANT |
| 13 | Test: 3-beat collapsed passage → 2 transition instructions | CONFORMANT |
| 14 | Test: `transition_guidance` on passage node after Phase 6 | CONFORMANT |

**14/14 CONFORMANT. 0 MISSING / 0 DEAD.**

Resolves conformance report items #12 and #31 from the March 5 review.

Closes #1157
Closes #1158