### PR TITLE
ci: claude-review needs pull-requests:write to post inline comments

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
+      pull-requests: write  # Required so the review action can post inline comments
       issues: read
       id-token: write
 
@@ -41,4 +41,3 @@ jobs:
           prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
-


### PR DESCRIPTION
## Summary

The Claude code-review action installed by \`/install-github-app\` (#1224) was generated with \`pull-requests: read\`. As a result, on PRs #1225/#1226/#1228 the action ran fully (~\$3 USD per PR in tokens), produced a review internally, but ended with \`No buffered inline comments\` — the post step had no permission to actually create review comments on the PR. The runs all show as green ✓ which masks the silent failure.

This bumps the permission to \`pull-requests: write\` so reviews actually land.

## Verification

After merge, any new push or new PR should produce visible inline review comments from the claude-review action (look for it under "Files changed → Reviews"). The previous PRs (#1225/#1226/#1228) will also start posting comments on their next push event.

🤖 Generated with [Claude Code](https://claude.com/claude-code)