### PR TITLE
fix(prompts): restructure SEED summarize dilemmas prompt for branching (#1241)

### DIFF
--- a/prompts/templates/summarize_seed_sections.yaml
+++ b/prompts/templates/summarize_seed_sections.yaml
@@ -48,19 +48,60 @@ dilemmas_system: |
   Use dilemma IDs and answer IDs EXACTLY as listed below. Copy-paste them.
   Do NOT reconstruct IDs from dilemma names or descriptions.
 
-  ## DEFAULT ANSWER RULE (MOST IMPORTANT RULE)
+  ## MINIMUM BRANCHING REQUIREMENT (HARD CONSTRAINT — READ FIRST)
+
+  At least 2 dilemmas MUST have ALL their answers in `explored` (with `unexplored=[]`).
+  This is required for the story to have meaningful branching. A story with fewer than
+  2 fully-explored dilemmas produces a near-linear story and WILL BE REJECTED downstream.
+
+  BAD (rejected): only one answer per dilemma in `explored` → no real branching → pipeline fails
+  ```
+  - dilemma::host_benevolent_or_selfish: explored=[protector], unexplored=[manipulator]
+  - dilemma::artifact_safe_or_dangerous: explored=[safe], unexplored=[dangerous]
+  ```
+  GOOD (valid): 2 dilemmas fully explored → 4 arcs → passes
+  ```
+  - dilemma::host_benevolent_or_selfish: explored=[protector, manipulator], unexplored=[]
+  - dilemma::artifact_safe_or_dangerous: explored=[safe, dangerous], unexplored=[]
+  ```
+
+  ## EXTRACTION FIDELITY (CRITICAL)
+  If the discussion says "EXPLORE BOTH" / "explore both answers" / similar for a dilemma,
+  that dilemma MUST appear with both answers in `explored` (and `unexplored=[]`).
+  Do NOT downgrade an "EXPLORE BOTH" decision to single-answer-explored — that drops
+  branching information the discussion already established and produces a linear story.
+
+  ## DEFAULT ANSWER RULE
   In the answer list below, one answer per dilemma is marked `(default)`.
   The `(default)` answer is the canonical story spine. It MUST ALWAYS go in `explored`.
   You may NEVER put the `(default)` answer in `unexplored`.
+  The alternative (non-default) answer MAY ALSO be in `explored` — and for binary
+  dilemmas (2 answers), it SHOULD be in `explored` most of the time.
 
   EXAMPLE: answers are [`reliable` (default), `falsified`]
-  - CORRECT: explored=[reliable, falsified], unexplored=[]
-  - CORRECT: explored=[reliable], unexplored=[falsified]
+  - CORRECT: explored=[reliable, falsified], unexplored=[]  ← PREFERRED for binary
+  - ALSO CORRECT: explored=[reliable], unexplored=[falsified]  ← only if you must limit scope
   - WRONG:   explored=[falsified], unexplored=[reliable]  <-- default in unexplored!
 
   COMMON MISTAKE: The discussion may say "explore canonical only (X as shadow)".
   "X as shadow" means X goes in `unexplored`. The CANONICAL answer (the one marked
   `(default)` below) goes in `explored`. Do NOT put the shadow answer in explored.
+
+  ## When to Leave an Answer Unexplored
+
+  "Soft" dilemmas (only the default explored) add flavor without adding branching arcs.
+  Use them sparingly — at most 30-50% of your dilemmas. The rest MUST be fully explored
+  to drive branching. Leaving the alternative unexplored is a deliberate scope reduction,
+  not a default behavior.
+
+  GOOD branching distribution for 8 dilemmas:
+  - 4 fully explored (both answers in `explored`): creates 8 branching arcs
+  - 4 default-only (only default in `explored`): adds 4 flavor arcs
+  - TOTAL: 12 arcs, 8 branching — passes validation, rich story
+
+  BAD distribution for 8 dilemmas:
+  - 0 fully explored: 8 arcs total, all default-only, no branching
+  - 0 arcs with real choices → FAILS validation downstream
 
   ## Required Dilemma IDs ({dilemma_count} total)
   {dilemma_manifest}
@@ -79,11 +120,31 @@ dilemmas_system: |
   dilemma names.
 
   ## Output Format
-  List EVERY dilemma with its decision:
+  List EVERY dilemma with its decision. The example below shows a healthy 4-fully + 4-default-only
+  distribution for an 8-dilemma story (50% soft cap):
   ```
-  - dilemma::trust_or_betray: explored=[trust, betray], unexplored=[]
-  - dilemma::weather_storm_or_clear: explored=[storm], unexplored=[clear]
+  - dilemma::host_benevolent_or_selfish: explored=[protector, manipulator], unexplored=[]
+  - dilemma::artifact_safe_or_dangerous: explored=[safe, dangerous], unexplored=[]
+  - dilemma::mentor_trust_or_betray:     explored=[trust, betray], unexplored=[]
+  - dilemma::ending_hope_or_despair:     explored=[hope, despair], unexplored=[]
+  - dilemma::faction_help_or_hinder:     explored=[help], unexplored=[hinder]
+  - dilemma::weather_storm_or_clear:     explored=[storm], unexplored=[clear]
+  - dilemma::city_quiet_or_loud:         explored=[quiet], unexplored=[loud]
+  - dilemma::artifact_old_or_new:        explored=[old], unexplored=[new]
   ```
+
+  ## What NOT to Do
+  - Do NOT explore only the default answer for every dilemma — that produces no branching
+  - Do NOT put the `(default)` answer in `unexplored` — it MUST be in `explored`
+  - Do NOT downgrade "EXPLORE BOTH" decisions from the discussion to single-answer-explored
+  - Do NOT invent answer IDs not in the Valid Answer IDs list
+
+  ## FINAL CHECK before returning
+  Count how many of your dilemmas have ALL answers in `explored` (`unexplored=[]`).
+  If that count is less than 2, GO BACK and fully explore at least 2 dilemmas
+  by moving ALL their answers from `unexplored` into `explored`.
+  A story with fewer than 2 fully-explored dilemmas is REJECTED downstream.
+
   VERIFY: Your list MUST have exactly {dilemma_count} items.
   VERIFY: For each dilemma, EVERY answer ID MUST appear in EITHER explored OR unexplored (not both, not missing).
   VERIFY: The `(default)` answer for each dilemma is in `explored`, NEVER in `unexplored`.

--- a/tests/unit/test_summarize.py
+++ b/tests/unit/test_summarize.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -16,6 +17,10 @@ from questfoundry.agents.summarize import (
     summarize_discussion,
     summarize_seed_chunked,
 )
+
+# Minimum fully-explored dilemmas required for the SEED stage to pass validation
+# (mirrors the threshold cited in src/questfoundry/pipeline/stages/seed.py).
+MIN_FULLY_EXPLORED_DILEMMAS = 2
 
 
 class TestGetSummarizePrompt:
@@ -619,21 +624,35 @@ class TestDilemmasSummarizePromptStructure:
         assert "REJECTED" in prompt or "FAILS" in prompt or "pipeline fails" in prompt
 
     def test_output_format_example_shows_fully_explored_dilemmas(self) -> None:
-        """The output-format example must demonstrate ≥2 fully-explored dilemmas.
+        """The output-format example must demonstrate ≥MIN_FULLY_EXPLORED_DILEMMAS
+        fully-explored dilemmas.
 
         Small models anchor on the most recent example; an example dominated
         by single-answer-explored entries normalizes the failure mode.
+
+        Scopes the search to the `## Output Format` section so the assertion
+        reflects the test name — instructional `unexplored=[]` mentions
+        elsewhere in the prompt do not satisfy this check.
         """
         prompt = self._get_dilemmas_prompt()
-        # Find the output-format code block and count entries with `unexplored=[]`
-        # vs entries with a non-empty unexplored.
-        import re
 
-        # Look for explored=[a, b], unexplored=[] pattern (fully explored)
-        fully_explored = len(re.findall(r"unexplored=\[\]", prompt))
-        # We expect at least 2 fully-explored entries in the visible example.
-        assert fully_explored >= 2, (
-            f"Output-format example must show ≥2 fully-explored entries; found {fully_explored}"
+        # Extract the "## Output Format" section (up to the next "##" header
+        # or end of prompt).
+        section_match = re.search(
+            r"## Output Format\b(.*?)(?=\n  ## |\Z)",
+            prompt,
+            flags=re.DOTALL,
+        )
+        assert section_match is not None, "Output Format section is missing"
+        output_format_section = section_match.group(1)
+
+        # Count list-item entries (`- dilemma::...`) with `unexplored=[]`.
+        # Anchoring on `- dilemma::` excludes prose mentions of `unexplored=[]`.
+        fully_explored = len(re.findall(r"- dilemma::[^\n]*unexplored=\[\]", output_format_section))
+        assert fully_explored >= MIN_FULLY_EXPLORED_DILEMMAS, (
+            f"Output-format example must show "
+            f"≥{MIN_FULLY_EXPLORED_DILEMMAS} fully-explored entries; "
+            f"found {fully_explored}"
         )
 
 

--- a/tests/unit/test_summarize.py
+++ b/tests/unit/test_summarize.py
@@ -542,6 +542,101 @@ class TestGetSeedSectionSummarizePrompts:
             assert len(prompt) > 50, f"{section} should be non-trivial"
 
 
+class TestDilemmasSummarizePromptStructure:
+    """Structural tests for the summarize dilemmas_system prompt (#1241).
+
+    Mirrors TestDilemmasPromptStructure in test_serialize.py. The summarize
+    prompt is upstream of serialize — if it produces a single-answer-explored
+    brief, no serialize-time guard rail can recover. These tests enforce the
+    same sandwich pattern (hard constraint at top, FINAL CHECK at bottom).
+    """
+
+    def _get_dilemmas_prompt(self) -> str:
+        prompts = get_seed_section_summarize_prompts(
+            dilemma_count=8,
+            dilemma_manifest="- dilemma::trust_or_betray",
+            dilemma_answers="- `dilemma::trust_or_betray` -> [trust (default), betray]",
+        )
+        return prompts["dilemmas"]
+
+    def test_dilemmas_prompt_is_nonempty(self) -> None:
+        """Summarize dilemmas prompt must load and be non-trivially long."""
+        prompt = self._get_dilemmas_prompt()
+        assert isinstance(prompt, str)
+        assert len(prompt) > 200
+
+    def test_hard_constraint_appears_before_default_rule(self) -> None:
+        """MINIMUM BRANCHING REQUIREMENT must appear before DEFAULT ANSWER RULE.
+
+        Sandwich-top pattern: hard constraints first, not buried.
+        """
+        prompt = self._get_dilemmas_prompt()
+        assert "MINIMUM BRANCHING REQUIREMENT" in prompt
+        assert "DEFAULT ANSWER RULE" in prompt
+        idx_constraint = prompt.index("MINIMUM BRANCHING REQUIREMENT")
+        idx_default = prompt.index("DEFAULT ANSWER RULE")
+        assert idx_constraint < idx_default, (
+            "MINIMUM BRANCHING REQUIREMENT must appear before DEFAULT ANSWER RULE"
+        )
+
+    def test_final_check_section_present(self) -> None:
+        """FINAL CHECK section must be present (sandwich-bottom pattern)."""
+        prompt = self._get_dilemmas_prompt()
+        assert "FINAL CHECK" in prompt
+
+    def test_final_check_appears_after_hard_constraint(self) -> None:
+        """FINAL CHECK must appear after the main hard constraint."""
+        prompt = self._get_dilemmas_prompt()
+        idx_constraint = prompt.index("MINIMUM BRANCHING REQUIREMENT")
+        idx_final = prompt.index("FINAL CHECK")
+        assert idx_final > idx_constraint
+
+    def test_extraction_fidelity_directive_present(self) -> None:
+        """Prompt must instruct the model to preserve EXPLORE BOTH decisions
+        from the discussion — not downgrade them to single-answer-explored.
+
+        Regression for #1241: the discuss phase correctly identified 6 of 8
+        dilemmas as EXPLORE BOTH, but summarize ignored that and emitted
+        single-answer-explored for all 8.
+        """
+        prompt = self._get_dilemmas_prompt()
+        assert "EXTRACTION FIDELITY" in prompt
+        assert "EXPLORE BOTH" in prompt
+
+    def test_alternative_may_also_be_explored_language_present(self) -> None:
+        """Prompt must clarify that the alternative answer MAY ALSO be in explored.
+
+        Prevents the old framing where 'default in explored' implied
+        'alternative goes in unexplored'.
+        """
+        prompt = self._get_dilemmas_prompt()
+        assert "MAY ALSO be in `explored`" in prompt
+
+    def test_bad_distribution_example_links_to_failure(self) -> None:
+        """BAD example must explicitly link single-answer-explored to pipeline failure."""
+        prompt = self._get_dilemmas_prompt()
+        assert "BAD" in prompt
+        assert "REJECTED" in prompt or "FAILS" in prompt or "pipeline fails" in prompt
+
+    def test_output_format_example_shows_fully_explored_dilemmas(self) -> None:
+        """The output-format example must demonstrate ≥2 fully-explored dilemmas.
+
+        Small models anchor on the most recent example; an example dominated
+        by single-answer-explored entries normalizes the failure mode.
+        """
+        prompt = self._get_dilemmas_prompt()
+        # Find the output-format code block and count entries with `unexplored=[]`
+        # vs entries with a non-empty unexplored.
+        import re
+
+        # Look for explored=[a, b], unexplored=[] pattern (fully explored)
+        fully_explored = len(re.findall(r"unexplored=\[\]", prompt))
+        # We expect at least 2 fully-explored entries in the visible example.
+        assert fully_explored >= 2, (
+            f"Output-format example must show ≥2 fully-explored entries; found {fully_explored}"
+        )
+
+
 class TestSummarizeSeedChunked:
     """Test summarize_seed_chunked function."""
 


### PR DESCRIPTION
## Summary

Mirror PR #1234/#1235's serialize-prompt fix into the upstream summarize prompt. The summarize phase produces the brief that serialize transcribes — without branching constraints here, no serialize-time guard rail can recover. Closes #1241.

## What changed

`prompts/templates/summarize_seed_sections.yaml` `dilemmas_system`:

- **Move MINIMUM BRANCHING REQUIREMENT to the top** (sandwich pattern — small models need the hard constraint first, not buried)
- **Add EXTRACTION FIDELITY directive**: "EXPLORE BOTH" decisions from the discussion MUST be preserved, not downgraded to single-answer-explored
- **Reframe DEFAULT ANSWER RULE** so the alternative MAY ALSO be in `explored` (PREFERRED for binary). Previously two equally-weighted "CORRECT" examples normalized the worst case
- **Replace the 2-line GOOD output-format example** with an 8-dilemma worked example showing 4 fully-explored + 4 default-only (the 50% soft cap), so small models anchor on the desired distribution rather than `explored=[1], unexplored=[1]`
- **Add a "When to Leave an Answer Unexplored" section** consistent with `serialize_seed_sections.yaml`
- **Add a FINAL CHECK** that counts fully-explored dilemmas before returning

`tests/unit/test_summarize.py`:

- Add `TestDilemmasSummarizePromptStructure` mirroring `TestDilemmasPromptStructure` in `test_serialize.py` (8 structural invariants — sandwich-top, sandwich-bottom, fidelity directive, no single-explored anchor in output example, etc.)

## Why this matters

`projects/test-new2/` ran for 50 minutes on qwen3:4b-instruct-32k (2026-04-15) and failed with `SEED produced only 1 arc(s) (a linear story) — minimum required is 4. Only 0 dilemma(s) have both answers explored.`

The DISCUSS phase **correctly** identified 6 of 8 dilemmas as ✅ EXPLORE BOTH and 2 as ❌ canonical-only. The SUMMARIZE phase **ignored that** and emitted single-answer-explored for all 8 dilemmas (with the default-rule violated 4 of 8 times). SERIALIZE then transcribed the brief verbatim into JSON. PR #1235's serialize-time guard rails are useless because the brief is already wrong by the time serialize runs.

`git log -- prompts/templates/summarize_seed_sections.yaml` confirms this prompt was last touched in #1228 (Y-shape framing only); PR #1234/#1235 only restructured the serialize variant.

## Test plan

- [x] `uv run pytest tests/unit/test_summarize.py::TestDilemmasSummarizePromptStructure -x -q` — 8/8 pass
- [x] `uv run pytest tests/unit/test_summarize.py tests/unit/test_serialize.py::TestDilemmasPromptStructure -x -q` — 53/53 pass (no regression in serialize tests)
- [x] `uv run ruff check tests/unit/test_summarize.py` — clean
- [x] `uv run ruff format` — applied
- [x] `uv run mypy src/questfoundry/agents/prompts.py` — clean
- [x] `uv run pre-commit run --files prompts/templates/summarize_seed_sections.yaml tests/unit/test_summarize.py` — pass
- [ ] **Empirical**: re-run `qf seed --project test-new3` on qwen3:4b and confirm ≥2 fully-explored dilemmas in summarize output. *(Manual verification by maintainer — small-model behavioral change is hard to assert in unit tests.)*

## Not in scope

- The discuss prompt is **not** changed — it correctly produced "EXPLORE BOTH" decisions in the failing run; the bug is purely summarize-side.
- The serialize prompt is **not** changed — PR #1234/#1235 already restructured it.
- The 3× retry behavior observed in the failing run (full summarize/serialize loop ran 3 times, ~15 min each) is upstream of this fix and not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)