### PR TITLE
fix: GROW intra-path predecessor edges phase (#1180)

### DIFF
--- a/docs/design/procedures/grow.md
+++ b/docs/design/procedures/grow.md
@@ -137,7 +137,7 @@ If the non-canonical answer is not promoted to a path in SEED, that dilemma has 
 > (#1123) by resolving all conflicts before interleave creates any edges.
 > Phase numbering is preserved for historical continuity; execution order is
 > defined in `_phase_order()`.
-> Actual order: `validate_dag → intersections → resolve_temporal_hints →
+> Actual order: `validate_dag → intersections → intra_path_predecessors → resolve_temporal_hints →
 > interleave_beats → scene_types → narrative_gaps → pacing_gaps → atmospheric →
 > path_arcs → entity_arcs → …`
 > See also: **No-Conditional-Prerequisites Invariant** under Phase 3.

--- a/src/questfoundry/pipeline/stages/grow/deterministic.py
+++ b/src/questfoundry/pipeline/stages/grow/deterministic.py
@@ -61,6 +61,128 @@ async def phase_validate_dag(graph: Graph, model: BaseChatModel) -> GrowPhaseRes
     return GrowPhaseResult(phase="validate_dag", status="completed")
 
 
+# --- Phase 1a: Intra-Path Predecessor Edges ---
+
+
+@grow_phase(
+    name="intra_path_predecessors",
+    depends_on=["validate_dag"],
+    is_deterministic=True,
+    priority=1,
+)
+async def phase_intra_path_predecessors(
+    graph: Graph,
+    model: BaseChatModel,  # noqa: ARG001
+) -> GrowPhaseResult:
+    """Phase 1a: Create predecessor edges between consecutive beats on the same path.
+
+    SEED creates beat nodes with ``belongs_to`` edges linking each beat to a
+    path, but does not create ``predecessor`` edges between consecutive beats
+    on the same path.  Beat ordering within a path therefore relies entirely
+    on alphabetical tie-breaking in ``topological_sort_beats``.
+
+    When ``interleave_cross_path_beats`` subsequently adds a cross-path
+    ``predecessor`` edge from a beat on path A to a beat on path B, that
+    cross-path edge may become the only explicit successor for the source
+    beat in arcs that select a different answer on the destination dilemma.
+    The source beat then has no in-arc successors and
+    ``_check_arc_traversal_completeness`` flags it as a dead-end.
+
+    This phase fixes that by creating explicit intra-path predecessor chains
+    **before** cross-path interleaving runs, so every beat has its in-path
+    successor as a structural predecessor child.
+
+    Only beats that are **exclusive to one path** participate in the chain.
+    Shared beats (belonging to multiple paths) already have or will receive
+    ordering from cross-path interleaving; adding alphabetical edges for them
+    risks creating cycles with those existing edges.
+
+    Preconditions:
+    - Beat DAG validated (Phase 1 passed).
+    - Path nodes exist with beats linked via ``belongs_to`` edges.
+
+    Postconditions:
+    - For each path, single-path-exclusive beats are sorted alphabetically
+      (canonical SEED naming: ``_beat_01``, ``_beat_02``, …) and chained:
+      ``predecessor(beat_n+1, beat_n)`` for every consecutive pair.
+    - Edges are only added, never removed; existing edges are not duplicated.
+    - No edge is added whose reverse already exists (prevents cycles).
+
+    Invariants:
+    - Deterministic: same graph always produces same edges.
+    - Idempotent: running twice produces the same edge set.
+    - Skips paths with fewer than 2 exclusive beats (no chain to form).
+    """
+    path_nodes = graph.get_nodes_by_type("path")
+    if not path_nodes:
+        return GrowPhaseResult(
+            phase="intra_path_predecessors",
+            status="completed",
+            detail="No path nodes found; nothing to do",
+        )
+
+    # Build path → beats mapping and beat → paths mapping from belongs_to edges.
+    # We only chain beats that are exclusive to a single path.  Shared beats
+    # (belonging to multiple paths) already have cross-path predecessor edges
+    # created by SEED or earlier phases; adding alphabetical intra-path edges
+    # for them risks creating cycles with those existing edges.
+    path_beats: dict[str, list[str]] = {path_id: [] for path_id in path_nodes}
+    beat_path_count: dict[str, int] = {}
+    belongs_to_edges = graph.get_edges(edge_type="belongs_to")
+    beat_nodes = graph.get_nodes_by_type("beat")
+    for edge in belongs_to_edges:
+        beat_id = edge["from"]
+        path_id = edge["to"]
+        if path_id in path_nodes and beat_id in beat_nodes:
+            path_beats[path_id].append(beat_id)
+            beat_path_count[beat_id] = beat_path_count.get(beat_id, 0) + 1
+
+    # Restrict each path's beat list to single-path-exclusive beats.
+    exclusive_path_beats: dict[str, list[str]] = {}
+    for path_id in path_nodes:
+        exclusive = [b for b in path_beats.get(path_id, []) if beat_path_count.get(b, 0) == 1]
+        exclusive_path_beats[path_id] = sorted(exclusive)
+
+    # Build existing predecessor edge set for idempotency check.
+    # We track both directions to avoid creating edges that conflict with
+    # (i.e., reverse) an existing predecessor relationship.
+    existing_edges: set[tuple[str, str]] = set()
+    for edge in graph.get_edges(edge_type="predecessor"):
+        existing_edges.add((edge["from"], edge["to"]))
+
+    edges_created = 0
+    paths_processed = 0
+
+    for path_id in sorted(path_nodes):
+        beats = exclusive_path_beats.get(path_id, [])
+        if len(beats) < 2:
+            continue
+
+        paths_processed += 1
+        for i in range(1, len(beats)):
+            successor = beats[i]
+            predecessor = beats[i - 1]
+            # predecessor(successor, predecessor): successor comes after predecessor.
+            # Skip if this exact edge already exists (idempotency).
+            # Also skip if the reverse edge exists — adding both directions would
+            # introduce a cycle (the reverse edge encodes a different ordering that
+            # SEED or an earlier phase already established).
+            forward = (successor, predecessor)
+            reverse = (predecessor, successor)
+            if forward not in existing_edges and reverse not in existing_edges:
+                graph.add_edge("predecessor", successor, predecessor)
+                existing_edges.add(forward)
+                edges_created += 1
+
+    return GrowPhaseResult(
+        phase="intra_path_predecessors",
+        status="completed",
+        detail=(
+            f"Created {edges_created} intra-path predecessor edges across {paths_processed} paths"
+        ),
+    )
+
+
 # --- Phase 1b: Interleave Cross-Path Beats ---
 
 

--- a/src/questfoundry/pipeline/stages/grow/deterministic.py
+++ b/src/questfoundry/pipeline/stages/grow/deterministic.py
@@ -113,6 +113,7 @@ async def phase_intra_path_predecessors(
     - Idempotent: running twice produces the same edge set.
     - Skips paths with fewer than 2 exclusive beats (no chain to form).
     """
+    log.info("intra_path_predecessors_start")
     path_nodes = graph.get_nodes_by_type("path")
     if not path_nodes:
         return GrowPhaseResult(
@@ -174,11 +175,18 @@ async def phase_intra_path_predecessors(
                 existing_edges.add(forward)
                 edges_created += 1
 
+    log.info(
+        "intra_path_predecessors_complete",
+        edges_created=edges_created,
+        paths_processed=paths_processed,
+    )
     return GrowPhaseResult(
         phase="intra_path_predecessors",
         status="completed",
         detail=(
-            f"Created {edges_created} intra-path predecessor edges across {paths_processed} paths"
+            f"Created {edges_created} intra-path predecessor "
+            f"edge{'s' if edges_created != 1 else ''} "
+            f"across {paths_processed} path{'s' if paths_processed != 1 else ''}"
         ),
     )
 

--- a/src/questfoundry/pipeline/stages/grow/deterministic.py
+++ b/src/questfoundry/pipeline/stages/grow/deterministic.py
@@ -66,9 +66,9 @@ async def phase_validate_dag(graph: Graph, model: BaseChatModel) -> GrowPhaseRes
 
 @grow_phase(
     name="intra_path_predecessors",
-    depends_on=["validate_dag"],
+    depends_on=["intersections"],
     is_deterministic=True,
-    priority=1,
+    priority=2,
 )
 async def phase_intra_path_predecessors(
     graph: Graph,

--- a/src/questfoundry/pipeline/stages/grow/llm_phases.py
+++ b/src/questfoundry/pipeline/stages/grow/llm_phases.py
@@ -346,7 +346,7 @@ class _LLMPhaseMixin:
             tokens_used=total_tokens,
         )
 
-    @grow_phase(name="resolve_temporal_hints", depends_on=["intersections"], priority=2)
+    @grow_phase(name="resolve_temporal_hints", depends_on=["intra_path_predecessors"], priority=2)
     async def _phase_resolve_temporal_hints(
         self, graph: Graph, model: BaseChatModel
     ) -> GrowPhaseResult:

--- a/src/questfoundry/pipeline/stages/grow/stage.py
+++ b/src/questfoundry/pipeline/stages/grow/stage.py
@@ -42,6 +42,7 @@ from questfoundry.pipeline.stages.grow.deterministic import (  # noqa: F401 - re
     phase_convergence,
     phase_divergence,
     phase_enumerate_arcs,
+    phase_intra_path_predecessors,
     phase_state_flags,
     phase_validate_dag,
     phase_validation,
@@ -71,7 +72,7 @@ if TYPE_CHECKING:
 
 # Phases that write predecessor edges — DAG acyclicity is asserted after each.
 _PREDECESSOR_PHASES: frozenset[str] = frozenset(
-    {"interleave_beats", "narrative_gaps", "pacing_gaps", "atmospheric"}
+    {"intra_path_predecessors", "interleave_beats", "narrative_gaps", "pacing_gaps", "atmospheric"}
 )
 
 
@@ -143,6 +144,7 @@ class GrowStage(_LLMHelperMixin, _LLMPhaseMixin):
     # take effect.  Entries here are the names imported at module top level.
     _FREE_PHASES: ClassVar[dict[str, str]] = {
         "validate_dag": "phase_validate_dag",
+        "intra_path_predecessors": "phase_intra_path_predecessors",
         "enumerate_arcs": "phase_enumerate_arcs",
         "divergence": "phase_divergence",
         "convergence": "phase_convergence",

--- a/tests/unit/test_grow_deterministic.py
+++ b/tests/unit/test_grow_deterministic.py
@@ -84,7 +84,7 @@ class TestPhaseIntraPathPredecessors:
 
     @pytest.mark.asyncio
     async def test_multiple_paths_each_get_chains(self) -> None:
-        """2 paths with 2 beats each → 2 predecessor edges per path (4 total)."""
+        """2 paths with 2 beats each → 1 predecessor edge per path (2 total)."""
         graph = Graph.empty()
 
         # Path A: 2 beats
@@ -129,6 +129,48 @@ class TestPhaseIntraPathPredecessors:
 
         assert result.status == "completed"
         edges = graph.get_edges(edge_type="predecessor")
+        assert len(edges) == 0
+
+    @pytest.mark.asyncio
+    async def test_shared_beat_excluded_from_chaining(self) -> None:
+        """A beat belonging to two paths is excluded from intra-path chaining.
+
+        beat::shared belongs to both path::a and path::b.  Only path-exclusive
+        beats (beat::a_only, beat::b_only) should be chained.  beat::shared
+        must not appear in any predecessor edge created by this phase.
+        """
+        graph = Graph.empty()
+
+        graph.create_node("path::a", {"type": "path", "raw_id": "a"})
+        graph.create_node("path::b", {"type": "path", "raw_id": "b"})
+        graph.create_node("beat::shared", {"type": "beat", "raw_id": "shared"})
+        graph.create_node("beat::a_only", {"type": "beat", "raw_id": "a_only"})
+        graph.create_node("beat::b_only", {"type": "beat", "raw_id": "b_only"})
+
+        # shared belongs to BOTH paths
+        graph.add_edge("belongs_to", "beat::shared", "path::a")
+        graph.add_edge("belongs_to", "beat::shared", "path::b")
+        # exclusive beats
+        graph.add_edge("belongs_to", "beat::a_only", "path::a")
+        graph.add_edge("belongs_to", "beat::b_only", "path::b")
+
+        result = await phase_intra_path_predecessors(graph, _make_mock_model())
+
+        assert result.status == "completed"
+
+        edges = graph.get_edges(edge_type="predecessor")
+        edge_pairs = {(e["from"], e["to"]) for e in edges}
+
+        # No edge should involve beat::shared (it is shared, not exclusive)
+        for from_id, to_id in edge_pairs:
+            assert from_id != "beat::shared", (
+                f"shared beat appeared as successor in edge {from_id}->{to_id}"
+            )
+            assert to_id != "beat::shared", (
+                f"shared beat appeared as predecessor in edge {from_id}->{to_id}"
+            )
+
+        # Each path has only 1 exclusive beat → no chain can be formed → 0 edges
         assert len(edges) == 0
 
     @pytest.mark.asyncio

--- a/tests/unit/test_grow_deterministic.py
+++ b/tests/unit/test_grow_deterministic.py
@@ -1,0 +1,274 @@
+"""Tests for deterministic GROW phase functions."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from questfoundry.graph.graph import Graph
+from questfoundry.pipeline.stages.grow.deterministic import phase_intra_path_predecessors
+
+
+def _make_mock_model() -> MagicMock:
+    return MagicMock()
+
+
+# ---------------------------------------------------------------------------
+# TestPhaseIntraPathPredecessors
+# ---------------------------------------------------------------------------
+
+
+class TestPhaseIntraPathPredecessors:
+    """Tests for phase_intra_path_predecessors."""
+
+    @pytest.mark.asyncio
+    async def test_creates_predecessor_chain_for_single_path(self) -> None:
+        """3 beats on one path → 2 predecessor edges created in correct order."""
+        graph = Graph.empty()
+
+        graph.create_node("path::p1", {"type": "path", "raw_id": "p1"})
+        graph.create_node("beat::p1_beat_01", {"type": "beat", "raw_id": "p1_beat_01"})
+        graph.create_node("beat::p1_beat_02", {"type": "beat", "raw_id": "p1_beat_02"})
+        graph.create_node("beat::p1_beat_03", {"type": "beat", "raw_id": "p1_beat_03"})
+
+        graph.add_edge("belongs_to", "beat::p1_beat_01", "path::p1")
+        graph.add_edge("belongs_to", "beat::p1_beat_02", "path::p1")
+        graph.add_edge("belongs_to", "beat::p1_beat_03", "path::p1")
+
+        result = await phase_intra_path_predecessors(graph, _make_mock_model())
+
+        assert result.status == "completed"
+        assert result.phase == "intra_path_predecessors"
+
+        # Verify edge chain: beat_02 → beat_01 and beat_03 → beat_02
+        edges = graph.get_edges(edge_type="predecessor")
+        edge_pairs = {(e["from"], e["to"]) for e in edges}
+
+        assert ("beat::p1_beat_02", "beat::p1_beat_01") in edge_pairs
+        assert ("beat::p1_beat_03", "beat::p1_beat_02") in edge_pairs
+        # No direct edge from beat_03 to beat_01 (only consecutive pairs)
+        assert ("beat::p1_beat_03", "beat::p1_beat_01") not in edge_pairs
+
+        assert "2" in result.detail
+        assert "1" in result.detail  # 1 path processed
+
+    @pytest.mark.asyncio
+    async def test_idempotent_does_not_duplicate_edges(self) -> None:
+        """Running the phase twice produces the same edges, no duplicates."""
+        graph = Graph.empty()
+
+        graph.create_node("path::p1", {"type": "path", "raw_id": "p1"})
+        graph.create_node("beat::p1_beat_01", {"type": "beat", "raw_id": "p1_beat_01"})
+        graph.create_node("beat::p1_beat_02", {"type": "beat", "raw_id": "p1_beat_02"})
+
+        graph.add_edge("belongs_to", "beat::p1_beat_01", "path::p1")
+        graph.add_edge("belongs_to", "beat::p1_beat_02", "path::p1")
+
+        # Run once
+        result1 = await phase_intra_path_predecessors(graph, _make_mock_model())
+        assert result1.status == "completed"
+
+        edges_after_first = graph.get_edges(edge_type="predecessor")
+        edge_count_after_first = len(edges_after_first)
+
+        # Run again — should not add duplicate edges
+        result2 = await phase_intra_path_predecessors(graph, _make_mock_model())
+        assert result2.status == "completed"
+
+        edges_after_second = graph.get_edges(edge_type="predecessor")
+        assert len(edges_after_second) == edge_count_after_first
+
+        # The second run created 0 new edges (all already existed)
+        assert "0" in result2.detail
+
+    @pytest.mark.asyncio
+    async def test_multiple_paths_each_get_chains(self) -> None:
+        """2 paths with 2 beats each → 2 predecessor edges per path (4 total)."""
+        graph = Graph.empty()
+
+        # Path A: 2 beats
+        graph.create_node("path::a", {"type": "path", "raw_id": "a"})
+        graph.create_node("beat::a_beat_01", {"type": "beat", "raw_id": "a_beat_01"})
+        graph.create_node("beat::a_beat_02", {"type": "beat", "raw_id": "a_beat_02"})
+        graph.add_edge("belongs_to", "beat::a_beat_01", "path::a")
+        graph.add_edge("belongs_to", "beat::a_beat_02", "path::a")
+
+        # Path B: 2 beats
+        graph.create_node("path::b", {"type": "path", "raw_id": "b"})
+        graph.create_node("beat::b_beat_01", {"type": "beat", "raw_id": "b_beat_01"})
+        graph.create_node("beat::b_beat_02", {"type": "beat", "raw_id": "b_beat_02"})
+        graph.add_edge("belongs_to", "beat::b_beat_01", "path::b")
+        graph.add_edge("belongs_to", "beat::b_beat_02", "path::b")
+
+        result = await phase_intra_path_predecessors(graph, _make_mock_model())
+
+        assert result.status == "completed"
+
+        edges = graph.get_edges(edge_type="predecessor")
+        edge_pairs = {(e["from"], e["to"]) for e in edges}
+
+        # Path A chain
+        assert ("beat::a_beat_02", "beat::a_beat_01") in edge_pairs
+        # Path B chain
+        assert ("beat::b_beat_02", "beat::b_beat_01") in edge_pairs
+
+        assert len(edges) == 2
+        assert "2" in result.detail  # 2 paths processed
+
+    @pytest.mark.asyncio
+    async def test_single_beat_path_skipped(self) -> None:
+        """A path with only 1 beat produces no predecessor edges."""
+        graph = Graph.empty()
+
+        graph.create_node("path::p1", {"type": "path", "raw_id": "p1"})
+        graph.create_node("beat::p1_beat_01", {"type": "beat", "raw_id": "p1_beat_01"})
+        graph.add_edge("belongs_to", "beat::p1_beat_01", "path::p1")
+
+        result = await phase_intra_path_predecessors(graph, _make_mock_model())
+
+        assert result.status == "completed"
+        edges = graph.get_edges(edge_type="predecessor")
+        assert len(edges) == 0
+
+    @pytest.mark.asyncio
+    async def test_no_paths_returns_completed(self) -> None:
+        """Graph with no path nodes returns completed with informational detail."""
+        graph = Graph.empty()
+
+        result = await phase_intra_path_predecessors(graph, _make_mock_model())
+
+        assert result.status == "completed"
+        assert "No path nodes" in result.detail
+
+    @pytest.mark.asyncio
+    async def test_dead_end_resolved_by_intra_path_edges(self) -> None:
+        """Verify the root-cause scenario: dead-end detection passes after intra-path edges.
+
+        Without intra-path edges: if cross-path interleave adds predecessor(beat_b, beat_a)
+        and the arc picks a *different* answer on the destination dilemma (excluding beat_b),
+        beat_a has a successor (beat_b) outside its arc but none within — dead end.
+
+        With intra-path edges: beat_a has beat_a2 as its in-path successor, so even if
+        beat_b is outside the arc, beat_a is not a dead end within the arc.
+        """
+        from questfoundry.graph.polish_validation import _check_arc_traversal_completeness
+
+        graph = Graph.empty()
+
+        # d1: two paths (d1_yes has 2 beats, d1_no has no beats)
+        graph.create_node(
+            "dilemma::d1",
+            {"type": "dilemma", "raw_id": "d1", "dilemma_role": "hard"},
+        )
+        graph.create_node(
+            "path::d1_yes",
+            {"type": "path", "raw_id": "d1_yes", "dilemma_id": "dilemma::d1", "is_canonical": True},
+        )
+        graph.create_node(
+            "path::d1_no",
+            {"type": "path", "raw_id": "d1_no", "dilemma_id": "dilemma::d1", "is_canonical": False},
+        )
+
+        # d2: two paths; d2_yes has a beat that follows d1_yes_beat_01 via cross-path edge.
+        # d2_no has a different beat. This means arc (d1_yes + d2_no) excludes d2_yes_beat_01.
+        graph.create_node(
+            "dilemma::d2",
+            {"type": "dilemma", "raw_id": "d2", "dilemma_role": "soft"},
+        )
+        graph.create_node(
+            "path::d2_yes",
+            {"type": "path", "raw_id": "d2_yes", "dilemma_id": "dilemma::d2", "is_canonical": True},
+        )
+        graph.create_node(
+            "path::d2_no",
+            {"type": "path", "raw_id": "d2_no", "dilemma_id": "dilemma::d2", "is_canonical": False},
+        )
+
+        # Two beats on path d1_yes
+        graph.create_node(
+            "beat::d1_yes_beat_01",
+            {
+                "type": "beat",
+                "raw_id": "d1_yes_beat_01",
+                "summary": "First beat",
+                "dilemma_impacts": [{"dilemma_id": "dilemma::d1", "effect": "setup"}],
+            },
+        )
+        graph.create_node(
+            "beat::d1_yes_beat_02",
+            {
+                "type": "beat",
+                "raw_id": "d1_yes_beat_02",
+                "summary": "Second beat (commits)",
+                "dilemma_impacts": [{"dilemma_id": "dilemma::d1", "effect": "commits"}],
+            },
+        )
+        graph.add_edge("belongs_to", "beat::d1_yes_beat_01", "path::d1_yes")
+        graph.add_edge("belongs_to", "beat::d1_yes_beat_02", "path::d1_yes")
+
+        # d2_yes beat — linked by cross-path predecessor to d1_yes_beat_01
+        graph.create_node(
+            "beat::d2_yes_beat_01",
+            {
+                "type": "beat",
+                "raw_id": "d2_yes_beat_01",
+                "summary": "D2 yes path beat",
+                "dilemma_impacts": [{"dilemma_id": "dilemma::d2", "effect": "commits"}],
+            },
+        )
+        graph.add_edge("belongs_to", "beat::d2_yes_beat_01", "path::d2_yes")
+
+        # d2_no beat — distinct from d2_yes_beat_01
+        graph.create_node(
+            "beat::d2_no_beat_01",
+            {
+                "type": "beat",
+                "raw_id": "d2_no_beat_01",
+                "summary": "D2 no path beat",
+                "dilemma_impacts": [{"dilemma_id": "dilemma::d2", "effect": "commits"}],
+            },
+        )
+        graph.add_edge("belongs_to", "beat::d2_no_beat_01", "path::d2_no")
+
+        # Cross-path edge: d2_yes_beat_01 follows d1_yes_beat_01
+        # (simulating what interleave_cross_path_beats would create)
+        graph.add_edge("predecessor", "beat::d2_yes_beat_01", "beat::d1_yes_beat_01")
+
+        beat_nodes = graph.get_nodes_by_type("beat")
+
+        # Without intra-path edges:
+        # Arc (d1_yes + d2_no) has beats {d1_yes_beat_01, d1_yes_beat_02, d2_no_beat_01}.
+        # d1_yes_beat_01 has child d2_yes_beat_01 (NOT in this arc) but no child in the arc.
+        # d1_yes_beat_02 has no children at all → not a dead end (it's the terminal beat).
+        # So d1_yes_beat_01 is a dead end in arc d1_yes + d2_no.
+        errors_before: list[str] = []
+        _check_arc_traversal_completeness(graph, beat_nodes, errors_before)
+        dead_end_errors_before = [
+            e for e in errors_before if "dead-end" in e and "d1_yes_beat_01" in e
+        ]
+        assert dead_end_errors_before, (
+            f"Expected dead-end error for d1_yes_beat_01 before intra-path edges. "
+            f"Got errors: {errors_before}"
+        )
+
+        # Now add the intra-path predecessor edge
+        result = await phase_intra_path_predecessors(graph, _make_mock_model())
+        assert result.status == "completed"
+
+        # Verify intra-path edge was created: d1_yes_beat_02 → d1_yes_beat_01
+        edges = graph.get_edges(edge_type="predecessor")
+        edge_pairs = {(e["from"], e["to"]) for e in edges}
+        assert ("beat::d1_yes_beat_02", "beat::d1_yes_beat_01") in edge_pairs
+
+        # After adding intra-path edges: d1_yes_beat_01 has d1_yes_beat_02 as its
+        # in-arc successor in arc (d1_yes + d2_no), so it is no longer a dead end.
+        errors_after: list[str] = []
+        _check_arc_traversal_completeness(graph, beat_nodes, errors_after)
+        dead_end_errors_after = [
+            e for e in errors_after if "dead-end" in e and "d1_yes_beat_01" in e
+        ]
+        assert not dead_end_errors_after, (
+            f"Expected no dead-end errors for d1_yes_beat_01 after intra-path edges, "
+            f"got: {dead_end_errors_after}"
+        )

--- a/tests/unit/test_grow_registry.py
+++ b/tests/unit/test_grow_registry.py
@@ -216,11 +216,11 @@ class TestGrowPhaseDecorator:
 class TestGlobalRegistry:
     """Tests for the global registry populated by actual GROW phases."""
 
-    def test_global_registry_has_16_phases(self) -> None:
-        """All GROW phases are registered (16 after #1123 added resolve_temporal_hints)."""
+    def test_global_registry_has_17_phases(self) -> None:
+        """All GROW phases are registered (17 after #1180 added intra_path_predecessors)."""
         registry = get_registry()
-        assert len(registry) == 16, (
-            f"Expected 16 phases, got {len(registry)}: {registry.phase_names}"
+        assert len(registry) == 17, (
+            f"Expected 17 phases, got {len(registry)}: {registry.phase_names}"
         )
 
     def test_global_registry_validates(self) -> None:
@@ -230,14 +230,16 @@ class TestGlobalRegistry:
         assert errors == [], f"Registry validation errors: {errors}"
 
     def test_global_registry_execution_order_matches_expected(self) -> None:
-        """Execution order matches the post-#1123/#1124 phase structure (16 phases).
+        """Execution order matches the post-#1180 phase structure (17 phases).
 
         #1124: intersections moved before interleave_beats (clean DAG for compat check).
         #1123: resolve_temporal_hints inserted between intersections and interleave_beats.
+        #1180: intra_path_predecessors inserted between intersections and resolve_temporal_hints.
         """
         expected = [
             "validate_dag",
             "intersections",
+            "intra_path_predecessors",
             "resolve_temporal_hints",
             "interleave_beats",
             "scene_types",

--- a/tests/unit/test_grow_stage.py
+++ b/tests/unit/test_grow_stage.py
@@ -183,10 +183,10 @@ class TestGrowStageExecute:
 
 class TestGrowStagePhaseOrder:
     def test_phase_order_returns_correct_count(self) -> None:
-        """16 phases; resolve_temporal_hints added in #1123, intersections moved in #1124."""
+        """17 phases; intra_path_predecessors added in #1180."""
         stage = GrowStage()
         phases = stage._phase_order()
-        assert len(phases) == 16
+        assert len(phases) == 17
 
     def test_phase_order_names(self) -> None:
         stage = GrowStage()
@@ -194,6 +194,7 @@ class TestGrowStagePhaseOrder:
         assert names == [
             "validate_dag",
             "intersections",
+            "intra_path_predecessors",
             "resolve_temporal_hints",
             "interleave_beats",
             "scene_types",


### PR DESCRIPTION
## Summary

Adds a new deterministic GROW phase (`phase_intra_path_predecessors`) that creates explicit `predecessor` edges between consecutive beats on the same path. Without these edges, beat ordering within a path relied entirely on alphabetical tiebreaking in `topological_sort_beats`, causing `_check_arc_traversal_completeness` to report false dead-end errors for beats whose only cross-path successor was excluded from the current arc.

- New phase `intra_path_predecessors` in `grow/deterministic.py`: for each path, collects beats exclusive to that path (belonging to exactly one path), sorts by `raw_id`, and creates `predecessor(beat_n+1, beat_n)` chains
- Registered in `grow/stage.py` under `_FREE_PHASES` and `_PREDECESSOR_PHASES`; `depends_on=["intersections"]` (explicit, not alphabetical tiebreaking); `priority=2`
- Phase skips shared beats (beats belonging to 2+ paths) to avoid incorrect cross-path ordering constraints
- `docs/design/procedures/grow.md` execution-order note updated to include `intra_path_predecessors` between `intersections` and `resolve_temporal_hints`
- Full test suite in `tests/unit/test_grow_deterministic.py` (7 tests) covering: single path chain, idempotency, multi-path, single-beat skip, shared-beat exclusion, empty graph, and end-to-end DAG dead-end resolution

## Design Conformance

Architect-reviewer was run against `docs/design/procedures/grow.md`. The only MISSING finding was the doc omission of `intra_path_predecessors` in the execution-order note — corrected in this PR. All implementation requirements are CONFORMANT:

| # | Requirement | Status |
|---|-------------|--------|
| 1 | Phase creates `predecessor(beat_n+1, beat_n)` for consecutive same-path beats | CONFORMANT |
| 2 | Shared beats (belonging to multiple paths) are excluded | CONFORMANT |
| 3 | Phase runs after `intersections`, before `resolve_temporal_hints` | CONFORMANT |
| 4 | Phase is idempotent (no duplicate edges) | CONFORMANT |
| 5 | DAG cycle check runs after phase (via `_PREDECESSOR_PHASES`) | CONFORMANT |
| 6 | Execution-order note in design doc updated | CONFORMANT |

## Test Plan

- [x] `uv run pytest tests/unit/test_grow_deterministic.py -x -q` — 7/7 pass
- [x] `uv run ruff check src/` — clean
- [x] `uv run mypy src/questfoundry/` — clean

Closes #1180