### PR TITLE
chore(pyright): point pyright-lsp at uv .venv

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,9 @@ jobs:
       - name: Run mypy
         run: uv run mypy src/
 
+      - name: Run pyright
+        run: uv run pyright src/
+
   test:
     name: Test (Python ${{ matrix.python-version }})
     runs-on: ubuntu-latest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,6 +81,7 @@ dev = [
     "pytest-asyncio>=0.24",
     "pytest-cov>=5.0",
     "mypy>=1.11",
+    "pyright>=1.1",
     "ruff>=0.6",
     "pre-commit>=3.8",
     "types-jsonschema>=4.0",
@@ -174,7 +175,7 @@ ignore_missing_imports = true
 venvPath = "."
 venv = ".venv"
 pythonVersion = "3.11"
-typeCheckingMode = "basic"
+typeCheckingMode = "standard"
 
 [tool.ruff]
 target-version = "py311"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -171,7 +171,9 @@ module = [
 ignore_missing_imports = true
 
 [tool.pyright]
-# Editor / pyright-lsp only. CI still uses mypy (see [tool.mypy]).
+# Runs in CI alongside mypy; pyright-lsp picks this up in the editor too.
+# Per-file ignores in late-stage code are tagged TODO(#<epic>) and removed
+# as each stage's spec-compliance PR lands.
 venvPath = "."
 venv = ".venv"
 pythonVersion = "3.11"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -170,13 +170,11 @@ module = [
 ignore_missing_imports = true
 
 [tool.pyright]
-# Point the pyright-lsp plugin (invoked by editors / Claude Code) at the
-# uv-managed virtual environment. Without this, pyright uses its bundled
-# typeshed only and cannot resolve third-party imports such as
-# langchain_core — producing noise that doesn't match `uv run mypy`.
+# Editor / pyright-lsp only. CI still uses mypy (see [tool.mypy]).
 venvPath = "."
 venv = ".venv"
 pythonVersion = "3.11"
+typeCheckingMode = "basic"
 
 [tool.ruff]
 target-version = "py311"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,7 +81,7 @@ dev = [
     "pytest-asyncio>=0.24",
     "pytest-cov>=5.0",
     "mypy>=1.11",
-    "pyright>=1.1",
+    "pyright>=1.1,<2",
     "ruff>=0.6",
     "pre-commit>=3.8",
     "types-jsonschema>=4.0",
@@ -171,9 +171,7 @@ module = [
 ignore_missing_imports = true
 
 [tool.pyright]
-# Runs in CI alongside mypy; pyright-lsp picks this up in the editor too.
-# Per-file ignores in late-stage code are tagged TODO(#<epic>) and removed
-# as each stage's spec-compliance PR lands.
+# Runs in CI alongside mypy; also picked up by pyright-lsp in editors.
 venvPath = "."
 venv = ".venv"
 pythonVersion = "3.11"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -169,6 +169,15 @@ module = [
 ]
 ignore_missing_imports = true
 
+[tool.pyright]
+# Point the pyright-lsp plugin (invoked by editors / Claude Code) at the
+# uv-managed virtual environment. Without this, pyright uses its bundled
+# typeshed only and cannot resolve third-party imports such as
+# langchain_core — producing noise that doesn't match `uv run mypy`.
+venvPath = "."
+venv = ".venv"
+pythonVersion = "3.11"
+
 [tool.ruff]
 target-version = "py311"
 line-length = 100

--- a/src/questfoundry/graph/context.py
+++ b/src/questfoundry/graph/context.py
@@ -4,6 +4,9 @@ Provides functions to format graph data as context for LLM serialization,
 giving the model authoritative lists of valid IDs to reference.
 """
 
+# pyright: reportPossiblyUnboundVariable=false, reportInvalidTypeForm=false
+# TODO(#1319): cleanup during M-FILL-spec compliance work (lines-based functions used primarily by FILL context builders); tracked in epic #1319
+
 from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any

--- a/src/questfoundry/graph/context.py
+++ b/src/questfoundry/graph/context.py
@@ -5,7 +5,7 @@ giving the model authoritative lists of valid IDs to reference.
 """
 
 # pyright: reportPossiblyUnboundVariable=false, reportInvalidTypeForm=false
-# TODO(#1319): cleanup during M-FILL-spec compliance work (lines-based functions used primarily by FILL context builders); tracked in epic #1319
+# TODO(#1319): cleanup during M-FILL-spec compliance work
 
 from __future__ import annotations
 

--- a/src/questfoundry/models/seed.py
+++ b/src/questfoundry/models/seed.py
@@ -14,6 +14,9 @@ Terminology (v5):
 - answer: Possible resolutions to dilemmas
 """
 
+# pyright: reportInvalidTypeForm=false
+# TODO(#1281): cleanup during M-SEED-spec compliance work; tracked in epic #1281
+
 from __future__ import annotations
 
 import warnings

--- a/src/questfoundry/observability/langchain_callbacks.py
+++ b/src/questfoundry/observability/langchain_callbacks.py
@@ -4,6 +4,9 @@ Provides callback handlers that integrate with QuestFoundry's logging system,
 including JSONL logging for LLM calls.
 """
 
+# pyright: reportAttributeAccessIssue=false
+# TODO(#1353): langchain API drift — BaseMessage.tool_calls and Generation.message attribute access; tracked in issue #1353
+
 # ruff: noqa: ARG002 - Callback interface methods require unused parameters
 
 from __future__ import annotations

--- a/src/questfoundry/pipeline/orchestrator.py
+++ b/src/questfoundry/pipeline/orchestrator.py
@@ -1,7 +1,7 @@
 """Pipeline orchestrator for stage execution."""
 
-# pyright: reportReturnType=false, reportAttributeAccessIssue=false, reportGeneralTypeIssues=false
-# TODO(#1354): orchestrator tuple-return widening in provider resolution and langchain .close() API drift; tracked in issue #1354
+# pyright: reportReturnType=false, reportAttributeAccessIssue=false
+# TODO(#1354): cleanup during orchestrator tuple-return widening work
 
 from __future__ import annotations
 
@@ -852,7 +852,7 @@ class PipelineOrchestrator:
                 if callable(close_method):
                     result = close_method()
                     if hasattr(result, "__await__"):
-                        await result
+                        await result  # pyright: ignore[reportGeneralTypeIssues]
             self._creative_model = None
 
         # Clear other model references

--- a/src/questfoundry/pipeline/orchestrator.py
+++ b/src/questfoundry/pipeline/orchestrator.py
@@ -1,5 +1,8 @@
 """Pipeline orchestrator for stage execution."""
 
+# pyright: reportReturnType=false, reportAttributeAccessIssue=false, reportGeneralTypeIssues=false
+# TODO(#1354): orchestrator tuple-return widening in provider resolution and langchain .close() API drift; tracked in issue #1354
+
 from __future__ import annotations
 
 import os

--- a/src/questfoundry/pipeline/stages/base.py
+++ b/src/questfoundry/pipeline/stages/base.py
@@ -2,10 +2,13 @@
 
 from __future__ import annotations
 
-from collections.abc import Awaitable, Callable
+from collections.abc import Awaitable, Callable, Coroutine
 from typing import TYPE_CHECKING, Any, Protocol
 
 if TYPE_CHECKING:
+    from pathlib import Path
+
+    from langchain_core.callbacks import BaseCallbackHandler
     from langchain_core.language_models import BaseChatModel
 
 # Type aliases for interactive mode callbacks
@@ -33,7 +36,7 @@ class Stage(Protocol):
 
     name: str
 
-    async def execute(
+    def execute(
         self,
         model: BaseChatModel,
         user_prompt: str,
@@ -45,11 +48,16 @@ class Stage(Protocol):
         on_llm_start: LLMCallbackFn | None = None,
         on_llm_end: LLMCallbackFn | None = None,
         on_phase_progress: PhaseProgressFn | None = None,
+        project_path: Path | None = None,
+        callbacks: list[BaseCallbackHandler] | None = None,
         summarize_model: BaseChatModel | None = None,
         serialize_model: BaseChatModel | None = None,
         summarize_provider_name: str | None = None,
         serialize_provider_name: str | None = None,
-    ) -> tuple[dict[str, Any], int, int]:
+        unload_after_discuss: UnloadHookFn | None = None,
+        unload_after_summarize: UnloadHookFn | None = None,
+        **kwargs: Any,
+    ) -> Coroutine[Any, Any, tuple[dict[str, Any], int, int]]:
         """Execute the stage.
 
         Args:
@@ -61,10 +69,16 @@ class Stage(Protocol):
             on_assistant_message: Callback when assistant responds.
             on_llm_start: Callback when LLM call starts.
             on_llm_end: Callback when LLM call ends.
+            on_phase_progress: Callback for phase progress updates.
+            project_path: Path to project directory for graph access.
+            callbacks: LangChain callback handlers for logging LLM calls.
             summarize_model: Optional LLM model for summarize phase (defaults to model).
             serialize_model: Optional LLM model for serialize phase (defaults to model).
             summarize_provider_name: Provider name for summarize phase.
             serialize_provider_name: Provider name for serialize phase.
+            unload_after_discuss: Async hook to unload model from VRAM after discuss.
+            unload_after_summarize: Async hook to unload model from VRAM after summarize.
+            **kwargs: Additional stage-specific keyword arguments.
 
         Returns:
             Tuple of (artifact_data, llm_calls, tokens_used).

--- a/src/questfoundry/pipeline/stages/base.py
+++ b/src/questfoundry/pipeline/stages/base.py
@@ -36,6 +36,11 @@ class Stage(Protocol):
 
     name: str
 
+    # Declared as sync `def … -> Coroutine[...]` rather than `async def` because
+    # concrete implementations wrap `execute` in `@traceable`, which pyright
+    # infers as returning `collections.abc.Coroutine` instead of the
+    # `CoroutineType` produced by `async def`. Semantically equivalent at
+    # runtime; keeps conforming classes compatible with `@traceable`.
     def execute(
         self,
         model: BaseChatModel,

--- a/src/questfoundry/pipeline/stages/fill.py
+++ b/src/questfoundry/pipeline/stages/fill.py
@@ -13,6 +13,9 @@ LLM phases use direct structured output: context from graph state →
 single LLM call → validate → retry (max 3).
 """
 
+# pyright: reportPossiblyUnboundVariable=false
+# TODO(#1319): cleanup during M-FILL-spec compliance work; tracked in epic #1319
+
 from __future__ import annotations
 
 import re

--- a/src/questfoundry/pipeline/stages/grow/llm_phases.py
+++ b/src/questfoundry/pipeline/stages/grow/llm_phases.py
@@ -7,6 +7,9 @@ GrowStage inherits this mixin so ``execute()`` can delegate to
 ``self._phase_3_intersections()``, etc.
 """
 
+# pyright: reportPossiblyUnboundVariable=false, reportInvalidTypeForm=false
+# TODO(#1296): cleanup during M-GROW-spec compliance work; tracked in epic #1296
+
 from __future__ import annotations
 
 from functools import partial

--- a/src/questfoundry/pipeline/stages/grow/stage.py
+++ b/src/questfoundry/pipeline/stages/grow/stage.py
@@ -16,6 +16,9 @@ LLM phases use direct structured output (not discuss→summarize→serialize):
 context from graph state → single LLM call → validate → retry (max 3).
 """
 
+# pyright: reportArgumentType=false
+# TODO(#1296): cleanup during M-GROW-spec compliance work; tracked in epic #1296
+
 from __future__ import annotations
 
 from collections.abc import Awaitable, Callable

--- a/src/questfoundry/pipeline/stages/polish/stage.py
+++ b/src/questfoundry/pipeline/stages/polish/stage.py
@@ -13,6 +13,9 @@ direct structured output: context from graph state → single LLM call
 → validate → retry (max 3).
 """
 
+# pyright: reportArgumentType=false
+# TODO(#1310): cleanup during M-POLISH-spec compliance work; tracked in epic #1310
+
 from __future__ import annotations
 
 from collections.abc import Awaitable, Callable

--- a/uv.lock
+++ b/uv.lock
@@ -113,6 +113,11 @@ dependencies = [
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/84/85/57c314a6b35336efbbdc13e5fc9ae13f6b60a0647cfa7c1221178ac6d8ae/brotlicffi-1.2.0.0.tar.gz", hash = "sha256:34345d8d1f9d534fcac2249e57a4c3c8801a33c9942ff9f8574f67a175e17adb", size = 476682, upload-time = "2025-11-21T18:17:57.334Z" }
 wheels = [
+    { url = "https://files.pythonhosted.org/packages/7c/87/ba6298c3d7f8d66ce80d7a487f2a487ebae74a79c6049c7c2990178ce529/brotlicffi-1.2.0.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:b13fb476a96f02e477a506423cb5e7bc21e0e3ac4c060c20ba31c44056e38c68", size = 433038, upload-time = "2026-03-05T17:57:37.96Z" },
+    { url = "https://files.pythonhosted.org/packages/00/49/16c7a77d1cae0519953ef0389a11a9c2e2e62e87d04f8e7afbae40124255/brotlicffi-1.2.0.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:17db36fb581f7b951635cd6849553a95c6f2f53c1a707817d06eae5aeff5f6af", size = 1541124, upload-time = "2026-03-05T17:57:39.488Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/17/fab2c36ea820e2288f8c1bf562de1b6cd9f30e28d66f1ce2929a4baff6de/brotlicffi-1.2.0.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:40190192790489a7b054312163d0ce82b07d1b6e706251036898ce1684ef12e9", size = 1541983, upload-time = "2026-03-05T17:57:41.061Z" },
+    { url = "https://files.pythonhosted.org/packages/78/c9/849a669b3b3bb8ac96005cdef04df4db658c33443a7fc704a6d4a2f07a56/brotlicffi-1.2.0.0-cp314-cp314t-win32.whl", hash = "sha256:a8079e8ecc32ecef728036a1d9b7105991ce6a5385cf51ee8c02297c90fb08c2", size = 349046, upload-time = "2026-03-05T17:57:42.76Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/25/09c0fd21cfc451fa38ad538f4d18d8be566746531f7f27143f63f8c45a9f/brotlicffi-1.2.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:ca90c4266704ca0a94de8f101b4ec029624273380574e4cf19301acfa46c61a0", size = 385653, upload-time = "2026-03-05T17:57:44.224Z" },
     { url = "https://files.pythonhosted.org/packages/e4/df/a72b284d8c7bef0ed5756b41c2eb7d0219a1dd6ac6762f1c7bdbc31ef3af/brotlicffi-1.2.0.0-cp38-abi3-macosx_11_0_arm64.whl", hash = "sha256:9458d08a7ccde8e3c0afedbf2c70a8263227a68dea5ab13590593f4c0a4fd5f4", size = 432340, upload-time = "2025-11-21T18:17:42.277Z" },
     { url = "https://files.pythonhosted.org/packages/74/2b/cc55a2d1d6fb4f5d458fba44a3d3f91fb4320aa14145799fd3a996af0686/brotlicffi-1.2.0.0-cp38-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:84e3d0020cf1bd8b8131f4a07819edee9f283721566fe044a20ec792ca8fd8b7", size = 1534002, upload-time = "2025-11-21T18:17:43.746Z" },
     { url = "https://files.pythonhosted.org/packages/e4/9c/d51486bf366fc7d6735f0e46b5b96ca58dc005b250263525a1eea3cd5d21/brotlicffi-1.2.0.0-cp38-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:33cfb408d0cff64cd50bef268c0fed397c46fbb53944aa37264148614a62e990", size = 1536547, upload-time = "2025-11-21T18:17:45.729Z" },
@@ -1804,6 +1809,19 @@ wheels = [
 ]
 
 [[package]]
+name = "pyright"
+version = "1.1.408"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nodeenv" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/74/b2/5db700e52554b8f025faa9c3c624c59f1f6c8841ba81ab97641b54322f16/pyright-1.1.408.tar.gz", hash = "sha256:f28f2321f96852fa50b5829ea492f6adb0e6954568d1caa3f3af3a5f555eb684", size = 4400578, upload-time = "2026-01-08T08:07:38.795Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/82/a2c93e32800940d9573fb28c346772a14778b84ba7524e691b324620ab89/pyright-1.1.408-py3-none-any.whl", hash = "sha256:090b32865f4fdb1e0e6cd82bf5618480d48eecd2eb2e70f960982a3d9a4c17c1", size = 6399144, upload-time = "2026-01-08T08:07:37.082Z" },
+]
+
+[[package]]
 name = "pytest"
 version = "9.0.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1947,6 +1965,7 @@ anthropic = [
 dev = [
     { name = "mypy" },
     { name = "pre-commit" },
+    { name = "pyright" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
@@ -2020,6 +2039,7 @@ requires-dist = [
     { name = "pvl-webtools", marker = "extra == 'research'", git = "https://github.com/pvliesdonk/pvl-webtools.git" },
     { name = "pvl-webtools", marker = "extra == 'research-web'", git = "https://github.com/pvliesdonk/pvl-webtools.git" },
     { name = "pydantic", specifier = ">=2.0" },
+    { name = "pyright", marker = "extra == 'dev'", specifier = ">=1.1" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.24" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=5.0" },


### PR DESCRIPTION
## TL;DR — scope grew beyond the original title

This PR started as a narrow fix ("point pyright at `.venv` so imports resolve"). Reviewer #1 correctly flagged that the initial config had no `typeCheckingMode`, which led to a strategic question: since every remaining spec-compliance epic (#1281 / #1296 / #1310 / #1319 / #1325 / #1331) will rewrite its stage anyway, does it still make sense to keep pyright editor-only and migrate CI later?

Answer (agreed in review): no — fold the migration in now and let each stage's compliance PR drop its own epic-tagged suppressions as part of "done." The scope of this PR is therefore broader than the title suggests. It is called out explicitly below and the title now undersells it; renaming would lose the review history.

## What this PR actually does

1. **`[tool.pyright]` in `pyproject.toml`** — `venvPath` / `venv` / `pythonVersion` / `typeCheckingMode = "standard"`. Pyright-lsp resolves third-party imports; CI picks up the same config.
2. **Pyright in CI alongside mypy** (`.github/workflows/ci.yml`). Both run on PRs. Plan: drop mypy when DRESS or SHIP lands, once every stage has passed standard mode cleanly.
3. **Stage protocol widened** (`pipeline/stages/base.py`) to match what concrete stages actually provide — `project_path`, `callbacks`, `unload_after_*` hooks, and a catch-all `**kwargs: Any`. Every stage now satisfies the protocol without ignores.
4. **Per-file pyright suppressions in late-stage code** — each tagged `TODO(#<epic>)` so the owning epic's PR removes them as part of compliance work.

## Decisions, with rationale

### `typeCheckingMode` escalation: `basic` → `standard`

Commit `1da9d53` set `basic`; commit `425eebb` escalated to `standard`. Silent change — my mistake, flagged by reviewer. The reasoning:

| Mode | pyright errors on src/ | Value |
|---|---|---|
| off | 0 | import resolution only; no type checks |
| basic | 20 | hides ~26 real `reportPossiblyUnboundVariable` findings that mypy also misses |
| **standard** (chosen) | 46 | surfaces real issues (unbound vars, Optional handling, attribute drift) |
| strict | 894 | mostly inference noise; would require Any→explicit annotations pass |

`basic` hides exactly the kind of bug this migration is meant to catch. `standard` is the usable middle ground.

### Pyright in CI alongside mypy

Reviewer #1's suggestion ("keep editor-only for now, migrate later") is sensible under normal conditions. It breaks down here because every upcoming epic rewrites its stage. Tagging each file's current findings to the epic that will clean them up means the migration has zero net cost — the work was happening anyway.

### `Stage` Protocol changes (`base.py`)

Two deliberate weakenings, both flagged by reviewer and both accepted:

- **`async def execute` → `def execute(...) -> Coroutine[...]`.** Concrete stages wrap `execute` in `@traceable`. Pyright infers the decorated return as `collections.abc.Coroutine`, which fails to match the `CoroutineType` that `async def` on the Protocol would require. Inline comment added. Semantically equivalent at runtime.
- **`**kwargs: Any` added.** Stage-specific parameters (SEED's `max_outer_retries`, various `unload_after_*` hooks) vary per stage. Alternatives considered: (a) remove from concrete stages — out of scope; (b) Protocol union — adds more complexity than it removes. Accepted tradeoff: keyword typos at `stage.execute(...)` call sites won't be caught. Call sites go through the orchestrator and are few.

### Per-file suppressions

Each late-stage file gets a module-level `# pyright: report…=false` + `# TODO(#<epic>)` comment. Reviewer rightly noted this covers future violations in the same file. Accepted because:

- The TODO tag points at the epic that will own the cleanup.
- Each stage's compliance PR removes its own suppressions before landing.
- Inline `# pyright: ignore[…]` per-line would be noisier and would still hide new violations unless future authors happen to notice the pattern.

If any suppressed file stays untouched after its epic is closed, that's a scope slip we can catch in that epic's review.

## Epic-tagged cleanup map

| Epic | Files carrying ignores |
|---|---|
| #1296 M-GROW | `grow/stage.py`, `grow/llm_phases.py` |
| #1310 M-POLISH | `polish/stage.py` |
| #1319 M-FILL | `fill.py`, `graph/context.py` |
| #1281 M-SEED | `models/seed.py` |
| #1353 (filed) | `observability/langchain_callbacks.py` — langchain API drift |
| #1354 (filed) | `pipeline/orchestrator.py` — tuple-return widening in provider resolution |

DREAM+BRAINSTORM code (validators, stages, mutations) has **no pyright suppressions**. They passed through compliance and stay passing.

## Verification

```
$ uv run pyright src/           # 0 errors, 0 warnings, 0 informations
$ uv run mypy src/              # Success: no issues found in 119 source files
$ uv run ruff check src/        # All checks passed
$ uv run pytest tests/unit/test_dream*.py tests/unit/test_brainstorm*.py   # 84 passed
```

## Test plan

- [x] Pyright 0 errors on `src/` at standard mode
- [x] Mypy --strict baseline unchanged
- [x] DREAM+BRAINSTORM suites still green
- [ ] Editor / Claude Code pyright-lsp picks up the new config on a fresh `uv sync`
- [ ] Each stage's upcoming compliance PR drops its epic-tagged ignores

🤖 Generated with [Claude Code](https://claude.com/claude-code)