### PR TITLE
chore: add .worktrees/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -93,3 +93,4 @@ projects/
 # OS files
 .DS_Store
 Thumbs.db
+.worktrees/


### PR DESCRIPTION
Keeps local git worktrees (used for feature development) out of `git status` and out of accidental commits. One-line change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)