### PR TITLE
feat(validation): GROW Y-shape guard-rail checks (#1219)

### DIFF
--- a/src/questfoundry/graph/grow_validation.py
+++ b/src/questfoundry/graph/grow_validation.py
@@ -771,6 +771,12 @@ def check_no_pre_commit_intersections(graph: Graph) -> ValidationCheck:
     Such beats already co-occur by definition (Story Graph Ontology §8);
     declaring them as an intersection is redundant and creates false
     structural implications.
+
+    Implementation note: under the binary Y-shape assumption (guard rail 1),
+    two pre-commit beats belong to the same dilemma if and only if they have
+    identical `belongs_to` path frozensets. This check enforces that
+    constraint by checking for beat pairs that share the same path set
+    within an intersection group.
     """
     beat_nodes = graph.get_nodes_by_type("beat")
     group_nodes = graph.get_nodes_by_type("intersection_group")
@@ -794,7 +800,7 @@ def check_no_pre_commit_intersections(graph: Graph) -> ValidationCheck:
             if len(bids) >= 2:
                 violations.append(
                     f"{gid} contains {len(bids)} pre-commit beats sharing paths "
-                    f"{sorted(pset)}: {bids}"
+                    f"{sorted(pset)}: {', '.join(bids)}"
                 )
 
     if not violations:

--- a/src/questfoundry/graph/grow_validation.py
+++ b/src/questfoundry/graph/grow_validation.py
@@ -711,7 +711,7 @@ def check_no_cross_dilemma_belongs_to(graph: Graph) -> ValidationCheck:
         if len(paths) < 2:
             continue
         dilemmas = {path_to_dilemma.get(p) for p in paths}
-        dilemmas.discard(None)
+        dilemmas.discard(None)  # paths without dilemma_id are caught by earlier checks
         if len(dilemmas) > 1:
             violations.append(
                 f"{beat_id} -> {sorted(paths)} across dilemmas {sorted(d for d in dilemmas if d)}"

--- a/src/questfoundry/graph/grow_validation.py
+++ b/src/questfoundry/graph/grow_validation.py
@@ -32,6 +32,9 @@ __all__ = [
     "build_passage_adjacency",
     "check_dilemma_role_compliance",
     "check_dilemmas_resolved",
+    "check_no_cross_dilemma_belongs_to",
+    "check_no_dual_on_commit_beat",
+    "check_no_pre_commit_intersections",
     "check_passage_dag_cycles",
     "check_single_root_beat",
     "check_single_start",
@@ -677,6 +680,137 @@ def check_dilemma_role_compliance(graph: Graph) -> list[ValidationCheck]:
 
 
 # ---------------------------------------------------------------------------
+# Y-shape guard rail checks (Story Graph Ontology §8)
+# ---------------------------------------------------------------------------
+
+
+def check_no_cross_dilemma_belongs_to(graph: Graph) -> ValidationCheck:
+    """Guard rail 1: dual belongs_to must reference paths of the same dilemma.
+
+    Cross-dilemma dual belongs_to is a hard-convergence violation (Story Graph
+    Ontology §8 "Path Membership ≠ Scene Participation").
+    """
+    path_nodes = graph.get_nodes_by_type("path")
+    beat_nodes = graph.get_nodes_by_type("beat")
+
+    # path → dilemma map (normalized)
+    path_to_dilemma: dict[str, str] = {}
+    for pid, pdata in path_nodes.items():
+        did = pdata.get("dilemma_id")
+        if did:
+            path_to_dilemma[pid] = normalize_scoped_id(did, "dilemma")
+
+    # beat → set of paths
+    beat_paths: dict[str, set[str]] = {}
+    for e in graph.get_edges(edge_type="belongs_to"):
+        if e["from"] in beat_nodes:
+            beat_paths.setdefault(e["from"], set()).add(e["to"])
+
+    violations: list[str] = []
+    for beat_id, paths in beat_paths.items():
+        if len(paths) < 2:
+            continue
+        dilemmas = {path_to_dilemma.get(p) for p in paths}
+        dilemmas.discard(None)
+        if len(dilemmas) > 1:
+            violations.append(
+                f"{beat_id} -> {sorted(paths)} across dilemmas {sorted(d for d in dilemmas if d)}"
+            )
+
+    dual_count = sum(1 for p in beat_paths.values() if len(p) >= 2)
+    if not violations:
+        return ValidationCheck(
+            name="no_cross_dilemma_belongs_to",
+            severity="pass",
+            message=f"All {dual_count} dual-belongs_to beats are same-dilemma",
+        )
+    return ValidationCheck(
+        name="no_cross_dilemma_belongs_to",
+        severity="fail",
+        message=f"cross-dilemma dual belongs_to (guard rail 1): {'; '.join(violations[:3])}",
+    )
+
+
+def check_no_dual_on_commit_beat(graph: Graph) -> ValidationCheck:
+    """Guard rail 2: commit beats must have a single belongs_to.
+
+    A commit beat is the first beat exclusive to its path; dual membership
+    on a commit beat is structurally impossible (Story Graph Ontology §8).
+    """
+    beat_nodes = graph.get_nodes_by_type("beat")
+    beat_paths: dict[str, set[str]] = {}
+    for e in graph.get_edges(edge_type="belongs_to"):
+        if e["from"] in beat_nodes:
+            beat_paths.setdefault(e["from"], set()).add(e["to"])
+
+    violations: list[str] = []
+    for bid, pset in beat_paths.items():
+        if len(pset) < 2:
+            continue
+        impacts = beat_nodes[bid].get("dilemma_impacts", [])
+        if any(imp.get("effect") == "commits" for imp in impacts):
+            violations.append(f"{bid} commits AND has {len(pset)} belongs_to edges")
+
+    if not violations:
+        return ValidationCheck(
+            name="no_dual_on_commit_beat",
+            severity="pass",
+            message="No commit beats with dual belongs_to",
+        )
+    return ValidationCheck(
+        name="no_dual_on_commit_beat",
+        severity="fail",
+        message=f"commit beat with dual belongs_to (guard rail 2): {'; '.join(violations[:3])}",
+    )
+
+
+def check_no_pre_commit_intersections(graph: Graph) -> ValidationCheck:
+    """Guard rail 3: intersection groups must not contain two pre-commit
+    beats from the same dilemma.
+
+    Such beats already co-occur by definition (Story Graph Ontology §8);
+    declaring them as an intersection is redundant and creates false
+    structural implications.
+    """
+    beat_nodes = graph.get_nodes_by_type("beat")
+    group_nodes = graph.get_nodes_by_type("intersection_group")
+
+    _accum: dict[str, set[str]] = {}
+    for e in graph.get_edges(edge_type="belongs_to"):
+        if e["from"] in beat_nodes:
+            _accum.setdefault(e["from"], set()).add(e["to"])
+    beat_paths: dict[str, frozenset[str]] = {b: frozenset(p) for b, p in _accum.items()}
+
+    violations: list[str] = []
+    for gid, gdata in group_nodes.items():
+        beat_ids = gdata.get("beat_ids", [])
+        dual_by_pathset: dict[frozenset[str], list[str]] = {}
+        for bid in beat_ids:
+            pset = beat_paths.get(bid, frozenset())
+            if len(pset) < 2:
+                continue
+            dual_by_pathset.setdefault(pset, []).append(bid)
+        for pset, bids in dual_by_pathset.items():
+            if len(bids) >= 2:
+                violations.append(
+                    f"{gid} contains {len(bids)} pre-commit beats sharing paths "
+                    f"{sorted(pset)}: {bids}"
+                )
+
+    if not violations:
+        return ValidationCheck(
+            name="no_pre_commit_intersections",
+            severity="pass",
+            message="No intersection groups with pre-commit collisions",
+        )
+    return ValidationCheck(
+        name="no_pre_commit_intersections",
+        severity="fail",
+        message=f"pre-commit beats grouped in intersection (guard rail 3): {'; '.join(violations[:3])}",
+    )
+
+
+# ---------------------------------------------------------------------------
 # Entry points
 # ---------------------------------------------------------------------------
 
@@ -712,6 +846,9 @@ def run_grow_checks(graph: Graph) -> ValidationReport:
         check_passage_dag_cycles(graph),
         check_spine_arc_exists(graph),
         check_dilemmas_resolved(graph),
+        check_no_cross_dilemma_belongs_to(graph),
+        check_no_dual_on_commit_beat(graph),
+        check_no_pre_commit_intersections(graph),
     ]
     checks.extend(check_dilemma_role_compliance(graph))
     return ValidationReport(checks=checks)

--- a/src/questfoundry/graph/grow_validation.py
+++ b/src/questfoundry/graph/grow_validation.py
@@ -749,7 +749,7 @@ def check_no_dual_on_commit_beat(graph: Graph) -> ValidationCheck:
             continue
         impacts = beat_nodes[bid].get("dilemma_impacts", [])
         if any(imp.get("effect") == "commits" for imp in impacts):
-            violations.append(f"{bid} commits AND has {len(pset)} belongs_to edges")
+            violations.append(f"{bid} commits AND has {len(pset)} belongs_to edges: {sorted(pset)}")
 
     if not violations:
         return ValidationCheck(
@@ -775,11 +775,11 @@ def check_no_pre_commit_intersections(graph: Graph) -> ValidationCheck:
     beat_nodes = graph.get_nodes_by_type("beat")
     group_nodes = graph.get_nodes_by_type("intersection_group")
 
-    _accum: dict[str, set[str]] = {}
+    raw_beat_paths: dict[str, set[str]] = {}
     for e in graph.get_edges(edge_type="belongs_to"):
         if e["from"] in beat_nodes:
-            _accum.setdefault(e["from"], set()).add(e["to"])
-    beat_paths: dict[str, frozenset[str]] = {b: frozenset(p) for b, p in _accum.items()}
+            raw_beat_paths.setdefault(e["from"], set()).add(e["to"])
+    beat_paths: dict[str, frozenset[str]] = {b: frozenset(p) for b, p in raw_beat_paths.items()}
 
     violations: list[str] = []
     for gid, gdata in group_nodes.items():

--- a/src/questfoundry/graph/polish_validation.py
+++ b/src/questfoundry/graph/polish_validation.py
@@ -65,7 +65,11 @@ def validate_grow_output(graph: Graph) -> list[str]:
     if beat_nodes:
         _check_predecessor_cycles(graph, beat_nodes, errors)
 
-    # 3. Every beat has exactly one belongs_to edge
+    # 3. Every beat has at least one belongs_to edge.
+    # Pre-commit beats may have multiple belongs_to edges (Y-shape: one edge per path
+    # of their dilemma). Guard rails for dual-belongs_to correctness are enforced by
+    # check_no_cross_dilemma_belongs_to and check_no_dual_on_commit_beat in
+    # grow_validation.py.
     belongs_to_edges = graph.get_edges(edge_type="belongs_to")
     beats_with_path: dict[str, list[str]] = {}
     for edge in belongs_to_edges:
@@ -78,10 +82,6 @@ def validate_grow_output(graph: Graph) -> list[str]:
         paths = beats_with_path.get(beat_id, [])
         if len(paths) == 0:
             errors.append(f"Beat {beat_id} has no belongs_to edge (no path assignment)")
-        elif len(paths) > 1:
-            errors.append(
-                f"Beat {beat_id} has {len(paths)} belongs_to edges (must have exactly 1): {', '.join(paths)}"
-            )
 
     # 4. State flag nodes exist for explored dilemmas
     dilemma_nodes = graph.get_nodes_by_type("dilemma")

--- a/tests/unit/test_grow_validation.py
+++ b/tests/unit/test_grow_validation.py
@@ -1263,7 +1263,7 @@ class TestCheckNoPreCommitIntersections:
         assert check.severity == "pass"
 
     def test_passes_when_group_has_one_shared_beat(self) -> None:
-        """A group with only one shared pre-commit beat is valid (cross-dilemma intersection)."""
+        """A group with one dual-path beat and one single-path beat is valid — only one beat qualifies as dual, so no same-dilemma collision."""
         from questfoundry.graph.grow_validation import check_no_pre_commit_intersections
 
         graph = Graph.empty()

--- a/tests/unit/test_grow_validation.py
+++ b/tests/unit/test_grow_validation.py
@@ -1051,3 +1051,243 @@ class TestSingleRootBeat:
             f"Synthetic beats should be excluded, got: {result.message}"
         )
         assert "beat::real_root" in result.message
+
+
+# ---------------------------------------------------------------------------
+# Y-shape guard rail test helpers
+# ---------------------------------------------------------------------------
+
+
+def _build_valid_y_shape() -> Graph:
+    """Build a minimal Y-shape graph: two paths from the same dilemma,
+    with one shared pre-commit beat (dual belongs_to) and one commit beat
+    per path (single belongs_to). Used by guard rail 1 and 3 tests.
+    """
+    graph = Graph.empty()
+    graph.create_node("dilemma::d1", {"type": "dilemma", "raw_id": "d1"})
+    graph.create_node(
+        "path::d1_a",
+        {"type": "path", "raw_id": "d1_a", "dilemma_id": "dilemma::d1", "is_canonical": True},
+    )
+    graph.create_node(
+        "path::d1_b",
+        {"type": "path", "raw_id": "d1_b", "dilemma_id": "dilemma::d1", "is_canonical": False},
+    )
+    # Pre-commit beat: shared (dual belongs_to, same dilemma)
+    graph.create_node("beat::shared", {"type": "beat", "raw_id": "shared", "dilemma_impacts": []})
+    graph.add_edge("belongs_to", "beat::shared", "path::d1_a")
+    graph.add_edge("belongs_to", "beat::shared", "path::d1_b")
+    # Commit beats: one per path (single belongs_to, effect==commits)
+    graph.create_node(
+        "beat::commit_a",
+        {
+            "type": "beat",
+            "raw_id": "commit_a",
+            "dilemma_impacts": [{"dilemma_id": "dilemma::d1", "effect": "commits"}],
+        },
+    )
+    graph.add_edge("belongs_to", "beat::commit_a", "path::d1_a")
+    graph.create_node(
+        "beat::commit_b",
+        {
+            "type": "beat",
+            "raw_id": "commit_b",
+            "dilemma_impacts": [{"dilemma_id": "dilemma::d1", "effect": "commits"}],
+        },
+    )
+    graph.add_edge("belongs_to", "beat::commit_b", "path::d1_b")
+    return graph
+
+
+def _build_cross_dilemma_dual() -> Graph:
+    """Build a graph where one beat has belongs_to pointing at paths from two
+    different dilemmas — a guard rail 1 violation.
+    """
+    graph = Graph.empty()
+    graph.create_node("dilemma::d1", {"type": "dilemma", "raw_id": "d1"})
+    graph.create_node("dilemma::d2", {"type": "dilemma", "raw_id": "d2"})
+    graph.create_node(
+        "path::d1_a",
+        {"type": "path", "raw_id": "d1_a", "dilemma_id": "dilemma::d1"},
+    )
+    graph.create_node(
+        "path::d2_a",
+        {"type": "path", "raw_id": "d2_a", "dilemma_id": "dilemma::d2"},
+    )
+    # Beat points to paths from two different dilemmas — the violation.
+    graph.create_node(
+        "beat::bad",
+        {"type": "beat", "raw_id": "bad", "dilemma_impacts": []},
+    )
+    graph.add_edge("belongs_to", "beat::bad", "path::d1_a")
+    graph.add_edge("belongs_to", "beat::bad", "path::d2_a")
+    return graph
+
+
+# ---------------------------------------------------------------------------
+# Guard rail 1: check_no_cross_dilemma_belongs_to
+# ---------------------------------------------------------------------------
+
+
+class TestCheckNoCrossDilemmaBelongsTo:
+    def test_passes_for_valid_y_shape(self) -> None:
+        from questfoundry.graph.grow_validation import check_no_cross_dilemma_belongs_to
+
+        graph = _build_valid_y_shape()
+        check = check_no_cross_dilemma_belongs_to(graph)
+        assert check.severity == "pass"
+
+    def test_fails_for_cross_dilemma(self) -> None:
+        from questfoundry.graph.grow_validation import check_no_cross_dilemma_belongs_to
+
+        graph = _build_cross_dilemma_dual()
+        check = check_no_cross_dilemma_belongs_to(graph)
+        assert check.severity == "fail"
+        assert "cross-dilemma" in check.message
+
+    def test_passes_for_empty_graph(self) -> None:
+        from questfoundry.graph.grow_validation import check_no_cross_dilemma_belongs_to
+
+        graph = Graph.empty()
+        check = check_no_cross_dilemma_belongs_to(graph)
+        assert check.severity == "pass"
+
+    def test_passes_for_single_belongs_to_beats(self) -> None:
+        """Beats with a single belongs_to never trigger the cross-dilemma check."""
+        from questfoundry.graph.grow_validation import check_no_cross_dilemma_belongs_to
+
+        graph = Graph.empty()
+        graph.create_node("dilemma::d1", {"type": "dilemma", "raw_id": "d1"})
+        graph.create_node(
+            "path::d1_a", {"type": "path", "raw_id": "d1_a", "dilemma_id": "dilemma::d1"}
+        )
+        graph.create_node("beat::b1", {"type": "beat", "raw_id": "b1"})
+        graph.add_edge("belongs_to", "beat::b1", "path::d1_a")
+        check = check_no_cross_dilemma_belongs_to(graph)
+        assert check.severity == "pass"
+
+
+# ---------------------------------------------------------------------------
+# Guard rail 2: check_no_dual_on_commit_beat
+# ---------------------------------------------------------------------------
+
+
+class TestCheckNoDualOnCommitBeat:
+    def test_fails_when_commit_has_dual(self) -> None:
+        from questfoundry.graph.grow_validation import check_no_dual_on_commit_beat
+
+        graph = Graph.empty()
+        graph.create_node("path::a", {"type": "path", "dilemma_id": "d"})
+        graph.create_node("path::b", {"type": "path", "dilemma_id": "d"})
+        graph.create_node(
+            "beat::bad_commit",
+            {
+                "type": "beat",
+                "dilemma_impacts": [{"dilemma_id": "d", "effect": "commits"}],
+            },
+        )
+        graph.add_edge("belongs_to", "beat::bad_commit", "path::a")
+        graph.add_edge("belongs_to", "beat::bad_commit", "path::b")
+
+        check = check_no_dual_on_commit_beat(graph)
+        assert check.severity == "fail"
+        assert "commit beat" in check.message
+
+    def test_passes_for_valid_y_shape(self) -> None:
+        """In a valid Y-shape, commit beats have single belongs_to."""
+        from questfoundry.graph.grow_validation import check_no_dual_on_commit_beat
+
+        graph = _build_valid_y_shape()
+        check = check_no_dual_on_commit_beat(graph)
+        assert check.severity == "pass"
+
+    def test_passes_for_pre_commit_dual(self) -> None:
+        """Pre-commit (non-commit) beats are allowed to have dual belongs_to."""
+        from questfoundry.graph.grow_validation import check_no_dual_on_commit_beat
+
+        graph = Graph.empty()
+        graph.create_node("path::a", {"type": "path", "dilemma_id": "d"})
+        graph.create_node("path::b", {"type": "path", "dilemma_id": "d"})
+        # No effect=="commits" in dilemma_impacts -> pre-commit beat
+        graph.create_node(
+            "beat::pre",
+            {"type": "beat", "dilemma_impacts": [{"dilemma_id": "d", "effect": "explores"}]},
+        )
+        graph.add_edge("belongs_to", "beat::pre", "path::a")
+        graph.add_edge("belongs_to", "beat::pre", "path::b")
+
+        check = check_no_dual_on_commit_beat(graph)
+        assert check.severity == "pass"
+
+    def test_passes_for_empty_graph(self) -> None:
+        from questfoundry.graph.grow_validation import check_no_dual_on_commit_beat
+
+        graph = Graph.empty()
+        check = check_no_dual_on_commit_beat(graph)
+        assert check.severity == "pass"
+
+
+# ---------------------------------------------------------------------------
+# Guard rail 3: check_no_pre_commit_intersections
+# ---------------------------------------------------------------------------
+
+
+class TestCheckNoPreCommitIntersections:
+    def test_fails_when_group_has_two_shared(self) -> None:
+        from questfoundry.graph.grow_validation import check_no_pre_commit_intersections
+
+        graph = Graph.empty()
+        graph.create_node("path::a", {"type": "path", "dilemma_id": "d"})
+        graph.create_node("path::b", {"type": "path", "dilemma_id": "d"})
+        graph.create_node("beat::s1", {"type": "beat", "dilemma_impacts": []})
+        graph.create_node("beat::s2", {"type": "beat", "dilemma_impacts": []})
+        graph.add_edge("belongs_to", "beat::s1", "path::a")
+        graph.add_edge("belongs_to", "beat::s1", "path::b")
+        graph.add_edge("belongs_to", "beat::s2", "path::a")
+        graph.add_edge("belongs_to", "beat::s2", "path::b")
+        graph.create_node(
+            "intersection_group::bad",
+            {"type": "intersection_group", "beat_ids": ["beat::s1", "beat::s2"]},
+        )
+
+        check = check_no_pre_commit_intersections(graph)
+        assert check.severity == "fail"
+        assert "pre-commit" in check.message
+
+    def test_passes_for_valid_y_shape(self) -> None:
+        """No intersection groups in a basic Y-shape -> passes."""
+        from questfoundry.graph.grow_validation import check_no_pre_commit_intersections
+
+        graph = _build_valid_y_shape()
+        check = check_no_pre_commit_intersections(graph)
+        assert check.severity == "pass"
+
+    def test_passes_when_group_has_one_shared_beat(self) -> None:
+        """A group with only one shared pre-commit beat is valid (cross-dilemma intersection)."""
+        from questfoundry.graph.grow_validation import check_no_pre_commit_intersections
+
+        graph = Graph.empty()
+        graph.create_node("path::a", {"type": "path", "dilemma_id": "d1"})
+        graph.create_node("path::b", {"type": "path", "dilemma_id": "d1"})
+        graph.create_node("path::c", {"type": "path", "dilemma_id": "d2"})
+        graph.create_node("beat::s1", {"type": "beat", "dilemma_impacts": []})
+        graph.create_node("beat::s2", {"type": "beat", "dilemma_impacts": []})
+        # s1 is pre-commit from d1 (dual), s2 is pre-commit from d2 (single)
+        graph.add_edge("belongs_to", "beat::s1", "path::a")
+        graph.add_edge("belongs_to", "beat::s1", "path::b")
+        graph.add_edge("belongs_to", "beat::s2", "path::c")
+        # Group containing one dual and one single -> only 1 dual per path-set -> pass
+        graph.create_node(
+            "intersection_group::ok",
+            {"type": "intersection_group", "beat_ids": ["beat::s1", "beat::s2"]},
+        )
+
+        check = check_no_pre_commit_intersections(graph)
+        assert check.severity == "pass"
+
+    def test_passes_for_empty_graph(self) -> None:
+        from questfoundry.graph.grow_validation import check_no_pre_commit_intersections
+
+        graph = Graph.empty()
+        check = check_no_pre_commit_intersections(graph)
+        assert check.severity == "pass"

--- a/tests/unit/test_grow_validation.py
+++ b/tests/unit/test_grow_validation.py
@@ -1291,3 +1291,34 @@ class TestCheckNoPreCommitIntersections:
         graph = Graph.empty()
         check = check_no_pre_commit_intersections(graph)
         assert check.severity == "pass"
+
+    def test_passes_when_two_dual_beats_from_different_dilemmas(self) -> None:
+        """An intersection group may contain two dual-path beats if they're from DIFFERENT dilemmas."""
+        from questfoundry.graph.grow_validation import check_no_pre_commit_intersections
+
+        graph = Graph.empty()
+        # Dilemma A with two paths
+        graph.create_node("path::d_a__x", {"type": "path", "dilemma_id": "dilemma::d_a"})
+        graph.create_node("path::d_a__y", {"type": "path", "dilemma_id": "dilemma::d_a"})
+        # Dilemma B with two paths
+        graph.create_node("path::d_b__p", {"type": "path", "dilemma_id": "dilemma::d_b"})
+        graph.create_node("path::d_b__q", {"type": "path", "dilemma_id": "dilemma::d_b"})
+        # Pre-commit beat for dilemma A (dual belongs_to)
+        graph.create_node("beat::pre_a", {"type": "beat", "dilemma_impacts": []})
+        graph.add_edge("belongs_to", "beat::pre_a", "path::d_a__x")
+        graph.add_edge("belongs_to", "beat::pre_a", "path::d_a__y")
+        # Pre-commit beat for dilemma B (dual belongs_to)
+        graph.create_node("beat::pre_b", {"type": "beat", "dilemma_impacts": []})
+        graph.add_edge("belongs_to", "beat::pre_b", "path::d_b__p")
+        graph.add_edge("belongs_to", "beat::pre_b", "path::d_b__q")
+        # Intersection group containing both — legal because different dilemmas
+        graph.create_node(
+            "intersection_group::ig1",
+            {
+                "type": "intersection_group",
+                "beat_ids": ["beat::pre_a", "beat::pre_b"],
+            },
+        )
+
+        result = check_no_pre_commit_intersections(graph)
+        assert result.severity == "pass"

--- a/tests/unit/test_polish_entry_contract.py
+++ b/tests/unit/test_polish_entry_contract.py
@@ -152,9 +152,9 @@ class TestValidateGrowOutput:
         assert any("beat::orphan" in e and "belongs_to" in e for e in errors)
 
     def test_beat_multiple_belongs_to(self) -> None:
-        """Beat with multiple belongs_to edges fails validation."""
+        """Beat with multiple belongs_to edges is legal under Y-shape (pre-commit beats share paths)."""
         graph = _make_valid_grow_graph()
-        # Create second path and duplicate belongs_to
+        # Create second path and add a second belongs_to edge (simulates a pre-commit beat)
         graph.create_node(
             "path::coward",
             {"type": "path", "raw_id": "coward", "label": "Coward Path"},
@@ -163,8 +163,9 @@ class TestValidateGrowOutput:
 
         errors = validate_grow_output(graph)
         multi_errors = [e for e in errors if "beat::intro" in e and "belongs_to" in e]
-        assert multi_errors, f"Expected multiple belongs_to error for beat::intro, got: {errors}"
-        assert any("must have exactly 1" in e for e in multi_errors)
+        assert not multi_errors, (
+            f"Multiple belongs_to should be legal under Y-shape, got errors: {multi_errors}"
+        )
 
     def test_dilemma_missing_role(self) -> None:
         """Dilemma without dilemma_role fails validation."""


### PR DESCRIPTION
## Summary

Adds three post-hoc guard-rail checks to `grow_validation.py` that mirror the write-time enforcement in #1216 (merged). Defense-in-depth: catches graphs built by tests or code paths that bypass `apply_seed_mutations`.

Also drops a stale single-`belongs_to` assertion in `polish_validation.py` that would have failed legitimate Y-shape pre-commit beats.

## What changed

- **`check_no_cross_dilemma_belongs_to`** (guard rail 1) — fails when a beat's two `belongs_to` edges point at paths from different dilemmas
- **`check_no_dual_on_commit_beat`** (guard rail 2) — fails when a beat with `effect: commits` in `dilemma_impacts` has >1 `belongs_to` edge
- **`check_no_pre_commit_intersections`** (guard rail 3) — fails when an `intersection_group` contains ≥2 beats with identical path frozensets (same-dilemma pre-commit beats)
- `polish_validation.validate_grow_output` — removed `elif len(paths) > 1: errors.append(...)` (pre-commit beats legitimately have 2 edges); kept the `== 0` check

## Test plan

- [ ] `uv run pytest tests/unit/test_grow_validation.py -x -q` — 54 tests pass (13 new guard-rail tests)
- [ ] `uv run pytest tests/unit/test_polish_passage_validation.py -x -q` — 71 tests pass
- [ ] All three checks wired into `run_grow_checks()` and listed in `__all__`

## Closes

Closes #1219

🤖 Generated with [Claude Code](https://claude.com/claude-code)