### PR TITLE
fix: restrict compute_choice_edges to commit beats on same-dilemma paths

### DIFF
--- a/src/questfoundry/pipeline/stages/polish/deterministic.py
+++ b/src/questfoundry/pipeline/stages/polish/deterministic.py
@@ -16,6 +16,7 @@ from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 
 from questfoundry.graph.algorithms import compute_active_flags_at_beat, compute_passage_traversals
+from questfoundry.graph.context import normalize_scoped_id
 from questfoundry.models.pipeline import PhaseResult
 from questfoundry.models.polish import (
     AmbiguousFeasibilityCase,
@@ -652,6 +653,19 @@ def compute_choice_edges(
         for bid in spec.beat_ids:
             beat_to_passage[bid] = spec.passage_id
 
+    # Build path → dilemma mapping so we can restrict choices to same-dilemma
+    # divergences (#1197). Cross-dilemma predecessor edges (from interleave)
+    # are temporal ordering, not player choices.
+    path_to_dilemma: dict[str, str] = {}
+    path_nodes = graph.get_nodes_by_type("path")
+    dilemma_nodes = graph.get_nodes_by_type("dilemma")
+    for pid, pdata in path_nodes.items():
+        did = pdata.get("dilemma_id")
+        if did:
+            prefixed = normalize_scoped_id(did, "dilemma")
+            if prefixed in dilemma_nodes:
+                path_to_dilemma[pid] = prefixed
+
     # Keyed by (from_passage, to_passage) to deduplicate multiple beats in the
     # same passage that independently diverge to the same target (#1185).
     choices_map: dict[tuple[str, str], ChoiceSpec] = {}
@@ -659,93 +673,113 @@ def compute_choice_edges(
     # Build passage_id_to_spec once outside the loop (not per-divergence-point)
     passage_id_to_spec: dict[str, PassageSpec] = {s.passage_id: s for s in specs}
 
-    # Find divergence points: beats with children on different paths
+    # Find divergence points: commit beats with children on different paths
+    # of the SAME dilemma (#1197). Only commits create player choices — see
+    # docs/design/procedures/polish.md Phase 4c step 1.
     for bid in sorted(beat_nodes.keys()):
+        data = beat_nodes.get(bid, {})
+
+        # Extract dilemma IDs this beat commits — only commit beats diverge
+        committing_dilemmas: set[str] = set()
+        for impact in data.get("dilemma_impacts", []):
+            if impact.get("effect") == "commits":
+                did = impact.get("dilemma_id", "")
+                if did:
+                    committing_dilemmas.add(normalize_scoped_id(did, "dilemma"))
+        if not committing_dilemmas:
+            continue
+
         child_ids = children[bid]
         if len(child_ids) < 2:
             continue
 
-        # Check if children are on different paths
+        # Group children by path
         child_paths: dict[str, list[str]] = {}
         for cid in child_ids:
             path_id = beat_to_path.get(cid, "")
             child_paths.setdefault(path_id, []).append(cid)
 
         if len(child_paths) < 2:
-            # All children on same path — not a real divergence
             continue
 
-        # This is a divergence point
         from_passage = beat_to_passage.get(bid, "")
         if not from_passage:
             continue
 
-        for path_id, path_children in sorted(child_paths.items()):
-            # Pick the topologically earliest child on each path (#1187).
-            # Using sorted(path_children)[0] (alphabetical) can skip gap beats
-            # when a transitive predecessor edge also links the divergence beat
-            # directly to the beat after the gap.
-            target_beat = _topo_first(path_children, children)
-            to_passage = beat_to_passage.get(target_beat, "")
-            if not to_passage or to_passage == from_passage:
+        # For each committing dilemma, create choices only between that
+        # dilemma's paths. Children on other dilemmas' paths are interleave
+        # ordering, not player choices.
+        for committing_dilemma in sorted(committing_dilemmas):
+            dilemma_child_paths: dict[str, list[str]] = {}
+            for path_id, path_children in child_paths.items():
+                if path_to_dilemma.get(path_id) == committing_dilemma:
+                    dilemma_child_paths[path_id] = path_children
+
+            if len(dilemma_child_paths) < 2:
                 continue
 
-            # Compute grants: state flags activated by taking this path
-            grants: list[str] = []
-            for cid in path_children:
-                data = beat_nodes.get(cid, {})
-                for impact in data.get("dilemma_impacts", []):
-                    if impact.get("effect") == "commits":
-                        dilemma_id = impact.get("dilemma_id", "")
-                        if dilemma_id and path_id:
-                            grants.append(f"{dilemma_id}:{path_id}")
+            for path_id, path_children in sorted(dilemma_child_paths.items()):
+                # Pick the topologically earliest child on each path (#1187).
+                target_beat = _topo_first(path_children, children)
+                to_passage = beat_to_passage.get(target_beat, "")
+                if not to_passage or to_passage == from_passage:
+                    continue
 
-            # Compute requires: for choices from intersection passages, populate
-            # the required state flags for the target passage.
-            requires: list[str] = []
-            from_spec = passage_id_to_spec.get(from_passage)
-            if from_spec and from_spec.grouping_type == "intersection":
-                try:
-                    flag_combos = compute_active_flags_at_beat(graph, target_beat)
-                    if len(flag_combos) == 1:
-                        combo = next(iter(flag_combos))
-                        if combo:  # non-empty
-                            requires = sorted(combo)
-                    elif len(flag_combos) > 1:
+                # Compute grants: state flags activated by taking this path
+                grants: list[str] = []
+                for cid in path_children:
+                    cdata = beat_nodes.get(cid, {})
+                    for impact in cdata.get("dilemma_impacts", []):
+                        if impact.get("effect") == "commits":
+                            grant_did = impact.get("dilemma_id", "")
+                            if grant_did and path_id:
+                                grants.append(f"{grant_did}:{path_id}")
+
+                # Compute requires: for choices from intersection passages,
+                # populate the required state flags for the target passage.
+                requires: list[str] = []
+                from_spec = passage_id_to_spec.get(from_passage)
+                if from_spec and from_spec.grouping_type == "intersection":
+                    try:
+                        flag_combos = compute_active_flags_at_beat(graph, target_beat)
+                        if len(flag_combos) == 1:
+                            combo = next(iter(flag_combos))
+                            if combo:
+                                requires = sorted(combo)
+                        elif len(flag_combos) > 1:
+                            log.warning(
+                                "choice_requires_multi_combo",
+                                from_passage=from_passage,
+                                to_passage=to_passage,
+                                combo_count=len(flag_combos),
+                            )
+                    except ValueError as e:
                         log.warning(
-                            "choice_requires_multi_combo",
+                            "choice_requires_compute_failed",
                             from_passage=from_passage,
-                            to_passage=to_passage,
-                            combo_count=len(flag_combos),
+                            error=str(e),
                         )
-                except ValueError as e:
-                    log.warning(
-                        "choice_requires_compute_failed",
-                        from_passage=from_passage,
-                        error=str(e),
-                    )
 
-            key = (from_passage, to_passage)
-            if key in choices_map:
-                # Merge grants from multiple beats in the same passage that
-                # independently diverge to the same target (#1185).
-                existing = choices_map[key]
-                choices_map[key] = ChoiceSpec(
-                    from_passage=from_passage,
-                    to_passage=to_passage,
-                    grants=sorted(set(existing.grants) | set(grants)),
-                    requires=existing.requires,  # keep first-seen: beats in the same
-                    # passage share identical upstream flag state for a given target
-                    label=existing.label,
-                )
-            else:
-                choices_map[key] = ChoiceSpec(
-                    from_passage=from_passage,
-                    to_passage=to_passage,
-                    grants=grants,
-                    requires=requires,
-                    label="",  # Populated by Phase 5
-                )
+                key = (from_passage, to_passage)
+                if key in choices_map:
+                    # Merge grants from multiple beats in the same passage
+                    # that independently diverge to the same target (#1185).
+                    existing = choices_map[key]
+                    choices_map[key] = ChoiceSpec(
+                        from_passage=from_passage,
+                        to_passage=to_passage,
+                        grants=sorted(set(existing.grants) | set(grants)),
+                        requires=existing.requires,
+                        label=existing.label,
+                    )
+                else:
+                    choices_map[key] = ChoiceSpec(
+                        from_passage=from_passage,
+                        to_passage=to_passage,
+                        grants=grants,
+                        requires=requires,
+                        label="",  # Populated by Phase 5
+                    )
 
     return list(choices_map.values())
 

--- a/src/questfoundry/pipeline/stages/polish/deterministic.py
+++ b/src/questfoundry/pipeline/stages/polish/deterministic.py
@@ -769,7 +769,7 @@ def compute_choice_edges(
                         from_passage=from_passage,
                         to_passage=to_passage,
                         grants=sorted(set(existing.grants) | set(grants)),
-                        requires=existing.requires,
+                        requires=existing.requires,  # keep first-seen; beats in same passage share upstream flag state
                         label=existing.label,
                     )
                 else:

--- a/tests/unit/test_polish_deterministic.py
+++ b/tests/unit/test_polish_deterministic.py
@@ -1242,9 +1242,9 @@ class TestChoiceSpecRequires:
         returns a single-combo result for each child, allowing requires to be set.
         """
         graph.create_node("dilemma::d1", {"type": "dilemma", "raw_id": "d1", "status": "explored"})
-        graph.create_node("path::pa", {"type": "path", "raw_id": "pa", "dilemma_id": "d1"})
-        graph.create_node("path::pc", {"type": "path", "raw_id": "pc", "dilemma_id": "d1"})
-        graph.create_node("path::pd", {"type": "path", "raw_id": "pd", "dilemma_id": "d1"})
+        graph.create_node("path::pa", {"type": "path", "raw_id": "pa", "dilemma_id": "dilemma::d1"})
+        graph.create_node("path::pc", {"type": "path", "raw_id": "pc", "dilemma_id": "dilemma::d1"})
+        graph.create_node("path::pd", {"type": "path", "raw_id": "pd", "dilemma_id": "dilemma::d1"})
         graph.create_node(
             "state_flag::d1_pc",
             {

--- a/tests/unit/test_polish_deterministic.py
+++ b/tests/unit/test_polish_deterministic.py
@@ -256,10 +256,14 @@ class TestComputeProseFeasibility:
 
 
 def _setup_dilemma(graph: Graph, dilemma_id: str, path_ids: list[str]) -> None:
-    """Helper to create a dilemma node and set dilemma_id on path nodes."""
+    """Helper to create a dilemma node and set dilemma_id on path nodes.
+
+    Stores the prefixed dilemma_id (e.g. "dilemma::d1") on path nodes to
+    match production data shape from mutations.py:apply_seed_output().
+    """
     graph.create_node(dilemma_id, {"type": "dilemma", "raw_id": dilemma_id.split("::")[-1]})
     for pid in path_ids:
-        graph.update_node(pid, dilemma_id=dilemma_id.split("::")[-1])
+        graph.update_node(pid, dilemma_id=dilemma_id)
 
 
 class TestComputeChoiceEdges:

--- a/tests/unit/test_polish_deterministic.py
+++ b/tests/unit/test_polish_deterministic.py
@@ -255,16 +255,30 @@ class TestComputeProseFeasibility:
         assert result["residue_specs"] == []
 
 
+def _setup_dilemma(graph: Graph, dilemma_id: str, path_ids: list[str]) -> None:
+    """Helper to create a dilemma node and set dilemma_id on path nodes."""
+    graph.create_node(dilemma_id, {"type": "dilemma", "raw_id": dilemma_id.split("::")[-1]})
+    for pid in path_ids:
+        graph.update_node(pid, dilemma_id=dilemma_id.split("::")[-1])
+
+
 class TestComputeChoiceEdges:
     """Tests for Phase 4c: choice edge derivation."""
 
     def test_simple_divergence(self) -> None:
-        """Beat with children on different paths produces choices."""
+        """Commit beat with children on different same-dilemma paths produces choices."""
         graph = Graph.empty()
         graph.create_node("path::pa", {"type": "path", "raw_id": "pa"})
         graph.create_node("path::pb", {"type": "path", "raw_id": "pb"})
+        _setup_dilemma(graph, "dilemma::d1", ["path::pa", "path::pb"])
 
-        _make_beat(graph, "beat::start", "Start", entities=["entity::hero"])
+        _make_beat(
+            graph,
+            "beat::start",
+            "Start",
+            entities=["entity::hero"],
+            dilemma_impacts=[{"dilemma_id": "dilemma::d1", "effect": "commits"}],
+        )
         _make_beat(graph, "beat::a", "Path A", entities=["entity::hero"])
         _make_beat(graph, "beat::b", "Path B", entities=["entity::hero"])
 
@@ -311,8 +325,14 @@ class TestComputeChoiceEdges:
         graph = Graph.empty()
         graph.create_node("path::pa", {"type": "path", "raw_id": "pa"})
         graph.create_node("path::pb", {"type": "path", "raw_id": "pb"})
+        _setup_dilemma(graph, "dilemma::d1", ["path::pa", "path::pb"])
 
-        _make_beat(graph, "beat::start", "Start")
+        _make_beat(
+            graph,
+            "beat::start",
+            "Start",
+            dilemma_impacts=[{"dilemma_id": "dilemma::d1", "effect": "commits"}],
+        )
         _make_beat(
             graph,
             "beat::commit_a",
@@ -351,16 +371,28 @@ class TestChoiceEdgesIntersectionMultiBeat:
     """
 
     def test_deduplicates_same_target_from_multiple_beats(self) -> None:
-        """Two beats in the same intersection passage that both diverge to single_A
-        must produce exactly one ChoiceSpec(intersection_0 → single_A), not two."""
+        """Two commit beats in the same intersection passage that both diverge to
+        single_A must produce exactly one ChoiceSpec(intersection_0 → single_A)."""
         graph = Graph.empty()
         graph.create_node("path::p1", {"type": "path", "raw_id": "p1"})
         graph.create_node("path::p2", {"type": "path", "raw_id": "p2"})
         graph.create_node("path::p3", {"type": "path", "raw_id": "p3"})
+        _setup_dilemma(graph, "dilemma::d1", ["path::p1", "path::p2", "path::p3"])
 
-        # Three beats, one per path — all in the intersection passage
-        _make_beat(graph, "beat::b_p1", "P1 beat in intersection")
-        _make_beat(graph, "beat::b_p2", "P2 beat in intersection")
+        # Three beats, one per path — all in the intersection passage.
+        # b_p1 and b_p2 commit d1 (divergence beats); b_p3 does not commit.
+        _make_beat(
+            graph,
+            "beat::b_p1",
+            "P1 beat in intersection",
+            dilemma_impacts=[{"dilemma_id": "dilemma::d1", "effect": "commits"}],
+        )
+        _make_beat(
+            graph,
+            "beat::b_p2",
+            "P2 beat in intersection",
+            dilemma_impacts=[{"dilemma_id": "dilemma::d1", "effect": "commits"}],
+        )
         _make_beat(graph, "beat::b_p3", "P3 beat in intersection")
         _add_belongs_to(graph, "beat::b_p1", "path::p1")
         _add_belongs_to(graph, "beat::b_p2", "path::p2")
@@ -409,17 +441,28 @@ class TestChoiceEdgesIntersectionMultiBeat:
         assert to_passages == {"passage::single_A", "passage::single_B", "passage::single_C"}
 
     def test_grants_merged_on_deduplication(self) -> None:
-        """When two beats in the same passage diverge to the same target passage
+        """When two commit beats in the same passage diverge to the same target
         via different child beats (each with different dilemma_impacts), grants
         from both children are merged (union) in the single deduplicated ChoiceSpec."""
         graph = Graph.empty()
         graph.create_node("path::p1", {"type": "path", "raw_id": "p1"})
         graph.create_node("path::p2", {"type": "path", "raw_id": "p2"})
         graph.create_node("path::p3", {"type": "path", "raw_id": "p3"})
+        _setup_dilemma(graph, "dilemma::d1", ["path::p1", "path::p2", "path::p3"])
 
-        # Two divergence beats in the intersection passage
-        _make_beat(graph, "beat::b_p1", "P1 beat in intersection")
-        _make_beat(graph, "beat::b_p2", "P2 beat in intersection")
+        # Two divergence beats in the intersection passage — both commit d1
+        _make_beat(
+            graph,
+            "beat::b_p1",
+            "P1 beat in intersection",
+            dilemma_impacts=[{"dilemma_id": "dilemma::d1", "effect": "commits"}],
+        )
+        _make_beat(
+            graph,
+            "beat::b_p2",
+            "P2 beat in intersection",
+            dilemma_impacts=[{"dilemma_id": "dilemma::d1", "effect": "commits"}],
+        )
         _add_belongs_to(graph, "beat::b_p1", "path::p1")
         _add_belongs_to(graph, "beat::b_p2", "path::p2")
 
@@ -494,9 +537,15 @@ class TestChoiceEdgesGapBeatChild:
         graph = Graph.empty()
         graph.create_node("path::p1", {"type": "path", "raw_id": "p1"})
         graph.create_node("path::p2", {"type": "path", "raw_id": "p2"})
+        _setup_dilemma(graph, "dilemma::d1", ["path::p1", "path::p2"])
 
-        # Divergence beat (shared / on p1)
-        _make_beat(graph, "beat::div", "Divergence")
+        # Divergence beat (commit beat on p1)
+        _make_beat(
+            graph,
+            "beat::div",
+            "Divergence",
+            dilemma_impacts=[{"dilemma_id": "dilemma::d1", "effect": "commits"}],
+        )
         _add_belongs_to(graph, "beat::div", "path::p1")
 
         # Gap beat on p1 — the true next beat after div
@@ -554,8 +603,14 @@ class TestChoiceEdgesGapBeatChild:
         graph = Graph.empty()
         graph.create_node("path::p1", {"type": "path", "raw_id": "p1"})
         graph.create_node("path::p2", {"type": "path", "raw_id": "p2"})
+        _setup_dilemma(graph, "dilemma::d1", ["path::p1", "path::p2"])
 
-        _make_beat(graph, "beat::div", "Divergence")
+        _make_beat(
+            graph,
+            "beat::div",
+            "Divergence",
+            dilemma_impacts=[{"dilemma_id": "dilemma::d1", "effect": "commits"}],
+        )
         _add_belongs_to(graph, "beat::div", "path::p1")
 
         # Only one direct child on p1 (no transitive shortcut)
@@ -579,6 +634,310 @@ class TestChoiceEdgesGapBeatChild:
         assert "passage::next" in to_passages
         assert "passage::p2" in to_passages
         assert len(from_div) == 2
+
+
+class TestChoiceEdgesMultiDilemma:
+    """Tests for #1197/#1198: multi-dilemma interleaved DAGs.
+
+    Real GROW output has multiple concurrent dilemmas with interleave
+    predecessor edges between their paths. These interleave edges are
+    temporal ordering, NOT player choices. compute_choice_edges() must
+    only create choices at commit beats for the committing dilemma's paths.
+    """
+
+    def test_non_commit_beat_with_cross_dilemma_children_produces_zero_choices(
+        self,
+    ) -> None:
+        """A non-commit beat on dilemma_1::path_a with interleave-ordered
+        children on dilemma_2::path_x and dilemma_3::path_y must produce
+        no choice edges — interleave ordering is not a player choice."""
+        graph = Graph.empty()
+        # Dilemma 1 with 2 paths
+        graph.create_node("path::d1_a", {"type": "path", "raw_id": "d1_a"})
+        graph.create_node("path::d1_b", {"type": "path", "raw_id": "d1_b"})
+        _setup_dilemma(graph, "dilemma::d1", ["path::d1_a", "path::d1_b"])
+        # Dilemma 2 with 1 path
+        graph.create_node("path::d2_a", {"type": "path", "raw_id": "d2_a"})
+        _setup_dilemma(graph, "dilemma::d2", ["path::d2_a"])
+        # Dilemma 3 with 1 path
+        graph.create_node("path::d3_a", {"type": "path", "raw_id": "d3_a"})
+        _setup_dilemma(graph, "dilemma::d3", ["path::d3_a"])
+
+        # Non-commit beat on d1_a — has interleave children on other dilemmas
+        _make_beat(graph, "beat::advance", "Advance d1")
+        _add_belongs_to(graph, "beat::advance", "path::d1_a")
+
+        # Interleave-ordered children on different dilemmas
+        _make_beat(graph, "beat::d2_child", "D2 beat")
+        _add_belongs_to(graph, "beat::d2_child", "path::d2_a")
+        _make_beat(graph, "beat::d3_child", "D3 beat")
+        _add_belongs_to(graph, "beat::d3_child", "path::d3_a")
+        # Also a same-path child (linear continuation)
+        _make_beat(graph, "beat::d1_next", "D1 next")
+        _add_belongs_to(graph, "beat::d1_next", "path::d1_a")
+
+        _add_predecessor(graph, "beat::d2_child", "beat::advance")
+        _add_predecessor(graph, "beat::d3_child", "beat::advance")
+        _add_predecessor(graph, "beat::d1_next", "beat::advance")
+
+        specs = [
+            PassageSpec(passage_id="passage::adv", beat_ids=["beat::advance"], summary="adv"),
+            PassageSpec(passage_id="passage::d2", beat_ids=["beat::d2_child"], summary="d2"),
+            PassageSpec(passage_id="passage::d3", beat_ids=["beat::d3_child"], summary="d3"),
+            PassageSpec(passage_id="passage::d1n", beat_ids=["beat::d1_next"], summary="d1n"),
+        ]
+
+        choices = compute_choice_edges(graph, specs)
+        assert len(choices) == 0, (
+            f"Non-commit beat should produce zero choices, got {len(choices)}: "
+            f"{[(c.from_passage, c.to_passage) for c in choices]}"
+        )
+
+    def test_commit_beat_creates_choices_only_for_own_dilemma(self) -> None:
+        """A commit beat on dilemma_1::path_a with children on
+        dilemma_1::path_b (same dilemma) AND dilemma_2::path_x (different
+        dilemma) must produce exactly 1 choice edge (to path_b's passage)."""
+        graph = Graph.empty()
+        # Dilemma 1 with 2 paths
+        graph.create_node("path::d1_a", {"type": "path", "raw_id": "d1_a"})
+        graph.create_node("path::d1_b", {"type": "path", "raw_id": "d1_b"})
+        _setup_dilemma(graph, "dilemma::d1", ["path::d1_a", "path::d1_b"])
+        # Dilemma 2 with 1 path
+        graph.create_node("path::d2_x", {"type": "path", "raw_id": "d2_x"})
+        _setup_dilemma(graph, "dilemma::d2", ["path::d2_x"])
+
+        # Commit beat on d1_a — commits dilemma d1
+        _make_beat(
+            graph,
+            "beat::commit_d1",
+            "Commit on d1",
+            dilemma_impacts=[{"dilemma_id": "dilemma::d1", "effect": "commits"}],
+        )
+        _add_belongs_to(graph, "beat::commit_d1", "path::d1_a")
+
+        # Child on d1_b (same dilemma, different path → real choice)
+        _make_beat(graph, "beat::d1b_child", "D1 path B beat")
+        _add_belongs_to(graph, "beat::d1b_child", "path::d1_b")
+        _add_predecessor(graph, "beat::d1b_child", "beat::commit_d1")
+
+        # Child on d1_a (same path → no divergence for this path)
+        _make_beat(graph, "beat::d1a_next", "D1 path A next")
+        _add_belongs_to(graph, "beat::d1a_next", "path::d1_a")
+        _add_predecessor(graph, "beat::d1a_next", "beat::commit_d1")
+
+        # Child on d2_x (different dilemma → interleave, NOT a choice)
+        _make_beat(graph, "beat::d2x_child", "D2 interleave beat")
+        _add_belongs_to(graph, "beat::d2x_child", "path::d2_x")
+        _add_predecessor(graph, "beat::d2x_child", "beat::commit_d1")
+
+        specs = [
+            PassageSpec(
+                passage_id="passage::commit",
+                beat_ids=["beat::commit_d1"],
+                summary="commit",
+            ),
+            PassageSpec(
+                passage_id="passage::d1a_next",
+                beat_ids=["beat::d1a_next"],
+                summary="d1a_next",
+            ),
+            PassageSpec(
+                passage_id="passage::d1b",
+                beat_ids=["beat::d1b_child"],
+                summary="d1b",
+            ),
+            PassageSpec(
+                passage_id="passage::d2x",
+                beat_ids=["beat::d2x_child"],
+                summary="d2x",
+            ),
+        ]
+
+        choices = compute_choice_edges(graph, specs)
+
+        # Exactly 2 choices: commit → d1a_next (same dilemma, path a) and
+        # commit → d1b (same dilemma, path b). NOT commit → d2x.
+        assert len(choices) == 2, (
+            f"Expected 2 choices (d1 paths only), got {len(choices)}: "
+            f"{[(c.from_passage, c.to_passage) for c in choices]}"
+        )
+        to_passages = {c.to_passage for c in choices}
+        assert to_passages == {"passage::d1a_next", "passage::d1b"}, (
+            f"Expected choices to d1 paths only, got {to_passages}"
+        )
+
+    def test_intersection_with_commit_beat_from_one_dilemma(self) -> None:
+        """An intersection containing beats from 2 dilemmas where one beat
+        commits its dilemma: choices only for that dilemma's paths."""
+        graph = Graph.empty()
+        # Dilemma 1 with 2 paths
+        graph.create_node("path::d1_a", {"type": "path", "raw_id": "d1_a"})
+        graph.create_node("path::d1_b", {"type": "path", "raw_id": "d1_b"})
+        _setup_dilemma(graph, "dilemma::d1", ["path::d1_a", "path::d1_b"])
+        # Dilemma 2 with 2 paths
+        graph.create_node("path::d2_x", {"type": "path", "raw_id": "d2_x"})
+        graph.create_node("path::d2_y", {"type": "path", "raw_id": "d2_y"})
+        _setup_dilemma(graph, "dilemma::d2", ["path::d2_x", "path::d2_y"])
+
+        # Intersection beat from d1_a — commits d1
+        _make_beat(
+            graph,
+            "beat::inter_d1",
+            "D1 intersection beat",
+            dilemma_impacts=[{"dilemma_id": "dilemma::d1", "effect": "commits"}],
+        )
+        _add_belongs_to(graph, "beat::inter_d1", "path::d1_a")
+
+        # Intersection beat from d2_x — does NOT commit
+        _make_beat(graph, "beat::inter_d2", "D2 intersection beat")
+        _add_belongs_to(graph, "beat::inter_d2", "path::d2_x")
+
+        # Children on d1's paths (real choices for d1)
+        _make_beat(graph, "beat::d1a_next", "D1A next")
+        _add_belongs_to(graph, "beat::d1a_next", "path::d1_a")
+        _add_predecessor(graph, "beat::d1a_next", "beat::inter_d1")
+
+        _make_beat(graph, "beat::d1b_next", "D1B next")
+        _add_belongs_to(graph, "beat::d1b_next", "path::d1_b")
+        _add_predecessor(graph, "beat::d1b_next", "beat::inter_d1")
+
+        # Children on d2's paths (interleave from inter_d1, NOT choices)
+        _make_beat(graph, "beat::d2x_next", "D2X next")
+        _add_belongs_to(graph, "beat::d2x_next", "path::d2_x")
+        _add_predecessor(graph, "beat::d2x_next", "beat::inter_d1")
+
+        _make_beat(graph, "beat::d2y_next", "D2Y next")
+        _add_belongs_to(graph, "beat::d2y_next", "path::d2_y")
+        _add_predecessor(graph, "beat::d2y_next", "beat::inter_d1")
+
+        specs = [
+            PassageSpec(
+                passage_id="passage::inter",
+                beat_ids=["beat::inter_d1", "beat::inter_d2"],
+                summary="intersection",
+                grouping_type="intersection",
+            ),
+            PassageSpec(
+                passage_id="passage::d1a",
+                beat_ids=["beat::d1a_next"],
+                summary="d1a",
+            ),
+            PassageSpec(
+                passage_id="passage::d1b",
+                beat_ids=["beat::d1b_next"],
+                summary="d1b",
+            ),
+            PassageSpec(
+                passage_id="passage::d2x",
+                beat_ids=["beat::d2x_next"],
+                summary="d2x",
+            ),
+            PassageSpec(
+                passage_id="passage::d2y",
+                beat_ids=["beat::d2y_next"],
+                summary="d2y",
+            ),
+        ]
+
+        choices = compute_choice_edges(graph, specs)
+
+        # Only 2 choices: inter → d1a and inter → d1b (d1's commit)
+        # NOT inter → d2x or inter → d2y (d2 has no commit here)
+        assert len(choices) == 2, (
+            f"Expected 2 choices (d1 commit only), got {len(choices)}: "
+            f"{[(c.from_passage, c.to_passage) for c in choices]}"
+        )
+        to_passages = {c.to_passage for c in choices}
+        assert to_passages == {"passage::d1a", "passage::d1b"}
+
+    def test_realistic_fanout_bounded(self) -> None:
+        """With 3 dilemmas (6 paths), interleave-style edges, and one commit
+        per dilemma: total choices ≈ 2 per dilemma = 6, not combinatorial."""
+        graph = Graph.empty()
+
+        # 3 dilemmas x 2 paths each
+        dilemmas = ["dilemma::d1", "dilemma::d2", "dilemma::d3"]
+        all_paths: dict[str, list[str]] = {}
+        for i, did in enumerate(dilemmas, 1):
+            pa = f"path::d{i}_a"
+            pb = f"path::d{i}_b"
+            graph.create_node(pa, {"type": "path", "raw_id": f"d{i}_a"})
+            graph.create_node(pb, {"type": "path", "raw_id": f"d{i}_b"})
+            _setup_dilemma(graph, did, [pa, pb])
+            all_paths[did] = [pa, pb]
+
+        # One commit beat per dilemma (on path_a), with children on both paths
+        specs_list: list[PassageSpec] = []
+        for i, did in enumerate(dilemmas, 1):
+            pa, pb = all_paths[did]
+            commit_id = f"beat::commit_d{i}"
+            _make_beat(
+                graph,
+                commit_id,
+                f"Commit D{i}",
+                dilemma_impacts=[{"dilemma_id": did, "effect": "commits"}],
+            )
+            _add_belongs_to(graph, commit_id, pa)
+
+            # Child on path_a (same path continuation)
+            ca = f"beat::d{i}_a_next"
+            _make_beat(graph, ca, f"D{i} A next")
+            _add_belongs_to(graph, ca, pa)
+            _add_predecessor(graph, ca, commit_id)
+
+            # Child on path_b (real choice)
+            cb = f"beat::d{i}_b_next"
+            _make_beat(graph, cb, f"D{i} B next")
+            _add_belongs_to(graph, cb, pb)
+            _add_predecessor(graph, cb, commit_id)
+
+            # Cross-dilemma interleave children (NOT choices)
+            for j, other_did in enumerate(dilemmas, 1):
+                if other_did == did:
+                    continue
+                for suffix in ["a", "b"]:
+                    other_path = f"path::d{j}_{suffix}"
+                    interleave_id = f"beat::interleave_d{i}_to_d{j}_{suffix}"
+                    _make_beat(graph, interleave_id, f"Interleave {i}→{j}{suffix}")
+                    _add_belongs_to(graph, interleave_id, other_path)
+                    _add_predecessor(graph, interleave_id, commit_id)
+
+            specs_list.append(
+                PassageSpec(
+                    passage_id=f"passage::commit_d{i}",
+                    beat_ids=[commit_id],
+                    summary=f"commit d{i}",
+                )
+            )
+            specs_list.append(
+                PassageSpec(passage_id=f"passage::d{i}_a", beat_ids=[ca], summary=f"d{i} a")
+            )
+            specs_list.append(
+                PassageSpec(passage_id=f"passage::d{i}_b", beat_ids=[cb], summary=f"d{i} b")
+            )
+
+        # Add passages for interleave beats
+        for i in range(1, 4):
+            for j in range(1, 4):
+                if i == j:
+                    continue
+                for suffix in ["a", "b"]:
+                    bid = f"beat::interleave_d{i}_to_d{j}_{suffix}"
+                    specs_list.append(
+                        PassageSpec(
+                            passage_id=f"passage::il_d{i}_d{j}_{suffix}",
+                            beat_ids=[bid],
+                            summary=f"il {i}→{j}{suffix}",
+                        )
+                    )
+
+        choices = compute_choice_edges(graph, specs_list)
+
+        # 3 dilemmas x 2 choices each = 6 total, NOT the combinatorial explosion
+        assert len(choices) == 6, (
+            f"Expected 6 choices (2 per dilemma), got {len(choices)}: "
+            f"{[(c.from_passage, c.to_passage) for c in choices]}"
+        )
 
 
 class TestFindFalseBranchCandidates:
@@ -867,11 +1226,11 @@ class TestChoiceSpecRequires:
     """compute_choice_edges must populate requires for choices from intersection passages."""
 
     def _build_convergence_graph(self, graph: Graph) -> None:
-        """Build a graph where an intersection beat diverges to two paths.
+        """Build a graph where an intersection commit beat diverges to two paths.
 
         Structure:
-          start (pa) → merge (intersection, pa) → c (pc, commits d1) ──┐
-                                                → d (pd, commits d1) ──┴→ (end)
+          start (pa) → merge (intersection, pa, commits d1) → c (pc, commits d1) ──┐
+                                                             → d (pd, commits d1) ──┴→ (end)
 
         The intersection passage (containing beat::merge) diverges to paths pc
         and pd. beat::c and beat::d are the first commit beats on their paths,
@@ -879,9 +1238,9 @@ class TestChoiceSpecRequires:
         returns a single-combo result for each child, allowing requires to be set.
         """
         graph.create_node("dilemma::d1", {"type": "dilemma", "raw_id": "d1", "status": "explored"})
-        graph.create_node("path::pa", {"type": "path", "raw_id": "pa"})
-        graph.create_node("path::pc", {"type": "path", "raw_id": "pc"})
-        graph.create_node("path::pd", {"type": "path", "raw_id": "pd"})
+        graph.create_node("path::pa", {"type": "path", "raw_id": "pa", "dilemma_id": "d1"})
+        graph.create_node("path::pc", {"type": "path", "raw_id": "pc", "dilemma_id": "d1"})
+        graph.create_node("path::pd", {"type": "path", "raw_id": "pd", "dilemma_id": "d1"})
         graph.create_node(
             "state_flag::d1_pc",
             {
@@ -907,28 +1266,24 @@ class TestChoiceSpecRequires:
         _make_beat(graph, "beat::start", "Start")
         graph.add_edge("belongs_to", "beat::start", "path::pa")
 
-        # Intersection beat (no commit ancestors)
-        _make_beat(graph, "beat::merge", "Merge beat")
+        # Intersection beat — commits d1, creating the divergence point
+        _make_beat(
+            graph,
+            "beat::merge",
+            "Merge beat",
+            dilemma_impacts=[{"dilemma_id": "dilemma::d1", "effect": "commits"}],
+        )
         graph.add_edge("belongs_to", "beat::merge", "path::pa")
         graph.create_node(
             "intersection_group::g1",
             {"type": "intersection_group", "raw_id": "g1", "beat_ids": ["beat::merge"]},
         )
 
-        # Post-intersection beats on two different paths — each commits to d1
-        _make_beat(
-            graph,
-            "beat::c",
-            "Path C beat",
-            dilemma_impacts=[{"effect": "commits", "dilemma_id": "dilemma::d1"}],
-        )
+        # Post-intersection beats on two different paths — the commit already
+        # happened at merge; these are regular beats on d1's diverging paths.
+        _make_beat(graph, "beat::c", "Path C beat")
         graph.add_edge("belongs_to", "beat::c", "path::pc")
-        _make_beat(
-            graph,
-            "beat::d",
-            "Path D beat",
-            dilemma_impacts=[{"effect": "commits", "dilemma_id": "dilemma::d1"}],
-        )
+        _make_beat(graph, "beat::d", "Path D beat")
         graph.add_edge("belongs_to", "beat::d", "path::pd")
 
         # Predecessor edges
@@ -941,8 +1296,14 @@ class TestChoiceSpecRequires:
         graph = Graph.empty()
         graph.create_node("path::pa", {"type": "path", "raw_id": "pa"})
         graph.create_node("path::pb", {"type": "path", "raw_id": "pb"})
+        _setup_dilemma(graph, "dilemma::d1", ["path::pa", "path::pb"])
 
-        _make_beat(graph, "beat::start", "Start")
+        _make_beat(
+            graph,
+            "beat::start",
+            "Start",
+            dilemma_impacts=[{"dilemma_id": "dilemma::d1", "effect": "commits"}],
+        )
         _make_beat(graph, "beat::a", "Path A")
         _make_beat(graph, "beat::b", "Path B")
 


### PR DESCRIPTION
## Summary

- `compute_choice_edges()` previously treated ALL beats with children on different paths as divergence points, including cross-dilemma interleave ordering edges
- This produced ~273 choices when only ~16-30 should exist, causing POLISH Phase 7 "duplicate choice labels" validation failures
- Now only commit beats create choices, and only between paths of the committing dilemma

## Design Conformance

| # | Requirement | Status |
|---|---|---|
| 1 | Choice edges only at commit beats | CONFORMANT |
| 2 | Choices only between same-dilemma paths | CONFORMANT |
| 3 | Path→dilemma mapping via path node dilemma_id | CONFORMANT |
| 4 | Non-commit beats → zero choice edges | CONFORMANT |
| 5 | Choice specs carry from/to/requires/grants | CONFORMANT |
| 6 | Labels deferred to Phase 5 | CONFORMANT |
| 7 | Deduplication with grant merging (#1185) | CONFORMANT |
| 8 | Topological child selection (#1187) | CONFORMANT |
| 9 | Requires populated for intersection passages | CONFORMANT |
| 10 | All existing tests updated with commit markers | CONFORMANT |
| 11 | New multi-dilemma test class (4 tests) | CONFORMANT |

Pre-existing DEAD finding: `_check_divergences_have_choices()` reads nonexistent edge types → tracked in #1199.

## Changes

### `src/questfoundry/pipeline/stages/polish/deterministic.py`
- Build `path_to_dilemma` mapping from path node `dilemma_id` field
- Filter divergence beats to only those with `dilemma_impacts` `effect: commits`
- For each committing dilemma, create choices only between that dilemma's paths
- Cross-dilemma interleave children no longer produce choice edges

### `tests/unit/test_polish_deterministic.py`
- Add `_setup_dilemma()` helper for creating dilemma context in fixtures
- Update all existing choice edge test classes with commit beat markers and dilemma nodes
- Add `TestChoiceEdgesMultiDilemma` class with 4 tests:
  - Non-commit beat with cross-dilemma children → zero choices
  - Commit beat creates choices only for own dilemma's paths
  - Intersection with commit from one dilemma → only that dilemma's choices
  - Realistic fanout: 3 dilemmas x 2 paths = 6 choices (not combinatorial)

## Test plan

- [x] `uv run pytest tests/unit/test_polish_deterministic.py -x -q` — 61 passed
- [x] `uv run pytest tests/unit/ -x -q` — 2727 passed (1 pre-existing failure in test_provider_factory.py)
- [x] `uv run ruff check` + `uv run mypy` — clean
- [x] `@architect-reviewer` conformance sign-off — all CONFORMANT

Closes #1197
Closes #1198

🤖 Generated with [Claude Code](https://claude.com/claude-code)