### PR TITLE
docs: amend belongs_to semantics for pre-commit beats

### DIFF
--- a/docs/design/document-3-ontology.md
+++ b/docs/design/document-3-ontology.md
@@ -312,7 +312,7 @@ A beat that co-occurs with another path's beat does not become part of that path
 An intersection is represented as a grouping relationship between beats:
 
 - An **intersection group** links two or more beats from different paths that co-occur in one scene.
-- Each beat retains its original `belongs_to` edge to its own path.
+- Each beat retains its existing `belongs_to` edges (one for post-commit beats; two for same-dilemma pre-commit beats — see Part 8, "Path Membership ≠ Scene Participation").
 - The intersection group carries the resolved scene context: shared location, shared entities, and a rationale for why these beats work as one scene.
 
 The grouping tells POLISH: "when you create passages, these beats should become one passage (or part of one passage)." It tells FILL: "write one scene that advances dilemma A through beat X AND dilemma B through beat Y simultaneously."

--- a/docs/design/document-3-ontology.md
+++ b/docs/design/document-3-ontology.md
@@ -568,7 +568,15 @@ Only the first is narrative convergence. An LLM seeing "two edges point to the s
 
 A beat's `belongs_to` edge means "this beat serves this path's storyline — it advances this path's dilemma." It does NOT mean "this beat only appears on this path" or "this beat is about this path."
 
-Intersection beats participate in scenes with beats from other paths, but they still belong to their original path. The current implementation's cross-assignment of `belongs_to` edges conflated "shares a scene with beats from path B" with "is part of path B's storyline." This produced the hard-convergence violation: beats from mutually exclusive paths appeared to belong to both, creating structurally impossible scenes.
+Intersection beats participate in scenes with beats from other paths, but they still belong to their original path. The historical cross-assignment of `belongs_to` edges across dilemmas conflated "shares a scene with beats from path B" with "is part of path B's storyline." This produced the hard-convergence violation: beats from mutually exclusive dilemmas appeared to belong to both, creating structurally impossible scenes.
+
+**Same-dilemma pre-commit multi-`belongs_to` is permitted.** A pre-commit beat — one that occurs before the dilemma's commit point — belongs to both paths of its own dilemma. This is structurally correct: every player experiences pre-commit beats regardless of which path they will later choose. Pre-commit beats have two `belongs_to` edges (one to each path in the dilemma); post-commit beats have exactly one. This is not the same as cross-dilemma multi-assignment, which remains forbidden.
+
+Guard rails:
+
+1. **Same-dilemma constraint.** A beat with two `belongs_to` edges must reference two paths that belong to the same dilemma. Cross-dilemma multi-`belongs_to` is a hard-convergence violation.
+2. **Pre-commit only.** Only beats before the dilemma's commit may have two `belongs_to` edges. The commit beat itself has one (it is the first beat exclusive to its path). Post-commit beats always have one.
+3. **Intersection exclusion.** An intersection group must not contain two pre-commit beats from the same dilemma — they already co-occur by definition; declaring them as an intersection is redundant and creates false structural implications.
 
 ### Beat Ordering ≠ Temporal Position Relative to Commits
 
@@ -655,7 +663,7 @@ The danger: creating separate entity nodes for each state combination (`mentor_t
 | `anchored_to` | Dilemma → Entity | BRAINSTORM | Entities central to this dilemma |
 | `explores` | Path → Answer | SEED | Which answer this path develops |
 | `has_consequence` | Path → Consequence | SEED | Narrative outcomes of this path |
-| `belongs_to` | Beat → Path | SEED | Which path this beat serves (single path) |
+| `belongs_to` | Beat → Path | SEED | Which path this beat serves. Pre-commit beats have two edges (both paths in the dilemma); post-commit beats have one. |
 | `flexibility` | Beat → Entity | SEED | Substitutable entity with role annotation. Working — consumed by GROW. |
 | `predecessor` | Beat → Beat | GROW | Ordering in the beat DAG (B comes after A) |
 | `intersection` | Beat → Intersection Group | GROW | This beat participates in this co-occurrence group |
@@ -838,10 +846,10 @@ This section documents where the current implementation (`docs/design/00-spec.md
 
 **Impact:** The `RoutingPlan` architecture transfers to POLISH as `PolishPlan`. ADR-017 needs supersession. GROW phases 7–9 (passage creation, choice creation, routing) move to POLISH.
 
-### InitialBeat.paths — List vs Singular belongs_to
+### InitialBeat.paths — Same-Dilemma Dual belongs_to
 
-**Current:** `InitialBeat.paths` is `list[str]` with `min_length=1`. The mutation creates one `belongs_to` edge per path in the list, allowing a beat to belong to multiple paths simultaneously. The serialize prompt shows multiple paths as valid.
+**Current:** `InitialBeat.paths` is `list[str]` with `min_length=1`. The mutation creates one `belongs_to` edge per path in the list.
 
-**This document:** Each beat has exactly one `belongs_to` edge to one path (Part 1, Part 3, Part 9). Multi-path membership conflates path membership with scene co-occurrence — the exact pattern that caused the hard-convergence violation. Co-occurrence is modeled by intersection groups (Part 4), not by multiple `belongs_to` edges.
+**This document:** Pre-commit beats belong to both paths of their dilemma (two `belongs_to` edges); post-commit beats belong to one path (one `belongs_to` edge). This is structurally correct: pre-commit beats are experienced by all players before the choice is made. The historical prohibition on multi-path `belongs_to` (Part 8) targeted cross-dilemma multi-assignment — the pattern that caused hard-convergence violations. Same-dilemma pre-commit dual membership is a different structural relationship and is explicitly permitted (see Part 8, "Path Membership ≠ Scene Participation").
 
-**Impact:** `InitialBeat.paths` becomes singular `path_id: str`. Intersection co-occurrence is signaled through entity flexibility annotations, not multi-path assignment. The mutation, prompt, and validation all need updating.
+**Impact:** `InitialBeat` needs a mechanism to signal which beats are pre-commit (dual `belongs_to`) vs post-commit (singular `belongs_to`). The recommended approach is an `also_belongs_to: str | null` field — null for post-commit beats, the other path's ID for pre-commit beats. GROW and POLISH consumers that assume one `belongs_to` per beat need auditing. See #1206.

--- a/docs/design/document-3-ontology.md
+++ b/docs/design/document-3-ontology.md
@@ -736,7 +736,7 @@ This section documents where the current implementation (`docs/design/00-spec.md
 
 **Current:** Intersection is modeled by cross-assigning `belongs_to` edges. A beat from path A gets an additional `belongs_to` edge to path B, making it "belong to" both paths. This was the direct cause of the hard-convergence violation fixed on the `fix/hard-convergence-intersection` branch.
 
-**This document:** Intersection is a co-occurrence grouping. Beats retain their single `belongs_to` edge. A separate intersection group declares which beats from different paths share a scene. Path membership and scene participation are distinct concepts.
+**This document:** Intersection is a co-occurrence grouping. Beats retain their existing `belongs_to` edges (one for post-commit beats; two for same-dilemma pre-commit beats — see Part 8, "Path Membership ≠ Scene Participation"). A separate intersection group declares which beats from different paths share a scene. Path membership and scene participation are distinct concepts.
 
 **Impact:** The `apply_intersection_mark()` function in `grow_algorithms.py` and all code that queries `belongs_to` edges to determine intersection membership needs redesign.
 

--- a/docs/design/how-branching-stories-work.md
+++ b/docs/design/how-branching-stories-work.md
@@ -130,7 +130,7 @@ Each explored path needs a skeleton: a sequence of beats that carries the dilemm
 
 Each path's beats should form a coherent story on their own. If you read just one path's beats in order, they should make narrative sense — a beginning, a middle, and an end. GROW will interleave beats from different paths, but it shouldn't need to invent missing structural beats. If the scaffold is incomplete, GROW is forced to fill gaps that are really SEED's responsibility.
 
-A note about pre-commit beats: beats that come before a dilemma's commit are "experienced by every player" — both path A and path B players encounter them. But each pre-commit beat still **belongs to one path**. Path membership describes which dilemma storyline the beat serves, not which players encounter it. A beat on the mentor-trust path that introduces the mentor is encountered by all players (the dilemma hasn't committed yet), but it advances the trust storyline specifically. Its reachability from all starting points comes from the DAG topology — not from belonging to multiple paths.
+A note about pre-commit beats: beats that come before a dilemma's commit are experienced by every player — both path A and path B players encounter them. Pre-commit beats **belong to both paths** of the dilemma (two `belongs_to` edges). This reflects a structural fact: before the commit, no choice has been made, so the beat is part of both storylines. The commit beat is the first beat exclusive to one path — it is where the fork happens. Post-commit beats belong to exactly one path. This produces a Y-shaped DAG per dilemma: shared pre-commit beats → commit fork → two path-specific post-commit chains.
 
 ### Entity Flexibility
 


### PR DESCRIPTION
## Summary

- **Document 3** (ontology): Amend `belongs_to` edge definition and multi-path prohibition to explicitly permit same-dilemma pre-commit dual `belongs_to` edges, with three guard rails
- **Document 1** (how branching stories work): Replace incorrect "belongs to one path" explanation with Y-shaped DAG model
- **Document 3** reconciliation section: Rewrite from "make singular" to "dual is correct", referencing `also_belongs_to: str | null` approach

Closes #1206 (doc amendment portion only — implementation tracked separately in #1206)

## Context

`compute_choice_edges()` in POLISH Phase 4c produces 0 choices because SEED creates independent parallel path chains instead of Y-shaped forks. The design docs (polish.md Phase 4c) are correct — the algorithm needs DAG divergence points. But Document 3 and Document 1 incorrectly prohibited the multi-`belongs_to` structure that creates those divergence points.

The historical prohibition targeted cross-dilemma multi-assignment (hard-convergence bug). Same-dilemma pre-commit dual `belongs_to` is a structurally different relationship and is now explicitly permitted.

## Changes

### Document 3 (`document-3-ontology.md`)
1. **Edge table** (line 666): `belongs_to` description updated from "single path" to dual-edge semantics
2. **Part 8, "Path Membership ≠ Scene Participation"**: New paragraph + 3 guard rails:
   - Same-dilemma constraint (cross-dilemma remains forbidden)
   - Pre-commit only (commit beat is first exclusive beat)
   - Intersection exclusion (pre-commit beats from same dilemma already co-occur)
3. **Reconciliation section**: Rewritten to align with the corrected model, referencing #1206

### Document 1 (`how-branching-stories-work.md`)
4. **Line 133**: "belongs to one path" → pre-commit beats belong to both paths, producing Y-shaped DAG

## Test plan

- [ ] No code changes — doc-only PR
- [ ] Verify guard rails are consistent with Part 8's existing hard-convergence discussion
- [ ] Verify reconciliation section correctly references Part 8 and #1206

🤖 Generated with [Claude Code](https://claude.com/claude-code)