### PR TITLE
fix: preserve shared pre-commit beats during beats retry (#1246)

### DIFF
--- a/src/questfoundry/agents/serialize.py
+++ b/src/questfoundry/agents/serialize.py
@@ -2514,7 +2514,14 @@ async def serialize_seed_as_function(
                         callbacks=callbacks,
                         on_phase_progress=on_phase_progress,
                     )
-                    collected["initial_beats"] = beats
+                    # Preserve shared pre-commit beats (Y-shape dual belongs_to)
+                    # at the front — _serialize_beats_per_path only produces
+                    # per-path post-commit beats.  The initial serialization
+                    # at line ~2336 does the same prepend; the retry must match.
+                    shared = [
+                        b for b in collected.get("initial_beats", []) if b.get("also_belongs_to")
+                    ]
+                    collected["initial_beats"] = shared + beats
                     total_tokens += beats_tokens
                     retried_any = True
                 except SerializationError as e:

--- a/tests/unit/test_serialize.py
+++ b/tests/unit/test_serialize.py
@@ -1455,6 +1455,129 @@ class TestBeatRetryAndContextRefresh:
             assert result.success is True
 
     @pytest.mark.asyncio
+    async def test_beats_retry_preserves_shared_beats(self) -> None:
+        """Shared pre-commit beats (with also_belongs_to) must survive beats retry.
+
+        Regression for #1246: the retry code replaced collected["initial_beats"]
+        with only per-path beats, dropping all shared beats and destroying the
+        Y-shape dual belongs_to structure.
+        """
+        from questfoundry.agents.serialize import serialize_seed_as_function
+        from questfoundry.graph.mutations import SeedValidationError
+
+        mock_model = MagicMock()
+        mock_graph = MagicMock()
+
+        # Beat error to trigger retry
+        beat_errors = [
+            SeedValidationError(
+                field_path="initial_beats.commit.arc_structure",
+                issue="No beat after commit.",
+                available=[],
+                provided="",
+            )
+        ]
+
+        # Per-path beats returned by retry (no also_belongs_to)
+        retried_per_path_beats = [
+            {
+                "beat_id": "path_beat_01",
+                "summary": "Post-commit beat",
+                "path_id": "path::test_dilemma__alt1",
+                "also_belongs_to": None,
+                "dilemma_impacts": [
+                    {"dilemma_id": "dilemma::test_dilemma", "effect": "commits", "note": "x"}
+                ],
+                "entities": [],
+                "location": "location::place",
+            },
+        ]
+
+        retry_count = [0]
+
+        def mock_beats_retry(*_args, **_kwargs):
+            retry_count[0] += 1
+            return (retried_per_path_beats, 20)
+
+        mock_beats = AsyncMock(side_effect=mock_beats_retry)
+
+        validation_call_count = [0]
+
+        def mock_validate(_graph, _output):
+            validation_call_count[0] += 1
+            if validation_call_count[0] == 1:
+                return beat_errors
+            return []
+
+        mock_path = {
+            "path_id": "path::test_dilemma__alt1",
+            "name": "Test Path",
+            "dilemma_id": "dilemma::test_dilemma",
+            "answer_id": "alt1",
+            "unexplored_answer_ids": [],
+            "path_importance": "major",
+            "description": "desc",
+        }
+
+        # Shared beat that must survive the retry
+        shared_beat = {
+            "beat_id": "shared_setup_01",
+            "summary": "Shared beat",
+            "path_id": "path::test_dilemma__alt1",
+            "also_belongs_to": "path::test_dilemma__alt2",
+            "dilemma_impacts": [
+                {"dilemma_id": "dilemma::test_dilemma", "effect": "reveals", "note": "x"}
+            ],
+            "entities": [],
+            "location": "location::place",
+        }
+
+        with (
+            patch("questfoundry.agents.serialize.serialize_to_artifact") as mock_serialize,
+            patch(
+                "questfoundry.agents.serialize._serialize_paths_per_dilemma",
+                return_value=([mock_path], 15),
+            ),
+            patch(
+                "questfoundry.agents.serialize._serialize_beats_per_path",
+                new=mock_beats,
+            ),
+            patch(
+                "questfoundry.agents.serialize._serialize_shared_beats_per_dilemma",
+                return_value=([shared_beat], 10),
+            ),
+            patch(
+                "questfoundry.agents.serialize.validate_seed_mutations",
+                side_effect=mock_validate,
+            ),
+        ):
+            mock_serialize.side_effect = [
+                (MagicMock(model_dump=lambda: {"entities": []}), 10),
+                (MagicMock(model_dump=lambda: {"dilemmas": [_MOCK_DILEMMA]}), 10),
+                (MagicMock(model_dump=lambda: {"consequences": []}), 10),
+            ]
+
+            result = await serialize_seed_as_function(
+                model=mock_model,
+                brief="Test brief",
+                graph=mock_graph,
+                max_semantic_retries=2,
+            )
+
+            assert result.success is True
+            # The retry should have run
+            assert retry_count[0] == 2  # initial + retry
+
+            # Critical: shared beat must survive the retry
+            beats = result.artifact.model_dump()["initial_beats"]
+            shared_in_output = [b for b in beats if b.get("also_belongs_to")]
+            assert len(shared_in_output) == 1, (
+                f"Shared beat dropped during retry! "
+                f"Found {len(shared_in_output)} shared beats, expected 1"
+            )
+            assert shared_in_output[0]["beat_id"] == "shared_setup_01"
+
+    @pytest.mark.asyncio
     async def test_path_retry_refreshes_context(self) -> None:
         """Should refresh brief_with_paths when paths are retried via per-dilemma."""
         from questfoundry.agents.serialize import serialize_seed_as_function


### PR DESCRIPTION
## Summary

The beats retry code replaced `collected["initial_beats"]` with only per-path beats, silently dropping all shared pre-commit beats and destroying Y-shape dual `belongs_to` edges. Closes #1246.

## Root cause

Line ~2517 in the retry path:
```python
collected["initial_beats"] = beats  # per-path only — shared beats gone
```

The initial serialization flow at line ~2336 correctly prepends:
```python
collected["initial_beats"] = existing_beats + beats  # shared + per-path
```

The retry didn't match.

## Fix

Filter shared beats (those with `also_belongs_to` set) from the current list and prepend them before the retried per-path beats:
```python
shared = [b for b in collected.get("initial_beats", []) if b.get("also_belongs_to")]
collected["initial_beats"] = shared + beats
```

## Impact

In `projects/test-new4`, SEED's LLM correctly produced 16 shared beats with `also_belongs_to` values (verified in `llm_calls.jsonl`). A semantic retry ran `_serialize_beats_per_path` → 48 per-path beats → replaced the list → 0 dual `belongs_to` edges in the graph. GROW and POLISH operated on a flat single-membership beat DAG, losing Y-shape entirely.

## Test plan

- [x] `test_beats_retry_preserves_shared_beats` — new regression test that sets up shared beats with `also_belongs_to`, triggers a beats retry, and verifies shared beats survive in the final output
- [x] `uv run pytest tests/unit/test_serialize.py -x -q` — 114/114 pass
- [x] Pre-commit, mypy, ruff — clean
- [ ] **Empirical**: re-run `qf seed` and verify shared beats appear with dual `belongs_to` edges in `pre-grow.db`

🤖 Generated with [Claude Code](https://claude.com/claude-code)