### PR TITLE
fix: order concurrent dilemma entry beats for single-root DAG (#1186)

### DIFF
--- a/src/questfoundry/graph/grow_algorithms.py
+++ b/src/questfoundry/graph/grow_algorithms.py
@@ -2880,11 +2880,17 @@ def _build_hint_base_dag(
 ) -> tuple[set[tuple[str, str]], dict[str, set[str]]]:
     """Build the base DAG for hint conflict detection/postcondition checking.
 
-    Pre-loads ALL non-hint edges (predecessor + serial + wraps + concurrent
-    commit-ordering) from ALL relationship pairs into the base DAG.  Hints are
+    Pre-loads non-hint heuristic edges (predecessor + serial + wraps + concurrent
+    commit-ordering) from all relationship pairs into the base DAG.  Hints are
     NOT included.  This is the shared DAG construction used by both
     ``build_hint_conflict_graph`` (detection) and ``verify_hints_acyclic``
     (postcondition), ensuring they produce consistent results.
+
+    Concurrent entry-beat ordering is intentionally absent from this base DAG.
+    Entry-beat ordering is a soft heuristic that must yield to hints rather than
+    block them.  Cycle-safety for accepted hints against entry-beat edges is
+    guaranteed by ``detect_temporal_hint_conflicts``, which simulates entry-beat
+    edges when testing each hint individually.
 
     Args:
         graph: The story graph.

--- a/src/questfoundry/graph/grow_algorithms.py
+++ b/src/questfoundry/graph/grow_algorithms.py
@@ -3495,9 +3495,12 @@ def interleave_cross_path_beats(graph: Graph) -> int:
         return 0
 
     # Initialise the cycle-detection DAG from the same base as detection/postcondition.
-    # _build_hint_base_dag pre-loads ALL non-hint heuristic edges from ALL pairs so
-    # that a hint accepted by build_hint_conflict_graph cannot create a cycle here
-    # due to a narrower incremental DAG (#1147).
+    # _build_hint_base_dag pre-loads non-hint heuristic edges (serial, wraps, commit-ordering)
+    # so that a hint accepted by build_hint_conflict_graph cannot create a cycle here
+    # due to a narrower incremental DAG (#1147).  Entry-beat ordering is intentionally
+    # absent from _build_hint_base_dag — it is a soft heuristic that must yield to hints
+    # rather than block them.  detect_temporal_hint_conflicts simulates entry-beat edges
+    # when testing each hint, so accepted hints are already safe against that ordering.
     #
     # ``_base_edges`` contains real graph edges + simulated heuristic edges.
     # ``successors`` is derived from the full base and is used for cycle detection.

--- a/src/questfoundry/graph/grow_algorithms.py
+++ b/src/questfoundry/graph/grow_algorithms.py
@@ -2677,6 +2677,20 @@ def detect_temporal_hint_conflicts(graph: Graph) -> list[TemporalHintConflict]:
                     for dependent in sorted(dependent_commits):
                         _sim_add(dependent, prereq)
 
+            # Entry beats follow the same relative ordering as commit beats —
+            # MUST match interleave_cross_path_beats (#1186).
+            first_beats_a = {seq[0] for seq in ordered_a if seq}
+            first_beats_b = {seq[0] for seq in ordered_b if seq}
+            if first_beats_a and first_beats_b:
+                if dilemma_a < dilemma_b:
+                    for fa in sorted(first_beats_a):
+                        for fb in sorted(first_beats_b):
+                            _sim_add(fb, fa)
+                else:
+                    for fb in sorted(first_beats_b):
+                        for fa in sorted(first_beats_a):
+                            _sim_add(fa, fb)
+
     return conflicts
 
 
@@ -2945,6 +2959,20 @@ def _build_hint_base_dag(
                 for prereq in sorted(prereq_commits):
                     for dependent in sorted(dependent_commits):
                         _sim(dependent, prereq)
+
+            # Entry beats follow the same relative ordering as commit beats —
+            # MUST match interleave_cross_path_beats (#1186).
+            first_beats_a = {seq[0] for seq in ordered_a if seq}
+            first_beats_b = {seq[0] for seq in ordered_b if seq}
+            if first_beats_a and first_beats_b:
+                if dilemma_a < dilemma_b:
+                    for fa in sorted(first_beats_a):
+                        for fb in sorted(first_beats_b):
+                            _sim(fb, fa)
+                else:
+                    for fb in sorted(first_beats_b):
+                        for fa in sorted(first_beats_a):
+                            _sim(fa, fb)
     return existing, succ
 
 

--- a/src/questfoundry/graph/grow_algorithms.py
+++ b/src/questfoundry/graph/grow_algorithms.py
@@ -3656,6 +3656,24 @@ def interleave_cross_path_beats(graph: Graph) -> int:
                         for ca in sorted(commits_a):
                             _add_predecessor(ca, cb)
 
+            # Entry beats follow the same relative ordering as commit beats:
+            # whichever dilemma's commits go first also has its entry beats first.
+            # This ensures the beat DAG has a single root even when all dilemmas
+            # are concurrent (no serial/wraps edges) — fixing #1186.
+            first_beats_a = {seq[0] for seq in ordered_a if seq}
+            first_beats_b = {seq[0] for seq in ordered_b if seq}
+            if first_beats_a and first_beats_b:
+                if dilemma_a < dilemma_b:
+                    # A entry beats before B entry beats (consistent with A commits first)
+                    for fa in sorted(first_beats_a):
+                        for fb in sorted(first_beats_b):
+                            _add_predecessor(fb, fa)
+                else:
+                    # B entry beats before A entry beats (consistent with B commits first)
+                    for fb in sorted(first_beats_b):
+                        for fa in sorted(first_beats_a):
+                            _add_predecessor(fa, fb)
+
     log.info(
         "interleave_cross_path_beats_complete",
         edges_created=created,

--- a/src/questfoundry/graph/grow_algorithms.py
+++ b/src/questfoundry/graph/grow_algorithms.py
@@ -2960,19 +2960,6 @@ def _build_hint_base_dag(
                     for dependent in sorted(dependent_commits):
                         _sim(dependent, prereq)
 
-            # Entry beats follow the same relative ordering as commit beats —
-            # MUST match interleave_cross_path_beats (#1186).
-            first_beats_a = {seq[0] for seq in ordered_a if seq}
-            first_beats_b = {seq[0] for seq in ordered_b if seq}
-            if first_beats_a and first_beats_b:
-                if dilemma_a < dilemma_b:
-                    for fa in sorted(first_beats_a):
-                        for fb in sorted(first_beats_b):
-                            _sim(fb, fa)
-                else:
-                    for fb in sorted(first_beats_b):
-                        for fa in sorted(first_beats_a):
-                            _sim(fa, fb)
     return existing, succ
 
 

--- a/tests/unit/test_grow_algorithms.py
+++ b/tests/unit/test_grow_algorithms.py
@@ -4535,7 +4535,7 @@ class TestInterleavecrossPathBeats:
         )
         graph.update_node(
             "beat::aq_intro",
-            temporal_hint={"relative_to": "dilemma::mentor_trust", "position": "after_introduce"},
+            temporal_hint={"relative_to": "dilemma::mentor_trust", "position": "before_commit"},
         )
 
         # Both hints present before interleaving

--- a/tests/unit/test_grow_algorithms.py
+++ b/tests/unit/test_grow_algorithms.py
@@ -4915,8 +4915,11 @@ class TestInterleavecrossPathBeats:
         # Concurrent relationship: a_alpha concurrent with b_beta
         graph.add_edge("concurrent", "dilemma::a_alpha", "dilemma::b_beta")
 
-        # Before the fix there are 2 root beats (a_entry and b_entry) — verify
-        # the test would fail on unpatched code by checking this precondition.
+        # Pre-fix state: the intra-path predecessor edges above only chain the three
+        # beats within each dilemma.  Both a_entry and b_entry are DAG roots (they have
+        # no predecessor edges pointing at them).  The concurrent commit-beat heuristic
+        # links commit beats (a_commit ← b_commit) but leaves entry beats untouched,
+        # so without the fix len(root_beats) == 2 and this assertion would fail.
         all_beat_ids = {
             "beat::a_entry",
             "beat::a_mid",

--- a/tests/unit/test_grow_algorithms.py
+++ b/tests/unit/test_grow_algorithms.py
@@ -4649,7 +4649,11 @@ class TestInterleavecrossPathBeats:
         This guards against the same-dilemma violation: a beat that references
         its own dilemma in a temporal hint would create a within-dilemma predecessor
         edge, which is illegal for intersections (conditional prerequisite invariant).
-        The hint must be discarded and no predecessor edge created.
+        The hint must be discarded and no intra-dilemma predecessor edge created.
+
+        Note: the entry-beat heuristic (#1186) legitimately creates a cross-dilemma
+        edge involving aq_intro (predecessor(mt_intro, aq_intro)) — that is correct
+        behaviour and is NOT what this test is guarding against.
         """
         graph = _make_two_dilemma_graph_with_relationship("concurrent")
 
@@ -4667,14 +4671,18 @@ class TestInterleavecrossPathBeats:
         interleave_cross_path_beats(graph)
         edges_after = {(e["from"], e["to"]) for e in graph.get_edges(edge_type="predecessor")}
 
-        # No new predecessor edges should reference aq_intro as a node added due
-        # to the same-dilemma hint (the hint must be dropped entirely)
+        # The hint (before_commit of artifact_quest on aq_intro) would produce an
+        # intra-dilemma edge: predecessor(aq_commit, aq_intro) = aq_commit requires
+        # aq_intro.  This already exists from the fixture, so no new intra-dilemma
+        # edge can appear — but even if the fixture changed, the hint must be skipped.
+        # Guard: no NEW edge between two artifact_quest beats was added.
+        artifact_quest_beats = {"beat::aq_intro", "beat::aq_commit"}
         new_edges = edges_after - edges_before
-        edges_from_aq_intro = {
-            (f, t) for f, t in new_edges if f == "beat::aq_intro" or t == "beat::aq_intro"
+        intra_aq_edges = {
+            (f, t) for f, t in new_edges if f in artifact_quest_beats and t in artifact_quest_beats
         }
-        assert edges_from_aq_intro == set(), (
-            f"Expected no predecessor edges created from same-dilemma hint, got {edges_from_aq_intro}"
+        assert intra_aq_edges == set(), (
+            f"Expected no new intra-dilemma edges from same-dilemma hint, got {intra_aq_edges}"
         )
 
     def test_skips_predecessor_between_same_intersection_beats(self) -> None:
@@ -4829,6 +4837,140 @@ class TestInterleavecrossPathBeats:
 
         assert count > 0, "Expected at least one cross-path predecessor edge"
         assert validate_beat_dag(graph) == [], "DAG must remain acyclic after interleave"
+
+    def test_concurrent_all_dilemmas_produces_single_root_beat(self) -> None:
+        """All-concurrent dilemmas must yield a single DAG root after interleaving (#1186).
+
+        When every dilemma relationship is 'concurrent' the commit-beat heuristic
+        alone leaves entry beats (_beat_01 equivalents) as independent DAG roots —
+        one per path — causing POLISH to fail with 'Multiple start passages'.
+
+        The fix adds entry-beat ordering in the same direction as commit-beat ordering
+        so the resulting DAG has exactly one root.
+
+        Graph: two dilemmas (a_alpha, b_beta), each with one path and three beats:
+          a_alpha: a_entry → a_mid → a_commit
+          b_beta:  b_entry → b_mid → b_commit
+        Dilemmas linked by a 'concurrent' edge (a_alpha → b_beta).
+        After interleave, exactly one beat must have no predecessor edges where it
+        appears as the 'from' side (i.e. no prerequisites).
+        """
+        graph = Graph.empty()
+
+        # Use alphabetically ordered dilemma IDs so the heuristic direction is
+        # deterministic: a_alpha < b_beta → a's commits/entries go first.
+        for dil in ("a_alpha", "b_beta"):
+            graph.create_node(f"dilemma::{dil}", {"type": "dilemma", "raw_id": dil})
+
+        for dil, path_id in (("a_alpha", "aa_path"), ("b_beta", "bb_path")):
+            graph.create_node(
+                f"path::{path_id}",
+                {
+                    "type": "path",
+                    "raw_id": path_id,
+                    "dilemma_id": f"dilemma::{dil}",
+                    "is_canonical": True,
+                },
+            )
+
+        # a_alpha beats: a_entry → a_mid → a_commit
+        for raw_id, effect, path_id in (
+            ("a_entry", "advances", "aa_path"),
+            ("a_mid", "advances", "aa_path"),
+            ("a_commit", "commits", "aa_path"),
+        ):
+            graph.create_node(
+                f"beat::{raw_id}",
+                {
+                    "type": "beat",
+                    "raw_id": raw_id,
+                    "summary": f"a_alpha {raw_id}.",
+                    "dilemma_impacts": [{"dilemma_id": "dilemma::a_alpha", "effect": effect}],
+                },
+            )
+            graph.add_edge("belongs_to", f"beat::{raw_id}", f"path::{path_id}")
+        # Within-path ordering (commit requires mid requires entry)
+        graph.add_edge("predecessor", "beat::a_mid", "beat::a_entry")
+        graph.add_edge("predecessor", "beat::a_commit", "beat::a_mid")
+
+        # b_beta beats: b_entry → b_mid → b_commit
+        for raw_id, effect, path_id in (
+            ("b_entry", "advances", "bb_path"),
+            ("b_mid", "advances", "bb_path"),
+            ("b_commit", "commits", "bb_path"),
+        ):
+            graph.create_node(
+                f"beat::{raw_id}",
+                {
+                    "type": "beat",
+                    "raw_id": raw_id,
+                    "summary": f"b_beta {raw_id}.",
+                    "dilemma_impacts": [{"dilemma_id": "dilemma::b_beta", "effect": effect}],
+                },
+            )
+            graph.add_edge("belongs_to", f"beat::{raw_id}", f"path::{path_id}")
+        graph.add_edge("predecessor", "beat::b_mid", "beat::b_entry")
+        graph.add_edge("predecessor", "beat::b_commit", "beat::b_mid")
+
+        # Concurrent relationship: a_alpha concurrent with b_beta
+        graph.add_edge("concurrent", "dilemma::a_alpha", "dilemma::b_beta")
+
+        # Before the fix there are 2 root beats (a_entry and b_entry) — verify
+        # the test would fail on unpatched code by checking this precondition.
+        all_beat_ids = {
+            "beat::a_entry",
+            "beat::a_mid",
+            "beat::a_commit",
+            "beat::b_entry",
+            "beat::b_mid",
+            "beat::b_commit",
+        }
+
+        # Run interleave
+        count = interleave_cross_path_beats(graph)
+        assert count > 0, "Expected cross-path predecessor edges to be created"
+
+        # Find root beats: beats that appear as 'from' side of NO predecessor edge
+        # (i.e. they have no prerequisites themselves).
+        beats_with_prereqs: set[str] = {
+            edge["from"]
+            for edge in graph.get_edges(edge_type="predecessor")
+            if edge["from"] in all_beat_ids
+        }
+        root_beats = all_beat_ids - beats_with_prereqs
+
+        assert len(root_beats) == 1, (
+            f"Expected exactly 1 root beat, got {len(root_beats)}: {sorted(root_beats)}"
+        )
+
+        # All other beats must be reachable from the single root via predecessor edges.
+        # predecessor(from, to): 'from' requires 'to' as prerequisite.
+        # To traverse forward: from root, find beats where root is their prerequisite,
+        # i.e. edges where edge["to"] == root → edge["from"] comes after root.
+        root = next(iter(root_beats))
+        reachable: set[str] = {root}
+        frontier = {root}
+        while frontier:
+            next_frontier: set[str] = set()
+            for beat in frontier:
+                # Find beats that require 'beat' (i.e. come after it in narrative)
+                for edge in graph.get_edges(edge_type="predecessor"):
+                    if (
+                        edge["to"] == beat
+                        and edge["from"] in all_beat_ids
+                        and edge["from"] not in reachable
+                    ):
+                        reachable.add(edge["from"])
+                        next_frontier.add(edge["from"])
+            frontier = next_frontier
+
+        assert reachable == all_beat_ids, (
+            f"Not all beats reachable from root {root!r}. "
+            f"Unreachable: {sorted(all_beat_ids - reachable)}"
+        )
+
+        # DAG must remain acyclic
+        assert validate_beat_dag(graph) == [], "Beat DAG must remain acyclic after interleave"
 
 
 class TestDetectTemporalHintConflicts:


### PR DESCRIPTION
## Summary

When all dilemmas have `concurrent` relationships, `interleave_cross_path_beats()` only ordered commit beats, leaving every path's `_beat_01` as an independent DAG root. POLISH Phase 7 rejected this as "multiple start passages."

**Root cause:** `interleave_cross_path_beats()` was incomplete for the concurrent case. The concurrent docstring says "any interleaving is valid" — fixing the multi-root bug means picking one valid interleaving deterministically. Entry beats now follow the same relative ordering as commit beats: the dilemma whose commits go first also has its entry beats first.

**Critical gap found by architect-reviewer:** `detect_temporal_hint_conflicts()` must mirror `interleave_cross_path_beats()` edge-by-edge. Without updating it, a temporal hint on an entry beat could pass conflict detection but then cycle at interleave time, causing a `RuntimeError` that `resolve_temporal_hints` was supposed to prevent. `detect_temporal_hint_conflicts` is updated in commit 2.

**`_build_hint_base_dag` intentionally excluded:** Entry-beat ordering is a soft heuristic that must yield to hints, not block them. Adding it to the base DAG (commit 2 initially did this) caused valid temporal hints that reverse entry-beat ordering to be incorrectly classified as mandatory solo-drops instead of swap pairs. Commit 4 reverts this: `_build_hint_base_dag` pre-loads only commit-ordering edges; `detect_temporal_hint_conflicts` simulates entry-beat edges when testing each hint, so accepted hints are already safe against that ordering.

## Commits

1. `fix: order concurrent dilemma entry beats for single-root DAG` — adds entry beat ordering to `interleave_cross_path_beats()` in the `concurrent` block
2. `fix: mirror entry beat ordering in detect_temporal_hint_conflicts and _build_hint_base_dag` — extends the logic to both sibling functions; updates tests affected by the new heuristic
3. `fix: address PR review nits` — comment and docstring updates
4. `fix: remove entry-beat ordering from _build_hint_base_dag (#1186)` — reverts the `_build_hint_base_dag` addition from commit 2; entry-beat ordering is a soft heuristic that must yield to hints; treating it as a hard base-DAG constraint caused 8 TestBuildHintConflictGraph failures

## Design Conformance

Reviewed by `architect-reviewer` against `docs/design/procedures/grow.md` interleave phase and `docs/design/document-3-ontology.md`.

| Requirement | Source | Status |
|---|---|---|
| Concurrent beats interleave freely | doc-3, Part 2 | CONFORMANT |
| Heuristic commit-ordering for concurrent | grow.md §3b step 1 | CONFORMANT |
| Introduction beats cluster near beginning | doc-1, Part 3 | CONFORMANT |
| Serial: last A beats before first B beats | grow.md §3b | CONFORMANT |
| Wraps: A intro before B intro; B last before A commits | grow.md §3b | CONFORMANT |
| Single start passage | grow.md §10 / polish.md §7 | CONFORMANT |
| All passages reachable from start | grow.md §10 / polish.md §7 | CONFORMANT |
| `_build_hint_base_dag` pre-loads commit-ordering heuristic edges | grow_algorithms.py | CONFORMANT — entry-beat edges intentionally absent (soft heuristic must yield to hints; safety guaranteed by `detect_temporal_hint_conflicts`) |
| `detect_temporal_hint_conflicts` mirrors interleave | grow_algorithms.py docstring | CONFORMANT (fixed in commit 2) |
| Hint-induced cycles raise RuntimeError | grow_algorithms.py | CONFORMANT |
| Heuristic-induced cycles soft-skipped | grow_algorithms.py | CONFORMANT |
| Fix in `interleave_cross_path_beats()` | Issue #1186 | CONFORMANT |
| N concurrent dilemmas → no multiple start passages | Issue #1186 | CONFORMANT |

0 MISSING / 0 DEAD findings.

## Test plan

- [ ] `uv run pytest tests/unit/test_grow_algorithms.py -x -q -k "single_root"` — 1 test passes
- [ ] `uv run pytest tests/unit/test_grow_algorithms.py -x -q -k "interleave or temporal_hint or hint_conflict"` — 38 tests pass
- [ ] `uv run pytest tests/unit/test_grow_algorithms.py -x -q -k "temporal_hints_stripped"` — 1 test passes with updated hint fixture

Closes #1186

🤖 Generated with [Claude Code](https://claude.com/claude-code)