### PR TITLE
feat(grow): persist soft-dilemma convergence on dilemma nodes (#1221, #1222, #1209)

### DIFF
--- a/docs/design/how-branching-stories-work.md
+++ b/docs/design/how-branching-stories-work.md
@@ -204,7 +204,7 @@ This is not a rigid formula. A twist dilemma might introduce late in the story, 
 
 Here is the central structural reality of branching fiction:
 
-**Any beat that comes after a committed dilemma exists in multiple versions.** If the mentor dilemma has committed (the player chose to trust or distrust), then every beat that follows exists in two worlds — one where the mentor is trusted, one where they are not. If the artifact dilemma has *also* committed, every beat now exists in four worlds. Three committed dilemmas: eight worlds.
+**After a dilemma commits, each path has its own beats.** If the mentor dilemma has committed (the player chose to trust or distrust), each path's post-commit beats are separate, independently authored story moments — not versions of one beat. The player on one path never sees the other path's beats. If the artifact dilemma has *also* committed, each combination of choices has its own set of post-commit beats. Three committed dilemmas: eight possible worlds, each with distinct beats.
 
 This is where combinatorial explosion actually lives — not in the number of dilemmas, but in the relationship between beats and commits. A beat placed before any commit exists once. A beat placed after all commits exists in every possible world.
 

--- a/docs/design/story-graph-ontology.md
+++ b/docs/design/story-graph-ontology.md
@@ -58,7 +58,7 @@ Each dilemma also carries a **role** and associated structural properties, discu
 
 After GROW interleaves the beat DAG, soft dilemmas gain two convergence fields:
 - **converges_at** — the beat ID where diverged paths rejoin (the first beat reachable from all terminal exclusive beats of the dilemma, typically the first shared setup beat of the next dilemma in sequence). `null` for hard dilemmas.
-- **convergence_payoff** — the minimum number of exclusive post-commit beats per path before convergence. `null` for hard dilemmas.
+- **convergence_payoff** — the minimum number of single-path-exclusive beats (commit + post-commit) per path before convergence. `null` for hard dilemmas.
 
 **Working.** Dilemmas are consumed by the pipeline. By SHIP, they have been absorbed into the story structure — paths, beats, choices. The player never sees "dilemma" as a concept.
 

--- a/docs/design/story-graph-ontology.md
+++ b/docs/design/story-graph-ontology.md
@@ -56,6 +56,10 @@ The `anchored_to` edges are proper graph edges (dilemma → entity), not embedde
 
 Each dilemma also carries a **role** and associated structural properties, discussed in Part 2.
 
+After GROW interleaves the beat DAG, soft dilemmas gain two convergence fields:
+- **converges_at** — the beat ID where diverged paths rejoin (the first beat reachable from all terminal exclusive beats of the dilemma, typically the first shared setup beat of the next dilemma in sequence). `null` for hard dilemmas.
+- **convergence_payoff** — the minimum number of exclusive post-commit beats per path before convergence. `null` for hard dilemmas.
+
 **Working.** Dilemmas are consumed by the pipeline. By SHIP, they have been absorbed into the story structure — paths, beats, choices. The player never sees "dilemma" as a concept.
 
 ### Answer
@@ -496,7 +500,7 @@ SEED is the heaviest mutation stage. It triages, scaffolds, orders, and sketches
 | **Creates** | Ordering edges (beat → beat), intersection groups, state flags |
 | **Edges created** | Predecessor/successor edges in the beat DAG, intersection grouping edges, `derived_from` (state flag → consequence) |
 | **Reads** | All SEED output (paths, beats, consequences, dilemma relationships, temporal hints) |
-| **Modifies** | Beat nodes (enriched with intersection membership), entity nodes (activates overlays with state flags — overlays are an embedded list on the entity, not a separate node type; see Part 6) |
+| **Modifies** | Beat nodes (enriched with intersection membership), dilemma nodes (soft dilemmas gain `converges_at` and `convergence_payoff` from DAG topology), entity nodes (activates overlays with state flags — overlays are an embedded list on the entity, not a separate node type; see Part 6) |
 | **Consumes** | Entity flexibility annotations (used to find intersections, then discarded), temporal hints (used for interleaving, then discarded) |
 | **Validates** | Every computed arc traversal is complete and has no dead ends |
 

--- a/src/questfoundry/graph/grow_algorithms.py
+++ b/src/questfoundry/graph/grow_algorithms.py
@@ -1205,28 +1205,36 @@ def find_convergence_points(
 def find_dag_convergence_beat(
     graph: Graph,
     dilemma_id: str,
+    dilemma_paths: set[str] | None = None,
 ) -> tuple[str, int] | None:
     """Find the convergence beat for a soft dilemma from the interleaved beat DAG.
 
     For a soft dilemma, the convergence beat is the earliest beat reachable from
-    ALL terminal exclusive beats of the dilemma that is NOT exclusive to this dilemma.
+    ALL terminal exclusive beats of the dilemma that is NOT exclusive to this
+    dilemma.
 
     Algorithm:
-    1. Return None if dilemma_role is "hard" or dilemma has < 2 paths.
-    2. Find terminal exclusive beats: beats whose belongs_to paths are a strict
+    1. Return ``None`` if ``dilemma_role`` is absent or ``"hard"``, or if the
+       dilemma has fewer than 2 explored paths.
+    2. Find terminal exclusive beats: beats whose ``belongs_to`` paths are a
        subset of this dilemma's paths, AND that have no successor that is also
-       exclusive to this dilemma.
-    3. BFS forward from each terminal beat (via predecessor edges: successor is the
-       beat with a predecessor edge whose ``to`` field is this beat).
+       exclusive to this dilemma.  A path may have multiple terminals (e.g.
+       when cross-dilemma beats from a ``wraps`` relationship split the
+       exclusive chain); all terminals participate in the BFS.
+    3. BFS forward from **every** terminal beat across all paths.
     4. Collect the non-exclusive beats reachable from each terminal.
-    5. Intersect all reachable sets; pick the earliest common beat (alphabetical
-       tiebreak).
-    6. convergence_payoff = minimum number of exclusive beats across all paths.
-    7. Return (converges_at, convergence_payoff) or None if no common beat found.
+    5. Intersect all reachable sets; pick the beat with the lowest maximum BFS
+       distance across all terminal runs (alphabetical tiebreak for ties).
+    6. ``convergence_payoff`` = minimum count of single-path-exclusive beats
+       (commit + post-commit) across paths.
+    7. Return ``(converges_at, convergence_payoff)`` or ``None``.
 
     Args:
         graph: The interleaved beat DAG.
         dilemma_id: Scoped dilemma ID (e.g. ``"dilemma::d1"``).
+        dilemma_paths: Pre-computed set of path IDs for this dilemma.  When
+            ``None``, looked up from the graph.  Passing this avoids repeated
+            full-graph scans when calling in a loop over dilemmas.
 
     Returns:
         ``(converges_at_beat_id, convergence_payoff)`` for soft dilemmas that
@@ -1238,18 +1246,22 @@ def find_dag_convergence_beat(
     if dilemma_node is None:
         return None
 
-    dilemma_role = dilemma_node.get("dilemma_role", "soft")
+    dilemma_role = dilemma_node.get("dilemma_role")
+    if dilemma_role is None:
+        log.warning("convergence_dilemma_role_missing", dilemma_id=dilemma_id)
+        return None
     if dilemma_role == "hard":
         return None
 
-    # Collect this dilemma's path IDs
-    path_nodes = graph.get_nodes_by_type("path")
-    dilemma_paths: set[str] = set()
-    for path_id, path_data in path_nodes.items():
-        raw_did = path_data.get("dilemma_id", "")
-        scoped_did = normalize_scoped_id(raw_did.split("::")[-1], "dilemma") if raw_did else ""
-        if scoped_did == dilemma_id:
-            dilemma_paths.add(path_id)
+    # Collect this dilemma's path IDs (use pre-computed set if provided)
+    if dilemma_paths is None:
+        path_nodes = graph.get_nodes_by_type("path")
+        dilemma_paths = set()
+        for path_id, path_data in path_nodes.items():
+            raw_did = path_data.get("dilemma_id", "")
+            scoped_did = normalize_scoped_id(raw_did.split("::")[-1], "dilemma") if raw_did else ""
+            if scoped_did == dilemma_id:
+                dilemma_paths.add(path_id)
 
     if len(dilemma_paths) < 2:
         return None
@@ -1293,20 +1305,20 @@ def find_dag_convergence_beat(
                 if path_id in dilemma_paths:
                     terminal_by_path[path_id].append(beat_id)
 
-    # Gather one representative terminal per path (for BFS)
-    # If any path has no terminal exclusive beat, we cannot compute convergence
-    terminal_beats: list[str] = []
+    # Gather ALL terminal exclusive beats across all paths (not one per path).
+    # A path may have multiple terminals when cross-dilemma beats from wraps
+    # relationships split the exclusive chain.  The convergence beat must be
+    # reachable from every terminal.
+    all_terminals: list[str] = []
     exclusive_count_per_path: dict[str, int] = {}
     for path_id in dilemma_paths:
         terminals = terminal_by_path[path_id]
         if not terminals:
             return None
-        # Use the first terminal alphabetically (stable selection)
-        terminal_beats.append(sorted(terminals)[0])
-        # Count path-exclusive beats: beats that belong to this path AND ONLY to paths
-        # of this dilemma, where the beat belongs to exactly this one path (not shared
-        # across all dilemma paths).  Shared pre-commit beats (belonging to all dilemma
-        # paths) are NOT counted because they are not exclusive to any single path.
+        all_terminals.extend(terminals)
+        # Count single-path-exclusive beats (commit + post-commit): beats that
+        # belong to exactly this one path.  Shared pre-commit beats (belonging
+        # to all dilemma paths) are NOT counted.
         exclusive_count_per_path[path_id] = sum(
             1 for bid in exclusive_beats if beat_paths.get(bid) == {path_id}
         )
@@ -1333,7 +1345,7 @@ def find_dag_convergence_beat(
                     frontier.append((successor, level + 1))
         return distances
 
-    distance_maps = [_bfs_distances(t) for t in terminal_beats]
+    distance_maps = [_bfs_distances(t) for t in all_terminals]
 
     if not distance_maps:
         return None

--- a/src/questfoundry/graph/grow_algorithms.py
+++ b/src/questfoundry/graph/grow_algorithms.py
@@ -1202,6 +1202,161 @@ def find_convergence_points(
     return result
 
 
+def find_dag_convergence_beat(
+    graph: Graph,
+    dilemma_id: str,
+) -> tuple[str, int] | None:
+    """Find the convergence beat for a soft dilemma from the interleaved beat DAG.
+
+    For a soft dilemma, the convergence beat is the earliest beat reachable from
+    ALL terminal exclusive beats of the dilemma that is NOT exclusive to this dilemma.
+
+    Algorithm:
+    1. Return None if dilemma_role is "hard" or dilemma has < 2 paths.
+    2. Find terminal exclusive beats: beats whose belongs_to paths are a strict
+       subset of this dilemma's paths, AND that have no successor that is also
+       exclusive to this dilemma.
+    3. BFS forward from each terminal beat (via predecessor edges: successor is the
+       beat with a predecessor edge whose ``to`` field is this beat).
+    4. Collect the non-exclusive beats reachable from each terminal.
+    5. Intersect all reachable sets; pick the earliest common beat (alphabetical
+       tiebreak).
+    6. convergence_payoff = minimum number of exclusive beats across all paths.
+    7. Return (converges_at, convergence_payoff) or None if no common beat found.
+
+    Args:
+        graph: The interleaved beat DAG.
+        dilemma_id: Scoped dilemma ID (e.g. ``"dilemma::d1"``).
+
+    Returns:
+        ``(converges_at_beat_id, convergence_payoff)`` for soft dilemmas that
+        converge, ``None`` otherwise.
+    """
+    dilemma_id = normalize_scoped_id(dilemma_id.split("::")[-1], "dilemma")
+
+    dilemma_node = graph.get_node(dilemma_id)
+    if dilemma_node is None:
+        return None
+
+    dilemma_role = dilemma_node.get("dilemma_role", "soft")
+    if dilemma_role == "hard":
+        return None
+
+    # Collect this dilemma's path IDs
+    path_nodes = graph.get_nodes_by_type("path")
+    dilemma_paths: set[str] = set()
+    for path_id, path_data in path_nodes.items():
+        raw_did = path_data.get("dilemma_id", "")
+        scoped_did = normalize_scoped_id(raw_did.split("::")[-1], "dilemma") if raw_did else ""
+        if scoped_did == dilemma_id:
+            dilemma_paths.add(path_id)
+
+    if len(dilemma_paths) < 2:
+        return None
+
+    # Build belongs_to index: beat_id → set of path_ids
+    belongs_to_edges = graph.get_edges(edge_type="belongs_to")
+    beat_paths: dict[str, set[str]] = {}
+    for edge in belongs_to_edges:
+        beat_id = edge["from"]
+        path_id = edge["to"]
+        beat_paths.setdefault(beat_id, set()).add(path_id)
+
+    # Build successor index: beat_id → list[beat_id]
+    # predecessor edge: from=later_beat, to=earlier_beat
+    # successors of X = all beats where to_id == X
+    predecessor_edges = graph.get_edges(edge_type="predecessor")
+    successors_of: dict[str, list[str]] = {}
+    for edge in predecessor_edges:
+        later_beat = edge["from"]  # the beat that comes after
+        earlier_beat = edge["to"]  # the prerequisite
+        successors_of.setdefault(earlier_beat, []).append(later_beat)
+
+    # Helper: is a beat exclusive to this dilemma?
+    def _is_exclusive(beat_id: str) -> bool:
+        """Return True if beat's belongs_to paths are a non-empty subset of dilemma_paths."""
+        bpaths = beat_paths.get(beat_id, set())
+        return bool(bpaths) and bpaths.issubset(dilemma_paths)
+
+    # Find all exclusive beats
+    beat_nodes = graph.get_nodes_by_type("beat")
+    exclusive_beats: set[str] = {bid for bid in beat_nodes if _is_exclusive(bid)}
+
+    # Find terminal exclusive beats per path:
+    # a beat is terminal if none of its successors are also exclusive to this dilemma
+    terminal_by_path: dict[str, list[str]] = {pid: [] for pid in dilemma_paths}
+    for beat_id in exclusive_beats:
+        succ_exclusive = [s for s in successors_of.get(beat_id, []) if s in exclusive_beats]
+        if not succ_exclusive:
+            # This is a terminal exclusive beat; add it to each path it belongs to
+            for path_id in beat_paths.get(beat_id, set()):
+                if path_id in dilemma_paths:
+                    terminal_by_path[path_id].append(beat_id)
+
+    # Gather one representative terminal per path (for BFS)
+    # If any path has no terminal exclusive beat, we cannot compute convergence
+    terminal_beats: list[str] = []
+    exclusive_count_per_path: dict[str, int] = {}
+    for path_id in dilemma_paths:
+        terminals = terminal_by_path[path_id]
+        if not terminals:
+            return None
+        # Use the first terminal alphabetically (stable selection)
+        terminal_beats.append(sorted(terminals)[0])
+        # Count path-exclusive beats: beats that belong to this path AND ONLY to paths
+        # of this dilemma, where the beat belongs to exactly this one path (not shared
+        # across all dilemma paths).  Shared pre-commit beats (belonging to all dilemma
+        # paths) are NOT counted because they are not exclusive to any single path.
+        exclusive_count_per_path[path_id] = sum(
+            1 for bid in exclusive_beats if beat_paths.get(bid) == {path_id}
+        )
+
+    convergence_payoff = min(exclusive_count_per_path.values()) if exclusive_count_per_path else 0
+
+    # BFS forward from each terminal beat, collecting non-exclusive reachable beats
+    # with their BFS distance (level) from the terminal.
+    def _bfs_distances(start: str) -> dict[str, int]:
+        """Return mapping of non-exclusive reachable beat → BFS level from start."""
+        distances: dict[str, int] = {}
+        frontier: deque[tuple[str, int]] = deque([(start, 0)])
+        visited: set[str] = set()
+        while frontier:
+            current, level = frontier.popleft()
+            if current in visited:
+                continue
+            visited.add(current)
+            if current != start and not _is_exclusive(current):
+                distances[current] = level
+            # Continue BFS regardless (exclusive beats can be intermediate nodes)
+            for successor in successors_of.get(current, []):
+                if successor not in visited:
+                    frontier.append((successor, level + 1))
+        return distances
+
+    distance_maps = [_bfs_distances(t) for t in terminal_beats]
+
+    if not distance_maps:
+        return None
+
+    # Intersect: only beats reachable from ALL terminals
+    common = set(distance_maps[0].keys())
+    for dm in distance_maps[1:]:
+        common = common & dm.keys()
+
+    if not common:
+        return None
+
+    # Pick earliest common beat: minimum max-distance across all terminal BFS runs
+    # (i.e., the beat that is reached earliest when considering all paths).
+    # Alphabetical tiebreak within equal max-distances.
+    def _sort_key(beat_id: str) -> tuple[int, str]:
+        max_dist = max(dm[beat_id] for dm in distance_maps)
+        return (max_dist, beat_id)
+
+    converges_at = min(common, key=_sort_key)
+    return converges_at, convergence_payoff
+
+
 # ---------------------------------------------------------------------------
 # Phase 3: Intersection Detection
 # ---------------------------------------------------------------------------

--- a/src/questfoundry/pipeline/stages/grow/deterministic.py
+++ b/src/questfoundry/pipeline/stages/grow/deterministic.py
@@ -435,52 +435,71 @@ async def phase_divergence(graph: Graph, model: BaseChatModel) -> GrowPhaseResul
 
 @grow_phase(name="convergence", depends_on=["divergence"], is_deterministic=True, priority=11)
 async def phase_convergence(graph: Graph, model: BaseChatModel) -> GrowPhaseResult:  # noqa: ARG001
-    """Phase 7: Find convergence points for diverged arcs (validation only).
+    """Phase 7: Identify and persist convergence points for soft dilemmas.
+
+    For each soft dilemma with 2+ explored paths, walks the interleaved beat
+    DAG to find the first beat reachable from all terminal exclusive beats.
+    Persists ``converges_at`` (beat ID) and ``convergence_payoff`` (exclusive
+    beat count) on each soft dilemma node.
+
+    Also runs the existing arc-level ``find_convergence_points()`` for
+    diagnostic logging.
 
     Preconditions:
-    - Divergence points computed (Phase 6 complete).
+    - Interleaving complete (predecessor edges exist).
     - Dilemma nodes have dilemma_role from SEED analysis.
 
     Postconditions:
-    - Convergence points computed and validated.
-    - No graph writes — convergence metadata is computed on-the-fly
-      by downstream consumers per the Story Graph Ontology.
-
-    Invariants:
-    - Deterministic: convergence derived from dilemma policies and beat sequences.
+    - Soft dilemma nodes have ``converges_at`` and ``convergence_payoff`` set.
+    - Hard dilemma nodes are unchanged.
     """
     from questfoundry.graph.grow_algorithms import (
         compute_divergence_points,
         enumerate_arcs,
         find_convergence_points,
+        find_dag_convergence_beat,
     )
 
+    # --- DAG-based convergence: persist on dilemma nodes ---
+    dilemma_nodes = graph.get_nodes_by_type("dilemma")
+    persisted = 0
+
+    for dilemma_id, ddata in dilemma_nodes.items():
+        if ddata.get("dilemma_role") == "hard":
+            continue
+
+        result = find_dag_convergence_beat(graph, dilemma_id)
+        if result is not None:
+            converges_at, payoff = result
+            graph.update_node(
+                dilemma_id,
+                converges_at=converges_at,
+                convergence_payoff=payoff,
+            )
+            persisted += 1
+            log.debug(
+                "convergence_persisted",
+                dilemma_id=dilemma_id,
+                converges_at=converges_at,
+                convergence_payoff=payoff,
+            )
+
+    # --- Arc-level convergence: diagnostic logging (existing behavior) ---
     arcs = enumerate_arcs(graph)
-    if not arcs:
-        return GrowPhaseResult(
-            phase="convergence",
-            status="completed",
-            detail="No arcs to process",
-        )
+    arc_convergence_count = 0
+    if arcs:
+        spine_arc_id = next((a.arc_id for a in arcs if a.arc_type == "spine"), None)
+        divergence_map = compute_divergence_points(arcs, spine_arc_id)
+        convergence_map = find_convergence_points(graph, arcs, divergence_map, spine_arc_id)
+        arc_convergence_count = sum(1 for info in convergence_map.values() if info.converges_at)
 
-    spine_arc_id = next((a.arc_id for a in arcs if a.arc_type == "spine"), None)
-
-    # Compute divergence first (needed for convergence)
-    divergence_map = compute_divergence_points(arcs, spine_arc_id)
-    convergence_map = find_convergence_points(graph, arcs, divergence_map, spine_arc_id)
-
-    if not convergence_map:
-        return GrowPhaseResult(
-            phase="convergence",
-            status="completed",
-            detail="No convergence points found",
-        )
-
-    convergence_count = sum(1 for info in convergence_map.values() if info.converges_at)
     return GrowPhaseResult(
         phase="convergence",
         status="completed",
-        detail=f"Found {convergence_count} convergence points",
+        detail=(
+            f"Persisted convergence for {persisted} dilemma(s); "
+            f"arc-level: {arc_convergence_count} convergence points"
+        ),
     )
 
 

--- a/src/questfoundry/pipeline/stages/grow/deterministic.py
+++ b/src/questfoundry/pipeline/stages/grow/deterministic.py
@@ -452,6 +452,10 @@ async def phase_convergence(graph: Graph, model: BaseChatModel) -> GrowPhaseResu
     Postconditions:
     - Soft dilemma nodes have ``converges_at`` and ``convergence_payoff`` set.
     - Hard dilemma nodes are unchanged.
+
+    Invariants:
+    - Deterministic: convergence derived from DAG topology and dilemma roles.
+    - Idempotent: calling twice produces the same node data.
     """
     from questfoundry.graph.grow_algorithms import (
         compute_divergence_points,
@@ -464,11 +468,28 @@ async def phase_convergence(graph: Graph, model: BaseChatModel) -> GrowPhaseResu
     dilemma_nodes = graph.get_nodes_by_type("dilemma")
     persisted = 0
 
+    # Pre-build dilemma → paths map to avoid repeated full-graph scans.
+    path_nodes = graph.get_nodes_by_type("path")
+    dilemma_paths_map: dict[str, set[str]] = {}
+    for path_id, pdata in path_nodes.items():
+        raw_did = pdata.get("dilemma_id", "")
+        if raw_did:
+            scoped = normalize_scoped_id(raw_did, "dilemma")
+            dilemma_paths_map.setdefault(scoped, set()).add(path_id)
+
     for dilemma_id, ddata in dilemma_nodes.items():
-        if ddata.get("dilemma_role") == "hard":
+        role = ddata.get("dilemma_role")
+        if role is None:
+            log.warning("convergence_dilemma_role_missing", dilemma_id=dilemma_id)
+            continue
+        if role == "hard":
             continue
 
-        result = find_dag_convergence_beat(graph, dilemma_id)
+        result = find_dag_convergence_beat(
+            graph,
+            dilemma_id,
+            dilemma_paths=dilemma_paths_map.get(dilemma_id),
+        )
         if result is not None:
             converges_at, payoff = result
             graph.update_node(

--- a/tests/unit/test_grow_algorithms.py
+++ b/tests/unit/test_grow_algorithms.py
@@ -7645,3 +7645,294 @@ class TestApplyIntersectionMarkGuardRail3:
             beat_ids=["beat::pre_dilemma1", "beat::pre_dilemma2"],
             resolved_location=None,
         )
+
+
+# ---------------------------------------------------------------------------
+# TestFindDagConvergenceBeat
+# ---------------------------------------------------------------------------
+
+
+def _make_convergence_test_graph() -> Graph:
+    """Build a two-dilemma interleaved graph for convergence tests.
+
+    Structure (Y-shape per dilemma, interleaved into a single DAG):
+
+    d1 (soft, payoff_budget=2):
+        shared_d1_01 → shared_d1_02 → commit_d1_a → post_d1_a_01
+                                     ↘ commit_d1_b → post_d1_b_01
+
+    d2 (hard):
+        shared_d2_01 → shared_d2_02 → commit_d2_a
+                                     ↘ commit_d2_b
+
+    Cross-dilemma interleave edges:
+        post_d1_a_01 → shared_d2_01
+        post_d1_b_01 → shared_d2_01
+
+    d1 terminal exclusive beats: post_d1_a_01 (path d1_a), post_d1_b_01 (path d1_b)
+    Both reach shared_d2_01 as first non-exclusive successor → converges_at = shared_d2_01
+    convergence_payoff = min(exclusive beats per path) = min(2, 2) = 2
+      (d1_a exclusive: commit_d1_a, post_d1_a_01; d1_b exclusive: commit_d1_b, post_d1_b_01)
+    """
+    graph = Graph.empty()
+
+    # --- Dilemma d1 (soft) ---
+    graph.create_node(
+        "dilemma::d1",
+        {"type": "dilemma", "raw_id": "d1", "dilemma_role": "soft", "payoff_budget": 2},
+    )
+    graph.create_node(
+        "path::d1_a",
+        {"type": "path", "raw_id": "d1_a", "dilemma_id": "dilemma::d1", "is_canonical": True},
+    )
+    graph.create_node(
+        "path::d1_b",
+        {"type": "path", "raw_id": "d1_b", "dilemma_id": "dilemma::d1", "is_canonical": False},
+    )
+
+    # --- Dilemma d2 (hard) ---
+    graph.create_node(
+        "dilemma::d2",
+        {"type": "dilemma", "raw_id": "d2", "dilemma_role": "hard", "payoff_budget": 0},
+    )
+    graph.create_node(
+        "path::d2_a",
+        {"type": "path", "raw_id": "d2_a", "dilemma_id": "dilemma::d2", "is_canonical": True},
+    )
+    graph.create_node(
+        "path::d2_b",
+        {"type": "path", "raw_id": "d2_b", "dilemma_id": "dilemma::d2", "is_canonical": False},
+    )
+
+    # --- d1 beats ---
+    # Pre-commit shared beats (belong to both d1 paths)
+    graph.create_node(
+        "beat::shared_d1_01",
+        {"type": "beat", "raw_id": "shared_d1_01", "summary": "D1 setup 1", "dilemma_impacts": []},
+    )
+    graph.add_edge("belongs_to", "beat::shared_d1_01", "path::d1_a")
+    graph.add_edge("belongs_to", "beat::shared_d1_01", "path::d1_b")
+
+    graph.create_node(
+        "beat::shared_d1_02",
+        {"type": "beat", "raw_id": "shared_d1_02", "summary": "D1 setup 2", "dilemma_impacts": []},
+    )
+    graph.add_edge("belongs_to", "beat::shared_d1_02", "path::d1_a")
+    graph.add_edge("belongs_to", "beat::shared_d1_02", "path::d1_b")
+
+    # Commit beats (exclusive per path)
+    graph.create_node(
+        "beat::commit_d1_a",
+        {
+            "type": "beat",
+            "raw_id": "commit_d1_a",
+            "summary": "D1 commit a",
+            "dilemma_impacts": [{"dilemma_id": "dilemma::d1", "effect": "commits"}],
+        },
+    )
+    graph.add_edge("belongs_to", "beat::commit_d1_a", "path::d1_a")
+
+    graph.create_node(
+        "beat::commit_d1_b",
+        {
+            "type": "beat",
+            "raw_id": "commit_d1_b",
+            "summary": "D1 commit b",
+            "dilemma_impacts": [{"dilemma_id": "dilemma::d1", "effect": "commits"}],
+        },
+    )
+    graph.add_edge("belongs_to", "beat::commit_d1_b", "path::d1_b")
+
+    # Post-commit beats (1 per path, exclusive)
+    graph.create_node(
+        "beat::post_d1_a_01",
+        {"type": "beat", "raw_id": "post_d1_a_01", "summary": "D1 post-a 1", "dilemma_impacts": []},
+    )
+    graph.add_edge("belongs_to", "beat::post_d1_a_01", "path::d1_a")
+
+    graph.create_node(
+        "beat::post_d1_b_01",
+        {"type": "beat", "raw_id": "post_d1_b_01", "summary": "D1 post-b 1", "dilemma_impacts": []},
+    )
+    graph.add_edge("belongs_to", "beat::post_d1_b_01", "path::d1_b")
+
+    # --- d2 beats ---
+    # Pre-commit shared beats (belong to both d2 paths)
+    graph.create_node(
+        "beat::shared_d2_01",
+        {"type": "beat", "raw_id": "shared_d2_01", "summary": "D2 setup 1", "dilemma_impacts": []},
+    )
+    graph.add_edge("belongs_to", "beat::shared_d2_01", "path::d2_a")
+    graph.add_edge("belongs_to", "beat::shared_d2_01", "path::d2_b")
+
+    graph.create_node(
+        "beat::shared_d2_02",
+        {"type": "beat", "raw_id": "shared_d2_02", "summary": "D2 setup 2", "dilemma_impacts": []},
+    )
+    graph.add_edge("belongs_to", "beat::shared_d2_02", "path::d2_a")
+    graph.add_edge("belongs_to", "beat::shared_d2_02", "path::d2_b")
+
+    graph.create_node(
+        "beat::commit_d2_a",
+        {
+            "type": "beat",
+            "raw_id": "commit_d2_a",
+            "summary": "D2 commit a",
+            "dilemma_impacts": [{"dilemma_id": "dilemma::d2", "effect": "commits"}],
+        },
+    )
+    graph.add_edge("belongs_to", "beat::commit_d2_a", "path::d2_a")
+
+    graph.create_node(
+        "beat::commit_d2_b",
+        {
+            "type": "beat",
+            "raw_id": "commit_d2_b",
+            "summary": "D2 commit b",
+            "dilemma_impacts": [{"dilemma_id": "dilemma::d2", "effect": "commits"}],
+        },
+    )
+    graph.add_edge("belongs_to", "beat::commit_d2_b", "path::d2_b")
+
+    # --- Predecessor edges (from=later, to=earlier) ---
+    # d1 internal chain
+    graph.add_edge("predecessor", "beat::shared_d1_02", "beat::shared_d1_01")
+    graph.add_edge("predecessor", "beat::commit_d1_a", "beat::shared_d1_02")
+    graph.add_edge("predecessor", "beat::commit_d1_b", "beat::shared_d1_02")
+    graph.add_edge("predecessor", "beat::post_d1_a_01", "beat::commit_d1_a")
+    graph.add_edge("predecessor", "beat::post_d1_b_01", "beat::commit_d1_b")
+
+    # d2 internal chain
+    graph.add_edge("predecessor", "beat::shared_d2_02", "beat::shared_d2_01")
+    graph.add_edge("predecessor", "beat::commit_d2_a", "beat::shared_d2_02")
+    graph.add_edge("predecessor", "beat::commit_d2_b", "beat::shared_d2_02")
+
+    # Cross-dilemma interleave: d1 terminals → d2 entry
+    graph.add_edge("predecessor", "beat::shared_d2_01", "beat::post_d1_a_01")
+    graph.add_edge("predecessor", "beat::shared_d2_01", "beat::post_d1_b_01")
+
+    return graph
+
+
+class TestFindDagConvergenceBeat:
+    """Tests for find_dag_convergence_beat."""
+
+    def test_soft_dilemma_converges_at_next_dilemma_entry(self) -> None:
+        """Soft d1 with two exclusive chains converges at shared_d2_01.
+
+        Both chains end in their respective terminal beat (post_d1_a_01 / post_d1_b_01)
+        which each have shared_d2_01 as their only successor.  shared_d2_01 belongs to
+        d2 paths so it is non-exclusive to d1 → convergence point.
+        Payoff = min(exclusive beats per path) = min(2, 2) = 2.
+          d1_a exclusive: commit_d1_a, post_d1_a_01
+          d1_b exclusive: commit_d1_b, post_d1_b_01
+        """
+        from questfoundry.graph.grow_algorithms import find_dag_convergence_beat
+
+        graph = _make_convergence_test_graph()
+        result = find_dag_convergence_beat(graph, "dilemma::d1")
+
+        assert result is not None
+        converges_at, payoff = result
+        assert converges_at == "beat::shared_d2_01"
+        assert payoff == 2
+
+    def test_hard_dilemma_returns_none(self) -> None:
+        """Hard dilemma (d2) must return None regardless of successors."""
+        from questfoundry.graph.grow_algorithms import find_dag_convergence_beat
+
+        graph = _make_convergence_test_graph()
+        result = find_dag_convergence_beat(graph, "dilemma::d2")
+
+        assert result is None
+
+    def test_last_dilemma_no_successor_returns_none(self) -> None:
+        """A soft dilemma whose terminal beats have no cross-dilemma successors returns None."""
+        from questfoundry.graph.grow_algorithms import find_dag_convergence_beat
+
+        graph = Graph.empty()
+
+        graph.create_node(
+            "dilemma::only",
+            {"type": "dilemma", "raw_id": "only", "dilemma_role": "soft", "payoff_budget": 1},
+        )
+        graph.create_node(
+            "path::only_a",
+            {
+                "type": "path",
+                "raw_id": "only_a",
+                "dilemma_id": "dilemma::only",
+                "is_canonical": True,
+            },
+        )
+        graph.create_node(
+            "path::only_b",
+            {
+                "type": "path",
+                "raw_id": "only_b",
+                "dilemma_id": "dilemma::only",
+                "is_canonical": False,
+            },
+        )
+
+        # Shared pre-commit beat
+        graph.create_node(
+            "beat::shared",
+            {"type": "beat", "raw_id": "shared", "summary": "Setup", "dilemma_impacts": []},
+        )
+        graph.add_edge("belongs_to", "beat::shared", "path::only_a")
+        graph.add_edge("belongs_to", "beat::shared", "path::only_b")
+
+        # Commit beats (exclusive, no successors after them)
+        graph.create_node(
+            "beat::commit_a",
+            {
+                "type": "beat",
+                "raw_id": "commit_a",
+                "summary": "Commit A",
+                "dilemma_impacts": [{"dilemma_id": "dilemma::only", "effect": "commits"}],
+            },
+        )
+        graph.add_edge("belongs_to", "beat::commit_a", "path::only_a")
+
+        graph.create_node(
+            "beat::commit_b",
+            {
+                "type": "beat",
+                "raw_id": "commit_b",
+                "summary": "Commit B",
+                "dilemma_impacts": [{"dilemma_id": "dilemma::only", "effect": "commits"}],
+            },
+        )
+        graph.add_edge("belongs_to", "beat::commit_b", "path::only_b")
+
+        graph.add_edge("predecessor", "beat::commit_a", "beat::shared")
+        graph.add_edge("predecessor", "beat::commit_b", "beat::shared")
+
+        result = find_dag_convergence_beat(graph, "dilemma::only")
+        assert result is None
+
+    def test_single_dilemma_returns_none(self) -> None:
+        """A graph with only one dilemma (< 2 paths reachable cross-dilemma) returns None.
+
+        When there is only one dilemma and no cross-dilemma successors, the
+        terminal exclusive beats have no reachable non-exclusive beats, so the
+        function must return None.
+        """
+        from questfoundry.graph.grow_algorithms import find_dag_convergence_beat
+
+        # make_single_dilemma_graph builds mentor_trust with 2 paths and no cross-dilemma edges
+        from tests.fixtures.grow_fixtures import make_single_dilemma_graph
+
+        graph = make_single_dilemma_graph()
+
+        # The fixture doesn't have dilemma_role set; treat absence as soft for test
+        # (function should return None when no cross-dilemma successor exists)
+        node = graph.get_node("dilemma::mentor_trust")
+        assert node is not None
+        # Manually patch dilemma_role so the function doesn't short-circuit on hard
+        node["dilemma_role"] = "soft"
+        node["payoff_budget"] = 1
+
+        result = find_dag_convergence_beat(graph, "dilemma::mentor_trust")
+        assert result is None

--- a/tests/unit/test_grow_algorithms.py
+++ b/tests/unit/test_grow_algorithms.py
@@ -1902,7 +1902,6 @@ class TestPhase7Integration:
         mock_model = MagicMock()
         result = await phase_convergence(graph, mock_model)
         assert result.status == "completed"
-        assert "No arcs" in result.detail
 
     @pytest.mark.asyncio
     async def test_phase_7_completes_convergence(self) -> None:

--- a/tests/unit/test_grow_algorithms.py
+++ b/tests/unit/test_grow_algorithms.py
@@ -7912,26 +7912,34 @@ class TestFindDagConvergenceBeat:
         assert result is None
 
     def test_single_dilemma_returns_none(self) -> None:
-        """A graph with only one dilemma (< 2 paths reachable cross-dilemma) returns None.
+        """A graph with only one dilemma (no cross-dilemma successors) returns None.
 
         When there is only one dilemma and no cross-dilemma successors, the
         terminal exclusive beats have no reachable non-exclusive beats, so the
         function must return None.
         """
         from questfoundry.graph.grow_algorithms import find_dag_convergence_beat
-
-        # make_single_dilemma_graph builds mentor_trust with 2 paths and no cross-dilemma edges
         from tests.fixtures.grow_fixtures import make_single_dilemma_graph
 
         graph = make_single_dilemma_graph()
 
-        # The fixture doesn't have dilemma_role set; treat absence as soft for test
-        # (function should return None when no cross-dilemma successor exists)
-        node = graph.get_node("dilemma::mentor_trust")
-        assert node is not None
-        # Manually patch dilemma_role so the function doesn't short-circuit on hard
-        node["dilemma_role"] = "soft"
-        node["payoff_budget"] = 1
+        # Set dilemma_role via update_node so the function proceeds past the
+        # role check (the test intent is "no cross-dilemma successor → None").
+        graph.update_node("dilemma::mentor_trust", dilemma_role="soft", payoff_budget=1)
 
         result = find_dag_convergence_beat(graph, "dilemma::mentor_trust")
+        assert result is None
+
+    def test_missing_dilemma_role_returns_none(self) -> None:
+        """A dilemma with no dilemma_role returns None (not silently treated as soft)."""
+        from questfoundry.graph.grow_algorithms import find_dag_convergence_beat
+
+        graph = _make_convergence_test_graph()
+
+        # Remove dilemma_role from d1 to simulate a malformed graph
+        node = graph.get_node("dilemma::d1")
+        assert node is not None
+        node.pop("dilemma_role", None)
+
+        result = find_dag_convergence_beat(graph, "dilemma::d1")
         assert result is None

--- a/tests/unit/test_grow_deterministic.py
+++ b/tests/unit/test_grow_deterministic.py
@@ -7,7 +7,10 @@ from unittest.mock import MagicMock
 import pytest
 
 from questfoundry.graph.graph import Graph
-from questfoundry.pipeline.stages.grow.deterministic import phase_intra_path_predecessors
+from questfoundry.pipeline.stages.grow.deterministic import (
+    phase_convergence,
+    phase_intra_path_predecessors,
+)
 
 
 def _make_mock_model() -> MagicMock:
@@ -326,3 +329,231 @@ class TestPhaseIntraPathPredecessors:
             f"Expected no dead-end errors for d1_yes_beat_01 after intra-path edges, "
             f"got: {dead_end_errors_after}"
         )
+
+
+# ---------------------------------------------------------------------------
+# TestPhaseConvergencePersistence
+# ---------------------------------------------------------------------------
+
+
+def _make_convergence_fixture() -> Graph:
+    """Build a two-dilemma interleaved graph for phase_convergence persistence tests.
+
+    Structure (Y-shape per dilemma, interleaved into a single DAG):
+
+    d1 (soft, payoff_budget=2):
+        shared_d1_01 → shared_d1_02 → d1_a_beat_01 → d1_a_beat_02
+                                     ↘ d1_b_beat_01 → d1_b_beat_02
+
+    d2 (hard, payoff_budget=3):
+        shared_d2_01 → shared_d2_02 → d2_a_beat_01
+                                     ↘ d2_b_beat_01
+
+    Cross-dilemma interleave edges (d1 terminals → d2 entry):
+        d1_a_beat_02 → shared_d2_01
+        d1_b_beat_02 → shared_d2_01
+
+    d1 terminal exclusive beats: d1_a_beat_02 (path d1_a), d1_b_beat_02 (path d1_b)
+    Both reach shared_d2_01 as first non-exclusive successor → converges_at = shared_d2_01
+    convergence_payoff = min(exclusive beats per path) = min(2, 2) = 2
+      (d1_a exclusive: d1_a_beat_01, d1_a_beat_02; d1_b exclusive: d1_b_beat_01, d1_b_beat_02)
+
+    d2 is hard → not processed by phase_convergence.
+    """
+    graph = Graph.empty()
+
+    # --- Dilemma d1 (soft) ---
+    graph.create_node(
+        "dilemma::d1",
+        {"type": "dilemma", "raw_id": "d1", "dilemma_role": "soft", "payoff_budget": 2},
+    )
+    graph.create_node(
+        "path::d1_a",
+        {"type": "path", "raw_id": "d1_a", "dilemma_id": "dilemma::d1", "is_canonical": True},
+    )
+    graph.create_node(
+        "path::d1_b",
+        {"type": "path", "raw_id": "d1_b", "dilemma_id": "dilemma::d1", "is_canonical": False},
+    )
+
+    # --- Dilemma d2 (hard) ---
+    graph.create_node(
+        "dilemma::d2",
+        {"type": "dilemma", "raw_id": "d2", "dilemma_role": "hard", "payoff_budget": 3},
+    )
+    graph.create_node(
+        "path::d2_a",
+        {"type": "path", "raw_id": "d2_a", "dilemma_id": "dilemma::d2", "is_canonical": True},
+    )
+    graph.create_node(
+        "path::d2_b",
+        {"type": "path", "raw_id": "d2_b", "dilemma_id": "dilemma::d2", "is_canonical": False},
+    )
+
+    # Dilemma relationship: d1 concurrent with d2
+    graph.add_edge("concurrent", "dilemma::d1", "dilemma::d2")
+
+    # --- d1 beats ---
+    # Shared pre-commit beats (belong to both d1 paths)
+    graph.create_node(
+        "beat::shared_d1_01",
+        {"type": "beat", "raw_id": "shared_d1_01", "summary": "D1 setup 1", "dilemma_impacts": []},
+    )
+    graph.add_edge("belongs_to", "beat::shared_d1_01", "path::d1_a")
+    graph.add_edge("belongs_to", "beat::shared_d1_01", "path::d1_b")
+
+    graph.create_node(
+        "beat::shared_d1_02",
+        {"type": "beat", "raw_id": "shared_d1_02", "summary": "D1 setup 2", "dilemma_impacts": []},
+    )
+    graph.add_edge("belongs_to", "beat::shared_d1_02", "path::d1_a")
+    graph.add_edge("belongs_to", "beat::shared_d1_02", "path::d1_b")
+
+    # Exclusive beats per d1 path (2 per path: commit + post-commit)
+    graph.create_node(
+        "beat::d1_a_beat_01",
+        {
+            "type": "beat",
+            "raw_id": "d1_a_beat_01",
+            "summary": "D1 path-a commit",
+            "dilemma_impacts": [{"dilemma_id": "dilemma::d1", "effect": "commits"}],
+        },
+    )
+    graph.add_edge("belongs_to", "beat::d1_a_beat_01", "path::d1_a")
+
+    graph.create_node(
+        "beat::d1_a_beat_02",
+        {
+            "type": "beat",
+            "raw_id": "d1_a_beat_02",
+            "summary": "D1 path-a post",
+            "dilemma_impacts": [],
+        },
+    )
+    graph.add_edge("belongs_to", "beat::d1_a_beat_02", "path::d1_a")
+
+    graph.create_node(
+        "beat::d1_b_beat_01",
+        {
+            "type": "beat",
+            "raw_id": "d1_b_beat_01",
+            "summary": "D1 path-b commit",
+            "dilemma_impacts": [{"dilemma_id": "dilemma::d1", "effect": "commits"}],
+        },
+    )
+    graph.add_edge("belongs_to", "beat::d1_b_beat_01", "path::d1_b")
+
+    graph.create_node(
+        "beat::d1_b_beat_02",
+        {
+            "type": "beat",
+            "raw_id": "d1_b_beat_02",
+            "summary": "D1 path-b post",
+            "dilemma_impacts": [],
+        },
+    )
+    graph.add_edge("belongs_to", "beat::d1_b_beat_02", "path::d1_b")
+
+    # --- d2 beats ---
+    # Shared pre-commit beats (belong to both d2 paths)
+    graph.create_node(
+        "beat::shared_d2_01",
+        {"type": "beat", "raw_id": "shared_d2_01", "summary": "D2 setup 1", "dilemma_impacts": []},
+    )
+    graph.add_edge("belongs_to", "beat::shared_d2_01", "path::d2_a")
+    graph.add_edge("belongs_to", "beat::shared_d2_01", "path::d2_b")
+
+    graph.create_node(
+        "beat::shared_d2_02",
+        {"type": "beat", "raw_id": "shared_d2_02", "summary": "D2 setup 2", "dilemma_impacts": []},
+    )
+    graph.add_edge("belongs_to", "beat::shared_d2_02", "path::d2_a")
+    graph.add_edge("belongs_to", "beat::shared_d2_02", "path::d2_b")
+
+    graph.create_node(
+        "beat::d2_a_beat_01",
+        {
+            "type": "beat",
+            "raw_id": "d2_a_beat_01",
+            "summary": "D2 path-a commit",
+            "dilemma_impacts": [{"dilemma_id": "dilemma::d2", "effect": "commits"}],
+        },
+    )
+    graph.add_edge("belongs_to", "beat::d2_a_beat_01", "path::d2_a")
+
+    graph.create_node(
+        "beat::d2_b_beat_01",
+        {
+            "type": "beat",
+            "raw_id": "d2_b_beat_01",
+            "summary": "D2 path-b commit",
+            "dilemma_impacts": [{"dilemma_id": "dilemma::d2", "effect": "commits"}],
+        },
+    )
+    graph.add_edge("belongs_to", "beat::d2_b_beat_01", "path::d2_b")
+
+    # --- Predecessor edges (from=later, to=earlier) ---
+    # d1 internal chain
+    graph.add_edge("predecessor", "beat::shared_d1_02", "beat::shared_d1_01")
+    graph.add_edge("predecessor", "beat::d1_a_beat_01", "beat::shared_d1_02")
+    graph.add_edge("predecessor", "beat::d1_b_beat_01", "beat::shared_d1_02")
+    graph.add_edge("predecessor", "beat::d1_a_beat_02", "beat::d1_a_beat_01")
+    graph.add_edge("predecessor", "beat::d1_b_beat_02", "beat::d1_b_beat_01")
+
+    # d2 internal chain
+    graph.add_edge("predecessor", "beat::shared_d2_02", "beat::shared_d2_01")
+    graph.add_edge("predecessor", "beat::d2_a_beat_01", "beat::shared_d2_02")
+    graph.add_edge("predecessor", "beat::d2_b_beat_01", "beat::shared_d2_02")
+
+    # Cross-dilemma interleave: d1 terminals → d2 entry
+    graph.add_edge("predecessor", "beat::shared_d2_01", "beat::d1_a_beat_02")
+    graph.add_edge("predecessor", "beat::shared_d2_01", "beat::d1_b_beat_02")
+
+    # Consequence nodes (one per path) — required for enumerate_arcs via has_consequence
+    graph.create_node("consequence::c_d1_a", {"type": "consequence", "raw_id": "c_d1_a"})
+    graph.create_node("consequence::c_d1_b", {"type": "consequence", "raw_id": "c_d1_b"})
+    graph.create_node("consequence::c_d2_a", {"type": "consequence", "raw_id": "c_d2_a"})
+    graph.create_node("consequence::c_d2_b", {"type": "consequence", "raw_id": "c_d2_b"})
+    graph.add_edge("has_consequence", "path::d1_a", "consequence::c_d1_a")
+    graph.add_edge("has_consequence", "path::d1_b", "consequence::c_d1_b")
+    graph.add_edge("has_consequence", "path::d2_a", "consequence::c_d2_a")
+    graph.add_edge("has_consequence", "path::d2_b", "consequence::c_d2_b")
+
+    graph.set_last_stage("grow")
+    return graph
+
+
+class TestPhaseConvergencePersistence:
+    """Tests for phase_convergence: convergence data persisted on dilemma nodes."""
+
+    @pytest.mark.asyncio
+    async def test_soft_dilemma_gets_converges_at(self) -> None:
+        """Soft d1 gets converges_at and convergence_payoff written to graph.
+
+        Both exclusive chains of d1 (d1_a_beat_02, d1_b_beat_02) have
+        shared_d2_01 as their first non-exclusive successor, so that is the
+        convergence point.  Payoff = min(2, 2) = 2.
+        """
+        graph = _make_convergence_fixture()
+
+        result = await phase_convergence(graph, _make_mock_model())
+
+        assert result.status == "completed"
+        assert "1 dilemma" in result.detail  # 1 soft dilemma persisted
+
+        d1_node = graph.get_node("dilemma::d1")
+        assert d1_node is not None
+        assert d1_node.get("converges_at") == "beat::shared_d2_01"
+        assert d1_node.get("convergence_payoff") == 2
+
+    @pytest.mark.asyncio
+    async def test_hard_dilemma_no_converges_at(self) -> None:
+        """Hard d2 is skipped; converges_at is absent (or None) on the node."""
+        graph = _make_convergence_fixture()
+
+        await phase_convergence(graph, _make_mock_model())
+
+        d2_node = graph.get_node("dilemma::d2")
+        assert d2_node is not None
+        # Hard dilemma must not have converges_at set by phase_convergence
+        assert d2_node.get("converges_at") is None


### PR DESCRIPTION
## Summary

GROW's `phase_convergence` computed convergence points but discarded the result — no data reached the graph. This PR makes it identify convergence from the interleaved beat DAG topology and persist it on dilemma nodes. Closes #1221, closes #1222, partially addresses #1209.

## What changed

**`src/questfoundry/graph/grow_algorithms.py`** — new `find_dag_convergence_beat(graph, dilemma_id)`:
- Walks the post-interleave beat DAG to find the convergence beat for a soft dilemma
- Finds terminal exclusive beats (last beat on each path exclusive to this dilemma)
- BFS forward from each terminal to find the first beat reachable from ALL terminals that is NOT exclusive to this dilemma (typically the first shared setup beat of the next dilemma)
- Returns `(converges_at, convergence_payoff)` or `None`

**`src/questfoundry/pipeline/stages/grow/deterministic.py`** — `phase_convergence` updated:
- Iterates soft dilemmas, calls `find_dag_convergence_beat`, writes `converges_at` (beat ID) and `convergence_payoff` (int) to dilemma nodes via `graph.update_node()`
- Hard dilemmas skipped (no convergence by spec)
- Existing `find_convergence_points()` retained for diagnostic logging

**`docs/design/story-graph-ontology.md`**:
- Added `converges_at` and `convergence_payoff` to dilemma node field list (Part 1)
- Updated GROW stage table Modifies row to include dilemma node writes

**`docs/design/how-branching-stories-work.md`**:
- Fixed #1209 stale "exists in multiple versions" language — post-commit beats are separate beats, not versions

## Why #1222 is addressed without new predecessor edges

The original scope of #1222 was to create predecessor edges for convergence topology. Investigation showed that GROW's interleaving already creates cross-dilemma predecessor edges connecting each dilemma's terminal beats to the next dilemma's entry beats. The convergence topology is already structurally present — what was missing was GROW recognizing and recording it.

## Test plan

- [x] `TestFindDagConvergenceBeat` — 4 tests: soft converges at next dilemma entry, hard returns None, last dilemma returns None, single dilemma returns None
- [x] `TestPhaseConvergencePersistence` — 2 tests: soft dilemma gets converges_at + payoff, hard dilemma unchanged
- [x] Full GROW suite: 431/431 pass
- [x] Pre-commit, ruff, mypy — clean
- [ ] **Empirical**: re-run GROW on test-new4 and verify soft dilemma nodes have `converges_at` pointing to expected beats

🤖 Generated with [Claude Code](https://claude.com/claude-code)