### PR TITLE
docs: align with Y-shape dilemma model and deprecate 00-spec.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -137,20 +137,21 @@ log.error("provider_error", provider="ollama", message=str(e))
 
 ### Model Workflow (Ontology → Pydantic → Graph)
 
-**The design specification (`docs/design/00-spec.md`) defines the ontology.** Pydantic models in `src/questfoundry/models/` are hand-written implementations of that ontology. The graph (`graph.db`) is the runtime source of truth for story state.
+**The Story Graph Ontology (`docs/design/story-graph-ontology.md`) defines the ontology**, working alongside the narrative principles in `docs/design/how-branching-stories-work.md`. Hand-written Pydantic models in `src/questfoundry/models/` implement that ontology. The graph (`graph.db`) is the runtime source of truth for story state.
 
 ```
-docs/design/00-spec.md        ← Ontology definition (node types, relationships)
+docs/design/story-graph-ontology.md   ← Ontology definition (node types, edges, invariants)
+docs/design/how-branching-stories-work.md ← Narrative model the ontology serves
         ↓
-src/questfoundry/models/*.py  ← Hand-written Pydantic models (validate LLM output)
+src/questfoundry/models/*.py          ← Hand-written Pydantic models (validate LLM output)
         ↓
-graph/mutations.py            ← Semantic validation against graph state
+graph/mutations.py                    ← Semantic validation against graph state
         ↓
-graph.db                      ← Runtime source of truth (SQLite, nodes + edges)
+graph.db                              ← Runtime source of truth (SQLite, nodes + edges)
 ```
 
 **When adding new stage models:**
-1. Check the ontology in `docs/design/00-spec.md` for the node types and fields
+1. Check the ontology in `docs/design/story-graph-ontology.md` for the node types, edges, and invariants that apply
 2. Create/update Pydantic models in `src/questfoundry/models/`
 3. Add semantic validation in `graph/mutations.py` if needed
 4. Export from `models/__init__.py`
@@ -292,10 +293,12 @@ qf inspect -p <project> --json # Machine-readable JSON output
 
 ## Key Files to Reference
 
-- `docs/design/00-spec.md` - Unified v5 specification (vision, pipeline, schemas)
-- `docs/design/procedures/` - Stage algorithm specifications
+- `docs/design/how-branching-stories-work.md` - Narrative model: dilemmas, paths, beats, intersections, convergence (authoritative)
+- `docs/design/story-graph-ontology.md` - Graph/data model: node types, edge types, invariants (authoritative; supersedes the ontology sections of `00-spec.md`)
+- `docs/design/procedures/` - Per-stage algorithm specifications (DREAM, BRAINSTORM, SEED, GROW, POLISH, FILL, DRESS, SHIP)
 - `docs/design/01-prompt-compiler.md` - Prompt assembly system
 - `docs/design/07-getting-started.md` - Implementation slices
+- `docs/design/00-spec.md` - **Deprecated.** Historical reference only. Non-ontology content (Anti-Patterns, Design Decisions, Context Budget Analysis, Open Questions, Future Bolt-ons) has not yet been migrated; do not cite as authoritative.
 
 ## Anti-Patterns to Avoid
 
@@ -593,8 +596,8 @@ that hurt structured output quality.
 ### 8. Context Enrichment Principle (Ontology-Driven)
 
 > **Every LLM call MUST receive all ontologically relevant graph data available at
-> call time. The ontology (`docs/design/00-spec.md`) is the authoritative source for
-> what fields exist on each node type — consult it, don't guess.**
+> call time. The ontology (`docs/design/story-graph-ontology.md`) is the authoritative
+> source for what fields exist on each node type — consult it, don't guess.**
 
 Small models (4B parameters) cannot infer narrative meaning from identifiers alone.
 When a `format_*_context()` function builds context for an LLM call, it MUST include
@@ -617,7 +620,7 @@ the LLM's decision about how to handle that dilemma.
 - Someone eventually notices and enriches the context
 
 **When writing or modifying any `format_*_context()` function:**
-1. **Read the ontology** (`docs/design/00-spec.md`) for the relevant node type(s)
+1. **Read the ontology** (`docs/design/story-graph-ontology.md`) for the relevant node type(s)
 2. List every field defined in the spec for those node types
 3. Include all fields that would help the LLM make an informed decision
 4. Keep it compact (5-8 lines per item) but never strip to bare IDs

--- a/docs/design/00-spec.md
+++ b/docs/design/00-spec.md
@@ -1,10 +1,19 @@
 # QuestFoundry v5 — Unified Specification
 
-**Version:** 2.0
-**Status:** Working draft — partially superseded
-**Supersedes:** qf-v5-vision.md, qf-v5-vision-delta001.md, questfoundry-v5-graph-ontology-v1-1.md
+> **DEPRECATED (2026-04-14):** This document is retained for historical reference only.
+>
+> The authoritative sources for the QuestFoundry v5 design are:
+> - [How Branching Stories Work](./how-branching-stories-work.md) — narrative principles
+> - [Story Graph Ontology](./story-graph-ontology.md) — graph/data model
+> - [`procedures/*.md`](./procedures/) — per-stage algorithm specifications
+>
+> Content that appears only in this document (Anti-Patterns, Design Decisions,
+> Context Budget Analysis, Open Questions, Future Bolt-ons) has not yet been
+> migrated and may be outdated. Do not treat it as authoritative; migrate any
+> still-relevant content to the appropriate new doc before citing.
 
-> **Status update (2026-02-24):** ["How Branching Stories Work"](how-branching-stories-work.md) and the [Story Graph Ontology](story-graph-ontology.md) are now the authoritative source of truth for QuestFoundry's story model and graph ontology. Sections of this document marked "Superseded" below have been replaced by those documents. Unmarked sections remain valid. See [Issue #977](https://github.com/pvliesdonk/questfoundry/issues/977).
+**Version:** 2.0
+**Supersedes:** qf-v5-vision.md, qf-v5-vision-delta001.md, questfoundry-v5-graph-ontology-v1-1.md
 
 ---
 

--- a/docs/design/procedures/grow.md
+++ b/docs/design/procedures/grow.md
@@ -10,7 +10,7 @@
 >
 > **Additional terminology transitions:**
 > - `convergence_policy` (hard/soft/flavor) → `dilemma_role` (hard/soft). `flavor` is removed — handled by POLISH as false branches.
-> - Intersection model: the Story Graph Ontology redefines intersections as co-occurrence groupings. Beats retain their single `belongs_to` edge; an intersection group node declares scene sharing. The current implementation uses cross-assigned `belongs_to` edges.
+> - Intersection model: the Story Graph Ontology redefines intersections as co-occurrence groupings. Beats retain their existing `belongs_to` edges under the Y-shape invariant — pre-commit beats belong to every path of their dilemma (dual for a binary dilemma), commit and post-commit beats belong to exactly one path — and an intersection group node declares scene sharing across dilemmas. Three guard rails apply: (1) **same-dilemma constraint** — any beat with two `belongs_to` edges must reference paths of the same dilemma; cross-dilemma multi-`belongs_to` remains forbidden; (2) **pre-commit only** — only beats before the dilemma's commit may have multi-`belongs_to`; (3) **intersection exclusion** — intersection groups must not contain two pre-commit beats from the same dilemma (they already co-occur by definition). The current implementation still cross-assigns `belongs_to` edges to model intersections, which is incorrect on both axes. See the [Story Graph Ontology, Part 8](../story-graph-ontology.md).
 > - Arc model: the Story Graph Ontology treats arcs as computed DAG traversals, not stored graph nodes.
 > - `sequenced_after` → `predecessor`/`successor` edges.
 > - `location_alternatives` → entity flexibility edges (generalized to any entity category).
@@ -168,14 +168,16 @@ If the non-canonical answer is not promoted to a path in SEED, that dilemma has 
 > assess which beats were "prose-compatible" across paths and marked them with
 > `path_agnostic_for`. This was replaced by residue beats (Phase 8d) which
 > handle post-convergence variation without requiring upfront prose compatibility
-> assessment. Beats that belong to multiple arcs are now detected structurally
-> via `belongs_to` edges rather than LLM annotation.
+> assessment. Whether a beat is shared across multiple arcs is now inferred
+> structurally from the beat DAG (a beat's `belongs_to` edges plus its position
+> relative to commit beats determines which arcs traverse it), rather than
+> from LLM annotation.
 
 ---
 
 ### Phase 3: Intersection Detection
 
-> **Intersection model change:** The [Story Graph Ontology, Part 4](../story-graph-ontology.md) redefines intersections as co-occurrence groupings. Beats retain their single `belongs_to` edge; an intersection group node declares which beats share a scene. The current implementation uses cross-assigned `belongs_to` edges. See the Story Graph Ontology for the new model.
+> **Intersection model change:** The [Story Graph Ontology, Part 4](../story-graph-ontology.md) redefines intersections as co-occurrence groupings. Beats retain their existing `belongs_to` edges under the Y-shape invariant (pre-commit beats: every path of their dilemma; commit and post-commit beats: exactly one path), and an intersection group node declares which beats share a scene across dilemmas. The three guard rails in the transition admonition at the top of this document apply: same-dilemma constraint, pre-commit only, intersection exclusion. The current implementation still cross-assigns `belongs_to` edges to model intersections — this must be replaced with intersection group nodes. See the Story Graph Ontology for the new model.
 
 **Purpose:** Find beats from different paths (different dilemmas) that should be one scene.
 
@@ -389,9 +391,11 @@ membership, which would invalidate pre-intersection pivot beats. Runs before Pha
    - `pivot_beat` must exist in path-scoped beat set
 5. Results stored on path nodes: `entity_arcs: [{entity_id, arc_line, pivot_beat, arc_type}]`
 
-**Shared pivot policy:** If `pivot_beat` belongs to multiple arcs (detected via
-`belongs_to` edges), a warning is logged but no error raised. Path-specific
-pivot beats are preferred.
+**Shared pivot policy:** If `pivot_beat` is shared across multiple arcs (either a
+pre-commit beat with multi-`belongs_to` within its dilemma, or an intersection-
+shared scene), a warning is logged but no error raised. Post-commit, path-
+specific pivot beats are preferred because the entity's trajectory usually
+turns *on* the commit, not before it.
 
 **Output:** Path nodes annotated with `entity_arcs`
 

--- a/docs/design/procedures/polish.md
+++ b/docs/design/procedures/polish.md
@@ -16,7 +16,7 @@ POLISH transforms GROW's beat DAG into a prose-ready passage graph. It is the br
 **Input (from GROW):**
 - Beat nodes with summaries, dilemma impacts, entity references, scene types
 - Predecessor/successor ordering edges in the beat DAG
-- `belongs_to` edges (each beat → exactly one path)
+- `belongs_to` edges (pre-commit beats → every path of their dilemma; commit and post-commit beats → exactly one path — see the [Story Graph Ontology, Part 8](../story-graph-ontology.md))
 - Intersection group nodes with grouped beat references
 - State flag nodes derived from consequences
 - Entity overlay nodes with state flag activation
@@ -48,7 +48,7 @@ def validate_grow_output(graph: Graph) -> list[str]:
 **Required conditions:**
 - Beat nodes exist with summaries and dilemma_impacts
 - No cycles in the predecessor/successor DAG
-- Every beat has exactly one `belongs_to` edge (singular path membership)
+- Every beat has at least one `belongs_to` edge, conforming to the Y-shape invariant: pre-commit beats within a dilemma carry one `belongs_to` edge per path of that dilemma (dual for a binary dilemma); commit beats and post-commit beats carry exactly one. Cross-dilemma multi-`belongs_to` is forbidden. See the [Story Graph Ontology, Part 8, "Path Membership ≠ Scene Participation"](../story-graph-ontology.md) for the three guard rails.
 - State flag nodes exist for each explored dilemma's consequences
 - Dilemma nodes have `dilemma_role` (hard/soft) set
 - Every computed arc traversal is complete (no dead ends)

--- a/docs/design/procedures/seed.md
+++ b/docs/design/procedures/seed.md
@@ -2,6 +2,13 @@
 
 > For the narrative description of the SEED stage, see ["How Branching Stories Work", Part 2](../how-branching-stories-work.md). This document provides the detailed algorithm specification.
 >
+> **Y-shape structure SEED is responsible for creating (#1206).** A dilemma is a minimal branching story shaped like the letter Y. SEED must produce, per dilemma:
+> - A **shared pre-commit chain** — beats that introduce and develop the dilemma. These beats belong to *every* path of the dilemma (two `belongs_to` edges for a binary dilemma) — every player experiences them regardless of which answer they will later choose.
+> - A **commit beat per path** — the first beat exclusive to that path. Each commit beat carries a `dilemma_impacts` entry with `effect: commits`. Commit beats have exactly one `belongs_to` edge.
+> - **2–4 post-commit beats per path** — beats that prove that path's answer. Post-commit beats have exactly one `belongs_to` edge.
+>
+> In the beat DAG, the last shared pre-commit beat has one successor per path (the divergence point); each successor is that path's commit beat. Without this Y-shape, POLISH Phase 4c's `compute_choice_edges()` finds no divergence and produces zero choices. The three guard rails from the [Story Graph Ontology, Part 8, "Path Membership ≠ Scene Participation"](../story-graph-ontology.md) apply: same-dilemma constraint, pre-commit only, intersection exclusion.
+>
 > **Terminology transitions (2026-02-24):** The [Story Graph Ontology](../story-graph-ontology.md) replaces several terms used in this document. The code has not yet been updated.
 > - `convergence_policy` (hard/soft/flavor) → `dilemma_role` (hard/soft). Convergence behavior is derived from the role, not declared directly. `flavor` is removed — flavor-level choices are handled by POLISH as false branches.
 > - `InteractionConstraint` (shared_entity/causal_chain/resource_conflict) → dilemma ordering relationships. The three declared relationships are `wraps`, `concurrent`, and `serial`. `shared_entity` is derived from `anchored_to` edges (not explicitly declared). `causal_chain` is subsumed by `serial`. `resource_conflict` is removed.
@@ -219,13 +226,20 @@ consequences:
       - "Mentor's knowledge becomes available resource"
 ```
 
-LLM also generates 2-4 initial beats per path:
+LLM generates the full Y-shape beat scaffold for each dilemma (see the transition admonition at the top of this document for the complete structure):
+
+- **Shared pre-commit beats** — one chain per dilemma, introducing and developing the dramatic question. Each pre-commit beat carries a `paths` list naming *every* explored path of the dilemma, producing one `belongs_to` edge per listed path. The chain terminates at the last shared pre-commit beat, whose successors in the DAG are the per-path commit beats.
+- **Commit beat per path** — the first beat exclusive to that path, carrying `dilemma_impacts.effect: commits`. Its `paths` list names exactly one path.
+- **Post-commit beats per path** — 2–4 beats that prove the path's answer. Each names exactly one path.
 
 ```yaml
 initial_beats:
+  # Shared pre-commit beat — dual belongs_to within the dilemma
   - id: mentor_warning
     summary: "Mentor delivers cryptic warning about the investigation"
-    paths: [path::mentor_trust__protector]
+    paths:
+      - path::mentor_trust__protector
+      - path::mentor_trust__manipulator
     dilemma_impacts:
       - dilemma_id: dilemma::mentor_trust
         effect: advances
@@ -233,7 +247,20 @@ initial_beats:
     entities: [mentor, kay]
     location: archive_entrance          # primary location
     location_alternatives: []           # filled in Phase 3b
+
+  # Commit beat — first beat exclusive to the protector path (singular belongs_to)
+  - id: mentor_confession_protector
+    summary: "Mentor reveals the protective motive behind the warnings"
+    paths: [path::mentor_trust__protector]
+    dilemma_impacts:
+      - dilemma_id: dilemma::mentor_trust
+        effect: commits
+        path_id: path::mentor_trust__protector
+    entities: [mentor, kay]
+    location: archive_reading_room
 ```
+
+Pre-commit beats have one `belongs_to` edge per path of the dilemma; commit and post-commit beats have exactly one. The number of pre-commit beats is a narrative decision, not a fixed quota — a dilemma may need one shared setup beat or several, depending on how much development the question needs before the fork.
 
 **Human Gate:** Yes
 
@@ -792,7 +819,8 @@ Before SEED is complete, verify:
 - [ ] All dilemmas have exploration decisions
 - [ ] All explored answers have path definitions
 - [ ] All paths have consequences with ripples
-- [ ] All paths have initial beats (2-4 each)
+- [ ] Every explored dilemma has a shared pre-commit chain (one or more beats with `belongs_to` edges to every path of the dilemma)
+- [ ] Every path has a commit beat (singular `belongs_to`, `effect: commits` in `dilemma_impacts`) and 2–4 post-commit beats
 - [ ] Convergence sketch exists
 - [ ] Viability analysis reviewed
 - [ ] No orphan references

--- a/docs/design/procedures/seed.md
+++ b/docs/design/procedures/seed.md
@@ -228,18 +228,17 @@ consequences:
 
 LLM generates the full Y-shape beat scaffold for each dilemma (see the transition admonition at the top of this document for the complete structure):
 
-- **Shared pre-commit beats** — one chain per dilemma, introducing and developing the dramatic question. Each pre-commit beat carries a `paths` list naming *every* explored path of the dilemma, producing one `belongs_to` edge per listed path. The chain terminates at the last shared pre-commit beat, whose successors in the DAG are the per-path commit beats.
-- **Commit beat per path** — the first beat exclusive to that path, carrying `dilemma_impacts.effect: commits`. Its `paths` list names exactly one path.
-- **Post-commit beats per path** — 2–4 beats that prove the path's answer. Each names exactly one path.
+- **Shared pre-commit beats** — one chain per dilemma, introducing and developing the dramatic question. Each pre-commit beat has a `path_id` (its primary path) and an `also_belongs_to` field naming the other explored path of the dilemma, producing one `belongs_to` edge per path. The chain terminates at the last shared pre-commit beat, whose successors in the DAG are the per-path commit beats.
+- **Commit beat per path** — the first beat exclusive to that path, carrying `dilemma_impacts.effect: commits`. It has only `path_id`; `also_belongs_to` is absent or null.
+- **Post-commit beats per path** — 2–4 beats that prove the path's answer. Each has only `path_id`.
 
 ```yaml
 initial_beats:
   # Shared pre-commit beat — dual belongs_to within the dilemma
   - id: mentor_warning
     summary: "Mentor delivers cryptic warning about the investigation"
-    paths:
-      - path::mentor_trust__protector
-      - path::mentor_trust__manipulator
+    path_id: path::mentor_trust__protector
+    also_belongs_to: path::mentor_trust__manipulator
     dilemma_impacts:
       - dilemma_id: dilemma::mentor_trust
         effect: advances
@@ -251,7 +250,7 @@ initial_beats:
   # Commit beat — first beat exclusive to the protector path (singular belongs_to)
   - id: mentor_confession_protector
     summary: "Mentor reveals the protective motive behind the warnings"
-    paths: [path::mentor_trust__protector]
+    path_id: path::mentor_trust__protector
     dilemma_impacts:
       - dilemma_id: dilemma::mentor_trust
         effect: commits

--- a/docs/design/procedures/seed.md
+++ b/docs/design/procedures/seed.md
@@ -254,7 +254,7 @@ initial_beats:
     dilemma_impacts:
       - dilemma_id: dilemma::mentor_trust
         effect: commits
-        path_id: path::mentor_trust__protector
+        note: "Mentor's confession locks in the protective reading"
     entities: [mentor, kay]
     location: archive_reading_room
 ```

--- a/docs/design/story-graph-ontology.md
+++ b/docs/design/story-graph-ontology.md
@@ -85,7 +85,7 @@ A concrete story moment that advances a dilemma toward resolution. The fundament
 Each beat carries:
 - A **summary** of what happens
 - **Dilemma impacts** — which dilemma it serves, and how (advances, reveals, commits, or complicates)
-- **Path membership** — which path this beat belongs to (via `belongs_to` edge)
+- **Path membership** — which path(s) this beat serves (via `belongs_to` edges). Pre-commit beats belong to every path of their dilemma (two edges for a binary dilemma); commit and post-commit beats belong to exactly one path. See Part 8, "Path Membership ≠ Scene Participation" for the full invariant.
 - **Entity references** — which entities are present
 - **Working annotations** that are consumed during the pipeline and do not persist (see Part 3)
 
@@ -216,14 +216,14 @@ The beat DAG (directed acyclic graph) is the central artifact of the pipeline. S
 
 Each node in the DAG is a beat. Each directed edge means "this beat comes before that beat" — a predecessor/successor relationship. The DAG encodes every valid ordering of story moments across all possible playthroughs.
 
-A beat with two successors (one per path of a dilemma) represents a **divergence**: the story splits at the commit. A beat with two predecessors (from different paths) represents a **convergence**: the storylines rejoin. These structural moments are not separate node types — they are visible in the DAG's topology. The commit beat IS the divergence point. The first shared beat after payoff beats IS the convergence point.
+A beat with two successors (one per path of a dilemma) represents a **divergence**: the story splits at the commit. A beat with two predecessors (from different paths) represents a **convergence**: the storylines rejoin. These structural moments are not separate node types — they are visible in the DAG's topology. Divergence happens *between* the last shared pre-commit beat (which has one successor per path) and the per-path commit beats that follow it — each commit beat is the first beat exclusive to its path. The first shared beat after payoff beats IS the convergence point.
 
 ### Beat Lifecycle
 
 A beat passes through several stages, accumulating and shedding metadata:
 
 **Created by SEED:**
-- Summary, dilemma impacts, path membership (`belongs_to` edge), entity references
+- Summary, dilemma impacts, path membership (`belongs_to` edges — dual for pre-commit beats within one dilemma, singular for commit and post-commit beats), entity references
 - **Working annotations** consumed by GROW:
   - Entity flexibility (substitution edges to alternative entities — "the spy could be the informant")
   - Temporal hints (position relative to other dilemmas — "should come before dilemma B commits")
@@ -274,13 +274,13 @@ Temporal hints are optional. A beat with no hint has no constraint on its placem
 
 ### The 2^N Law in Graph Terms
 
-The central structural insight of "How Branching Stories Work": any beat placed after N committed dilemmas exists in up to 2^N versions. In the DAG, this is visible as the branching factor:
+The central structural insight of "How Branching Stories Work": after N commits have been made, the player is on one of up to 2^N distinct paths through the story. In the DAG, this is visible as the branching factor:
 
-- A beat before any commit has one predecessor path through the DAG — it exists once.
-- A beat after one commit has predecessors from two branches — it exists in two versions (or is shared if it belongs to both paths).
-- A beat after two commits has predecessors from four branches — up to four versions.
+- A beat before any commit is shared: every player experiences it, and it belongs to every path of its dilemma.
+- After one commit, the player is on one of two paths. Each post-commit beat belongs to exactly one of those paths.
+- After two commits, the player is on one of up to four paths; each post-commit beat belongs to one of them.
 
-This is not a property of the beat itself but of its **position in the DAG relative to commit beats**. The same beat, moved earlier in the DAG (before a commit), would exist in fewer versions. This is why dilemma ordering matters: hard dilemmas committing late keeps most beats in the shared region, minimizing multiplication.
+Beats are not cloned per reachable state — each beat is one node with one set of `belongs_to` edges. The multiplication is in the number of distinct traversals through the DAG, not in the number of beat nodes. This is why dilemma ordering matters: hard dilemmas committing late keeps most beats in the shared region (where they belong to every path of their dilemma), minimizing the fraction of the story that is path-specific.
 
 ### Total Order Per Arc
 


### PR DESCRIPTION
## Summary

This is PR 2 of a three-PR documentation cleanup. It aligns the authoritative design docs with the Y-shape dilemma beat structure (from #1206) and deprecates the legacy `docs/design/00-spec.md` in favor of the new doc set.

**Stacked on:** #1211 (base = `docs/rename-design-doc-titles`). Please review/merge after #1211.

### Y-shape invariant enforced across the docs

Every dilemma is a Y-shaped minimal branching story:

- **Shared pre-commit chain** — one or more beats that introduce and develop the dramatic question. Each pre-commit beat belongs to *every* path of the dilemma (two `belongs_to` edges for a binary dilemma). Every player experiences these beats.
- **Commit beat per path** — the first beat exclusive to that path; carries a `dilemma_impacts` entry with `effect: commits` and has exactly one `belongs_to` edge.
- **Post-commit beats per path** — 2–4 beats that prove the path's answer; each has exactly one `belongs_to` edge.

Divergence happens *between* the last shared pre-commit beat and the per-path commit beats that follow it. Three guard rails apply (from Story Graph Ontology Part 8):
1. **Same-dilemma constraint** — any beat with two `belongs_to` edges must reference paths of the same dilemma; cross-dilemma multi-`belongs_to` is forbidden.
2. **Pre-commit only** — only beats before the dilemma's commit may have multi-`belongs_to`.
3. **Intersection exclusion** — intersection groups must not contain two pre-commit beats from the same dilemma (they already co-occur by definition).

### Changes

- **`docs/design/story-graph-ontology.md`**
  - Part 2 "Beats": path membership bullet describes dual pre-commit vs. singular commit/post-commit `belongs_to`.
  - Part 3 "Beat DAG": divergence reframed as the transition between the last shared pre-commit beat and the per-path commit beats.
  - Part 3 "Beat Lifecycle": SEED-created items list updated for dual-edge pre-commit beats.
  - Part 3 "2^N Law in Graph Terms": clarified that "2^N" counts distinct paths the player can be on, not versions of each beat node. Beats are not cloned per reachable state.

- **`docs/design/procedures/seed.md`**
  - Added transition admonition at the top spelling out SEED's Y-shape responsibility and the three guard rails (#1206 rationale).
  - Phase 3 beat scaffold shows a pre-commit beat with dual `paths` and a commit beat with singular `paths`; explains pre-commit beat count is a narrative decision, not a fixed quota.
  - Output Checklist updated to require a shared pre-commit chain per dilemma and a commit beat + 2–4 post-commit beats per path.

- **`docs/design/procedures/grow.md`**
  - Top admonition intersection bullet describes the Y-shape `belongs_to` semantics and three guard rails.
  - Phase 2 removal note: multi-arc membership now derived from DAG position relative to commit beats, not from multi-arc `belongs_to` annotations.
  - Phase 3 intersection detection admonition rewritten for the Y-shape invariant.
  - Shared pivot policy expanded to cover pre-commit multi-`belongs_to` beats and intersection-shared scenes; post-commit path-specific pivots remain preferred.

- **`docs/design/procedures/polish.md`**
  - GROW-output description updated to reference Y-shape `belongs_to` edges (with pointer to Part 8).
  - Input validation requirement: every beat has at least one `belongs_to`; pre-commit beats within a dilemma carry one per path (dual for binary), commit and post-commit beats carry exactly one; cross-dilemma multi-`belongs_to` remains forbidden.

- **`docs/design/00-spec.md`**
  - Added a prominent deprecation banner at the top pointing to `how-branching-stories-work.md`, `story-graph-ontology.md`, and `procedures/*.md` as the authoritative sources.
  - Removed the older "Status update" paragraph it replaces.

- **`CLAUDE.md`**
  - "Model Workflow (Ontology → Pydantic → Graph)" cites `story-graph-ontology.md` (alongside `how-branching-stories-work.md`) instead of `00-spec.md`.
  - "Key Files to Reference" reordered with the two authoritative docs first; `00-spec.md` moved to the bottom and marked **Deprecated.**
  - "Context Enrichment Principle (Ontology-Driven)" — both references to "the ontology (`docs/design/00-spec.md`)" redirected to `story-graph-ontology.md`.

### Scope

Documentation only. No code, models, prompts, or tests change. The implementation is still on the old model — PR 3 of this series tracks code alignment, and #1206 is the umbrella issue.

### Stragglers from `docs/amend-belongs-to-precommit`

The two post-merge fix commits on `docs/amend-belongs-to-precommit` (`561218b` "update stale 'single belongs_to' in intersection reconciliation section" and `2002ccc` "update stale singular `belongs_to` in intersection graph representation") were already squash-merged as part of #1208; no re-application was needed in this PR.

## Test plan

- [ ] Verify deprecation banner renders at the top of `docs/design/00-spec.md`.
- [ ] `grep -i "single[- ]belongs[_ ]to\|exactly one belongs_to\|one belongs_to edge" docs/design/` returns no matches that claim singular membership as a universal invariant.
- [ ] `grep "2\^N versions" docs/design/` returns no matches.
- [ ] `grep "belongs to (one|exactly one|a single) path" -iE docs/design/` returns no matches.
- [ ] `grep "00-spec" CLAUDE.md` only matches the explicit deprecation callout in "Key Files to Reference" (no authoritative-source references remain).
- [ ] Three guard rails are referenced consistently from grow.md, polish.md, seed.md, and anchored in `story-graph-ontology.md` Part 8.
- [ ] Narrative sanity-check: confirm SEED admonition matches the Y-shape structure described in `how-branching-stories-work.md` Part 2.

Refs #1206