### PR TITLE
fix: validate gap anchors belong to gap path in _validate_and_insert_gaps (#1181)

### DIFF
--- a/src/questfoundry/pipeline/stages/grow/llm_helper.py
+++ b/src/questfoundry/pipeline/stages/grow/llm_helper.py
@@ -337,7 +337,7 @@ class _LLMHelperMixin:
                 }
                 if prefixed_pid not in after_paths:
                     log.warning(
-                        "gap_anchor_wrong_path",
+                        f"{phase_name}_anchor_wrong_path",
                         after_beat=after_beat,
                         path_id=prefixed_pid,
                     )
@@ -349,7 +349,7 @@ class _LLMHelperMixin:
                 }
                 if prefixed_pid not in before_paths:
                     log.warning(
-                        "gap_anchor_wrong_path",
+                        f"{phase_name}_anchor_wrong_path",
                         before_beat=before_beat,
                         path_id=prefixed_pid,
                     )

--- a/src/questfoundry/pipeline/stages/grow/llm_helper.py
+++ b/src/questfoundry/pipeline/stages/grow/llm_helper.py
@@ -48,6 +48,7 @@ class GapInsertionReport:
     invalid_before_beat: int = 0
     invalid_beat_order: int = 0
     beat_not_in_sequence: int = 0
+    anchor_wrong_path: int = 0
 
     @property
     def total_invalid(self) -> int:
@@ -57,6 +58,7 @@ class GapInsertionReport:
             + self.invalid_before_beat
             + self.invalid_beat_order
             + self.beat_not_in_sequence
+            + self.anchor_wrong_path
         )
 
 
@@ -339,6 +341,7 @@ class _LLMHelperMixin:
                         after_beat=after_beat,
                         path_id=prefixed_pid,
                     )
+                    report.anchor_wrong_path += 1
                     continue
             if before_beat:
                 before_paths = {
@@ -350,6 +353,7 @@ class _LLMHelperMixin:
                         before_beat=before_beat,
                         path_id=prefixed_pid,
                     )
+                    report.anchor_wrong_path += 1
                     continue
             # Validate ordering: after_beat must come before before_beat
             if after_beat and before_beat:

--- a/src/questfoundry/pipeline/stages/grow/llm_helper.py
+++ b/src/questfoundry/pipeline/stages/grow/llm_helper.py
@@ -327,6 +327,30 @@ class _LLMHelperMixin:
                 log.warning(f"{phase_name}_invalid_before_beat", beat_id=before_beat)
                 report.invalid_before_beat += 1
                 continue
+            # Validate path membership: anchors must belong to the gap's path.
+            # A beat belongs to a path if it has a belongs_to edge pointing to it.
+            if after_beat:
+                after_paths = {
+                    e["to"] for e in graph.get_edges(edge_type="belongs_to", from_id=after_beat)
+                }
+                if prefixed_pid not in after_paths:
+                    log.warning(
+                        "gap_anchor_wrong_path",
+                        after_beat=after_beat,
+                        path_id=prefixed_pid,
+                    )
+                    continue
+            if before_beat:
+                before_paths = {
+                    e["to"] for e in graph.get_edges(edge_type="belongs_to", from_id=before_beat)
+                }
+                if prefixed_pid not in before_paths:
+                    log.warning(
+                        "gap_anchor_wrong_path",
+                        before_beat=before_beat,
+                        path_id=prefixed_pid,
+                    )
+                    continue
             # Validate ordering: after_beat must come before before_beat
             if after_beat and before_beat:
                 sequence = get_path_beat_sequence(graph, prefixed_pid)

--- a/tests/unit/test_grow_stage.py
+++ b/tests/unit/test_grow_stage.py
@@ -2547,3 +2547,91 @@ class TestValidateAndInsertGapsCyclePrevention:
         beat_nodes = graph.get_nodes_by_type("beat")
         gap_beats = [bid for bid in beat_nodes if "gap" in bid]
         assert len(gap_beats) == 1
+
+
+class TestValidateAndInsertGapsCrossPathAnchorRejection:
+    """Tests for cross-path anchor rejection in _validate_and_insert_gaps."""
+
+    def test_after_beat_from_wrong_path_rejected(self, caplog: pytest.LogCaptureFixture) -> None:
+        """Gap on path A with after_beat belonging only to path B is skipped.
+
+        Uses make_single_dilemma_graph which has two paths:
+        - path::mentor_trust_canonical: beats opening, mentor_meet, mentor_commits_canonical
+        - path::mentor_trust_alt: beats opening, mentor_meet, mentor_commits_alt
+
+        beat::mentor_commits_alt belongs only to path::mentor_trust_alt.
+        A gap on path::mentor_trust_canonical with after_beat=mentor_commits_alt
+        should be rejected with a gap_anchor_wrong_path warning.
+        """
+        import logging
+
+        from questfoundry.models.grow import GapProposal
+        from tests.fixtures.grow_fixtures import make_single_dilemma_graph
+
+        graph = make_single_dilemma_graph()
+        stage = GrowStage()
+
+        gaps = [
+            GapProposal(
+                path_id="path::mentor_trust_canonical",
+                after_beat="beat::mentor_commits_alt",  # Belongs to alt path only
+                before_beat=None,
+                summary="Cross-path after_beat gap",
+                scene_type="sequel",
+            ),
+        ]
+        path_nodes = graph.get_nodes_by_type("path")
+        beat_ids = {
+            "beat::opening",
+            "beat::mentor_meet",
+            "beat::mentor_commits_canonical",
+            "beat::mentor_commits_alt",
+        }
+
+        with caplog.at_level(logging.WARNING):
+            report = stage._validate_and_insert_gaps(
+                graph, gaps, path_nodes, beat_ids, "test_phase"
+            )
+
+        assert report.inserted == 0
+        # Verify no gap beats were created
+        beat_nodes = graph.get_nodes_by_type("beat")
+        gap_beats = [bid for bid in beat_nodes if "gap" in bid]
+        assert len(gap_beats) == 0
+        # Verify structured warning was logged
+        assert any("gap_anchor_wrong_path" in r.message for r in caplog.records)
+
+    def test_correct_path_anchors_inserted(self) -> None:
+        """Gap with both anchors on the correct path is inserted normally.
+
+        beat::opening and beat::mentor_meet both belong to
+        path::mentor_trust_canonical, so the gap should be accepted.
+        """
+        from questfoundry.models.grow import GapProposal
+        from tests.fixtures.grow_fixtures import make_single_dilemma_graph
+
+        graph = make_single_dilemma_graph()
+        stage = GrowStage()
+
+        gaps = [
+            GapProposal(
+                path_id="path::mentor_trust_canonical",
+                after_beat="beat::opening",
+                before_beat="beat::mentor_meet",
+                summary="Both anchors on correct path",
+                scene_type="sequel",
+            ),
+        ]
+        path_nodes = graph.get_nodes_by_type("path")
+        beat_ids = {
+            "beat::opening",
+            "beat::mentor_meet",
+            "beat::mentor_commits_canonical",
+        }
+
+        report = stage._validate_and_insert_gaps(graph, gaps, path_nodes, beat_ids, "test_phase")
+
+        assert report.inserted == 1
+        beat_nodes = graph.get_nodes_by_type("beat")
+        gap_beats = [bid for bid in beat_nodes if "gap" in bid]
+        assert len(gap_beats) == 1

--- a/tests/unit/test_grow_stage.py
+++ b/tests/unit/test_grow_stage.py
@@ -2561,7 +2561,7 @@ class TestValidateAndInsertGapsCrossPathAnchorRejection:
 
         beat::mentor_commits_alt belongs only to path::mentor_trust_alt.
         A gap on path::mentor_trust_canonical with after_beat=mentor_commits_alt
-        should be rejected with a gap_anchor_wrong_path warning.
+        should be rejected with a {phase_name}_anchor_wrong_path warning.
         """
         import logging
 
@@ -2600,7 +2600,7 @@ class TestValidateAndInsertGapsCrossPathAnchorRejection:
         gap_beats = [bid for bid in beat_nodes if "gap" in bid]
         assert len(gap_beats) == 0
         # Verify structured warning was logged
-        assert any("gap_anchor_wrong_path" in r.message for r in caplog.records)
+        assert any("test_phase_anchor_wrong_path" in r.message for r in caplog.records)
 
     def test_correct_path_anchors_inserted(self) -> None:
         """Gap with both anchors on the correct path is inserted normally.
@@ -2642,7 +2642,7 @@ class TestValidateAndInsertGapsCrossPathAnchorRejection:
 
         beat::mentor_commits_alt belongs only to path::mentor_trust_alt.
         A gap on path::mentor_trust_canonical with before_beat=mentor_commits_alt
-        and no after_beat should be rejected with gap_anchor_wrong_path warning.
+        and no after_beat should be rejected with {phase_name}_anchor_wrong_path warning.
         """
         import logging
 
@@ -2679,4 +2679,4 @@ class TestValidateAndInsertGapsCrossPathAnchorRejection:
         beat_nodes = graph.get_nodes_by_type("beat")
         gap_beats = [bid for bid in beat_nodes if "gap" in bid]
         assert len(gap_beats) == 0
-        assert any("gap_anchor_wrong_path" in r.message for r in caplog.records)
+        assert any("test_phase_anchor_wrong_path" in r.message for r in caplog.records)

--- a/tests/unit/test_grow_stage.py
+++ b/tests/unit/test_grow_stage.py
@@ -2594,6 +2594,7 @@ class TestValidateAndInsertGapsCrossPathAnchorRejection:
             )
 
         assert report.inserted == 0
+        assert report.anchor_wrong_path == 1
         # Verify no gap beats were created
         beat_nodes = graph.get_nodes_by_type("beat")
         gap_beats = [bid for bid in beat_nodes if "gap" in bid]
@@ -2635,3 +2636,47 @@ class TestValidateAndInsertGapsCrossPathAnchorRejection:
         beat_nodes = graph.get_nodes_by_type("beat")
         gap_beats = [bid for bid in beat_nodes if "gap" in bid]
         assert len(gap_beats) == 1
+
+    def test_before_beat_from_wrong_path_rejected(self, caplog: pytest.LogCaptureFixture) -> None:
+        """Gap with before_beat from wrong path (no after_beat) is rejected.
+
+        beat::mentor_commits_alt belongs only to path::mentor_trust_alt.
+        A gap on path::mentor_trust_canonical with before_beat=mentor_commits_alt
+        and no after_beat should be rejected with gap_anchor_wrong_path warning.
+        """
+        import logging
+
+        from questfoundry.models.grow import GapProposal
+        from tests.fixtures.grow_fixtures import make_single_dilemma_graph
+
+        graph = make_single_dilemma_graph()
+        stage = GrowStage()
+
+        gaps = [
+            GapProposal(
+                path_id="path::mentor_trust_canonical",
+                after_beat=None,
+                before_beat="beat::mentor_commits_alt",  # Belongs to alt path only
+                summary="Cross-path before_beat gap",
+                scene_type="sequel",
+            ),
+        ]
+        path_nodes = graph.get_nodes_by_type("path")
+        beat_ids = {
+            "beat::opening",
+            "beat::mentor_meet",
+            "beat::mentor_commits_canonical",
+            "beat::mentor_commits_alt",
+        }
+
+        with caplog.at_level(logging.WARNING):
+            report = stage._validate_and_insert_gaps(
+                graph, gaps, path_nodes, beat_ids, "test_phase"
+            )
+
+        assert report.inserted == 0
+        assert report.anchor_wrong_path == 1
+        beat_nodes = graph.get_nodes_by_type("beat")
+        gap_beats = [bid for bid in beat_nodes if "gap" in bid]
+        assert len(gap_beats) == 0
+        assert any("gap_anchor_wrong_path" in r.message for r in caplog.records)


### PR DESCRIPTION
## Summary

`_validate_and_insert_gaps` in `llm_helper.py` previously only checked path membership when **both** `after_beat` AND `before_beat` were provided. When only one anchor was given, the check was skipped — allowing an LLM to propose a gap on `path::A` anchored to a beat on `path::B`, producing structurally invalid predecessor edges.

- Added path membership validation for `after_beat` and `before_beat` independently: each anchor is checked against the gap's `path_id` via `belongs_to` edges before insertion proceeds
- Added `anchor_wrong_path: int = 0` field to `GapInsertionReport` dataclass; incremented on each rejection; included in `total_invalid` property
- Logs `gap_anchor_wrong_path` warning with the offending beat ID and path ID
- New test `test_before_beat_from_wrong_path_rejected` for the single-anchor (`before_beat` only) case; existing `test_after_beat_from_wrong_path_rejected` extended to assert `report.anchor_wrong_path == 1`

## Design Conformance

Architect-reviewer was run against `docs/design/procedures/grow.md` (gap insertion sections). The path membership check is a defensive invariant of the insertion helper, not a named design requirement — the reviewer confirmed no new spec requirements exist and no MISSING/DEAD findings were raised for this fix.

| # | Requirement | Status |
|---|-------------|--------|
| 1 | `after_beat` anchor validated against gap `path_id` | CONFORMANT |
| 2 | `before_beat` anchor validated against gap `path_id` | CONFORMANT |
| 3 | Rejection counted in `GapInsertionReport.anchor_wrong_path` | CONFORMANT |
| 4 | `total_invalid` includes `anchor_wrong_path` | CONFORMANT |
| 5 | Warning logged with beat ID and path ID | CONFORMANT |

## Test Plan

- [x] `uv run pytest tests/unit/test_grow_stage.py -x -q` — pass
- [x] `uv run ruff check src/` — clean
- [x] `uv run mypy src/questfoundry/` — clean

Closes #1181