### PR TITLE
feat: overlay composition audit for prose feasibility (#1162)

### DIFF
--- a/src/questfoundry/pipeline/stages/polish/deterministic.py
+++ b/src/questfoundry/pipeline/stages/polish/deterministic.py
@@ -163,6 +163,10 @@ async def phase_plan_computation(
 
     # 4b: Prose feasibility audit
     feasibility = compute_prose_feasibility(graph, plan.passage_specs)
+
+    # 4b (overlay audit): Overlay composition check (Doc 3 §6)
+    _audit_overlay_composition(graph, plan.passage_specs, feasibility)
+
     plan.feasibility_annotations = feasibility["annotations"]
     plan.variant_specs = feasibility["variant_specs"]
     plan.residue_specs = feasibility["residue_specs"]
@@ -472,6 +476,101 @@ def compute_prose_feasibility(
         "ambiguous_specs": ambiguous_specs,
         "warnings": warnings,
     }
+
+
+# ---------------------------------------------------------------------------
+# 4b (overlay audit): Overlay Composition Check
+# ---------------------------------------------------------------------------
+
+
+def _audit_overlay_composition(
+    graph: Graph,
+    specs: list[PassageSpec],
+    feasibility: dict[str, Any],
+) -> None:
+    """Audit overlay composition for prose feasibility (Doc 3 §6).
+
+    For each passage, checks whether any entity present in its beats could
+    have 4 or more overlays simultaneously active under any single flag
+    combination that is reachable at that passage. If so, the passage is
+    flagged as ``structural_split`` in the feasibility warnings.
+
+    Overlays are designed to compose (stack), not conflict. The threshold is
+    purely a count limit: 2-3 simultaneously active overlays are manageable;
+    4+ makes coherent prose infeasible.
+
+    Mutates ``feasibility`` in-place: appends to ``feasibility["warnings"]``
+    for each passage that exceeds the overlay count threshold and is not
+    already flagged.
+
+    Args:
+        graph: Graph with entity and beat nodes.
+        specs: Passage specs from Phase 4a.
+        feasibility: Existing feasibility dict from ``compute_prose_feasibility``.
+            Modified in-place.
+    """
+    _OVERLAY_THRESHOLD = 4
+
+    # Pre-fetch entity overlay data once
+    entity_nodes = graph.get_nodes_by_type("entity")
+
+    # Build passage_id → set of already-flagged passages (structural_split in warnings)
+    # Phase 4b emits structural_split warnings with this format:
+    #   "Passage {passage_id} has N narratively relevant flags — structural split recommended"
+    already_split: set[str] = set()
+    for warning in feasibility.get("warnings", []):
+        # Extract passage_id from the warning string
+        if "structural split recommended" in warning and warning.startswith("Passage "):
+            parts = warning.split(" ", 2)
+            if len(parts) >= 2:
+                already_split.add(parts[1])
+
+    for spec in specs:
+        if spec.passage_id in already_split:
+            continue
+
+        # Collect all reachable flag combinations across all beats in this passage
+        all_flag_combos: set[frozenset[str]] = set()
+        for beat_id in spec.beat_ids:
+            try:
+                combos = compute_active_flags_at_beat(graph, beat_id)
+                all_flag_combos.update(combos)
+            except ValueError as e:
+                log.warning("overlay_audit_flag_error", beat_id=beat_id, error=str(e))
+                continue
+
+        if not all_flag_combos:
+            continue
+
+        # Check each entity present in this passage
+        passage_entities = spec.entities
+        flagged = False
+        for entity_id in passage_entities:
+            if flagged:
+                break
+            edata = entity_nodes.get(entity_id)
+            if edata is None:
+                continue
+            overlays = edata.get("overlays") or []
+            if not overlays:
+                continue
+
+            # For each reachable flag combination, count active overlays on this entity
+            for flag_combo in all_flag_combos:
+                active_count = 0
+                for overlay in overlays:
+                    when_flags = overlay.get("when") or []
+                    # Overlay is active when ALL its when-flags are in the combo
+                    if all(wf in flag_combo for wf in when_flags):
+                        active_count += 1
+                if active_count >= _OVERLAY_THRESHOLD:
+                    feasibility["warnings"].append(
+                        f"Passage {spec.passage_id} has {active_count} simultaneously active "
+                        f"overlays on entity {entity_id} — structural split recommended "
+                        f"(overlay composition limit exceeded)"
+                    )
+                    flagged = True
+                    break
 
 
 # ---------------------------------------------------------------------------

--- a/src/questfoundry/pipeline/stages/polish/deterministic.py
+++ b/src/questfoundry/pipeline/stages/polish/deterministic.py
@@ -36,6 +36,15 @@ if TYPE_CHECKING:
 
 
 # ---------------------------------------------------------------------------
+# Module-level constants
+# ---------------------------------------------------------------------------
+
+# Maximum number of simultaneously active overlays on a single entity before
+# prose is considered infeasible. 2-3 active overlays are manageable; 4+ makes
+# coherent prose structurally unsound and triggers a structural_split warning.
+_OVERLAY_THRESHOLD = 4
+
+# ---------------------------------------------------------------------------
 # Shared flag parsing helper
 # ---------------------------------------------------------------------------
 
@@ -503,13 +512,16 @@ def _audit_overlay_composition(
     for each passage that exceeds the overlay count threshold and is not
     already flagged.
 
+    Note: Overlays with an empty ``when`` list are unconditional and always
+    counted as active, regardless of the current flag combination. An entity
+    with 4+ unconditional overlays will therefore always be flagged.
+
     Args:
         graph: Graph with entity and beat nodes.
         specs: Passage specs from Phase 4a.
         feasibility: Existing feasibility dict from ``compute_prose_feasibility``.
             Modified in-place.
     """
-    _OVERLAY_THRESHOLD = 4
 
     # Pre-fetch entity overlay data once
     entity_nodes = graph.get_nodes_by_type("entity")

--- a/tests/unit/test_polish_deterministic.py
+++ b/tests/unit/test_polish_deterministic.py
@@ -1140,26 +1140,6 @@ class TestAuditOverlayComposition:
     """_audit_overlay_composition must flag passages where any entity has 4+
     simultaneously active overlays under any reachable flag combination."""
 
-    def _make_commit_beat(
-        self,
-        graph: Graph,
-        beat_id: str,
-        path_id: str,
-        dilemma_id: str,
-    ) -> None:
-        graph.create_node(
-            beat_id,
-            {
-                "type": "beat",
-                "raw_id": beat_id.split("::")[-1],
-                "summary": f"Commit on {path_id}",
-                "dilemma_impacts": [{"dilemma_id": dilemma_id, "effect": "commits"}],
-                "entities": [],
-                "scene_type": "scene",
-            },
-        )
-        graph.add_edge("belongs_to", beat_id, path_id)
-
     def _build_graph_with_overlays(
         self,
         overlay_when_lists: list[list[str]],
@@ -1395,3 +1375,243 @@ class TestAuditOverlayComposition:
         # Should still have exactly 1 warning (not double-added)
         assert len(feasibility["warnings"]) == 1
         assert feasibility["warnings"][0] == existing_warning
+
+    def test_unconditional_overlays_always_active(self) -> None:
+        """Overlays with empty ``when`` lists are always active regardless of flag combo.
+
+        4 unconditional overlays (when=[]) on an entity in a passage → flagged
+        as structural_split, even with no commit ancestors (empty flag combo).
+        """
+        from questfoundry.pipeline.stages.polish.deterministic import _audit_overlay_composition
+
+        graph = Graph.empty()
+        graph.create_node("path::p1", {"type": "path", "raw_id": "p1"})
+
+        # Entity with 4 unconditional overlays (when: [])
+        graph.create_node(
+            "entity::hero",
+            {
+                "type": "entity",
+                "raw_id": "hero",
+                "overlays": [
+                    {"when": [], "details": {"key": "a"}},
+                    {"when": [], "details": {"key": "b"}},
+                    {"when": [], "details": {"key": "c"}},
+                    {"when": [], "details": {"key": "d"}},
+                ],
+            },
+        )
+
+        # Single beat with no commit ancestors → empty flag combo
+        graph.create_node(
+            "beat::target",
+            {
+                "type": "beat",
+                "raw_id": "target",
+                "summary": "Target beat",
+                "dilemma_impacts": [],
+                "entities": ["entity::hero"],
+                "scene_type": "scene",
+            },
+        )
+        graph.add_edge("belongs_to", "beat::target", "path::p1")
+
+        spec = PassageSpec(
+            passage_id="passage::unconditional",
+            beat_ids=["beat::target"],
+            summary="unconditional overlay test",
+            entities=["entity::hero"],
+        )
+
+        feasibility: dict = {"warnings": []}
+        _audit_overlay_composition(graph, [spec], feasibility)
+
+        assert len(feasibility["warnings"]) == 1
+        assert "passage::unconditional" in feasibility["warnings"][0]
+        assert "structural split recommended" in feasibility["warnings"][0]
+
+    def test_entity_with_no_overlays_not_flagged(self) -> None:
+        """Passage where the entity has no overlays is NOT flagged.
+
+        Exercises the ``if not overlays: continue`` path.
+        """
+        from questfoundry.pipeline.stages.polish.deterministic import _audit_overlay_composition
+
+        graph = Graph.empty()
+        graph.create_node("path::p1", {"type": "path", "raw_id": "p1"})
+
+        # Entity with no overlays at all
+        graph.create_node(
+            "entity::hero",
+            {"type": "entity", "raw_id": "hero"},  # no "overlays" key
+        )
+
+        graph.create_node(
+            "beat::target",
+            {
+                "type": "beat",
+                "raw_id": "target",
+                "summary": "Target beat",
+                "dilemma_impacts": [],
+                "entities": ["entity::hero"],
+                "scene_type": "scene",
+            },
+        )
+        graph.add_edge("belongs_to", "beat::target", "path::p1")
+
+        spec = PassageSpec(
+            passage_id="passage::no_overlays",
+            beat_ids=["beat::target"],
+            summary="no overlay test",
+            entities=["entity::hero"],
+        )
+
+        feasibility: dict = {"warnings": []}
+        _audit_overlay_composition(graph, [spec], feasibility)
+
+        assert feasibility["warnings"] == []
+
+    def test_entity_not_in_entity_nodes_skipped(self) -> None:
+        """Passage referencing an entity ID not in the graph is NOT flagged.
+
+        Exercises the ``if edata is None: continue`` path.
+        """
+        from questfoundry.pipeline.stages.polish.deterministic import _audit_overlay_composition
+
+        graph = Graph.empty()
+        graph.create_node("path::p1", {"type": "path", "raw_id": "p1"})
+
+        # No entity node created for entity::ghost
+        graph.create_node(
+            "beat::target",
+            {
+                "type": "beat",
+                "raw_id": "target",
+                "summary": "Target beat",
+                "dilemma_impacts": [],
+                "entities": [],
+                "scene_type": "scene",
+            },
+        )
+        graph.add_edge("belongs_to", "beat::target", "path::p1")
+
+        # PassageSpec references entity::ghost which does not exist in the graph
+        spec = PassageSpec(
+            passage_id="passage::ghost_entity",
+            beat_ids=["beat::target"],
+            summary="ghost entity test",
+            entities=["entity::ghost"],
+        )
+
+        feasibility: dict = {"warnings": []}
+        _audit_overlay_composition(graph, [spec], feasibility)
+
+        assert feasibility["warnings"] == []
+
+    def test_compute_active_flags_raises_warning_and_skips(self) -> None:
+        """ValueError from compute_active_flags_at_beat → warning logged, beat skipped.
+
+        Exercises the ``except ValueError`` path by referencing a beat_id that
+        exists in the graph but is NOT a beat-type node. compute_active_flags_at_beat
+        raises ValueError for non-beat nodes.
+        """
+        from questfoundry.pipeline.stages.polish.deterministic import _audit_overlay_composition
+
+        graph = Graph.empty()
+        graph.create_node("path::p1", {"type": "path", "raw_id": "p1"})
+
+        # Entity with 4 unconditional overlays (normally would trigger threshold)
+        graph.create_node(
+            "entity::hero",
+            {
+                "type": "entity",
+                "raw_id": "hero",
+                "overlays": [
+                    {"when": [], "details": {"key": "a"}},
+                    {"when": [], "details": {"key": "b"}},
+                    {"when": [], "details": {"key": "c"}},
+                    {"when": [], "details": {"key": "d"}},
+                ],
+            },
+        )
+
+        # A node that is NOT a beat type — compute_active_flags_at_beat raises ValueError
+        graph.create_node(
+            "beat::not_really_a_beat",
+            {"type": "path", "raw_id": "not_really_a_beat"},  # wrong type
+        )
+
+        # A real beat so we have at least one valid combo (empty)
+        graph.create_node(
+            "beat::real",
+            {
+                "type": "beat",
+                "raw_id": "real",
+                "summary": "Real beat",
+                "dilemma_impacts": [],
+                "entities": ["entity::hero"],
+                "scene_type": "scene",
+            },
+        )
+        graph.add_edge("belongs_to", "beat::real", "path::p1")
+
+        spec = PassageSpec(
+            passage_id="passage::mixed_beats",
+            beat_ids=["beat::not_really_a_beat", "beat::real"],
+            summary="mixed beat types",
+            entities=["entity::hero"],
+        )
+
+        feasibility: dict = {"warnings": []}
+        # Should not raise; ValueError for the non-beat is caught and logged
+        _audit_overlay_composition(graph, [spec], feasibility)
+
+        # The real beat provides an empty flag combo → 4 unconditional overlays
+        # are all active → passage IS flagged (the ValueError path was exercised
+        # but the valid beat still produces a combo)
+        assert any("structural split" in w for w in feasibility["warnings"])
+
+    def test_passage_with_no_flag_combos_not_flagged(self) -> None:
+        """Passage where all beats raise ValueError → no flag combos → NOT flagged.
+
+        Exercises the ``if not all_flag_combos: continue`` path. When every
+        beat_id in the spec raises ValueError, all_flag_combos stays empty
+        and the passage is skipped entirely.
+        """
+        from questfoundry.pipeline.stages.polish.deterministic import _audit_overlay_composition
+
+        graph = Graph.empty()
+
+        # Entity with 4 unconditional overlays (would trigger threshold if evaluated)
+        graph.create_node(
+            "entity::hero",
+            {
+                "type": "entity",
+                "raw_id": "hero",
+                "overlays": [
+                    {"when": [], "details": {"key": "a"}},
+                    {"when": [], "details": {"key": "b"}},
+                    {"when": [], "details": {"key": "c"}},
+                    {"when": [], "details": {"key": "d"}},
+                ],
+            },
+        )
+
+        # Non-beat node in beat position → ValueError on every beat_id in spec
+        graph.create_node(
+            "beat::not_a_beat",
+            {"type": "path", "raw_id": "not_a_beat"},  # wrong type
+        )
+
+        spec = PassageSpec(
+            passage_id="passage::no_combos",
+            beat_ids=["beat::not_a_beat"],
+            summary="no combos test",
+            entities=["entity::hero"],
+        )
+
+        feasibility: dict = {"warnings": []}
+        _audit_overlay_composition(graph, [spec], feasibility)
+
+        # all_flag_combos is empty (all beats raised ValueError) → passage skipped
+        assert not any("structural split" in w for w in feasibility["warnings"])

--- a/tests/unit/test_polish_deterministic.py
+++ b/tests/unit/test_polish_deterministic.py
@@ -1129,3 +1129,269 @@ class TestFindFalseBranchCandidatesBranchingAndDisconnected:
         # Chain B's 4 passages form one candidate
         assert len(candidates) == 1
         assert len(candidates[0].passage_ids) == 4
+
+
+# ---------------------------------------------------------------------------
+# Tests for Issue #1162: Overlay composition audit in Phase 4 (after 4b)
+# ---------------------------------------------------------------------------
+
+
+class TestAuditOverlayComposition:
+    """_audit_overlay_composition must flag passages where any entity has 4+
+    simultaneously active overlays under any reachable flag combination."""
+
+    def _make_commit_beat(
+        self,
+        graph: Graph,
+        beat_id: str,
+        path_id: str,
+        dilemma_id: str,
+    ) -> None:
+        graph.create_node(
+            beat_id,
+            {
+                "type": "beat",
+                "raw_id": beat_id.split("::")[-1],
+                "summary": f"Commit on {path_id}",
+                "dilemma_impacts": [{"dilemma_id": dilemma_id, "effect": "commits"}],
+                "entities": [],
+                "scene_type": "scene",
+            },
+        )
+        graph.add_edge("belongs_to", beat_id, path_id)
+
+    def _build_graph_with_overlays(
+        self,
+        overlay_when_lists: list[list[str]],
+        commit_flags: list[tuple[str, str, str]],
+    ) -> tuple[Graph, PassageSpec]:
+        """Build a minimal graph with one entity having `len(overlay_when_lists)` overlays.
+
+        Args:
+            overlay_when_lists: Each element is the `when` list for one overlay.
+            commit_flags: List of (path_id, dilemma_id, beat_id) tuples for commit beats
+                that are ancestors of beat::target (chained in given order).
+
+        Returns:
+            (graph, spec) ready for _audit_overlay_composition.
+        """
+
+        graph = Graph.empty()
+
+        overlays = [
+            {"when": when, "details": {"key": f"val_{i}"}}
+            for i, when in enumerate(overlay_when_lists)
+        ]
+        graph.create_node(
+            "entity::hero",
+            {"type": "entity", "raw_id": "hero", "overlays": overlays},
+        )
+
+        # Create paths + dilemmas
+        for path_id, dilemma_id, _ in commit_flags:
+            if path_id not in graph.get_nodes_by_type("path"):
+                graph.create_node(path_id, {"type": "path", "raw_id": path_id.split("::")[-1]})
+            if dilemma_id not in graph.get_nodes_by_type("dilemma"):
+                graph.create_node(
+                    dilemma_id, {"type": "dilemma", "raw_id": dilemma_id.split("::")[-1]}
+                )
+
+        # Create commit beats chained: last→...→first→target
+        prev_beat = None
+        for path_id, dilemma_id, beat_id in commit_flags:
+            graph.create_node(
+                beat_id,
+                {
+                    "type": "beat",
+                    "raw_id": beat_id.split("::")[-1],
+                    "summary": f"Commit on {path_id}",
+                    "dilemma_impacts": [{"dilemma_id": dilemma_id, "effect": "commits"}],
+                    "entities": [],
+                    "scene_type": "scene",
+                },
+            )
+            graph.add_edge("belongs_to", beat_id, path_id)
+            if prev_beat is not None:
+                graph.add_edge("predecessor", beat_id, prev_beat)
+            prev_beat = beat_id
+
+        # Target beat containing entity::hero
+        first_path = commit_flags[0][0] if commit_flags else "path::p1"
+        if first_path not in graph.get_nodes_by_type("path"):
+            graph.create_node(first_path, {"type": "path", "raw_id": first_path.split("::")[-1]})
+
+        graph.create_node(
+            "beat::target",
+            {
+                "type": "beat",
+                "raw_id": "target",
+                "summary": "Target beat",
+                "dilemma_impacts": [],
+                "entities": ["entity::hero"],
+                "scene_type": "scene",
+            },
+        )
+        graph.add_edge("belongs_to", "beat::target", first_path)
+        if prev_beat is not None:
+            graph.add_edge("predecessor", "beat::target", prev_beat)
+
+        spec = PassageSpec(
+            passage_id="passage::test",
+            beat_ids=["beat::target"],
+            summary="test passage",
+            entities=["entity::hero"],
+        )
+        return graph, spec
+
+    def test_four_overlays_all_coactive_flagged(self) -> None:
+        """Entity with 4 overlays whose when-flags can all be simultaneously active
+        → passage flagged as structural_split."""
+        from questfoundry.pipeline.stages.polish.deterministic import _audit_overlay_composition
+
+        # Four dilemmas, four paths, each overlay's when has exactly 1 flag
+        # All four flags will be ancestors of beat::target → all 4 active in 1 combo
+        commit_flags = [
+            ("path::pa", "dilemma::da", "beat::ca"),
+            ("path::pb", "dilemma::db", "beat::cb"),
+            ("path::pc", "dilemma::dc", "beat::cc"),
+            ("path::pd", "dilemma::dd", "beat::cd"),
+        ]
+        overlay_when_lists = [
+            ["dilemma::da:path::pa"],
+            ["dilemma::db:path::pb"],
+            ["dilemma::dc:path::pc"],
+            ["dilemma::dd:path::pd"],
+        ]
+        graph, spec = self._build_graph_with_overlays(overlay_when_lists, commit_flags)
+
+        feasibility: dict = {"warnings": []}
+        _audit_overlay_composition(graph, [spec], feasibility)
+
+        assert len(feasibility["warnings"]) == 1
+        assert "passage::test" in feasibility["warnings"][0]
+        assert "structural split recommended" in feasibility["warnings"][0]
+
+    def test_four_overlays_mutually_exclusive_not_flagged(self) -> None:
+        """Entity with 4 overlays but each requires a different path of the SAME dilemma
+        → at most 1 can be active at a time → passage NOT flagged."""
+        from questfoundry.pipeline.stages.polish.deterministic import _audit_overlay_composition
+
+        # One dilemma with four paths (mutually exclusive by belongs_to)
+        # Only one commit beat → only one flag active at a time
+        graph = Graph.empty()
+
+        # Single dilemma, single commit beat for path::pa
+        graph.create_node("dilemma::d1", {"type": "dilemma", "raw_id": "d1"})
+        graph.create_node("path::pa", {"type": "path", "raw_id": "pa"})
+        graph.create_node("path::pb", {"type": "path", "raw_id": "pb"})
+        graph.create_node("path::pc", {"type": "path", "raw_id": "pc"})
+        graph.create_node("path::pd", {"type": "path", "raw_id": "pd"})
+
+        # One commit beat on path::pa only
+        graph.create_node(
+            "beat::ca",
+            {
+                "type": "beat",
+                "raw_id": "ca",
+                "summary": "Commit a",
+                "dilemma_impacts": [{"dilemma_id": "dilemma::d1", "effect": "commits"}],
+                "entities": [],
+                "scene_type": "scene",
+            },
+        )
+        graph.add_edge("belongs_to", "beat::ca", "path::pa")
+
+        # Target beat
+        graph.create_node(
+            "beat::target",
+            {
+                "type": "beat",
+                "raw_id": "target",
+                "summary": "Target",
+                "dilemma_impacts": [],
+                "entities": ["entity::hero"],
+                "scene_type": "scene",
+            },
+        )
+        graph.add_edge("belongs_to", "beat::target", "path::pa")
+        graph.add_edge("predecessor", "beat::target", "beat::ca")
+
+        # Entity with 4 overlays, each requiring a different path of dilemma::d1
+        # Since they're mutually exclusive (only 1 can be committed), at most 1 active at once
+        graph.create_node(
+            "entity::hero",
+            {
+                "type": "entity",
+                "raw_id": "hero",
+                "overlays": [
+                    {"when": ["dilemma::d1:path::pa"], "details": {}},
+                    {"when": ["dilemma::d1:path::pb"], "details": {}},
+                    {"when": ["dilemma::d1:path::pc"], "details": {}},
+                    {"when": ["dilemma::d1:path::pd"], "details": {}},
+                ],
+            },
+        )
+
+        spec = PassageSpec(
+            passage_id="passage::test",
+            beat_ids=["beat::target"],
+            summary="test",
+            entities=["entity::hero"],
+        )
+
+        feasibility: dict = {"warnings": []}
+        _audit_overlay_composition(graph, [spec], feasibility)
+
+        # Only path::pa was committed → active flag combo is {dilemma::d1:path::pa}
+        # Only 1 overlay matches that combo → not flagged
+        assert feasibility["warnings"] == []
+
+    def test_three_overlays_coactive_not_flagged(self) -> None:
+        """Entity with exactly 3 simultaneously active overlays → NOT flagged (3 is manageable)."""
+        from questfoundry.pipeline.stages.polish.deterministic import _audit_overlay_composition
+
+        commit_flags = [
+            ("path::pa", "dilemma::da", "beat::ca"),
+            ("path::pb", "dilemma::db", "beat::cb"),
+            ("path::pc", "dilemma::dc", "beat::cc"),
+        ]
+        overlay_when_lists = [
+            ["dilemma::da:path::pa"],
+            ["dilemma::db:path::pb"],
+            ["dilemma::dc:path::pc"],
+        ]
+        graph, spec = self._build_graph_with_overlays(overlay_when_lists, commit_flags)
+
+        feasibility: dict = {"warnings": []}
+        _audit_overlay_composition(graph, [spec], feasibility)
+
+        assert feasibility["warnings"] == []
+
+    def test_already_structural_split_not_double_added(self) -> None:
+        """If a passage is already flagged as structural_split in warnings, it is not added again."""
+        from questfoundry.pipeline.stages.polish.deterministic import _audit_overlay_composition
+
+        commit_flags = [
+            ("path::pa", "dilemma::da", "beat::ca"),
+            ("path::pb", "dilemma::db", "beat::cb"),
+            ("path::pc", "dilemma::dc", "beat::cc"),
+            ("path::pd", "dilemma::dd", "beat::cd"),
+        ]
+        overlay_when_lists = [
+            ["dilemma::da:path::pa"],
+            ["dilemma::db:path::pb"],
+            ["dilemma::dc:path::pc"],
+            ["dilemma::dd:path::pd"],
+        ]
+        graph, spec = self._build_graph_with_overlays(overlay_when_lists, commit_flags)
+
+        # Pre-seed a structural_split warning for this passage (as Phase 4b would emit)
+        existing_warning = (
+            "Passage passage::test has 5 narratively relevant flags — structural split recommended"
+        )
+        feasibility: dict = {"warnings": [existing_warning]}
+        _audit_overlay_composition(graph, [spec], feasibility)
+
+        # Should still have exactly 1 warning (not double-added)
+        assert len(feasibility["warnings"]) == 1
+        assert feasibility["warnings"][0] == existing_warning


### PR DESCRIPTION
## Summary

Implements Doc 3 §6 overlay composition audit in POLISH Phase 4 (#1162).

New `_audit_overlay_composition` function in `deterministic.py`, called from `phase_plan_computation` after the existing Phase 4b feasibility audit. For each passage, it checks whether any entity present in its beats could have 4+ overlays simultaneously active under any single reachable flag combination. If so, the passage is flagged as `structural_split` in the feasibility warnings.

**Design clarification applied**: Overlays are designed to compose (stack), not conflict. The audit is purely count-based — consistent with Doc 3: "two or three active overlays are manageable, more than that and FILL cannot portray the entity coherently." No mutual exclusivity determination is needed.

## Design Conformance

Architect-reviewer sign-off on branch `fix/polish-overlay-audit-1162` — 8 requirements checked, 8 CONFORMANT, 0 MISSING/DEAD. Prior conformance report item #36 (MISSING → CONFORMANT). No data flow breaks.

## Tests

36 passing (4 new tests: 4+ co-active overlays flagged, 4 mutually exclusive not flagged, 3 co-active not flagged, passage already-flagged not double-added).

Closes #1162