### PR TITLE
fix(polish): detect Y-shape divergence from path membership, not effect=commits (#1254)

### DIFF
--- a/src/questfoundry/pipeline/stages/polish/deterministic.py
+++ b/src/questfoundry/pipeline/stages/polish/deterministic.py
@@ -723,22 +723,28 @@ def compute_choice_edges(
                 if did:
                     committing_dilemmas.add(normalize_scoped_id(did, "dilemma"))
 
-        # Case B (Y-shape): beat has dual belongs_to (pre-commit, multi-path)
-        # and its children are single-membership commit beats. Derive the
-        # dilemma from the children's commit impacts rather than from this beat.
+        # Case B (Y-shape, #1254): A shared pre-commit beat whose immediate
+        # children include single-path beats from the same dilemma on different
+        # paths.  The commit beat may be deeper in the chain (e.g., beat_01 is
+        # advances, beat_02 is commits), so we detect divergence from *path
+        # membership* rather than effect=commits.
         if not committing_dilemmas:
             own_paths = beat_to_paths_ce.get(bid, frozenset())
             if len(own_paths) >= 2:
-                # Collect dilemmas that children commit to
-                child_committing_dilemmas: set[str] = set()
-                for cid in child_ids:
-                    cdata = beat_nodes.get(cid, {})
-                    for impact in cdata.get("dilemma_impacts", []):
-                        if impact.get("effect") == "commits":
-                            cdid = impact.get("dilemma_id", "")
-                            if cdid:
-                                child_committing_dilemmas.add(normalize_scoped_id(cdid, "dilemma"))
-                committing_dilemmas = child_committing_dilemmas
+                # Identify this beat's dilemma
+                own_dilemmas = {path_to_dilemma[p] for p in own_paths if p in path_to_dilemma}
+                if len(own_dilemmas) == 1:
+                    own_dilemma = next(iter(own_dilemmas))
+                    # Find immediate children that are single-path and same-dilemma
+                    same_dilemma_child_paths: dict[str, list[str]] = {}
+                    for cid in child_ids:
+                        cpaths = beat_to_paths_ce.get(cid, frozenset())
+                        if len(cpaths) == 1:
+                            cpath = next(iter(cpaths))
+                            if path_to_dilemma.get(cpath) == own_dilemma:
+                                same_dilemma_child_paths.setdefault(cpath, []).append(cid)
+                    if len(same_dilemma_child_paths) >= 2:
+                        committing_dilemmas = {own_dilemma}
 
         if not committing_dilemmas:
             continue
@@ -766,15 +772,32 @@ def compute_choice_edges(
                 if not to_passage or to_passage == from_passage:
                     continue
 
-                # Compute grants: state flags activated by taking this path
+                # Compute grants: state flags activated by taking this path.
+                # The commits beat may not be the immediate child (Y-shape:
+                # advances → commits → aftermath).  Walk forward from each
+                # path child to find the first commits beat in the chain.
                 grants: list[str] = []
-                for cid in path_children:
+                visited_for_grants: set[str] = set()
+                search_queue = list(path_children)
+                while search_queue:
+                    cid = search_queue.pop(0)
+                    if cid in visited_for_grants:
+                        continue
+                    visited_for_grants.add(cid)
                     cdata = beat_nodes.get(cid, {})
+                    found_commit = False
                     for impact in cdata.get("dilemma_impacts", []):
                         if impact.get("effect") == "commits":
                             grant_did = impact.get("dilemma_id", "")
                             if grant_did and path_id:
                                 grants.append(f"{grant_did}:{path_id}")
+                            found_commit = True
+                    # Stop walking once we find a commits beat; otherwise
+                    # continue to children that are on the same single path.
+                    if not found_commit:
+                        for next_cid in children.get(cid, []):
+                            if beat_to_paths_ce.get(next_cid, frozenset()) == frozenset({path_id}):
+                                search_queue.append(next_cid)
 
                 # Compute requires: for choices from intersection passages,
                 # populate the required state flags for the target passage.

--- a/tests/unit/test_polish_deterministic.py
+++ b/tests/unit/test_polish_deterministic.py
@@ -969,6 +969,210 @@ class TestChoiceEdgesMultiDilemma:
         )
 
 
+class TestChoiceEdgesYShapeAdvancesChild:
+    """Tests for #1254: Y-shape where commit beat is NOT the immediate child.
+
+    SEED produces: shared_02 → beat_01 (advances) → beat_02 (commits) → beat_03
+    The fork is at shared_02, but the commits effect is on beat_02 (grandchild).
+    compute_choice_edges must detect the fork from path membership and walk
+    deeper for grants.
+    """
+
+    def test_y_shape_with_advances_child_produces_choices(self) -> None:
+        """Shared beat → advances child → commits grandchild must still produce choices."""
+        graph = Graph.empty()
+
+        graph.create_node("path::d1_a", {"type": "path", "raw_id": "d1_a"})
+        graph.create_node("path::d1_b", {"type": "path", "raw_id": "d1_b"})
+        _setup_dilemma(graph, "dilemma::d1", ["path::d1_a", "path::d1_b"])
+
+        # Shared pre-commit beat (dual belongs_to)
+        graph.create_node(
+            "beat::shared_02",
+            {
+                "type": "beat",
+                "raw_id": "shared_02",
+                "summary": "Last shared",
+                "dilemma_impacts": [{"dilemma_id": "dilemma::d1", "effect": "reveals"}],
+            },
+        )
+        _add_belongs_to(graph, "beat::shared_02", "path::d1_a")
+        _add_belongs_to(graph, "beat::shared_02", "path::d1_b")
+
+        # First exclusive beats — advances, NOT commits
+        graph.create_node(
+            "beat::d1_a_01",
+            {
+                "type": "beat",
+                "raw_id": "d1_a_01",
+                "summary": "Path A setup",
+                "dilemma_impacts": [{"dilemma_id": "dilemma::d1", "effect": "advances"}],
+            },
+        )
+        _add_belongs_to(graph, "beat::d1_a_01", "path::d1_a")
+        graph.create_node(
+            "beat::d1_b_01",
+            {
+                "type": "beat",
+                "raw_id": "d1_b_01",
+                "summary": "Path B setup",
+                "dilemma_impacts": [{"dilemma_id": "dilemma::d1", "effect": "advances"}],
+            },
+        )
+        _add_belongs_to(graph, "beat::d1_b_01", "path::d1_b")
+
+        # Commit beats — deeper in the chain
+        graph.create_node(
+            "beat::d1_a_02",
+            {
+                "type": "beat",
+                "raw_id": "d1_a_02",
+                "summary": "Path A commits",
+                "dilemma_impacts": [{"dilemma_id": "dilemma::d1", "effect": "commits"}],
+            },
+        )
+        _add_belongs_to(graph, "beat::d1_a_02", "path::d1_a")
+        graph.create_node(
+            "beat::d1_b_02",
+            {
+                "type": "beat",
+                "raw_id": "d1_b_02",
+                "summary": "Path B commits",
+                "dilemma_impacts": [{"dilemma_id": "dilemma::d1", "effect": "commits"}],
+            },
+        )
+        _add_belongs_to(graph, "beat::d1_b_02", "path::d1_b")
+
+        # Predecessor chain: shared_02 → a_01 → a_02, shared_02 → b_01 → b_02
+        graph.add_edge("predecessor", "beat::d1_a_01", "beat::shared_02")
+        graph.add_edge("predecessor", "beat::d1_b_01", "beat::shared_02")
+        graph.add_edge("predecessor", "beat::d1_a_02", "beat::d1_a_01")
+        graph.add_edge("predecessor", "beat::d1_b_02", "beat::d1_b_01")
+
+        # Passages: shared_02 in its own, each path beat in its own
+        specs = [
+            PassageSpec(
+                passage_id="passage::shared", beat_ids=["beat::shared_02"], grouping_type="single"
+            ),
+            PassageSpec(
+                passage_id="passage::a_setup", beat_ids=["beat::d1_a_01"], grouping_type="single"
+            ),
+            PassageSpec(
+                passage_id="passage::b_setup", beat_ids=["beat::d1_b_01"], grouping_type="single"
+            ),
+            PassageSpec(
+                passage_id="passage::a_commit", beat_ids=["beat::d1_a_02"], grouping_type="single"
+            ),
+            PassageSpec(
+                passage_id="passage::b_commit", beat_ids=["beat::d1_b_02"], grouping_type="single"
+            ),
+        ]
+
+        choices = compute_choice_edges(graph, specs)
+
+        # Should produce 2 choices: shared → a_setup, shared → b_setup
+        assert len(choices) == 2, (
+            f"Expected 2 choices, got {len(choices)}: "
+            f"{[(c.from_passage, c.to_passage) for c in choices]}"
+        )
+        to_passages = {c.to_passage for c in choices}
+        assert "passage::a_setup" in to_passages
+        assert "passage::b_setup" in to_passages
+        # All choices should originate from the shared passage
+        assert all(c.from_passage == "passage::shared" for c in choices)
+
+    def test_grants_found_via_deep_walk(self) -> None:
+        """Grants should be populated even when commits beat is a grandchild."""
+        graph = Graph.empty()
+
+        graph.create_node("path::d1_a", {"type": "path", "raw_id": "d1_a"})
+        graph.create_node("path::d1_b", {"type": "path", "raw_id": "d1_b"})
+        _setup_dilemma(graph, "dilemma::d1", ["path::d1_a", "path::d1_b"])
+
+        graph.create_node(
+            "beat::shared",
+            {
+                "type": "beat",
+                "raw_id": "shared",
+                "summary": "Shared",
+                "dilemma_impacts": [{"dilemma_id": "dilemma::d1", "effect": "reveals"}],
+            },
+        )
+        _add_belongs_to(graph, "beat::shared", "path::d1_a")
+        _add_belongs_to(graph, "beat::shared", "path::d1_b")
+
+        graph.create_node(
+            "beat::a_01",
+            {
+                "type": "beat",
+                "raw_id": "a_01",
+                "summary": "A advances",
+                "dilemma_impacts": [{"dilemma_id": "dilemma::d1", "effect": "advances"}],
+            },
+        )
+        _add_belongs_to(graph, "beat::a_01", "path::d1_a")
+        graph.create_node(
+            "beat::a_02",
+            {
+                "type": "beat",
+                "raw_id": "a_02",
+                "summary": "A commits",
+                "dilemma_impacts": [{"dilemma_id": "dilemma::d1", "effect": "commits"}],
+            },
+        )
+        _add_belongs_to(graph, "beat::a_02", "path::d1_a")
+
+        graph.create_node(
+            "beat::b_01",
+            {
+                "type": "beat",
+                "raw_id": "b_01",
+                "summary": "B advances",
+                "dilemma_impacts": [{"dilemma_id": "dilemma::d1", "effect": "advances"}],
+            },
+        )
+        _add_belongs_to(graph, "beat::b_01", "path::d1_b")
+        graph.create_node(
+            "beat::b_02",
+            {
+                "type": "beat",
+                "raw_id": "b_02",
+                "summary": "B commits",
+                "dilemma_impacts": [{"dilemma_id": "dilemma::d1", "effect": "commits"}],
+            },
+        )
+        _add_belongs_to(graph, "beat::b_02", "path::d1_b")
+
+        graph.add_edge("predecessor", "beat::a_01", "beat::shared")
+        graph.add_edge("predecessor", "beat::b_01", "beat::shared")
+        graph.add_edge("predecessor", "beat::a_02", "beat::a_01")
+        graph.add_edge("predecessor", "beat::b_02", "beat::b_01")
+
+        specs = [
+            PassageSpec(
+                passage_id="passage::shared", beat_ids=["beat::shared"], grouping_type="single"
+            ),
+            PassageSpec(passage_id="passage::a", beat_ids=["beat::a_01"], grouping_type="single"),
+            PassageSpec(passage_id="passage::b", beat_ids=["beat::b_01"], grouping_type="single"),
+            PassageSpec(
+                passage_id="passage::a_commit", beat_ids=["beat::a_02"], grouping_type="single"
+            ),
+            PassageSpec(
+                passage_id="passage::b_commit", beat_ids=["beat::b_02"], grouping_type="single"
+            ),
+        ]
+
+        choices = compute_choice_edges(graph, specs)
+
+        assert len(choices) == 2
+        # Each choice should have grants from the commits beat downstream
+        for choice in choices:
+            assert len(choice.grants) > 0, (
+                f"Choice {choice.from_passage}→{choice.to_passage} has no grants; "
+                f"commits beat should have been found via deep walk"
+            )
+
+
 class TestFindFalseBranchCandidates:
     """Tests for Phase 4d: false branch identification."""
 


### PR DESCRIPTION
## Summary

`compute_choice_edges` Case B assumed the shared beat's immediate children carry `effect=commits`. The actual Y-shape pattern puts an `advances` beat between the shared fork and the commit: `shared_02 (reveals) → beat_01 (advances) → beat_02 (commits)`. Case B found 0 commit children on every Y-shape fork, producing 0 choices. Closes #1254.

## What changed

**`src/questfoundry/pipeline/stages/polish/deterministic.py`**:

**Case B detection** (lines ~726-760): Instead of checking children for `effect=commits`, detect divergence from path membership:
- Shared beat has dual `belongs_to` (same dilemma)
- Immediate children include single-path beats from the same dilemma on different paths → divergence

**Grants computation** (lines ~770-795): Walk forward from each path child through same-path successors until finding the first `commits` beat, instead of only checking the immediate child. Stops walking once a commits beat is found.

## Why this is correct

Verified on test-new4: all 8 `shared_setup_*_02` beats have exactly 2 same-dilemma single-path children with 0 cross-dilemma noise. The path-membership approach correctly identifies these as forks while ignoring cross-dilemma interleave edges (which create children on other dilemmas' paths).

## Test plan

- [x] `TestChoiceEdgesYShapeAdvancesChild::test_y_shape_with_advances_child_produces_choices` — shared → advances child → commits grandchild produces 2 choices
- [x] `TestChoiceEdgesYShapeAdvancesChild::test_grants_found_via_deep_walk` — grants populated from commits beat found via forward walk
- [x] 65/65 POLISH deterministic tests pass (no regressions on existing 13 choice tests)
- [x] Pre-commit, ruff, mypy clean
- [ ] **Empirical**: re-run `qf polish` on test-new4 and verify `phase4c_complete: choices > 0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)