### PR TITLE
fix: compute_active_flags_at_beat returns state_flag node IDs via grants edges (#1256)

### DIFF
--- a/src/questfoundry/graph/algorithms.py
+++ b/src/questfoundry/graph/algorithms.py
@@ -120,6 +120,13 @@ def compute_active_flags_at_beat(graph: Graph, beat_id: str) -> set[frozenset[st
                     dilemma_id=dilemma_id,
                 )
                 continue
+            if len(flag_ids) > 1:
+                log.warning(
+                    "commit_beat_multiple_grants",
+                    beat_id=candidate_id,
+                    dilemma_id=dilemma_id,
+                    flag_ids=flag_ids,
+                )
             for flag_id in flag_ids:
                 dilemma_flags.setdefault(dilemma_id, []).append(flag_id)
 

--- a/src/questfoundry/graph/algorithms.py
+++ b/src/questfoundry/graph/algorithms.py
@@ -24,20 +24,22 @@ def compute_active_flags_at_beat(graph: Graph, beat_id: str) -> set[frozenset[st
     """Compute all valid state flag combinations at a beat position.
 
     Returns a set of frozensets, where each frozenset is one possible
-    combination of active state flags at this beat's position in the DAG.
+    combination of active ``state_flag::*`` node IDs at this beat's
+    position in the DAG.
 
-    A "state flag" here is a string identifier derived from a commit beat's
-    dilemma/path membership. When a player reaches beat B, they have
-    necessarily traversed some subset of commit beats. This function
-    computes all valid subsets respecting mutual exclusivity (cannot
-    have committed to both paths of the same dilemma).
+    When a player reaches beat B, they have necessarily traversed some
+    subset of commit beats. Each commit beat has ``grants`` edges to
+    ``state_flag::*`` nodes. This function resolves those real node IDs
+    (not synthetic dilemma:path strings) so that downstream consumers
+    (prose feasibility, overlays) can cross-reference against entity
+    overlay ``when`` fields, which also use ``state_flag::*`` IDs.
 
     Algorithm:
         1. Build predecessor adjacency and reverse-BFS from beat_id
            to find all ancestor beats (including beat_id itself).
         2. Filter ancestors to commit beats (effect="commits").
-        3. Group commit beats by dilemma, using belongs_to path as flag.
-        4. Compute Cartesian product of per-dilemma flag options.
+        3. Resolve each commit beat's ``grants`` edges to state_flag node IDs.
+        4. Group by dilemma and compute Cartesian product (mutual exclusivity).
 
     Args:
         graph: Graph containing beat DAG with predecessor edges.
@@ -78,26 +80,26 @@ def compute_active_flags_at_beat(graph: Graph, beat_id: str) -> set[frozenset[st
         ancestors.add(current)
         queue.extend(parents.get(current, []))
 
-    # Step 3: Find commit beats among ancestors and group by dilemma
-    # A commit beat has dilemma_impacts with effect="commits"
-    # Y-shape (Story Graph Ontology §8): pre-commit beats have two belongs_to edges (same
-    # dilemma, both paths); post-commit beats have exactly one. A beat's
-    # state-flag contribution depends on which path the player is on, not on
-    # which belongs_to edge we happen to read first.
-    belongs_to_edges = graph.get_edges(edge_type="belongs_to")
-    _accum: dict[str, set[str]] = {}
-    for edge in belongs_to_edges:
-        from_id = edge["from"]
-        if from_id in beat_nodes:
-            _accum.setdefault(from_id, set()).add(edge["to"])
-    beat_to_paths: dict[str, frozenset[str]] = {
-        bid: frozenset(paths) for bid, paths in _accum.items()
-    }
+    # Step 3: Find commit beats among ancestors and resolve their state flags.
+    #
+    # Each commit beat has a ``grants`` edge to a ``state_flag::*`` node.
+    # We use those real node IDs (not synthetic dilemma:path strings) so that
+    # downstream consumers (prose feasibility, overlays) can cross-reference
+    # state flags against entity overlay ``when`` fields, which also use
+    # ``state_flag::*`` IDs.
+    #
+    # Group by dilemma so the Cartesian product respects mutual exclusivity:
+    # a player can only be on one path per dilemma.
+
+    # Build beat → grants targets (state flag IDs) from grants edges.
+    beat_grants: dict[str, list[str]] = {}
+    for edge in graph.get_edges(edge_type="grants"):
+        beat_grants.setdefault(edge["from"], []).append(edge["to"])
 
     # Include beat_id itself as a candidate (it may be a commit beat)
     candidates = ancestors | {beat_id}
 
-    # dilemma_id → list of state flag identifiers from different paths
+    # dilemma_id → list of state_flag node IDs (one per path of that dilemma)
     dilemma_flags: dict[str, list[str]] = {}
 
     for candidate_id in candidates:
@@ -109,22 +111,10 @@ def compute_active_flags_at_beat(graph: Graph, beat_id: str) -> set[frozenset[st
             dilemma_id = impact.get("dilemma_id", "")
             if not dilemma_id:
                 continue
-            # Commit beats are single-membership (guard rail 2), so
-            # beat_to_paths[candidate] has exactly one element. If code
-            # elsewhere produces a multi-membership commit beat, that is a
-            # guard-rail violation and we raise instead of guessing.
-            paths = beat_to_paths.get(candidate_id, frozenset())
-            if len(paths) == 0:
-                continue
-            if len(paths) > 1:
-                msg = (
-                    f"commit beat {candidate_id!r} has multiple belongs_to edges "
-                    f"(guard rail 2 violation): {sorted(paths)!r}"
-                )
-                raise ValueError(msg)
-            (path_id,) = paths
-            flag = f"{dilemma_id}:{path_id}"
-            dilemma_flags.setdefault(dilemma_id, []).append(flag)
+            # Resolve to actual state_flag node IDs via grants edges.
+            flag_ids = beat_grants.get(candidate_id, [])
+            for flag_id in flag_ids:
+                dilemma_flags.setdefault(dilemma_id, []).append(flag_id)
 
     if not dilemma_flags:
         return {frozenset()}

--- a/src/questfoundry/graph/algorithms.py
+++ b/src/questfoundry/graph/algorithms.py
@@ -113,6 +113,13 @@ def compute_active_flags_at_beat(graph: Graph, beat_id: str) -> set[frozenset[st
                 continue
             # Resolve to actual state_flag node IDs via grants edges.
             flag_ids = beat_grants.get(candidate_id, [])
+            if not flag_ids:
+                log.warning(
+                    "commit_beat_no_grants",
+                    beat_id=candidate_id,
+                    dilemma_id=dilemma_id,
+                )
+                continue
             for flag_id in flag_ids:
                 dilemma_flags.setdefault(dilemma_id, []).append(flag_id)
 

--- a/src/questfoundry/pipeline/stages/polish/deterministic.py
+++ b/src/questfoundry/pipeline/stages/polish/deterministic.py
@@ -383,6 +383,16 @@ def compute_prose_feasibility(
     for did, ddata in dilemma_nodes.items():
         dilemma_residue[did] = ddata.get("residue_weight", "light")
 
+    # Build state_flag → dilemma mapping so that state_flag node IDs (the new
+    # format returned by compute_active_flags_at_beat) can be resolved to their
+    # dilemma for residue-weight lookup.
+    state_flag_nodes = graph.get_nodes_by_type("state_flag")
+    flag_to_dilemma: dict[str, str] = {}
+    for sf_id, sf_data in state_flag_nodes.items():
+        did = sf_data.get("dilemma_id", "")
+        if did:
+            flag_to_dilemma[sf_id] = did
+
     variant_counter = 0
 
     for spec in specs:
@@ -438,11 +448,10 @@ def compute_prose_feasibility(
         heavy_flags: list[str] = []
         light_flags: list[str] = []
         for flag in relevant_flags:
-            # Flag format: "{dilemma_id}:{path_id}" e.g. "dilemma::d1:path::brave"
-            # Extract dilemma_id: find the colon that separates dilemma from path.
-            # Both parts use "::" internally, so the separator is the ":" right
-            # before "path::" (or the first ":" if the old short format is used).
-            dilemma_id = _parse_flag_dilemma_id(flag)
+            # Resolve dilemma ID from either a state_flag node ID (new format,
+            # returned by compute_active_flags_at_beat) or the legacy synthetic
+            # "{dilemma_id}:path::{path_raw}" string (old format).
+            dilemma_id = flag_to_dilemma.get(flag) or _parse_flag_dilemma_id(flag)
             weight = dilemma_residue.get(dilemma_id, "light")
             if weight in ("heavy", "hard"):
                 heavy_flags.append(flag)
@@ -636,6 +645,7 @@ def compute_choice_edges(
     """
     beat_nodes = graph.get_nodes_by_type("beat")
     predecessor_edges = graph.get_edges(edge_type="predecessor")
+    grants_edges = graph.get_edges(edge_type="grants")
 
     # Build adjacency
     children: dict[str, list[str]] = {bid: [] for bid in beat_nodes}
@@ -772,10 +782,9 @@ def compute_choice_edges(
                 if not to_passage or to_passage == from_passage:
                     continue
 
-                # Compute grants: state flags activated by taking this path.
-                # The commits beat may not be the immediate child (Y-shape:
-                # advances → commits → aftermath).  Walk forward from each
-                # path child to find the first commits beat in the chain.
+                # Compute grants: state flag node IDs activated by taking this path.
+                # Walk forward from each path child to find the first commits
+                # beat, then resolve its ``grants`` edges to state_flag nodes.
                 grants: list[str] = []
                 visited_for_grants: set[str] = set()
                 search_queue = list(path_children)
@@ -785,16 +794,16 @@ def compute_choice_edges(
                         continue
                     visited_for_grants.add(cid)
                     cdata = beat_nodes.get(cid, {})
-                    found_commit = False
-                    for impact in cdata.get("dilemma_impacts", []):
-                        if impact.get("effect") == "commits":
-                            grant_did = impact.get("dilemma_id", "")
-                            if grant_did and path_id:
-                                grants.append(f"{grant_did}:{path_id}")
-                            found_commit = True
-                    # Stop walking once we find a commits beat; otherwise
-                    # continue to children that are on the same single path.
-                    if not found_commit:
+                    found_commit = any(
+                        imp.get("effect") == "commits" for imp in cdata.get("dilemma_impacts", [])
+                    )
+                    if found_commit:
+                        # Resolve via grants edges to state_flag node IDs
+                        for ge in grants_edges:
+                            if ge["from"] == cid:
+                                grants.append(ge["to"])
+                    else:
+                        # Continue to children on the same single path
                         for next_cid in children.get(cid, []):
                             if beat_to_paths_ce.get(next_cid, frozenset()) == frozenset({path_id}):
                                 search_queue.append(next_cid)

--- a/src/questfoundry/pipeline/stages/polish/deterministic.py
+++ b/src/questfoundry/pipeline/stages/polish/deterministic.py
@@ -645,7 +645,6 @@ def compute_choice_edges(
     """
     beat_nodes = graph.get_nodes_by_type("beat")
     predecessor_edges = graph.get_edges(edge_type="predecessor")
-    grants_edges = graph.get_edges(edge_type="grants")
 
     # Build adjacency
     children: dict[str, list[str]] = {bid: [] for bid in beat_nodes}
@@ -654,6 +653,11 @@ def compute_choice_edges(
         to_id = edge["to"]
         if from_id in beat_nodes and to_id in beat_nodes:
             children[to_id].append(from_id)
+
+    # Build beat → grants targets index (state_flag node IDs)
+    beat_grants: dict[str, list[str]] = {}
+    for edge in graph.get_edges(edge_type="grants"):
+        beat_grants.setdefault(edge["from"], []).append(edge["to"])
 
     # Build beat → path-set mapping (Y-shape: pre-commit beats have dual membership)
     belongs_to_edges = graph.get_edges(edge_type="belongs_to")
@@ -798,10 +802,9 @@ def compute_choice_edges(
                         imp.get("effect") == "commits" for imp in cdata.get("dilemma_impacts", [])
                     )
                     if found_commit:
-                        # Resolve via grants edges to state_flag node IDs
-                        for ge in grants_edges:
-                            if ge["from"] == cid:
-                                grants.append(ge["to"])
+                        # Resolve via grants edge index to state_flag node IDs
+                        for sf_id in beat_grants.get(cid, []):
+                            grants.append(sf_id)
                     else:
                         # Continue to children on the same single path
                         for next_cid in children.get(cid, []):

--- a/tests/integration/test_y_shape_end_to_end.py
+++ b/tests/integration/test_y_shape_end_to_end.py
@@ -227,12 +227,41 @@ def _add_predecessor_edges(graph: Graph) -> None:
 # ---------------------------------------------------------------------------
 
 
+def _add_state_flags(graph: Graph) -> None:
+    """Add state_flag nodes + grants edges matching what GROW would produce.
+
+    The e2e fixture skips GROW, so state_flags (which GROW derives from
+    consequences) must be added manually for POLISH to populate grants
+    on choice edges.
+    """
+    graph.create_node(
+        "state_flag::protector_committed",
+        {
+            "type": "state_flag",
+            "raw_id": "protector_committed",
+            "dilemma_id": "dilemma::trust_protector_or_manipulator",
+        },
+    )
+    graph.add_edge("grants", "beat::commit_protector", "state_flag::protector_committed")
+
+    graph.create_node(
+        "state_flag::manipulator_committed",
+        {
+            "type": "state_flag",
+            "raw_id": "manipulator_committed",
+            "dilemma_id": "dilemma::trust_protector_or_manipulator",
+        },
+    )
+    graph.add_edge("grants", "beat::commit_manipulator", "state_flag::manipulator_committed")
+
+
 @pytest.fixture
 def y_shape_graph() -> Graph:
     """Graph after apply_seed_mutations + predecessor edges — no LLM required."""
     graph = _make_brainstorm_graph()
     apply_seed_mutations(graph, _make_seed_output())
     _add_predecessor_edges(graph)
+    _add_state_flags(graph)
     return graph
 
 
@@ -327,6 +356,6 @@ def test_polish_produces_two_choice_specs_for_y_shape(y_shape_graph: Graph) -> N
             f"ChoiceSpec {cs.from_passage} → {cs.to_passage} missing grants; "
             "Y-shape commit beats should produce state flags"
         )
-        assert any("trust_protector_or_manipulator" in g for g in cs.grants), (
-            f"grants {cs.grants!r} should reference the dilemma under test"
+        assert any("state_flag::" in g for g in cs.grants), (
+            f"grants {cs.grants!r} should be state_flag node IDs"
         )

--- a/tests/integration/test_y_shape_end_to_end.py
+++ b/tests/integration/test_y_shape_end_to_end.py
@@ -356,6 +356,7 @@ def test_polish_produces_two_choice_specs_for_y_shape(y_shape_graph: Graph) -> N
             f"ChoiceSpec {cs.from_passage} → {cs.to_passage} missing grants; "
             "Y-shape commit beats should produce state flags"
         )
-        assert any("state_flag::" in g for g in cs.grants), (
-            f"grants {cs.grants!r} should be state_flag node IDs"
+        expected_flags = {"state_flag::protector_committed", "state_flag::manipulator_committed"}
+        assert any(g in expected_flags for g in cs.grants), (
+            f"grants {cs.grants!r} should reference one of {expected_flags}"
         )

--- a/tests/unit/test_algorithms.py
+++ b/tests/unit/test_algorithms.py
@@ -35,13 +35,16 @@ def _add_predecessor(graph: Graph, child: str, parent: str) -> None:
     graph.add_edge("predecessor", child, parent)
 
 
-def _add_grants(graph: Graph, beat_id: str, state_flag_id: str) -> None:
+def _add_grants(graph: Graph, beat_id: str, state_flag_id: str, dilemma_id: str = "") -> None:
     """Create a state_flag node and grants edge from a commit beat."""
     if not graph.get_node(state_flag_id):
-        graph.create_node(
-            state_flag_id,
-            {"type": "state_flag", "raw_id": state_flag_id.split("::")[-1]},
-        )
+        data: dict[str, str] = {
+            "type": "state_flag",
+            "raw_id": state_flag_id.split("::")[-1],
+        }
+        if dilemma_id:
+            data["dilemma_id"] = dilemma_id
+        graph.create_node(state_flag_id, data)
     graph.add_edge("grants", beat_id, state_flag_id)
 
 

--- a/tests/unit/test_algorithms.py
+++ b/tests/unit/test_algorithms.py
@@ -35,6 +35,16 @@ def _add_predecessor(graph: Graph, child: str, parent: str) -> None:
     graph.add_edge("predecessor", child, parent)
 
 
+def _add_grants(graph: Graph, beat_id: str, state_flag_id: str) -> None:
+    """Create a state_flag node and grants edge from a commit beat."""
+    if not graph.get_node(state_flag_id):
+        graph.create_node(
+            state_flag_id,
+            {"type": "state_flag", "raw_id": state_flag_id.split("::")[-1]},
+        )
+    graph.add_edge("grants", beat_id, state_flag_id)
+
+
 class TestComputeActiveFlagsNoPredecessors:
     """Tests with no commit beat ancestors."""
 
@@ -95,11 +105,12 @@ class TestComputeActiveFlagsSingleDilemma:
         _make_beat(graph, "beat::after", "After commitment", [])
 
         _add_belongs_to(graph, "beat::commit_brave", "path::brave")
+        _add_grants(graph, "beat::commit_brave", "state_flag::brave_committed")
         _add_belongs_to(graph, "beat::after", "path::brave")
         _add_predecessor(graph, "beat::after", "beat::commit_brave")
 
         result = compute_active_flags_at_beat(graph, "beat::after")
-        assert result == {frozenset({"dilemma::courage:path::brave"})}
+        assert result == {frozenset({"state_flag::brave_committed"})}
 
     def test_commit_beat_itself_has_own_flag(self) -> None:
         """A commit beat includes its own flag in the result."""
@@ -117,9 +128,10 @@ class TestComputeActiveFlagsSingleDilemma:
             [{"dilemma_id": "dilemma::bravery", "effect": "commits"}],
         )
         _add_belongs_to(graph, "beat::the_commit", "path::bold")
+        _add_grants(graph, "beat::the_commit", "state_flag::bold_committed")
 
         result = compute_active_flags_at_beat(graph, "beat::the_commit")
-        assert result == {frozenset({"dilemma::bravery:path::bold"})}
+        assert result == {frozenset({"state_flag::bold_committed"})}
 
     def test_deep_chain(self) -> None:
         """Commit at start of a long chain is still found."""
@@ -137,6 +149,7 @@ class TestComputeActiveFlagsSingleDilemma:
             [{"dilemma_id": "dilemma::d1", "effect": "commits"}],
         )
         _add_belongs_to(graph, "beat::b0", "path::p1")
+        _add_grants(graph, "beat::b0", "state_flag::p1_committed")
 
         # Chain: b0 → b1 → b2 → b3 → b4
         for i in range(1, 5):
@@ -145,7 +158,7 @@ class TestComputeActiveFlagsSingleDilemma:
             _add_predecessor(graph, f"beat::b{i}", f"beat::b{i - 1}")
 
         result = compute_active_flags_at_beat(graph, "beat::b4")
-        assert result == {frozenset({"dilemma::d1:path::p1"})}
+        assert result == {frozenset({"state_flag::p1_committed"})}
 
 
 class TestComputeActiveFlagsTwoDilemmas:
@@ -194,7 +207,9 @@ class TestComputeActiveFlagsTwoDilemmas:
 
         # Path assignments
         _add_belongs_to(graph, "beat::commit_d1_a", "path::path_a")
+        _add_grants(graph, "beat::commit_d1_a", "state_flag::path_a_committed")
         _add_belongs_to(graph, "beat::commit_d2_x", "path::path_x")
+        _add_grants(graph, "beat::commit_d2_x", "state_flag::path_x_committed")
         _add_belongs_to(graph, "beat::final", "path::path_a")
 
         # Ordering
@@ -208,7 +223,7 @@ class TestComputeActiveFlagsTwoDilemmas:
         graph = self._build_two_dilemma_graph()
 
         result = compute_active_flags_at_beat(graph, "beat::final")
-        expected = {frozenset({"dilemma::d1:path::path_a", "dilemma::d2:path::path_x"})}
+        expected = {frozenset({"state_flag::path_a_committed", "state_flag::path_x_committed"})}
         assert result == expected
 
     def test_commit_beat_includes_own_and_ancestor_flags(self) -> None:
@@ -217,7 +232,7 @@ class TestComputeActiveFlagsTwoDilemmas:
 
         result = compute_active_flags_at_beat(graph, "beat::commit_d2_x")
         # commit_d2_x is downstream of commit_d1_a, and IS itself a commit
-        expected = {frozenset({"dilemma::d1:path::path_a", "dilemma::d2:path::path_x"})}
+        expected = {frozenset({"state_flag::path_a_committed", "state_flag::path_x_committed"})}
         assert result == expected
 
 
@@ -258,18 +273,20 @@ class TestComputeActiveFlagsBranching:
 
         _add_belongs_to(graph, "beat::start", "path::pa")
         _add_belongs_to(graph, "beat::a", "path::pa")
+        _add_grants(graph, "beat::a", "state_flag::pa_committed")
         _add_belongs_to(graph, "beat::b", "path::pb")
+        _add_grants(graph, "beat::b", "state_flag::pb_committed")
 
         _add_predecessor(graph, "beat::a", "beat::start")
         _add_predecessor(graph, "beat::b", "beat::start")
 
         # Beat A only sees path_a's commit
         result_a = compute_active_flags_at_beat(graph, "beat::a")
-        assert result_a == {frozenset({"dilemma::d1:path::pa"})}
+        assert result_a == {frozenset({"state_flag::pa_committed"})}
 
         # Beat B only sees path_b's commit
         result_b = compute_active_flags_at_beat(graph, "beat::b")
-        assert result_b == {frozenset({"dilemma::d1:path::pb"})}
+        assert result_b == {frozenset({"state_flag::pb_committed"})}
 
     def test_shared_beat_downstream_of_two_paths(self) -> None:
         """A shared beat downstream of commits from different paths of same dilemma.
@@ -306,7 +323,9 @@ class TestComputeActiveFlagsBranching:
         _make_beat(graph, "beat::shared", "Shared beat", [])
 
         _add_belongs_to(graph, "beat::commit_a", "path::pa")
+        _add_grants(graph, "beat::commit_a", "state_flag::pa_committed")
         _add_belongs_to(graph, "beat::commit_b", "path::pb")
+        _add_grants(graph, "beat::commit_b", "state_flag::pb_committed")
         _add_belongs_to(graph, "beat::shared", "path::pa")  # doesn't matter which
 
         _add_predecessor(graph, "beat::shared", "beat::commit_a")
@@ -315,8 +334,8 @@ class TestComputeActiveFlagsBranching:
         result = compute_active_flags_at_beat(graph, "beat::shared")
         # Two possible flag sets: one for path_a, one for path_b
         expected = {
-            frozenset({"dilemma::d1:path::pa"}),
-            frozenset({"dilemma::d1:path::pb"}),
+            frozenset({"state_flag::pa_committed"}),
+            frozenset({"state_flag::pb_committed"}),
         }
         assert result == expected
 
@@ -360,6 +379,7 @@ class TestComputeActiveFlagsCartesianProduct:
             [{"dilemma_id": "dilemma::d1", "effect": "commits"}],
         )
         _add_belongs_to(graph, "beat::d1_pa", "path::pa")
+        _add_grants(graph, "beat::d1_pa", "state_flag::pa_committed")
 
         _make_beat(
             graph,
@@ -368,6 +388,7 @@ class TestComputeActiveFlagsCartesianProduct:
             [{"dilemma_id": "dilemma::d1", "effect": "commits"}],
         )
         _add_belongs_to(graph, "beat::d1_pb", "path::pb")
+        _add_grants(graph, "beat::d1_pb", "state_flag::pb_committed")
 
         # Merge point
         _make_beat(graph, "beat::merge", "Merge point", [])
@@ -383,6 +404,7 @@ class TestComputeActiveFlagsCartesianProduct:
             [{"dilemma_id": "dilemma::d2", "effect": "commits"}],
         )
         _add_belongs_to(graph, "beat::d2_px", "path::px")
+        _add_grants(graph, "beat::d2_px", "state_flag::px_committed")
         _add_predecessor(graph, "beat::d2_px", "beat::merge")
 
         _make_beat(
@@ -392,6 +414,7 @@ class TestComputeActiveFlagsCartesianProduct:
             [{"dilemma_id": "dilemma::d2", "effect": "commits"}],
         )
         _add_belongs_to(graph, "beat::d2_py", "path::py")
+        _add_grants(graph, "beat::d2_py", "state_flag::py_committed")
         _add_predecessor(graph, "beat::d2_py", "beat::merge")
 
         # Final convergence point
@@ -404,10 +427,10 @@ class TestComputeActiveFlagsCartesianProduct:
 
         # 2 options for d1 x 2 options for d2 = 4 combinations
         expected = {
-            frozenset({"dilemma::d1:path::pa", "dilemma::d2:path::px"}),
-            frozenset({"dilemma::d1:path::pa", "dilemma::d2:path::py"}),
-            frozenset({"dilemma::d1:path::pb", "dilemma::d2:path::px"}),
-            frozenset({"dilemma::d1:path::pb", "dilemma::d2:path::py"}),
+            frozenset({"state_flag::pa_committed", "state_flag::px_committed"}),
+            frozenset({"state_flag::pa_committed", "state_flag::py_committed"}),
+            frozenset({"state_flag::pb_committed", "state_flag::px_committed"}),
+            frozenset({"state_flag::pb_committed", "state_flag::py_committed"}),
         }
         assert result == expected
         assert len(result) == 4
@@ -972,14 +995,16 @@ class TestComputeActiveFlagsDualBelongsTo:
         graph.add_edge("belongs_to", "beat::shared_setup", "path::trust__a")
         graph.add_edge("belongs_to", "beat::shared_setup", "path::trust__b")
         graph.add_edge("belongs_to", "beat::commit_a", "path::trust__a")
+        _add_grants(graph, "beat::commit_a", "state_flag::trust__a_committed")
         graph.add_edge("belongs_to", "beat::commit_b", "path::trust__b")
+        _add_grants(graph, "beat::commit_b", "state_flag::trust__b_committed")
         graph.add_edge("predecessor", "beat::commit_a", "beat::shared_setup")
         graph.add_edge("predecessor", "beat::commit_b", "beat::shared_setup")
 
         # Flags at beat::commit_a should not raise and should yield exactly one
-        # flag: "trust:path::trust__a".
+        # flag: state_flag::trust__a_committed.
         flags = compute_active_flags_at_beat(graph, "beat::commit_a")
-        assert flags == {frozenset({"trust:path::trust__a"})}
+        assert flags == {frozenset({"state_flag::trust__a_committed"})}
 
     def test_dual_belongs_to_pre_commit_ancestor_commit_b_path(self) -> None:
         """Flags at commit_b resolve to path B, not path A."""
@@ -1010,9 +1035,11 @@ class TestComputeActiveFlagsDualBelongsTo:
         graph.add_edge("belongs_to", "beat::shared_setup", "path::trust__a")
         graph.add_edge("belongs_to", "beat::shared_setup", "path::trust__b")
         graph.add_edge("belongs_to", "beat::commit_a", "path::trust__a")
+        _add_grants(graph, "beat::commit_a", "state_flag::trust__a_committed")
         graph.add_edge("belongs_to", "beat::commit_b", "path::trust__b")
+        _add_grants(graph, "beat::commit_b", "state_flag::trust__b_committed")
         graph.add_edge("predecessor", "beat::commit_a", "beat::shared_setup")
         graph.add_edge("predecessor", "beat::commit_b", "beat::shared_setup")
 
         flags = compute_active_flags_at_beat(graph, "beat::commit_b")
-        assert flags == {frozenset({"trust:path::trust__b"})}
+        assert flags == {frozenset({"state_flag::trust__b_committed"})}

--- a/tests/unit/test_polish_deterministic.py
+++ b/tests/unit/test_polish_deterministic.py
@@ -386,7 +386,6 @@ class TestComputeChoiceEdges:
         graph.create_node(
             "state_flag::pa_committed", {"type": "state_flag", "raw_id": "pa_committed"}
         )
-        graph.add_edge("grants", "beat::start", "state_flag::pa_committed")
         graph.add_edge("grants", "beat::commit_a", "state_flag::pa_committed")
 
         specs = [

--- a/tests/unit/test_polish_deterministic.py
+++ b/tests/unit/test_polish_deterministic.py
@@ -232,7 +232,7 @@ class TestComputeProseFeasibility:
             {"type": "dilemma", "raw_id": "d1", "dilemma_role": "soft", "residue_weight": "light"},
         )
 
-        # Commit beat as ancestor
+        # Commit beat as ancestor, with grants edge to a state_flag node
         _make_beat(
             graph,
             "beat::commit",
@@ -243,6 +243,11 @@ class TestComputeProseFeasibility:
         _add_belongs_to(graph, "beat::commit", "path::brave")
         _add_belongs_to(graph, "beat::target", "path::brave")
         _add_predecessor(graph, "beat::target", "beat::commit")
+        graph.create_node(
+            "state_flag::brave_committed",
+            {"type": "state_flag", "raw_id": "brave_committed"},
+        )
+        graph.add_edge("grants", "beat::commit", "state_flag::brave_committed")
 
         # Overlay for a DIFFERENT entity than the passage's entity (embedded on entity node)
         graph.create_node(
@@ -252,7 +257,7 @@ class TestComputeProseFeasibility:
                 "raw_id": "npc",
                 "overlays": [
                     {
-                        "when": ["dilemma::d1:path::brave"],
+                        "when": ["state_flag::brave_committed"],
                         "details": {"description": "NPC changes"},
                     }
                 ],
@@ -376,6 +381,13 @@ class TestComputeChoiceEdges:
 
         _add_predecessor(graph, "beat::commit_a", "beat::start")
         _add_predecessor(graph, "beat::b", "beat::start")
+
+        # state_flag nodes and grants edges for commit beats
+        graph.create_node(
+            "state_flag::pa_committed", {"type": "state_flag", "raw_id": "pa_committed"}
+        )
+        graph.add_edge("grants", "beat::start", "state_flag::pa_committed")
+        graph.add_edge("grants", "beat::commit_a", "state_flag::pa_committed")
 
         specs = [
             PassageSpec(passage_id="p_start", beat_ids=["beat::start"], summary="start"),
@@ -521,6 +533,17 @@ class TestChoiceEdgesIntersectionMultiBeat:
         _add_predecessor(graph, "beat::child_X2", "beat::b_p2")
         _add_predecessor(graph, "beat::child_B", "beat::b_p2")
 
+        # state_flag nodes and grants edges for commit beats
+        # child_X1 commits d1 on p1; child_X2 commits d2 on p1 — use distinct IDs
+        graph.create_node(
+            "state_flag::p1_d1_committed", {"type": "state_flag", "raw_id": "p1_d1_committed"}
+        )
+        graph.add_edge("grants", "beat::child_X1", "state_flag::p1_d1_committed")
+        graph.create_node(
+            "state_flag::p1_d2_committed", {"type": "state_flag", "raw_id": "p1_d2_committed"}
+        )
+        graph.add_edge("grants", "beat::child_X2", "state_flag::p1_d2_committed")
+
         # Both child_X1 and child_X2 land in the SAME target passage (passage::X)
         specs = [
             PassageSpec(
@@ -544,10 +567,10 @@ class TestChoiceEdgesIntersectionMultiBeat:
         to_X = [c for c in choices if c.to_passage == "passage::X"]
         assert len(to_X) == 1
 
-        # Grants: b_p1 contributed d1:p1 (from child_X1); b_p2 contributed d2:p1 (from child_X2)
+        # Grants: child_X1 contributed state_flag::p1_d1_committed; child_X2 contributed state_flag::p1_d2_committed
         # Merged union should contain both
         assert len(to_X[0].grants) == 2
-        assert set(to_X[0].grants) == {"dilemma::d1:path::p1", "dilemma::d2:path::p1"}
+        assert set(to_X[0].grants) == {"state_flag::p1_d1_committed", "state_flag::p1_d2_committed"}
 
 
 class TestChoiceEdgesGapBeatChild:
@@ -1148,6 +1171,16 @@ class TestChoiceEdgesYShapeAdvancesChild:
         graph.add_edge("predecessor", "beat::a_02", "beat::a_01")
         graph.add_edge("predecessor", "beat::b_02", "beat::b_01")
 
+        # state_flag nodes and grants edges for commit beats
+        graph.create_node(
+            "state_flag::d1_a_committed", {"type": "state_flag", "raw_id": "d1_a_committed"}
+        )
+        graph.add_edge("grants", "beat::a_02", "state_flag::d1_a_committed")
+        graph.create_node(
+            "state_flag::d1_b_committed", {"type": "state_flag", "raw_id": "d1_b_committed"}
+        )
+        graph.add_edge("grants", "beat::b_02", "state_flag::d1_b_committed")
+
         specs = [
             PassageSpec(
                 passage_id="passage::shared", beat_ids=["beat::shared"], grouping_type="single"
@@ -1475,6 +1508,15 @@ class TestChoiceSpecRequires:
         graph.create_node("path::pc", {"type": "path", "raw_id": "pc", "dilemma_id": "dilemma::d1"})
         graph.create_node("path::pd", {"type": "path", "raw_id": "pd", "dilemma_id": "dilemma::d1"})
         graph.create_node(
+            "state_flag::d1_pa",
+            {
+                "type": "state_flag",
+                "raw_id": "d1_pa",
+                "dilemma_id": "dilemma::d1",
+                "path_id": "path::pa",
+            },
+        )
+        graph.create_node(
             "state_flag::d1_pc",
             {
                 "type": "state_flag",
@@ -1507,6 +1549,8 @@ class TestChoiceSpecRequires:
             dilemma_impacts=[{"dilemma_id": "dilemma::d1", "effect": "commits"}],
         )
         graph.add_edge("belongs_to", "beat::merge", "path::pa")
+        # grants edge: beat::merge activates state_flag::d1_pa (its own path)
+        graph.add_edge("grants", "beat::merge", "state_flag::d1_pa")
         graph.create_node(
             "intersection_group::g1",
             {"type": "intersection_group", "raw_id": "g1", "beat_ids": ["beat::merge"]},
@@ -1592,7 +1636,12 @@ class TestAmbiguousFeasibilityDetection:
         beat_id: str,
         path_id: str,
         dilemma_id: str,
-    ) -> None:
+        state_flag_id: str | None = None,
+    ) -> str:
+        """Create a commit beat with an associated state_flag node and grants edge.
+
+        Returns the state_flag_id used (derived from path_id if not provided).
+        """
         graph.create_node(
             beat_id,
             {
@@ -1605,6 +1654,22 @@ class TestAmbiguousFeasibilityDetection:
             },
         )
         graph.add_edge("belongs_to", beat_id, path_id)
+        # Create state_flag node and grants edge so compute_active_flags_at_beat returns
+        # real state_flag::* node IDs instead of synthetic dilemma::*:path::* strings.
+        if state_flag_id is None:
+            path_raw = path_id.split("::")[-1]
+            state_flag_id = f"state_flag::{path_raw}_committed"
+        if not graph.get_node(state_flag_id):
+            graph.create_node(
+                state_flag_id,
+                {
+                    "type": "state_flag",
+                    "raw_id": state_flag_id.split("::")[-1],
+                    "dilemma_id": dilemma_id,
+                },
+            )
+        graph.add_edge("grants", beat_id, state_flag_id)
+        return state_flag_id
 
     def test_mixed_weights_produces_ambiguous_spec(self) -> None:
         """Passage with one heavy flag and one light flag → ambiguous_specs, NOT in variant or residue."""
@@ -1632,24 +1697,23 @@ class TestAmbiguousFeasibilityDetection:
         graph.create_node("path::ph", {"type": "path", "raw_id": "ph"})
         graph.create_node("path::pl", {"type": "path", "raw_id": "pl"})
 
-        # Entity that appears in the passage
+        # Commit beats first so state_flag nodes exist before entity references them
+        # Chain: commit_h → commit_l → target
+        sf_h = self._make_commit_beat(graph, "beat::commit_h", "path::ph", "dilemma::heavy")
+        sf_l = self._make_commit_beat(graph, "beat::commit_l", "path::pl", "dilemma::light")
+
+        # Entity that appears in the passage — overlays use state_flag node IDs
         graph.create_node(
             "entity::hero",
             {
                 "type": "entity",
                 "raw_id": "hero",
                 "overlays": [
-                    {"when": ["dilemma::heavy:path::ph"], "details": {"mood": "grim"}},
-                    {"when": ["dilemma::light:path::pl"], "details": {"mood": "relieved"}},
+                    {"when": [sf_h], "details": {"mood": "grim"}},
+                    {"when": [sf_l], "details": {"mood": "relieved"}},
                 ],
             },
         )
-
-        # Commit beats (ancestors of the target passage).
-        # Both need to be in the ancestor chain so both flags are active at beat::target.
-        # Chain: commit_h → commit_l → target
-        self._make_commit_beat(graph, "beat::commit_h", "path::ph", "dilemma::heavy")
-        self._make_commit_beat(graph, "beat::commit_l", "path::pl", "dilemma::light")
         _add_predecessor(graph, "beat::commit_l", "beat::commit_h")
 
         # Target beat referencing entity::hero
@@ -1692,20 +1756,22 @@ class TestAmbiguousFeasibilityDetection:
         graph.create_node("path::p1", {"type": "path", "raw_id": "p1"})
         graph.create_node("path::p2", {"type": "path", "raw_id": "p2"})
 
+        # Create commit beats first so state_flag IDs are available for overlays
+        sf_p1 = self._make_commit_beat(graph, "beat::c1", "path::p1", "dilemma::d1")
+        sf_p2 = self._make_commit_beat(graph, "beat::c2", "path::p2", "dilemma::d2")
+
         graph.create_node(
             "entity::hero",
             {
                 "type": "entity",
                 "raw_id": "hero",
                 "overlays": [
-                    {"when": ["dilemma::d1:path::p1"], "details": {"mood": "dark"}},
-                    {"when": ["dilemma::d2:path::p2"], "details": {"mood": "grim"}},
+                    {"when": [sf_p1], "details": {"mood": "dark"}},
+                    {"when": [sf_p2], "details": {"mood": "grim"}},
                 ],
             },
         )
 
-        self._make_commit_beat(graph, "beat::c1", "path::p1", "dilemma::d1")
-        self._make_commit_beat(graph, "beat::c2", "path::p2", "dilemma::d2")
         # Chain: c2 → c1 → target so both flags are ancestors of beat::target
         _add_predecessor(graph, "beat::c1", "beat::c2")
 
@@ -1735,18 +1801,20 @@ class TestAmbiguousFeasibilityDetection:
         )
         graph.create_node("path::p1", {"type": "path", "raw_id": "p1"})
 
+        # Create commit beat first so state_flag ID is available for overlay
+        sf_p1 = self._make_commit_beat(graph, "beat::c1", "path::p1", "dilemma::d1")
+
         graph.create_node(
             "entity::hero",
             {
                 "type": "entity",
                 "raw_id": "hero",
                 "overlays": [
-                    {"when": ["dilemma::d1:path::p1"], "details": {"mood": "dark"}},
+                    {"when": [sf_p1], "details": {"mood": "dark"}},
                 ],
             },
         )
 
-        self._make_commit_beat(graph, "beat::c1", "path::p1", "dilemma::d1")
         _make_beat(graph, "beat::target", "Target", entities=["entity::hero"])
         graph.add_edge("belongs_to", "beat::target", "path::p1")
         _add_predecessor(graph, "beat::target", "beat::c1")
@@ -2033,6 +2101,7 @@ class TestAuditOverlayComposition:
                 )
 
         # Create commit beats chained: last→...→first→target
+        # Also create a state_flag node and grants edge for each commit beat.
         prev_beat = None
         for path_id, dilemma_id, beat_id in commit_flags:
             graph.create_node(
@@ -2047,6 +2116,19 @@ class TestAuditOverlayComposition:
                 },
             )
             graph.add_edge("belongs_to", beat_id, path_id)
+            # state_flag: named after path raw ID so callers can predict the ID
+            path_raw = path_id.split("::")[-1]
+            sf_id = f"state_flag::{path_raw}_committed"
+            if not graph.get_node(sf_id):
+                graph.create_node(
+                    sf_id,
+                    {
+                        "type": "state_flag",
+                        "raw_id": f"{path_raw}_committed",
+                        "dilemma_id": dilemma_id,
+                    },
+                )
+            graph.add_edge("grants", beat_id, sf_id)
             if prev_beat is not None:
                 graph.add_edge("predecessor", beat_id, prev_beat)
             prev_beat = beat_id
@@ -2092,11 +2174,12 @@ class TestAuditOverlayComposition:
             ("path::pc", "dilemma::dc", "beat::cc"),
             ("path::pd", "dilemma::dd", "beat::cd"),
         ]
+        # Overlay when-flags use state_flag node IDs (state_flag::{path_raw}_committed)
         overlay_when_lists = [
-            ["dilemma::da:path::pa"],
-            ["dilemma::db:path::pb"],
-            ["dilemma::dc:path::pc"],
-            ["dilemma::dd:path::pd"],
+            ["state_flag::pa_committed"],
+            ["state_flag::pb_committed"],
+            ["state_flag::pc_committed"],
+            ["state_flag::pd_committed"],
         ]
         graph, spec = self._build_graph_with_overlays(overlay_when_lists, commit_flags)
 
@@ -2123,7 +2206,7 @@ class TestAuditOverlayComposition:
         graph.create_node("path::pc", {"type": "path", "raw_id": "pc"})
         graph.create_node("path::pd", {"type": "path", "raw_id": "pd"})
 
-        # One commit beat on path::pa only
+        # One commit beat on path::pa only, with state_flag node and grants edge
         graph.create_node(
             "beat::ca",
             {
@@ -2136,6 +2219,11 @@ class TestAuditOverlayComposition:
             },
         )
         graph.add_edge("belongs_to", "beat::ca", "path::pa")
+        graph.create_node(
+            "state_flag::pa_committed",
+            {"type": "state_flag", "raw_id": "pa_committed", "dilemma_id": "dilemma::d1"},
+        )
+        graph.add_edge("grants", "beat::ca", "state_flag::pa_committed")
 
         # Target beat
         graph.create_node(
@@ -2152,18 +2240,20 @@ class TestAuditOverlayComposition:
         graph.add_edge("belongs_to", "beat::target", "path::pa")
         graph.add_edge("predecessor", "beat::target", "beat::ca")
 
-        # Entity with 4 overlays, each requiring a different path of dilemma::d1
-        # Since they're mutually exclusive (only 1 can be committed), at most 1 active at once
+        # Entity with 4 overlays, each requiring a different path of dilemma::d1.
+        # Overlay when-flags use state_flag node IDs.
+        # Only state_flag::pa_committed is active (beat::ca on path::pa was committed).
+        # state_flag::pb/pc/pd_committed don't exist → 0 active overlays for those → not flagged.
         graph.create_node(
             "entity::hero",
             {
                 "type": "entity",
                 "raw_id": "hero",
                 "overlays": [
-                    {"when": ["dilemma::d1:path::pa"], "details": {}},
-                    {"when": ["dilemma::d1:path::pb"], "details": {}},
-                    {"when": ["dilemma::d1:path::pc"], "details": {}},
-                    {"when": ["dilemma::d1:path::pd"], "details": {}},
+                    {"when": ["state_flag::pa_committed"], "details": {}},
+                    {"when": ["state_flag::pb_committed"], "details": {}},
+                    {"when": ["state_flag::pc_committed"], "details": {}},
+                    {"when": ["state_flag::pd_committed"], "details": {}},
                 ],
             },
         )
@@ -2178,7 +2268,7 @@ class TestAuditOverlayComposition:
         feasibility: dict = {"warnings": []}
         _audit_overlay_composition(graph, [spec], feasibility)
 
-        # Only path::pa was committed → active flag combo is {dilemma::d1:path::pa}
+        # Only path::pa was committed → active flag combo is {state_flag::pa_committed}
         # Only 1 overlay matches that combo → not flagged
         assert feasibility["warnings"] == []
 
@@ -2191,10 +2281,11 @@ class TestAuditOverlayComposition:
             ("path::pb", "dilemma::db", "beat::cb"),
             ("path::pc", "dilemma::dc", "beat::cc"),
         ]
+        # Overlay when-flags use state_flag node IDs (state_flag::{path_raw}_committed)
         overlay_when_lists = [
-            ["dilemma::da:path::pa"],
-            ["dilemma::db:path::pb"],
-            ["dilemma::dc:path::pc"],
+            ["state_flag::pa_committed"],
+            ["state_flag::pb_committed"],
+            ["state_flag::pc_committed"],
         ]
         graph, spec = self._build_graph_with_overlays(overlay_when_lists, commit_flags)
 
@@ -2213,11 +2304,12 @@ class TestAuditOverlayComposition:
             ("path::pc", "dilemma::dc", "beat::cc"),
             ("path::pd", "dilemma::dd", "beat::cd"),
         ]
+        # Overlay when-flags use state_flag node IDs (state_flag::{path_raw}_committed)
         overlay_when_lists = [
-            ["dilemma::da:path::pa"],
-            ["dilemma::db:path::pb"],
-            ["dilemma::dc:path::pc"],
-            ["dilemma::dd:path::pd"],
+            ["state_flag::pa_committed"],
+            ["state_flag::pb_committed"],
+            ["state_flag::pc_committed"],
+            ["state_flag::pd_committed"],
         ]
         graph, spec = self._build_graph_with_overlays(overlay_when_lists, commit_flags)
 


### PR DESCRIPTION
## Summary

`compute_active_flags_at_beat` synthesized flag IDs as `{dilemma_id}:{path_id}` which never matched the actual `state_flag::*` node IDs that entity overlays reference in their `when` fields. This caused `compute_prose_feasibility` (Phase 4b) to always find 0 narratively relevant flags → 0 variants, 0 residues → FILL writes generic prose for all arcs. Closes #1256.

## Root cause

Two separate flag ID systems existed in the graph:
- `compute_active_flags_at_beat`: `"dilemma::d1:path::d1_a"` (synthetic)
- Entity overlay `when` + state_flag nodes: `"state_flag::mentor_hostile_committed"` (real)

Phase 4b cross-referenced them — the lookup always returned empty.

## What changed

**`src/questfoundry/graph/algorithms.py`** — `compute_active_flags_at_beat`:
- Replaced synthetic `f"{dilemma_id}:{path_id}"` flag construction with `grants` edge lookup
- Each commit beat's `grants` edges point to `state_flag::*` nodes — those IDs are now returned
- Docstring updated to reflect the real-node-ID contract

**`src/questfoundry/pipeline/stages/polish/deterministic.py`** — `compute_choice_edges`:
- Choice grants also now use `state_flag::*` IDs via `grants` edges (was same synthetic format)
- Added `grants_edges` index to the function setup

**`src/questfoundry/pipeline/stages/polish/deterministic.py`** — `compute_prose_feasibility`:
- Added state_flag → dilemma_id lookup for residue weight classification (reads `dilemma_id` from state_flag node data instead of parsing synthetic strings)

**Tests**: Updated all fixtures across `test_algorithms.py` (37 tests) and `test_polish_deterministic.py` (65 tests) to create state_flag nodes with grants edges.

## Test plan

- [x] 37/37 algorithm tests pass
- [x] 65/65 POLISH deterministic tests pass  
- [x] Pre-commit, ruff, mypy clean
- [ ] **Empirical**: re-run POLISH on test-new4 and verify Phase 4b produces variant_specs > 0 and/or residue_specs > 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)