### PR TITLE
fix: validate_grow_output traverses derived_from edges to find state flags per spec (#1171)

### DIFF
--- a/src/questfoundry/graph/polish_validation.py
+++ b/src/questfoundry/graph/polish_validation.py
@@ -85,18 +85,33 @@ def validate_grow_output(graph: Graph) -> list[str]:
 
     # 4. State flag nodes exist for explored dilemmas
     dilemma_nodes = graph.get_nodes_by_type("dilemma")
-    state_flag_nodes = graph.get_nodes_by_type("state_flag")
     explored_dilemmas = {
         did
         for did, ddata in dilemma_nodes.items()
         # GROW may omit status for dilemmas it fully explored; treat None as "explored".
         if ddata.get("status") in ("explored", None)
     }
+    # Build consequence → state_flag map via derived_from edges (Doc 3 Part 9).
+    # state_flag nodes have no dilemma_id field; the association is:
+    #   state_flag --derived_from--> consequence <--has_consequence-- path.dilemma_id
+    _cons_to_flag: set[str] = {
+        edge["to"] for edge in graph.get_edges(from_id=None, to_id=None, edge_type="derived_from")
+    }
+    # Build consequence → dilemma lookup via has_consequence edges + path.dilemma_id
+    _path_nodes = graph.get_nodes_by_type("path")
+    _cons_to_dilemma: dict[str, str] = {}
+    for edge in graph.get_edges(from_id=None, to_id=None, edge_type="has_consequence"):
+        path_data = _path_nodes.get(edge["from"], {})
+        raw_did = path_data.get("dilemma_id", "")
+        if raw_did:
+            linked_did = normalize_scoped_id(raw_did, "dilemma")
+            _cons_to_dilemma[edge["to"]] = linked_did
+
     dilemmas_with_flags: set[str] = set()
-    for _flag_id, flag_data in state_flag_nodes.items():
-        dilemma_ref = flag_data.get("dilemma_id") or flag_data.get("dilemma")
-        if dilemma_ref:
-            dilemmas_with_flags.add(dilemma_ref)
+    for cons_id in _cons_to_flag:
+        linked_dilemma = _cons_to_dilemma.get(cons_id)
+        if linked_dilemma:
+            dilemmas_with_flags.add(linked_dilemma)
 
     for dilemma_id in explored_dilemmas:
         if dilemma_id not in dilemmas_with_flags:

--- a/src/questfoundry/graph/polish_validation.py
+++ b/src/questfoundry/graph/polish_validation.py
@@ -94,13 +94,13 @@ def validate_grow_output(graph: Graph) -> list[str]:
     # Build consequence → state_flag map via derived_from edges (Doc 3 Part 9).
     # state_flag nodes have no dilemma_id field; the association is:
     #   state_flag --derived_from--> consequence <--has_consequence-- path.dilemma_id
-    _cons_to_flag: set[str] = {
-        edge["to"] for edge in graph.get_edges(from_id=None, to_id=None, edge_type="derived_from")
+    _flagged_consequences: set[str] = {
+        edge["to"] for edge in graph.get_edges(edge_type="derived_from")
     }
     # Build consequence → dilemma lookup via has_consequence edges + path.dilemma_id
     _path_nodes = graph.get_nodes_by_type("path")
     _cons_to_dilemma: dict[str, str] = {}
-    for edge in graph.get_edges(from_id=None, to_id=None, edge_type="has_consequence"):
+    for edge in graph.get_edges(edge_type="has_consequence"):
         path_data = _path_nodes.get(edge["from"], {})
         raw_did = path_data.get("dilemma_id", "")
         if raw_did:
@@ -108,7 +108,7 @@ def validate_grow_output(graph: Graph) -> list[str]:
             _cons_to_dilemma[edge["to"]] = linked_did
 
     dilemmas_with_flags: set[str] = set()
-    for cons_id in _cons_to_flag:
+    for cons_id in _flagged_consequences:
         linked_dilemma = _cons_to_dilemma.get(cons_id)
         if linked_dilemma:
             dilemmas_with_flags.add(linked_dilemma)

--- a/tests/unit/test_polish_entry_contract.py
+++ b/tests/unit/test_polish_entry_contract.py
@@ -31,15 +31,27 @@ def _make_valid_grow_graph() -> Graph:
         },
     )
 
-    # Create path
+    # Create path (dilemma_id links path to its dilemma)
     graph.create_node(
         "path::brave",
         {
             "type": "path",
             "raw_id": "brave",
             "label": "The Brave Path",
+            "dilemma_id": "dilemma::courage_or_caution",
         },
     )
+
+    # Create consequence node (path outcome that state flags are derived from)
+    graph.create_node(
+        "consequence::brave_outcome",
+        {
+            "type": "consequence",
+            "raw_id": "brave_outcome",
+            "description": "The hero fights bravely",
+        },
+    )
+    graph.add_edge("has_consequence", "path::brave", "consequence::brave_outcome")
 
     # Create beats with required fields
     graph.create_node(
@@ -68,15 +80,17 @@ def _make_valid_grow_graph() -> Graph:
     # predecessor edge (fight comes after intro)
     graph.add_edge("predecessor", "beat::fight", "beat::intro")
 
-    # State flag for the dilemma
+    # State flag derived from the consequence (spec-conformant: no dilemma_id field)
     graph.create_node(
         "state_flag::courage_active",
         {
             "type": "state_flag",
             "raw_id": "courage_active",
-            "dilemma_id": "dilemma::courage_or_caution",
+            "derived_from": "consequence::brave_outcome",
+            "flag_type": "granted",
         },
     )
+    graph.add_edge("derived_from", "state_flag::courage_active", "consequence::brave_outcome")
 
     return graph
 
@@ -168,8 +182,8 @@ class TestValidateGrowOutput:
     def test_explored_dilemma_missing_state_flags(self) -> None:
         """Explored dilemma without state flags fails validation."""
         graph = _make_valid_grow_graph()
-        # Remove the state flag node
-        graph.delete_node("state_flag::courage_active")
+        # Remove the state flag node (cascade=True removes the derived_from edge too)
+        graph.delete_node("state_flag::courage_active", cascade=True)
 
         errors = validate_grow_output(graph)
         assert any("state flag" in e.lower() for e in errors)
@@ -228,6 +242,55 @@ class TestValidateGrowOutput:
         errors = validate_grow_output(graph)
         assert any("ig_missing" in e and "empty beat_ids" in e for e in errors)
 
+    def test_state_flag_found_via_edge_traversal(self) -> None:
+        """State flags are found by traversing derived_from edges, not dilemma_id field.
+
+        Verifies the fix for #1171: validation must traverse
+        state_flag --derived_from--> consequence <--has_consequence-- path.dilemma_id
+        rather than reading a (non-existent) dilemma_id field on state_flag nodes.
+        """
+        graph = _make_valid_grow_graph()
+        errors = validate_grow_output(graph)
+        # No state-flag related errors — edge traversal finds the flag
+        flag_errors = [e for e in errors if "state flag" in e.lower()]
+        assert flag_errors == [], f"Unexpected state-flag errors: {flag_errors}"
+
+    def test_explored_dilemma_no_consequence_chain_reported_missing(self) -> None:
+        """Explored dilemma with state_flag but no has_consequence edge is reported missing.
+
+        If the path→consequence→state_flag chain is broken (no has_consequence edge),
+        the dilemma should still be reported as having no state flags.
+        """
+        graph = _make_valid_grow_graph()
+        # Remove the has_consequence edge — breaks the traversal chain
+        graph.remove_edge("has_consequence", "path::brave", "consequence::brave_outcome")
+
+        errors = validate_grow_output(graph)
+        assert any("courage_or_caution" in e and "state flag" in e.lower() for e in errors), (
+            f"Expected missing state-flag error for courage_or_caution, got: {errors}"
+        )
+
+    def test_unexplored_dilemma_not_checked_for_state_flags(self) -> None:
+        """Dilemmas with status='unexplored' are not checked for state flags."""
+        graph = _make_valid_grow_graph()
+        # Add an unexplored dilemma with no state flags at all
+        graph.create_node(
+            "dilemma::dormant",
+            {
+                "type": "dilemma",
+                "raw_id": "dormant",
+                "dilemma_role": "soft",
+                "status": "unexplored",
+            },
+        )
+
+        errors = validate_grow_output(graph)
+        # No error about the unexplored dilemma missing state flags
+        flag_errors = [e for e in errors if "dormant" in e and "state flag" in e.lower()]
+        assert flag_errors == [], (
+            f"Unexplored dilemma should not trigger state-flag check: {flag_errors}"
+        )
+
     def test_intersection_group_different_paths_passes(self) -> None:
         """Intersection group with beats from different paths passes."""
         graph = _make_valid_grow_graph()
@@ -263,19 +326,36 @@ class TestArcTraversalCompleteness:
         """Create a graph with two paths (two dilemmas) for arc traversal testing."""
         graph = Graph.empty()
 
-        # Two dilemmas, each with two paths
+        # Two dilemmas, each with paths and consequences (spec-conformant)
         for label in ("choice_a", "choice_b"):
             graph.create_node(
                 f"dilemma::{label}",
                 {"type": "dilemma", "raw_id": label, "dilemma_role": "hard", "status": "explored"},
             )
             graph.create_node(
+                f"consequence::{label}_outcome",
+                {"type": "consequence", "raw_id": f"{label}_outcome"},
+            )
+            graph.create_node(
+                f"path::{label}_path",
+                {"type": "path", "raw_id": f"{label}_path", "dilemma_id": f"dilemma::{label}"},
+            )
+            graph.add_edge(
+                "has_consequence", f"path::{label}_path", f"consequence::{label}_outcome"
+            )
+            graph.create_node(
                 f"state_flag::{label}_flag",
                 {
                     "type": "state_flag",
                     "raw_id": f"{label}_flag",
-                    "dilemma_id": f"dilemma::{label}",
+                    "derived_from": f"consequence::{label}_outcome",
+                    "flag_type": "granted",
                 },
+            )
+            graph.add_edge(
+                "derived_from",
+                f"state_flag::{label}_flag",
+                f"consequence::{label}_outcome",
             )
 
         for path_label in ("brave", "cautious"):
@@ -306,8 +386,8 @@ class TestArcTraversalCompleteness:
             {"type": "dilemma", "raw_id": "d1", "dilemma_role": "hard", "status": "explored"},
         )
         graph.create_node(
-            "state_flag::d1_flag",
-            {"type": "state_flag", "raw_id": "d1_flag", "dilemma_id": "dilemma::d1"},
+            "consequence::d1_outcome",
+            {"type": "consequence", "raw_id": "d1_outcome"},
         )
         graph.create_node(
             "path::p_brave",
@@ -317,6 +397,17 @@ class TestArcTraversalCompleteness:
             "path::p_cautious",
             {"type": "path", "raw_id": "p_cautious", "dilemma_id": "dilemma::d1"},
         )
+        graph.add_edge("has_consequence", "path::p_brave", "consequence::d1_outcome")
+        graph.create_node(
+            "state_flag::d1_flag",
+            {
+                "type": "state_flag",
+                "raw_id": "d1_flag",
+                "derived_from": "consequence::d1_outcome",
+                "flag_type": "granted",
+            },
+        )
+        graph.add_edge("derived_from", "state_flag::d1_flag", "consequence::d1_outcome")
 
         # b0 and b1 belong to brave; b2 belongs to cautious
         # predecessor chain: b2 → b1 → b0 (all belong to brave)


### PR DESCRIPTION
## Summary

Fixes `validate_grow_output` in `polish_validation.py`: state flags for explored dilemmas were not found because the code looked for a non-existent `dilemma_id` field on `state_flag` nodes. The correct association is a two-hop edge traversal:

```
state_flag --derived_from--> consequence <--has_consequence-- path (path.dilemma_id)
```

This is specified in Doc 3 Part 9 of the graph schema.

**Files changed:**
- `src/questfoundry/graph/polish_validation.py`: replaced direct field lookup with `derived_from` + `has_consequence` edge traversal
- `tests/unit/test_polish_entry_contract.py`: updated fixture and added 3 new tests

## Design Conformance

This PR fixes a bug in the POLISH stage's entry contract checker (`validate_grow_output`), aligning it with the `state_flag` schema in Doc 3 Part 9.

The architect-reviewer reviewed this fix as part of the broader investigation that produced issues #1171–#1173. Key design doc requirements checked:

| Requirement | Status |
|---|---|
| `state_flag` schema: fields are `type`, `raw_id`, `derived_from`, `flag_type` — **no** `dilemma_id` field (Doc 3 §9) | CONFORMANT — field lookup removed |
| `state_flag --derived_from→ consequence ←has_consequence-- path.dilemma_id` traversal (Doc 3 §9) | CONFORMANT — two-hop traversal implemented |
| Explored dilemmas with no state flag chain → validation error | CONFORMANT |
| Unexplored dilemmas not checked for state flags | CONFORMANT |

MISSING/DEAD findings: **0**

## Test Plan

- [x] Updated `_make_valid_grow_graph()` fixture: consequence node + `has_consequence` + `derived_from` edges (spec-conformant; removed incorrect `dilemma_id` field)
- [x] `test_state_flag_found_via_edge_traversal` — valid two-hop chain passes
- [x] `test_explored_dilemma_no_consequence_chain_reported_missing` — broken chain → error
- [x] `test_unexplored_dilemma_not_checked_for_state_flags` — unexplored dilemmas skipped

Stacked on PR #1175 (`fix/1172-intersection-group-beat-ids`).

Closes #1171

🤖 Generated with [Claude Code](https://claude.com/claude-code)