### PR TITLE
feat(y-shape): Phase 1+2 — InitialBeat.also_belongs_to + dual belongs_to emission + write-time guard rails

### DIFF
--- a/src/questfoundry/graph/algorithms.py
+++ b/src/questfoundry/graph/algorithms.py
@@ -80,17 +80,19 @@ def compute_active_flags_at_beat(graph: Graph, beat_id: str) -> set[frozenset[st
 
     # Step 3: Find commit beats among ancestors and group by dilemma
     # A commit beat has dilemma_impacts with effect="commits"
+    # Y-shape (Story Graph Ontology §8): pre-commit beats have two belongs_to edges (same
+    # dilemma, both paths); post-commit beats have exactly one. A beat's
+    # state-flag contribution depends on which path the player is on, not on
+    # which belongs_to edge we happen to read first.
     belongs_to_edges = graph.get_edges(edge_type="belongs_to")
-    beat_to_path: dict[str, str] = {}
+    _accum: dict[str, set[str]] = {}
     for edge in belongs_to_edges:
         from_id = edge["from"]
         if from_id in beat_nodes:
-            if from_id in beat_to_path:
-                # Entry contract (validate_grow_output) enforces exactly-one belongs_to
-                # per beat, so this should never happen on valid GROW output.
-                msg = f"Beat {from_id!r} has multiple belongs_to edges"
-                raise ValueError(msg)
-            beat_to_path[from_id] = edge["to"]
+            _accum.setdefault(from_id, set()).add(edge["to"])
+    beat_to_paths: dict[str, frozenset[str]] = {
+        bid: frozenset(paths) for bid, paths in _accum.items()
+    }
 
     # Include beat_id itself as a candidate (it may be a commit beat)
     candidates = ancestors | {beat_id}
@@ -102,13 +104,27 @@ def compute_active_flags_at_beat(graph: Graph, beat_id: str) -> set[frozenset[st
         candidate_data = beat_nodes[candidate_id]
         impacts = candidate_data.get("dilemma_impacts", [])
         for impact in impacts:
-            if impact.get("effect") == "commits":
-                dilemma_id = impact.get("dilemma_id", "")
-                path_id = beat_to_path.get(candidate_id, "")
-                if dilemma_id and path_id:
-                    # State flag: "{dilemma_id}:{path_id}"
-                    flag = f"{dilemma_id}:{path_id}"
-                    dilemma_flags.setdefault(dilemma_id, []).append(flag)
+            if impact.get("effect") != "commits":
+                continue
+            dilemma_id = impact.get("dilemma_id", "")
+            if not dilemma_id:
+                continue
+            # Commit beats are single-membership (guard rail 2), so
+            # beat_to_paths[candidate] has exactly one element. If code
+            # elsewhere produces a multi-membership commit beat, that is a
+            # guard-rail violation and we raise instead of guessing.
+            paths = beat_to_paths.get(candidate_id, frozenset())
+            if len(paths) == 0:
+                continue
+            if len(paths) > 1:
+                msg = (
+                    f"commit beat {candidate_id!r} has multiple belongs_to edges "
+                    f"(guard rail 2 violation): {sorted(paths)!r}"
+                )
+                raise ValueError(msg)
+            (path_id,) = paths
+            flag = f"{dilemma_id}:{path_id}"
+            dilemma_flags.setdefault(dilemma_id, []).append(flag)
 
     if not dilemma_flags:
         return {frozenset()}

--- a/src/questfoundry/graph/grow_algorithms.py
+++ b/src/questfoundry/graph/grow_algorithms.py
@@ -1981,6 +1981,9 @@ def apply_intersection_mark(
     pre_commits = [bid for bid, pids in beat_path_ids.items() if len(pids) >= 2]
     if len(pre_commits) >= 2:
         # Check whether any two share the exact same path set (same dilemma).
+        # Binary Y-shape: same frozenset of path IDs implies same dilemma
+        # (pre-commit beats of a dilemma belong to exactly its two explored paths).
+        # Non-binary dilemmas (3+ paths) would require explicit dilemma_id comparison.
         seen: dict[frozenset[str], str] = {}
         for bid in pre_commits:
             key = frozenset(beat_path_ids[bid])

--- a/src/questfoundry/graph/grow_algorithms.py
+++ b/src/questfoundry/graph/grow_algorithms.py
@@ -1970,6 +1970,30 @@ def apply_intersection_mark(
         shared_entities: Entity IDs shared between the intersecting beats.
         rationale: One-sentence explanation of why these beats form a natural scene.
     """
+    # Guard rail 3 (Story Graph Ontology §8 "Path Membership"):
+    # an intersection group must not contain two pre-commit beats from the same
+    # dilemma -- those beats already co-occur by definition.
+    belongs_to = graph.get_edges(edge_type="belongs_to")
+    beat_path_ids: dict[str, set[str]] = {}
+    for e in belongs_to:
+        if e["from"] in beat_ids:
+            beat_path_ids.setdefault(e["from"], set()).add(e["to"])
+    pre_commits = [bid for bid, pids in beat_path_ids.items() if len(pids) >= 2]
+    if len(pre_commits) >= 2:
+        # Check whether any two share the exact same path set (same dilemma).
+        seen: dict[frozenset[str], str] = {}
+        for bid in pre_commits:
+            key = frozenset(beat_path_ids[bid])
+            if key in seen:
+                msg = (
+                    "guard rail 3: intersection group would contain two "
+                    f"pre-commit beats from the same dilemma ({seen[key]!r}, {bid!r}). "
+                    "Pre-commit beats of the same dilemma already co-occur; "
+                    "declaring them as an intersection is forbidden."
+                )
+                raise ValueError(msg)
+            seen[key] = bid
+
     # Derive a stable group ID from the sorted beat IDs
     sorted_ids = sorted(beat_ids)
     raw_group_id = "--".join(strip_scope_prefix(b) for b in sorted_ids)

--- a/src/questfoundry/graph/grow_algorithms.py
+++ b/src/questfoundry/graph/grow_algorithms.py
@@ -1973,11 +1973,10 @@ def apply_intersection_mark(
     # Guard rail 3 (Story Graph Ontology §8 "Path Membership"):
     # an intersection group must not contain two pre-commit beats from the same
     # dilemma -- those beats already co-occur by definition.
-    belongs_to = graph.get_edges(edge_type="belongs_to")
     beat_path_ids: dict[str, set[str]] = {}
-    for e in belongs_to:
-        if e["from"] in beat_ids:
-            beat_path_ids.setdefault(e["from"], set()).add(e["to"])
+    for bid in beat_ids:
+        for e in graph.get_edges(from_id=bid, edge_type="belongs_to"):
+            beat_path_ids.setdefault(bid, set()).add(e["to"])
     pre_commits = [bid for bid, pids in beat_path_ids.items() if len(pids) >= 2]
     if len(pre_commits) >= 2:
         # Check whether any two share the exact same path set (same dilemma).

--- a/src/questfoundry/graph/mutations.py
+++ b/src/questfoundry/graph/mutations.py
@@ -1851,6 +1851,14 @@ def apply_seed_mutations(graph: Graph, output: dict[str, Any]) -> None:
         if prefixed_path_id and graph.has_node(prefixed_path_id):
             graph.add_edge("has_consequence", prefixed_path_id, consequence_id)
 
+    # Build a raw path -> dilemma map for guard-rail 1 enforcement.
+    _path_to_dilemma: dict[str, str] = {}
+    for p in output.get("paths", []):
+        pid = p.get("path_id")
+        did = p.get("dilemma_id")
+        if pid and did:
+            _path_to_dilemma[pid] = did
+
     # Create initial beats
     for i, beat in enumerate(output.get("initial_beats", [])):
         raw_id = _require_field(beat, "beat_id", f"Beat at index {i}")
@@ -1910,6 +1918,35 @@ def apply_seed_mutations(graph: Graph, output: dict[str, Any]) -> None:
         # Link beat to its path(s). Post-commit beats emit one belongs_to;
         # pre-commit (Y-shape) beats with ``also_belongs_to`` emit two.
         raw_path_ids = _get_path_ids_from_beat(beat)
+
+        # Guard rail 1 (Story Graph Ontology §8 "Path Membership"):
+        # dual belongs_to must reference paths of the same dilemma.
+        if len(raw_path_ids) == 2:
+            d0 = _path_to_dilemma.get(raw_path_ids[0])
+            d1 = _path_to_dilemma.get(raw_path_ids[1])
+            if d0 is None or d1 is None or d0 != d1:
+                msg = (
+                    "cross-dilemma dual belongs_to is forbidden (guard rail 1). "
+                    f"Beat {raw_id!r} has path_id={raw_path_ids[0]!r} (dilemma={d0!r}) and "
+                    f"also_belongs_to={raw_path_ids[1]!r} (dilemma={d1!r})."
+                )
+                raise ValueError(msg)
+
+        # Guard rail 2: commit beats are single-membership. A commit beat is
+        # the first beat exclusive to its path - it cannot also belong to the
+        # sibling path.
+        if len(raw_path_ids) == 2:
+            has_commit = any(
+                imp.get("effect") == "commits" for imp in beat.get("dilemma_impacts", [])
+            )
+            if has_commit:
+                msg = (
+                    "guard rail 2: a beat with effect=commits must have a single "
+                    f"belongs_to (no also_belongs_to). Beat {raw_id!r} has both "
+                    f"a commits impact and also_belongs_to={raw_path_ids[1]!r}."
+                )
+                raise ValueError(msg)
+
         for raw_path_id in raw_path_ids:
             prefixed_path_id = _prefix_id("path", raw_path_id)
             graph.add_edge("belongs_to", beat_id, prefixed_path_id)

--- a/src/questfoundry/graph/mutations.py
+++ b/src/questfoundry/graph/mutations.py
@@ -1903,10 +1903,11 @@ def apply_seed_mutations(graph: Graph, output: dict[str, Any]) -> None:
         # Link beat to its path(s). Post-commit beats emit one belongs_to;
         # pre-commit (Y-shape) beats with ``also_belongs_to`` emit two.
         raw_path_ids = _get_path_ids_from_beat(beat)
+        is_dual = len(raw_path_ids) == 2
 
         # Guard rail 1 (Story Graph Ontology §8 "Path Membership"):
         # dual belongs_to must reference paths of the same dilemma.
-        if len(raw_path_ids) == 2:
+        if is_dual:
             d0 = _path_to_dilemma.get(raw_path_ids[0])
             d1 = _path_to_dilemma.get(raw_path_ids[1])
             if d0 is None or d1 is None or d0 != d1:
@@ -1920,7 +1921,7 @@ def apply_seed_mutations(graph: Graph, output: dict[str, Any]) -> None:
         # Guard rail 2: commit beats are single-membership. A commit beat is
         # the first beat exclusive to its path - it cannot also belong to the
         # sibling path.
-        if len(raw_path_ids) == 2:
+        if is_dual:
             has_commit = any(
                 imp.get("effect") == "commits" for imp in beat.get("dilemma_impacts", [])
             )

--- a/src/questfoundry/graph/mutations.py
+++ b/src/questfoundry/graph/mutations.py
@@ -765,21 +765,6 @@ def _prefix_entity_id(category: str, raw_id: str) -> str:
     return format_entity_id(category, raw_id)
 
 
-def _get_path_id_from_beat(beat: dict[str, Any]) -> str | None:
-    """Extract path ID from a beat dict, supporting both current and legacy formats.
-
-    Args:
-        beat: Beat dict with ``path_id`` (current) or ``paths`` (legacy).
-
-    Returns:
-        Raw path ID string, or None if not present.
-
-    .. deprecated::
-        Use :func:`_get_path_ids_from_beat` which supports Y-shape dual membership.
-    """
-    return beat.get("path_id") or (beat.get("paths", [None])[0] if beat.get("paths") else None)
-
-
 def _get_path_ids_from_beat(beat: dict[str, Any]) -> tuple[str, ...]:
     """Extract path IDs from a beat dict, supporting current and legacy formats.
 

--- a/src/questfoundry/graph/mutations.py
+++ b/src/questfoundry/graph/mutations.py
@@ -1929,6 +1929,12 @@ def apply_seed_mutations(graph: Graph, output: dict[str, Any]) -> None:
                     f"also_belongs_to={raw_path_ids[1]!r} (dilemma={d1!r})."
                 )
                 raise ValueError(msg)
+            if strip_scope_prefix(raw_path_ids[0]) == strip_scope_prefix(raw_path_ids[1]):
+                msg = (
+                    f"beat {raw_id!r}: path_id and also_belongs_to must be distinct paths "
+                    f"({raw_path_ids[0]!r} == {raw_path_ids[1]!r})."
+                )
+                raise ValueError(msg)
 
         # Guard rail 2: commit beats are single-membership. A commit beat is
         # the first beat exclusive to its path - it cannot also belong to the

--- a/src/questfoundry/graph/mutations.py
+++ b/src/questfoundry/graph/mutations.py
@@ -773,8 +773,41 @@ def _get_path_id_from_beat(beat: dict[str, Any]) -> str | None:
 
     Returns:
         Raw path ID string, or None if not present.
+
+    .. deprecated::
+        Use :func:`_get_path_ids_from_beat` which supports Y-shape dual membership.
     """
     return beat.get("path_id") or (beat.get("paths", [None])[0] if beat.get("paths") else None)
+
+
+def _get_path_ids_from_beat(beat: dict[str, Any]) -> tuple[str, ...]:
+    """Extract path IDs from a beat dict, supporting current and legacy formats.
+
+    Supports:
+    - Y-shape current: ``path_id`` + optional ``also_belongs_to``.
+    - Legacy single: ``path_id`` alone.
+    - Legacy list: ``paths: [p]`` or ``paths: [p_a, p_b]`` (pre-Y-shape).
+
+    Args:
+        beat: Beat dict, either model-dumped or raw LLM output.
+
+    Returns:
+        Tuple of 0, 1, or 2 raw path IDs in declaration order (``path_id``
+        first, then ``also_belongs_to``). A return of 2 always represents a
+        pre-commit Y-shape beat. A return of 0 means the beat has no path
+        reference (caught by validation).
+    """
+    if beat.get("path_id"):
+        primary = str(beat["path_id"])
+        also = beat.get("also_belongs_to")
+        if also:
+            return (primary, str(also))
+        return (primary,)
+    # Legacy fallback.
+    paths = beat.get("paths")
+    if isinstance(paths, list) and paths:
+        return tuple(str(p) for p in paths[:2])
+    return ()
 
 
 def _resolve_entity_ref(graph: Graph, entity_ref: str) -> str:

--- a/src/questfoundry/graph/mutations.py
+++ b/src/questfoundry/graph/mutations.py
@@ -1907,9 +1907,10 @@ def apply_seed_mutations(graph: Graph, output: dict[str, Any]) -> None:
         beat_data = _clean_dict(beat_data)
         graph.create_node(beat_id, beat_data)
 
-        # Link beat to its path (singular belongs_to edge)
-        raw_path_id = _get_path_id_from_beat(beat)
-        if raw_path_id:
+        # Link beat to its path(s). Post-commit beats emit one belongs_to;
+        # pre-commit (Y-shape) beats with ``also_belongs_to`` emit two.
+        raw_path_ids = _get_path_ids_from_beat(beat)
+        for raw_path_id in raw_path_ids:
             prefixed_path_id = _prefix_id("path", raw_path_id)
             graph.add_edge("belongs_to", beat_id, prefixed_path_id)
 

--- a/src/questfoundry/graph/mutations.py
+++ b/src/questfoundry/graph/mutations.py
@@ -1341,14 +1341,15 @@ def validate_seed_mutations(graph: Graph, output: dict[str, Any]) -> list[SeedVa
                     )
                 )
 
-        # 6. Path reference (singular — each beat belongs to exactly one path)
-        raw_path_id = _get_path_id_from_beat(beat)
-        if raw_path_id:
+        # 6. Path references (Y-shape: path_id + optional also_belongs_to).
+        raw_path_ids = _get_path_ids_from_beat(beat)
+        for idx, raw_path_id in enumerate(raw_path_ids):
+            field_name = "path_id" if idx == 0 else "also_belongs_to"
             _validate_id(
                 raw_path_id,
                 "path",
                 seed_path_ids,
-                f"initial_beats.{i}.path_id",
+                f"initial_beats.{i}.{field_name}",
                 errors,
                 sorted_path_ids,
                 cross_type_sets=cross_type_sets,
@@ -1558,10 +1559,13 @@ def validate_seed_mutations(graph: Graph, output: dict[str, Any]) -> list[SeedVa
     # Per-path: list of (beat_index, effects_set) for parent dilemma impacts
     path_beat_effects: dict[str, list[tuple[int, set[str]]]] = {}
     for i, beat in enumerate(output.get("initial_beats", [])):
-        # Resolve beat's path (singular path_id, with legacy paths fallback)
-        raw_pid = _get_path_id_from_beat(beat)
-        if not raw_pid:
+        # Resolve beat's primary path; pre-commit beats have a second membership
+        # (also_belongs_to) but the commits-per-path accumulator is only
+        # concerned with single-membership commit beats (guard rail 2).
+        raw_path_ids = _get_path_ids_from_beat(beat)
+        if not raw_path_ids:
             continue  # Missing path — already caught by check 6
+        raw_pid = raw_path_ids[0]
         normalized_pid, _ = _normalize_id(raw_pid, "path")
 
         # Collect normalized dilemma_ids referenced in this beat's impacts

--- a/src/questfoundry/graph/mutations.py
+++ b/src/questfoundry/graph/mutations.py
@@ -1842,7 +1842,7 @@ def apply_seed_mutations(graph: Graph, output: dict[str, Any]) -> None:
         pid = p.get("path_id")
         did = p.get("dilemma_id")
         if pid and did:
-            _path_to_dilemma[pid] = did
+            _path_to_dilemma[strip_scope_prefix(str(pid))] = strip_scope_prefix(str(did))
 
     # Create initial beats
     for i, beat in enumerate(output.get("initial_beats", [])):
@@ -1908,9 +1908,21 @@ def apply_seed_mutations(graph: Graph, output: dict[str, Any]) -> None:
         # Guard rail 1 (Story Graph Ontology §8 "Path Membership"):
         # dual belongs_to must reference paths of the same dilemma.
         if is_dual:
-            d0 = _path_to_dilemma.get(raw_path_ids[0])
-            d1 = _path_to_dilemma.get(raw_path_ids[1])
-            if d0 is None or d1 is None or d0 != d1:
+            d0 = _path_to_dilemma.get(strip_scope_prefix(raw_path_ids[0]))
+            d1 = _path_to_dilemma.get(strip_scope_prefix(raw_path_ids[1]))
+            if d0 is None:
+                msg = (
+                    f"beat {raw_id!r}: path_id={raw_path_ids[0]!r} has no known dilemma "
+                    "(not in output paths); cannot enforce guard rail 1."
+                )
+                raise ValueError(msg)
+            if d1 is None:
+                msg = (
+                    f"beat {raw_id!r}: also_belongs_to={raw_path_ids[1]!r} has no known dilemma "
+                    "(not in output paths); cannot enforce guard rail 1."
+                )
+                raise ValueError(msg)
+            if d0 != d1:
                 msg = (
                     "cross-dilemma dual belongs_to is forbidden (guard rail 1). "
                     f"Beat {raw_id!r} has path_id={raw_path_ids[0]!r} (dilemma={d0!r}) and "

--- a/src/questfoundry/models/seed.py
+++ b/src/questfoundry/models/seed.py
@@ -235,13 +235,28 @@ class TemporalHint(BaseModel):
 class InitialBeat(BaseModel):
     """Initial beat created by SEED.
 
-    Each beat belongs to exactly one path (single ``belongs_to`` edge in the
-    graph).  SEED creates initial beats per path; GROW mutates and adds more.
+    Beats carry either a single or a dual ``belongs_to`` edge to path nodes:
+
+    * **Post-commit beats** (the default) belong to exactly one path via
+      ``path_id``; ``also_belongs_to`` is ``None``. These beats prove one
+      answer and are exclusive to the path they belong to.
+    * **Pre-commit beats** (shared dilemma setup) belong to *both* paths of
+      their dilemma via ``path_id`` and ``also_belongs_to``. This is the
+      Y-shape ratified in #1206/#1208: every player experiences pre-commit
+      beats regardless of which answer they later choose.
+
+    The commit beat itself is single-``belongs_to`` — it is the first beat
+    exclusive to its path.
 
     Attributes:
         beat_id: Unique identifier for the beat.
         summary: What happens in this beat.
-        path_id: The single path this beat belongs to.
+        path_id: Primary path this beat belongs to.
+        also_belongs_to: Sibling path for pre-commit (shared) beats. ``None``
+            for post-commit beats. MUST reference a path that shares the same
+            parent dilemma with ``path_id`` — cross-dilemma dual membership
+            is a Part-8 guard-rail violation and is rejected by the mutation
+            layer.
         dilemma_impacts: How this beat affects dilemmas.
         entities: Entity IDs present in this beat.
         location: Primary location entity ID.
@@ -253,7 +268,15 @@ class InitialBeat(BaseModel):
     summary: str = Field(min_length=1, description="What happens in this beat")
     path_id: str = Field(
         min_length=1,
-        description="Path ID this beat belongs to (single belongs_to edge)",
+        description="Primary path this beat belongs to (first belongs_to edge)",
+    )
+    also_belongs_to: str | None = Field(
+        default=None,
+        description=(
+            "Sibling path for pre-commit (Y-shape) beats: creates a second "
+            "belongs_to edge. Must be null for post-commit beats. Must "
+            "reference a path with the same parent dilemma as path_id."
+        ),
     )
 
     @model_validator(mode="before")
@@ -278,6 +301,14 @@ class InitialBeat(BaseModel):
                 msg = "InitialBeat.paths is empty — each beat must belong to a path."
                 raise ValueError(msg)
         return data
+
+    @model_validator(mode="after")
+    def _also_belongs_to_differs_from_path_id(self) -> InitialBeat:
+        """Dual membership requires two distinct path IDs."""
+        if self.also_belongs_to is not None and self.also_belongs_to == self.path_id:
+            msg = "also_belongs_to must differ from path_id — dual membership needs two paths."
+            raise ValueError(msg)
+        return self
 
     dilemma_impacts: list[DilemmaImpact] = Field(
         default_factory=list,

--- a/src/questfoundry/models/seed.py
+++ b/src/questfoundry/models/seed.py
@@ -282,24 +282,39 @@ class InitialBeat(BaseModel):
     @model_validator(mode="before")
     @classmethod
     def _migrate_paths_to_path_id(cls, data: Any) -> Any:
-        """Accept legacy ``paths: [single_id]`` and convert to ``path_id``."""
+        """Accept legacy ``paths`` and convert to Y-shape (``path_id`` + optional ``also_belongs_to``).
+
+        - ``paths: [single_id]`` → ``path_id = single_id`` (post-commit beat).
+        - ``paths: [p_a, p_b]`` → ``path_id = p_a``, ``also_belongs_to = p_b``
+          (pre-commit beat, Y-shape dual membership).
+        - ``paths: []`` is rejected — every beat must reference at least one path.
+        - ``paths`` with 3+ entries is rejected — dual membership is bounded to
+          the two paths of one dilemma (Part 8 guard rail 1).
+        """
         if not isinstance(data, dict):
             return data
         if "paths" in data and "path_id" not in data:
             paths = data.pop("paths")
-            if isinstance(paths, list) and len(paths) == 1:
-                data["path_id"] = paths[0]
-            elif isinstance(paths, list) and len(paths) > 1:
+            if not isinstance(paths, list):
+                return data  # Let Pydantic reject the non-list type.
+            if len(paths) == 0:
+                msg = "InitialBeat.paths is empty — each beat must belong to at least one path."
+                raise ValueError(msg)
+            if len(paths) > 2:
+                msg = (
+                    "InitialBeat.paths has at most 2 entries (Y-shape guard rail 1). "
+                    f"Got {len(paths)}: {paths!r}."
+                )
+                raise ValueError(msg)
+            data["path_id"] = paths[0]
+            if len(paths) == 2:
                 warnings.warn(
-                    f"InitialBeat.paths had {len(paths)} entries; using first. "
-                    "Multi-path beats are handled via intersection groups.",
+                    "InitialBeat.paths=[p_a, p_b] is deprecated — use "
+                    "path_id=p_a and also_belongs_to=p_b directly.",
                     DeprecationWarning,
                     stacklevel=2,
                 )
-                data["path_id"] = paths[0]
-            elif isinstance(paths, list) and len(paths) == 0:
-                msg = "InitialBeat.paths is empty — each beat must belong to a path."
-                raise ValueError(msg)
+                data["also_belongs_to"] = paths[1]
         return data
 
     @model_validator(mode="after")

--- a/src/questfoundry/models/seed.py
+++ b/src/questfoundry/models/seed.py
@@ -310,8 +310,8 @@ class InitialBeat(BaseModel):
             data["path_id"] = paths[0]
             if len(paths) == 2:
                 warnings.warn(
-                    "InitialBeat.paths=[p_a, p_b] is deprecated — use "
-                    "path_id=p_a and also_belongs_to=p_b directly.",
+                    f"InitialBeat.paths=[{paths[0]!r}, {paths[1]!r}] is deprecated — use "
+                    "path_id and also_belongs_to directly.",
                     DeprecationWarning,
                     stacklevel=2,
                 )

--- a/src/questfoundry/models/seed.py
+++ b/src/questfoundry/models/seed.py
@@ -272,6 +272,7 @@ class InitialBeat(BaseModel):
     )
     also_belongs_to: str | None = Field(
         default=None,
+        min_length=1,
         description=(
             "Sibling path for pre-commit (Y-shape) beats: creates a second "
             "belongs_to edge. Must be null for post-commit beats. Must "

--- a/tests/unit/test_algorithms.py
+++ b/tests/unit/test_algorithms.py
@@ -930,3 +930,89 @@ class TestComputePassageTraversalsFallback:
         result = compute_passage_traversals(graph)
         # Should use grouped_in only, ignoring passage_from
         assert result == {"alpha": ["passage::p1"]}
+
+
+# ---------------------------------------------------------------------------
+# Task 2.7: compute_active_flags_at_beat handles dual belongs_to (Y-shape)
+# ---------------------------------------------------------------------------
+
+
+class TestComputeActiveFlagsDualBelongsTo:
+    """Tests for Y-shape pre-commit beats with dual belongs_to edges."""
+
+    def test_dual_belongs_to_pre_commit_ancestor_does_not_raise(self) -> None:
+        """Pre-commit ancestors with dual belongs_to do not crash flag derivation."""
+        graph = Graph.empty()
+        # Manually construct a minimal Y-shape:
+        # shared_setup (pre-commit, dual) -> commit_a (commits trust, path A)
+        # shared_setup                    -> commit_b (commits trust, path B)
+        graph.create_node("path::trust__a", {"type": "path", "dilemma_id": "trust"})
+        graph.create_node("path::trust__b", {"type": "path", "dilemma_id": "trust"})
+        graph.create_node(
+            "beat::shared_setup",
+            {
+                "type": "beat",
+                "dilemma_impacts": [{"dilemma_id": "trust", "effect": "advances"}],
+            },
+        )
+        graph.create_node(
+            "beat::commit_a",
+            {
+                "type": "beat",
+                "dilemma_impacts": [{"dilemma_id": "trust", "effect": "commits"}],
+            },
+        )
+        graph.create_node(
+            "beat::commit_b",
+            {
+                "type": "beat",
+                "dilemma_impacts": [{"dilemma_id": "trust", "effect": "commits"}],
+            },
+        )
+        graph.add_edge("belongs_to", "beat::shared_setup", "path::trust__a")
+        graph.add_edge("belongs_to", "beat::shared_setup", "path::trust__b")
+        graph.add_edge("belongs_to", "beat::commit_a", "path::trust__a")
+        graph.add_edge("belongs_to", "beat::commit_b", "path::trust__b")
+        graph.add_edge("predecessor", "beat::commit_a", "beat::shared_setup")
+        graph.add_edge("predecessor", "beat::commit_b", "beat::shared_setup")
+
+        # Flags at beat::commit_a should not raise and should yield exactly one
+        # flag: "trust:path::trust__a".
+        flags = compute_active_flags_at_beat(graph, "beat::commit_a")
+        assert flags == {frozenset({"trust:path::trust__a"})}
+
+    def test_dual_belongs_to_pre_commit_ancestor_commit_b_path(self) -> None:
+        """Flags at commit_b resolve to path B, not path A."""
+        graph = Graph.empty()
+        graph.create_node("path::trust__a", {"type": "path", "dilemma_id": "trust"})
+        graph.create_node("path::trust__b", {"type": "path", "dilemma_id": "trust"})
+        graph.create_node(
+            "beat::shared_setup",
+            {
+                "type": "beat",
+                "dilemma_impacts": [{"dilemma_id": "trust", "effect": "advances"}],
+            },
+        )
+        graph.create_node(
+            "beat::commit_a",
+            {
+                "type": "beat",
+                "dilemma_impacts": [{"dilemma_id": "trust", "effect": "commits"}],
+            },
+        )
+        graph.create_node(
+            "beat::commit_b",
+            {
+                "type": "beat",
+                "dilemma_impacts": [{"dilemma_id": "trust", "effect": "commits"}],
+            },
+        )
+        graph.add_edge("belongs_to", "beat::shared_setup", "path::trust__a")
+        graph.add_edge("belongs_to", "beat::shared_setup", "path::trust__b")
+        graph.add_edge("belongs_to", "beat::commit_a", "path::trust__a")
+        graph.add_edge("belongs_to", "beat::commit_b", "path::trust__b")
+        graph.add_edge("predecessor", "beat::commit_a", "beat::shared_setup")
+        graph.add_edge("predecessor", "beat::commit_b", "beat::shared_setup")
+
+        flags = compute_active_flags_at_beat(graph, "beat::commit_b")
+        assert flags == {frozenset({"trust:path::trust__b"})}

--- a/tests/unit/test_grow_algorithms.py
+++ b/tests/unit/test_grow_algorithms.py
@@ -7485,3 +7485,182 @@ class TestBuildHintConflictGraph:
         assert still_cyclic == [], (
             f"verify_hints_acyclic must return [] after MDS; got {still_cyclic}"
         )
+
+
+# ---------------------------------------------------------------------------
+# Task 2.6: guard rail 3 - intersection pre-commit exclusion
+# ---------------------------------------------------------------------------
+
+
+class TestApplyIntersectionMarkGuardRail3:
+    """Guard rail 3: two pre-commit beats from same dilemma cannot form an intersection."""
+
+    def _seed_with_two_pre_commit_beats(self) -> Graph:
+        """Build a graph with two pre-commit beats sharing the same dilemma."""
+        from questfoundry.graph.mutations import apply_seed_mutations
+        from tests.unit.test_mutations import _trust_graph, _trust_seed_output
+
+        graph = _trust_graph()
+        seed = _trust_seed_output(
+            initial_beats=[
+                {
+                    "beat_id": "shared_setup",
+                    "summary": "Both players see this setup.",
+                    "path_id": "trust_protector_or_manipulator__protector",
+                    "also_belongs_to": "trust_protector_or_manipulator__manipulator",
+                    "dilemma_impacts": [
+                        {
+                            "dilemma_id": "trust_protector_or_manipulator",
+                            "effect": "advances",
+                            "note": "x",
+                        },
+                    ],
+                },
+                {
+                    "beat_id": "shared_reveal",
+                    "summary": "Both players see this reveal.",
+                    "path_id": "trust_protector_or_manipulator__protector",
+                    "also_belongs_to": "trust_protector_or_manipulator__manipulator",
+                    "dilemma_impacts": [
+                        {
+                            "dilemma_id": "trust_protector_or_manipulator",
+                            "effect": "advances",
+                            "note": "y",
+                        },
+                    ],
+                },
+                {
+                    "beat_id": "commit_protector",
+                    "summary": "Protector commits.",
+                    "path_id": "trust_protector_or_manipulator__protector",
+                    "dilemma_impacts": [
+                        {
+                            "dilemma_id": "trust_protector_or_manipulator",
+                            "effect": "commits",
+                            "note": "locked",
+                        }
+                    ],
+                },
+                {
+                    "beat_id": "post_protector",
+                    "summary": "Protector aftermath.",
+                    "path_id": "trust_protector_or_manipulator__protector",
+                    "dilemma_impacts": [
+                        {
+                            "dilemma_id": "trust_protector_or_manipulator",
+                            "effect": "advances",
+                            "note": "fallout",
+                        }
+                    ],
+                },
+                {
+                    "beat_id": "commit_manipulator",
+                    "summary": "Manipulator commits.",
+                    "path_id": "trust_protector_or_manipulator__manipulator",
+                    "dilemma_impacts": [
+                        {
+                            "dilemma_id": "trust_protector_or_manipulator",
+                            "effect": "commits",
+                            "note": "locked",
+                        }
+                    ],
+                },
+                {
+                    "beat_id": "post_manipulator",
+                    "summary": "Manipulator aftermath.",
+                    "path_id": "trust_protector_or_manipulator__manipulator",
+                    "dilemma_impacts": [
+                        {
+                            "dilemma_id": "trust_protector_or_manipulator",
+                            "effect": "advances",
+                            "note": "fallout",
+                        }
+                    ],
+                },
+            ]
+        )
+        apply_seed_mutations(graph, seed)
+        return graph
+
+    def test_rejects_two_pre_commit_beats_same_dilemma(self) -> None:
+        """Guard rail 3: two pre-commit beats from same dilemma cannot form an intersection."""
+        from questfoundry.graph.grow_algorithms import apply_intersection_mark
+
+        graph = self._seed_with_two_pre_commit_beats()
+
+        with pytest.raises(ValueError, match="guard rail 3"):
+            apply_intersection_mark(
+                graph,
+                beat_ids=["beat::shared_setup", "beat::shared_reveal"],
+                resolved_location=None,
+            )
+
+    def test_allows_pre_commit_beats_different_dilemmas(self) -> None:
+        """Guard rail 3 is NOT triggered for pre-commit beats from different dilemmas."""
+        from questfoundry.graph.grow_algorithms import apply_intersection_mark
+        from questfoundry.graph.mutations import apply_seed_mutations
+        from tests.unit.test_mutations import _two_dilemma_graph, _two_dilemma_seed_output
+
+        graph = _two_dilemma_graph()
+        seed = _two_dilemma_seed_output(
+            initial_beats=[
+                # One pre-commit beat per dilemma (different dilemmas, so guard rail 3 is fine)
+                {
+                    "beat_id": "pre_a",
+                    "summary": "Dilemma A advances.",
+                    "path_id": "dilemma_a__answer_a1",
+                    "dilemma_impacts": [
+                        {"dilemma_id": "dilemma_a", "effect": "advances", "note": "x"}
+                    ],
+                },
+                {
+                    "beat_id": "commit_a",
+                    "summary": "Dilemma A commits.",
+                    "path_id": "dilemma_a__answer_a1",
+                    "dilemma_impacts": [
+                        {"dilemma_id": "dilemma_a", "effect": "commits", "note": "x"}
+                    ],
+                },
+                {
+                    "beat_id": "post_a",
+                    "summary": "Dilemma A aftermath.",
+                    "path_id": "dilemma_a__answer_a1",
+                    "dilemma_impacts": [
+                        {"dilemma_id": "dilemma_a", "effect": "advances", "note": "x"}
+                    ],
+                },
+                {
+                    "beat_id": "pre_b",
+                    "summary": "Dilemma B advances.",
+                    "path_id": "dilemma_b__answer_b1",
+                    "dilemma_impacts": [
+                        {"dilemma_id": "dilemma_b", "effect": "advances", "note": "x"}
+                    ],
+                },
+                {
+                    "beat_id": "commit_b",
+                    "summary": "Dilemma B commits.",
+                    "path_id": "dilemma_b__answer_b1",
+                    "dilemma_impacts": [
+                        {"dilemma_id": "dilemma_b", "effect": "commits", "note": "x"}
+                    ],
+                },
+                {
+                    "beat_id": "post_b",
+                    "summary": "Dilemma B aftermath.",
+                    "path_id": "dilemma_b__answer_b1",
+                    "dilemma_impacts": [
+                        {"dilemma_id": "dilemma_b", "effect": "advances", "note": "x"}
+                    ],
+                },
+            ]
+        )
+        apply_seed_mutations(graph, seed)
+
+        # pre_a and pre_b are from different dilemmas - guard rail 3 should not fire.
+        # This should not raise.
+        apply_intersection_mark(
+            graph,
+            beat_ids=["beat::pre_a", "beat::pre_b"],
+            resolved_location=None,
+        )

--- a/tests/unit/test_grow_algorithms.py
+++ b/tests/unit/test_grow_algorithms.py
@@ -7596,71 +7596,52 @@ class TestApplyIntersectionMarkGuardRail3:
             )
 
     def test_allows_pre_commit_beats_different_dilemmas(self) -> None:
-        """Guard rail 3 is NOT triggered for pre-commit beats from different dilemmas."""
+        """Guard rail 3 is NOT triggered for pre-commit beats from different dilemmas.
+
+        This test builds the graph manually so that the pre-commit beats actually have
+        dual ``belongs_to`` edges (one per path of their respective dilemma).  Without
+        dual edges ``len(pids) >= 2`` is never True and guard rail 3 never fires --
+        which means a single-membership fixture does not actually exercise it.
+        """
+        from questfoundry.graph.graph import Graph
         from questfoundry.graph.grow_algorithms import apply_intersection_mark
-        from questfoundry.graph.mutations import apply_seed_mutations
-        from tests.unit.test_mutations import _two_dilemma_graph, _two_dilemma_seed_output
 
-        graph = _two_dilemma_graph()
-        seed = _two_dilemma_seed_output(
-            initial_beats=[
-                # One pre-commit beat per dilemma (different dilemmas, so guard rail 3 is fine)
-                {
-                    "beat_id": "pre_a",
-                    "summary": "Dilemma A advances.",
-                    "path_id": "dilemma_a__answer_a1",
-                    "dilemma_impacts": [
-                        {"dilemma_id": "dilemma_a", "effect": "advances", "note": "x"}
-                    ],
-                },
-                {
-                    "beat_id": "commit_a",
-                    "summary": "Dilemma A commits.",
-                    "path_id": "dilemma_a__answer_a1",
-                    "dilemma_impacts": [
-                        {"dilemma_id": "dilemma_a", "effect": "commits", "note": "x"}
-                    ],
-                },
-                {
-                    "beat_id": "post_a",
-                    "summary": "Dilemma A aftermath.",
-                    "path_id": "dilemma_a__answer_a1",
-                    "dilemma_impacts": [
-                        {"dilemma_id": "dilemma_a", "effect": "advances", "note": "x"}
-                    ],
-                },
-                {
-                    "beat_id": "pre_b",
-                    "summary": "Dilemma B advances.",
-                    "path_id": "dilemma_b__answer_b1",
-                    "dilemma_impacts": [
-                        {"dilemma_id": "dilemma_b", "effect": "advances", "note": "x"}
-                    ],
-                },
-                {
-                    "beat_id": "commit_b",
-                    "summary": "Dilemma B commits.",
-                    "path_id": "dilemma_b__answer_b1",
-                    "dilemma_impacts": [
-                        {"dilemma_id": "dilemma_b", "effect": "commits", "note": "x"}
-                    ],
-                },
-                {
-                    "beat_id": "post_b",
-                    "summary": "Dilemma B aftermath.",
-                    "path_id": "dilemma_b__answer_b1",
-                    "dilemma_impacts": [
-                        {"dilemma_id": "dilemma_b", "effect": "advances", "note": "x"}
-                    ],
-                },
-            ]
+        graph = Graph.empty()
+
+        # --- Dilemma 1: two paths ---
+        graph.create_node("dilemma::dilemma1", {"type": "dilemma", "raw_id": "dilemma1"})
+        graph.create_node(
+            "path::d1_a", {"type": "path", "raw_id": "d1_a", "dilemma_id": "dilemma1"}
         )
-        apply_seed_mutations(graph, seed)
+        graph.create_node(
+            "path::d1_b", {"type": "path", "raw_id": "d1_b", "dilemma_id": "dilemma1"}
+        )
 
-        # pre_a and pre_b are from different dilemmas - guard rail 3 should not fire.
-        # This should not raise.
+        # --- Dilemma 2: two paths ---
+        graph.create_node("dilemma::dilemma2", {"type": "dilemma", "raw_id": "dilemma2"})
+        graph.create_node(
+            "path::d2_a", {"type": "path", "raw_id": "d2_a", "dilemma_id": "dilemma2"}
+        )
+        graph.create_node(
+            "path::d2_b", {"type": "path", "raw_id": "d2_b", "dilemma_id": "dilemma2"}
+        )
+
+        # --- Pre-commit beat for dilemma 1 (dual belongs_to: d1_a and d1_b) ---
+        graph.create_node("beat::pre_dilemma1", {"type": "beat", "raw_id": "pre_dilemma1"})
+        graph.add_edge("belongs_to", "beat::pre_dilemma1", "path::d1_a")
+        graph.add_edge("belongs_to", "beat::pre_dilemma1", "path::d1_b")
+
+        # --- Pre-commit beat for dilemma 2 (dual belongs_to: d2_a and d2_b) ---
+        graph.create_node("beat::pre_dilemma2", {"type": "beat", "raw_id": "pre_dilemma2"})
+        graph.add_edge("belongs_to", "beat::pre_dilemma2", "path::d2_a")
+        graph.add_edge("belongs_to", "beat::pre_dilemma2", "path::d2_b")
+
+        # pre_dilemma1 and pre_dilemma2 are pre-commit beats from DIFFERENT dilemmas.
+        # Guard rail 3 checks that two pre-commits in the same intersection share the
+        # same dilemma (same frozenset of path IDs).  These two beats have disjoint path
+        # sets so the check must NOT fire -- this call must not raise.
         apply_intersection_mark(
             graph,
-            beat_ids=["beat::pre_a", "beat::pre_b"],
+            beat_ids=["beat::pre_dilemma1", "beat::pre_dilemma2"],
             resolved_location=None,
         )

--- a/tests/unit/test_mutations.py
+++ b/tests/unit/test_mutations.py
@@ -5565,3 +5565,138 @@ def test_apply_seed_mutations_emits_dual_belongs_to_for_pre_commit_beat() -> Non
         "path::trust_protector_or_manipulator__protector",
         "path::trust_protector_or_manipulator__manipulator",
     }
+
+
+# ---------------------------------------------------------------------------
+# Task 2.4: guard rail 1 - cross-dilemma dual belongs_to is forbidden
+# ---------------------------------------------------------------------------
+
+
+def test_apply_seed_mutations_rejects_cross_dilemma_dual_belongs_to() -> None:
+    """Guard rail 1: pre-commit beats must share a dilemma across both paths."""
+    from questfoundry.graph.mutations import apply_seed_mutations
+
+    graph = _two_dilemma_graph()
+    seed = _two_dilemma_seed_output(
+        initial_beats=[
+            {
+                "beat_id": "bad_dual",
+                "summary": "Cross-dilemma.",
+                "path_id": "dilemma_a__answer_a1",
+                "also_belongs_to": "dilemma_b__answer_b1",
+                "dilemma_impacts": [
+                    {"dilemma_id": "dilemma_a", "effect": "advances", "note": "x"},
+                ],
+            },
+            # Still need commits beats for validation to pass other checks.
+            {
+                "beat_id": "commit_a",
+                "summary": "Dilemma A commits.",
+                "path_id": "dilemma_a__answer_a1",
+                "dilemma_impacts": [{"dilemma_id": "dilemma_a", "effect": "commits", "note": "x"}],
+            },
+            {
+                "beat_id": "post_a",
+                "summary": "Dilemma A aftermath.",
+                "path_id": "dilemma_a__answer_a1",
+                "dilemma_impacts": [{"dilemma_id": "dilemma_a", "effect": "advances", "note": "x"}],
+            },
+            {
+                "beat_id": "commit_b",
+                "summary": "Dilemma B commits.",
+                "path_id": "dilemma_b__answer_b1",
+                "dilemma_impacts": [{"dilemma_id": "dilemma_b", "effect": "commits", "note": "x"}],
+            },
+            {
+                "beat_id": "post_b",
+                "summary": "Dilemma B aftermath.",
+                "path_id": "dilemma_b__answer_b1",
+                "dilemma_impacts": [{"dilemma_id": "dilemma_b", "effect": "advances", "note": "x"}],
+            },
+        ]
+    )
+
+    with pytest.raises(ValueError, match="cross-dilemma dual belongs_to"):
+        apply_seed_mutations(graph, seed)
+
+
+# ---------------------------------------------------------------------------
+# Task 2.5: guard rail 2 - commit beats must be single-membership
+# ---------------------------------------------------------------------------
+
+
+def test_apply_seed_mutations_rejects_dual_on_commit_beat() -> None:
+    """Guard rail 2: a beat with ``effect=commits`` must have only one belongs_to."""
+    from questfoundry.graph.mutations import apply_seed_mutations
+
+    graph = _trust_graph()
+    # Provide valid commit beats for each path (so validation passes),
+    # then the bad_commit beat with dual membership + commits effect hits guard rail 2.
+    seed = _trust_seed_output(
+        initial_beats=[
+            {
+                "beat_id": "bad_commit",
+                "summary": "A commit beat cannot be pre-commit.",
+                "path_id": "trust_protector_or_manipulator__protector",
+                "also_belongs_to": "trust_protector_or_manipulator__manipulator",
+                "dilemma_impacts": [
+                    {
+                        "dilemma_id": "trust_protector_or_manipulator",
+                        "effect": "commits",
+                        "note": "Bad: commit with dual.",
+                    },
+                ],
+            },
+            # Valid single-membership commit beats so the per-path validation passes.
+            {
+                "beat_id": "commit_protector",
+                "summary": "Protector commits.",
+                "path_id": "trust_protector_or_manipulator__protector",
+                "dilemma_impacts": [
+                    {
+                        "dilemma_id": "trust_protector_or_manipulator",
+                        "effect": "commits",
+                        "note": "locked",
+                    }
+                ],
+            },
+            {
+                "beat_id": "post_protector",
+                "summary": "Protector aftermath.",
+                "path_id": "trust_protector_or_manipulator__protector",
+                "dilemma_impacts": [
+                    {
+                        "dilemma_id": "trust_protector_or_manipulator",
+                        "effect": "advances",
+                        "note": "fallout",
+                    }
+                ],
+            },
+            {
+                "beat_id": "commit_manipulator",
+                "summary": "Manipulator commits.",
+                "path_id": "trust_protector_or_manipulator__manipulator",
+                "dilemma_impacts": [
+                    {
+                        "dilemma_id": "trust_protector_or_manipulator",
+                        "effect": "commits",
+                        "note": "locked",
+                    }
+                ],
+            },
+            {
+                "beat_id": "post_manipulator",
+                "summary": "Manipulator aftermath.",
+                "path_id": "trust_protector_or_manipulator__manipulator",
+                "dilemma_impacts": [
+                    {
+                        "dilemma_id": "trust_protector_or_manipulator",
+                        "effect": "advances",
+                        "note": "fallout",
+                    }
+                ],
+            },
+        ]
+    )
+    with pytest.raises(ValueError, match="guard rail 2"):
+        apply_seed_mutations(graph, seed)

--- a/tests/unit/test_mutations.py
+++ b/tests/unit/test_mutations.py
@@ -5271,3 +5271,297 @@ def test_get_path_ids_from_beat_empty_returns_empty_tuple() -> None:
     from questfoundry.graph.mutations import _get_path_ids_from_beat
 
     assert _get_path_ids_from_beat({}) == ()
+
+
+# ---------------------------------------------------------------------------
+# Shared helpers for Y-shape guard rail tests
+# ---------------------------------------------------------------------------
+
+
+def _trust_graph() -> Graph:
+    """Return a graph pre-populated with BRAINSTORM state for the trust dilemma.
+
+    Dilemma: ``trust_protector_or_manipulator`` with answers ``protector`` and
+    ``manipulator``. Entity: ``mentor``.  Matches the seed returned by
+    :func:`_trust_seed_output`.
+    """
+    g = Graph.empty()
+    g.create_node("entity::mentor", {"type": "entity", "raw_id": "mentor"})
+    g.create_node(
+        "dilemma::trust_protector_or_manipulator",
+        {"type": "dilemma", "raw_id": "trust_protector_or_manipulator"},
+    )
+    g.create_node(
+        "dilemma::trust_protector_or_manipulator::alt::protector",
+        {"type": "answer", "raw_id": "protector", "is_canonical": True},
+    )
+    g.add_edge(
+        "has_answer",
+        "dilemma::trust_protector_or_manipulator",
+        "dilemma::trust_protector_or_manipulator::alt::protector",
+    )
+    g.create_node(
+        "dilemma::trust_protector_or_manipulator::alt::manipulator",
+        {"type": "answer", "raw_id": "manipulator", "is_canonical": False},
+    )
+    g.add_edge(
+        "has_answer",
+        "dilemma::trust_protector_or_manipulator",
+        "dilemma::trust_protector_or_manipulator::alt::manipulator",
+    )
+    g.add_edge("anchored_to", "dilemma::trust_protector_or_manipulator", "entity::mentor")
+    return g
+
+
+def _trust_seed_output(initial_beats: list[dict[str, Any]] | None = None) -> dict[str, Any]:
+    """SEED output for the trust dilemma with two explored paths.
+
+    Callers supply ``initial_beats``; defaults to two commit beats (one per
+    path) so the output is structurally valid and all paths have a commits beat.
+    """
+    if initial_beats is None:
+        initial_beats = [
+            {
+                "beat_id": "commit_protector",
+                "summary": "Protector path commits.",
+                "path_id": "trust_protector_or_manipulator__protector",
+                "dilemma_impacts": [
+                    {
+                        "dilemma_id": "trust_protector_or_manipulator",
+                        "effect": "commits",
+                        "note": "locked",
+                    }
+                ],
+            },
+            {
+                "beat_id": "commit_manipulator",
+                "summary": "Manipulator path commits.",
+                "path_id": "trust_protector_or_manipulator__manipulator",
+                "dilemma_impacts": [
+                    {
+                        "dilemma_id": "trust_protector_or_manipulator",
+                        "effect": "commits",
+                        "note": "locked",
+                    }
+                ],
+            },
+        ]
+    return {
+        "entities": [{"entity_id": "mentor", "disposition": "retained"}],
+        "dilemmas": [
+            {
+                "dilemma_id": "trust_protector_or_manipulator",
+                "explored": ["protector", "manipulator"],
+                "unexplored": [],
+            }
+        ],
+        "paths": [
+            {
+                "path_id": "trust_protector_or_manipulator__protector",
+                "dilemma_id": "trust_protector_or_manipulator",
+                "answer_id": "protector",
+                "name": "Protector",
+                "description": "The protector arc.",
+            },
+            {
+                "path_id": "trust_protector_or_manipulator__manipulator",
+                "dilemma_id": "trust_protector_or_manipulator",
+                "answer_id": "manipulator",
+                "name": "Manipulator",
+                "description": "The manipulator arc.",
+            },
+        ],
+        "consequences": [
+            {
+                "consequence_id": "mentor_trusted",
+                "path_id": "trust_protector_or_manipulator__protector",
+                "description": "Trust.",
+                "narrative_effects": ["x"],
+            },
+            {
+                "consequence_id": "mentor_distrusted",
+                "path_id": "trust_protector_or_manipulator__manipulator",
+                "description": "Distrust.",
+                "narrative_effects": ["x"],
+            },
+        ],
+        "initial_beats": initial_beats,
+    }
+
+
+def _two_dilemma_graph() -> Graph:
+    """Return a graph pre-populated with two unrelated BRAINSTORM dilemmas."""
+    g = Graph.empty()
+    g.create_node("entity::mentor", {"type": "entity", "raw_id": "mentor"})
+    # Dilemma A
+    g.create_node("dilemma::dilemma_a", {"type": "dilemma", "raw_id": "dilemma_a"})
+    g.create_node(
+        "dilemma::dilemma_a::alt::answer_a1",
+        {"type": "answer", "raw_id": "answer_a1", "is_canonical": True},
+    )
+    g.add_edge("has_answer", "dilemma::dilemma_a", "dilemma::dilemma_a::alt::answer_a1")
+    g.create_node(
+        "dilemma::dilemma_a::alt::answer_a2",
+        {"type": "answer", "raw_id": "answer_a2", "is_canonical": False},
+    )
+    g.add_edge("has_answer", "dilemma::dilemma_a", "dilemma::dilemma_a::alt::answer_a2")
+    g.add_edge("anchored_to", "dilemma::dilemma_a", "entity::mentor")
+    # Dilemma B
+    g.create_node("dilemma::dilemma_b", {"type": "dilemma", "raw_id": "dilemma_b"})
+    g.create_node(
+        "dilemma::dilemma_b::alt::answer_b1",
+        {"type": "answer", "raw_id": "answer_b1", "is_canonical": True},
+    )
+    g.add_edge("has_answer", "dilemma::dilemma_b", "dilemma::dilemma_b::alt::answer_b1")
+    g.create_node(
+        "dilemma::dilemma_b::alt::answer_b2",
+        {"type": "answer", "raw_id": "answer_b2", "is_canonical": False},
+    )
+    g.add_edge("has_answer", "dilemma::dilemma_b", "dilemma::dilemma_b::alt::answer_b2")
+    g.add_edge("anchored_to", "dilemma::dilemma_b", "entity::mentor")
+    return g
+
+
+def _two_dilemma_seed_output(initial_beats: list[dict[str, Any]] | None = None) -> dict[str, Any]:
+    """SEED output for two unrelated dilemmas with one explored path each."""
+    if initial_beats is None:
+        initial_beats = [
+            {
+                "beat_id": "commit_a",
+                "summary": "Dilemma A commits.",
+                "path_id": "dilemma_a__answer_a1",
+                "dilemma_impacts": [{"dilemma_id": "dilemma_a", "effect": "commits", "note": "x"}],
+            },
+            {
+                "beat_id": "commit_b",
+                "summary": "Dilemma B commits.",
+                "path_id": "dilemma_b__answer_b1",
+                "dilemma_impacts": [{"dilemma_id": "dilemma_b", "effect": "commits", "note": "x"}],
+            },
+        ]
+    return {
+        "entities": [{"entity_id": "mentor", "disposition": "retained"}],
+        "dilemmas": [
+            {"dilemma_id": "dilemma_a", "explored": ["answer_a1"], "unexplored": ["answer_a2"]},
+            {"dilemma_id": "dilemma_b", "explored": ["answer_b1"], "unexplored": ["answer_b2"]},
+        ],
+        "paths": [
+            {
+                "path_id": "dilemma_a__answer_a1",
+                "dilemma_id": "dilemma_a",
+                "answer_id": "answer_a1",
+                "name": "A1",
+                "description": "a",
+            },
+            {
+                "path_id": "dilemma_b__answer_b1",
+                "dilemma_id": "dilemma_b",
+                "answer_id": "answer_b1",
+                "name": "B1",
+                "description": "b",
+            },
+        ],
+        "consequences": [
+            {
+                "consequence_id": "c_a",
+                "path_id": "dilemma_a__answer_a1",
+                "description": "ca",
+                "narrative_effects": ["x"],
+            },
+            {
+                "consequence_id": "c_b",
+                "path_id": "dilemma_b__answer_b1",
+                "description": "cb",
+                "narrative_effects": ["x"],
+            },
+        ],
+        "initial_beats": initial_beats,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Task 2.3: dual belongs_to edge emission
+# ---------------------------------------------------------------------------
+
+
+def test_apply_seed_mutations_emits_dual_belongs_to_for_pre_commit_beat() -> None:
+    """Pre-commit beats with ``also_belongs_to`` get two ``belongs_to`` edges."""
+    from questfoundry.graph.mutations import apply_seed_mutations
+
+    graph = _trust_graph()
+    seed = _trust_seed_output(
+        initial_beats=[
+            {
+                "beat_id": "shared_setup",
+                "summary": "Both players see this setup.",
+                "path_id": "trust_protector_or_manipulator__protector",
+                "also_belongs_to": "trust_protector_or_manipulator__manipulator",
+                "dilemma_impacts": [
+                    {
+                        "dilemma_id": "trust_protector_or_manipulator",
+                        "effect": "advances",
+                        "note": "x",
+                    },
+                ],
+            },
+            # Each path still needs a commit beat and a post-commit beat.
+            {
+                "beat_id": "commit_protector",
+                "summary": "Protector path commits.",
+                "path_id": "trust_protector_or_manipulator__protector",
+                "dilemma_impacts": [
+                    {
+                        "dilemma_id": "trust_protector_or_manipulator",
+                        "effect": "commits",
+                        "note": "locked",
+                    }
+                ],
+            },
+            {
+                "beat_id": "post_protector",
+                "summary": "Protector aftermath.",
+                "path_id": "trust_protector_or_manipulator__protector",
+                "dilemma_impacts": [
+                    {
+                        "dilemma_id": "trust_protector_or_manipulator",
+                        "effect": "advances",
+                        "note": "fallout",
+                    }
+                ],
+            },
+            {
+                "beat_id": "commit_manipulator",
+                "summary": "Manipulator path commits.",
+                "path_id": "trust_protector_or_manipulator__manipulator",
+                "dilemma_impacts": [
+                    {
+                        "dilemma_id": "trust_protector_or_manipulator",
+                        "effect": "commits",
+                        "note": "locked",
+                    }
+                ],
+            },
+            {
+                "beat_id": "post_manipulator",
+                "summary": "Manipulator aftermath.",
+                "path_id": "trust_protector_or_manipulator__manipulator",
+                "dilemma_impacts": [
+                    {
+                        "dilemma_id": "trust_protector_or_manipulator",
+                        "effect": "advances",
+                        "note": "fallout",
+                    }
+                ],
+            },
+        ]
+    )
+    apply_seed_mutations(graph, seed)
+
+    edges = [
+        e for e in graph.get_edges(edge_type="belongs_to") if e["from"] == "beat::shared_setup"
+    ]
+    to_ids = {e["to"] for e in edges}
+    assert to_ids == {
+        "path::trust_protector_or_manipulator__protector",
+        "path::trust_protector_or_manipulator__manipulator",
+    }

--- a/tests/unit/test_mutations.py
+++ b/tests/unit/test_mutations.py
@@ -5239,3 +5239,35 @@ class TestApplySeedConvergenceAnalysis:
 
         node = graph.get_node("dilemma::trust_or_not")
         assert "residue_weight" not in node
+
+
+# ---------------------------------------------------------------------------
+# Phase 2 - Y-shape dual belongs_to tests (Tasks 2.1-2.7)
+# ---------------------------------------------------------------------------
+
+
+def test_get_path_ids_from_beat_post_commit_returns_one() -> None:
+    from questfoundry.graph.mutations import _get_path_ids_from_beat
+
+    beat = {"path_id": "path::a"}
+    assert _get_path_ids_from_beat(beat) == ("path::a",)
+
+
+def test_get_path_ids_from_beat_pre_commit_returns_both() -> None:
+    from questfoundry.graph.mutations import _get_path_ids_from_beat
+
+    beat = {"path_id": "path::a", "also_belongs_to": "path::b"}
+    assert _get_path_ids_from_beat(beat) == ("path::a", "path::b")
+
+
+def test_get_path_ids_from_beat_legacy_paths_list_returns_all() -> None:
+    from questfoundry.graph.mutations import _get_path_ids_from_beat
+
+    beat = {"paths": ["path::a", "path::b"]}
+    assert _get_path_ids_from_beat(beat) == ("path::a", "path::b")
+
+
+def test_get_path_ids_from_beat_empty_returns_empty_tuple() -> None:
+    from questfoundry.graph.mutations import _get_path_ids_from_beat
+
+    assert _get_path_ids_from_beat({}) == ()

--- a/tests/unit/test_mutations.py
+++ b/tests/unit/test_mutations.py
@@ -5620,6 +5620,57 @@ def test_apply_seed_mutations_rejects_cross_dilemma_dual_belongs_to() -> None:
         apply_seed_mutations(graph, seed)
 
 
+def test_apply_seed_mutations_rejects_also_belongs_to_equal_path_id() -> None:
+    """Raw-dict input with path_id == also_belongs_to must be rejected (defense-in-depth)."""
+    # Bypass Pydantic by constructing the seed dict directly.
+    from questfoundry.graph.mutations import apply_seed_mutations
+
+    graph = _two_dilemma_graph()
+    seed = _two_dilemma_seed_output(
+        initial_beats=[
+            {
+                "beat_id": "bad_beat",
+                "summary": "Same path twice.",
+                "path_id": "dilemma_a__answer_a1",
+                "also_belongs_to": "dilemma_a__answer_a1",
+                "dilemma_impacts": [
+                    {
+                        "dilemma_id": "dilemma_a",
+                        "effect": "advances",
+                        "note": "x",
+                    }
+                ],
+            },
+            {
+                "beat_id": "commit_a",
+                "summary": "Dilemma A commits.",
+                "path_id": "dilemma_a__answer_a1",
+                "dilemma_impacts": [{"dilemma_id": "dilemma_a", "effect": "commits", "note": "x"}],
+            },
+            {
+                "beat_id": "post_a",
+                "summary": "Dilemma A aftermath.",
+                "path_id": "dilemma_a__answer_a1",
+                "dilemma_impacts": [{"dilemma_id": "dilemma_a", "effect": "advances", "note": "x"}],
+            },
+            {
+                "beat_id": "commit_b",
+                "summary": "Dilemma B commits.",
+                "path_id": "dilemma_b__answer_b1",
+                "dilemma_impacts": [{"dilemma_id": "dilemma_b", "effect": "commits", "note": "x"}],
+            },
+            {
+                "beat_id": "post_b",
+                "summary": "Dilemma B aftermath.",
+                "path_id": "dilemma_b__answer_b1",
+                "dilemma_impacts": [{"dilemma_id": "dilemma_b", "effect": "advances", "note": "x"}],
+            },
+        ]
+    )
+    with pytest.raises(ValueError, match="must be distinct paths"):
+        apply_seed_mutations(graph, seed)
+
+
 # ---------------------------------------------------------------------------
 # Task 2.5: guard rail 2 - commit beats must be single-membership
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_seed_models.py
+++ b/tests/unit/test_seed_models.py
@@ -1005,3 +1005,44 @@ class TestInitialBeatPathId:
         """Empty paths list raises ValueError — beats must belong to a path."""
         with pytest.raises(ValidationError, match="must belong to a path"):
             InitialBeat(beat_id="b1", summary="Test", paths=[])
+
+
+def test_initial_beat_pre_commit_dual_belongs_to() -> None:
+    """Pre-commit beats carry ``also_belongs_to`` pointing at the sibling path."""
+    from questfoundry.models.seed import InitialBeat
+
+    beat = InitialBeat(
+        beat_id="b1",
+        summary="Shared setup before the fork.",
+        path_id="path::trust__protector",
+        also_belongs_to="path::trust__manipulator",
+    )
+    assert beat.path_id == "path::trust__protector"
+    assert beat.also_belongs_to == "path::trust__manipulator"
+
+
+def test_initial_beat_post_commit_single_belongs_to_default() -> None:
+    """Post-commit beats default to ``also_belongs_to = None``."""
+    from questfoundry.models.seed import InitialBeat
+
+    beat = InitialBeat(
+        beat_id="b1",
+        summary="Payoff beat.",
+        path_id="path::trust__protector",
+    )
+    assert beat.also_belongs_to is None
+
+
+def test_initial_beat_also_belongs_to_equal_path_id_is_rejected() -> None:
+    """``also_belongs_to`` must differ from ``path_id`` — dual membership needs two paths."""
+    import pytest
+
+    from questfoundry.models.seed import InitialBeat
+
+    with pytest.raises(ValueError, match="also_belongs_to must differ from path_id"):
+        InitialBeat(
+            beat_id="b1",
+            summary="Broken dual.",
+            path_id="path::trust__protector",
+            also_belongs_to="path::trust__protector",
+        )

--- a/tests/unit/test_seed_models.py
+++ b/tests/unit/test_seed_models.py
@@ -988,14 +988,15 @@ class TestInitialBeatPathId:
         assert beat.path_id == "path::trust__yes"
 
     def test_legacy_multi_paths_warns(self) -> None:
-        """Multi-element paths list triggers deprecation warning, uses first."""
-        with pytest.warns(DeprecationWarning, match="had 2 entries"):
+        """Two-element paths list triggers deprecation warning and maps to Y-shape dual."""
+        with pytest.warns(DeprecationWarning, match="also_belongs_to"):
             beat = InitialBeat(
                 beat_id="b1",
                 summary="Test",
                 paths=["path::a__x", "path::b__y"],
             )
         assert beat.path_id == "path::a__x"
+        assert beat.also_belongs_to == "path::b__y"
 
     def test_empty_path_id_rejected(self) -> None:
         with pytest.raises(ValidationError, match="path_id"):
@@ -1003,7 +1004,7 @@ class TestInitialBeatPathId:
 
     def test_legacy_empty_paths_rejected(self) -> None:
         """Empty paths list raises ValueError — beats must belong to a path."""
-        with pytest.raises(ValidationError, match="must belong to a path"):
+        with pytest.raises(ValidationError, match="must belong to at least one path"):
             InitialBeat(beat_id="b1", summary="Test", paths=[])
 
 
@@ -1045,4 +1046,37 @@ def test_initial_beat_also_belongs_to_equal_path_id_is_rejected() -> None:
             summary="Broken dual.",
             path_id="path::trust__protector",
             also_belongs_to="path::trust__protector",
+        )
+
+
+def test_initial_beat_legacy_paths_two_elements_becomes_dual() -> None:
+    """Legacy ``paths: [p_a, p_b]`` migrates to Y-shape dual membership."""
+    import warnings
+
+    from questfoundry.models.seed import InitialBeat
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        beat = InitialBeat(
+            beat_id="b1",
+            summary="Legacy dual.",
+            paths=["path::trust__protector", "path::trust__manipulator"],
+        )
+
+    assert beat.path_id == "path::trust__protector"
+    assert beat.also_belongs_to == "path::trust__manipulator"
+    assert any(issubclass(w.category, DeprecationWarning) for w in caught)
+
+
+def test_initial_beat_legacy_paths_three_elements_is_rejected() -> None:
+    """A list of three or more paths is a schema error — not a migration target."""
+    import pytest
+
+    from questfoundry.models.seed import InitialBeat
+
+    with pytest.raises(ValueError, match="at most 2 entries"):
+        InitialBeat(
+            beat_id="b1",
+            summary="Bad.",
+            paths=["p_a", "p_b", "p_c"],
         )

--- a/tests/unit/test_seed_models.py
+++ b/tests/unit/test_seed_models.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import warnings
 from typing import ClassVar
 
 import pytest
@@ -1010,8 +1011,6 @@ class TestInitialBeatPathId:
 
 def test_initial_beat_pre_commit_dual_belongs_to() -> None:
     """Pre-commit beats carry ``also_belongs_to`` pointing at the sibling path."""
-    from questfoundry.models.seed import InitialBeat
-
     beat = InitialBeat(
         beat_id="b1",
         summary="Shared setup before the fork.",
@@ -1024,8 +1023,6 @@ def test_initial_beat_pre_commit_dual_belongs_to() -> None:
 
 def test_initial_beat_post_commit_single_belongs_to_default() -> None:
     """Post-commit beats default to ``also_belongs_to = None``."""
-    from questfoundry.models.seed import InitialBeat
-
     beat = InitialBeat(
         beat_id="b1",
         summary="Payoff beat.",
@@ -1036,11 +1033,7 @@ def test_initial_beat_post_commit_single_belongs_to_default() -> None:
 
 def test_initial_beat_also_belongs_to_equal_path_id_is_rejected() -> None:
     """``also_belongs_to`` must differ from ``path_id`` — dual membership needs two paths."""
-    import pytest
-
-    from questfoundry.models.seed import InitialBeat
-
-    with pytest.raises(ValueError, match="also_belongs_to must differ from path_id"):
+    with pytest.raises(ValidationError, match="also_belongs_to must differ from path_id"):
         InitialBeat(
             beat_id="b1",
             summary="Broken dual.",
@@ -1051,10 +1044,6 @@ def test_initial_beat_also_belongs_to_equal_path_id_is_rejected() -> None:
 
 def test_initial_beat_legacy_paths_two_elements_becomes_dual() -> None:
     """Legacy ``paths: [p_a, p_b]`` migrates to Y-shape dual membership."""
-    import warnings
-
-    from questfoundry.models.seed import InitialBeat
-
     with warnings.catch_warnings(record=True) as caught:
         warnings.simplefilter("always")
         beat = InitialBeat(
@@ -1070,13 +1059,19 @@ def test_initial_beat_legacy_paths_two_elements_becomes_dual() -> None:
 
 def test_initial_beat_legacy_paths_three_elements_is_rejected() -> None:
     """A list of three or more paths is a schema error — not a migration target."""
-    import pytest
-
-    from questfoundry.models.seed import InitialBeat
-
-    with pytest.raises(ValueError, match="at most 2 entries"):
+    with pytest.raises(ValidationError, match="at most 2 entries"):
         InitialBeat(
             beat_id="b1",
             summary="Bad.",
             paths=["p_a", "p_b", "p_c"],
+        )
+
+
+def test_initial_beat_also_belongs_to_empty_string_is_rejected() -> None:
+    with pytest.raises(ValidationError):
+        InitialBeat(
+            beat_id="b1",
+            summary="Test.",
+            path_id="path::trust__protector",
+            also_belongs_to="",
         )


### PR DESCRIPTION
## Summary

Implements the write surface of the Y-shape code alignment epic (#1214), covering issues #1215 and #1216.

**Phase 1 — `InitialBeat.also_belongs_to` schema** (#1215)
- Added `also_belongs_to: str | None = Field(default=None, min_length=1)` to `InitialBeat`
- Pre-commit (shared) beats set `also_belongs_to` to the sibling path; post-commit beats leave it `None`
- Cross-field validator rejects `also_belongs_to == path_id`
- Legacy `paths: [a, b]` migrates to Y-shape dual with `DeprecationWarning`; `paths` with 3+ entries raises `ValueError`
- Updated class docstring to describe Y-shape semantics

**Phase 2 — Dual-edge emission + write-time guard rails** (#1216)
- Replaced `_get_path_id_from_beat` with `_get_path_ids_from_beat` returning `tuple[str, ...]` (0, 1, or 2 entries)
- Beat-insertion in `apply_seed_mutations` now emits one `belongs_to` edge per path ID — pre-commit beats get 2 edges
- Guard rail 1 enforced: cross-dilemma `also_belongs_to` raises `ValueError` at write time
- Guard rail 2 enforced: commit beats (`effect == "commits"`) with `also_belongs_to` raise `ValueError`
- Guard rail 3 enforced: `apply_intersection_mark` rejects two same-dilemma pre-commit beats
- `algorithms.py` updated: `beat_to_path: dict[str, str]` → `beat_to_paths: dict[str, frozenset[str]]`; the old "multiple belongs_to" ValueError removed (now legal for pre-commit beats)

## Test plan

- [ ] `uv run pytest tests/unit/test_seed_models.py -x -q` — 117 tests, Phase 1 coverage
- [ ] `uv run pytest tests/unit/test_mutations.py -x -q` — guard rails 1+2, dual emission
- [ ] `uv run pytest tests/unit/test_grow_algorithms.py -x -q` — guard rail 3
- [ ] `uv run pytest tests/unit/test_algorithms.py -x -q` — beat_to_paths + Y-shape flag derivation
- [ ] All 620 tests pass together

## Not included / Future PRs

- POLISH `beat_to_path` consumers → #1217
- SEED prompts two-call pattern → #1218
- GROW validation guard-rail checks → #1219
- E2e acceptance test → #1220

## Closes

Closes #1215
Closes #1216

🤖 Generated with [Claude Code](https://claude.com/claude-code)