### PR TITLE
fix(grow): include Y-shape shared beats in intra-path predecessor chains (#1248)

### DIFF
--- a/src/questfoundry/pipeline/stages/grow/deterministic.py
+++ b/src/questfoundry/pipeline/stages/grow/deterministic.py
@@ -150,7 +150,7 @@ async def phase_intra_path_predecessors(
     for path_id, pdata in path_nodes.items():
         did = pdata.get("dilemma_id", "")
         if did:
-            path_dilemma[path_id] = did
+            path_dilemma[path_id] = normalize_scoped_id(did, "dilemma")
 
     def _is_intra_dilemma_shared(beat_id: str) -> bool:
         """True if beat belongs to >1 path but all paths share the same dilemma.
@@ -158,11 +158,21 @@ async def phase_intra_path_predecessors(
         Y-shape shared pre-commit beats satisfy this — they belong to both
         paths of one dilemma.  Cross-dilemma shared beats (e.g., a fixture's
         opening/finale beat that belongs to paths from 2+ dilemmas) do NOT.
+
+        Raises ValueError if a path is missing its dilemma mapping — this
+        indicates a broken graph (SEED always sets dilemma_id on paths).
         """
         paths = beat_paths.get(beat_id, set())
         if len(paths) <= 1:
             return False
-        dilemmas = {path_dilemma.get(p) for p in paths} - {None}
+        dilemmas: set[str] = set()
+        for p in paths:
+            if p not in path_dilemma:
+                raise ValueError(
+                    f"Path {p!r} has no dilemma_id — cannot determine "
+                    f"whether beat {beat_id!r} is intra-dilemma shared."
+                )
+            dilemmas.add(path_dilemma[p])
         return len(dilemmas) == 1
 
     # Determine which beats to include per path.

--- a/src/questfoundry/pipeline/stages/grow/deterministic.py
+++ b/src/questfoundry/pipeline/stages/grow/deterministic.py
@@ -92,26 +92,35 @@ async def phase_intra_path_predecessors(
     **before** cross-path interleaving runs, so every beat has its in-path
     successor as a structural predecessor child.
 
-    Only beats that are **exclusive to one path** participate in the chain.
-    Shared beats (belonging to multiple paths) already have or will receive
-    ordering from cross-path interleaving; adding alphabetical edges for them
-    risks creating cycles with those existing edges.
+    **All** beats on each path participate in the chain, including Y-shape
+    shared pre-commit beats (dual ``belongs_to``).  Shared beats appear in
+    both sibling paths' beat lists; when the second path is processed, the
+    shared-beat edges already exist and are idempotently skipped.  This
+    produces the correct Y-shape DAG::
+
+        shared_01 → shared_02 → commit_P1 → post_P1_01 → ...
+                               → commit_P2 → post_P2_01 → ...
+
+    Cross-dilemma cycle risk does not apply because guard rail 1 (Story
+    Graph Ontology Part 8) guarantees that dual ``belongs_to`` is always
+    intra-dilemma — shared beats cannot conflict with cross-dilemma
+    interleaving edges created by ``interleave_cross_path_beats``.
 
     Preconditions:
     - Beat DAG validated (Phase 1 passed).
     - Path nodes exist with beats linked via ``belongs_to`` edges.
 
     Postconditions:
-    - For each path, single-path-exclusive beats are sorted alphabetically
-      (canonical SEED naming: ``_beat_01``, ``_beat_02``, …) and chained:
-      ``predecessor(beat_n+1, beat_n)`` for every consecutive pair.
+    - For each path, beats are sorted alphabetically (canonical SEED naming:
+      ``shared_setup_…_01``, ``shared_setup_…_02``, ``…_beat_01``, …) and
+      chained: ``predecessor(beat_n+1, beat_n)`` for every consecutive pair.
     - Edges are only added, never removed; existing edges are not duplicated.
     - No edge is added whose reverse already exists (prevents cycles).
 
     Invariants:
     - Deterministic: same graph always produces same edges.
     - Idempotent: running twice produces the same edge set.
-    - Skips paths with fewer than 2 exclusive beats (no chain to form).
+    - Skips paths with fewer than 2 beats (no chain to form).
     """
     log.info("intra_path_predecessors_start")
     path_nodes = graph.get_nodes_by_type("path")
@@ -122,13 +131,9 @@ async def phase_intra_path_predecessors(
             detail="No path nodes found; nothing to do",
         )
 
-    # Build path → beats mapping and beat → paths mapping from belongs_to edges.
-    # We only chain beats that are exclusive to a single path.  Shared beats
-    # (belonging to multiple paths) already have cross-path predecessor edges
-    # created by SEED or earlier phases; adding alphabetical intra-path edges
-    # for them risks creating cycles with those existing edges.
+    # Build path → beats mapping, beat → paths, and path → dilemma index.
     path_beats: dict[str, list[str]] = {path_id: [] for path_id in path_nodes}
-    beat_path_count: dict[str, int] = {}
+    beat_paths: dict[str, set[str]] = {}
     belongs_to_edges = graph.get_edges(edge_type="belongs_to")
     beat_nodes = graph.get_nodes_by_type("beat")
     for edge in belongs_to_edges:
@@ -136,13 +141,55 @@ async def phase_intra_path_predecessors(
         path_id = edge["to"]
         if path_id in path_nodes and beat_id in beat_nodes:
             path_beats[path_id].append(beat_id)
-            beat_path_count[beat_id] = beat_path_count.get(beat_id, 0) + 1
+            beat_paths.setdefault(beat_id, set()).add(path_id)
 
-    # Restrict each path's beat list to single-path-exclusive beats.
-    exclusive_path_beats: dict[str, list[str]] = {}
-    for path_id in path_nodes:
-        exclusive = [b for b in path_beats.get(path_id, []) if beat_path_count.get(b, 0) == 1]
-        exclusive_path_beats[path_id] = sorted(exclusive)
+    # Resolve path → dilemma_id so we can distinguish Y-shape intra-dilemma
+    # shared beats from cross-dilemma shared beats (e.g., opening/finale
+    # that belong to paths from multiple dilemmas).
+    path_dilemma: dict[str, str] = {}
+    for path_id, pdata in path_nodes.items():
+        did = pdata.get("dilemma_id", "")
+        if did:
+            path_dilemma[path_id] = did
+
+    def _is_intra_dilemma_shared(beat_id: str) -> bool:
+        """True if beat belongs to >1 path but all paths share the same dilemma.
+
+        Y-shape shared pre-commit beats satisfy this — they belong to both
+        paths of one dilemma.  Cross-dilemma shared beats (e.g., a fixture's
+        opening/finale beat that belongs to paths from 2+ dilemmas) do NOT.
+        """
+        paths = beat_paths.get(beat_id, set())
+        if len(paths) <= 1:
+            return False
+        dilemmas = {path_dilemma.get(p) for p in paths} - {None}
+        return len(dilemmas) == 1
+
+    # Determine which beats to include per path.
+    # - Exclusive beats (single path): always included.
+    # - Y-shape intra-dilemma shared beats: included — they form the shared
+    #   pre-commit chain that must connect to each path's commit beat.
+    # - Cross-dilemma shared beats: excluded — their ordering comes from
+    #   cross-path interleaving; alphabetical chaining here would conflict
+    #   with pre-existing predecessor edges.
+    def _chainable(beat_id: str) -> bool:
+        paths = beat_paths.get(beat_id, set())
+        if len(paths) <= 1:
+            return True  # exclusive
+        return _is_intra_dilemma_shared(beat_id)  # Y-shape: yes; cross-dilemma: no
+
+    # Sort chainable beats: Y-shape shared beats first (they're the setup
+    # that precedes the per-path fork), then exclusive beats, alphabetical
+    # within each group.
+    def _beat_sort_key(beat_id: str) -> tuple[int, str]:
+        # 0 = intra-dilemma shared (pre-commit setup), 1 = exclusive
+        return (0 if _is_intra_dilemma_shared(beat_id) else 1, beat_id)
+
+    for path_id in path_beats:
+        path_beats[path_id] = sorted(
+            [b for b in path_beats[path_id] if _chainable(b)],
+            key=_beat_sort_key,
+        )
 
     # Build existing predecessor edge set for idempotency check.
     # We track both directions to avoid creating edges that conflict with
@@ -155,7 +202,7 @@ async def phase_intra_path_predecessors(
     paths_processed = 0
 
     for path_id in sorted(path_nodes):
-        beats = exclusive_path_beats.get(path_id, [])
+        beats = path_beats.get(path_id, [])
         if len(beats) < 2:
             continue
 

--- a/tests/unit/test_grow_deterministic.py
+++ b/tests/unit/test_grow_deterministic.py
@@ -132,27 +132,43 @@ class TestPhaseIntraPathPredecessors:
         assert len(edges) == 0
 
     @pytest.mark.asyncio
-    async def test_shared_beat_excluded_from_chaining(self) -> None:
-        """A beat belonging to two paths is excluded from intra-path chaining.
+    async def test_y_shape_shared_beats_included_in_chain(self) -> None:
+        """Y-shape shared pre-commit beats participate in intra-path chaining.
 
-        beat::shared belongs to both path::a and path::b.  Only path-exclusive
-        beats (beat::a_only, beat::b_only) should be chained.  beat::shared
-        must not appear in any predecessor edge created by this phase.
+        Regression for #1248: shared beats (dual belongs_to) were excluded
+        from chaining, leaving them as disconnected floating nodes.
+
+        With two shared setup beats and one exclusive beat per path, the
+        expected chain per path is:
+            shared_01 → shared_02 → exclusive_beat
+
+        Processing both paths creates the Y-fork:
+            shared_01 → shared_02 → a_beat_01
+                                  → b_beat_01
         """
         graph = Graph.empty()
 
-        graph.create_node("path::a", {"type": "path", "raw_id": "a"})
-        graph.create_node("path::b", {"type": "path", "raw_id": "b"})
-        graph.create_node("beat::shared", {"type": "beat", "raw_id": "shared"})
-        graph.create_node("beat::a_only", {"type": "beat", "raw_id": "a_only"})
-        graph.create_node("beat::b_only", {"type": "beat", "raw_id": "b_only"})
+        graph.create_node(
+            "path::a",
+            {"type": "path", "raw_id": "a", "dilemma_id": "dilemma::d1"},
+        )
+        graph.create_node(
+            "path::b",
+            {"type": "path", "raw_id": "b", "dilemma_id": "dilemma::d1"},
+        )
+        graph.create_node("beat::shared_setup_01", {"type": "beat", "raw_id": "shared_setup_01"})
+        graph.create_node("beat::shared_setup_02", {"type": "beat", "raw_id": "shared_setup_02"})
+        graph.create_node("beat::a_beat_01", {"type": "beat", "raw_id": "a_beat_01"})
+        graph.create_node("beat::b_beat_01", {"type": "beat", "raw_id": "b_beat_01"})
 
-        # shared belongs to BOTH paths
-        graph.add_edge("belongs_to", "beat::shared", "path::a")
-        graph.add_edge("belongs_to", "beat::shared", "path::b")
-        # exclusive beats
-        graph.add_edge("belongs_to", "beat::a_only", "path::a")
-        graph.add_edge("belongs_to", "beat::b_only", "path::b")
+        # Shared beats belong to BOTH paths (Y-shape dual belongs_to)
+        graph.add_edge("belongs_to", "beat::shared_setup_01", "path::a")
+        graph.add_edge("belongs_to", "beat::shared_setup_01", "path::b")
+        graph.add_edge("belongs_to", "beat::shared_setup_02", "path::a")
+        graph.add_edge("belongs_to", "beat::shared_setup_02", "path::b")
+        # Exclusive beats
+        graph.add_edge("belongs_to", "beat::a_beat_01", "path::a")
+        graph.add_edge("belongs_to", "beat::b_beat_01", "path::b")
 
         result = await phase_intra_path_predecessors(graph, _make_mock_model())
 
@@ -161,17 +177,13 @@ class TestPhaseIntraPathPredecessors:
         edges = graph.get_edges(edge_type="predecessor")
         edge_pairs = {(e["from"], e["to"]) for e in edges}
 
-        # No edge should involve beat::shared (it is shared, not exclusive)
-        for from_id, to_id in edge_pairs:
-            assert from_id != "beat::shared", (
-                f"shared beat appeared as successor in edge {from_id}->{to_id}"
-            )
-            assert to_id != "beat::shared", (
-                f"shared beat appeared as predecessor in edge {from_id}->{to_id}"
-            )
-
-        # Each path has only 1 exclusive beat → no chain can be formed → 0 edges
-        assert len(edges) == 0
+        # Shared chain: shared_02 comes after shared_01
+        assert ("beat::shared_setup_02", "beat::shared_setup_01") in edge_pairs
+        # Y-fork: both exclusive beats come after shared_02
+        assert ("beat::a_beat_01", "beat::shared_setup_02") in edge_pairs
+        assert ("beat::b_beat_01", "beat::shared_setup_02") in edge_pairs
+        # 3 unique edges (shared→shared is created once, idempotent on second path)
+        assert len(edge_pairs) == 3
 
     @pytest.mark.asyncio
     async def test_no_paths_returns_completed(self) -> None:


### PR DESCRIPTION
## Summary

GROW's `phase_intra_path_predecessors` excluded all multi-path beats from predecessor chaining, leaving Y-shape shared pre-commit beats as disconnected floating nodes (zero predecessor edges). GROW then failed `single_root_beat` validation with 19 roots. Closes #1248.

## Root cause

The phase filtered out beats with `beat_path_count > 1`, assuming "shared" meant cross-dilemma intersection-assigned beats whose ordering would come from cross-path interleaving. Y-shape shared beats (dual `belongs_to` within the SAME dilemma) were caught by this filter but have no other source of intra-dilemma ordering — they need to be chained here.

## Fix

Distinguish intra-dilemma shared beats (Y-shape — safe to chain) from cross-dilemma shared beats (intersection/fixture — must stay excluded):

```python
def _chainable(beat_id: str) -> bool:
    paths = beat_paths.get(beat_id, set())
    if len(paths) <= 1:
        return True  # exclusive
    return _is_intra_dilemma_shared(beat_id)  # Y-shape: yes; cross-dilemma: no
```

A beat is intra-dilemma shared if all its `belongs_to` paths resolve to the same `dilemma_id`. Shared beats sort before exclusive beats within each path so the chain produces:

```
shared_01 → shared_02 → commit_P1 → post_P1_01 → ...
                       → commit_P2 → post_P2_01 → ...
```

## Test changes

- **Replaced** `test_shared_beat_excluded_from_chaining` with `test_y_shape_shared_beats_included_in_chain` — verifies the Y-fork structure: shared chain + two fork edges to exclusive beats (3 edges total)
- **Existing tests**: `make_two_dilemma_graph` fixture has cross-dilemma shared beats (`opening`/`finale` belonging to all 4 paths) — these correctly remain excluded

## Test plan

- [x] `uv run pytest tests/unit/test_grow_deterministic.py tests/unit/test_grow_algorithms.py tests/unit/test_grow_validation.py tests/unit/test_grow_stage.py tests/unit/test_grow_registry.py -x -q` — 425/425 pass
- [x] Pre-commit, mypy, ruff — clean
- [ ] **Empirical**: re-run `qf seed && qf grow` on test-new4 and verify `single_root_beat` passes and shared beats have predecessor edges

🤖 Generated with [Claude Code](https://claude.com/claude-code)