### PR TITLE
fix: add beat-DAG single-root-beat validation to GROW Phase 10 (#1193)

### DIFF
--- a/src/questfoundry/graph/grow_validation.py
+++ b/src/questfoundry/graph/grow_validation.py
@@ -33,6 +33,7 @@ __all__ = [
     "check_dilemma_role_compliance",
     "check_dilemmas_resolved",
     "check_passage_dag_cycles",
+    "check_single_root_beat",
     "check_single_start",
     "check_spine_arc_exists",
     "compute_linear_threshold",
@@ -278,6 +279,51 @@ def _build_beat_dilemma_map(graph: Graph) -> dict[str, set[str]]:
 # ---------------------------------------------------------------------------
 # Beat-DAG check functions (stay in GROW)
 # ---------------------------------------------------------------------------
+
+
+def check_single_root_beat(graph: Graph) -> ValidationCheck:
+    """Verify the beat DAG has exactly one root beat.
+
+    A root beat is a beat with no prerequisites — it does not appear as
+    ``from_id`` in any predecessor edge. The beat DAG must have exactly one
+    root for POLISH to produce a single start passage.
+    """
+    beat_nodes = graph.get_nodes_by_type("beat")
+    if not beat_nodes:
+        return ValidationCheck(
+            name="single_root_beat",
+            severity="pass",
+            message="No beats to check",
+        )
+
+    # Collect all beats that appear as from_id in predecessor edges.
+    # predecessor(from_id, to_id) means from_id requires to_id as a
+    # prerequisite — so from_id comes AFTER to_id in the narrative.
+    # A root beat is one that never appears as from_id (no prerequisites).
+    beats_with_prereqs: set[str] = set()
+    for edge in graph.get_edges(edge_type="predecessor"):
+        if edge["from"] in beat_nodes:
+            beats_with_prereqs.add(edge["from"])
+
+    root_beats = sorted(bid for bid in beat_nodes if bid not in beats_with_prereqs)
+
+    if len(root_beats) == 1:
+        return ValidationCheck(
+            name="single_root_beat",
+            severity="pass",
+            message=f"Single root beat: {root_beats[0]}",
+        )
+    if len(root_beats) == 0:
+        return ValidationCheck(
+            name="single_root_beat",
+            severity="fail",
+            message="No root beat found (all beats have predecessors — possible cycle)",
+        )
+    return ValidationCheck(
+        name="single_root_beat",
+        severity="fail",
+        message=f"Multiple root beats found ({len(root_beats)}): {', '.join(root_beats)}",
+    )
 
 
 def check_single_start(graph: Graph) -> ValidationCheck:
@@ -643,6 +689,7 @@ def run_grow_checks(graph: Graph) -> ValidationReport:
         )
 
     checks: list[ValidationCheck] = [
+        check_single_root_beat(graph),
         check_single_start(graph),
         check_passage_dag_cycles(graph),
         check_spine_arc_exists(graph),

--- a/src/questfoundry/graph/grow_validation.py
+++ b/src/questfoundry/graph/grow_validation.py
@@ -308,11 +308,11 @@ def check_single_root_beat(graph: Graph) -> ValidationCheck:
     # Exclude synthetic beat roles that are created by POLISH, not GROW.
     # At GROW Phase 10 none exist, but run_all_checks() (used by qf inspect)
     # may run after POLISH when synthetic beats are present.
-    _synthetic_roles = {"micro_beat", "residue_beat", "sidetrack_beat"}
+    synthetic_roles = {"micro_beat", "residue_beat", "sidetrack_beat"}
     root_beats = sorted(
         bid
         for bid in beat_nodes
-        if bid not in beats_with_prereqs and beat_nodes[bid].get("role", "") not in _synthetic_roles
+        if bid not in beats_with_prereqs and beat_nodes[bid].get("role", "") not in synthetic_roles
     )
 
     if len(root_beats) == 1:

--- a/src/questfoundry/graph/grow_validation.py
+++ b/src/questfoundry/graph/grow_validation.py
@@ -305,7 +305,15 @@ def check_single_root_beat(graph: Graph) -> ValidationCheck:
         if edge["from"] in beat_nodes:
             beats_with_prereqs.add(edge["from"])
 
-    root_beats = sorted(bid for bid in beat_nodes if bid not in beats_with_prereqs)
+    # Exclude synthetic beat roles that are created by POLISH, not GROW.
+    # At GROW Phase 10 none exist, but run_all_checks() (used by qf inspect)
+    # may run after POLISH when synthetic beats are present.
+    _synthetic_roles = {"micro_beat", "residue_beat", "sidetrack_beat"}
+    root_beats = sorted(
+        bid
+        for bid in beat_nodes
+        if bid not in beats_with_prereqs and beat_nodes[bid].get("role", "") not in _synthetic_roles
+    )
 
     if len(root_beats) == 1:
         return ValidationCheck(

--- a/src/questfoundry/graph/grow_validation.py
+++ b/src/questfoundry/graph/grow_validation.py
@@ -287,6 +287,16 @@ def check_single_root_beat(graph: Graph) -> ValidationCheck:
     A root beat is a beat with no prerequisites — it does not appear as
     ``from_id`` in any predecessor edge. The beat DAG must have exactly one
     root for POLISH to produce a single start passage.
+
+    Synthetic beat roles (micro_beat, residue_beat, sidetrack_beat) are
+    excluded since they are created by POLISH, not GROW.
+
+    Args:
+        graph: The story graph to validate.
+
+    Returns:
+        A ValidationCheck with severity "pass" if exactly one root beat
+        exists, or "fail" if zero or multiple roots are found.
     """
     beat_nodes = graph.get_nodes_by_type("beat")
     if not beat_nodes:

--- a/tests/unit/test_grow_validation.py
+++ b/tests/unit/test_grow_validation.py
@@ -21,6 +21,7 @@ from questfoundry.graph.grow_validation import (
     check_dilemma_role_compliance,
     check_dilemmas_resolved,
     check_passage_dag_cycles,
+    check_single_root_beat,
     check_single_start,
     check_spine_arc_exists,
     run_all_checks,
@@ -945,3 +946,75 @@ class TestPhase10Integration:
         result = await phase_validation(graph, MagicMock())
         assert result.status == "completed"
         assert "passed" in result.detail
+
+
+class TestSingleRootBeat:
+    """Tests for check_single_root_beat."""
+
+    def test_single_root_beat_pass(self) -> None:
+        """Graph with one root beat passes."""
+        graph = Graph.empty()
+        # Create 3 beats chained: b1 -> b2 -> b3 (b1 is root)
+        for bid in ("b1", "b2", "b3"):
+            graph.create_node(
+                f"beat::{bid}",
+                {"type": "beat", "raw_id": bid, "summary": f"Beat {bid}."},
+            )
+        # predecessor(from=b2, to=b1) means b2 comes after b1
+        # predecessor(from=b3, to=b2) means b3 comes after b2
+        # b1 is never from_id → b1 is the single root
+        graph.add_edge("predecessor", "beat::b2", "beat::b1")
+        graph.add_edge("predecessor", "beat::b3", "beat::b2")
+        result = check_single_root_beat(graph)
+        assert result.severity == "pass"
+        assert "beat::b1" in result.message
+
+    def test_multiple_root_beats_fail(self) -> None:
+        """Graph with two root beats fails."""
+        graph = Graph.empty()
+        for bid in ("b1", "b2", "b3"):
+            graph.create_node(
+                f"beat::{bid}",
+                {"type": "beat", "raw_id": bid, "summary": f"Beat {bid}."},
+            )
+        # predecessor(from=b3, to=b2) means b3 requires b2 as prerequisite.
+        # b3 appears as from_id → b3 has prerequisites, not a root.
+        # b1 and b2 do NOT appear as from_id → both are roots.
+        graph.add_edge("predecessor", "beat::b3", "beat::b2")
+        result = check_single_root_beat(graph)
+        assert result.severity == "fail"
+        assert "beat::b1" in result.message
+        assert "beat::b2" in result.message
+
+    def test_zero_root_beats_fail(self) -> None:
+        """All beats have predecessors (cycle) — fails."""
+        graph = Graph.empty()
+        for bid in ("b1", "b2"):
+            graph.create_node(
+                f"beat::{bid}",
+                {"type": "beat", "raw_id": bid, "summary": f"Beat {bid}."},
+            )
+        # Cycle: b1 requires b2, b2 requires b1
+        graph.add_edge("predecessor", "beat::b1", "beat::b2")
+        graph.add_edge("predecessor", "beat::b2", "beat::b1")
+        result = check_single_root_beat(graph)
+        assert result.severity == "fail"
+        assert "No root beat" in result.message
+
+    def test_no_beats_pass(self) -> None:
+        """Empty graph passes vacuously."""
+        graph = Graph.empty()
+        result = check_single_root_beat(graph)
+        assert result.severity == "pass"
+        assert "No beats" in result.message
+
+    def test_single_beat_no_edges_pass(self) -> None:
+        """A single beat with no edges is a valid single root."""
+        graph = Graph.empty()
+        graph.create_node(
+            "beat::only",
+            {"type": "beat", "raw_id": "only", "summary": "Only beat."},
+        )
+        result = check_single_root_beat(graph)
+        assert result.severity == "pass"
+        assert "beat::only" in result.message

--- a/tests/unit/test_grow_validation.py
+++ b/tests/unit/test_grow_validation.py
@@ -1018,3 +1018,36 @@ class TestSingleRootBeat:
         result = check_single_root_beat(graph)
         assert result.severity == "pass"
         assert "beat::only" in result.message
+
+    def test_synthetic_roles_excluded(self) -> None:
+        """Synthetic beats (micro_beat, residue_beat, sidetrack_beat) are ignored."""
+        graph = Graph.empty()
+        # One real root beat
+        graph.create_node(
+            "beat::real_root",
+            {"type": "beat", "raw_id": "real_root", "summary": "Root."},
+        )
+        graph.create_node(
+            "beat::real_child",
+            {"type": "beat", "raw_id": "real_child", "summary": "Child."},
+        )
+        graph.add_edge("predecessor", "beat::real_child", "beat::real_root")
+
+        # Synthetic beats with no predecessor edges — would be extra roots
+        # if not excluded
+        for role in ("micro_beat", "residue_beat", "sidetrack_beat"):
+            graph.create_node(
+                f"beat::syn_{role}",
+                {
+                    "type": "beat",
+                    "raw_id": f"syn_{role}",
+                    "summary": f"Synthetic {role}.",
+                    "role": role,
+                },
+            )
+
+        result = check_single_root_beat(graph)
+        assert result.severity == "pass", (
+            f"Synthetic beats should be excluded, got: {result.message}"
+        )
+        assert "beat::real_root" in result.message


### PR DESCRIPTION
## Summary

- Adds `check_single_root_beat(graph)` to GROW validation that verifies the beat DAG has exactly one root beat (a beat with no predecessor edges as `from_id`)
- Excludes synthetic roles (`micro_beat`, `residue_beat`, `sidetrack_beat`) which are created by POLISH, not GROW
- Registers the check in `run_grow_checks()` as the first check (before `check_single_start`)
- Adds 6 unit tests including synthetic role exclusion coverage

## Design Conformance

Architect-reviewer sign-off: **10/10 CONFORMANT** (after fixing 1 MISSING finding for synthetic role exclusion).

| # | Requirement | Status |
|---|------------|--------|
| 1a | `check_single_root_beat(graph)` exists | CONFORMANT |
| 1b | Finds beats with no predecessor edge as `from_id` | CONFORMANT |
| 1c | Excludes synthetic roles | CONFORMANT (fixed after review) |
| 1d | Returns pass/fail correctly | CONFORMANT |
| 1e | Message includes root beat IDs on failure | CONFORMANT |
| 2 | Registered in GROW validation runner | CONFORMANT |
| 3a | Test: 1 root → pass | CONFORMANT |
| 3b | Test: 2 roots → fail with both IDs | CONFORMANT |
| 3c | Test: 0 roots (cycle) → fail | CONFORMANT |
| 4 | `check_single_start()` still exists and registered | CONFORMANT |

## Test plan

- [x] `uv run pytest tests/unit/test_grow_validation.py -x -q -k "SingleRootBeat"` — 6 tests pass
- [x] `uv run pytest tests/unit/test_grow_validation.py -x -q` — all 41 tests pass
- [x] ruff + mypy clean

Closes #1193

🤖 Generated with [Claude Code](https://claude.com/claude-code)