### PR TITLE
fix: route arc_structure semantic errors to beats retry, not paths (#1243)

### DIFF
--- a/src/questfoundry/agents/serialize.py
+++ b/src/questfoundry/agents/serialize.py
@@ -1673,7 +1673,7 @@ def _format_section_corrections(errors: list[SeedValidationError]) -> str:
         # actionable ("Path X has no beat after its commit beat... Add a beat
         # with effect 'advances' or 'complicates' after the commit beat.").
         # The generic COMPLETENESS handler would misformat these as "missing items".
-        if ".arc_structure" in error.field_path:
+        if error.field_path.endswith(".arc_structure"):
             corrections.append(f"- ARC FIX: {error.issue}")
             continue
 

--- a/src/questfoundry/agents/serialize.py
+++ b/src/questfoundry/agents/serialize.py
@@ -1669,6 +1669,14 @@ def _format_section_corrections(errors: list[SeedValidationError]) -> str:
     cross_ref_items: list[str] = []
 
     for error in errors:
+        # Handle arc_structure errors first — their issue text is already
+        # actionable ("Path X has no beat after its commit beat... Add a beat
+        # with effect 'advances' or 'complicates' after the commit beat.").
+        # The generic COMPLETENESS handler would misformat these as "missing items".
+        if ".arc_structure" in error.field_path:
+            corrections.append(f"- ARC FIX: {error.issue}")
+            continue
+
         category = categorize_error(error)
 
         # Handle CROSS_REFERENCE errors (bucket misplacement, answer not in explored)

--- a/src/questfoundry/graph/mutations.py
+++ b/src/questfoundry/graph/mutations.py
@@ -1084,7 +1084,7 @@ def validate_seed_mutations(graph: Graph, output: dict[str, Any]) -> list[SeedVa
     12. Each beat references its path's parent dilemma in dilemma_impacts
     13. Each path has at least one beat with effect="commits" for its dilemma
     14. Each path has advances/reveals beat before commit (WARNING, non-blocking)
-    15. Each path has at least one beat after commit (WARNING, non-blocking)
+    15. Each path has at least one beat after commit (COMPLETENESS, blocking)
 
     Args:
         graph: Graph containing BRAINSTORM data (entities, dilemmas, answers).

--- a/src/questfoundry/graph/mutations.py
+++ b/src/questfoundry/graph/mutations.py
@@ -1652,7 +1652,9 @@ def validate_seed_mutations(graph: Graph, output: dict[str, Any]) -> list[SeedVa
             expected_dilemma = path_dilemma_map[path_id]
             errors.append(
                 SeedValidationError(
-                    field_path=f"paths.{path_id}.arc_structure",
+                    # initial_beats prefix → routes to "beats" section for retry,
+                    # where the per_path_beats prompt can act on the feedback.
+                    field_path=f"initial_beats.{path_id}.arc_structure",
                     issue=(
                         f"Path '{path_id}' has no beat with effect 'advances' "
                         f"or 'reveals' before its commit beat for dilemma "
@@ -1671,7 +1673,9 @@ def validate_seed_mutations(graph: Graph, output: dict[str, Any]) -> list[SeedVa
             expected_dilemma = path_dilemma_map[path_id]
             errors.append(
                 SeedValidationError(
-                    field_path=f"paths.{path_id}.arc_structure",
+                    # initial_beats prefix → routes to "beats" section for retry,
+                    # where the per_path_beats prompt can act on the feedback.
+                    field_path=f"initial_beats.{path_id}.arc_structure",
                     issue=(
                         f"Path '{path_id}' has no beat after its commit beat "
                         f"for dilemma '{expected_dilemma}'. Every path MUST have "

--- a/tests/unit/test_mutations.py
+++ b/tests/unit/test_mutations.py
@@ -2406,7 +2406,7 @@ class TestSeedArcStructureValidation:
         assert "advances" in warnings[0].issue
         assert "reveals" in warnings[0].issue
         assert "before" in warnings[0].issue
-        assert warnings[0].field_path == "paths.trust_arc.arc_structure"
+        assert warnings[0].field_path == "initial_beats.trust_arc.arc_structure"
 
     def test_missing_post_commit_beat_warns(self) -> None:
         """Commit without any following beat produces a COMPLETENESS error."""
@@ -2440,7 +2440,7 @@ class TestSeedArcStructureValidation:
         assert blocking[0].category == SeedErrorCategory.COMPLETENESS
         assert "after" in blocking[0].issue
         assert "consequence" in blocking[0].issue
-        assert blocking[0].field_path == "paths.trust_arc.arc_structure"
+        assert blocking[0].field_path == "initial_beats.trust_arc.arc_structure"
         assert warnings == []
 
     def test_single_commit_beat_produces_both_warnings(self) -> None:

--- a/tests/unit/test_serialize.py
+++ b/tests/unit/test_serialize.py
@@ -1291,7 +1291,7 @@ class TestFormatSectionCorrections:
 
 
 class TestArcStructureErrorRouting:
-    """Tests for arc_structure error routing and formatting (#1241 follow-up).
+    """Tests for arc_structure error routing and formatting (#1243 fix).
 
     Arc structure errors (e.g., 'no beat after commit') are about beat ordering,
     not path descriptions. They must route to the "beats" section so correction

--- a/tests/unit/test_serialize.py
+++ b/tests/unit/test_serialize.py
@@ -1290,6 +1290,85 @@ class TestFormatSectionCorrections:
         assert "BUCKET MISPLACEMENT" in result
 
 
+class TestArcStructureErrorRouting:
+    """Tests for arc_structure error routing and formatting (#1241 follow-up).
+
+    Arc structure errors (e.g., 'no beat after commit') are about beat ordering,
+    not path descriptions. They must route to the "beats" section so correction
+    feedback reaches the per_path_beats prompt — not the paths prompt.
+    """
+
+    def test_arc_structure_errors_route_to_beats_section(self) -> None:
+        """arc_structure errors with initial_beats prefix must group into 'beats'."""
+        from questfoundry.agents.serialize import _group_errors_by_section
+        from questfoundry.graph.mutations import SeedErrorCategory, SeedValidationError
+
+        errors = [
+            SeedValidationError(
+                field_path="initial_beats.some_path.arc_structure",
+                issue="Path 'some_path' has no beat after its commit beat.",
+                available=[],
+                provided="",
+                category=SeedErrorCategory.COMPLETENESS,
+            ),
+        ]
+        grouped = _group_errors_by_section(errors)
+        assert "beats" in grouped
+        assert "paths" not in grouped
+
+    def test_arc_structure_corrections_are_actionable(self) -> None:
+        """arc_structure corrections must contain the full issue text, not 'missing items'."""
+        from questfoundry.agents.serialize import _format_section_corrections
+        from questfoundry.graph.mutations import SeedErrorCategory, SeedValidationError
+
+        errors = [
+            SeedValidationError(
+                field_path="initial_beats.trust_arc.arc_structure",
+                issue=(
+                    "Path 'trust_arc' has no beat after its commit beat for "
+                    "dilemma 'trust'. Add a beat with effect 'advances' or "
+                    "'complicates' after the commit beat."
+                ),
+                available=[],
+                provided="",
+                category=SeedErrorCategory.COMPLETENESS,
+            ),
+        ]
+        result = _format_section_corrections(errors)
+        assert "ARC FIX" in result
+        assert "trust_arc" in result
+        assert "after the commit beat" in result
+        # Must NOT be formatted as a "missing item"
+        assert "MISSING ITEMS" not in result
+
+    def test_arc_structure_not_misrouted_to_paths(self) -> None:
+        """Errors with initial_beats prefix must not land in the paths section."""
+        from questfoundry.agents.serialize import _group_errors_by_section
+        from questfoundry.graph.mutations import SeedErrorCategory, SeedValidationError
+
+        errors = [
+            SeedValidationError(
+                field_path="initial_beats.foo.arc_structure",
+                issue="No beat after commit.",
+                available=[],
+                provided="",
+                category=SeedErrorCategory.COMPLETENESS,
+            ),
+            SeedValidationError(
+                field_path="paths.bar.answer_id",
+                issue="Path answer mismatch.",
+                available=["x"],
+                provided="y",
+                category=SeedErrorCategory.SEMANTIC,
+            ),
+        ]
+        grouped = _group_errors_by_section(errors)
+        assert "beats" in grouped
+        assert len(grouped["beats"]) == 1
+        assert "paths" in grouped
+        assert len(grouped["paths"]) == 1
+
+
 class TestBeatRetryAndContextRefresh:
     """Tests for beat retry and path context refresh functionality."""
 


### PR DESCRIPTION
## Summary

Arc structure errors ("no beat after commit beat") were routed to the **paths** retry prompt instead of the **beats** prompt. The model that produces beat ordering never saw the correction feedback. Closes #1243.

## What changed

**`src/questfoundry/graph/mutations.py`** — checks #14 and #15:
- Change `field_path` prefix from `"paths.{path_id}.arc_structure"` to `"initial_beats.{path_id}.arc_structure"`
- This maps to the `"beats"` section via `_FIELD_PATH_TO_SECTION`, routing corrections to the per_path_beats prompt

**`src/questfoundry/agents/serialize.py`** — `_format_section_corrections`:
- Add early handling for `.arc_structure` field_paths that passes through the issue text as an `ARC FIX:` directive
- Previously, the COMPLETENESS handler extracted the first quoted string and formatted it as `MISSING ITEMS: archive_alive_or_dead__dead` — telling the model to create a path that already existed

Before (routed to paths prompt, wrong format):
```
## MISSING ITEMS
The following items are MISSING and MUST be included:
- archive_alive_or_dead__dead
```

After (routed to beats prompt, actionable):
```
## MANDATORY CORRECTIONS
- ARC FIX: Path 'archive_alive_or_dead__dead' has no beat after its commit beat
  for dilemma 'archive_alive_or_dead'. Every path MUST have at least one
  consequence beat after the commit beat — the beat that shows the player what
  their choice led to. Add a beat with effect 'advances' or 'complicates' after
  the commit beat.
```

**Tests:**
- `tests/unit/test_mutations.py`: Updated 2 field_path assertions for the new prefix
- `tests/unit/test_serialize.py`: Added `TestArcStructureErrorRouting` (3 tests: routing, formatting, non-misrouting)

## Why this matters

In `projects/test-new3`, 3 of 16 per-path beat calls put `commits` as the last beat across 6 retry iterations (3 outer × 2 inner). Each retry produced identical output because the per_path_beats prompt never received the correction. The per_path_beats prompt already has explicit ARC STRUCTURE instructions with WRONG/RIGHT examples — with targeted feedback it should self-correct.

## Test plan

- [x] `uv run pytest tests/unit/test_serialize.py::TestArcStructureErrorRouting -x -v` — 3/3 pass
- [x] `uv run pytest tests/unit/test_mutations.py tests/unit/test_serialize.py -x -q` — 314/314 pass
- [x] `uv run mypy src/questfoundry/graph/mutations.py src/questfoundry/agents/serialize.py` — clean
- [x] `uv run ruff check` + `ruff format` — clean
- [x] `uv run pre-commit run --files` — all pass
- [ ] **Empirical**: re-run `qf seed` on qwen3:4b and confirm that the 3 failing paths self-correct after receiving ARC FIX feedback. *(Manual verification by maintainer.)*

🤖 Generated with [Claude Code](https://claude.com/claude-code)