### PR TITLE
fix: add beat predecessor DAG cycle check to GROW validation phase (#1179)

### DIFF
--- a/src/questfoundry/graph/grow_validation.py
+++ b/src/questfoundry/graph/grow_validation.py
@@ -621,7 +621,27 @@ def run_grow_checks(graph: Graph) -> ValidationReport:
     """Run beat-DAG validation checks only (GROW Phase 10).
 
     Returns a ValidationReport containing structural beat-DAG checks.
+    The predecessor DAG cycle check runs first; if a cycle is found, the
+    report contains a single fail check and no further checks are run.
     """
+    from questfoundry.graph.invariants import (
+        PipelineInvariantError,
+        assert_predecessor_dag_acyclic,
+    )
+
+    try:
+        assert_predecessor_dag_acyclic(graph, "validation")
+    except PipelineInvariantError as exc:
+        return ValidationReport(
+            checks=[
+                ValidationCheck(
+                    name="predecessor_dag_acyclic",
+                    severity="fail",
+                    message=str(exc),
+                )
+            ]
+        )
+
     checks: list[ValidationCheck] = [
         check_single_start(graph),
         check_passage_dag_cycles(graph),

--- a/tests/unit/test_grow_validation.py
+++ b/tests/unit/test_grow_validation.py
@@ -830,6 +830,27 @@ class TestDilemmaRoleCompliance:
         assert all(r.severity == "pass" for r in results)
 
 
+class TestRunGrowChecks:
+    def test_run_grow_checks_beat_dag_cycle_fails_first(self) -> None:
+        """run_grow_checks returns a cycle-fail check before any other check when
+        the beat predecessor DAG contains a cycle."""
+        graph = Graph.empty()
+        # Two beats with a cycle: predecessor(A, B) + predecessor(B, A)
+        graph.create_node("beat::a", {"type": "beat", "raw_id": "a"})
+        graph.create_node("beat::b", {"type": "beat", "raw_id": "b"})
+        graph.add_edge("predecessor", "beat::a", "beat::b")
+        graph.add_edge("predecessor", "beat::b", "beat::a")
+
+        from questfoundry.graph.grow_validation import run_grow_checks
+
+        report = run_grow_checks(graph)
+        assert report.has_failures
+        assert len(report.checks) == 1
+        fail_check = report.checks[0]
+        assert fail_check.severity == "fail"
+        assert "cycle" in fail_check.message.lower()
+
+
 class TestRunAllChecks:
     def test_run_all_checks_aggregates(self) -> None:
         """run_all_checks produces a report combining grow + passage checks."""

--- a/tests/unit/test_grow_validation.py
+++ b/tests/unit/test_grow_validation.py
@@ -24,6 +24,7 @@ from questfoundry.graph.grow_validation import (
     check_single_start,
     check_spine_arc_exists,
     run_all_checks,
+    run_grow_checks,
 )
 from questfoundry.pipeline.stages.grow.deterministic import phase_validation
 
@@ -840,8 +841,6 @@ class TestRunGrowChecks:
         graph.create_node("beat::b", {"type": "beat", "raw_id": "b"})
         graph.add_edge("predecessor", "beat::a", "beat::b")
         graph.add_edge("predecessor", "beat::b", "beat::a")
-
-        from questfoundry.graph.grow_validation import run_grow_checks
 
         report = run_grow_checks(graph)
         assert report.has_failures


### PR DESCRIPTION
## Summary

- `run_grow_checks` in `grow_validation.py` now calls `assert_predecessor_dag_acyclic(graph, "validation")` as its **first** action
- On cycle detection, returns a single `ValidationCheck(severity="fail")` immediately — all other checks are skipped (fail-fast)
- Adds `TestRunGrowChecks.test_run_grow_checks_beat_dag_cycle_fails_first` unit test

## Design Conformance

Reviewed against `docs/design/procedures/grow.md` Phase 10 validation requirements.

| # | Requirement | Status |
|---|---|---|
| 1 | `run_grow_checks` calls `assert_predecessor_dag_acyclic` as first check | CONFORMANT |
| 2 | Cycle detected → single fail check, no other checks run | CONFORMANT |
| 3 | `ValidationCheck` correctly shaped (name, severity, message) | CONFORMANT |
| 4 | Test verifies `has_failures`, single check, "cycle" in message | CONFORMANT |
| 5 | Design doc Phase 10 "No cycles in `requires`" requirement addressed | CONFORMANT |

0 MISSING / 0 DEAD findings.

## Motivation

The post-phase detective guards in `_PREDECESSOR_PHASES` catch cycles immediately after
each predecessor-writing phase. Phase 10 (`validation`) is the last safety net — if
`_PREDECESSOR_PHASES` ever drifts or a future phase adds edges outside the tracked set,
a cycle could persist in `graph.db`. This adds the defensive final check.

Closes #1179