### PR TITLE
ci: make claude-review actually post — add --comment + track_progress + display_report

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -38,6 +38,13 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
-          prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
+          # `--comment` tells the plugin to actually post (without it, the plugin
+          # runs the full review and stops silently — burning ~$3/PR for no output).
+          prompt: '/code-review:code-review --comment ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
+          # Surface progress so a silent failure is visible: a sticky tracking
+          # comment updates during the run, and the Claude Code Report appears
+          # in the job's GitHub Step Summary.
+          track_progress: true
+          display_report: true
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options


### PR DESCRIPTION
## Summary

The default `/install-github-app` workflow generated in #1224 runs `/code-review:code-review` without `--comment`, which causes the plugin to run its full review (~$3/PR in tokens) and stop silently at step 7 of its command (`"If --comment argument was NOT provided, stop here"`). The action reports success with `No buffered inline comments` and users see nothing.

Observed on PRs #1225 / #1226 / #1228. Verified via the plugin's own [README](https://github.com/anthropics/claude-code/tree/main/plugins/code-review) and [command source](https://github.com/anthropics/claude-code/blob/main/plugins/code-review/commands/code-review.md).

## Changes

1. **`--comment`** — the flag the plugin's own README recommends for CI. Without it the plugin never posts.
2. **`track_progress: true`** — sticky tracking comment updates live during the run; makes silent failures immediately visible.
3. **`display_report: true`** — Claude Code Report shown in the job's GitHub Step Summary for post-hoc inspection.

## Caveat

Open PRs (#1225, #1226, #1228) will need a rebase to pick this up — `pull_request` events use the workflow from the PR's HEAD, not main.

## Why this is a general upstream bug

The broken default template has been generated by `/install-github-app` since at least 2026-01-13 (verified by checking `anthropics/life-sciences` and `anthropics/healthcare` — same SHA, no modifications). Even Anthropic doesn't use the default — they wrote a custom `claude-skill-review.yml` for actual reviews. Worth a separate upstream issue; this PR just unblocks us locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)