### PR TITLE
docs: rename Document 3 -> Story Graph Ontology and drop Document N nomenclature

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -247,20 +247,20 @@ log.error("provider_error", provider="ollama", message=str(e))
 
 ### Model Workflow (Ontology → Pydantic → Graph)
 
-**[Document 3](docs/design/document-3-ontology.md) defines the authoritative ontology.** The design specification (`docs/design/00-spec.md`) provides supplementary context. Pydantic models in `src/questfoundry/models/` are hand-written implementations of that ontology. The graph (`graph.db`) is the runtime source of truth for story state.
+**The [Story Graph Ontology](docs/design/story-graph-ontology.md) defines the authoritative ontology.** The design specification (`docs/design/00-spec.md`) provides supplementary context. Pydantic models in `src/questfoundry/models/` are hand-written implementations of that ontology. The graph (`graph.db`) is the runtime source of truth for story state.
 
 ```
-docs/design/document-3-ontology.md  ← Authoritative ontology (node types, relationships)
+docs/design/story-graph-ontology.md  ← Authoritative ontology (node types, relationships)
         ↓
-src/questfoundry/models/*.py        ← Hand-written Pydantic models (validate LLM output)
+src/questfoundry/models/*.py         ← Hand-written Pydantic models (validate LLM output)
         ↓
-graph/mutations.py                  ← Semantic validation against graph state
+graph/mutations.py                   ← Semantic validation against graph state
         ↓
-graph.db                            ← Runtime source of truth (SQLite, nodes + edges)
+graph.db                             ← Runtime source of truth (SQLite, nodes + edges)
 ```
 
 **When adding new stage models:**
-1. Check the ontology in `docs/design/document-3-ontology.md` for the node types and fields
+1. Check the ontology in `docs/design/story-graph-ontology.md` for the node types and fields
 2. Create/update Pydantic models in `src/questfoundry/models/`
 3. Add semantic validation in `graph/mutations.py` if needed
 4. Export from `models/__init__.py`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -325,7 +325,7 @@ The codebase has a history of implementations that run without errors but are mi
 Before creating a PR or closing an issue that touches pipeline stages:
 
 1. **Launch the `architect-reviewer` subagent** with:
-   - The relevant design document sections (Doc 1, Doc 3, procedure docs)
+   - The relevant design document sections ("How Branching Stories Work", the Story Graph Ontology, procedure docs)
    - The implementation files being changed
    - The issue acceptance criteria (if applicable)
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ DREAM → BRAINSTORM → SEED → GROW → FILL → SHIP
 
 ## Development
 
-QuestFoundry uses an **ontology-first** approach: the [graph ontology](docs/design/document-3-ontology.md) defines node types and relationships, and hand-written Pydantic models in `src/questfoundry/models/` implement it. The graph (`graph.db`) is the runtime source of truth.
+QuestFoundry uses an **ontology-first** approach: the [graph ontology](docs/design/story-graph-ontology.md) defines node types and relationships, and hand-written Pydantic models in `src/questfoundry/models/` implement it. The graph (`graph.db`) is the runtime source of truth.
 
 ## License
 

--- a/docs/analysis/polish-conformance-report-2026-03-05.md
+++ b/docs/analysis/polish-conformance-report-2026-03-05.md
@@ -4,7 +4,7 @@
 **Reviewer**: architect-reviewer subagent (adversarial review)
 **Design documents reviewed**:
 - `docs/design/how-branching-stories-work.md`
-- `docs/design/document-3-ontology.md`
+- `docs/design/story-graph-ontology.md`
 - `docs/design/procedures/polish.md`
 
 **Implementation reviewed**:
@@ -30,7 +30,7 @@
 | 5 | Phase 2: pacing flags (3+ scene/sequel runs, post-commit sequel) | polish.md, Phase 2 | CONFORMANT | `llm_phases.py:645-794` |
 | 6 | Phase 2: micro-beats with `role: "micro_beat"` in linear sections | polish.md, Phase 2 | CONFORMANT | `llm_phases.py:797-850` |
 | 7 | Phase 3: character arc synthesis (entities in 2+ beats) | polish.md, Phase 3 | CONFORMANT | `llm_phases.py:212-288` |
-| 8 | Phase 3: arc metadata annotated on entity nodes (via graph edge) | Doc 3, Part 1 | PARTIAL | Stored as orphan `character_arc_metadata::` nodes; no `has_arc_metadata` edge to entity; consumers match by string → **#1154** |
+| 8 | Phase 3: arc metadata annotated on entity nodes (via graph edge) | Story Graph Ontology, Part 1 | PARTIAL | Stored as orphan `character_arc_metadata::` nodes; no `has_arc_metadata` edge to entity; consumers match by string → **#1154** |
 | 9 | Human gate after Phase 3 | polish.md, "Human Gates" | PARTIAL | Gate fires after every phase generically; no special post-Phase-3 behavior. AutoApprovePhaseGate auto-approves. |
 | 10 | Phase 4a: beat grouping (intersection, collapse, singleton) | polish.md, Phase 4a | CONFORMANT | `deterministic.py:181-299` |
 | 11 | Phase 4b: prose feasibility audit (two passes, 5 categories) | polish.md, Phase 4b | CONFORMANT | `deterministic.py:307-426` |
@@ -52,14 +52,14 @@
 | 27 | Phase 7: no passage has outgoing choices with overlapping `requires` | polish.md, Phase 7 | MISSING | Not checked → **#1156** |
 | 28 | Phase 7: arc completeness (every arc = complete passage sequence) | polish.md, Phase 7 | DEAD | Structurally impossible while `arc_traversals == {}` (see #15) → **#1153, #1156** |
 | 29 | Phase 7: no structural split left unresolved | polish.md, Phase 7 | MISSING | Structural split warnings from 4b are not validated against phase 7 state → **#1156** |
-| 30 | Residue beats: one variant per path, gated by state flag | Doc 1, Part 4; Doc 3, Part 5 | CONFORMANT | `deterministic.py:759-802` |
-| 31 | Transition guidance for collapsed passages | Doc 1, Part 4, "Passage Collapse" | MISSING | `_merge_summaries` joins with "; " — no bridging instructions generated → **#1158** |
-| 32 | Phase 2 injects micro-beats for pacing | Doc 1, Part 4, "Pacing" | CONFORMANT | Phase 2 |
-| 33 | `grouped_in` edge (beat → passage) | Doc 3, Part 9 | CONFORMANT | `deterministic.py:740` |
-| 34 | `choice` edge with label, requires, grants | Doc 3, Part 9 | CONFORMANT | `deterministic.py:805-815` |
-| 35 | `variant_of` edge (variant → base passage) | Doc 3, Part 9 | CONFORMANT | `deterministic.py:756` |
-| 36 | POLISH audits overlay composition for prose feasibility | Doc 3, Part 6 | MISSING | Phase 4b checks state flags vs entity overlap but not multi-overlay infeasibility → **#1162** |
-| 37 | POLISH may create cosmetic codewords | Doc 3, Part 1 | DEFERRED | Doc 3 line 719 explicitly defers this pattern. Filed as design discussion → **#1163** |
+| 30 | Residue beats: one variant per path, gated by state flag | "How Branching Stories Work", Part 4; Story Graph Ontology, Part 5 | CONFORMANT | `deterministic.py:759-802` |
+| 31 | Transition guidance for collapsed passages | "How Branching Stories Work", Part 4, "Passage Collapse" | MISSING | `_merge_summaries` joins with "; " — no bridging instructions generated → **#1158** |
+| 32 | Phase 2 injects micro-beats for pacing | "How Branching Stories Work", Part 4, "Pacing" | CONFORMANT | Phase 2 |
+| 33 | `grouped_in` edge (beat → passage) | Story Graph Ontology, Part 9 | CONFORMANT | `deterministic.py:740` |
+| 34 | `choice` edge with label, requires, grants | Story Graph Ontology, Part 9 | CONFORMANT | `deterministic.py:805-815` |
+| 35 | `variant_of` edge (variant → base passage) | Story Graph Ontology, Part 9 | CONFORMANT | `deterministic.py:756` |
+| 36 | POLISH audits overlay composition for prose feasibility | Story Graph Ontology, Part 6 | MISSING | Phase 4b checks state flags vs entity overlap but not multi-overlay infeasibility → **#1162** |
+| 37 | POLISH may create cosmetic codewords | Story Graph Ontology, Part 1 | DEFERRED | Story Graph Ontology line 719 explicitly defers this pattern. Filed as design discussion → **#1163** |
 | 38 | Phase ordering: collapse_linear_beats between character_arcs and plan_computation | Registry | CONFORMANT | `deterministic.py:66-69` |
 
 ---
@@ -89,7 +89,7 @@
 ### MISSING (most impactful)
 
 **#13: `ChoiceSpec.requires` never populated** (`#1152`)
-`compute_choice_edges` only computes `grants`. Post-convergence gated choices — a core design concept in Doc 1 ("Gates appear after soft dilemma convergence") — are never generated. All choices are always visible to all players regardless of prior decisions. Soft dilemma convergence routing is non-functional.
+`compute_choice_edges` only computes `grants`. Post-convergence gated choices — a core design concept in "How Branching Stories Work" ("Gates appear after soft dilemma convergence") — are never generated. All choices are always visible to all players regardless of prior decisions. Soft dilemma convergence routing is non-functional.
 
 **#23–#29: Phase 7 validation is a skeleton** (`#1156`)
 Of 10+ required checks, only ~5 are implemented. `check_all_endings_reachable` and `check_gate_satisfiability` exist but are never called. Critical structural invariants (divergences have choices, arc completeness, no unresolved splits) are unchecked.

--- a/docs/architecture/decisions.md
+++ b/docs/architecture/decisions.md
@@ -513,9 +513,9 @@ Key design choices:
 - Topology enforcement for `hard` policy deferred to #751
 - Spoke grants wiring deferred to #752
 
-> **Forward-looking note (2026-02-24):** [Document 3](../design/document-3-ontology.md) replaces `convergence_policy` (hard/soft/flavor) with `dilemma_role` (hard/soft). Convergence behavior is derived from the role. `flavor` is removed — handled by POLISH as false branches. A superseding ADR will be created when the code migration is implemented. See [Issue #977](https://github.com/pvliesdonk/questfoundry/issues/977).
+> **Forward-looking note (2026-02-24):** The [Story Graph Ontology](../design/story-graph-ontology.md) replaces `convergence_policy` (hard/soft/flavor) with `dilemma_role` (hard/soft). Convergence behavior is derived from the role. `flavor` is removed — handled by POLISH as false branches. A superseding ADR will be created when the code migration is implemented. See [Issue #977](https://github.com/pvliesdonk/questfoundry/issues/977).
 >
-> **Impact on `flavor` (2026-02-25):** The `flavor` convergence category is fully removed from the ontology. During migration, existing `flavor` values are mapped to `soft` with `residue_weight: cosmetic` (a field defined in [Document 3, Part 2](../design/document-3-ontology.md)). A Pydantic model validator with a deprecation warning handles backward compatibility with existing graph data. Flavor-level choices are not dilemmas — they become false branches or minor passage variants created by POLISH. See [Issue #984](https://github.com/pvliesdonk/questfoundry/issues/984) for the migration plan.
+> **Impact on `flavor` (2026-02-25):** The `flavor` convergence category is fully removed from the ontology. During migration, existing `flavor` values are mapped to `soft` with `residue_weight: cosmetic` (a field defined in the [Story Graph Ontology, Part 2](../design/story-graph-ontology.md)). A Pydantic model validator with a deprecation warning handles backward compatibility with existing graph data. Flavor-level choices are not dilemmas — they become false branches or minor passage variants created by POLISH. See [Issue #984](https://github.com/pvliesdonk/questfoundry/issues/984) for the migration plan.
 
 ---
 
@@ -586,7 +586,7 @@ Key design choices:
 - `grow_phase2_agnostic.yaml` template deleted.
 - No behavioral change for stories — residue beats were already generating variation before the cleanup.
 
-> **Note (2026-02-24):** [Document 3](../design/document-3-ontology.md) retains the residue beats concept but splits the unified "codeword" concept into "state flags" (internal routing) and "codewords" (player-facing gamebook markers). The structural approach is preserved; the terminology changes in a future PR. See [Issue #977](https://github.com/pvliesdonk/questfoundry/issues/977).
+> **Note (2026-02-24):** The [Story Graph Ontology](../design/story-graph-ontology.md) retains the residue beats concept but splits the unified "codeword" concept into "state flags" (internal routing) and "codewords" (player-facing gamebook markers). The structural approach is preserved; the terminology changes in a future PR. See [Issue #977](https://github.com/pvliesdonk/questfoundry/issues/977).
 >
 > **Stage boundary note (2026-02-25):** Residue beat creation moves from GROW Phase 8d to POLISH Phase 5 (LLM enrichment) and Phase 6 (atomic application). The concept and its structural approach are unchanged — only the stage attribution shifts. See [ADR-019](#adr-019-polish-stage-supersedes-grow-routing).
 
@@ -705,7 +705,7 @@ Key design choices:
 - [ADR-013: Branching Contract Design](https://github.com/pvliesdonk/questfoundry/blob/main/docs/architecture/decisions.md#adr-013-branching-contract-design)
 - [ADR-015: Residue Beats Replace Poly-State Prose](https://github.com/pvliesdonk/questfoundry/blob/main/docs/architecture/decisions.md#adr-015-residue-beats-replace-poly-state-prose)
 
-> **Note (2026-02-24):** [Document 3](../design/document-3-ontology.md) redefines intersections as co-occurrence groups (not cross-path `belongs_to` edges) and moves passage/choice creation to the POLISH stage. The Unified Routing Plan architecture may need redesign to account for the POLISH stage boundary. Status remains Proposed pending Document 3 convergence work. See [Issue #977](https://github.com/pvliesdonk/questfoundry/issues/977).
+> **Note (2026-02-24):** The [Story Graph Ontology](../design/story-graph-ontology.md) redefines intersections as co-occurrence groups (not cross-path `belongs_to` edges) and moves passage/choice creation to the POLISH stage. The Unified Routing Plan architecture may need redesign to account for the POLISH stage boundary. Status remains Proposed pending Story Graph Ontology convergence work. See [Issue #977](https://github.com/pvliesdonk/questfoundry/issues/977).
 >
 > **Superseded (2026-02-25):** ADR-019 supersedes this ADR. The plan-then-execute architecture is preserved but moves from GROW to the new POLISH stage. `RoutingPlan` becomes `PolishPlan`. See [ADR-019](#adr-019-polish-stage-supersedes-grow-routing).
 
@@ -830,8 +830,8 @@ ADR-017's architecture (compute a complete plan, then apply atomically) is sound
 ### Links
 
 - [Discussion #980: Design Review — GROW/POLISH Stage Boundary](https://github.com/pvliesdonk/questfoundry/discussions/980)
-- [Document 1, Part 4: Shaping the Story (POLISH)](../design/how-branching-stories-work.md)
-- [Document 3, Parts 5-6: Passage Layer and Entity Overlays](../design/document-3-ontology.md)
+- ["How Branching Stories Work", Part 4: Shaping the Story (POLISH)](../design/how-branching-stories-work.md)
+- [Story Graph Ontology, Parts 5-6: Passage Layer and Entity Overlays](../design/story-graph-ontology.md)
 - [ADR-017: Unified Routing Plan (superseded)](#adr-017-unified-routing-plan-for-grow-variant-routing)
 - [Epic #990: Converge with Documents 1 and 3](https://github.com/pvliesdonk/questfoundry/issues/990)
 

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -3,7 +3,7 @@
 **Last Updated**: 2026-02-24
 **Implementation Status**: Slices 1–3 complete, Slice 4 (FILL) in progress
 
-> **Note (2026-02-24):** This document has not been kept fully up to date. The component status table and data flow diagram below are stale — they reflect Slice 1 state. For authoritative information, see [Document 1](../design/how-branching-stories-work.md) (story model), [Document 3](../design/document-3-ontology.md) (graph ontology), and the [ADRs](decisions.md). Key changes since this document was written: graph storage is now SQLite (`graph.db`, see ADR-014); all stage artifacts consolidated into the graph (see ADR-016); GROW is substantially implemented; POLISH stage specified but not yet implemented.
+> **Note (2026-02-24):** This document has not been kept fully up to date. The component status table and data flow diagram below are stale — they reflect Slice 1 state. For authoritative information, see ["How Branching Stories Work"](../design/how-branching-stories-work.md) (story model), the [Story Graph Ontology](../design/story-graph-ontology.md) (graph ontology), and the [ADRs](decisions.md). Key changes since this document was written: graph storage is now SQLite (`graph.db`, see ADR-014); all stage artifacts consolidated into the graph (see ADR-016); GROW is substantially implemented; POLISH stage specified but not yet implemented.
 
 ---
 

--- a/docs/design/00-spec.md
+++ b/docs/design/00-spec.md
@@ -4,7 +4,7 @@
 **Status:** Working draft — partially superseded
 **Supersedes:** qf-v5-vision.md, qf-v5-vision-delta001.md, questfoundry-v5-graph-ontology-v1-1.md
 
-> **Status update (2026-02-24):** [Document 1](how-branching-stories-work.md) and [Document 3](document-3-ontology.md) are now the authoritative source of truth for QuestFoundry's story model and graph ontology. Sections of this document marked "Superseded" below have been replaced by those documents. Unmarked sections remain valid. See [Issue #977](https://github.com/pvliesdonk/questfoundry/issues/977).
+> **Status update (2026-02-24):** ["How Branching Stories Work"](how-branching-stories-work.md) and the [Story Graph Ontology](story-graph-ontology.md) are now the authoritative source of truth for QuestFoundry's story model and graph ontology. Sections of this document marked "Superseded" below have been replaced by those documents. Unmarked sections remain valid. See [Issue #977](https://github.com/pvliesdonk/questfoundry/issues/977).
 
 ---
 
@@ -46,7 +46,7 @@ The complexity of the tooling exceeded what an AI coding agent could hold in wor
 
 ## Pipeline Overview
 
-> **Note:** The pipeline now includes a POLISH stage between GROW and FILL. See [Document 1, Part 4](how-branching-stories-work.md).
+> **Note:** The pipeline now includes a POLISH stage between GROW and FILL. See ["How Branching Stories Work", Part 4](how-branching-stories-work.md).
 
 ```
 DREAM → BRAINSTORM → SEED → GROW → POLISH → FILL → DRESS → SHIP
@@ -92,7 +92,7 @@ This keeps human cognitive load manageable while preserving authorial control.
 
 ## Graph Ontology
 
-> **Note:** [Document 3](document-3-ontology.md) is now the authoritative reference for the graph ontology (node types, edge types, properties). The general principles below (unified graph, graph-as-source-of-truth) remain valid. Specific node type definitions, edge types, and property details should be verified against Document 3.
+> **Note:** The [Story Graph Ontology](story-graph-ontology.md) is now the authoritative reference for the graph ontology (node types, edge types, properties). The general principles below (unified graph, graph-as-source-of-truth) remain valid. Specific node type definitions, edge types, and property details should be verified against the Story Graph Ontology.
 
 ### The Unified Graph
 
@@ -275,7 +275,7 @@ overlays:
 
 #### Codeword
 
-> **Superseded by [Document 3, Part 1](document-3-ontology.md).** Document 3 splits the unified "codeword" concept into *state flags* (internal routing markers) and *codewords* (player-facing gamebook markers). State flags are the primary mechanism; codewords are a SHIP-time projection of a subset of state flags. See Document 3, Part 6 for the full model.
+> **Superseded by the [Story Graph Ontology, Part 1](story-graph-ontology.md).** The Story Graph Ontology splits the unified "codeword" concept into *state flags* (internal routing markers) and *codewords* (player-facing gamebook markers). State flags are the primary mechanism; codewords are a SHIP-time projection of a subset of state flags. See the Story Graph Ontology, Part 6 for the full model.
 
 State marker. Universal mechanism for both plot progression and player choice.
 
@@ -580,7 +580,7 @@ Scene type is assigned during GROW (Phase 4: Gap Detection) to ensure pacing var
 
 #### Arc
 
-> **Superseded by [Document 3, Part 3](document-3-ontology.md).** Arcs are now computed DAG traversals (Cartesian product of path choices), not stored graph nodes. Diagnostic snapshots use a `materialized_` prefix to signal derived/read-only data. See Document 3, Appendix item 6.
+> **Superseded by the [Story Graph Ontology, Part 3](story-graph-ontology.md).** Arcs are now computed DAG traversals (Cartesian product of path choices), not stored graph nodes. Diagnostic snapshots use a `materialized_` prefix to signal derived/read-only data. See the Story Graph Ontology, Appendix item 6.
 
 Realized weaving of compatible paths.
 
@@ -642,7 +642,7 @@ illustration_brief:
 
 ## Edge Types
 
-> **Superseded by [Document 3](document-3-ontology.md).** Document 3 provides the authoritative edge type definitions with updated naming, new edge types (e.g., `anchored_to`, dilemma ordering relationships), and the intersection group model.
+> **Superseded by the [Story Graph Ontology](story-graph-ontology.md).** The Story Graph Ontology provides the authoritative edge type definitions with updated naming, new edge types (e.g., `anchored_to`, dilemma ordering relationships), and the intersection group model.
 
 > **Naming Convention:** Persistent edges use PascalCase (Choice, Appears) as they appear
 > in exports. Working edges use snake_case (belongs_to, has_answer) as they're internal only.
@@ -781,7 +781,7 @@ BRAINSTORM generates freely without worrying about path collision. Location flex
 
 ### Stage 3: SEED
 
-> **Terminology transition:** `convergence_policy` → `dilemma_role`, `InteractionConstraint` → dilemma ordering relationships. See [Document 3, Part 2](document-3-ontology.md) and the [procedure doc](procedures/seed.md) for details.
+> **Terminology transition:** `convergence_policy` → `dilemma_role`, `InteractionConstraint` → dilemma ordering relationships. See the [Story Graph Ontology, Part 2](story-graph-ontology.md) and the [procedure doc](procedures/seed.md) for details.
 
 **Purpose:** Triage brainstorm into committed structure. **Path creation gate.**
 
@@ -864,7 +864,7 @@ seed:
 
 #### Convergence: Topology Layer vs Prose Layer
 
-> **Superseded by [Document 3, Part 2](document-3-ontology.md).** The `convergence_policy` field (hard/soft/flavor) is replaced by `dilemma_role` (hard/soft). Convergence behavior is derived from the role. `flavor` is removed — flavor-level choices are handled by POLISH as false branches. The topology/prose layer separation concept is retained but the vocabulary changes. `ending_salience` and `residue_weight` remain as described. See also [Document 1, Part 2](how-branching-stories-work.md).
+> **Superseded by the [Story Graph Ontology, Part 2](story-graph-ontology.md).** The `convergence_policy` field (hard/soft/flavor) is replaced by `dilemma_role` (hard/soft). Convergence behavior is derived from the role. `flavor` is removed — flavor-level choices are handled by POLISH as false branches. The topology/prose layer separation concept is retained but the vocabulary changes. `ending_salience` and `residue_weight` remain as described. See also ["How Branching Stories Work", Part 2](how-branching-stories-work.md).
 
 Convergence control is split into two orthogonal layers:
 
@@ -959,7 +959,7 @@ Every codeword granted must appear in at least one `choice.requires_codewords` g
 
 ### Stage 4: GROW
 
-> **Scope change:** Documents 1 and 3 split the original GROW scope into GROW (beat DAG creation) and POLISH (passage layer). Passages, choices, codeword/state flag creation, and overlay creation move to POLISH. See [Document 1, Part 3–4](how-branching-stories-work.md) and the [procedure doc](procedures/grow.md) for details.
+> **Scope change:** "How Branching Stories Work" and the Story Graph Ontology split the original GROW scope into GROW (beat DAG creation) and POLISH (passage layer). Passages, choices, codeword/state flag creation, and overlay creation move to POLISH. See ["How Branching Stories Work", Part 3–4](how-branching-stories-work.md) and the [procedure doc](procedures/grow.md) for details.
 
 **Purpose:** Generate the complete story topology through graph mutation.
 
@@ -1028,7 +1028,7 @@ Every choice has a diegetic label.
 
 ### Stage 5: FILL
 
-> **Note:** FILL's input now comes from POLISH (not directly from GROW). Poly-state prose has been replaced by residue beats (see ADR-015). See [Document 1, Part 5](how-branching-stories-work.md) and the [procedure doc](procedures/fill.md).
+> **Note:** FILL's input now comes from POLISH (not directly from GROW). Poly-state prose has been replaced by residue beats (see ADR-015). See ["How Branching Stories Work", Part 5](how-branching-stories-work.md) and the [procedure doc](procedures/fill.md).
 
 **Purpose:** Generate prose for each passage.
 
@@ -1590,7 +1590,7 @@ When users run `qf review`:
 
 ## Summary Tables
 
-> **Note:** [Document 3, Appendix](document-3-ontology.md) provides updated summary tables reflecting the new ontology, including the state_flag/codeword split, intersection groups, and computed arcs.
+> **Note:** The [Story Graph Ontology, Appendix](story-graph-ontology.md) provides updated summary tables reflecting the new ontology, including the state_flag/codeword split, intersection groups, and computed arcs.
 
 ### All Node Types
 

--- a/docs/design/07-getting-started.md
+++ b/docs/design/07-getting-started.md
@@ -4,7 +4,7 @@
 **Last Updated**: 2026-02-24
 **Status**: Reference (partially complete)
 
-> **Note (2026-02-24):** Slices 1–3 are complete. GROW is substantially implemented. This document remains useful as a reference for the implementation approach but does not track current progress. For the authoritative story model, see [Document 1](how-branching-stories-work.md) and [Document 3](document-3-ontology.md). Note that Documents 1/3 introduce a POLISH stage (between GROW and FILL) not reflected in this guide's slice structure.
+> **Note (2026-02-24):** Slices 1–3 are complete. GROW is substantially implemented. This document remains useful as a reference for the implementation approach but does not track current progress. For the authoritative story model, see ["How Branching Stories Work"](how-branching-stories-work.md) and the [Story Graph Ontology](story-graph-ontology.md). Note that those two docs introduce a POLISH stage (between GROW and FILL) not reflected in this guide's slice structure.
 
 ---
 
@@ -18,7 +18,7 @@ This guide describes the recommended implementation order for a v5 cleanroom bui
 
 Before starting:
 
-1. Read [Document 1](./how-branching-stories-work.md) and [Document 3](./document-3-ontology.md) — Authoritative story model and graph ontology
+1. Read ["How Branching Stories Work"](./how-branching-stories-work.md) and the [Story Graph Ontology](./story-graph-ontology.md) — Authoritative story model and graph ontology
 2. Read [00-spec.md](./00-spec.md) — Supplementary specification
 3. Read [procedures/](./procedures/) — Stage algorithm specifications
 4. Set up development environment (see [06-proposed-dependencies.md](./06-proposed-dependencies.md))

--- a/docs/design/how-branching-stories-work.md
+++ b/docs/design/how-branching-stories-work.md
@@ -1,6 +1,6 @@
 # How to Build a Branching Interactive Story
 
-> **Status: Authoritative.** This document, together with [Document 3](document-3-ontology.md), is the authoritative source of truth for QuestFoundry's story model. Where other design documents contradict this one, this document takes precedence. See [Issue #977](https://github.com/pvliesdonk/questfoundry/issues/977).
+> **Status: Authoritative.** This document, together with the [Story Graph Ontology](story-graph-ontology.md), is the authoritative source of truth for QuestFoundry's story model. Where other design documents contradict this one, this document takes precedence. See [Issue #977](https://github.com/pvliesdonk/questfoundry/issues/977).
 
 ## Common Language
 
@@ -70,7 +70,7 @@ The pipeline builds a branching story in stages:
 | **DRESS** | Create illustrations and reference material |
 | **SHIP** | Export to playable formats |
 
-This document explains the creative process at each stage — not the code or the technical specification, but what an author is trying to accomplish and why. For the formal graph ontology that translates these narrative concepts into a data model, see [Document 3 — Story Graph Ontology](document-3-ontology.md).
+This document explains the creative process at each stage — not the code or the technical specification, but what an author is trying to accomplish and why. For the formal graph ontology that translates these narrative concepts into a data model, see the [Story Graph Ontology](story-graph-ontology.md).
 
 ---
 
@@ -156,7 +156,7 @@ SEED also identifies which soft dilemmas can be **serial** — one resolving bef
 
 A dilemma's commit is typically a single dramatic moment — one choice that locks in the path. But a commit can also be **distributed** across multiple smaller choices that accumulate toward resolution. Instead of one visible fork, the player makes three or five smaller decisions whose collective weight determines the outcome. The player may not realize which moments mattered until the reckoning — the point where the story reflects their accumulated pattern back to them.
 
-This pattern (known in interactive fiction craft as "moral dilemma chains" or "the Witcher Principle") makes hard choices less obvious and more resistant to save-scumming, but it has significant structural implications. It is not part of the current pipeline and is documented here as a known future direction. See [Document 3](document-3-ontology.md) for a discussion of the implementation options.
+This pattern (known in interactive fiction craft as "moral dilemma chains" or "the Witcher Principle") makes hard choices less obvious and more resistant to save-scumming, but it has significant structural implications. It is not part of the current pipeline and is documented here as a known future direction. See the [Story Graph Ontology](story-graph-ontology.md) for a discussion of the implementation options.
 
 ### Convergence Sketching
 

--- a/docs/design/procedures/brainstorm.md
+++ b/docs/design/procedures/brainstorm.md
@@ -1,6 +1,6 @@
 # BRAINSTORM Procedure
 
-> For the narrative description of the BRAINSTORM stage, see [Document 1, Part 1](../how-branching-stories-work.md). This document provides the detailed algorithm specification.
+> For the narrative description of the BRAINSTORM stage, see ["How Branching Stories Work", Part 1](../how-branching-stories-work.md). This document provides the detailed algorithm specification.
 
 ## Summary
 

--- a/docs/design/procedures/dream.md
+++ b/docs/design/procedures/dream.md
@@ -1,6 +1,6 @@
 # DREAM Procedure
 
-> For the narrative description of the DREAM stage, see [Document 1, Part 1](../how-branching-stories-work.md). This document provides the detailed algorithm specification.
+> For the narrative description of the DREAM stage, see ["How Branching Stories Work", Part 1](../how-branching-stories-work.md). This document provides the detailed algorithm specification.
 
 ## Summary
 

--- a/docs/design/procedures/dress.md
+++ b/docs/design/procedures/dress.md
@@ -4,9 +4,9 @@
 **Parent:** docs/design/00-spec.md
 **Purpose:** Detailed specification of the DRESS stage mechanics
 
-> For the narrative description of the DRESS stage, see [Document 1, Part 6](../how-branching-stories-work.md). This document provides the detailed algorithm specification.
+> For the narrative description of the DRESS stage, see ["How Branching Stories Work", Part 6](../how-branching-stories-work.md). This document provides the detailed algorithm specification.
 >
-> **Terminology note:** [Document 3](../document-3-ontology.md) distinguishes *state flags* (internal routing markers) from *codewords* (player-facing gamebook markers). This document uses "codewords" throughout, which maps to "state flags" in Document 3's vocabulary. Codex visibility gating uses state flags internally; SHIP projects a subset as player-facing codewords. The code has not yet been updated.
+> **Terminology note:** The [Story Graph Ontology](../story-graph-ontology.md) distinguishes *state flags* (internal routing markers) from *codewords* (player-facing gamebook markers). This document uses "codewords" throughout, which maps to "state flags" in the Story Graph Ontology's vocabulary. Codex visibility gating uses state flags internally; SHIP projects a subset as player-facing codewords. The code has not yet been updated.
 
 ---
 

--- a/docs/design/procedures/fill.md
+++ b/docs/design/procedures/fill.md
@@ -4,11 +4,11 @@
 **Parent:** questfoundry-v5-spec.md
 **Purpose:** Detailed specification of the FILL stage mechanics
 
-> For the narrative description of the FILL stage, see [Document 1, Part 5](../how-branching-stories-work.md). This document provides the detailed algorithm specification.
+> For the narrative description of the FILL stage, see ["How Branching Stories Work", Part 5](../how-branching-stories-work.md). This document provides the detailed algorithm specification.
 >
-> **Key changes from Documents 1/3 (2026-02-24):**
-> - The Poly-State Prose section below is **superseded** by ADR-015 (residue beats) and Document 1. See the note on that section.
-> - FILL receives character arc metadata produced by POLISH. See [Document 1, Part 4](../how-branching-stories-work.md) and [Document 3, Part 1](../document-3-ontology.md).
+> **Key changes from the authoritative design docs (2026-02-24):**
+> - The Poly-State Prose section below is **superseded** by ADR-015 (residue beats) and "How Branching Stories Work". See the note on that section.
+> - FILL receives character arc metadata produced by POLISH. See ["How Branching Stories Work", Part 4](../how-branching-stories-work.md) and the [Story Graph Ontology, Part 1](../story-graph-ontology.md).
 > - FILL's input comes from POLISH (not directly from GROW). The passage layer, choices, and state flags are created by POLISH.
 
 ---
@@ -173,7 +173,7 @@ If prose reveals that a new recurring entity is needed, FILL should flag and pau
 
 ### Poly-State Prose (Shared Beats)
 
-> **Superseded by ADR-015 and Document 1.** Poly-state prose has been replaced by residue beats (see [ADR-015](../../architecture/decisions.md#adr-015-residue-beats-replace-poly-state-prose)). Shared passages are kept neutral; residue beats set path-specific emotional context before convergence points. The `flag: incompatible_states` escape hatch described below no longer exists. This section is retained for historical context.
+> **Superseded by ADR-015 and "How Branching Stories Work".** Poly-state prose has been replaced by residue beats (see [ADR-015](../../architecture/decisions.md#adr-015-residue-beats-replace-poly-state-prose)). Shared passages are kept neutral; residue beats set path-specific emotional context before convergence points. The `flag: incompatible_states` escape hatch described below no longer exists. This section is retained for historical context.
 
 Shared beats (path-agnostic) appear in multiple arcs. When writing shared beats, FILL must produce **poly-state prose**: prose that is diegetically accurate for the active state but compatible with all shadow states.
 

--- a/docs/design/procedures/grow.md
+++ b/docs/design/procedures/grow.md
@@ -4,14 +4,14 @@
 **Parent:** questfoundry-v5-spec.md
 **Purpose:** Detailed specification of the GROW stage mechanics
 
-> For the narrative description of the GROW stage, see [Document 1, Part 3](../how-branching-stories-work.md). This document provides the detailed algorithm specification.
+> For the narrative description of the GROW stage, see ["How Branching Stories Work", Part 3](../how-branching-stories-work.md). This document provides the detailed algorithm specification.
 
-> **Major scope change (2026-02-24):** [Documents 1 and 3](../how-branching-stories-work.md) split the original GROW scope into **GROW** (beat DAG creation) and **POLISH** (passage layer creation). Phases 8a–9 (passage creation, codeword creation, overlay creation, choice derivation) move to POLISH. See Document 1, Part 4 for the POLISH specification. The code has not yet been reorganized.
+> **Major scope change (2026-02-24):** "How Branching Stories Work" and the [Story Graph Ontology](../story-graph-ontology.md) split the original GROW scope into **GROW** (beat DAG creation) and **POLISH** (passage layer creation). Phases 8a–9 (passage creation, codeword creation, overlay creation, choice derivation) move to POLISH. See "How Branching Stories Work", Part 4 for the POLISH specification. The code has not yet been reorganized.
 >
 > **Additional terminology transitions:**
 > - `convergence_policy` (hard/soft/flavor) → `dilemma_role` (hard/soft). `flavor` is removed — handled by POLISH as false branches.
-> - Intersection model: Document 3 redefines intersections as co-occurrence groupings. Beats retain their single `belongs_to` edge; an intersection group node declares scene sharing. The current implementation uses cross-assigned `belongs_to` edges.
-> - Arc model: Document 3 treats arcs as computed DAG traversals, not stored graph nodes.
+> - Intersection model: the Story Graph Ontology redefines intersections as co-occurrence groupings. Beats retain their single `belongs_to` edge; an intersection group node declares scene sharing. The current implementation uses cross-assigned `belongs_to` edges.
+> - Arc model: the Story Graph Ontology treats arcs as computed DAG traversals, not stored graph nodes.
 > - `sequenced_after` → `predecessor`/`successor` edges.
 > - `location_alternatives` → entity flexibility edges (generalized to any entity category).
 
@@ -175,7 +175,7 @@ If the non-canonical answer is not promoted to a path in SEED, that dilemma has 
 
 ### Phase 3: Intersection Detection
 
-> **Intersection model change:** [Document 3, Part 4](../document-3-ontology.md) redefines intersections as co-occurrence groupings. Beats retain their single `belongs_to` edge; an intersection group node declares which beats share a scene. The current implementation uses cross-assigned `belongs_to` edges. See Document 3 for the new model.
+> **Intersection model change:** The [Story Graph Ontology, Part 4](../story-graph-ontology.md) redefines intersections as co-occurrence groupings. Beats retain their single `belongs_to` edge; an intersection group node declares which beats share a scene. The current implementation uses cross-assigned `belongs_to` edges. See the Story Graph Ontology for the new model.
 
 **Purpose:** Find beats from different paths (different dilemmas) that should be one scene.
 
@@ -359,7 +359,7 @@ After `resolve_temporal_hints` completes, the set of surviving temporal hints mu
 
 ### Phase 4f: Entity Arc Descriptors
 
-> **Moves to POLISH:** [Document 3, Part 1](../document-3-ontology.md) calls these "character arc metadata" and assigns their creation to the POLISH stage. The concept is preserved; the stage assignment changes.
+> **Moves to POLISH:** The [Story Graph Ontology, Part 1](../story-graph-ontology.md) calls these "character arc metadata" and assigns their creation to the POLISH stage. The concept is preserved; the stage assignment changes.
 
 **Purpose:** Derive per-entity arc trajectories for each path.
 
@@ -403,7 +403,7 @@ pivot beats are preferred.
 
 ### Phase 5: Arc Enumeration
 
-> **Arc model change:** [Document 3, Part 3](../document-3-ontology.md) treats arcs as computed DAG traversals, not stored graph nodes. Arc enumeration becomes a validation/diagnostic utility rather than a graph-building step.
+> **Arc model change:** The [Story Graph Ontology, Part 3](../story-graph-ontology.md) treats arcs as computed DAG traversals, not stored graph nodes. Arc enumeration becomes a validation/diagnostic utility rather than a graph-building step.
 
 **Purpose:** Enumerate all valid routes through the beat graph.
 
@@ -466,7 +466,7 @@ arc:
 
 ### Phase 7: Convergence Identification (Policy-Aware)
 
-> **Terminology transition:** [Document 3, Part 2](../document-3-ontology.md) replaces `convergence_policy` (hard/soft/flavor) with `dilemma_role` (hard/soft). Convergence behavior is derived from the role. `flavor` is removed — flavor-level choices are handled by POLISH as false branches. The code currently still uses `convergence_policy`.
+> **Terminology transition:** The [Story Graph Ontology, Part 2](../story-graph-ontology.md) replaces `convergence_policy` (hard/soft/flavor) with `dilemma_role` (hard/soft). Convergence behavior is derived from the role. `flavor` is removed — flavor-level choices are handled by POLISH as false branches. The code currently still uses `convergence_policy`.
 
 **Purpose:** Find where arcs can rejoin, respecting the branching contract.
 
@@ -493,7 +493,7 @@ arc:
 
 ### Phase 8: Passage and State Derivation
 
-> **Moves to POLISH:** [Document 1, Part 4](../how-branching-stories-work.md) assigns passage creation (8a), state flag/codeword creation (8b), overlay creation (8c), and choice derivation (Phase 9) to the POLISH stage. See also [Document 3, Part 5](../document-3-ontology.md) (The Passage Layer) and [Document 3, Part 6](../document-3-ontology.md) (Entity Overlays and State). The code has not yet been reorganized.
+> **Moves to POLISH:** ["How Branching Stories Work", Part 4](../how-branching-stories-work.md) assigns passage creation (8a), state flag/codeword creation (8b), overlay creation (8c), and choice derivation (Phase 9) to the POLISH stage. See also the [Story Graph Ontology, Part 5](../story-graph-ontology.md) (The Passage Layer) and [Part 6](../story-graph-ontology.md) (Entity Overlays and State). The code has not yet been reorganized.
 
 **Purpose:** Create player-facing passages from beats, and derive codewords and overlays from consequences.
 

--- a/docs/design/procedures/passage_collapse.md
+++ b/docs/design/procedures/passage_collapse.md
@@ -5,7 +5,7 @@
 **Issue:** #634
 **Purpose:** Detailed design for passage-level collapse and transition handling
 
-> **Superseded (2026-02-24).** [Document 1, Part 4](../how-branching-stories-work.md) (Passage Collapse section) and [Document 3, Part 5](../document-3-ontology.md) (The Passage Layer) move passage collapse from GROW to the POLISH stage. The concepts described here are largely preserved but the stage assignment changes. Retained for historical reference. The code has not yet been reorganized.
+> **Superseded (2026-02-24).** ["How Branching Stories Work", Part 4](../how-branching-stories-work.md) (Passage Collapse section) and the [Story Graph Ontology, Part 5](../story-graph-ontology.md) (The Passage Layer) move passage collapse from GROW to the POLISH stage. The concepts described here are largely preserved but the stage assignment changes. Retained for historical reference. The code has not yet been reorganized.
 
 ---
 

--- a/docs/design/procedures/polish.md
+++ b/docs/design/procedures/polish.md
@@ -1,11 +1,11 @@
 # QuestFoundry v5 — POLISH Algorithm Specification
 
 **Status:** Specification Complete
-**Parent:** [Document 1, Part 4](../how-branching-stories-work.md)
+**Parent:** ["How Branching Stories Work", Part 4](../how-branching-stories-work.md)
 **ADR:** [ADR-019](../../architecture/decisions.md#adr-019-polish-stage-supersedes-grow-routing) (supersedes ADR-017; created in parallel PR #1020)
 **Purpose:** Detailed specification of the POLISH stage mechanics
 
-> For the narrative description of the POLISH stage, see [Document 1, Part 4](../how-branching-stories-work.md). For the formal ontology of passages, choices, and variants, see [Document 3, Parts 5-6](../document-3-ontology.md). This document provides the algorithm specification.
+> For the narrative description of the POLISH stage, see ["How Branching Stories Work", Part 4](../how-branching-stories-work.md). For the formal ontology of passages, choices, and variants, see the [Story Graph Ontology, Parts 5-6](../story-graph-ontology.md). This document provides the algorithm specification.
 
 ---
 
@@ -502,8 +502,8 @@ The following GROW phases move to POLISH:
 
 ## References
 
-- [Document 1, Part 4: Shaping the Story](../how-branching-stories-work.md) — narrative description
-- [Document 3, Parts 5-6](../document-3-ontology.md) — passage layer and overlay ontology
+- ["How Branching Stories Work", Part 4: Shaping the Story](../how-branching-stories-work.md) — narrative description
+- [Story Graph Ontology, Parts 5-6](../story-graph-ontology.md) — passage layer and overlay ontology
 - [ADR-019: POLISH Stage Supersedes GROW Routing](../../architecture/decisions.md#adr-019-polish-stage-supersedes-grow-routing)
 - [ADR-017: Unified Routing Plan (superseded)](../../architecture/decisions.md#adr-017-unified-routing-plan-for-grow-variant-routing) — plan-then-execute architecture origin
 - [Discussion #980: Design Review](https://github.com/pvliesdonk/questfoundry/discussions/980) — three-round deliberation establishing this algorithm

--- a/docs/design/procedures/seed.md
+++ b/docs/design/procedures/seed.md
@@ -1,8 +1,8 @@
 # SEED Procedure
 
-> For the narrative description of the SEED stage, see [Document 1, Part 2](../how-branching-stories-work.md). This document provides the detailed algorithm specification.
+> For the narrative description of the SEED stage, see ["How Branching Stories Work", Part 2](../how-branching-stories-work.md). This document provides the detailed algorithm specification.
 >
-> **Terminology transitions (2026-02-24):** [Document 3](../document-3-ontology.md) replaces several terms used in this document. The code has not yet been updated.
+> **Terminology transitions (2026-02-24):** The [Story Graph Ontology](../story-graph-ontology.md) replaces several terms used in this document. The code has not yet been updated.
 > - `convergence_policy` (hard/soft/flavor) → `dilemma_role` (hard/soft). Convergence behavior is derived from the role, not declared directly. `flavor` is removed — flavor-level choices are handled by POLISH as false branches.
 > - `InteractionConstraint` (shared_entity/causal_chain/resource_conflict) → dilemma ordering relationships. The three declared relationships are `wraps`, `concurrent`, and `serial`. `shared_entity` is derived from `anchored_to` edges (not explicitly declared). `causal_chain` is subsumed by `serial`. `resource_conflict` is removed.
 > - `central_entity_ids` (list field on dilemmas) → `anchored_to` edges in the graph.

--- a/docs/design/story-graph-ontology.md
+++ b/docs/design/story-graph-ontology.md
@@ -1,12 +1,12 @@
 # Story Graph Ontology — Data Model for Branching Fiction
 
-> **Status: Authoritative.** This document, together with [Document 1](how-branching-stories-work.md), is the authoritative source of truth for QuestFoundry's graph ontology. Where other design documents contradict this one, this document takes precedence. See [Issue #977](https://github.com/pvliesdonk/questfoundry/issues/977).
+> **Status: Authoritative.** This document, together with ["How Branching Stories Work"](how-branching-stories-work.md), is the authoritative source of truth for QuestFoundry's graph ontology. Where other design documents contradict this one, this document takes precedence. See [Issue #977](https://github.com/pvliesdonk/questfoundry/issues/977).
 
 ## Guiding Principle
 
-The graph serves the story. Every node type, edge type, and property in this ontology exists because a narrative concept from [Document 1](how-branching-stories-work.md) requires it. If a graph concept cannot be traced to a narrative purpose, it does not belong.
+The graph serves the story. Every node type, edge type, and property in this ontology exists because a narrative concept from ["How Branching Stories Work"](how-branching-stories-work.md) requires it. If a graph concept cannot be traced to a narrative purpose, it does not belong.
 
-This document translates Document 1's storytelling language into a formal data model. It is not a replacement for Document 1 — it is a companion. Document 1 describes what authors are trying to accomplish. This document describes how the graph represents their work.
+This document translates the narrative guide's storytelling language into a formal data model. It is not a replacement for "How Branching Stories Work" — it is a companion. "How Branching Stories Work" describes what authors are trying to accomplish. This document describes how the graph represents their work.
 
 The direction is always: **narrative concept first, graph representation second.** The current ontology was built partly in the other direction (graph structure first, narrative meaning mapped onto it). Where this document diverges from the current implementation, the narrative intent takes precedence.
 
@@ -14,14 +14,14 @@ The direction is always: **narrative concept first, graph representation second.
 
 ## Part 1: Primitive Concepts
 
-These are the fundamental building blocks of the graph. Each traces directly to a Document 1 narrative concept.
+These are the fundamental building blocks of the graph. Each traces directly to a narrative concept from "How Branching Stories Work".
 
 ### Vision
 
 A singleton configuration node. Stores the creative contract established in DREAM: genre, subgenre, tone, themes, audience, scope, style preferences, content guidance, and an optional point-of-view hint.
 
 The vision's fields include:
-- **Genre and subgenre** — the primary genre (e.g., "mystery") and a more specific subgenre (e.g., "cozy mystery," "noir detective"). Document 1 discusses subgenre narratively; this document formalizes it as a distinct field.
+- **Genre and subgenre** — the primary genre (e.g., "mystery") and a more specific subgenre (e.g., "cozy mystery," "noir detective"). "How Branching Stories Work" discusses subgenre narratively; this document formalizes it as a distinct field.
 - **Point-of-view style** — a hint, not a binding constraint. Expressed as one of four narrative perspectives (first person, second person, third person limited, third person omniscient). FILL's voice document makes the final decision — the vision's `pov_style` is advisory context.
 - **Content notes** — explicit guidance on what the story should include or exclude (themes to embrace, topics to avoid, content boundaries). This is a substantive creative constraint, not a filter — it shapes what BRAINSTORM generates and what SEED retains.
 - **Scope** — expressed as a named preset (e.g., "vignette," "short story," "novella") that implies approximate sizes for the cast, dilemma count, beat count, and passage count. The preset system provides BRAINSTORM and SEED with concrete targets.
@@ -102,7 +102,7 @@ Beat subtypes (distinguished by a role marker):
 
 The narrative outcome of a path choice. Created by SEED, linked to a path via `has_consequence` edge. "The mentor becomes your adversary" is a consequence of the distrust path.
 
-Consequences are the bridge between narrative stakes (Document 1's "why it matters") and mechanical state tracking (state flags). Each consequence becomes one or more state flags in GROW.
+Consequences are the bridge between narrative stakes (the "why it matters" described in "How Branching Stories Work") and mechanical state tracking (state flags). Each consequence becomes one or more state flags in GROW.
 
 **Working.** Consumed when state flags are derived.
 
@@ -154,7 +154,7 @@ Scene blueprints are working data for FILL's own process — they structure the 
 
 ## Part 2: Dilemma Ordering and Relationships
 
-Not all dilemmas play the same role in a story. Document 1 distinguishes hard dilemmas (the backbone) from soft dilemmas (the subplots), and notes that the ordering of dilemmas has profound structural consequences. This section defines how the graph represents these roles and relationships.
+Not all dilemmas play the same role in a story. "How Branching Stories Work" distinguishes hard dilemmas (the backbone) from soft dilemmas (the subplots), and notes that the ordering of dilemmas has profound structural consequences. This section defines how the graph represents these roles and relationships.
 
 ### Dilemma Role
 
@@ -170,7 +170,7 @@ This replaces the current `convergence_policy` field. Rather than declaring conv
 
 ### Flavor Choices
 
-Document 1 also describes flavor-level choices that barely diverge — the choice affects tone and details but not which beats the player experiences. These are not full dilemmas in the ontological sense. They are handled by cosmetic state flags and minor prose variation, without the structural machinery of paths, commits, and convergence. POLISH creates them as false branches or minor passage variants.
+"How Branching Stories Work" also describes flavor-level choices that barely diverge — the choice affects tone and details but not which beats the player experiences. These are not full dilemmas in the ontological sense. They are handled by cosmetic state flags and minor prose variation, without the structural machinery of paths, commits, and convergence. POLISH creates them as false branches or minor passage variants.
 
 ### Pairwise Relationships
 
@@ -274,7 +274,7 @@ Temporal hints are optional. A beat with no hint has no constraint on its placem
 
 ### The 2^N Law in Graph Terms
 
-Document 1's central structural insight: any beat placed after N committed dilemmas exists in up to 2^N versions. In the DAG, this is visible as the branching factor:
+The central structural insight of "How Branching Stories Work": any beat placed after N committed dilemmas exists in up to 2^N versions. In the DAG, this is visible as the branching factor:
 
 - A beat before any commit has one predecessor path through the DAG — it exists once.
 - A beat after one commit has predecessors from two branches — it exists in two versions (or is shared if it belongs to both paths).
@@ -294,7 +294,7 @@ If pre-computed arc data is stored for debugging purposes, it uses a `materializ
 
 ## Part 4: Intersections
 
-Document 1 describes intersections as "where independent storylines share a scene." If the mentor path has "the mentor gives cryptic advice" and the artifact path has "study the artifact's markings," and both could happen in the mentor's study — that is a natural intersection. One scene where both storylines advance simultaneously.
+"How Branching Stories Work" describes intersections as "where independent storylines share a scene." If the mentor path has "the mentor gives cryptic advice" and the artifact path has "study the artifact's markings," and both could happen in the mentor's study — that is a natural intersection. One scene where both storylines advance simultaneously.
 
 ### What an Intersection Is
 
@@ -617,7 +617,7 @@ An LLM will naturally write "if the player chose X" when the correct formulation
 
 State flags are internal implementation machinery — the full set of boolean markers used by GROW, POLISH, entity overlays, and the runtime engine. Codewords are a player-facing subset surfaced in gamebook formats for manual state tracking.
 
-The current codebase uses "codeword" for both concepts. Document 3 defines them as distinct: every codeword is a state flag, but not every state flag is a codeword. Code that manipulates state flags for routing or overlay purposes must not be confused with code that presents codewords to the player.
+The current codebase uses "codeword" for both concepts. This ontology defines them as distinct: every codeword is a state flag, but not every state flag is a codeword. Code that manipulates state flags for routing or overlay purposes must not be confused with code that presents codewords to the player.
 
 ### Entity Overlays ≠ Entity Variants
 
@@ -730,7 +730,7 @@ Two patterns were identified during design but deferred from the minimal ontolog
 
 ## Appendix: Comparison with Current Ontology
 
-This section documents where the current implementation (`docs/design/00-spec.md`, `src/questfoundry/models/`, `src/questfoundry/graph/`) diverges from the ontology defined in this document. It is a diagnostic — a map of what needs to change, not a criticism of the current code, which was built before Document 1 existed.
+This section documents where the current implementation (`docs/design/00-spec.md`, `src/questfoundry/models/`, `src/questfoundry/graph/`) diverges from the ontology defined in this document. It is a diagnostic — a map of what needs to change, not a criticism of the current code, which was built before "How Branching Stories Work" existed.
 
 ### Intersection — Fundamental Redefinition
 

--- a/prompts/templates/serialize_seed_sections.yaml
+++ b/prompts/templates/serialize_seed_sections.yaml
@@ -1041,7 +1041,7 @@ dilemma_analyses_prompt: |
   ## Output
   Return ONLY valid JSON with the "dilemma_analyses" array. Classify ALL dilemmas.
 
-# Section 8: Dilemma Ordering Relationships (post-prune, Doc 3)
+# Section 8: Dilemma Ordering Relationships (post-prune, Story Graph Ontology)
 dilemma_relationships_prompt: |
   You are classifying the temporal ordering between ALL dilemma pairs for a SEED stage.
 

--- a/src/questfoundry/agents/serialize.py
+++ b/src/questfoundry/agents/serialize.py
@@ -2274,7 +2274,7 @@ async def serialize_dilemma_relationships(
     callbacks: list[BaseCallbackHandler] | None = None,
     on_phase_progress: PhaseProgressFn | None = None,
 ) -> tuple[list[DilemmaRelationship], int, int]:
-    """Run dilemma ordering relationship analysis (Section 8, Doc 3).
+    """Run dilemma ordering relationship analysis (Section 8, Story Graph Ontology).
 
     Identifies pairwise dilemma ordering (wraps, concurrent, serial).
     Runs AFTER pruning so only surviving dilemmas are analyzed.

--- a/src/questfoundry/export/context.py
+++ b/src/questfoundry/export/context.py
@@ -130,7 +130,7 @@ def _extract_entities(graph: Graph) -> list[ExportEntity]:
 def _project_state_flags_to_codewords(graph: Graph) -> list[ExportCodeword]:
     """Project state flags to player-facing codewords based on dilemma role.
 
-    Per Document 3 ontology: soft dilemma state flags become codewords
+    Per the Story Graph Ontology: soft dilemma state flags become codewords
     (the player carries state across convergence points). Hard dilemma
     state flags remain internal routing machinery and are not exported.
 

--- a/src/questfoundry/graph/grow_algorithms.py
+++ b/src/questfoundry/graph/grow_algorithms.py
@@ -1444,7 +1444,7 @@ def _group_by_location(
         primary = beat_data.get("location")
         if primary:
             location_beats[primary].append(beat_id)
-        # Read flexibility edges (Doc 3) instead of location_alternatives property.
+        # Read flexibility edges (Story Graph Ontology) instead of location_alternatives property.
         # NOTE: No role filter applied — currently only role="location" flexibility
         # edges exist (written by mutations.py). If other roles are added (e.g.,
         # role="entity"), this query must filter by role="location".
@@ -1923,7 +1923,7 @@ def resolve_intersection_location(graph: Graph, beat_ids: list[str]) -> str | No
         locs = set()
         if primary:
             locs.add(primary)
-        # Read flexibility edges (Doc 3) instead of location_alternatives property
+        # Read flexibility edges (Story Graph Ontology) instead of location_alternatives property
         for edge in graph.get_edges(from_id=bid, edge_type="flexibility"):
             locs.add(edge["to"])
         all_locations.append(locs)
@@ -1957,7 +1957,7 @@ def apply_intersection_mark(
     shared_entities: list[str] | None = None,
     rationale: str | None = None,
 ) -> None:
-    """Mark beats as co-occurring in an intersection group (Doc 3, Part 4).
+    """Mark beats as co-occurring in an intersection group (Story Graph Ontology, Part 4).
 
     Creates an ``intersection_group`` node and links each participating
     beat to it via ``intersection`` edges.  Each beat keeps its single

--- a/src/questfoundry/graph/mutations.py
+++ b/src/questfoundry/graph/mutations.py
@@ -1600,8 +1600,8 @@ def validate_seed_mutations(graph: Graph, output: dict[str, Any]) -> list[SeedVa
 
     # 14. Check arc structure: advances/reveals before commit (WARNING)
     # 15. Check arc structure: beat exists after commit (WARNING)
-    # Doc 1 Part 2: "This scaffold must be complete — the arc from beginning
-    # to end must be present."
+    # "How Branching Stories Work", Part 2: "This scaffold must be complete —
+    # the arc from beginning to end must be present."
     for path_id in sorted(path_dilemma_map.keys()):
         if path_id not in paths_with_commits:
             continue  # No commit beat; already reported as error in check 13
@@ -1833,7 +1833,7 @@ def apply_seed_mutations(graph: Graph, output: dict[str, Any]) -> None:
             with contextlib.suppress(ValueError):
                 prefixed_location = _resolve_entity_ref(graph, raw_location)
 
-        # Resolve location_alternatives → flexibility edges (Doc 3)
+        # Resolve location_alternatives → flexibility edges (Story Graph Ontology)
         raw_location_alts = beat.get("location_alternatives", [])
         prefixed_location_alts = []
         for eid in raw_location_alts:
@@ -1876,7 +1876,7 @@ def apply_seed_mutations(graph: Graph, output: dict[str, Any]) -> None:
             prefixed_path_id = _prefix_id("path", raw_path_id)
             graph.add_edge("belongs_to", beat_id, prefixed_path_id)
 
-        # Create flexibility edges for location alternatives (Doc 3)
+        # Create flexibility edges for location alternatives (Story Graph Ontology)
         for alt_entity in prefixed_location_alts:
             graph.add_edge("flexibility", beat_id, alt_entity, role="location")
 
@@ -1915,7 +1915,7 @@ def apply_seed_mutations(graph: Graph, output: dict[str, Any]) -> None:
                     update_fields[key] = data[key]
             graph.update_node(dilemma_node_id, **update_fields)
 
-    # Create dilemma ordering edges between dilemma pairs (Doc 3, Part 2)
+    # Create dilemma ordering edges between dilemma pairs (Story Graph Ontology, Part 2)
     for relationship in output.get("dilemma_relationships", []):
         a_raw = relationship.get("dilemma_a", "")
         b_raw = relationship.get("dilemma_b", "")

--- a/src/questfoundry/graph/polish_validation.py
+++ b/src/questfoundry/graph/polish_validation.py
@@ -91,7 +91,7 @@ def validate_grow_output(graph: Graph) -> list[str]:
         # GROW may omit status for dilemmas it fully explored; treat None as "explored".
         if ddata.get("status") in ("explored", None)
     }
-    # Build consequence → state_flag map via derived_from edges (Doc 3 Part 9).
+    # Build consequence → state_flag map via derived_from edges (Story Graph Ontology, Part 9).
     # state_flag nodes have no dilemma_id field; the association is:
     #   state_flag --derived_from--> consequence <--has_consequence-- path.dilemma_id
     _flagged_consequences: set[str] = {

--- a/src/questfoundry/models/seed.py
+++ b/src/questfoundry/models/seed.py
@@ -25,7 +25,8 @@ from pydantic import BaseModel, Field, model_validator
 
 # Type aliases for clarity
 EntityDisposition = Literal["retained", "cut"]
-# PathTier has no direct Document 1/3 counterpart but serves a real purpose:
+# PathTier has no direct counterpart in "How Branching Stories Work" or the
+# Story Graph Ontology, but serves a real purpose:
 # dilemma scoring uses it to weight non-canonical paths, and context formatting
 # displays it to guide LLM prose generation. Kept as-is.
 PathTier = Literal["major", "minor"]
@@ -212,7 +213,7 @@ class TemporalHint(BaseModel):
     Hints are advisory — GROW resolves conflicts in favor of dilemma ordering
     relationships (wraps/serial/concurrent).
 
-    See docs/design/document-3-ontology.md § Temporal Hints.
+    See docs/design/story-graph-ontology.md § Temporal Hints.
 
     Attributes:
         relative_to: The dilemma ID this hint is relative to.
@@ -293,7 +294,7 @@ class InitialBeat(BaseModel):
     location_alternatives: list[str] = Field(
         default_factory=list,
         description="Alternate location entities for intersection flexibility. "
-        "Stored as flexibility edges in graph (Doc 3), not as node property.",
+        "Stored as flexibility edges in graph (Story Graph Ontology), not as node property.",
     )
     temporal_hint: TemporalHint | None = Field(
         default=None,
@@ -403,7 +404,7 @@ class DilemmaAnalysis(BaseModel):
 
 
 class DilemmaRelationship(BaseModel):
-    """Pairwise dilemma ordering relationship from SEED (Document 3, Part 2).
+    """Pairwise dilemma ordering relationship from SEED (Story Graph Ontology, Part 2).
 
     Serialized as Section 8 (after prune). Tells GROW how two dilemmas
     relate temporally: one wrapping the other, running concurrently, or

--- a/src/questfoundry/pipeline/stages/grow/deterministic.py
+++ b/src/questfoundry/pipeline/stages/grow/deterministic.py
@@ -276,7 +276,7 @@ async def phase_enumerate_arcs(
     - Exactly one spine arc exists (containing all canonical paths).
     - Arc count bounded by 4x size_profile.max_arcs (if provided).
     - No arc nodes or arc_contains edges are stored — arcs are computed
-      traversals per Document 3 ontology.
+      traversals per the Story Graph Ontology.
 
     Invariants:
     - Deterministic: same graph always produces same arcs.
@@ -340,7 +340,7 @@ async def phase_divergence(graph: Graph, model: BaseChatModel) -> GrowPhaseResul
     Postconditions:
     - Divergence points computed and validated.
     - No graph writes — divergence metadata is computed on-the-fly
-      by downstream consumers per Document 3 ontology.
+      by downstream consumers per the Story Graph Ontology.
 
     Invariants:
     - Deterministic: divergence points derived from sequence comparison.
@@ -387,7 +387,7 @@ async def phase_convergence(graph: Graph, model: BaseChatModel) -> GrowPhaseResu
     Postconditions:
     - Convergence points computed and validated.
     - No graph writes — convergence metadata is computed on-the-fly
-      by downstream consumers per Document 3 ontology.
+      by downstream consumers per the Story Graph Ontology.
 
     Invariants:
     - Deterministic: convergence derived from dilemma policies and beat sequences.

--- a/src/questfoundry/pipeline/stages/polish/deterministic.py
+++ b/src/questfoundry/pipeline/stages/polish/deterministic.py
@@ -174,7 +174,7 @@ async def phase_plan_computation(
     # 4b: Prose feasibility audit
     feasibility = compute_prose_feasibility(graph, plan.passage_specs)
 
-    # 4b (overlay audit): Overlay composition check (Doc 3 §6)
+    # 4b (overlay audit): Overlay composition check (Story Graph Ontology §6)
     _audit_overlay_composition(graph, plan.passage_specs, feasibility)
 
     plan.feasibility_annotations = feasibility["annotations"]
@@ -498,7 +498,7 @@ def _audit_overlay_composition(
     specs: list[PassageSpec],
     feasibility: dict[str, Any],
 ) -> None:
-    """Audit overlay composition for prose feasibility (Doc 3 §6).
+    """Audit overlay composition for prose feasibility (Story Graph Ontology §6).
 
     For each passage, checks whether any entity present in its beats could
     have 4 or more overlays simultaneously active under any single flag

--- a/tests/fixtures/grow_fixtures.py
+++ b/tests/fixtures/grow_fixtures.py
@@ -649,7 +649,7 @@ def make_intersection_candidate_graph() -> Graph:
     # Add location data to some beats for intersection detection
     graph.update_node("beat::mentor_meet", location="location::market")
     graph.update_node("beat::artifact_discover", location="location::docks")
-    # Flexibility edge (Doc 3): beat can also occur at market
+    # Flexibility edge (Story Graph Ontology): beat can also occur at market
     graph.add_edge("flexibility", "beat::artifact_discover", "location::market", role="location")
 
     return graph

--- a/tests/unit/test_fill_continuity_warning.py
+++ b/tests/unit/test_fill_continuity_warning.py
@@ -79,7 +79,7 @@ def test_continuity_warning_suppressed_for_micro_beat() -> None:
 
 def test_continuity_warning_suppressed_for_intersection_hint() -> None:
     graph, arc_id = _make_two_passages_graph(shared_entity=False)
-    # Create intersection group node and edges (Doc 3 model)
+    # Create intersection group node and edges (Story Graph Ontology model)
     graph.create_node(
         "intersection_group::a--b",
         {"type": "intersection_group", "raw_id": "a--b", "beat_ids": ["beat::a", "beat::b"]},

--- a/tests/unit/test_grow_algorithms.py
+++ b/tests/unit/test_grow_algorithms.py
@@ -2293,7 +2293,7 @@ class TestApplyKnotMark:
         assert mentor_edges[0]["to"] == artifact_edges[0]["to"]  # Same group
 
     def test_no_cross_path_belongs_to_edges(self) -> None:
-        """Intersection does NOT add cross-path belongs_to edges (Doc 3)."""
+        """Intersection does NOT add cross-path belongs_to edges (Story Graph Ontology)."""
         from questfoundry.graph.grow_algorithms import apply_intersection_mark
         from tests.fixtures.grow_fixtures import make_intersection_candidate_graph
 

--- a/tests/unit/test_mutations.py
+++ b/tests/unit/test_mutations.py
@@ -2266,8 +2266,8 @@ class TestBeatDilemmaAlignment:
 class TestSeedArcStructureValidation:
     """Test SEED validation checks 14-15: arc structure warnings.
 
-    Doc 1 Part 2: "This scaffold must be complete — the arc from beginning
-    to end must be present." Checks:
+    "How Branching Stories Work", Part 2: "This scaffold must be complete —
+    the arc from beginning to end must be present." Checks:
     14. Each path has advances/reveals before its commit beat.
     15. Each path has at least one beat after its commit beat.
 


### PR DESCRIPTION
## Summary
- Rename `docs/design/document-3-ontology.md` -> `docs/design/story-graph-ontology.md`
- Replace all "Document 1" / "Document 3" / "Doc 1" / "Doc 3" references with their natural titles ("How Branching Stories Work", "Story Graph Ontology") or contextual equivalents across design docs, procedures, code, tests, and top-level files.

This is a mechanical cleanup. No conceptual content changes — Y-shape corrections and the `00-spec.md` deprecation come in a follow-up PR.

## Why
"Document 2" never existed; the numbered nomenclature was temporary language from an early planning phase that stuck. Using the actual titles is clearer for readers new to the codebase.

## Test plan
- [x] `rg '\b(Document|Doc) [13]\b'` returns no real (non-worktree) hits
- [x] `rg 'document-3-ontology\.md'` returns no hits
- [x] `uv run ruff check src/` clean
- [x] `uv run mypy src/questfoundry/` clean (pre-existing `openai` import error unrelated to this PR; pre-commit mypy with `--ignore-missing-imports` is clean)
- [x] Targeted unit tests (`test_grow_algorithms`, `test_mutations`, `test_fill_continuity_warning`) pass (466 tests)
- [x] `pre-commit` clean on changed files