### PR TITLE
feat(viz): PlantUML beat DAG visualization replacing DOT/Mermaid

### DIFF
--- a/src/questfoundry/cli.py
+++ b/src/questfoundry/cli.py
@@ -2529,14 +2529,6 @@ def graph_cmd(
             help="Project directory. Can be a path or name (looks in --projects-dir).",
         ),
     ] = None,
-    fmt: Annotated[
-        _GraphFormat,
-        typer.Option(
-            "--format",
-            "-f",
-            help="Output format.",
-        ),
-    ] = _GraphFormat.plantuml,
     output: Annotated[
         Path | None,
         typer.Option("--output", "-o", help="Output file (stdout if not specified)."),
@@ -2556,8 +2548,7 @@ def graph_cmd(
     graph = Graph.load(project_path)
     dag = build_beat_dag(graph)
 
-    if fmt == _GraphFormat.plantuml:
-        result = render_plantuml(dag, no_labels=no_labels)
+    result = render_plantuml(dag, no_labels=no_labels)
 
     if output:
         output.write_text(result)

--- a/src/questfoundry/cli.py
+++ b/src/questfoundry/cli.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import asyncio
 import atexit
 import sys
-from enum import StrEnum
 from pathlib import Path
 from typing import TYPE_CHECKING, Annotated, Any
 
@@ -2511,12 +2510,6 @@ def _check_project(project_path: Path) -> bool:
 
     console.print()
     return all_ok
-
-
-class _GraphFormat(StrEnum):
-    """Output format for the graph command."""
-
-    plantuml = "plantuml"
 
 
 @app.command(name="graph")

--- a/src/questfoundry/cli.py
+++ b/src/questfoundry/cli.py
@@ -2516,9 +2516,7 @@ def _check_project(project_path: Path) -> bool:
 class _GraphFormat(StrEnum):
     """Output format for the graph command."""
 
-    dot = "dot"
-    mermaid = "mermaid"
-    json = "json"
+    plantuml = "plantuml"
 
 
 @app.command(name="graph")
@@ -2538,39 +2536,28 @@ def graph_cmd(
             "-f",
             help="Output format.",
         ),
-    ] = _GraphFormat.dot,
+    ] = _GraphFormat.plantuml,
     output: Annotated[
         Path | None,
         typer.Option("--output", "-o", help="Output file (stdout if not specified)."),
     ] = None,
-    spine_only: Annotated[
-        bool,
-        typer.Option("--spine-only", help="Only show passages on the spine arc."),
-    ] = False,
     no_labels: Annotated[
         bool,
-        typer.Option("--no-labels", help="Omit choice labels on edges."),
+        typer.Option("--no-labels", help="Omit effect tags from beat boxes."),
     ] = False,
 ) -> None:
-    """Visualize story graph as DOT, Mermaid, or JSON."""
+    """Visualize beat DAG as PlantUML component diagram."""
     project_path = _resolve_project_path(project)
     _require_project(project_path)
 
     from questfoundry.graph.graph import Graph
-    from questfoundry.visualization import build_story_graph, render_dot, render_mermaid
+    from questfoundry.visualization import build_beat_dag, render_plantuml
 
     graph = Graph.load(project_path)
-    sg = build_story_graph(graph, spine_only=spine_only)
+    dag = build_beat_dag(graph)
 
-    if fmt == _GraphFormat.dot:
-        result = render_dot(sg, no_labels=no_labels)
-    elif fmt == _GraphFormat.mermaid:
-        result = render_mermaid(sg, no_labels=no_labels)
-    else:
-        import dataclasses
-        import json
-
-        result = json.dumps(dataclasses.asdict(sg), indent=2)
+    if fmt == _GraphFormat.plantuml:
+        result = render_plantuml(dag, no_labels=no_labels)
 
     if output:
         output.write_text(result)

--- a/src/questfoundry/visualization.py
+++ b/src/questfoundry/visualization.py
@@ -6,6 +6,7 @@ returns structured data for rendering. Pure graph analysis — no LLM calls.
 
 from __future__ import annotations
 
+import re
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
@@ -310,8 +311,6 @@ def _puml_alias(node_id: str) -> str:
 
     Replaces any non-alphanumeric/underscore character with ``_``.
     """
-    import re
-
     return re.sub(r"[^a-zA-Z0-9_]", "_", node_id)
 
 
@@ -320,7 +319,7 @@ def _sanitize_puml(text: str) -> str:
 
     ``]`` closes component labels; ``"`` breaks rectangle label strings.
     """
-    return text.replace("]", ")").replace('"', "'")
+    return text.replace("[", "(").replace("]", ")").replace('"', "'")
 
 
 def _beat_component_line(beat: BeatVizNode, *, no_labels: bool = False) -> str:

--- a/src/questfoundry/visualization.py
+++ b/src/questfoundry/visualization.py
@@ -49,13 +49,7 @@ class BeatVizNode:
 
 @dataclass
 class BeatVizEdge:
-    """A directed predecessor edge in the beat DAG.
-
-    Represents the *successor* direction: from_id comes *after* to_id
-    in narrative order (predecessor edge semantics: from=child, to=parent).
-    We store it as from_id → to_id in the DAG display sense (parent → child),
-    i.e., ``from_id`` is the *parent* beat and ``to_id`` is the *child* beat.
-    """
+    """A predecessor edge reoriented for display (parent → child / earlier → later)."""
 
     from_id: str
     to_id: str
@@ -67,7 +61,7 @@ class PassageGroup:
 
     id: str
     label: str
-    grouping_type: str = "grouped_in"
+    grouping_type: str = "single"
     beat_ids: list[str] = field(default_factory=list)
 
 
@@ -196,11 +190,12 @@ def build_beat_dag(graph: Graph) -> BeatDag:
     for passage_id, beat_ids in sorted(passage_to_beats.items()):
         pdata = passage_nodes.get(passage_id) or {}
         label = pdata.get("label") or strip_scope_prefix(passage_id)
+        grouping_type = pdata.get("grouping_type", "single")
         passages.append(
             PassageGroup(
                 id=passage_id,
                 label=label,
-                grouping_type="grouped_in",
+                grouping_type=grouping_type,
                 beat_ids=beat_ids,
             )
         )
@@ -243,7 +238,7 @@ def render_plantuml(dag: BeatDag, *, no_labels: bool = False) -> str:
 
     # Dilemma color skinparams — one block per dilemma, sorted for determinism.
     for dilemma_id in sorted(dag.dilemma_colors):
-        stereo = strip_scope_prefix(dilemma_id)
+        stereo = _puml_alias(strip_scope_prefix(dilemma_id))
         color = dag.dilemma_colors[dilemma_id]
         lines.append("skinparam component {")
         lines.append(f"  BackgroundColor<<{stereo}>> {color}")
@@ -270,9 +265,8 @@ def render_plantuml(dag: BeatDag, *, no_labels: bool = False) -> str:
 
     # Passage containers.
     for pg in sorted(dag.passages, key=lambda p: p.id):
-        raw_pid = strip_scope_prefix(pg.id)
-        # Use the grouping_type when it is a meaningful value, otherwise "collapse".
-        ptype = pg.grouping_type if pg.grouping_type not in ("grouped_in", "") else "collapse"
+        raw_pid = _sanitize_puml(strip_scope_prefix(pg.id))
+        ptype = _sanitize_puml(pg.grouping_type)
         lines.append(f'rectangle "{raw_pid} [{ptype}]" {{')
         for bid in pg.beat_ids:
             pg_beat = beat_map.get(bid)
@@ -285,7 +279,7 @@ def render_plantuml(dag: BeatDag, *, no_labels: bool = False) -> str:
     # Intersection group containers (beats not already in a passage).
     for ig_id in sorted(ig_to_beats):
         ig_beats = ig_to_beats[ig_id]
-        ig_label = strip_scope_prefix(ig_id)
+        ig_label = _sanitize_puml(strip_scope_prefix(ig_id))
         lines.append(f'rectangle "{ig_label}" #line.dashed {{')
         for beat in ig_beats:
             lines.append(f"  {_beat_component_line(beat, no_labels=no_labels)}")
@@ -314,9 +308,19 @@ def render_plantuml(dag: BeatDag, *, no_labels: bool = False) -> str:
 def _puml_alias(node_id: str) -> str:
     """Convert a node ID to a PlantUML-safe alias.
 
-    Replaces `::`, `-`, and spaces with `_`.
+    Replaces any non-alphanumeric/underscore character with ``_``.
     """
-    return node_id.replace("::", "_").replace("-", "_").replace(" ", "_")
+    import re
+
+    return re.sub(r"[^a-zA-Z0-9_]", "_", node_id)
+
+
+def _sanitize_puml(text: str) -> str:
+    """Escape characters that break PlantUML component or rectangle syntax.
+
+    ``]`` closes component labels; ``"`` breaks rectangle label strings.
+    """
+    return text.replace("]", ")").replace('"', "'")
 
 
 def _beat_component_line(beat: BeatVizNode, *, no_labels: bool = False) -> str:
@@ -327,20 +331,20 @@ def _beat_component_line(beat: BeatVizNode, *, no_labels: bool = False) -> str:
 
     When no_labels=True, the effects section (third ---\\n... block) is omitted.
     """
-    label = beat.label
-    summary = beat.summary
+    label = _sanitize_puml(beat.label)
+    summary = _sanitize_puml(beat.summary)
 
     if no_labels or not beat.effects:
         inner = f"{label}\\n---\\n{summary}"
     else:
-        effects_block = "\\n".join(f"[{e}]" for e in beat.effects)
+        effects_block = "\\n".join(f"({_sanitize_puml(e)})" for e in beat.effects)
         inner = f"{label}\\n---\\n{summary}\\n---\\n{effects_block}"
 
     alias = _puml_alias(beat.id)
 
     stereo_part = ""
     if beat.dilemma_id:
-        stereo = strip_scope_prefix(beat.dilemma_id)
+        stereo = _puml_alias(strip_scope_prefix(beat.dilemma_id))
         stereo_part = f" <<{stereo}>>"
 
     bold_part = " #line.bold" if beat.is_shared else ""

--- a/src/questfoundry/visualization.py
+++ b/src/questfoundry/visualization.py
@@ -254,8 +254,12 @@ def render_plantuml(dag: BeatDag, *, no_labels: bool = False) -> str:
     for pg in dag.passages:
         passage_beat_ids.update(pg.beat_ids)
 
-    # Collect which beats are inside an intersection group (and not in a passage).
-    # Build intersection_group → beats mapping.
+    # Collect which beats are inside an intersection group but not already in a
+    # passage container.  Beats in a passage are grouped there; they are excluded
+    # from intersection containers to avoid rendering a beat in two places.
+    # If all members of an intersection are in passages, the intersection container
+    # is simply not emitted — the co-occurrence is still visible from the beat's
+    # intersection_group field in the data model.
     ig_to_beats: dict[str, list[BeatVizNode]] = {}
     for beat in dag.beats:
         if beat.intersection_group and beat.id not in passage_beat_ids:
@@ -266,9 +270,9 @@ def render_plantuml(dag: BeatDag, *, no_labels: bool = False) -> str:
 
     # Passage containers.
     for pg in sorted(dag.passages, key=lambda p: p.id):
-        raw_pid = _sanitize_puml(strip_scope_prefix(pg.id))
+        plabel = _sanitize_puml(pg.label)
         ptype = _sanitize_puml(pg.grouping_type)
-        lines.append(f'rectangle "{raw_pid} [{ptype}]" {{')
+        lines.append(f'rectangle "{plabel} [{ptype}]" {{')
         for bid in pg.beat_ids:
             pg_beat = beat_map.get(bid)
             if pg_beat is not None:

--- a/src/questfoundry/visualization.py
+++ b/src/questfoundry/visualization.py
@@ -221,6 +221,133 @@ def build_beat_dag(graph: Graph) -> BeatDag:
     )
 
 
+def render_plantuml(dag: BeatDag, *, no_labels: bool = False) -> str:
+    """Render a BeatDag as a PlantUML component diagram string.
+
+    Args:
+        dag: Beat DAG data from build_beat_dag().
+        no_labels: If True, omit the effects section from beat components.
+
+    Returns:
+        PlantUML diagram string (starts with @startuml, ends with @enduml).
+    """
+    lines: list[str] = [
+        "@startuml",
+        "!theme plain",
+        "left to right direction",
+        "skinparam componentStyle rectangle",
+        "skinparam defaultTextAlignment left",
+        "skinparam wrapWidth 200",
+        "",
+    ]
+
+    # Dilemma color skinparams — one block per dilemma, sorted for determinism.
+    for dilemma_id in sorted(dag.dilemma_colors):
+        stereo = strip_scope_prefix(dilemma_id)
+        color = dag.dilemma_colors[dilemma_id]
+        lines.append("skinparam component {")
+        lines.append(f"  BackgroundColor<<{stereo}>> {color}")
+        lines.append("}")
+        lines.append("")
+
+    # Index beats by id for lookup.
+    beat_map = {b.id: b for b in dag.beats}
+
+    # Collect which beats are inside a passage.
+    passage_beat_ids: set[str] = set()
+    for pg in dag.passages:
+        passage_beat_ids.update(pg.beat_ids)
+
+    # Collect which beats are inside an intersection group (and not in a passage).
+    # Build intersection_group → beats mapping.
+    ig_to_beats: dict[str, list[BeatVizNode]] = {}
+    for beat in dag.beats:
+        if beat.intersection_group and beat.id not in passage_beat_ids:
+            ig_to_beats.setdefault(beat.intersection_group, []).append(beat)
+
+    # Beats already rendered (in a container).
+    rendered_beats: set[str] = set()
+
+    # Passage containers.
+    for pg in sorted(dag.passages, key=lambda p: p.id):
+        raw_pid = strip_scope_prefix(pg.id)
+        # Use the grouping_type when it is a meaningful value, otherwise "collapse".
+        ptype = pg.grouping_type if pg.grouping_type not in ("grouped_in", "") else "collapse"
+        lines.append(f'rectangle "{raw_pid} [{ptype}]" {{')
+        for bid in pg.beat_ids:
+            pg_beat = beat_map.get(bid)
+            if pg_beat is not None:
+                lines.append(f"  {_beat_component_line(pg_beat, no_labels=no_labels)}")
+                rendered_beats.add(bid)
+        lines.append("}")
+        lines.append("")
+
+    # Intersection group containers (beats not already in a passage).
+    for ig_id in sorted(ig_to_beats):
+        ig_beats = ig_to_beats[ig_id]
+        ig_label = strip_scope_prefix(ig_id)
+        lines.append(f'rectangle "{ig_label}" #line.dashed {{')
+        for beat in ig_beats:
+            lines.append(f"  {_beat_component_line(beat, no_labels=no_labels)}")
+            rendered_beats.add(beat.id)
+        lines.append("}")
+        lines.append("")
+
+    # Standalone beats (not in any container).
+    for beat in dag.beats:
+        if beat.id not in rendered_beats:
+            lines.append(_beat_component_line(beat, no_labels=no_labels))
+
+    lines.append("")
+
+    # Predecessor edges: from_id (parent/earlier) --> to_id (child/later).
+    for edge in dag.edges:
+        src = _puml_alias(edge.from_id)
+        dst = _puml_alias(edge.to_id)
+        lines.append(f"{src} --> {dst}")
+
+    lines.append("")
+    lines.append("@enduml")
+    return "\n".join(lines)
+
+
+def _puml_alias(node_id: str) -> str:
+    """Convert a node ID to a PlantUML-safe alias.
+
+    Replaces `::`, `-`, and spaces with `_`.
+    """
+    return node_id.replace("::", "_").replace("-", "_").replace(" ", "_")
+
+
+def _beat_component_line(beat: BeatVizNode, *, no_labels: bool = False) -> str:
+    """Render a single beat as a PlantUML component line.
+
+    Format:
+        [label\\n---\\nsummary\\n---\\n[eff1]\\n[eff2]] as alias <<stereo>> #line.bold?
+
+    When no_labels=True, the effects section (third ---\\n... block) is omitted.
+    """
+    label = beat.label
+    summary = beat.summary
+
+    if no_labels or not beat.effects:
+        inner = f"{label}\\n---\\n{summary}"
+    else:
+        effects_block = "\\n".join(f"[{e}]" for e in beat.effects)
+        inner = f"{label}\\n---\\n{summary}\\n---\\n{effects_block}"
+
+    alias = _puml_alias(beat.id)
+
+    stereo_part = ""
+    if beat.dilemma_id:
+        stereo = strip_scope_prefix(beat.dilemma_id)
+        stereo_part = f" <<{stereo}>>"
+
+    bold_part = " #line.bold" if beat.is_shared else ""
+
+    return f"[{inner}] as {alias}{stereo_part}{bold_part}"
+
+
 def _truncate(text: str, max_len: int = 60) -> str:
     """Truncate text with ellipsis if too long."""
     if len(text) <= max_len:

--- a/src/questfoundry/visualization.py
+++ b/src/questfoundry/visualization.py
@@ -1,7 +1,7 @@
-"""Story graph visualization.
+"""Beat DAG visualization.
 
-Extracts passage/choice structure from the graph and renders it as
-DOT (Graphviz) or Mermaid markup. Pure graph analysis — no LLM calls.
+Extracts the beat directed acyclic graph (DAG) from the story graph and
+returns structured data for rendering. Pure graph analysis — no LLM calls.
 """
 
 from __future__ import annotations
@@ -9,7 +9,7 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
-from questfoundry.graph.fill_context import get_arc_passage_order
+from questfoundry.graph.context import normalize_scoped_id, strip_scope_prefix
 from questfoundry.observability.logging import get_logger
 
 if TYPE_CHECKING:
@@ -17,374 +17,212 @@ if TYPE_CHECKING:
 
 log = get_logger(__name__)
 
-# Arc color palette: spine first, then branches.
-_ARC_COLORS = [
-    "#ADD8E6",  # light blue (spine)
+# Dilemma color palette — assigned by sorted dilemma ID, cycling through these.
+_DILEMMA_COLORS = [
+    "#ADD8E6",  # light blue
     "#FFD700",  # gold
     "#FFA07A",  # light salmon
     "#98FB98",  # pale green
     "#DDA0DD",  # plum
     "#87CEEB",  # sky blue
     "#F0E68C",  # khaki
+    "#FFB6C1",  # light pink
+    "#B0C4DE",  # light steel blue
+    "#FFDAB9",  # peach puff
 ]
-_SHARED_COLOR = "#D3D3D3"  # light grey for multi-arc passages
-_START_COLOR = "#90EE90"  # light green
-_ENDING_COLOR = "#FFB6C1"  # light pink
-_GRANTS_COLOR = "#6A5ACD"  # slate blue for state-changing choices
-_OVERLAY_BORDER = "#FF4500"  # orange-red border for overlay passages
-_ENTITY_PREFIXES = ("character::", "location::", "object::", "faction::")
 
 
 @dataclass
-class VizNode:
-    """A passage node in the visualization."""
+class BeatVizNode:
+    """A beat node in the visualization."""
 
     id: str
     label: str
-    arc_id: str | None = None
-    is_start: bool = False
-    is_ending: bool = False
-    is_hub: bool = False
-    has_overlays: bool = False
-    outgoing_count: int = 0
+    summary: str
+    dilemma_id: str | None
+    effects: list[str] = field(default_factory=list)
+    path_ids: list[str] = field(default_factory=list)
+    is_shared: bool = False
+    passage_id: str | None = None
+    intersection_group: str | None = None
 
 
 @dataclass
-class VizEdge:
-    """A choice edge in the visualization."""
+class BeatVizEdge:
+    """A directed predecessor edge in the beat DAG.
+
+    Represents the *successor* direction: from_id comes *after* to_id
+    in narrative order (predecessor edge semantics: from=child, to=parent).
+    We store it as from_id → to_id in the DAG display sense (parent → child),
+    i.e., ``from_id`` is the *parent* beat and ``to_id`` is the *child* beat.
+    """
 
     from_id: str
     to_id: str
-    label: str = ""
-    is_return: bool = False
-    requires_state_flags: list[str] = field(default_factory=list)
-    grants: list[str] = field(default_factory=list)
 
 
 @dataclass
-class StoryGraph:
-    """Complete visualization data extracted from the story graph."""
+class PassageGroup:
+    """A passage node and the beats grouped into it."""
 
-    nodes: list[VizNode]
-    edges: list[VizEdge]
-    arc_names: dict[str, str] = field(default_factory=dict)
+    id: str
+    label: str
+    grouping_type: str = "grouped_in"
+    beat_ids: list[str] = field(default_factory=list)
 
 
-def build_story_graph(
-    graph: Graph,
-    *,
-    spine_only: bool = False,
-) -> StoryGraph:
-    """Extract visualization data from the story graph.
+@dataclass
+class BeatDag:
+    """Complete beat DAG visualization data extracted from the story graph."""
+
+    beats: list[BeatVizNode]
+    edges: list[BeatVizEdge]
+    passages: list[PassageGroup]
+    dilemma_colors: dict[str, str] = field(default_factory=dict)
+
+
+def build_beat_dag(graph: Graph) -> BeatDag:
+    """Extract beat DAG visualization data from the story graph.
 
     Args:
-        graph: Loaded story graph (must have passages and choices).
-        spine_only: If True, include only passages on the spine arc.
+        graph: Loaded story graph (must have beat nodes with predecessor and
+            belongs_to edges).
 
     Returns:
-        StoryGraph with nodes, edges, and arc metadata.
+        BeatDag with beats, predecessor edges, passage groups, and dilemma
+        color assignments.
     """
-    passages = graph.get_nodes_by_type("passage")
-    choices = graph.get_nodes_by_type("choice")
-    arcs = graph.get_nodes_by_type("arc")
+    beat_nodes = graph.get_nodes_by_type("beat")
+    if not beat_nodes:
+        return BeatDag(beats=[], edges=[], passages=[], dilemma_colors={})
 
-    # Build passage→arc mapping
-    passage_to_arc: dict[str, str | None] = {}
-    arc_names: dict[str, str] = {}
-    spine_passages: set[str] = set()
+    # 1. Build path → dilemma map from path nodes.
+    path_nodes = graph.get_nodes_by_type("path")
+    path_to_dilemma: dict[str, str] = {}
+    for path_id, path_data in path_nodes.items():
+        raw_dilemma = path_data.get("dilemma_id")
+        if raw_dilemma:
+            path_to_dilemma[path_id] = normalize_scoped_id(raw_dilemma, "dilemma")
 
-    for arc_id, arc_data in arcs.items():
-        arc_type = arc_data.get("arc_type", "branch")
-        arc_names[arc_id] = arc_type
-        arc_passage_ids = get_arc_passage_order(graph, arc_id)
+    # 2. Build beat → paths from belongs_to edges.
+    beat_to_paths: dict[str, list[str]] = {bid: [] for bid in beat_nodes}
+    for edge in graph.get_edges(edge_type="belongs_to"):
+        beat_id = edge["from"]
+        path_id = edge["to"]
+        if beat_id in beat_to_paths:
+            beat_to_paths[beat_id].append(path_id)
 
-        if arc_type == "spine":
-            spine_passages.update(arc_passage_ids)
+    # 3. Build beat → passage from grouped_in edges (beat is from, passage is to).
+    beat_to_passage: dict[str, str] = {}
+    for edge in graph.get_edges(edge_type="grouped_in"):
+        beat_id = edge["from"]
+        passage_id = edge["to"]
+        if beat_id in beat_nodes:
+            beat_to_passage[beat_id] = passage_id
 
-        for pid in arc_passage_ids:
-            if pid in passage_to_arc:
-                # Passage on multiple arcs — mark as shared
-                passage_to_arc[pid] = None
-            else:
-                passage_to_arc[pid] = arc_id
+    # 4. Build beat → intersection_group from intersection edges.
+    beat_to_intersection: dict[str, str] = {}
+    for edge in graph.get_edges(edge_type="intersection"):
+        beat_id = edge["from"]
+        group_id = edge["to"]
+        if beat_id in beat_nodes:
+            beat_to_intersection[beat_id] = group_id
 
-    # Identify entities with overlays (state-flag-dependent content)
-    entities = graph.get_nodes_by_type("entity")
-    overlay_entity_ids: set[str] = set()
-    for eid, edata in entities.items():
-        if edata.get("overlays"):
-            overlay_entity_ids.add(eid)
+    # 5. Collect dilemma IDs and assign colors (sorted for determinism).
+    dilemma_ids: set[str] = set(path_to_dilemma.values())
+    dilemma_colors: dict[str, str] = {}
+    for idx, did in enumerate(sorted(dilemma_ids)):
+        dilemma_colors[did] = _DILEMMA_COLORS[idx % len(_DILEMMA_COLORS)]
 
-    # Track which passages contain overlay-affected entities
-    overlay_passages: set[str] = set()
-    for pid, pdata in passages.items():
-        for ent in pdata.get("entities") or []:
-            # Check both raw ID and scoped forms
-            if ent in overlay_entity_ids:
-                overlay_passages.add(pid)
-                break
-            if any(f"{prefix}{ent}" in overlay_entity_ids for prefix in _ENTITY_PREFIXES):
-                overlay_passages.add(pid)
-                break
+    # 6. Build BeatVizNode for each beat.
+    beats: list[BeatVizNode] = []
+    for bid, bdata in beat_nodes.items():
+        label = strip_scope_prefix(bid)
+        raw_summary = bdata.get("summary") or ""
+        summary = _truncate(raw_summary, 60)
 
-    # Determine start/ending passages and outgoing counts
-    has_incoming: set[str] = set()
-    has_outgoing: set[str] = set()
-    hub_passages: set[str] = set()
-    outgoing_count: dict[str, int] = {}
+        # Determine dilemma_id from first dilemma_impacts entry.
+        impacts = bdata.get("dilemma_impacts") or []
+        dilemma_id: str | None = None
+        if impacts:
+            first_impact = impacts[0]
+            raw_did = first_impact.get("dilemma_id")
+            if raw_did:
+                dilemma_id = normalize_scoped_id(raw_did, "dilemma")
 
-    for _cid, cdata in choices.items():
-        from_p = cdata.get("from_passage")
-        to_p = cdata.get("to_passage")
-        if not from_p or not to_p:
-            log.warning("choice_missing_passage", choice_id=_cid, from_p=from_p, to_p=to_p)
-            continue
-        if cdata.get("is_return"):
-            hub_passages.add(to_p)
-        else:
-            has_incoming.add(to_p)
-            outgoing_count[from_p] = outgoing_count.get(from_p, 0) + 1
-        has_outgoing.add(from_p)
+        # Format effects as "<effect> <stripped_dilemma_id>".
+        effects: list[str] = []
+        for impact in impacts:
+            effect = impact.get("effect")
+            raw_did = impact.get("dilemma_id")
+            if effect and raw_did:
+                stripped = strip_scope_prefix(normalize_scoped_id(raw_did, "dilemma"))
+                effects.append(f"{effect} {stripped}")
 
-    # Filter passages if spine_only
-    visible_passages = spine_passages if spine_only else set(passages.keys())
+        path_ids = beat_to_paths.get(bid, [])
+        is_shared = len(path_ids) > 1
 
-    # Build nodes
-    nodes: list[VizNode] = []
-    for pid, pdata in sorted(passages.items()):
-        if pid not in visible_passages:
-            continue
-        summary = pdata.get("summary", pid)
-        label = _truncate(summary, 40)
-        nodes.append(
-            VizNode(
-                id=pid,
+        beats.append(
+            BeatVizNode(
+                id=bid,
                 label=label,
-                arc_id=passage_to_arc.get(pid),
-                is_start=pid not in has_incoming,
-                is_ending=pid not in has_outgoing,
-                is_hub=pid in hub_passages,
-                has_overlays=pid in overlay_passages,
-                outgoing_count=outgoing_count.get(pid, 0),
+                summary=summary,
+                dilemma_id=dilemma_id,
+                effects=effects,
+                path_ids=path_ids,
+                is_shared=is_shared,
+                passage_id=beat_to_passage.get(bid),
+                intersection_group=beat_to_intersection.get(bid),
             )
         )
 
-    # Build edges
-    edges: list[VizEdge] = []
-    for _cid, cdata in sorted(choices.items()):
-        from_p = cdata.get("from_passage")
-        to_p = cdata.get("to_passage")
-        if not from_p or not to_p:
-            continue  # Already warned above
-        if from_p not in visible_passages or to_p not in visible_passages:
-            continue
-        edges.append(
-            VizEdge(
-                from_id=from_p,
-                to_id=to_p,
-                label=cdata.get("label", ""),
-                is_return=cdata.get("is_return", False),
-                requires_state_flags=cdata.get("requires_state_flags", []),
-                grants=cdata.get("grants", []),
+    # 7. Build BeatVizEdge for each predecessor edge between beats.
+    # Predecessor edge semantics: from=child, to=parent.
+    # We emit edges as parent → child for DAG display.
+    edges: list[BeatVizEdge] = []
+    for edge in graph.get_edges(edge_type="predecessor"):
+        child_id = edge["from"]
+        parent_id = edge["to"]
+        if child_id in beat_nodes and parent_id in beat_nodes:
+            edges.append(BeatVizEdge(from_id=parent_id, to_id=child_id))
+
+    # 8. Build PassageGroup for each passage that has grouped_in beats.
+    passage_to_beats: dict[str, list[str]] = {}
+    for beat_id, passage_id in beat_to_passage.items():
+        passage_to_beats.setdefault(passage_id, []).append(beat_id)
+
+    passage_nodes = graph.get_nodes_by_type("passage")
+    passages: list[PassageGroup] = []
+    for passage_id, beat_ids in sorted(passage_to_beats.items()):
+        pdata = passage_nodes.get(passage_id) or {}
+        label = pdata.get("label") or strip_scope_prefix(passage_id)
+        passages.append(
+            PassageGroup(
+                id=passage_id,
+                label=label,
+                grouping_type="grouped_in",
+                beat_ids=beat_ids,
             )
         )
 
     log.info(
-        "story_graph_built",
-        nodes=len(nodes),
+        "beat_dag_built",
+        beats=len(beats),
         edges=len(edges),
-        arcs=len(arc_names),
-        spine_only=spine_only,
+        passages=len(passages),
+        dilemmas=len(dilemma_colors),
     )
 
-    return StoryGraph(nodes=nodes, edges=edges, arc_names=arc_names)
+    return BeatDag(
+        beats=beats,
+        edges=edges,
+        passages=passages,
+        dilemma_colors=dilemma_colors,
+    )
 
 
-def render_dot(sg: StoryGraph, *, no_labels: bool = False) -> str:
-    """Render a StoryGraph as DOT (Graphviz) markup.
-
-    Args:
-        sg: Story graph data.
-        no_labels: If True, omit choice labels on edges.
-
-    Returns:
-        DOT format string.
-    """
-    # Assign colors to arcs
-    arc_color = _assign_arc_colors(sg.arc_names)
-
-    lines = [
-        "digraph story {",
-        "  rankdir=LR;",
-        '  node [fontname="Helvetica" fontsize=10 style="filled,solid"];',
-        '  edge [fontname="Helvetica" fontsize=8];',
-        "",
-    ]
-
-    # Nodes
-    for node in sg.nodes:
-        attrs = _dot_node_attrs(node, arc_color)
-        attr_str = " ".join(f"{k}={v}" for k, v in attrs.items())
-        lines.append(f'  "{node.id}" [{attr_str}];')
-
-    lines.append("")
-
-    # Edges
-    for edge in sg.edges:
-        edge_attrs: dict[str, str] = {}
-        if not no_labels and edge.label:
-            edge_attrs["label"] = f'"{_dot_escape(edge.label)}"'
-        if edge.is_return:
-            edge_attrs["style"] = '"dashed"'
-            edge_attrs["color"] = '"grey"'
-        # Requires (gated) takes precedence over grants (state-changing).
-        # Return edges keep their dashed grey style in both renderers.
-        if edge.requires_state_flags:
-            edge_attrs["color"] = '"orange"'
-            edge_attrs["penwidth"] = '"2"'
-        elif edge.grants and not edge.is_return:
-            edge_attrs["color"] = f'"{_GRANTS_COLOR}"'
-            edge_attrs["penwidth"] = '"2"'
-        edge_attr_str = " ".join(f"{k}={v}" for k, v in edge_attrs.items())
-        suffix = f" [{edge_attr_str}]" if edge_attr_str else ""
-        lines.append(f'  "{edge.from_id}" -> "{edge.to_id}"{suffix};')
-
-    lines.append("}")
-    return "\n".join(lines)
-
-
-def render_mermaid(sg: StoryGraph, *, no_labels: bool = False) -> str:
-    """Render a StoryGraph as Mermaid markup.
-
-    Args:
-        sg: Story graph data.
-        no_labels: If True, omit choice labels on edges.
-
-    Returns:
-        Mermaid format string.
-    """
-    lines = ["graph LR"]
-
-    # Node definitions
-    for node in sg.nodes:
-        safe_id = _mermaid_id(node.id)
-        label = _mermaid_escape(node.label)
-        if node.is_start:
-            cls = ":::startOverlay" if node.has_overlays else ":::start"
-            lines.append(f'  {safe_id}["{label}"]{cls}')
-        elif node.is_ending:
-            cls = ":::endingOverlay" if node.has_overlays else ":::ending"
-            lines.append(f'  {safe_id}["{label}"]{cls}')
-        elif node.is_hub:
-            lines.append(f"  {safe_id}{{{{{label}}}}}")
-            if node.has_overlays:
-                lines.append(f"  class {safe_id} overlay")
-        elif node.has_overlays:
-            lines.append(f'  {safe_id}["{label}"]:::overlay')
-        else:
-            lines.append(f'  {safe_id}["{label}"]')
-
-    lines.append("")
-
-    # Edges
-    for edge in sg.edges:
-        src = _mermaid_id(edge.from_id)
-        dst = _mermaid_id(edge.to_id)
-        arrow = "-.->" if edge.is_return else "-->"
-        if not no_labels and edge.label:
-            label = _mermaid_escape(edge.label)
-            lines.append(f'  {src} {arrow}|"{label}"| {dst}')
-        else:
-            lines.append(f"  {src} {arrow} {dst}")
-
-    # Style classes
-    lines.append("")
-    lines.append("  classDef start fill:#90EE90,stroke:#333")
-    lines.append("  classDef ending fill:#FFB6C1,stroke:#333")
-    lines.append(f"  classDef overlay stroke:{_OVERLAY_BORDER},stroke-width:3px")
-    lines.append(f"  classDef startOverlay fill:#90EE90,stroke:{_OVERLAY_BORDER},stroke-width:3px")
-    lines.append(f"  classDef endingOverlay fill:#FFB6C1,stroke:{_OVERLAY_BORDER},stroke-width:3px")
-    # Mermaid has limited edge styling; grants edges use linkStyle below
-    grants_indices = [
-        i
-        for i, e in enumerate(sg.edges)
-        if e.grants and not e.is_return and not e.requires_state_flags
-    ]
-    if grants_indices:
-        idx_list = ",".join(str(i) for i in grants_indices)
-        lines.append(f"  linkStyle {idx_list} stroke:{_GRANTS_COLOR},stroke-width:2px")
-
-    return "\n".join(lines)
-
-
-# ---------------------------------------------------------------------------
-# Helpers
-# ---------------------------------------------------------------------------
-
-
-def _truncate(text: str, max_len: int) -> str:
+def _truncate(text: str, max_len: int = 60) -> str:
     """Truncate text with ellipsis if too long."""
     if len(text) <= max_len:
         return text
     return text[: max_len - 3] + "..."
-
-
-def _assign_arc_colors(arc_names: dict[str, str]) -> dict[str, str]:
-    """Assign a color to each arc ID. Spine gets index 0."""
-    color_map: dict[str, str] = {}
-    branch_colors = _ARC_COLORS[1:]
-
-    branch_idx = 0
-    for arc_id, arc_type in sorted(arc_names.items()):
-        if arc_type == "spine":
-            color_map[arc_id] = _ARC_COLORS[0]
-        else:
-            if branch_colors:
-                color_map[arc_id] = branch_colors[branch_idx % len(branch_colors)]
-                branch_idx += 1
-            else:
-                color_map[arc_id] = _SHARED_COLOR
-    return color_map
-
-
-def _dot_node_attrs(node: VizNode, arc_color: dict[str, str]) -> dict[str, str]:
-    """Build DOT attribute dict for a node."""
-    attrs: dict[str, str] = {}
-
-    if node.is_start:
-        attrs["shape"] = "doubleoctagon"
-        attrs["fillcolor"] = f'"{_START_COLOR}"'
-    elif node.is_ending:
-        attrs["shape"] = "octagon"
-        attrs["fillcolor"] = f'"{_ENDING_COLOR}"'
-    elif node.is_hub:
-        attrs["shape"] = "diamond"
-        color = arc_color.get(node.arc_id or "", _SHARED_COLOR)
-        attrs["fillcolor"] = f'"{color}"'
-    else:
-        attrs["shape"] = "box"
-        color = arc_color.get(node.arc_id, _SHARED_COLOR) if node.arc_id else _SHARED_COLOR
-        attrs["fillcolor"] = f'"{color}"'
-
-    # Overlay passages get a thick orange-red border
-    if node.has_overlays:
-        attrs["color"] = f'"{_OVERLAY_BORDER}"'
-        attrs["penwidth"] = '"2.5"'
-
-    attrs["label"] = f'"{_dot_escape(node.label)}"'
-    return attrs
-
-
-def _dot_escape(text: str) -> str:
-    """Escape special characters for DOT labels."""
-    return text.replace('"', '\\"').replace("\n", "\\n")
-
-
-def _mermaid_id(node_id: str) -> str:
-    """Convert a node ID to a Mermaid-safe identifier."""
-    return node_id.replace("::", "_").replace(" ", "_").replace("-", "_")
-
-
-def _mermaid_escape(text: str) -> str:
-    """Escape special characters for Mermaid labels."""
-    return text.replace('"', "&quot;").replace("\n", " ")

--- a/tests/unit/test_visualization.py
+++ b/tests/unit/test_visualization.py
@@ -1,603 +1,232 @@
-"""Tests for story graph visualization module."""
+"""Tests for beat DAG visualization module."""
 
 from __future__ import annotations
 
 from questfoundry.graph.graph import Graph
-from questfoundry.visualization import (
-    build_story_graph,
-    render_dot,
-    render_mermaid,
-)
+from questfoundry.visualization import build_beat_dag
 
 
-def _make_simple_graph() -> Graph:
-    """Build a minimal graph with 3 passages, 2 choices, 1 arc."""
+def _make_y_shape_graph() -> Graph:
+    """Build a 2-dilemma graph with Y-shape structure.
+
+    Dilemma d1 (soft):
+      - shared_d1_01, shared_d1_02 (pre-commit, belongs_to path_a + path_b)
+      - d1_a_beat_01 (commit, belongs_to path_a only)
+      - d1_b_beat_01 (commit, belongs_to path_b only)
+
+    Dilemma d2 (hard):
+      - shared_d2_01 (pre-commit, belongs_to path_c + path_d)
+      - d2_a_beat_01 (commit, belongs_to path_c only)
+      - d2_b_beat_01 (commit, belongs_to path_d only)
+
+    Cross-dilemma chain: d1_a_beat_01 → shared_d2_01 (predecessor)
+
+    Passage grouping: shared_d1_01 + shared_d1_02 grouped into passage::p1
+
+    Intersection group: d1_a_beat_01 + d2_a_beat_01 in ig1
+    """
     graph = Graph.empty()
 
-    # Beats (arcs reference these in sequence)
-    graph.create_node("beat::intro", {"type": "beat", "summary": "intro"})
-    graph.create_node("beat::middle", {"type": "beat", "summary": "middle"})
-    graph.create_node("beat::ending", {"type": "beat", "summary": "ending"})
+    # Path nodes
+    graph.create_node("path::path_a", {"type": "path", "dilemma_id": "dilemma::d1"})
+    graph.create_node("path::path_b", {"type": "path", "dilemma_id": "dilemma::d1"})
+    graph.create_node("path::path_c", {"type": "path", "dilemma_id": "dilemma::d2"})
+    graph.create_node("path::path_d", {"type": "path", "dilemma_id": "dilemma::d2"})
 
-    # Passages
+    # Beat nodes — d1 shared (pre-commit)
     graph.create_node(
-        "passage::intro",
+        "beat::shared_d1_01",
         {
-            "type": "passage",
-            "raw_id": "intro",
-            "from_beat": "beat::intro",
-            "summary": "The story begins",
+            "type": "beat",
+            "summary": "The soft dilemma is introduced",
+            "dilemma_impacts": [{"dilemma_id": "dilemma::d1", "effect": "advances"}],
         },
     )
     graph.create_node(
-        "passage::middle",
+        "beat::shared_d1_02",
         {
-            "type": "passage",
-            "raw_id": "middle",
-            "from_beat": "beat::middle",
-            "summary": "A choice appears",
+            "type": "beat",
+            "summary": "Tension builds before the commitment",
+            "dilemma_impacts": [{"dilemma_id": "dilemma::d1", "effect": "advances"}],
+        },
+    )
+    # Beat nodes — d1 commit beats
+    graph.create_node(
+        "beat::d1_a_beat_01",
+        {
+            "type": "beat",
+            "summary": "Path A is chosen",
+            "dilemma_impacts": [{"dilemma_id": "dilemma::d1", "effect": "commits"}],
         },
     )
     graph.create_node(
-        "passage::ending",
+        "beat::d1_b_beat_01",
         {
-            "type": "passage",
-            "raw_id": "ending",
-            "from_beat": "beat::ending",
-            "summary": "The story ends",
+            "type": "beat",
+            "summary": "Path B is chosen",
+            "dilemma_impacts": [{"dilemma_id": "dilemma::d1", "effect": "commits"}],
         },
     )
 
-    # passage_from edges (passage -> beat)
-    graph.add_edge("passage_from", "passage::intro", "beat::intro")
-    graph.add_edge("passage_from", "passage::middle", "beat::middle")
-    graph.add_edge("passage_from", "passage::ending", "beat::ending")
+    # Beat nodes — d2 shared (pre-commit)
+    graph.create_node(
+        "beat::shared_d2_01",
+        {
+            "type": "beat",
+            "summary": "The hard dilemma appears",
+            "dilemma_impacts": [{"dilemma_id": "dilemma::d2", "effect": "advances"}],
+        },
+    )
+    # Beat nodes — d2 commit beats
+    graph.create_node(
+        "beat::d2_a_beat_01",
+        {
+            "type": "beat",
+            "summary": "Path C is chosen",
+            "dilemma_impacts": [{"dilemma_id": "dilemma::d2", "effect": "commits"}],
+        },
+    )
+    graph.create_node(
+        "beat::d2_b_beat_01",
+        {
+            "type": "beat",
+            "summary": "Path D is chosen",
+            "dilemma_impacts": [{"dilemma_id": "dilemma::d2", "effect": "commits"}],
+        },
+    )
 
-    # Choices
+    # Extra post-commit beats: d1 has 2 exclusive beats per path
     graph.create_node(
-        "choice::intro_middle",
+        "beat::d1_a_beat_02",
         {
-            "type": "choice",
-            "from_passage": "passage::intro",
-            "to_passage": "passage::middle",
-            "label": "Continue",
+            "type": "beat",
+            "summary": "Post-commit A epilogue",
+            "dilemma_impacts": [{"dilemma_id": "dilemma::d1", "effect": "advances"}],
         },
     )
     graph.create_node(
-        "choice::middle_ending",
+        "beat::d1_b_beat_02",
         {
-            "type": "choice",
-            "from_passage": "passage::middle",
-            "to_passage": "passage::ending",
-            "label": "End it",
+            "type": "beat",
+            "summary": "Post-commit B epilogue",
+            "dilemma_impacts": [{"dilemma_id": "dilemma::d1", "effect": "advances"}],
         },
     )
-    graph.add_edge("choice_from", "choice::intro_middle", "passage::intro")
-    graph.add_edge("choice_to", "choice::intro_middle", "passage::middle")
-    graph.add_edge("choice_from", "choice::middle_ending", "passage::middle")
-    graph.add_edge("choice_to", "choice::middle_ending", "passage::ending")
 
-    # Arc (spine)
+    # belongs_to edges: pre-commit beats belong to both paths
+    graph.add_edge("belongs_to", "beat::shared_d1_01", "path::path_a")
+    graph.add_edge("belongs_to", "beat::shared_d1_01", "path::path_b")
+    graph.add_edge("belongs_to", "beat::shared_d1_02", "path::path_a")
+    graph.add_edge("belongs_to", "beat::shared_d1_02", "path::path_b")
+    # commit beats — single belongs_to
+    graph.add_edge("belongs_to", "beat::d1_a_beat_01", "path::path_a")
+    graph.add_edge("belongs_to", "beat::d1_a_beat_02", "path::path_a")
+    graph.add_edge("belongs_to", "beat::d1_b_beat_01", "path::path_b")
+    graph.add_edge("belongs_to", "beat::d1_b_beat_02", "path::path_b")
+    # d2
+    graph.add_edge("belongs_to", "beat::shared_d2_01", "path::path_c")
+    graph.add_edge("belongs_to", "beat::shared_d2_01", "path::path_d")
+    graph.add_edge("belongs_to", "beat::d2_a_beat_01", "path::path_c")
+    graph.add_edge("belongs_to", "beat::d2_b_beat_01", "path::path_d")
+
+    # predecessor edges (from=child, to=parent — child comes after parent)
+    graph.add_edge("predecessor", "beat::shared_d1_02", "beat::shared_d1_01")
+    graph.add_edge("predecessor", "beat::d1_a_beat_01", "beat::shared_d1_02")
+    graph.add_edge("predecessor", "beat::d1_b_beat_01", "beat::shared_d1_02")
+    graph.add_edge("predecessor", "beat::d1_a_beat_02", "beat::d1_a_beat_01")
+    graph.add_edge("predecessor", "beat::d1_b_beat_02", "beat::d1_b_beat_01")
+    # cross-dilemma: d1_a_beat_01 → shared_d2_01 (d2 starts after d1 path A commits)
+    graph.add_edge("predecessor", "beat::shared_d2_01", "beat::d1_a_beat_01")
+    graph.add_edge("predecessor", "beat::d2_a_beat_01", "beat::shared_d2_01")
+    graph.add_edge("predecessor", "beat::d2_b_beat_01", "beat::shared_d2_01")
+    # d1_b post-commit to d2_b (another cross-dilemma path)
+    graph.add_edge("predecessor", "beat::d2_b_beat_01", "beat::d1_b_beat_01")
+
+    # Passage node + grouped_in edges
     graph.create_node(
-        "arc::spine",
-        {
-            "type": "arc",
-            "arc_type": "spine",
-            "paths": ["path::main"],
-            "sequence": ["beat::intro", "beat::middle", "beat::ending"],
-        },
+        "passage::p1",
+        {"type": "passage", "label": "Opening"},
     )
+    graph.add_edge("grouped_in", "beat::shared_d1_01", "passage::p1")
+    graph.add_edge("grouped_in", "beat::shared_d1_02", "passage::p1")
+
+    # Intersection group node + intersection edges
+    graph.create_node(
+        "intersection_group::ig1",
+        {"type": "intersection_group", "label": "Crossroads"},
+    )
+    graph.add_edge("intersection", "beat::d1_a_beat_01", "intersection_group::ig1")
+    graph.add_edge("intersection", "beat::d2_a_beat_01", "intersection_group::ig1")
 
     return graph
 
 
-def _make_branching_graph() -> Graph:
-    """Build a graph with spine + branch arc and a hub."""
-    graph = _make_simple_graph()
+class TestBuildBeatDag:
+    """Tests for build_beat_dag()."""
 
-    # Add a branch beat and passage
-    graph.create_node("beat::branch", {"type": "beat", "summary": "branch"})
-    graph.create_node(
-        "passage::branch",
-        {
-            "type": "passage",
-            "raw_id": "branch",
-            "from_beat": "beat::branch",
-            "summary": "A side path",
-        },
-    )
-    graph.add_edge("passage_from", "passage::branch", "beat::branch")
+    def test_extracts_all_beats(self) -> None:
+        graph = _make_y_shape_graph()
+        dag = build_beat_dag(graph)
+        assert len(dag.beats) == 9
 
-    # Branch arc
-    graph.create_node(
-        "arc::branch_1",
-        {
-            "type": "arc",
-            "arc_type": "branch",
-            "paths": ["path::alt"],
-            "sequence": ["beat::intro", "beat::branch", "beat::ending"],
-        },
-    )
+    def test_extracts_predecessor_edges(self) -> None:
+        graph = _make_y_shape_graph()
+        dag = build_beat_dag(graph)
+        assert len(dag.edges) == 9
+        edge_pairs = {(e.from_id, e.to_id) for e in dag.edges}
+        # Y-fork: shared_d1_02 → d1_a_beat_01 and shared_d1_02 → d1_b_beat_01
+        assert ("beat::shared_d1_02", "beat::d1_a_beat_01") in edge_pairs
+        assert ("beat::shared_d1_02", "beat::d1_b_beat_01") in edge_pairs
 
-    # Choice from intro to branch (branching point)
-    graph.create_node(
-        "choice::intro_branch",
-        {
-            "type": "choice",
-            "from_passage": "passage::intro",
-            "to_passage": "passage::branch",
-            "label": "Take the side path",
-        },
-    )
-    graph.add_edge("choice_from", "choice::intro_branch", "passage::intro")
-    graph.add_edge("choice_to", "choice::intro_branch", "passage::branch")
+    def test_detects_shared_beats(self) -> None:
+        graph = _make_y_shape_graph()
+        dag = build_beat_dag(graph)
+        beat_map = {b.id: b for b in dag.beats}
+        # shared_d1_01, shared_d1_02, shared_d2_01 have dual belongs_to
+        assert beat_map["beat::shared_d1_01"].is_shared is True
+        assert beat_map["beat::shared_d1_02"].is_shared is True
+        assert beat_map["beat::shared_d2_01"].is_shared is True
+        # commit beats are not shared
+        assert beat_map["beat::d1_a_beat_01"].is_shared is False
+        assert beat_map["beat::d1_b_beat_01"].is_shared is False
 
-    # Choice from branch back to ending (convergence)
-    graph.create_node(
-        "choice::branch_ending",
-        {
-            "type": "choice",
-            "from_passage": "passage::branch",
-            "to_passage": "passage::ending",
-            "label": "Rejoin the path",
-        },
-    )
-    graph.add_edge("choice_from", "choice::branch_ending", "passage::branch")
-    graph.add_edge("choice_to", "choice::branch_ending", "passage::ending")
+    def test_assigns_dilemma_colors(self) -> None:
+        graph = _make_y_shape_graph()
+        dag = build_beat_dag(graph)
+        # Both dilemmas present, colors assigned
+        assert "dilemma::d1" in dag.dilemma_colors
+        assert "dilemma::d2" in dag.dilemma_colors
+        # Colors must be different
+        assert dag.dilemma_colors["dilemma::d1"] != dag.dilemma_colors["dilemma::d2"]
 
-    return graph
+    def test_groups_beats_into_passages(self) -> None:
+        graph = _make_y_shape_graph()
+        dag = build_beat_dag(graph)
+        assert len(dag.passages) == 1
+        passage = dag.passages[0]
+        assert passage.id == "passage::p1"
+        assert set(passage.beat_ids) == {"beat::shared_d1_01", "beat::shared_d1_02"}
 
+    def test_detects_intersection_groups(self) -> None:
+        graph = _make_y_shape_graph()
+        dag = build_beat_dag(graph)
+        beat_map = {b.id: b for b in dag.beats}
+        assert beat_map["beat::d1_a_beat_01"].intersection_group == "intersection_group::ig1"
+        assert beat_map["beat::d2_a_beat_01"].intersection_group == "intersection_group::ig1"
 
-def _make_hub_graph() -> Graph:
-    """Build a graph with a hub-and-spoke pattern."""
-    graph = _make_simple_graph()
-
-    # Spoke passage
-    graph.create_node("beat::spoke", {"type": "beat", "summary": "spoke"})
-    graph.create_node(
-        "passage::spoke",
-        {
-            "type": "passage",
-            "raw_id": "spoke",
-            "from_beat": "beat::spoke",
-            "summary": "Explore an alcove",
-        },
-    )
-    graph.add_edge("passage_from", "passage::spoke", "beat::spoke")
-
-    # Choice: middle -> spoke
-    graph.create_node(
-        "choice::middle_spoke",
-        {
-            "type": "choice",
-            "from_passage": "passage::middle",
-            "to_passage": "passage::spoke",
-            "label": "Look around",
-        },
-    )
-    graph.add_edge("choice_from", "choice::middle_spoke", "passage::middle")
-    graph.add_edge("choice_to", "choice::middle_spoke", "passage::spoke")
-
-    # Return choice: spoke -> middle (is_return=True)
-    graph.create_node(
-        "choice::spoke_middle",
-        {
-            "type": "choice",
-            "from_passage": "passage::spoke",
-            "to_passage": "passage::middle",
-            "label": "Go back",
-            "is_return": True,
-        },
-    )
-    graph.add_edge("choice_from", "choice::spoke_middle", "passage::spoke")
-    graph.add_edge("choice_to", "choice::spoke_middle", "passage::middle")
-
-    return graph
-
-
-class TestBuildStoryGraph:
-    """Tests for build_story_graph()."""
-
-    def test_simple_graph_nodes(self) -> None:
-        graph = _make_simple_graph()
-        sg = build_story_graph(graph)
-        assert len(sg.nodes) == 3
-        ids = {n.id for n in sg.nodes}
-        assert ids == {"passage::intro", "passage::middle", "passage::ending"}
-
-    def test_simple_graph_edges(self) -> None:
-        graph = _make_simple_graph()
-        sg = build_story_graph(graph)
-        assert len(sg.edges) == 2
-        edge_pairs = {(e.from_id, e.to_id) for e in sg.edges}
-        assert ("passage::intro", "passage::middle") in edge_pairs
-        assert ("passage::middle", "passage::ending") in edge_pairs
-
-    def test_start_and_ending_detected(self) -> None:
-        graph = _make_simple_graph()
-        sg = build_story_graph(graph)
-        node_map = {n.id: n for n in sg.nodes}
-        assert node_map["passage::intro"].is_start is True
-        assert node_map["passage::intro"].is_ending is False
-        assert node_map["passage::ending"].is_ending is True
-        assert node_map["passage::ending"].is_start is False
-        assert node_map["passage::middle"].is_start is False
-        assert node_map["passage::middle"].is_ending is False
-
-    def test_arc_names_populated(self) -> None:
-        graph = _make_simple_graph()
-        sg = build_story_graph(graph)
-        assert "arc::spine" in sg.arc_names
-        assert sg.arc_names["arc::spine"] == "spine"
-
-    def test_arc_id_assigned_to_nodes(self) -> None:
-        graph = _make_simple_graph()
-        sg = build_story_graph(graph)
-        for node in sg.nodes:
-            assert node.arc_id == "arc::spine"
-
-    def test_spine_only_filters_branch_passages(self) -> None:
-        graph = _make_branching_graph()
-        sg = build_story_graph(graph, spine_only=True)
-        ids = {n.id for n in sg.nodes}
-        assert "passage::branch" not in ids
-        assert "passage::intro" in ids
-        assert "passage::middle" in ids
-
-    def test_branching_graph_has_both_arcs(self) -> None:
-        graph = _make_branching_graph()
-        sg = build_story_graph(graph)
-        assert len(sg.arc_names) == 2
-        assert "spine" in sg.arc_names.values()
-        assert "branch" in sg.arc_names.values()
-
-    def test_hub_detection(self) -> None:
-        graph = _make_hub_graph()
-        sg = build_story_graph(graph)
-        node_map = {n.id: n for n in sg.nodes}
-        assert node_map["passage::middle"].is_hub is True
-        assert node_map["passage::intro"].is_hub is False
-
-    def test_return_edge_marked(self) -> None:
-        graph = _make_hub_graph()
-        sg = build_story_graph(graph)
-        return_edges = [e for e in sg.edges if e.is_return]
-        assert len(return_edges) == 1
-        assert return_edges[0].from_id == "passage::spoke"
-        assert return_edges[0].to_id == "passage::middle"
+    def test_beat_effects_formatted(self) -> None:
+        graph = _make_y_shape_graph()
+        dag = build_beat_dag(graph)
+        beat_map = {b.id: b for b in dag.beats}
+        # advances d1 — stripped dilemma id
+        shared_beat = beat_map["beat::shared_d1_01"]
+        assert len(shared_beat.effects) == 1
+        assert shared_beat.effects[0] == "advances d1"
 
     def test_empty_graph(self) -> None:
         graph = Graph.empty()
-        sg = build_story_graph(graph)
-        assert sg.nodes == []
-        assert sg.edges == []
-        assert sg.arc_names == {}
-
-    def test_label_truncation(self) -> None:
-        graph = Graph.empty()
-        graph.create_node("beat::long", {"type": "beat", "summary": "long"})
-        graph.create_node(
-            "passage::long",
-            {
-                "type": "passage",
-                "raw_id": "long",
-                "from_beat": "beat::long",
-                "summary": "A" * 60,
-            },
-        )
-        graph.add_edge("passage_from", "passage::long", "beat::long")
-        sg = build_story_graph(graph)
-        assert len(sg.nodes) == 1
-        assert len(sg.nodes[0].label) <= 40
-        assert sg.nodes[0].label.endswith("...")
-
-
-class TestRenderDot:
-    """Tests for DOT output rendering."""
-
-    def test_dot_contains_digraph(self) -> None:
-        graph = _make_simple_graph()
-        sg = build_story_graph(graph)
-        dot = render_dot(sg)
-        assert dot.startswith("digraph story {")
-        assert dot.endswith("}")
-
-    def test_dot_contains_all_nodes(self) -> None:
-        graph = _make_simple_graph()
-        sg = build_story_graph(graph)
-        dot = render_dot(sg)
-        assert '"passage::intro"' in dot
-        assert '"passage::middle"' in dot
-        assert '"passage::ending"' in dot
-
-    def test_dot_contains_edges(self) -> None:
-        graph = _make_simple_graph()
-        sg = build_story_graph(graph)
-        dot = render_dot(sg)
-        assert '"passage::intro" -> "passage::middle"' in dot
-        assert '"passage::middle" -> "passage::ending"' in dot
-
-    def test_dot_edge_labels(self) -> None:
-        graph = _make_simple_graph()
-        sg = build_story_graph(graph)
-        dot = render_dot(sg)
-        assert 'label="Continue"' in dot
-        assert 'label="End it"' in dot
-
-    def test_dot_no_labels_flag(self) -> None:
-        graph = _make_simple_graph()
-        sg = build_story_graph(graph)
-        dot = render_dot(sg, no_labels=True)
-        # Edge lines should not have labels
-        edge_lines = [row for row in dot.split("\n") if "->" in row]
-        for row in edge_lines:
-            assert "label=" not in row
-
-    def test_dot_start_node_shape(self) -> None:
-        graph = _make_simple_graph()
-        sg = build_story_graph(graph)
-        dot = render_dot(sg)
-        intro_line = next(
-            row for row in dot.split("\n") if '"passage::intro"' in row and "->" not in row
-        )
-        assert "doubleoctagon" in intro_line
-
-    def test_dot_ending_node_shape(self) -> None:
-        graph = _make_simple_graph()
-        sg = build_story_graph(graph)
-        dot = render_dot(sg)
-        ending_line = next(
-            row for row in dot.split("\n") if '"passage::ending"' in row and "->" not in row
-        )
-        assert "octagon" in ending_line
-
-    def test_dot_return_edge_dashed(self) -> None:
-        graph = _make_hub_graph()
-        sg = build_story_graph(graph)
-        dot = render_dot(sg)
-        return_line = next(
-            row for row in dot.split("\n") if '"passage::spoke" -> "passage::middle"' in row
-        )
-        assert "dashed" in return_line
-
-
-class TestRenderMermaid:
-    """Tests for Mermaid output rendering."""
-
-    def test_mermaid_starts_with_graph(self) -> None:
-        graph = _make_simple_graph()
-        sg = build_story_graph(graph)
-        mmd = render_mermaid(sg)
-        assert mmd.startswith("graph LR")
-
-    def test_mermaid_contains_nodes(self) -> None:
-        graph = _make_simple_graph()
-        sg = build_story_graph(graph)
-        mmd = render_mermaid(sg)
-        assert "passage_intro" in mmd
-        assert "passage_middle" in mmd
-        assert "passage_ending" in mmd
-
-    def test_mermaid_contains_edges(self) -> None:
-        graph = _make_simple_graph()
-        sg = build_story_graph(graph)
-        mmd = render_mermaid(sg)
-        assert "passage_intro -->" in mmd
-        assert "passage_middle -->" in mmd
-
-    def test_mermaid_start_class(self) -> None:
-        graph = _make_simple_graph()
-        sg = build_story_graph(graph)
-        mmd = render_mermaid(sg)
-        assert ":::start" in mmd
-
-    def test_mermaid_ending_class(self) -> None:
-        graph = _make_simple_graph()
-        sg = build_story_graph(graph)
-        mmd = render_mermaid(sg)
-        assert ":::ending" in mmd
-
-    def test_mermaid_no_labels_flag(self) -> None:
-        graph = _make_simple_graph()
-        sg = build_story_graph(graph)
-        mmd = render_mermaid(sg, no_labels=True)
-        edge_lines = [row for row in mmd.split("\n") if "-->" in row]
-        for row in edge_lines:
-            assert '|"' not in row
-
-    def test_mermaid_hub_diamond(self) -> None:
-        graph = _make_hub_graph()
-        sg = build_story_graph(graph)
-        mmd = render_mermaid(sg)
-        middle_lines = [row for row in mmd.split("\n") if "passage_middle{" in row]
-        assert len(middle_lines) == 1
-
-    def test_mermaid_return_edge_dotted(self) -> None:
-        graph = _make_hub_graph()
-        sg = build_story_graph(graph)
-        mmd = render_mermaid(sg)
-        return_lines = [row for row in mmd.split("\n") if "passage_spoke" in row and "-.->" in row]
-        assert len(return_lines) == 1
-
-
-def _make_overlay_graph() -> Graph:
-    """Build a graph with overlay-affected entities on passages."""
-    graph = _make_simple_graph()
-
-    # Entity with overlays
-    graph.create_node(
-        "character::alice",
-        {
-            "type": "entity",
-            "entity_type": "character",
-            "name": "Alice",
-            "overlays": [{"state_flag": "saw_truth", "field": "mood", "value": "angry"}],
-        },
-    )
-
-    # Attach entity to intro passage
-    graph.update_node("passage::intro", entities=["character::alice"])
-
-    return graph
-
-
-def _make_grants_graph() -> Graph:
-    """Build a graph with a choice that grants state flags."""
-    graph = _make_simple_graph()
-
-    # Update existing choice to grant a state flag
-    graph.update_node("choice::intro_middle", grants=["saw_truth"])
-
-    return graph
-
-
-class TestOverlayPassages:
-    """Tests for overlay-affected passage detection."""
-
-    def test_overlay_passage_detected(self) -> None:
-        graph = _make_overlay_graph()
-        sg = build_story_graph(graph)
-        node_map = {n.id: n for n in sg.nodes}
-        assert node_map["passage::intro"].has_overlays is True
-
-    def test_non_overlay_passage_clean(self) -> None:
-        graph = _make_overlay_graph()
-        sg = build_story_graph(graph)
-        node_map = {n.id: n for n in sg.nodes}
-        assert node_map["passage::middle"].has_overlays is False
-        assert node_map["passage::ending"].has_overlays is False
-
-    def test_dot_overlay_border(self) -> None:
-        graph = _make_overlay_graph()
-        sg = build_story_graph(graph)
-        dot = render_dot(sg)
-        intro_line = next(
-            row for row in dot.split("\n") if '"passage::intro"' in row and "->" not in row
-        )
-        assert "#FF4500" in intro_line
-        assert "penwidth" in intro_line
-
-    def test_mermaid_overlay_class(self) -> None:
-        graph = _make_overlay_graph()
-        sg = build_story_graph(graph)
-        mmd = render_mermaid(sg)
-        # Start node with overlay gets startOverlay class
-        assert ":::startOverlay" in mmd
-        assert "classDef overlay" in mmd
-
-    def test_overlay_detected_via_raw_id(self) -> None:
-        """Passages referencing entities by raw ID (without prefix) are detected."""
-        graph = _make_simple_graph()
-        graph.create_node(
-            "character::bob",
-            {
-                "type": "entity",
-                "entity_type": "character",
-                "name": "Bob",
-                "overlays": [{"state_flag": "met_bob", "field": "mood", "value": "happy"}],
-            },
-        )
-        # Passage references entity by raw ID "bob" (not "character::bob")
-        graph.update_node("passage::middle", entities=["bob"])
-        sg = build_story_graph(graph)
-        node_map = {n.id: n for n in sg.nodes}
-        assert node_map["passage::middle"].has_overlays is True
-
-    def test_entities_none_does_not_crash(self) -> None:
-        """Passage with entities=None doesn't crash overlay detection."""
-        graph = _make_simple_graph()
-        graph.update_node("passage::intro", entities=None)
-        sg = build_story_graph(graph)
-        node_map = {n.id: n for n in sg.nodes}
-        assert node_map["passage::intro"].has_overlays is False
-
-
-class TestGrantsEdges:
-    """Tests for state-changing choice edges."""
-
-    def test_grants_field_populated(self) -> None:
-        graph = _make_grants_graph()
-        sg = build_story_graph(graph)
-        edge = next(e for e in sg.edges if e.from_id == "passage::intro")
-        assert edge.grants == ["saw_truth"]
-
-    def test_dot_grants_color(self) -> None:
-        graph = _make_grants_graph()
-        sg = build_story_graph(graph)
-        dot = render_dot(sg)
-        grants_line = next(
-            row for row in dot.split("\n") if '"passage::intro" -> "passage::middle"' in row
-        )
-        assert "#6A5ACD" in grants_line
-
-    def test_mermaid_grants_linkstyle(self) -> None:
-        graph = _make_grants_graph()
-        sg = build_story_graph(graph)
-        mmd = render_mermaid(sg)
-        assert "linkStyle" in mmd
-        assert "#6A5ACD" in mmd
-
-    def test_return_edge_with_grants_keeps_dashed_style(self) -> None:
-        """Return edges that also have grants keep grey dashed style, not grants color."""
-        graph = _make_hub_graph()
-        # Add grants to the return choice
-        graph.update_node("choice::spoke_middle", grants=["explored_alcove"])
-        sg = build_story_graph(graph)
-
-        # DOT: return edge should be dashed grey, not slate blue
-        dot = render_dot(sg)
-        return_line = next(
-            row for row in dot.split("\n") if '"passage::spoke" -> "passage::middle"' in row
-        )
-        assert "dashed" in return_line
-        assert "#6A5ACD" not in return_line
-
-        # Mermaid: grants linkStyle should exclude the return edge
-        mmd = render_mermaid(sg)
-        # The return edge should NOT appear in grants linkStyle
-        if "linkStyle" in mmd:
-            # If there are other grants edges they may produce linkStyle,
-            # but the return edge index should not be listed
-            return_idx = next(i for i, e in enumerate(sg.edges) if e.is_return)
-            link_line = next(row for row in mmd.split("\n") if "linkStyle" in row)
-            assert str(return_idx) not in link_line.split()
-
-    def test_requires_takes_precedence_over_grants(self) -> None:
-        """Edge with both requires and grants gets orange (requires) styling, not grants."""
-        graph = _make_simple_graph()
-        graph.update_node(
-            "choice::intro_middle",
-            requires_state_flags=["has_key"],
-            grants=["saw_truth"],
-        )
-        sg = build_story_graph(graph)
-        dot = render_dot(sg)
-        edge_line = next(
-            row for row in dot.split("\n") if '"passage::intro" -> "passage::middle"' in row
-        )
-        assert "orange" in edge_line
-        assert "#6A5ACD" not in edge_line
-
-
-class TestOutgoingCount:
-    """Tests for outgoing edge counting."""
-
-    def test_linear_passage_count(self) -> None:
-        graph = _make_simple_graph()
-        sg = build_story_graph(graph)
-        node_map = {n.id: n for n in sg.nodes}
-        assert node_map["passage::intro"].outgoing_count == 1
-        assert node_map["passage::middle"].outgoing_count == 1
-
-    def test_branching_passage_count(self) -> None:
-        graph = _make_branching_graph()
-        sg = build_story_graph(graph)
-        node_map = {n.id: n for n in sg.nodes}
-        # intro has 2 outgoing: middle + branch
-        assert node_map["passage::intro"].outgoing_count == 2
-
-    def test_ending_passage_zero_count(self) -> None:
-        graph = _make_simple_graph()
-        sg = build_story_graph(graph)
-        node_map = {n.id: n for n in sg.nodes}
-        assert node_map["passage::ending"].outgoing_count == 0
+        dag = build_beat_dag(graph)
+        assert dag.beats == []
+        assert dag.edges == []
+        assert dag.passages == []
+        assert dag.dilemma_colors == {}

--- a/tests/unit/test_visualization.py
+++ b/tests/unit/test_visualization.py
@@ -261,7 +261,7 @@ class TestRenderPlantUml:
         graph = _make_y_shape_graph()
         dag = build_beat_dag(graph)
         puml = render_plantuml(dag)
-        assert "p1" in puml
+        assert "Opening" in puml
         assert "collapse" in puml
 
     def test_dilemma_stereotypes_in_output(self) -> None:

--- a/tests/unit/test_visualization.py
+++ b/tests/unit/test_visualization.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from questfoundry.graph.graph import Graph
-from questfoundry.visualization import BeatDag, build_beat_dag, render_plantuml
+from questfoundry.visualization import BeatDag, BeatVizNode, build_beat_dag, render_plantuml
 
 
 def _make_y_shape_graph() -> Graph:
@@ -283,6 +283,25 @@ class TestRenderPlantUml:
         puml = render_plantuml(dag, no_labels=True)
         assert "advances" not in puml
         assert "commits" not in puml
+
+    def test_sanitizes_bracket_in_summary(self) -> None:
+        """Beat summary with ] must not break PlantUML component syntax."""
+        dag = BeatDag(
+            beats=[
+                BeatVizNode(
+                    id="beat::x",
+                    label="x",
+                    summary="The soldier [finally] retreats",
+                    dilemma_id=None,
+                )
+            ],
+            edges=[],
+            passages=[],
+            dilemma_colors={},
+        )
+        puml = render_plantuml(dag)
+        assert "[finally]" not in puml
+        assert "(finally)" in puml
 
     def test_empty_dag(self) -> None:
         dag = BeatDag(beats=[], edges=[], passages=[], dilemma_colors={})

--- a/tests/unit/test_visualization.py
+++ b/tests/unit/test_visualization.py
@@ -145,7 +145,7 @@ def _make_y_shape_graph() -> Graph:
     # Passage node + grouped_in edges
     graph.create_node(
         "passage::p1",
-        {"type": "passage", "label": "Opening"},
+        {"type": "passage", "label": "Opening", "grouping_type": "collapse"},
     )
     graph.add_edge("grouped_in", "beat::shared_d1_01", "passage::p1")
     graph.add_edge("grouped_in", "beat::shared_d1_02", "passage::p1")
@@ -254,7 +254,8 @@ class TestRenderPlantUml:
         graph = _make_y_shape_graph()
         dag = build_beat_dag(graph)
         puml = render_plantuml(dag)
-        assert "-->" in puml
+        # Specific arrow: shared_d1_01 (parent) --> shared_d1_02 (child)
+        assert "beat__shared_d1_01 --> beat__shared_d1_02" in puml
 
     def test_passage_container_rendered(self) -> None:
         graph = _make_y_shape_graph()

--- a/tests/unit/test_visualization.py
+++ b/tests/unit/test_visualization.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from questfoundry.graph.graph import Graph
-from questfoundry.visualization import build_beat_dag
+from questfoundry.visualization import BeatDag, build_beat_dag, render_plantuml
 
 
 def _make_y_shape_graph() -> Graph:
@@ -230,3 +230,61 @@ class TestBuildBeatDag:
         assert dag.edges == []
         assert dag.passages == []
         assert dag.dilemma_colors == {}
+
+
+class TestRenderPlantUml:
+    """Tests for render_plantuml()."""
+
+    def test_output_starts_with_startuml(self) -> None:
+        graph = _make_y_shape_graph()
+        dag = build_beat_dag(graph)
+        puml = render_plantuml(dag)
+        assert puml.startswith("@startuml")
+        assert puml.strip().endswith("@enduml")
+
+    def test_contains_beat_components(self) -> None:
+        graph = _make_y_shape_graph()
+        dag = build_beat_dag(graph)
+        puml = render_plantuml(dag)
+        assert "shared_d1_01" in puml
+        assert "d1_a_beat_01" in puml
+        assert "d2_b_beat_01" in puml
+
+    def test_contains_predecessor_arrows(self) -> None:
+        graph = _make_y_shape_graph()
+        dag = build_beat_dag(graph)
+        puml = render_plantuml(dag)
+        assert "-->" in puml
+
+    def test_passage_container_rendered(self) -> None:
+        graph = _make_y_shape_graph()
+        dag = build_beat_dag(graph)
+        puml = render_plantuml(dag)
+        assert "p1" in puml
+        assert "collapse" in puml
+
+    def test_dilemma_stereotypes_in_output(self) -> None:
+        graph = _make_y_shape_graph()
+        dag = build_beat_dag(graph)
+        puml = render_plantuml(dag)
+        assert "<<d1>>" in puml
+        assert "<<d2>>" in puml
+
+    def test_shared_beat_has_bold_border(self) -> None:
+        graph = _make_y_shape_graph()
+        dag = build_beat_dag(graph)
+        puml = render_plantuml(dag)
+        assert "#line.bold" in puml
+
+    def test_no_labels_omits_effects(self) -> None:
+        graph = _make_y_shape_graph()
+        dag = build_beat_dag(graph)
+        puml = render_plantuml(dag, no_labels=True)
+        assert "advances" not in puml
+        assert "commits" not in puml
+
+    def test_empty_dag(self) -> None:
+        dag = BeatDag(beats=[], edges=[], passages=[], dilemma_colors={})
+        puml = render_plantuml(dag)
+        assert "@startuml" in puml
+        assert "@enduml" in puml


### PR DESCRIPTION
## Summary

Replace the passage/choice graph visualization (`qf graph`) with a PlantUML component-diagram renderer that visualizes the beat DAG. The old DOT/Mermaid renderers operated on a passage/choice layer that currently has 0 choices — producing useless output. The beat DAG is where the actual Y-shape branching structure lives.

## What changed

**`src/questfoundry/visualization.py`** — complete replacement:
- Removed: `StoryGraph`, `VizNode`, `VizEdge`, `build_story_graph`, `render_dot`, `render_mermaid` and all helpers
- Added: `BeatDag`, `BeatVizNode`, `BeatVizEdge`, `PassageGroup` dataclasses
- Added: `build_beat_dag(graph)` — extracts beat nodes, predecessor edges, belongs_to membership, passage groups, intersection groups, dilemma colors
- Added: `render_plantuml(dag, *, no_labels=False)` — produces PlantUML component diagram
- Added: `_sanitize_puml()` — escapes `[]"` characters in labels to prevent PlantUML syntax breakage
- Added: `_puml_alias()` — regex-based ID sanitization for PlantUML aliases and stereotypes

**`src/questfoundry/cli.py`** — `qf graph` command:
- PlantUML output only (removed `--format` parameter and `_GraphFormat` enum)
- Removed `--spine-only` (tracked in #1252)
- `--no-labels` omits effect tags from beat boxes

**`tests/unit/test_visualization.py`** — complete replacement: 17 tests

## Deferred features

- #1252 — re-add `--spine-only` flag
- #1253 — re-add DOT/Mermaid/JSON formats

## Test plan

- [x] 17/17 visualization tests pass (including `]` escaping regression test)
- [x] `uv run qf graph --help` shows updated options
- [x] Real project output verified (test-new4: 562-line .puml, 68 beats, 264 arrows)
- [x] Pre-commit, ruff, mypy clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)