### PR TITLE
fix: enforce predecessor DAG acyclic invariant in GROW gap phases (#1173)

### DIFF
--- a/src/questfoundry/graph/invariants.py
+++ b/src/questfoundry/graph/invariants.py
@@ -52,20 +52,11 @@ def assert_predecessor_dag_acyclic(graph: Graph, phase_name: str) -> None:
     beat_ids = list(beat_nodes.keys())
 
     try:
-        sorted_beats = topological_sort_beats(graph, beat_ids)
+        topological_sort_beats(graph, beat_ids)
     except ValueError as exc:
         # topological_sort_beats raises ValueError on cycle detection
         raise PipelineInvariantError(
             f"Cycle detected in predecessor DAG after phase '{phase_name}': {exc}"
         ) from exc
-
-    if len(sorted_beats) != len(beat_ids):
-        in_cycle = sorted(set(beat_ids) - set(sorted_beats))
-        raise PipelineInvariantError(
-            f"Cycle detected in predecessor DAG among {len(in_cycle)} beats "
-            f"after phase '{phase_name}'. "
-            f"Beats involved: {', '.join(in_cycle[:10])}"
-            + (" (truncated)" if len(in_cycle) > 10 else "")
-        )
 
     log.debug("predecessor_dag_acyclic", phase=phase_name, beats=len(beat_ids))

--- a/src/questfoundry/graph/invariants.py
+++ b/src/questfoundry/graph/invariants.py
@@ -1,0 +1,71 @@
+"""Graph invariant assertions for pipeline stages.
+
+Each function raises PipelineInvariantError if an invariant is violated.
+These are detective checks called after phases that mutate the graph,
+complementing the preventive checks inside insertion helpers.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from questfoundry.observability.logging import get_logger
+
+if TYPE_CHECKING:
+    from questfoundry.graph.graph import Graph
+
+log = get_logger(__name__)
+
+
+class PipelineInvariantError(RuntimeError):
+    """Raised when a post-phase graph invariant is violated.
+
+    Unlike validation errors (which are recoverable), invariant violations
+    indicate a bug in phase logic and must stop pipeline execution immediately.
+    """
+
+
+def assert_predecessor_dag_acyclic(graph: Graph, phase_name: str) -> None:
+    """Raise PipelineInvariantError if the predecessor DAG contains a cycle.
+
+    Uses topological_sort_beats() from grow_algorithms.  If the sort produces
+    fewer beats than exist in the graph, at least one cycle is present.
+
+    Called after any phase that writes predecessor edges.  Failures here
+    indicate a bug in the phase — the error is hard (not a warning) so the
+    pipeline stops rather than producing a corrupt graph.
+
+    Args:
+        graph: Graph to inspect.
+        phase_name: Name of the phase just completed (included in the error
+            message so the caller can identify which phase introduced the cycle).
+
+    Raises:
+        PipelineInvariantError: If the predecessor DAG contains one or more cycles.
+    """
+    from questfoundry.graph.grow_algorithms import topological_sort_beats
+
+    beat_nodes = graph.get_nodes_by_type("beat")
+    if not beat_nodes:
+        return
+
+    beat_ids = list(beat_nodes.keys())
+
+    try:
+        sorted_beats = topological_sort_beats(graph, beat_ids)
+    except ValueError as exc:
+        # topological_sort_beats raises ValueError on cycle detection
+        raise PipelineInvariantError(
+            f"Cycle detected in predecessor DAG after phase '{phase_name}': {exc}"
+        ) from exc
+
+    if len(sorted_beats) != len(beat_ids):
+        in_cycle = sorted(set(beat_ids) - set(sorted_beats))
+        raise PipelineInvariantError(
+            f"Cycle detected in predecessor DAG among {len(in_cycle)} beats "
+            f"after phase '{phase_name}'. "
+            f"Beats involved: {', '.join(in_cycle[:10])}"
+            + (" (truncated)" if len(in_cycle) > 10 else "")
+        )
+
+    log.debug("predecessor_dag_acyclic", phase=phase_name, beats=len(beat_ids))

--- a/src/questfoundry/pipeline/stages/grow/llm_helper.py
+++ b/src/questfoundry/pipeline/stages/grow/llm_helper.py
@@ -247,8 +247,10 @@ class _LLMHelperMixin:
     ) -> GapInsertionReport:
         """Validate gap proposals and insert valid ones into the graph.
 
-        Checks path_id prefixing, beat ID existence, and ordering
-        before inserting each gap beat.
+        Checks path_id prefixing, beat ID existence, ordering, and cycle
+        safety before inserting each gap beat.  A cycle check is performed
+        before every insertion: if inserting the gap beat would close a cycle
+        in the predecessor DAG, the gap is skipped with a warning.
 
         Args:
             graph: Graph to insert beats into.
@@ -260,7 +262,10 @@ class _LLMHelperMixin:
         Returns:
             Report with counts of inserted and invalid gaps.
         """
+        from collections import defaultdict
+
         from questfoundry.graph.grow_algorithms import (
+            _would_create_cycle,
             get_path_beat_sequence,
             insert_gap_beat,
         )
@@ -272,6 +277,15 @@ class _LLMHelperMixin:
         valid_beat_set = (
             set(valid_beat_ids.keys()) if isinstance(valid_beat_ids, dict) else set(valid_beat_ids)
         )
+
+        # Build the successors dict (prerequisite → dependents) for cycle detection.
+        # predecessor(A, B) means B comes before A; successors[B] contains A.
+        # We keep this in sync after each successful insertion.
+        beat_set: set[str] = set(graph.get_nodes_by_type("beat").keys())
+        successors: dict[str, set[str]] = defaultdict(set)
+        for edge in graph.get_edges(from_id=None, to_id=None, edge_type="predecessor"):
+            # edge["from"] requires edge["to"] → edge["to"] is a prereq of edge["from"]
+            successors[edge["to"]].add(edge["from"])
 
         def _normalize_beat_id(beat_id: str | None) -> str | None:
             if not beat_id:
@@ -332,7 +346,30 @@ class _LLMHelperMixin:
                     report.beat_not_in_sequence += 1
                     continue
 
-            insert_gap_beat(
+            # Cycle prevention: if after_beat and before_beat are both given,
+            # check whether inserting the gap would create a cycle.
+            # The gap insertion adds predecessor(gap, after_beat) and
+            # predecessor(before_beat, gap).  A cycle forms if after_beat is
+            # already a transitive successor of before_beat — i.e. inserting
+            # gap closes a circle: before_beat → gap → after_beat → ... → before_beat.
+            # This is equivalent to asking: is after_beat reachable from
+            # before_beat via the current successors graph?
+            # _would_create_cycle(before_beat, after_beat, ...) returns True iff
+            # after_beat is reachable from before_beat, which is exactly that case.
+            if (
+                after_beat
+                and before_beat
+                and _would_create_cycle(before_beat, after_beat, successors, beat_set)
+            ):
+                log.warning(
+                    f"{phase_name}_gap_skipped_would_create_cycle",
+                    after_beat=after_beat,
+                    before_beat=before_beat,
+                    path_id=prefixed_pid,
+                )
+                continue
+
+            new_beat_id = insert_gap_beat(
                 graph,
                 path_id=prefixed_pid,
                 after_beat=after_beat,
@@ -342,4 +379,14 @@ class _LLMHelperMixin:
                 dilemma_impacts=[i.model_dump() for i in gap.dilemma_impacts],
             )
             report.inserted += 1
+
+            # Update successors and beat_set to reflect the newly inserted beat.
+            # predecessor(new_beat, after_beat) → after_beat is prereq of new_beat
+            # predecessor(before_beat, new_beat) → new_beat is prereq of before_beat
+            beat_set.add(new_beat_id)
+            if after_beat:
+                successors[after_beat].add(new_beat_id)
+            if before_beat:
+                successors[new_beat_id].add(before_beat)
+
         return report

--- a/src/questfoundry/pipeline/stages/grow/llm_helper.py
+++ b/src/questfoundry/pipeline/stages/grow/llm_helper.py
@@ -362,7 +362,8 @@ class _LLMHelperMixin:
                 and _would_create_cycle(before_beat, after_beat, successors, beat_set)
             ):
                 log.warning(
-                    f"{phase_name}_gap_skipped_would_create_cycle",
+                    "gap_skipped_would_create_cycle",
+                    phase=phase_name,
                     after_beat=after_beat,
                     before_beat=before_beat,
                     path_id=prefixed_pid,

--- a/src/questfoundry/pipeline/stages/grow/stage.py
+++ b/src/questfoundry/pipeline/stages/grow/stage.py
@@ -28,6 +28,7 @@ from questfoundry.graph.context_compact import (
     CompactContextConfig,
 )
 from questfoundry.graph.graph import Graph
+from questfoundry.graph.invariants import assert_predecessor_dag_acyclic
 from questfoundry.graph.mutations import GrowMutationError, GrowValidationError
 from questfoundry.graph.snapshots import save_snapshot
 from questfoundry.models.grow import GrowPhaseResult, GrowResult
@@ -318,6 +319,14 @@ class GrowStage(_LLMHelperMixin, _LLMPhaseMixin):
                         )
                     ]
                 )
+
+            # Detective invariant: predecessor DAG must remain acyclic after any
+            # phase that writes predecessor edges.
+            _PREDECESSOR_PHASES = frozenset(
+                {"interleave_beats", "narrative_gaps", "pacing_gaps", "atmospheric"}
+            )
+            if phase_name in _PREDECESSOR_PHASES:
+                assert_predecessor_dag_acyclic(graph, phase_name)
 
             decision = await self.gate.on_phase_complete("grow", phase_name, result)
             if decision == "reject":

--- a/src/questfoundry/pipeline/stages/grow/stage.py
+++ b/src/questfoundry/pipeline/stages/grow/stage.py
@@ -69,6 +69,12 @@ if TYPE_CHECKING:
     )
 
 
+# Phases that write predecessor edges — DAG acyclicity is asserted after each.
+_PREDECESSOR_PHASES: frozenset[str] = frozenset(
+    {"interleave_beats", "narrative_gaps", "pacing_gaps", "atmospheric"}
+)
+
+
 class GrowStage(_LLMHelperMixin, _LLMPhaseMixin):
     """GROW stage: builds complete branching structure from SEED graph.
 
@@ -322,9 +328,6 @@ class GrowStage(_LLMHelperMixin, _LLMPhaseMixin):
 
             # Detective invariant: predecessor DAG must remain acyclic after any
             # phase that writes predecessor edges.
-            _PREDECESSOR_PHASES = frozenset(
-                {"interleave_beats", "narrative_gaps", "pacing_gaps", "atmospheric"}
-            )
             if phase_name in _PREDECESSOR_PHASES:
                 assert_predecessor_dag_acyclic(graph, phase_name)
 

--- a/src/questfoundry/pipeline/stages/polish/stage.py
+++ b/src/questfoundry/pipeline/stages/polish/stage.py
@@ -54,6 +54,9 @@ if TYPE_CHECKING:
 # Type for async phase functions: (Graph, BaseChatModel) -> PhaseResult
 PhaseFunc = Callable[["Graph", "BaseChatModel"], Awaitable[PhaseResult]]
 
+# Phases that write predecessor edges — DAG acyclicity is asserted after each.
+_PREDECESSOR_PHASES: frozenset[str] = frozenset({"beat_reordering", "pacing"})
+
 
 class PolishStage(_PolishLLMHelperMixin, _PolishLLMPhaseMixin):
     """POLISH stage: transforms beat DAG into prose-ready passage graph.
@@ -265,7 +268,6 @@ class PolishStage(_PolishLLMHelperMixin, _PolishLLMPhaseMixin):
 
             # Detective invariant: predecessor DAG must remain acyclic after any
             # phase that writes predecessor edges.
-            _PREDECESSOR_PHASES = frozenset({"beat_reordering", "pacing"})
             if phase_name in _PREDECESSOR_PHASES:
                 assert_predecessor_dag_acyclic(graph, phase_name)
 

--- a/src/questfoundry/pipeline/stages/polish/stage.py
+++ b/src/questfoundry/pipeline/stages/polish/stage.py
@@ -20,6 +20,7 @@ from pathlib import Path  # noqa: TC003 - used at runtime
 from typing import TYPE_CHECKING, Any, ClassVar
 
 from questfoundry.graph.graph import Graph
+from questfoundry.graph.invariants import assert_predecessor_dag_acyclic
 from questfoundry.graph.polish_validation import validate_grow_output
 from questfoundry.graph.snapshots import save_snapshot
 from questfoundry.models.pipeline import PhaseResult
@@ -261,6 +262,12 @@ class PolishStage(_PolishLLMHelperMixin, _PolishLLMPhaseMixin):
             if result.status == "failed":
                 log.error("phase_failed", phase=phase_name, detail=result.detail)
                 raise PolishStageError(f"POLISH phase '{phase_name}' failed: {result.detail}")
+
+            # Detective invariant: predecessor DAG must remain acyclic after any
+            # phase that writes predecessor edges.
+            _PREDECESSOR_PHASES = frozenset({"beat_reordering", "pacing"})
+            if phase_name in _PREDECESSOR_PHASES:
+                assert_predecessor_dag_acyclic(graph, phase_name)
 
             decision = await self.gate.on_phase_complete("polish", phase_name, result)
             if decision == "reject":

--- a/tests/unit/test_grow_stage.py
+++ b/tests/unit/test_grow_stage.py
@@ -2423,3 +2423,126 @@ class TestGrowResume:
         enumerate_idx = phase_names.index("enumerate_arcs")
         expected_phases = phase_names[enumerate_idx:]
         assert called_phases == expected_phases
+
+
+class TestValidateAndInsertGapsCyclePrevention:
+    """Tests for cycle prevention in _validate_and_insert_gaps."""
+
+    def test_gap_skipped_when_would_create_cycle(self) -> None:
+        """Gap insertion is skipped when _would_create_cycle detects a conflict.
+
+        Uses unittest.mock.patch to inject a cycle signal into the check,
+        verifying that the gap-insertion guard acts on the result.
+        """
+        from unittest.mock import patch
+
+        from questfoundry.models.grow import GapProposal
+        from tests.fixtures.grow_fixtures import make_single_dilemma_graph
+
+        graph = make_single_dilemma_graph()
+        stage = GrowStage()
+
+        gaps = [
+            GapProposal(
+                path_id="path::mentor_trust_canonical",
+                after_beat="beat::opening",
+                before_beat="beat::mentor_meet",
+                summary="Would-be gap",
+                scene_type="sequel",
+            ),
+        ]
+        path_nodes = graph.get_nodes_by_type("path")
+        beat_ids = {
+            "beat::opening",
+            "beat::mentor_meet",
+            "beat::mentor_commits_canonical",
+        }
+
+        # Patch _would_create_cycle in the source module to always return True
+        with patch(
+            "questfoundry.graph.grow_algorithms._would_create_cycle",
+            return_value=True,
+        ):
+            report = stage._validate_and_insert_gaps(
+                graph, gaps, path_nodes, beat_ids, "test_phase"
+            )
+
+        assert report.inserted == 0
+        beat_nodes = graph.get_nodes_by_type("beat")
+        gap_beats = [bid for bid in beat_nodes if "gap" in bid]
+        assert len(gap_beats) == 0
+
+    def test_gap_skipped_logs_warning(self, caplog: pytest.LogCaptureFixture) -> None:
+        """Gap that would create a cycle logs a warning event."""
+        import logging
+        from unittest.mock import patch
+
+        from questfoundry.models.grow import GapProposal
+        from tests.fixtures.grow_fixtures import make_single_dilemma_graph
+
+        graph = make_single_dilemma_graph()
+        stage = GrowStage()
+
+        gaps = [
+            GapProposal(
+                path_id="path::mentor_trust_canonical",
+                after_beat="beat::opening",
+                before_beat="beat::mentor_meet",
+                summary="Cycle gap",
+                scene_type="sequel",
+            ),
+        ]
+        path_nodes = graph.get_nodes_by_type("path")
+        beat_ids = {
+            "beat::opening",
+            "beat::mentor_meet",
+            "beat::mentor_commits_canonical",
+        }
+
+        with (
+            patch(
+                "questfoundry.graph.grow_algorithms._would_create_cycle",
+                return_value=True,
+            ),
+            caplog.at_level(logging.WARNING),
+        ):
+            report = stage._validate_and_insert_gaps(
+                graph, gaps, path_nodes, beat_ids, "narrative_gaps"
+            )
+
+        assert report.inserted == 0
+        assert any("cycle" in r.message.lower() for r in caplog.records)
+
+    def test_gap_inserted_when_no_cycle(self) -> None:
+        """Gap insertion proceeds when it does not create a cycle."""
+        from questfoundry.models.grow import GapProposal
+        from tests.fixtures.grow_fixtures import make_single_dilemma_graph
+
+        graph = make_single_dilemma_graph()
+        stage = GrowStage()
+
+        # Insert gap between opening and mentor_meet. make_single_dilemma_graph has
+        # predecessor(mentor_meet, opening): opening < mentor_meet. No cross-path edges
+        # make this cyclic. Should succeed.
+        gaps = [
+            GapProposal(
+                path_id="path::mentor_trust_canonical",
+                after_beat="beat::opening",
+                before_beat="beat::mentor_meet",
+                summary="Reflection beat",
+                scene_type="sequel",
+            ),
+        ]
+        path_nodes = graph.get_nodes_by_type("path")
+        beat_ids = {
+            "beat::opening",
+            "beat::mentor_meet",
+            "beat::mentor_commits_canonical",
+        }
+
+        report = stage._validate_and_insert_gaps(graph, gaps, path_nodes, beat_ids, "test_phase")
+
+        assert report.inserted == 1
+        beat_nodes = graph.get_nodes_by_type("beat")
+        gap_beats = [bid for bid in beat_nodes if "gap" in bid]
+        assert len(gap_beats) == 1

--- a/tests/unit/test_invariants.py
+++ b/tests/unit/test_invariants.py
@@ -1,0 +1,91 @@
+"""Tests for graph invariant assertions in questfoundry/graph/invariants.py."""
+
+from __future__ import annotations
+
+import pytest
+
+from questfoundry.graph.graph import Graph
+from questfoundry.graph.invariants import PipelineInvariantError, assert_predecessor_dag_acyclic
+
+
+def _make_beat(graph: Graph, beat_id: str) -> None:
+    """Create a minimal beat node."""
+    graph.create_node(
+        beat_id,
+        {
+            "type": "beat",
+            "raw_id": beat_id.split("::")[-1],
+            "summary": f"Beat {beat_id}",
+            "dilemma_impacts": [],
+            "entities": [],
+            "scene_type": "scene",
+        },
+    )
+
+
+class TestAssertPredecessorDagAcyclic:
+    def test_passes_on_empty_graph(self) -> None:
+        """No beats → no cycle → no error."""
+        graph = Graph.empty()
+        assert_predecessor_dag_acyclic(graph, "test_phase")
+
+    def test_passes_on_valid_linear_dag(self) -> None:
+        """Linear chain A → B → C is acyclic."""
+        graph = Graph.empty()
+        _make_beat(graph, "beat::a")
+        _make_beat(graph, "beat::b")
+        _make_beat(graph, "beat::c")
+        # predecessor(b, a): a comes before b
+        graph.add_edge("predecessor", "beat::b", "beat::a")
+        # predecessor(c, b): b comes before c
+        graph.add_edge("predecessor", "beat::c", "beat::b")
+
+        assert_predecessor_dag_acyclic(graph, "test_phase")
+
+    def test_passes_on_diamond_dag(self) -> None:
+        """Diamond-shaped DAG (a→b, a→c, b→d, c→d) is acyclic."""
+        graph = Graph.empty()
+        for bid in ("beat::a", "beat::b", "beat::c", "beat::d"):
+            _make_beat(graph, bid)
+        graph.add_edge("predecessor", "beat::b", "beat::a")
+        graph.add_edge("predecessor", "beat::c", "beat::a")
+        graph.add_edge("predecessor", "beat::d", "beat::b")
+        graph.add_edge("predecessor", "beat::d", "beat::c")
+
+        assert_predecessor_dag_acyclic(graph, "test_phase")
+
+    def test_raises_on_direct_cycle(self) -> None:
+        """Two beats with mutual predecessor edges create a cycle."""
+        graph = Graph.empty()
+        _make_beat(graph, "beat::a")
+        _make_beat(graph, "beat::b")
+        # a requires b AND b requires a — direct cycle
+        graph.add_edge("predecessor", "beat::a", "beat::b")
+        graph.add_edge("predecessor", "beat::b", "beat::a")
+
+        with pytest.raises(PipelineInvariantError, match="Cycle detected"):
+            assert_predecessor_dag_acyclic(graph, "my_phase")
+
+    def test_raises_on_three_node_cycle(self) -> None:
+        """Three-beat cycle: a→b→c→a."""
+        graph = Graph.empty()
+        _make_beat(graph, "beat::a")
+        _make_beat(graph, "beat::b")
+        _make_beat(graph, "beat::c")
+        graph.add_edge("predecessor", "beat::b", "beat::a")
+        graph.add_edge("predecessor", "beat::c", "beat::b")
+        graph.add_edge("predecessor", "beat::a", "beat::c")  # closes cycle
+
+        with pytest.raises(PipelineInvariantError, match="Cycle detected"):
+            assert_predecessor_dag_acyclic(graph, "narrative_gaps")
+
+    def test_error_message_includes_phase_name(self) -> None:
+        """Error message contains the phase_name argument."""
+        graph = Graph.empty()
+        _make_beat(graph, "beat::x")
+        _make_beat(graph, "beat::y")
+        graph.add_edge("predecessor", "beat::x", "beat::y")
+        graph.add_edge("predecessor", "beat::y", "beat::x")
+
+        with pytest.raises(PipelineInvariantError, match="pacing_gaps"):
+            assert_predecessor_dag_acyclic(graph, "pacing_gaps")


### PR DESCRIPTION
## Summary

Enforces the predecessor DAG acyclic invariant throughout the GROW and POLISH stage pipelines. Two-pronged approach:

**Option B (preventive):** `_validate_and_insert_gaps()` in `grow/llm_helper.py` now checks `_would_create_cycle()` before each `insert_gap_beat()` call. If a cycle would result, the gap is skipped and a structured warning is logged.

**Option C (detective):** `assert_predecessor_dag_acyclic()` in the new `graph/invariants.py` uses `topological_sort_beats()` to detect cycles and raises `PipelineInvariantError`. Wired into `grow/stage.py` after `interleave_beats`, `narrative_gaps`, `pacing_gaps`, atmospheric phases, and into `polish/stage.py` after `beat_reordering` and pacing.

## Design Conformance

This PR implements a structural invariant enforcement mechanism. The predecessor DAG acyclicity invariant is implied throughout the GROW procedure (phases 4b/4c/4d/5 all operate on a DAG, Doc 2 §4b–§5); `topological_sort_beats()` was already present in `grow_algorithms.py` and used in post-phase validation, confirming the invariant was always intended. This PR makes cycle detection proactive and hard-failing.

| Requirement | Status |
|---|---|
| Predecessor DAG must remain acyclic after each phase that adds `predecessor` edges (Doc 2 §4b, §4c, §4d, §5) | CONFORMANT — post-phase assertion wired |
| Gap beats that would create cycles are skipped rather than inserted (Doc 2 §4c option B) | CONFORMANT — `_would_create_cycle()` guard added |
| Cycle detection failure raises a hard pipeline error (not a warning) | CONFORMANT — `PipelineInvariantError` raised |

MISSING/DEAD findings: **0**

## Test Plan

- [x] `tests/unit/test_invariants.py` — 6 tests: empty graph passes, linear DAG passes, diamond DAG passes, direct cycle raises, 3-node cycle raises, error message includes phase name
- [x] `tests/unit/test_grow_stage.py` — 3 new tests in `TestValidateAndInsertGapsCyclePrevention`: cycle detected → gap skipped, cycle detected → warning logged, no cycle → gap inserted

Stacked on PR #1176 (`fix/1171-state-flag-validation`), which is stacked on PR #1175 (`fix/1172-intersection-group-beat-ids`).

Closes #1173

🤖 Generated with [Claude Code](https://claude.com/claude-code)