### PR TITLE
fix: deduplicate choice edges and topological child selection in compute_choice_edges (#1185 #1187 #1188)

### DIFF
--- a/src/questfoundry/pipeline/stages/polish/deterministic.py
+++ b/src/questfoundry/pipeline/stages/polish/deterministic.py
@@ -604,7 +604,10 @@ def _topo_first(candidates: list[str], children: dict[str, list[str]]) -> str:
         The topologically earliest beat ID.
     """
     for c in sorted(candidates):  # sorted for deterministic tie-break
-        # c is earliest if it's not a successor of any other candidate
+        # Only direct successors are checked — this is correct because GROW's
+        # interleave phase adds transitive edges as explicit direct predecessor
+        # edges, so a later beat is always a direct child of every earlier beat
+        # in the candidate set.
         if not any(c in children.get(other, []) for other in candidates if other != c):
             return c
     # Safety fallback — only reachable if candidates form a cycle among

--- a/src/questfoundry/pipeline/stages/polish/deterministic.py
+++ b/src/questfoundry/pipeline/stages/polish/deterministic.py
@@ -590,6 +590,27 @@ def _audit_overlay_composition(
 # ---------------------------------------------------------------------------
 
 
+def _topo_first(candidates: list[str], children: dict[str, list[str]]) -> str:
+    """Return topologically earliest candidate from a list.
+
+    Uses children adjacency (beat → successors) to find the candidate
+    that no other candidate depends on (i.e., is not a successor of any other).
+    Falls back to sorted()[0] if no unique earliest exists.
+
+    Args:
+        candidates: Beat IDs to choose from.
+        children: Adjacency dict mapping beat → list of its successors.
+
+    Returns:
+        The topologically earliest beat ID.
+    """
+    for c in sorted(candidates):  # sorted for deterministic fallback
+        # c is earliest if it's not a successor of any other candidate
+        if not any(c in children.get(other, []) for other in candidates if other != c):
+            return c
+    return sorted(candidates)[0]
+
+
 def compute_choice_edges(
     graph: Graph,
     specs: list[PassageSpec],
@@ -627,7 +648,12 @@ def compute_choice_edges(
         for bid in spec.beat_ids:
             beat_to_passage[bid] = spec.passage_id
 
-    choices: list[ChoiceSpec] = []
+    # Keyed by (from_passage, to_passage) to deduplicate multiple beats in the
+    # same passage that independently diverge to the same target (#1185).
+    choices_map: dict[tuple[str, str], ChoiceSpec] = {}
+
+    # Build passage_id_to_spec once outside the loop (not per-divergence-point)
+    passage_id_to_spec: dict[str, PassageSpec] = {s.passage_id: s for s in specs}
 
     # Find divergence points: beats with children on different paths
     for bid in sorted(beat_nodes.keys()):
@@ -651,8 +677,11 @@ def compute_choice_edges(
             continue
 
         for path_id, path_children in sorted(child_paths.items()):
-            # Pick the first child (alphabetically) on each path for determinism
-            target_beat = sorted(path_children)[0]
+            # Pick the topologically earliest child on each path (#1187).
+            # Using sorted(path_children)[0] (alphabetical) can skip gap beats
+            # when a transitive predecessor edge also links the divergence beat
+            # directly to the beat after the gap.
+            target_beat = _topo_first(path_children, children)
             to_passage = beat_to_passage.get(target_beat, "")
             if not to_passage or to_passage == from_passage:
                 continue
@@ -670,7 +699,6 @@ def compute_choice_edges(
             # Compute requires: for choices from intersection passages, populate
             # the required state flags for the target passage.
             requires: list[str] = []
-            passage_id_to_spec: dict[str, PassageSpec] = {s.passage_id: s for s in specs}
             from_spec = passage_id_to_spec.get(from_passage)
             if from_spec and from_spec.grouping_type == "intersection":
                 try:
@@ -693,17 +721,28 @@ def compute_choice_edges(
                         error=str(e),
                     )
 
-            choices.append(
-                ChoiceSpec(
+            key = (from_passage, to_passage)
+            if key in choices_map:
+                # Merge grants from multiple beats in the same passage that
+                # independently diverge to the same target (#1185).
+                existing = choices_map[key]
+                choices_map[key] = ChoiceSpec(
+                    from_passage=from_passage,
+                    to_passage=to_passage,
+                    grants=sorted(set(existing.grants) | set(grants)),
+                    requires=existing.requires,  # keep first-seen requires
+                    label=existing.label,
+                )
+            else:
+                choices_map[key] = ChoiceSpec(
                     from_passage=from_passage,
                     to_passage=to_passage,
                     grants=grants,
                     requires=requires,
                     label="",  # Populated by Phase 5
                 )
-            )
 
-    return choices
+    return list(choices_map.values())
 
 
 # ---------------------------------------------------------------------------

--- a/src/questfoundry/pipeline/stages/polish/deterministic.py
+++ b/src/questfoundry/pipeline/stages/polish/deterministic.py
@@ -595,7 +595,6 @@ def _topo_first(candidates: list[str], children: dict[str, list[str]]) -> str:
 
     Uses children adjacency (beat → successors) to find the candidate
     that no other candidate depends on (i.e., is not a successor of any other).
-    Falls back to sorted()[0] if no unique earliest exists.
 
     Args:
         candidates: Beat IDs to choose from.
@@ -604,10 +603,12 @@ def _topo_first(candidates: list[str], children: dict[str, list[str]]) -> str:
     Returns:
         The topologically earliest beat ID.
     """
-    for c in sorted(candidates):  # sorted for deterministic fallback
+    for c in sorted(candidates):  # sorted for deterministic tie-break
         # c is earliest if it's not a successor of any other candidate
         if not any(c in children.get(other, []) for other in candidates if other != c):
             return c
+    # Safety fallback — only reachable if candidates form a cycle among
+    # themselves, which is an invariant violation (GROW guarantees acyclic DAG).
     return sorted(candidates)[0]
 
 
@@ -730,7 +731,8 @@ def compute_choice_edges(
                     from_passage=from_passage,
                     to_passage=to_passage,
                     grants=sorted(set(existing.grants) | set(grants)),
-                    requires=existing.requires,  # keep first-seen requires
+                    requires=existing.requires,  # keep first-seen: beats in the same
+                    # passage share identical upstream flag state for a given target
                     label=existing.label,
                 )
             else:

--- a/tests/unit/test_polish_deterministic.py
+++ b/tests/unit/test_polish_deterministic.py
@@ -341,6 +341,246 @@ class TestComputeChoiceEdges:
         assert len(choice_to_a[0].grants) > 0
 
 
+class TestChoiceEdgesIntersectionMultiBeat:
+    """Tests for #1185/#1188: intersection passages with multiple diverging beats.
+
+    Scenario: An intersection passage contains beats from multiple paths.
+    Two of those beats independently diverge to the same target passage.
+    Before the fix: two duplicate ChoiceSpec entries for that (from, to) pair.
+    After the fix: exactly one ChoiceSpec, with grants merged.
+    """
+
+    def test_deduplicates_same_target_from_multiple_beats(self) -> None:
+        """Two beats in the same intersection passage that both diverge to single_A
+        must produce exactly one ChoiceSpec(intersection_0 → single_A), not two."""
+        graph = Graph.empty()
+        graph.create_node("path::p1", {"type": "path", "raw_id": "p1"})
+        graph.create_node("path::p2", {"type": "path", "raw_id": "p2"})
+        graph.create_node("path::p3", {"type": "path", "raw_id": "p3"})
+
+        # Three beats, one per path — all in the intersection passage
+        _make_beat(graph, "beat::b_p1", "P1 beat in intersection")
+        _make_beat(graph, "beat::b_p2", "P2 beat in intersection")
+        _make_beat(graph, "beat::b_p3", "P3 beat in intersection")
+        _add_belongs_to(graph, "beat::b_p1", "path::p1")
+        _add_belongs_to(graph, "beat::b_p2", "path::p2")
+        _add_belongs_to(graph, "beat::b_p3", "path::p3")
+
+        # Children: b_p1 diverges → child_A (p1) and child_C (p3)
+        #           b_p2 diverges → child_A (same p1 target!) and child_B (p2)
+        _make_beat(graph, "beat::child_A", "Child on p1")
+        _make_beat(graph, "beat::child_B", "Child on p2")
+        _make_beat(graph, "beat::child_C", "Child on p3")
+        _add_belongs_to(graph, "beat::child_A", "path::p1")
+        _add_belongs_to(graph, "beat::child_B", "path::p2")
+        _add_belongs_to(graph, "beat::child_C", "path::p3")
+
+        _add_predecessor(graph, "beat::child_A", "beat::b_p1")
+        _add_predecessor(graph, "beat::child_C", "beat::b_p1")
+        _add_predecessor(graph, "beat::child_A", "beat::b_p2")
+        _add_predecessor(graph, "beat::child_B", "beat::b_p2")
+
+        specs = [
+            PassageSpec(
+                passage_id="passage::intersection_0",
+                beat_ids=["beat::b_p1", "beat::b_p2", "beat::b_p3"],
+                summary="intersection",
+                grouping_type="intersection",
+            ),
+            PassageSpec(passage_id="passage::single_A", beat_ids=["beat::child_A"], summary="A"),
+            PassageSpec(passage_id="passage::single_B", beat_ids=["beat::child_B"], summary="B"),
+            PassageSpec(passage_id="passage::single_C", beat_ids=["beat::child_C"], summary="C"),
+        ]
+
+        choices = compute_choice_edges(graph, specs)
+
+        # Exactly one ChoiceSpec per unique (from_passage, to_passage) pair
+        from_to_pairs = [(c.from_passage, c.to_passage) for c in choices]
+        assert len(from_to_pairs) == len(set(from_to_pairs)), (
+            f"Duplicate (from, to) pairs: {from_to_pairs}"
+        )
+
+        # Exactly one choice from intersection_0 → single_A (not two)
+        to_A = [c for c in choices if c.to_passage == "passage::single_A"]
+        assert len(to_A) == 1, f"Expected 1 choice to single_A, got {len(to_A)}"
+
+        # All three target passages reachable from intersection_0
+        to_passages = {c.to_passage for c in choices if c.from_passage == "passage::intersection_0"}
+        assert to_passages == {"passage::single_A", "passage::single_B", "passage::single_C"}
+
+    def test_grants_merged_on_deduplication(self) -> None:
+        """When two beats in the same passage diverge to the same target passage
+        via different child beats (each with different dilemma_impacts), grants
+        from both children are merged (union) in the single deduplicated ChoiceSpec."""
+        graph = Graph.empty()
+        graph.create_node("path::p1", {"type": "path", "raw_id": "p1"})
+        graph.create_node("path::p2", {"type": "path", "raw_id": "p2"})
+        graph.create_node("path::p3", {"type": "path", "raw_id": "p3"})
+
+        # Two divergence beats in the intersection passage
+        _make_beat(graph, "beat::b_p1", "P1 beat in intersection")
+        _make_beat(graph, "beat::b_p2", "P2 beat in intersection")
+        _add_belongs_to(graph, "beat::b_p1", "path::p1")
+        _add_belongs_to(graph, "beat::b_p2", "path::p2")
+
+        # b_p1 → child_X1 (p1, commits d1) and child_C (p3)
+        _make_beat(
+            graph,
+            "beat::child_X1",
+            "X1 on p1",
+            dilemma_impacts=[{"dilemma_id": "dilemma::d1", "effect": "commits"}],
+        )
+        _make_beat(graph, "beat::child_C", "C on p3")
+        _add_belongs_to(graph, "beat::child_X1", "path::p1")
+        _add_belongs_to(graph, "beat::child_C", "path::p3")
+        _add_predecessor(graph, "beat::child_X1", "beat::b_p1")
+        _add_predecessor(graph, "beat::child_C", "beat::b_p1")
+
+        # b_p2 → child_X2 (p1, commits d2) and child_B (p2)
+        _make_beat(
+            graph,
+            "beat::child_X2",
+            "X2 on p1",
+            dilemma_impacts=[{"dilemma_id": "dilemma::d2", "effect": "commits"}],
+        )
+        _make_beat(graph, "beat::child_B", "B on p2")
+        _add_belongs_to(graph, "beat::child_X2", "path::p1")
+        _add_belongs_to(graph, "beat::child_B", "path::p2")
+        _add_predecessor(graph, "beat::child_X2", "beat::b_p2")
+        _add_predecessor(graph, "beat::child_B", "beat::b_p2")
+
+        # Both child_X1 and child_X2 land in the SAME target passage (passage::X)
+        specs = [
+            PassageSpec(
+                passage_id="passage::inter",
+                beat_ids=["beat::b_p1", "beat::b_p2"],
+                summary="intersection",
+                grouping_type="intersection",
+            ),
+            PassageSpec(
+                passage_id="passage::X",
+                beat_ids=["beat::child_X1", "beat::child_X2"],
+                summary="X",
+            ),
+            PassageSpec(passage_id="passage::B", beat_ids=["beat::child_B"], summary="B"),
+            PassageSpec(passage_id="passage::C", beat_ids=["beat::child_C"], summary="C"),
+        ]
+
+        choices = compute_choice_edges(graph, specs)
+
+        # Exactly one choice to passage::X (deduplicated from two divergence beats)
+        to_X = [c for c in choices if c.to_passage == "passage::X"]
+        assert len(to_X) == 1
+
+        # Grants: b_p1 contributed d1:p1 (from child_X1); b_p2 contributed d2:p1 (from child_X2)
+        # Merged union should contain both
+        assert len(to_X[0].grants) == 2
+        assert set(to_X[0].grants) == {"dilemma::d1:path::p1", "dilemma::d2:path::p1"}
+
+
+class TestChoiceEdgesGapBeatChild:
+    """Tests for #1187/#1188: topological child selection avoids skipping gap beats.
+
+    Scenario: A divergence beat has both a gap beat and the gap's successor
+    as direct children on the same path (due to transitive interleave edges).
+    Before the fix: sorted()[0] picks the alphabetically first, which may be
+    the gap's successor, orphaning the gap beat's passage.
+    After the fix: _topo_first picks the topologically earliest (the gap beat).
+    """
+
+    def test_gap_beat_chosen_over_successor(self) -> None:
+        """Divergence beat with both gap and after_gap as direct children
+        on path p1 must target gap's passage, not after_gap's passage."""
+        graph = Graph.empty()
+        graph.create_node("path::p1", {"type": "path", "raw_id": "p1"})
+        graph.create_node("path::p2", {"type": "path", "raw_id": "p2"})
+
+        # Divergence beat (shared / on p1)
+        _make_beat(graph, "beat::div", "Divergence")
+        _add_belongs_to(graph, "beat::div", "path::p1")
+
+        # Gap beat on p1 — the true next beat after div
+        _make_beat(graph, "beat::gap_1", "Gap beat")
+        _add_belongs_to(graph, "beat::gap_1", "path::p1")
+
+        # Beat after the gap on p1
+        _make_beat(graph, "beat::after_gap", "After gap")
+        _add_belongs_to(graph, "beat::after_gap", "path::p1")
+
+        # DAG: gap_1 → after_gap (gap_1 is predecessor of after_gap)
+        _add_predecessor(graph, "beat::after_gap", "beat::gap_1")
+
+        # div → gap_1 (real next beat)
+        _add_predecessor(graph, "beat::gap_1", "beat::div")
+
+        # div → after_gap directly (transitive edge from interleave — the bug scenario)
+        _add_predecessor(graph, "beat::after_gap", "beat::div")
+
+        # Beat on p2 to make div a real divergence point
+        _make_beat(graph, "beat::p2_child", "P2 child")
+        _add_belongs_to(graph, "beat::p2_child", "path::p2")
+        _add_predecessor(graph, "beat::p2_child", "beat::div")
+
+        specs = [
+            PassageSpec(passage_id="passage::div", beat_ids=["beat::div"], summary="div"),
+            PassageSpec(passage_id="passage::gap", beat_ids=["beat::gap_1"], summary="gap"),
+            PassageSpec(
+                passage_id="passage::after_gap", beat_ids=["beat::after_gap"], summary="after_gap"
+            ),
+            PassageSpec(passage_id="passage::p2", beat_ids=["beat::p2_child"], summary="p2"),
+        ]
+
+        choices = compute_choice_edges(graph, specs)
+
+        # The choice from div's passage on path p1 must target gap's passage,
+        # not after_gap's passage (gap_1 is topologically earlier than after_gap).
+        from_div = [c for c in choices if c.from_passage == "passage::div"]
+        to_passages = {c.to_passage for c in from_div}
+
+        # gap passage must be reachable
+        assert "passage::gap" in to_passages, (
+            f"Expected passage::gap to be a choice target, got: {to_passages}"
+        )
+
+        # after_gap passage should NOT be a direct choice from div (it's behind gap)
+        assert "passage::after_gap" not in to_passages, (
+            f"passage::after_gap should not be a direct choice target when gap is present, "
+            f"got: {to_passages}"
+        )
+
+    def test_linear_children_not_affected(self) -> None:
+        """When children are in a simple linear chain (no transitive shortcut),
+        the result is unchanged — the head of the chain is selected."""
+        graph = Graph.empty()
+        graph.create_node("path::p1", {"type": "path", "raw_id": "p1"})
+        graph.create_node("path::p2", {"type": "path", "raw_id": "p2"})
+
+        _make_beat(graph, "beat::div", "Divergence")
+        _add_belongs_to(graph, "beat::div", "path::p1")
+
+        # Only one direct child on p1 (no transitive shortcut)
+        _make_beat(graph, "beat::next", "Next on p1")
+        _add_belongs_to(graph, "beat::next", "path::p1")
+        _add_predecessor(graph, "beat::next", "beat::div")
+
+        _make_beat(graph, "beat::p2_child", "P2 child")
+        _add_belongs_to(graph, "beat::p2_child", "path::p2")
+        _add_predecessor(graph, "beat::p2_child", "beat::div")
+
+        specs = [
+            PassageSpec(passage_id="passage::div", beat_ids=["beat::div"], summary="div"),
+            PassageSpec(passage_id="passage::next", beat_ids=["beat::next"], summary="next"),
+            PassageSpec(passage_id="passage::p2", beat_ids=["beat::p2_child"], summary="p2"),
+        ]
+
+        choices = compute_choice_edges(graph, specs)
+        from_div = [c for c in choices if c.from_passage == "passage::div"]
+        to_passages = {c.to_passage for c in from_div}
+        assert "passage::next" in to_passages
+        assert "passage::p2" in to_passages
+        assert len(from_div) == 2
+
+
 class TestFindFalseBranchCandidates:
     """Tests for Phase 4d: false branch identification."""
 


### PR DESCRIPTION
## Summary

- **#1185**: `compute_choice_edges()` emitted duplicate `(from_passage, to_passage)` pairs when multiple beats in the same intersection passage independently diverged to the same target. Fixed by replacing `list[ChoiceSpec]` accumulation with a `dict[(from, to), ChoiceSpec]` that merges `grants` (set union) on collision.
- **#1187**: `sorted(path_children)[0]` (alphabetical) skipped gap-beat passages when interleave added transitive edges making both a gap beat and its successor direct children of a divergence beat. Fixed by `_topo_first()` which picks the topologically earliest child using the existing `children` adjacency dict.
- **#1188**: Test coverage gap — added `TestChoiceEdgesIntersectionMultiBeat` (2 tests) and `TestChoiceEdgesGapBeatChild` (1 test) modeling real GROW pipeline output shapes.

## Design Conformance

Reviewed by `architect-reviewer` against `docs/design/procedures/polish.md` Phase 4c and `docs/design/document-3-ontology.md`.

| Requirement | Source | Status |
|---|---|---|
| Find divergence beats (successors on different paths) | polish.md §4c step 1 | CONFORMANT |
| Map divergence successors to passages | polish.md §4c step 2 | CONFORMANT |
| ChoiceSpec: `from_passage` | polish.md §4c step 3 | CONFORMANT |
| ChoiceSpec: `to_passage` | polish.md §4c step 3 | CONFORMANT |
| ChoiceSpec: `requires` (state flags for gates) | polish.md §4c step 3 | CONFORMANT |
| ChoiceSpec: `grants` (state flags activated by choice) | polish.md §4c step 3 | CONFORMANT |
| Labels deferred to Phase 5 | polish.md §4c step 4 | CONFORMANT |
| `requires` empty for most choices, gates after convergence | doc-3, Part 5 | CONFORMANT |
| One choice per (from_passage, to_passage) pair | doc-3, Part 5 edge table | CONFORMANT |
| Deduplicate choice edges (#1185) | Issue #1185 | CONFORMANT |
| Topological target beat selection (#1187) | Issue #1187 | CONFORMANT |
| `passage_id_to_spec` hoisted outside inner loop (#1188) | Issue #1188 | CONFORMANT |

0 MISSING / 0 DEAD findings.

## Test plan

- [ ] `uv run pytest tests/unit/test_polish_deterministic.py::TestChoiceEdgesIntersectionMultiBeat -x -q` — 2 tests pass
- [ ] `uv run pytest tests/unit/test_polish_deterministic.py::TestChoiceEdgesGapBeatChild -x -q` — 1 test passes
- [ ] `uv run pytest tests/unit/test_polish_deterministic.py -x -q` — all existing tests continue to pass

Closes #1185
Closes #1187
Closes #1188

🤖 Generated with [Claude Code](https://claude.com/claude-code)