### PR TITLE
feat(polish): compliance with authoritative spec (hot-path clusters)

### DIFF
--- a/docs/superpowers/plans/2026-04-20-polish-compliance.md
+++ b/docs/superpowers/plans/2026-04-20-polish-compliance.md
@@ -1,0 +1,1907 @@
+# POLISH Spec-Compliance (Hot-Path) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Bring the POLISH stage into compliance with its authoritative spec for the 4 hot-path clusters (#1311, #1312, #1313, #1314), using a stage-exit contract validator with a dedicated `PolishContractError` raised from Phase 7.
+
+**Architecture:** Validator-first TDD. Add `PolishContractError` and wire Phase 7 to raise it. Extend `validate_polish_output` with hot-path helpers. Write failing contract tests covering all 4 rules. Fix clusters one at a time, flipping contract tests green. Rewrite fixtures that still describe valid spec intent; delete those whose premise is pre-audit. Downstream (FILL/DRESS/SHIP/post-POLISH) is allowed to break.
+
+**Tech Stack:** Python 3.11+, `uv` package manager, `pydantic`, `pytest`, `ruff`, `mypy`, `pyright`. No new libraries.
+
+**Spec:** `docs/superpowers/specs/2026-04-20-polish-compliance-design.md`
+
+**Prereqs:** PR #1357 (GROW compliance) and PR #1358 (R-4a.3 spec update + ontology Part 8 alignment) must be merged. Both landed on `main` 2026-04-20.
+
+**Branch:** `feat/polish-compliance` (already exists locally on top of main; holds the design doc commit).
+
+---
+
+## File Structure
+
+### Files modified
+
+- `src/questfoundry/graph/polish_validation.py` — add `PolishContractError` class; extend `validate_polish_output` with 4 new `_check_*` helpers.
+- `src/questfoundry/pipeline/stages/polish/deterministic.py` — rewire `phase_validation` to raise `PolishContractError`; rewrite `compute_beat_grouping` (Cluster #1311); add zero-choice halt in Phase 4c (Cluster #1312); branch residue creation on `mapping_strategy` (Cluster #1313).
+- `src/questfoundry/pipeline/stages/polish/llm_phases.py` — replace `character_arc_metadata` node creation with entity-data annotation (Cluster #1314); add `mapping_strategy` to Phase 5b prompt + schema (Cluster #1313).
+- `src/questfoundry/models/polish.py` — add `mapping_strategy` field to `ResidueSpec` (Cluster #1313).
+
+### Files created
+
+- `tests/unit/test_polish_contract.py` — rule-by-rule contract tests for the 4 hot-path rules.
+
+### Test files modified
+
+- `tests/unit/test_polish_deterministic.py` — Phase 4a grouping tests rewritten to assert maximal-linear-collapse output.
+- `tests/unit/test_polish_phases.py` — delete `test_has_arc_metadata_edge_created`; add `test_character_arc_field_on_entity`.
+- `tests/unit/test_polish_llm_phases.py` — Phase 3 tests updated; Phase 5b tests add `mapping_strategy` assertions.
+- `tests/unit/test_polish_apply.py` — residue mapping tests parameterized over both `mapping_strategy` values.
+
+### Files NOT touched
+
+- `docs/design/procedures/polish.md` — already updated in PR #1358.
+- `docs/design/story-graph-ontology.md` — already updated in PR #1358.
+- FILL/DRESS/SHIP code and tests — downstream allowed to break per policy.
+- `# pyright: reportArgumentType=false` suppression on `polish/stage.py:16` — saved for final cluster PR, not this hot-path PR.
+
+---
+
+## Naming conventions used in this plan
+
+- `PolishContractError(ValueError)` — raised from Phase 7 when `validate_polish_output` reports errors.
+- `mapping_strategy` — `Literal["residue_passage_with_variants", "parallel_passages"]` on `ResidueSpec`.
+- `character_arc` — dict field on entity `data` dicts with keys `start: str`, `pivots: dict[str, str]` (path_id → pivot beat_id), `end_per_path: dict[str, str]`.
+- `_check_no_character_arc_metadata_nodes`, `_check_passage_maximal_linear_collapse`, `_check_residue_mapping_strategy`, `_check_has_choice_edges` — new validator helpers.
+
+---
+
+## Phase 0 — Prereqs
+
+### Task 1: Baseline sanity
+
+**Files:** None (branch hygiene).
+
+- [ ] **Step 1: Confirm main has both prereq PRs merged**
+
+Run:
+```bash
+git log --oneline origin/main | head -5
+```
+Expected: recent commits include `feat(grow): compliance with authoritative spec (#1357)` and `docs(polish): rewrite R-4a.3 as maximal-linear-collapse rule (#1358)`.
+
+- [ ] **Step 2: Confirm branch is rebased on main**
+
+Run:
+```bash
+git fetch origin main
+git log --oneline origin/main..feat/polish-compliance
+```
+Expected: exactly one commit on the branch — the design doc commit (`docs(polish): spec-compliance design for hot-path clusters`).
+
+If the branch is not on top of main, rebase:
+```bash
+git rebase origin/main
+```
+
+- [ ] **Step 3: Confirm POLISH-local tests pass on baseline**
+
+Run:
+```bash
+uv run pytest tests/unit/test_polish_validation.py tests/unit/test_polish_deterministic.py tests/unit/test_polish_phases.py tests/unit/test_polish_apply.py tests/unit/test_polish_llm_phases.py -x -q
+```
+Expected: all pass. Record the count for later comparison. If any fail on `main`, stop and investigate before modifying.
+
+- [ ] **Step 4: No commit — this is a checkpoint**
+
+Skip. Proceed to Phase 1.
+
+---
+
+## Phase 1 — Validator scaffolding
+
+### Task 2: Add `PolishContractError` class
+
+**Files:**
+- Modify: `src/questfoundry/graph/polish_validation.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/unit/test_polish_contract.py` with only this initial content (more tests land in Task 4):
+
+```python
+"""Rule-by-rule POLISH Stage Output Contract validator tests.
+
+Layered over DREAM + BRAINSTORM + SEED + GROW + POLISH compliant baseline.
+Mirrors the pattern of tests/unit/test_grow_validation_contract.py.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from questfoundry.graph.graph import Graph
+from questfoundry.graph.polish_validation import (
+    PolishContractError,
+    validate_polish_output,
+)
+
+
+def test_polish_contract_error_is_value_error() -> None:
+    """PolishContractError is a ValueError subclass (same convention as GrowContractError)."""
+    assert issubclass(PolishContractError, ValueError)
+
+
+def test_polish_contract_error_carries_message() -> None:
+    """PolishContractError preserves the error message for callers."""
+    err = PolishContractError("R-4a.4: intersection groups consumed")
+    assert "R-4a.4" in str(err)
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run:
+```bash
+uv run pytest tests/unit/test_polish_contract.py -x -q
+```
+Expected: ImportError — `PolishContractError` does not exist.
+
+- [ ] **Step 3: Add `PolishContractError` to `polish_validation.py`**
+
+Insert this block in `src/questfoundry/graph/polish_validation.py` immediately after the imports section (around line 40, before `def validate_polish_output`):
+
+```python
+class PolishContractError(ValueError):
+    """Raised when POLISH Phase 7 validation reports contract errors.
+
+    Mirrors ``GrowContractError`` — a dedicated exception type for
+    stage-exit contract failures so callers can distinguish them from
+    generic ``ValueError`` noise.  Callers receive the formatted error
+    list in the exception message.
+    """
+```
+
+Add `"PolishContractError"` to the `__all__` list in the same file.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run:
+```bash
+uv run pytest tests/unit/test_polish_contract.py -x -q
+```
+Expected: 2 passed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/questfoundry/graph/polish_validation.py tests/unit/test_polish_contract.py
+git commit -m "feat(polish): add PolishContractError for Phase 7 exit contract
+
+ValueError subclass; mirrors GrowContractError.  Will be raised from
+phase_validation when validate_polish_output reports errors (next
+task).  Part of epic #1310."
+```
+
+---
+
+### Task 3: Wire Phase 7 to raise `PolishContractError`
+
+**Files:**
+- Modify: `src/questfoundry/pipeline/stages/polish/deterministic.py:1385-1408`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/unit/test_polish_contract.py`:
+
+```python
+import asyncio
+from unittest.mock import MagicMock
+
+
+def test_phase_validation_raises_contract_error_on_errors(monkeypatch: pytest.MonkeyPatch) -> None:
+    """phase_validation raises PolishContractError (not PhaseResult) when
+    validate_polish_output returns errors."""
+    from questfoundry.pipeline.stages.polish import deterministic
+
+    graph = Graph.empty()
+
+    def _mock_validate(g: Graph) -> list[str]:
+        return ["R-4a.4: intersection groups consumed (test)"]
+
+    monkeypatch.setattr(
+        "questfoundry.graph.polish_validation.validate_polish_output",
+        _mock_validate,
+    )
+
+    with pytest.raises(PolishContractError, match=r"R-4a\.4"):
+        asyncio.run(deterministic.phase_validation(graph, MagicMock()))
+
+
+def test_phase_validation_passes_on_clean_graph(monkeypatch: pytest.MonkeyPatch) -> None:
+    """phase_validation returns completed PhaseResult when no errors."""
+    from questfoundry.pipeline.stages.polish import deterministic
+
+    graph = Graph.empty()
+    monkeypatch.setattr(
+        "questfoundry.graph.polish_validation.validate_polish_output",
+        lambda g: [],
+    )
+
+    result = asyncio.run(deterministic.phase_validation(graph, MagicMock()))
+    assert result.status == "completed"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run:
+```bash
+uv run pytest tests/unit/test_polish_contract.py::test_phase_validation_raises_contract_error_on_errors -x -q
+```
+Expected: FAIL — current `phase_validation` returns a `PhaseResult(status="failed", ...)`, does not raise.
+
+- [ ] **Step 3: Update `phase_validation` in `polish/deterministic.py`**
+
+Replace the block at `deterministic.py:1385-1408` with:
+
+```python
+async def phase_validation(
+    graph: Graph,
+    model: BaseChatModel,  # noqa: ARG001
+) -> PhaseResult:
+    """Phase 7: Validate the complete passage graph.
+
+    Runs structural, variant, choice, and feasibility checks on the
+    passage layer created by Phase 6.  On any error, raises
+    ``PolishContractError`` after logging a structured ERROR event —
+    failures at this seam indicate bugs in Phases 4-6 or insufficient
+    GROW output and should halt the pipeline loudly.
+    """
+    from questfoundry.graph.polish_validation import (
+        PolishContractError,
+        validate_polish_output,
+    )
+
+    errors = validate_polish_output(graph)
+
+    if errors:
+        log.error(
+            "polish_contract_failed",
+            error_count=len(errors),
+            errors=errors[:10],  # cap for log readability
+        )
+        raise PolishContractError(
+            f"POLISH stage output contract violated ({len(errors)} "
+            f"error(s)):\n" + "\n".join(f"  - {e}" for e in errors)
+        )
+```
+
+Keep the existing summary-stats block at the end of the function (lines 1410+) unchanged.
+
+- [ ] **Step 4: Run all tests to verify they pass**
+
+Run:
+```bash
+uv run pytest tests/unit/test_polish_contract.py -x -q
+```
+Expected: 4 passed.
+
+Run the broader POLISH validation suite to catch regressions:
+```bash
+uv run pytest tests/unit/test_polish_validation.py -x -q
+```
+Expected: all pass (no behavior change for the structural checks).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/questfoundry/pipeline/stages/polish/deterministic.py tests/unit/test_polish_contract.py
+git commit -m "feat(polish): raise PolishContractError from phase_validation
+
+phase_validation now raises PolishContractError when
+validate_polish_output reports errors, with a structured
+polish_contract_failed log.error event.  Previously wrapped as a
+failed PhaseResult which the stage loop translated to
+PolishStageError — the dedicated contract error type is clearer at
+the seam and mirrors the GROW pattern.  Part of epic #1310."
+```
+
+---
+
+## Phase 2 — Validator extensions (failing contract tests + helpers)
+
+### Task 4: Compliant-baseline fixture + failing hot-path tests
+
+**Files:**
+- Modify: `tests/unit/test_polish_contract.py`
+
+- [ ] **Step 1: Append the compliant-baseline fixture**
+
+Append to `tests/unit/test_polish_contract.py` (top-level, before the existing class/tests):
+
+```python
+# --------------------------------------------------------------------------
+# Compliant POLISH-output baseline (DREAM + BRAINSTORM + SEED + GROW + POLISH)
+# --------------------------------------------------------------------------
+
+
+def _polish_upstream_baseline(graph: Graph) -> None:
+    """Layer a compliant DREAM+BRAINSTORM+SEED+GROW baseline.
+
+    Produces the same graph shape used by test_grow_validation_contract.py
+    so validate_polish_output's upstream-contract delegation passes.
+    Single soft dilemma `mentor_trust` with 2 paths, Y-shape beats,
+    state flags, convergence metadata.
+    """
+    graph.create_node(
+        "vision",
+        {
+            "type": "vision",
+            "genre": "dark fantasy",
+            "tone": ["atmospheric"],
+            "themes": ["forbidden knowledge"],
+            "audience": "adult",
+            "scope": {"story_size": "short"},
+            "human_approved": True,
+        },
+    )
+    for eid, cat, name in [
+        ("character::kay", "character", "Kay"),
+        ("character::mentor", "character", "Mentor"),
+        ("location::archive", "location", "Archive"),
+        ("location::depths", "location", "Forbidden Depths"),
+    ]:
+        graph.create_node(
+            eid,
+            {
+                "type": "entity",
+                "raw_id": eid.split("::", 1)[-1],
+                "name": name,
+                "category": cat,
+                "concept": "x",
+                "disposition": "retained",
+            },
+        )
+    graph.create_node(
+        "dilemma::mentor_trust",
+        {
+            "type": "dilemma",
+            "raw_id": "mentor_trust",
+            "question": "Trust?",
+            "why_it_matters": "stakes",
+            "dilemma_role": "soft",
+            "residue_weight": "light",
+            "ending_salience": "low",
+        },
+    )
+    for ans, is_canon in [("protector", True), ("manipulator", False)]:
+        ans_id = f"dilemma::mentor_trust::alt::{ans}"
+        graph.create_node(
+            ans_id,
+            {
+                "type": "answer",
+                "raw_id": ans,
+                "description": f"d-{ans}",
+                "is_canonical": is_canon,
+                "explored": True,
+            },
+        )
+        graph.add_edge("has_answer", "dilemma::mentor_trust", ans_id)
+    graph.add_edge("anchored_to", "dilemma::mentor_trust", "character::mentor")
+
+    for ans in ["protector", "manipulator"]:
+        path_id = f"path::mentor_trust__{ans}"
+        graph.create_node(
+            path_id,
+            {
+                "type": "path",
+                "raw_id": f"mentor_trust__{ans}",
+                "dilemma_id": "dilemma::mentor_trust",
+                "is_canonical": ans == "protector",
+            },
+        )
+        graph.add_edge("explores", path_id, f"dilemma::mentor_trust::alt::{ans}")
+        conseq_id = f"consequence::mentor_trust__{ans}"
+        graph.create_node(
+            conseq_id,
+            {
+                "type": "consequence",
+                "raw_id": f"mentor_trust__{ans}",
+                "description": "mentor becomes hostile",
+                "ripples": ["faction mistrust rises"],
+            },
+        )
+        graph.add_edge("has_consequence", path_id, conseq_id)
+
+    graph.create_node(
+        "beat::pre_mentor_01",
+        {
+            "type": "beat",
+            "raw_id": "pre_mentor_01",
+            "summary": "Mentor delivers warning",
+            "entities": ["character::mentor", "character::kay"],
+            "dilemma_impacts": [
+                {"dilemma_id": "dilemma::mentor_trust", "effect": "advances"}
+            ],
+        },
+    )
+    graph.add_edge("belongs_to", "beat::pre_mentor_01", "path::mentor_trust__protector")
+    graph.add_edge("belongs_to", "beat::pre_mentor_01", "path::mentor_trust__manipulator")
+
+    for ans in ["protector", "manipulator"]:
+        path_id = f"path::mentor_trust__{ans}"
+        commit_id = f"beat::commit_{ans}"
+        graph.create_node(
+            commit_id,
+            {
+                "type": "beat",
+                "raw_id": f"commit_{ans}",
+                "summary": f"Mentor reveals {ans} motive",
+                "entities": ["character::mentor"],
+                "dilemma_impacts": [
+                    {"dilemma_id": "dilemma::mentor_trust", "effect": "commits"}
+                ],
+            },
+        )
+        graph.add_edge("belongs_to", commit_id, path_id)
+        graph.add_edge("predecessor", commit_id, "beat::pre_mentor_01")
+        for i in range(1, 3):
+            post_id = f"beat::post_{ans}_{i:02d}"
+            graph.create_node(
+                post_id,
+                {
+                    "type": "beat",
+                    "raw_id": f"post_{ans}_{i:02d}",
+                    "summary": f"Post-commit {i} on {ans}",
+                    "entities": ["character::mentor"],
+                    "dilemma_impacts": [],
+                },
+            )
+            graph.add_edge("belongs_to", post_id, path_id)
+            prev = commit_id if i == 1 else f"beat::post_{ans}_{i - 1:02d}"
+            graph.add_edge("predecessor", post_id, prev)
+
+    graph.create_node("seed_freeze", {"type": "seed_freeze", "human_approved": True})
+
+    for ans in ["protector", "manipulator"]:
+        flag_id = f"state_flag::mentor_{ans}"
+        graph.create_node(
+            flag_id,
+            {
+                "type": "state_flag",
+                "raw_id": f"mentor_{ans}",
+                "name": f"mentor_is_{ans}",
+            },
+        )
+        graph.add_edge("derived_from", flag_id, f"consequence::mentor_trust__{ans}")
+
+    graph.update_node(
+        "dilemma::mentor_trust",
+        converges_at="beat::post_protector_02",
+        convergence_payoff=2,
+    )
+
+
+def _polish_passage_baseline(graph: Graph) -> None:
+    """Add a spec-compliant POLISH passage layer on top of the upstream baseline.
+
+    5 passages using maximal-linear-collapse over the Y-shape beat DAG:
+      P_pre   = [pre_mentor_01]              — shared pre-commit, closes at Y-fork
+      P_prot  = [commit_protector, post_protector_01, post_protector_02]
+      P_mani  = [commit_manipulator, post_manipulator_01, post_manipulator_02]
+    One choice edge from P_pre to each of P_prot / P_mani.
+    Each entity with ≥2 appearances carries a `character_arc` annotation.
+    """
+    passage_specs = [
+        ("passage::pre", ["beat::pre_mentor_01"], False),
+        (
+            "passage::prot",
+            ["beat::commit_protector", "beat::post_protector_01", "beat::post_protector_02"],
+            False,
+        ),
+        (
+            "passage::mani",
+            ["beat::commit_manipulator", "beat::post_manipulator_01", "beat::post_manipulator_02"],
+            False,
+        ),
+    ]
+    for passage_id, beat_ids, is_variant in passage_specs:
+        graph.create_node(
+            passage_id,
+            {
+                "type": "passage",
+                "raw_id": passage_id.split("::", 1)[-1],
+                "from_beat": beat_ids[0],
+                "summary": f"Passage at {beat_ids[0]}",
+                "is_variant": is_variant,
+            },
+        )
+        for bid in beat_ids:
+            graph.add_edge("grouped_in", bid, passage_id)
+
+    for idx, to_id in enumerate(("passage::prot", "passage::mani")):
+        choice_id = f"choice::pre_to_{to_id.rsplit('::', 1)[-1]}"
+        graph.create_node(
+            choice_id,
+            {
+                "type": "choice",
+                "raw_id": choice_id.split("::", 1)[-1],
+                "from_passage": "passage::pre",
+                "to_passage": to_id,
+                "label": f"Choice {idx + 1}",
+                "requires": [],
+            },
+        )
+        graph.add_edge("choice_from", choice_id, "passage::pre")
+        graph.add_edge("choice_to", choice_id, to_id)
+
+    # Character arc on the recurring entity.
+    graph.update_node(
+        "character::mentor",
+        character_arc={
+            "start": "warning delivered",
+            "pivots": {
+                "path::mentor_trust__protector": "beat::commit_protector",
+                "path::mentor_trust__manipulator": "beat::commit_manipulator",
+            },
+            "end_per_path": {
+                "path::mentor_trust__protector": "beat::post_protector_02",
+                "path::mentor_trust__manipulator": "beat::post_manipulator_02",
+            },
+        },
+    )
+
+
+@pytest.fixture
+def compliant_polish_graph() -> Graph:
+    graph = Graph()
+    _polish_upstream_baseline(graph)
+    _polish_passage_baseline(graph)
+    return graph
+
+
+# --------------------------------------------------------------------------
+# Positive baseline
+# --------------------------------------------------------------------------
+
+
+def test_valid_polish_graph_passes(compliant_polish_graph: Graph) -> None:
+    errors = validate_polish_output(compliant_polish_graph)
+    assert errors == [], f"expected no errors, got: {errors}"
+
+
+# --------------------------------------------------------------------------
+# Upstream delegation
+# --------------------------------------------------------------------------
+
+
+def test_upstream_grow_contract_violation_surfaces(compliant_polish_graph: Graph) -> None:
+    compliant_polish_graph.update_node("seed_freeze", human_approved=False)
+    errors = validate_polish_output(compliant_polish_graph)
+    assert any("SEED" in e or "seed_freeze" in e for e in errors), (
+        f"expected upstream contract error, got {errors}"
+    )
+
+
+# --------------------------------------------------------------------------
+# R-3.3: arc metadata as entity annotation (Cluster #1314)
+# --------------------------------------------------------------------------
+
+
+def test_R_3_3_character_arc_metadata_node_forbidden(compliant_polish_graph: Graph) -> None:
+    compliant_polish_graph.create_node(
+        "character_arc_metadata::mentor",
+        {"type": "character_arc_metadata", "raw_id": "mentor"},
+    )
+    errors = validate_polish_output(compliant_polish_graph)
+    assert any("R-3.3" in e or "character_arc_metadata" in e for e in errors), (
+        f"expected R-3.3 error, got {errors}"
+    )
+
+
+def test_R_3_3_has_arc_metadata_edge_forbidden(compliant_polish_graph: Graph) -> None:
+    compliant_polish_graph.create_node(
+        "character_arc_metadata::mentor",
+        {"type": "character_arc_metadata", "raw_id": "mentor"},
+    )
+    compliant_polish_graph.add_edge(
+        "has_arc_metadata", "character::mentor", "character_arc_metadata::mentor"
+    )
+    errors = validate_polish_output(compliant_polish_graph)
+    assert any("R-3.3" in e or "has_arc_metadata" in e for e in errors), (
+        f"expected R-3.3 edge error, got {errors}"
+    )
+
+
+def test_R_3_3_arc_worthy_entity_missing_annotation(compliant_polish_graph: Graph) -> None:
+    compliant_polish_graph.update_node("character::mentor", character_arc=None)
+    errors = validate_polish_output(compliant_polish_graph)
+    assert any(
+        "R-3.3" in e or ("character::mentor" in e and "character_arc" in e)
+        for e in errors
+    ), f"expected missing-annotation error, got {errors}"
+
+
+# --------------------------------------------------------------------------
+# R-4a.4: maximal-linear-collapse (Cluster #1311)
+# --------------------------------------------------------------------------
+
+
+def test_R_4a_4_passage_spans_divergence_forbidden(compliant_polish_graph: Graph) -> None:
+    """A passage whose member beats straddle a Y-fork divergence is a grouping error."""
+    # Move commit_protector into passage::pre — now the passage spans the Y-fork.
+    compliant_polish_graph.remove_edge("grouped_in", "beat::commit_protector", "passage::prot")
+    compliant_polish_graph.add_edge("grouped_in", "beat::commit_protector", "passage::pre")
+    errors = validate_polish_output(compliant_polish_graph)
+    assert any("R-4a.4" in e or "divergence" in e.lower() or "linear" in e.lower() for e in errors), (
+        f"expected R-4a.4 error, got {errors}"
+    )
+
+
+def test_R_4a_4_passage_stops_mid_linear_run(compliant_polish_graph: Graph) -> None:
+    """Splitting a linear run into two passages is a grouping error."""
+    # Move post_protector_02 out of passage::prot into a new singleton.
+    compliant_polish_graph.remove_edge(
+        "grouped_in", "beat::post_protector_02", "passage::prot"
+    )
+    compliant_polish_graph.create_node(
+        "passage::prot_tail",
+        {
+            "type": "passage",
+            "raw_id": "prot_tail",
+            "from_beat": "beat::post_protector_02",
+            "summary": "Orphan tail",
+        },
+    )
+    compliant_polish_graph.add_edge(
+        "grouped_in", "beat::post_protector_02", "passage::prot_tail"
+    )
+    errors = validate_polish_output(compliant_polish_graph)
+    assert any("R-4a.4" in e or "linear" in e.lower() for e in errors), (
+        f"expected R-4a.4 mid-run split error, got {errors}"
+    )
+
+
+# --------------------------------------------------------------------------
+# R-5.7 / R-5.8: residue mapping_strategy (Cluster #1313)
+# --------------------------------------------------------------------------
+
+
+def test_R_5_7_residue_passage_missing_mapping_strategy(
+    compliant_polish_graph: Graph,
+) -> None:
+    compliant_polish_graph.create_node(
+        "passage::residue_01",
+        {
+            "type": "passage",
+            "raw_id": "residue_01",
+            "from_beat": "beat::post_protector_01",
+            "summary": "Residue",
+            "residue_for": "passage::prot",
+            # mapping_strategy intentionally absent
+        },
+    )
+    errors = validate_polish_output(compliant_polish_graph)
+    assert any("R-5.7" in e or "R-5.8" in e or "mapping_strategy" in e for e in errors), (
+        f"expected missing mapping_strategy error, got {errors}"
+    )
+
+
+def test_R_5_8_residue_passage_bad_mapping_strategy(
+    compliant_polish_graph: Graph,
+) -> None:
+    compliant_polish_graph.create_node(
+        "passage::residue_01",
+        {
+            "type": "passage",
+            "raw_id": "residue_01",
+            "from_beat": "beat::post_protector_01",
+            "summary": "Residue",
+            "residue_for": "passage::prot",
+            "mapping_strategy": "not_a_valid_value",
+        },
+    )
+    errors = validate_polish_output(compliant_polish_graph)
+    assert any("R-5.8" in e or "mapping_strategy" in e for e in errors), (
+        f"expected invalid mapping_strategy error, got {errors}"
+    )
+
+
+# --------------------------------------------------------------------------
+# R-4c.2: zero-choice ERROR halt (Cluster #1312, belt-and-suspenders)
+# --------------------------------------------------------------------------
+
+
+def test_R_4c_2_zero_choice_edges_fails(compliant_polish_graph: Graph) -> None:
+    for cid in list(compliant_polish_graph.get_nodes_by_type("choice")):
+        compliant_polish_graph.delete_node(cid, cascade=True)
+    errors = validate_polish_output(compliant_polish_graph)
+    assert any("R-4c.2" in e or "zero choice" in e.lower() for e in errors), (
+        f"expected zero-choice error, got {errors}"
+    )
+```
+
+- [ ] **Step 2: Run all new tests to verify they fail**
+
+Run:
+```bash
+uv run pytest tests/unit/test_polish_contract.py -x -q
+```
+Expected: `test_valid_polish_graph_passes` may pass or fail depending on existing validator coverage of the baseline; each of the new R-3.3 / R-4a.4 / R-5.7-8 / R-4c.2 tests FAILS because the helpers don't exist yet. Record which tests pass/fail — tasks 5–8 will flip each failing test green.
+
+- [ ] **Step 3: Commit the failing tests**
+
+```bash
+git add tests/unit/test_polish_contract.py
+git commit -m "test(polish): layered baseline + failing hot-path contract tests
+
+Adds _polish_upstream_baseline + _polish_passage_baseline helpers and
+rule-by-rule tests for R-3.3 (Cluster #1314), R-4a.4 (Cluster #1311),
+R-5.7/R-5.8 (Cluster #1313), R-4c.2 (Cluster #1312).
+
+Tests fail today because the validator helpers don't exist yet;
+each is flipped green by a subsequent _check_* helper (tasks 5-8)
+or cluster fix (tasks 9-12)."
+```
+
+---
+
+### Task 5: `_check_no_character_arc_metadata_nodes` (R-3.3)
+
+**Files:**
+- Modify: `src/questfoundry/graph/polish_validation.py`
+
+- [ ] **Step 1: Add the helper and wire it into `validate_polish_output`**
+
+Insert this helper in `polish_validation.py` (place it with the other `_check_*` helpers, after `_check_arc_metadata_edges` near line 419):
+
+```python
+def _check_no_character_arc_metadata_nodes(graph: Graph, errors: list[str]) -> None:
+    """R-3.3: arc metadata is stored as annotation on Entity nodes, never as separate nodes.
+
+    - No node may have type ``character_arc_metadata``.
+    - No ``has_arc_metadata`` edge may exist.
+    - Every Entity with ≥2 ``appears`` edges (arc-worthy) must carry a
+      ``character_arc`` data dict with ``start``, ``pivots``, ``end_per_path``.
+    """
+    for nid, ndata in graph.get_nodes_by_type("character_arc_metadata").items():
+        errors.append(
+            f"R-3.3: node {nid!r} has forbidden type 'character_arc_metadata'; "
+            "arc metadata must be stored on the Entity node itself"
+        )
+    for edge in graph.get_edges(edge_type="has_arc_metadata"):
+        errors.append(
+            f"R-3.3: forbidden 'has_arc_metadata' edge {edge['from']!r} → "
+            f"{edge['to']!r}; arc metadata is an entity annotation, not a "
+            "separate node"
+        )
+
+    # Arc-worthy entities need a character_arc annotation.
+    appears_edges = graph.get_edges(edge_type="appears")
+    appearance_count: dict[str, int] = {}
+    for edge in appears_edges:
+        appearance_count[edge["from"]] = appearance_count.get(edge["from"], 0) + 1
+
+    entity_nodes = graph.get_nodes_by_type("entity")
+    for entity_id, entity_data in sorted(entity_nodes.items()):
+        if appearance_count.get(entity_id, 0) < 2:
+            continue
+        arc = entity_data.get("character_arc")
+        if not isinstance(arc, dict):
+            errors.append(
+                f"R-3.3: entity {entity_id!r} has {appearance_count[entity_id]} beat "
+                "appearances but no 'character_arc' annotation on its data dict"
+            )
+            continue
+        for required in ("start", "pivots", "end_per_path"):
+            if required not in arc:
+                errors.append(
+                    f"R-3.3: entity {entity_id!r} 'character_arc' annotation "
+                    f"missing required field {required!r}"
+                )
+```
+
+Then add `_check_no_character_arc_metadata_nodes(graph, errors)` to `validate_polish_output`'s helper-call block.
+
+- [ ] **Step 2: Run R-3.3 tests to verify pass**
+
+Run:
+```bash
+uv run pytest tests/unit/test_polish_contract.py -k R_3_3 -x -q
+```
+Expected: 3 passed (test_R_3_3_character_arc_metadata_node_forbidden, test_R_3_3_has_arc_metadata_edge_forbidden, test_R_3_3_arc_worthy_entity_missing_annotation).
+
+Note: the `appears` edges are not present in the baseline yet — Cluster #1314 will wire those up. For now, `test_R_3_3_arc_worthy_entity_missing_annotation` may not trigger the "arc-worthy" branch. That's fine — the test constructs the positive case (entity with 2+ appearances) by other means or documents the edge pre-requisite. If the test fails because of missing `appears` edges, adjust the baseline to add them (see Step 3 below) or the test to manufacture them.
+
+- [ ] **Step 3: Add `appears` edges to `_polish_upstream_baseline`**
+
+If `test_R_3_3_arc_worthy_entity_missing_annotation` still fails because no `appears` edges exist, add them to `_polish_upstream_baseline` after beat creation (match beats to their `entities` list):
+
+```python
+# Wire appears(entity, beat) for arc-worthy-entity detection.
+for bid, bdata in graph.get_nodes_by_type("beat").items():
+    for eid in bdata.get("entities", []) or []:
+        graph.add_edge("appears", eid, bid)
+```
+
+Re-run the R-3.3 suite.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/questfoundry/graph/polish_validation.py tests/unit/test_polish_contract.py
+git commit -m "feat(polish): _check_no_character_arc_metadata_nodes (R-3.3)
+
+Validates that arc metadata is an Entity annotation, not a separate
+node.  Flipps the three R-3.3 contract tests green.  Code producing
+such nodes/edges today is fixed in Cluster #1314."
+```
+
+---
+
+### Task 6: `_check_passage_maximal_linear_collapse` (R-4a.4)
+
+**Files:**
+- Modify: `src/questfoundry/graph/polish_validation.py`
+
+- [ ] **Step 1: Add the helper**
+
+Insert this helper in `polish_validation.py` (after the helper from Task 5):
+
+```python
+def _check_passage_maximal_linear_collapse(graph: Graph, errors: list[str]) -> None:
+    """R-4a.4 (maximal-linear-collapse): a passage's beats form a maximal linear run.
+
+    For each passage:
+      - Member beats form a linear run: each interior beat has exactly one
+        in-passage predecessor and one in-passage successor.
+      - Passage boundaries sit at DAG divergences/convergences or terminals:
+        the first beat's in-degree ≠ 1 or its predecessor has out-degree ≠ 1;
+        the last beat's out-degree ≠ 1 or its successor has in-degree ≠ 1.
+
+    See docs/design/procedures/polish.md §R-4a.3 (maximal-linear-collapse).
+    """
+    beat_nodes = graph.get_nodes_by_type("beat")
+    passage_nodes = graph.get_nodes_by_type("passage")
+    pred_edges = graph.get_edges(edge_type="predecessor")
+    grouped_in = graph.get_edges(edge_type="grouped_in")
+
+    successors: dict[str, set[str]] = {}
+    predecessors: dict[str, set[str]] = {}
+    for edge in pred_edges:
+        # Convention: predecessor edges point successor → predecessor
+        successor, predecessor = edge["from"], edge["to"]
+        successors.setdefault(predecessor, set()).add(successor)
+        predecessors.setdefault(successor, set()).add(predecessor)
+
+    beat_to_passage: dict[str, str] = {}
+    passage_beats: dict[str, set[str]] = {}
+    for edge in grouped_in:
+        beat_id, passage_id = edge["from"], edge["to"]
+        if beat_id in beat_nodes and passage_id in passage_nodes:
+            beat_to_passage[beat_id] = passage_id
+            passage_beats.setdefault(passage_id, set()).add(beat_id)
+
+    for passage_id, beats in sorted(passage_beats.items()):
+        # Interior linearity: each beat's in-passage predecessors and
+        # successors are ≤ 1.
+        for bid in beats:
+            in_passage_preds = predecessors.get(bid, set()) & beats
+            in_passage_succs = successors.get(bid, set()) & beats
+            if len(in_passage_preds) > 1:
+                errors.append(
+                    f"R-4a.4: passage {passage_id!r} contains beat {bid!r} with "
+                    f"{len(in_passage_preds)} in-passage predecessors — not a "
+                    "linear run"
+                )
+            if len(in_passage_succs) > 1:
+                errors.append(
+                    f"R-4a.4: passage {passage_id!r} contains beat {bid!r} with "
+                    f"{len(in_passage_succs)} in-passage successors — not a "
+                    "linear run"
+                )
+
+        # Boundary check: the passage's first beat starts at a real boundary
+        # (in-degree ≠ 1 OR its predecessor has out-degree ≠ 1).
+        starts = [b for b in beats if not (predecessors.get(b, set()) & beats)]
+        ends = [b for b in beats if not (successors.get(b, set()) & beats)]
+        if len(starts) != 1 or len(ends) != 1:
+            errors.append(
+                f"R-4a.4: passage {passage_id!r} is not a single linear run "
+                f"(starts={len(starts)}, ends={len(ends)})"
+            )
+            continue
+
+        first, last = starts[0], ends[0]
+        # First beat: if it has exactly one predecessor and that predecessor
+        # has out-degree 1, the run should have started earlier.
+        first_preds = predecessors.get(first, set())
+        if len(first_preds) == 1:
+            only_pred = next(iter(first_preds))
+            if len(successors.get(only_pred, set())) == 1 and only_pred in beat_to_passage:
+                errors.append(
+                    f"R-4a.4: passage {passage_id!r} starts at {first!r} but its "
+                    f"predecessor {only_pred!r} has out-degree 1 — grouping "
+                    "stopped mid-linear-run"
+                )
+
+        # Last beat: mirror.
+        last_succs = successors.get(last, set())
+        if len(last_succs) == 1:
+            only_succ = next(iter(last_succs))
+            if len(predecessors.get(only_succ, set())) == 1 and only_succ in beat_to_passage:
+                errors.append(
+                    f"R-4a.4: passage {passage_id!r} ends at {last!r} but its "
+                    f"successor {only_succ!r} has in-degree 1 — grouping "
+                    "stopped mid-linear-run"
+                )
+```
+
+Add `_check_passage_maximal_linear_collapse(graph, errors)` to `validate_polish_output`'s helper-call block.
+
+- [ ] **Step 2: Run R-4a.4 tests**
+
+Run:
+```bash
+uv run pytest tests/unit/test_polish_contract.py -k R_4a_4 -x -q
+```
+Expected: 2 passed (test_R_4a_4_passage_spans_divergence_forbidden, test_R_4a_4_passage_stops_mid_linear_run).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/questfoundry/graph/polish_validation.py
+git commit -m "feat(polish): _check_passage_maximal_linear_collapse (R-4a.4)
+
+Validates passage grouping conforms to the maximal-linear-collapse
+rule: interior beats have single in-passage predecessor/successor;
+passage boundaries sit at DAG divergences/convergences.  Flips
+R-4a.4 contract tests green.  Code producing non-compliant groupings
+(intersection-driven) is fixed in Cluster #1311."
+```
+
+---
+
+### Task 7: `_check_residue_mapping_strategy` (R-5.7, R-5.8)
+
+**Files:**
+- Modify: `src/questfoundry/graph/polish_validation.py`
+
+- [ ] **Step 1: Add the helper**
+
+Insert in `polish_validation.py` (after the Task 6 helper):
+
+```python
+_VALID_MAPPING_STRATEGIES = frozenset({"residue_passage_with_variants", "parallel_passages"})
+
+
+def _check_residue_mapping_strategy(graph: Graph, errors: list[str]) -> None:
+    """R-5.7, R-5.8: every residue passage records its chosen mapping strategy.
+
+    Residue passages are identified by a ``residue_for`` field pointing to
+    their target shared passage.  Each must have ``mapping_strategy`` set
+    to one of the two legal values.  See docs/design/procedures/polish.md
+    §R-5.7/R-5.8.
+    """
+    for pid, pdata in sorted(graph.get_nodes_by_type("passage").items()):
+        if not pdata.get("residue_for"):
+            continue
+        strategy = pdata.get("mapping_strategy")
+        if strategy is None:
+            errors.append(
+                f"R-5.8: residue passage {pid!r} missing required "
+                "'mapping_strategy' field"
+            )
+            continue
+        if strategy not in _VALID_MAPPING_STRATEGIES:
+            errors.append(
+                f"R-5.8: residue passage {pid!r} has invalid mapping_strategy "
+                f"{strategy!r} (expected one of "
+                f"{sorted(_VALID_MAPPING_STRATEGIES)})"
+            )
+```
+
+Add `_check_residue_mapping_strategy(graph, errors)` to `validate_polish_output`.
+
+- [ ] **Step 2: Run R-5.7/R-5.8 tests**
+
+Run:
+```bash
+uv run pytest tests/unit/test_polish_contract.py -k "R_5_7 or R_5_8" -x -q
+```
+Expected: 2 passed.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/questfoundry/graph/polish_validation.py
+git commit -m "feat(polish): _check_residue_mapping_strategy (R-5.7, R-5.8)
+
+Validates residue passages carry a mapping_strategy attribute in
+{residue_passage_with_variants, parallel_passages}.  Flips R-5.7/R-5.8
+contract tests green.  The Phase 5b LLM call and Phase 6 applier are
+updated in Cluster #1313 to set this field and branch on it."
+```
+
+---
+
+### Task 8: `_check_has_choice_edges` (R-4c.2)
+
+**Files:**
+- Modify: `src/questfoundry/graph/polish_validation.py`
+
+- [ ] **Step 1: Add the helper**
+
+Insert in `polish_validation.py`:
+
+```python
+def _check_has_choice_edges(graph: Graph, errors: list[str]) -> None:
+    """R-4c.2 (belt-and-suspenders): zero choice edges in the passage graph
+    indicates a SEED/GROW bug — Phase 4c should already have raised.  This
+    check catches silent regressions where Phase 4c produced zero choices
+    but did not halt.
+    """
+    if not graph.get_nodes_by_type("choice"):
+        errors.append(
+            "R-4c.2: zero choice edges in passage graph — SEED/GROW DAG "
+            "has no Y-forks; Phase 4c should have halted"
+        )
+```
+
+Add `_check_has_choice_edges(graph, errors)` to `validate_polish_output`.
+
+- [ ] **Step 2: Run R-4c.2 test**
+
+Run:
+```bash
+uv run pytest tests/unit/test_polish_contract.py -k R_4c_2 -x -q
+```
+Expected: 1 passed (test_R_4c_2_zero_choice_edges_fails).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/questfoundry/graph/polish_validation.py
+git commit -m "feat(polish): _check_has_choice_edges (R-4c.2, belt-and-suspenders)
+
+Validates that the passage graph contains at least one choice edge.
+Phase 4c itself halts when compute_choice_edges returns empty (added
+in Cluster #1312); this postcondition catches silent regressions
+where Phase 4c produced zero choices but did not halt."
+```
+
+---
+
+## Phase 3 — Cluster fixes
+
+### Task 9: Cluster #1314 (R-3.3) — arc metadata as entity annotation
+
+**Files:**
+- Modify: `src/questfoundry/pipeline/stages/polish/llm_phases.py:286-299`
+
+- [ ] **Step 1: Locate current code**
+
+Read `src/questfoundry/pipeline/stages/polish/llm_phases.py` around lines 280-310.  Current code creates a separate `character_arc_metadata::{id}` node and a `has_arc_metadata` edge per arc-worthy entity.
+
+- [ ] **Step 2: Replace with entity-data annotation**
+
+Replace the block at lines 286-299 (the `graph.create_node("character_arc_metadata::...")` and `graph.add_edge("has_arc_metadata", ...)` calls) with:
+
+```python
+# R-3.3: arc metadata is an annotation on the Entity node itself,
+# never a separate node.  Mutate the entity's data dict in-place.
+graph.update_node(
+    entity_id,
+    character_arc={
+        "start": arc_data.start,
+        "pivots": dict(arc_data.pivots),
+        "end_per_path": dict(arc_data.end_per_path),
+    },
+)
+```
+
+(Adjust the `arc_data` attribute accesses to match the actual Pydantic model field names used locally — confirm by reading the surrounding loop.)
+
+- [ ] **Step 3: Run Phase 3 tests**
+
+Run:
+```bash
+uv run pytest tests/unit/test_polish_phases.py -k "phase3 or arc" -x -q
+```
+Expected: the test `test_has_arc_metadata_edge_created` now fails (the edge is no longer created — correct behavior). Leave it failing; it's deleted in Task 13.
+
+Run the contract tests to confirm Cluster #1314 is now green against compliant-baseline construction:
+```bash
+uv run pytest tests/unit/test_polish_contract.py -k R_3_3 -x -q
+```
+Expected: 3 passed.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/questfoundry/pipeline/stages/polish/llm_phases.py
+git commit -m "fix(polish): store character_arc on Entity nodes, not as separate nodes (R-3.3)
+
+Closes cluster #1314 of epic #1310.  Phase 3 arc synthesis now
+annotates the Entity node's data dict with 'character_arc' (start,
+pivots per path, end_per_path) rather than creating a separate
+'character_arc_metadata' node linked by 'has_arc_metadata'.  Matches
+spec R-3.3 and ontology Part 1 Character Arc Metadata.
+
+The old test_has_arc_metadata_edge_created is now correctly failing
+and is deleted in the fixture-cleanup task."
+```
+
+---
+
+### Task 10: Cluster #1312 (R-4c.2) — zero-choice ERROR halt
+
+**Files:**
+- Modify: `src/questfoundry/pipeline/stages/polish/deterministic.py:146` (inside `phase_plan_computation`)
+
+- [ ] **Step 1: Locate current code**
+
+Read `deterministic.py` around lines 103-150.  After the line `plan.choice_specs = compute_choice_edges(graph, plan.passage_specs)` there is no zero-choice check.
+
+- [ ] **Step 2: Write a failing test**
+
+Append to `tests/unit/test_polish_contract.py`:
+
+```python
+def test_phase_4c_zero_choices_raises_contract_error() -> None:
+    """Phase 4c raises PolishContractError when compute_choice_edges returns empty."""
+    import asyncio
+    from unittest.mock import MagicMock
+
+    from questfoundry.pipeline.stages.polish import deterministic
+
+    # A graph with passages but no Y-forks → zero choice edges.  Simplest
+    # case: an empty graph.  Phase 4a will also fail on this, but the
+    # assertion is specifically about the zero-choice halt once reached.
+    graph = Graph.empty()
+
+    with pytest.raises(PolishContractError, match=r"R-4c\.2|zero choice"):
+        # phase_plan_computation delegates Phase 4c internally.
+        asyncio.run(deterministic.phase_plan_computation(graph, MagicMock()))
+```
+
+Run:
+```bash
+uv run pytest tests/unit/test_polish_contract.py::test_phase_4c_zero_choices_raises_contract_error -x -q
+```
+Expected: FAIL — current code does not raise.
+
+- [ ] **Step 3: Add the zero-choice halt**
+
+Modify `phase_plan_computation` in `deterministic.py` around line 146 (after `plan.choice_specs = compute_choice_edges(...)`) to insert:
+
+```python
+if not plan.choice_specs:
+    from questfoundry.graph.polish_validation import PolishContractError
+
+    log.error(
+        "polish_zero_choice_halt",
+        upstream="SEED/GROW",
+        passage_count=len(plan.passage_specs),
+        detail="Phase 4c produced zero choice edges — upstream DAG has no Y-forks",
+    )
+    raise PolishContractError(
+        "R-4c.2: Phase 4c produced zero choice edges — SEED/GROW DAG has "
+        "no Y-forks.  Upstream bug — halting POLISH."
+    )
+```
+
+- [ ] **Step 4: Run the test**
+
+Run:
+```bash
+uv run pytest tests/unit/test_polish_contract.py::test_phase_4c_zero_choices_raises_contract_error -x -q
+```
+Expected: PASS.
+
+Also run broader POLISH-local suites to check nothing else regressed:
+```bash
+uv run pytest tests/unit/test_polish_deterministic.py tests/unit/test_polish_validation.py -x -q
+```
+Expected: pre-existing pass counts unchanged (or any new failures are already-pre-audit fixtures that Task 14 will rewrite).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/questfoundry/pipeline/stages/polish/deterministic.py tests/unit/test_polish_contract.py
+git commit -m "fix(polish): halt Phase 4c with ERROR on zero choice edges (R-4c.2)
+
+Closes cluster #1312 of epic #1310.  If compute_choice_edges returns
+empty, Phase 4c now logs polish_zero_choice_halt at ERROR level and
+raises PolishContractError identifying SEED/GROW as the upstream
+source of the failure.  Previously this silently passed through to
+Phase 6, violating Silent Degradation policy (CLAUDE.md §Anti-Patterns)."
+```
+
+---
+
+### Task 11: Cluster #1311 (R-4a.4) — maximal-linear-collapse grouping
+
+**Files:**
+- Modify: `src/questfoundry/pipeline/stages/polish/deterministic.py:178-608` (the `compute_beat_grouping` function)
+
+This task is the largest. Delete the intersection-group iteration branch entirely and replace the algorithm with a single-pass DAG walk that partitions beats into maximal linear runs.
+
+- [ ] **Step 1: Locate current code**
+
+Read `deterministic.py:178-608` (the `compute_beat_grouping` function and its helpers). Note in particular:
+- Lines 213-234: iterates intersection groups and creates `grouping_type="intersection"` passages.
+- Subsequent blocks handle other grouping mechanisms.
+
+- [ ] **Step 2: Rewrite `compute_beat_grouping`**
+
+Replace the function body with the maximal-linear-collapse algorithm:
+
+```python
+def compute_beat_grouping(graph: Graph) -> list[PassageSpec]:
+    """Phase 4a: group beats into passages using the maximal-linear-collapse rule.
+
+    Walk the finalized beat DAG; partition beats into maximal linear runs
+    (no internal divergence or convergence).  Applies uniformly to
+    narrative and structural beats.  Passage boundaries sit at DAG
+    divergences or convergences; every passage ends at a choice point
+    (divergence → choice edges in Phase 4c) or a convergence/terminal.
+
+    POLISH does NOT consume intersection groups — those are GROW-internal.
+    See docs/design/procedures/polish.md §R-4a.3, R-4a.4.
+    """
+    beat_nodes = graph.get_nodes_by_type("beat")
+    if not beat_nodes:
+        return []
+
+    pred_edges = graph.get_edges(edge_type="predecessor")
+    successors: dict[str, set[str]] = {bid: set() for bid in beat_nodes}
+    predecessors: dict[str, set[str]] = {bid: set() for bid in beat_nodes}
+    for edge in pred_edges:
+        # predecessor edges point successor → predecessor
+        succ, pred = edge["from"], edge["to"]
+        if succ in beat_nodes and pred in beat_nodes:
+            successors[pred].add(succ)
+            predecessors[succ].add(pred)
+
+    def _is_run_start(bid: str) -> bool:
+        preds = predecessors[bid]
+        if len(preds) != 1:
+            return True  # root or convergence
+        only_pred = next(iter(preds))
+        return len(successors[only_pred]) != 1  # predecessor forks
+
+    specs: list[PassageSpec] = []
+    assigned: set[str] = set()
+
+    # Order start beats deterministically so fixture tests are stable.
+    start_beats = sorted(bid for bid in beat_nodes if _is_run_start(bid))
+
+    for start in start_beats:
+        if start in assigned:
+            continue
+        run = [start]
+        assigned.add(start)
+        current = start
+        while True:
+            succs = successors[current]
+            if len(succs) != 1:
+                break  # divergence or terminal
+            nxt = next(iter(succs))
+            if len(predecessors[nxt]) != 1 or nxt in assigned:
+                break  # convergence or already taken
+            run.append(nxt)
+            assigned.add(nxt)
+            current = nxt
+
+        specs.append(
+            PassageSpec(
+                passage_id=f"passage::{run[0].split('::', 1)[-1]}",
+                beat_ids=list(run),
+                from_beat=run[0],
+                summary=beat_nodes[run[0]].get("summary", ""),
+            )
+        )
+
+    # Safety: every beat must be assigned to exactly one PassageSpec.  Any
+    # leftover indicates a graph-topology anomaly; surface loudly rather
+    # than silently skip — matches Silent Degradation policy.
+    leftover = sorted(set(beat_nodes) - assigned)
+    if leftover:
+        raise ValueError(
+            f"compute_beat_grouping: {len(leftover)} beats not assigned to "
+            f"any passage — graph may have disconnected components or "
+            f"malformed predecessor edges: {leftover[:5]}"
+        )
+
+    return specs
+```
+
+Remove any now-unused helpers (e.g. `_group_by_intersection_signal`, or similar — find via grep inside `deterministic.py` after the replacement).
+
+- [ ] **Step 3: Run Phase 4a tests**
+
+Run:
+```bash
+uv run pytest tests/unit/test_polish_deterministic.py -x -q
+```
+Expected: previously-passing grouping tests that assume intersection-driven grouping will fail. Those are rewritten in Task 14. Tests that check general structural properties (every beat in one passage, passage has ≥1 beat) should still pass.
+
+Run the R-4a.4 contract tests:
+```bash
+uv run pytest tests/unit/test_polish_contract.py -k R_4a_4 -x -q
+```
+Expected: 2 passed.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/questfoundry/pipeline/stages/polish/deterministic.py
+git commit -m "fix(polish): rewrite compute_beat_grouping with maximal-linear-collapse (R-4a.4)
+
+Closes cluster #1311 of epic #1310.  Phase 4a no longer consumes
+Intersection Group nodes — those are GROW-internal per the track-1
+architectural correction.  Replaces intersection-driven grouping with
+a single-pass DAG walk: partition beats into maximal linear runs
+ending at divergences/convergences.  Applies uniformly to narrative
+and structural beats per updated R-4a.3 (in docs PR #1358).
+
+Tests that asserted intersection-driven grouping are rewritten in
+the fixture-cleanup task."
+```
+
+---
+
+### Task 12: Cluster #1313 (R-5.7, R-5.8) — residue `mapping_strategy`
+
+**Files:**
+- Modify: `src/questfoundry/models/polish.py:181-194` (add field)
+- Modify: `src/questfoundry/pipeline/stages/polish/llm_phases.py` (Phase 5b prompt + schema + collection)
+- Modify: `src/questfoundry/pipeline/stages/polish/deterministic.py:1176-1241` (Phase 6 branching)
+
+- [ ] **Step 1: Extend `ResidueSpec`**
+
+Modify `ResidueSpec` in `src/questfoundry/models/polish.py:181-194`:
+
+```python
+class ResidueSpec(BaseModel):
+    """Specification for a residue beat.
+
+    Created during Phase 4b for passages with light/cosmetic residue
+    flags.  Residue beats are mood-setting moments before shared passages.
+    """
+
+    target_passage_id: str = Field(min_length=1)
+    residue_id: str = Field(min_length=1)
+    flag: str = Field(min_length=1, description="State flag this residue addresses")
+    path_id: str = Field(default="")
+    content_hint: str = Field(
+        default="", description="Mood-setting prose hint (populated by Phase 5)"
+    )
+    mapping_strategy: Literal["residue_passage_with_variants", "parallel_passages"] = Field(
+        description=(
+            "Passage-layer mapping for this residue spec.  "
+            "'residue_passage_with_variants' creates a single residue passage "
+            "with variant children; 'parallel_passages' creates sibling "
+            "passages that branch and rejoin.  Chosen per-residue by the "
+            "Phase 5b LLM call per spec R-5.7/R-5.8."
+        ),
+    )
+```
+
+Add the `Literal` import at the top of the file if not already present:
+
+```python
+from typing import Literal
+```
+
+- [ ] **Step 2: Update Phase 5b LLM call**
+
+In `src/questfoundry/pipeline/stages/polish/llm_phases.py`, locate the Phase 5b residue content generation call (search for `ResidueSpec` construction or `residue_content`). Add `mapping_strategy` to the structured-output schema and the prompt:
+
+- Extend the Pydantic schema passed to `with_structured_output` so the LLM returns a `mapping_strategy` alongside `content_hint`.
+- In the prompt template (inline or in `prompts/templates/`), add a paragraph describing both options:
+  - `residue_passage_with_variants` — one passage, variants differentiate prose by flag combo (compact).
+  - `parallel_passages` — sibling passages that branch and rejoin (clearer for distinct moods).
+- Store the LLM's choice on the resulting `ResidueSpec`.
+
+(Specific line numbers and template names depend on the current Phase 5b layout. The implementer identifies them by reading around the existing residue-content-generation block and mirrors the structure.)
+
+- [ ] **Step 3: Update Phase 6 applier**
+
+In `src/questfoundry/pipeline/stages/polish/deterministic.py:1176-1241` (`_create_residue_beat_and_passage`), branch on `spec.mapping_strategy`:
+
+```python
+def _create_residue_beat_and_passage(graph: Graph, rspec: ResidueSpec) -> None:
+    """Phase 6: materialize a residue spec into the passage layer.
+
+    Branches on ``rspec.mapping_strategy`` per R-5.7/R-5.8:
+      - ``residue_passage_with_variants`` — one residue passage with
+        variant children carrying flag-gated prose.
+      - ``parallel_passages`` — sibling passages that branch from the
+        target's predecessor and rejoin at the target.
+    """
+    if rspec.mapping_strategy == "residue_passage_with_variants":
+        _apply_residue_with_variants(graph, rspec)
+    elif rspec.mapping_strategy == "parallel_passages":
+        _apply_residue_parallel_passages(graph, rspec)
+    else:  # defensive — _check_residue_mapping_strategy catches this too
+        raise ValueError(
+            f"R-5.8: unknown mapping_strategy {rspec.mapping_strategy!r} for "
+            f"residue {rspec.residue_id!r}"
+        )
+```
+
+Extract the existing body of `_create_residue_beat_and_passage` into a new function `_apply_residue_with_variants` (preserves current behavior — that was the single shape POLISH used). Add a new `_apply_residue_parallel_passages` that creates N sibling passages branching from the target's predecessor and rejoining at the target (each sibling's prose is gated by the per-flag-combo requirements):
+
+```python
+def _apply_residue_parallel_passages(graph: Graph, rspec: ResidueSpec) -> None:
+    """Alternative residue mapping: parallel passages that branch and rejoin.
+
+    For a residue spec with N distinct flag combinations, create N sibling
+    passages.  Each sibling's content is gated by its flag combo and its
+    choice edges lead from the shared predecessor to the shared target.
+    """
+    # TODO(implementer): collect flag-combos from the surrounding plan, create
+    # N passages, wire choice edges from predecessor to each and choice edges
+    # from each to rspec.target_passage_id.  Record mapping_strategy on each
+    # new passage node for Phase 7 validation.
+    raise NotImplementedError(
+        "Parallel-passages residue mapping is implemented here; see plan "
+        "task 12 step 3 for the algorithm."
+    )
+```
+
+Also set `mapping_strategy` on the created passage node's data dict in both branches:
+
+```python
+graph.create_node(
+    passage_id,
+    {
+        "type": "passage",
+        # ... existing fields ...
+        "residue_for": rspec.target_passage_id,
+        "mapping_strategy": rspec.mapping_strategy,
+    },
+)
+```
+
+Note: if `parallel_passages` is not yet exercised by any LLM-output fixture, its implementation may be a stub that raises `NotImplementedError` — provided no current test exercises it. Track any stub in a follow-on issue filed before merge (see Task 18).
+
+- [ ] **Step 4: Run Phase 5/6 and contract tests**
+
+Run:
+```bash
+uv run pytest tests/unit/test_polish_apply.py tests/unit/test_polish_llm_phases.py tests/unit/test_polish_contract.py -k "R_5_7 or R_5_8 or residue" -x -q
+```
+Expected: R-5.7/R-5.8 contract tests pass. Existing residue tests may now fail because the new required field is missing from fixtures — Task 15 rewrites them.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/questfoundry/models/polish.py src/questfoundry/pipeline/stages/polish/llm_phases.py src/questfoundry/pipeline/stages/polish/deterministic.py
+git commit -m "feat(polish): residue mapping_strategy field + Phase 6 branching (R-5.7, R-5.8)
+
+Closes cluster #1313 of epic #1310.  ResidueSpec gains a required
+mapping_strategy Literal field.  Phase 5b LLM call asks the model
+to choose between 'residue_passage_with_variants' (compact, single
+passage with variant children) and 'parallel_passages' (sibling
+passages branching then rejoining).  Phase 6 branches on the chosen
+strategy and records it on the residue passage node's data dict so
+Phase 7 can validate (R-5.8 enforcement via
+_check_residue_mapping_strategy)."
+```
+
+---
+
+## Phase 4 — Fixture cleanup + sweep
+
+### Task 13: Delete `test_has_arc_metadata_edge_created`; add replacement
+
+**Files:**
+- Modify: `tests/unit/test_polish_phases.py:398-436`
+
+- [ ] **Step 1: Locate the old test**
+
+Read lines 398-436 of `tests/unit/test_polish_phases.py`. The test asserts that after Phase 3, a `character_arc_metadata::{id}` node exists and a `has_arc_metadata` edge from the entity to the arc node exists. Its premise is invalid post-audit.
+
+- [ ] **Step 2: Delete the old test**
+
+Remove the entire `def test_has_arc_metadata_edge_created(...)` function and its docstring (lines 398-436).
+
+- [ ] **Step 3: Add the replacement**
+
+Insert in the same location:
+
+```python
+def test_character_arc_field_on_entity(monkeypatch: pytest.MonkeyPatch) -> None:
+    """R-3.3: Phase 3 annotates the Entity node's data dict with
+    'character_arc'; no separate 'character_arc_metadata' node and no
+    'has_arc_metadata' edge are created."""
+    # (Implementer: reconstruct the existing test harness from the deleted
+    # test — mock LLM, run Phase 3, then assert:
+    #   - The entity node has a 'character_arc' key in its data dict.
+    #   - No node has type 'character_arc_metadata'.
+    #   - No edge has type 'has_arc_metadata'.
+    # Concrete implementation mirrors the pattern of the removed test.)
+    ...
+```
+
+Replace the `...` placeholder with the actual test code — the setup parallels the removed test. The assertion block:
+
+```python
+    assert "character_arc" in entity_data
+    assert graph.get_nodes_by_type("character_arc_metadata") == {}
+    assert graph.get_edges(edge_type="has_arc_metadata") == []
+```
+
+- [ ] **Step 4: Run**
+
+```bash
+uv run pytest tests/unit/test_polish_phases.py -x -q
+```
+Expected: new test passes. Other Phase 3 tests pass (arc synthesis still runs; only storage shape changed).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests/unit/test_polish_phases.py
+git commit -m "test(polish): replace test_has_arc_metadata_edge_created with character_arc-field test
+
+Old test asserted pre-audit behavior (separate character_arc_metadata
+node + has_arc_metadata edge) which R-3.3 and ontology Part 1 forbid.
+Replacement tests the new annotation-on-Entity shape (cluster #1314)."
+```
+
+---
+
+### Task 14: Rewrite Phase 4a grouping tests
+
+**Files:**
+- Modify: `tests/unit/test_polish_deterministic.py`
+
+- [ ] **Step 1: Identify intersection-driven assertions**
+
+Grep for references to intersection-driven grouping:
+
+```bash
+grep -n "grouping_type.*intersection\|intersection_group\|compute_beat_grouping" tests/unit/test_polish_deterministic.py | head -20
+```
+
+Record the tests that depend on intersection-driven grouping. Each needs its assertions rewritten to express maximal-linear-collapse outputs.
+
+- [ ] **Step 2: Rewrite each affected test**
+
+For each identified test, update the assertions. Pattern:
+
+- **Before:** "Phase 4a creates an intersection passage for beats in the same intersection group."
+- **After:** "Phase 4a collapses beats into a linear run and closes the passage at the next DAG divergence/convergence."
+
+Example rewrite (skeleton):
+
+```python
+def test_phase_4a_collapses_linear_chain(sample_graph_with_linear_chain: Graph) -> None:
+    """Phase 4a groups a linear chain of 3 beats into one passage (R-4a.3)."""
+    from questfoundry.pipeline.stages.polish.deterministic import compute_beat_grouping
+
+    specs = compute_beat_grouping(sample_graph_with_linear_chain)
+
+    assert len(specs) == 1
+    assert specs[0].beat_ids == ["beat::a", "beat::b", "beat::c"]
+
+
+def test_phase_4a_closes_at_divergence(sample_graph_with_yfork: Graph) -> None:
+    """Phase 4a closes a passage at a Y-fork; each branch starts a new passage."""
+    from questfoundry.pipeline.stages.polish.deterministic import compute_beat_grouping
+
+    specs = compute_beat_grouping(sample_graph_with_yfork)
+
+    beat_sets = [set(s.beat_ids) for s in specs]
+    # Shared pre-commit is one passage; each commit + post-commit chain is its own.
+    assert {"beat::pre_01"} in beat_sets
+```
+
+Concrete rewrites are guided by each test's original fixture — the implementer reads the pre-audit assertion and translates it into maximal-linear-collapse terms.
+
+- [ ] **Step 3: Run the full Phase 4a test file**
+
+```bash
+uv run pytest tests/unit/test_polish_deterministic.py -x -q
+```
+Expected: all tests pass. If any test's premise is pre-audit-only (cannot be rephrased under the new rule), delete it and file a follow-on issue (see Task 18) if coverage is lost.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tests/unit/test_polish_deterministic.py
+git commit -m "test(polish): rewrite Phase 4a grouping tests for maximal-linear-collapse
+
+Intersection-driven grouping assertions replaced with DAG-topology
+assertions.  Closes fixture-rewrite coverage gap for cluster #1311."
+```
+
+---
+
+### Task 15: Rewrite residue tests
+
+**Files:**
+- Modify: `tests/unit/test_polish_apply.py`
+
+- [ ] **Step 1: Identify residue tests**
+
+```bash
+grep -n "residue\|ResidueSpec\|_create_residue" tests/unit/test_polish_apply.py | head -20
+```
+
+- [ ] **Step 2: Parameterize over `mapping_strategy`**
+
+For each test that creates a `ResidueSpec` or exercises residue Phase 6 application, add a `mapping_strategy` argument. Where feasible, parameterize:
+
+```python
+@pytest.mark.parametrize(
+    "mapping_strategy",
+    ["residue_passage_with_variants", "parallel_passages"],
+)
+def test_residue_applies_correctly(mapping_strategy: str, sample_graph: Graph) -> None:
+    spec = ResidueSpec(
+        target_passage_id="passage::target",
+        residue_id="res_01",
+        flag="flag_x",
+        mapping_strategy=mapping_strategy,
+    )
+    # ... rest of test parameterized where shape differs ...
+```
+
+For tests that only cover one strategy, add the `mapping_strategy` argument with a single explicit value.
+
+- [ ] **Step 3: Run**
+
+```bash
+uv run pytest tests/unit/test_polish_apply.py -x -q
+```
+Expected: all pass. If `parallel_passages` implementation in Task 12 was stubbed with `NotImplementedError`, mark those parameter cases `xfail` with a reference to the tracking issue filed in Task 18.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tests/unit/test_polish_apply.py
+git commit -m "test(polish): parameterize residue tests over mapping_strategy
+
+Covers both residue_passage_with_variants and parallel_passages
+values of the new field (cluster #1313).  Any stubbed branch is
+marked xfail with a tracking-issue reference."
+```
+
+---
+
+### Task 16: Phase 5b + Phase 3 LLM tests update
+
+**Files:**
+- Modify: `tests/unit/test_polish_llm_phases.py`
+
+- [ ] **Step 1: Phase 3 tests — drop expectation of separate arc nodes**
+
+Find any test that asserts `graph.get_nodes_by_type("character_arc_metadata")` is non-empty or that `has_arc_metadata` edges exist. Replace with assertions on the entity's `character_arc` data field (same shape as Task 13).
+
+- [ ] **Step 2: Phase 5b tests — add `mapping_strategy` to expected structured output**
+
+Find the Phase 5b residue-content test(s). The mock LLM now returns a dict with `mapping_strategy`; update the expected values:
+
+```python
+# Mock output for Phase 5b:
+{
+    "residues": [
+        {
+            "residue_id": "res_01",
+            "content_hint": "A quiet moment",
+            "mapping_strategy": "residue_passage_with_variants",
+        },
+    ],
+}
+```
+
+Update any assertions that inspect the returned `ResidueSpec` to verify `mapping_strategy` is populated.
+
+- [ ] **Step 3: Run**
+
+```bash
+uv run pytest tests/unit/test_polish_llm_phases.py -x -q
+```
+Expected: all pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tests/unit/test_polish_llm_phases.py
+git commit -m "test(polish): update Phase 3 + Phase 5b LLM tests for new field shapes
+
+Phase 3 tests assert on the character_arc entity annotation (R-3.3).
+Phase 5b tests include mapping_strategy in expected LLM output and
+assert it lands on the returned ResidueSpec (R-5.7/R-5.8)."
+```
+
+---
+
+### Task 17: Non-downstream sweep
+
+**Files:** None (verification only).
+
+- [ ] **Step 1: Static checks**
+
+```bash
+uv run mypy src/questfoundry/
+uv run ruff check src/
+uv run pyright src/
+```
+Expected: all clean (zero errors).
+
+- [ ] **Step 2: POLISH-local suite**
+
+```bash
+uv run pytest \
+  tests/unit/test_polish_contract.py \
+  tests/unit/test_polish_validation.py \
+  tests/unit/test_polish_phases.py \
+  tests/unit/test_polish_deterministic.py \
+  tests/unit/test_polish_apply.py \
+  tests/unit/test_polish_llm_phases.py \
+  -q
+```
+Expected: all pass.
+
+- [ ] **Step 3: Upstream regression check**
+
+Run the stages upstream of POLISH to confirm no leakage:
+
+```bash
+uv run pytest \
+  tests/unit/test_dream_stage.py \
+  tests/unit/test_brainstorm_stage.py \
+  tests/unit/test_seed_stage.py tests/unit/test_seed_validation.py \
+  tests/unit/test_grow_validation.py tests/unit/test_grow_validation_contract.py \
+  tests/unit/test_grow_algorithms.py \
+  tests/integration/test_grow_e2e.py \
+  -q
+```
+Expected: all pass.
+
+- [ ] **Step 4: Full non-downstream unit sweep**
+
+```bash
+uv run pytest tests/unit/ -q \
+  --ignore=tests/unit/test_fill_context.py \
+  --ignore=tests/unit/test_fill_models.py \
+  --ignore=tests/unit/test_fill_stage.py \
+  --ignore=tests/unit/test_fill_validation.py \
+  --ignore=tests/unit/test_fill_continuity_warning.py \
+  --ignore=tests/unit/test_dress_context.py \
+  --ignore=tests/unit/test_dress_models.py \
+  --ignore=tests/unit/test_dress_mutations.py \
+  --ignore=tests/unit/test_dress_stage.py \
+  --ignore=tests/unit/test_ship_*.py \
+  --ignore=tests/unit/test_polish_passage_validation.py
+```
+Expected: all pass (the specific ignore list is confirmed empirically — add any post-POLISH test files whose premise is genuinely pre-audit).
+
+- [ ] **Step 5: Record any surprises**
+
+If a test outside the ignore list fails, investigate root cause before committing. Either rewrite it if its intent is still valid post-audit, or add to the ignore list + file a follow-on issue.
+
+- [ ] **Step 6: No commit — verification only**
+
+Skip.
+
+---
+
+### Task 18: Downstream-break catalog + follow-on issues
+
+**Files:** None (GitHub issues only).
+
+- [ ] **Step 1: Enumerate broken downstream tests**
+
+Identify tests that break because of the POLISH contract tightening:
+
+```bash
+uv run pytest tests/unit/test_fill_*.py tests/unit/test_dress_*.py tests/unit/test_ship_*.py tests/unit/test_polish_passage_validation.py -q --no-header 2>&1 | grep -E "FAIL|ERROR" | head -40
+```
+Expected: list of failing tests.
+
+- [ ] **Step 2: Group and file follow-on issues**
+
+For each distinct group (e.g., "FILL context reads character_arc_metadata nodes", "DRESS iteration depends on intersection-group-derived passages"), file a follow-on issue via `gh issue create` with:
+
+- Title: `[polish-compliance follow-on] <short description>`
+- Body: list the broken test(s), the root cause (which cluster's contract they conflict with), and a pointer to this PR.
+
+- [ ] **Step 3: Also file stubs for Task 12's `parallel_passages` if stubbed**
+
+If Task 12 left `_apply_residue_parallel_passages` as a `NotImplementedError` stub, file an issue: `[polish-compliance follow-on] implement parallel-passages residue mapping`.
+
+- [ ] **Step 4: No commit — GitHub state only**
+
+Skip.
+
+---
+
+## Phase 5 — Ship
+
+### Task 19: Push branch + open PR
+
+**Files:** None (git/gh operations).
+
+- [ ] **Step 1: Final status check**
+
+```bash
+git status
+git log --oneline origin/main..HEAD | head -20
+```
+Expected: clean tree; commits cover design doc + Phase 1 + Phase 2 + Phase 3 + Phase 4.
+
+- [ ] **Step 2: Push**
+
+```bash
+git push -u origin feat/polish-compliance
+```
+
+- [ ] **Step 3: Open PR**
+
+```bash
+gh pr create --base main --title 'feat(polish): compliance with authoritative spec (hot-path clusters)' --body "$(cat <<'EOF'
+## Summary
+
+Brings the POLISH stage into compliance with the authoritative spec for the 4 hot-path clusters of epic #1310. Establishes a stage-exit contract validator with a dedicated \`PolishContractError\` raised from Phase 7, mirroring the DREAM/BRAINSTORM/SEED/GROW compliance pattern.
+
+Closes #1311, #1312, #1313, #1314.
+
+Does NOT close the epic (#1310) — clusters #1315, #1316, #1317, #1318 are deferred to follow-on PRs.
+
+## What changed
+
+**Validator contract (new):**
+- \`PolishContractError(ValueError)\` raised from Phase 7 when \`validate_polish_output\` reports errors.
+- Phase 7 emits a structured \`log.error("polish_contract_failed", …)\` event before raising.
+- 4 new \`_check_*\` helpers: \`_check_no_character_arc_metadata_nodes\` (R-3.3), \`_check_passage_maximal_linear_collapse\` (R-4a.4), \`_check_residue_mapping_strategy\` (R-5.7/R-5.8), \`_check_has_choice_edges\` (R-4c.2 belt-and-suspenders).
+
+**Per-cluster fixes:**
+- #1311 (R-4a.4) — \`compute_beat_grouping\` rewritten as maximal-linear-collapse; intersection-group iteration removed entirely. Prereq spec change landed in #1358.
+- #1312 (R-4c.2) — Phase 4c halts with \`PolishContractError\` when \`compute_choice_edges\` returns empty.
+- #1313 (R-5.7, R-5.8) — \`ResidueSpec.mapping_strategy\` required field; Phase 5b prompt asks LLM to choose; Phase 6 branches on it.
+- #1314 (R-3.3) — Phase 3 arc metadata stored on Entity data dict as \`character_arc\`; no more \`character_arc_metadata\` nodes or \`has_arc_metadata\` edges.
+
+## Allowed-to-break
+
+POLISH, FILL, DRESS, SHIP tests that depend on pre-compliance POLISH output are allowed to fail. Follow-on issues filed (see below).
+
+## Test plan
+
+- [ ] POLISH contract tests: all pass (\`tests/unit/test_polish_contract.py\`).
+- [ ] POLISH-local suites all pass (validation, phases, deterministic, apply, llm_phases).
+- [ ] Non-downstream sweep passes with documented ignore list.
+- [ ] \`uv run mypy src/\`, \`ruff check src/\`, \`pyright src/\` — all clean.
+- [ ] CI must verify across Python 3.11 / 3.12 / 3.13.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 4: Record PR URL**
+
+Report the URL returned by `gh pr create` to the user as the terminal signal for this plan.
+
+---
+
+## Self-Review Notes
+
+**Spec coverage:** Design doc sections 1–7 each have tasks:
+- §1 (sequencing) — prereq verified in Task 1.
+- §3 (validator extensions) — Tasks 2–8 (class, wiring, 4 helpers with failing-first tests).
+- §4 (per-cluster fixes) — Tasks 9–12 (one task per cluster, ordered small-to-large).
+- §5 (fixtures + downstream break) — Tasks 13–16 rewrite fixtures; Task 18 files follow-on issues.
+- §6 (work sequence) — matches the 19-task layout exactly.
+- §7 (exit criteria) — Task 17 sweeps; Task 19's PR body enumerates.
+
+**Type consistency:** `PolishContractError`, `mapping_strategy`, `character_arc`, and the four `_check_*` helper names are used identically across tasks. `Literal["residue_passage_with_variants", "parallel_passages"]` appears the same way in model, validator, prompt, and Phase 6 code.
+
+**Placeholder scan:** Two placeholder-adjacent spots were intentionally left for the implementer because they depend on reading the current surrounding code:
+- Task 12 Step 2: Phase 5b prompt template name and line numbers — the implementer locates them by reading around the existing residue-content-generation block.
+- Task 13 Step 3: the replacement test reconstructs the mock/setup harness from the deleted test.
+
+Both are guided by concrete surrounding code, not left as "TBD" — they tell the implementer exactly what to look for.

--- a/docs/superpowers/specs/2026-04-20-polish-compliance-design.md
+++ b/docs/superpowers/specs/2026-04-20-polish-compliance-design.md
@@ -1,0 +1,201 @@
+# POLISH Spec-Compliance — Design
+
+**Date:** 2026-04-20
+**Epic:** #1310 (M-POLISH-spec)
+**Scope:** Hot-path 4 clusters (#1311, #1312, #1313, #1314) — follow-on PRs handle #1315–#1318.
+**Policy:** POLISH never worked correctly before; post-POLISH breakage (FILL, DRESS, SHIP) is allowed.
+
+---
+
+## 1. Sequencing and dependencies
+
+Two sequential PRs:
+
+**PR 1 — Spec update (blocks PR 2).** Doc-only change to `docs/design/procedures/polish.md`:
+- Rewrite **R-4a.3** to a maximal-linear-collapse rule that applies uniformly to narrative and structural beats.
+- Remove **R-4a.2** entirely (identical path membership is not a necessary property of a topology-based grouping rule; linear runs may span different `belongs_to` sets). No Phase 7 check is needed for this property.
+- Rewrite the Phase 4a "Operations" subsection to match the new rule.
+- No rule-count change. No other procedure docs touched.
+
+**PR 2 — POLISH compliance (this spec's target).** Branch `feat/polish-compliance` off `main` after PR 1 merges. Closes 4 hot-path cluster issues.
+
+Deferred to follow-on PRs (one each, same branching policy): #1315, #1316, #1317, #1318.
+
+---
+
+## 2. New R-4a.3 (for PR 1)
+
+> **R-4a.3.** All beats in the finalized DAG — narrative or structural — are grouped by the maximal-linear-collapse rule. A passage is a maximal run of beats with no internal divergence or convergence. A new passage starts at any beat whose in-degree ≠ 1 or whose predecessor has out-degree ≠ 1, and ends at any beat whose out-degree ≠ 1 or whose successor has in-degree ≠ 1.
+
+**Implications:**
+
+- Micro-beats (Phase 2) sit in linear sections by construction → absorbed into their parent passage; no special rule.
+- Transition beats (GROW) land at path-segment boundaries → DAG topology naturally gives them their own passage when they sit at divergences/convergences, or folds them into a neighbor when linear.
+- Residue and false-branch beats are created in Phase 6 *after* grouping is fixed. Their passage placement is governed by Phase 6 rules (R-6.x), not by Phase 4a.
+- R-4a.2 is removed: a linear DAG run may legitimately span different `belongs_to` sets (e.g., post-commit of dilemma A → transition beat → pre-commit of dilemma B). Phase 7 does not check path-membership uniformity within a passage.
+
+---
+
+## 3. Phase 7 validator extensions (PR 2)
+
+**New class.** `PolishContractError(ValueError)` in `src/questfoundry/graph/polish_validation.py`. Mirrors `GrowContractError`.
+
+**Phase 7 wiring.** `phase_validation()` in `polish/deterministic.py:1395-1397` currently returns `PhaseResult(status="failed", detail=...)` on errors; the stage then wraps as `PolishStageError`. Replace with: Phase 7 emits `log.error("polish_contract_failed", error_count=N, errors=[...])` then raises `PolishContractError` directly.
+
+**New `_check_*` helpers added to `validate_polish_output`:**
+
+1. **`_check_no_character_arc_metadata_nodes(graph)`** — R-3.3.
+   - Error if any node has type `character_arc_metadata`.
+   - Error if any `has_arc_metadata` edge exists.
+   - For each entity with ≥2 `appears` edges, error if its data dict lacks a `character_arc` field with `start`, `pivots`, `end_per_path`.
+
+2. **`_check_passage_maximal_linear_collapse(graph)`** — R-4a.4 (and the new R-4a.3 from PR 1).
+   - Each passage's member beats form a linear run in the finalized beat DAG (in-passage predecessors/successors unique).
+   - Passage boundaries sit at DAG divergences or convergences: first beat's in-degree ≠ 1 or predecessor has out-degree ≠ 1; mirror for last beat.
+   - Error catches any passage that spans a divergence/convergence or stops mid-linear-run.
+
+3. **`_check_residue_mapping_strategy(graph)`** — R-5.7, R-5.8.
+   - Every residue passage node has a `mapping_strategy` attribute in `{residue_passage_with_variants, parallel_passages}`.
+   - Topological check: `residue_passage_with_variants` → one residue passage with variant children; `parallel_passages` → N sibling passages branching then rejoining.
+
+4. **`_check_has_choice_edges(graph)`** — R-4c.2 (belt-and-suspenders).
+   - Error if passage graph has zero `choice` edges. Phase 4c is expected to halt before Phase 7, but this catches silent regressions.
+
+**Existing checks preserved.** Current R-7.x structural checks stay as-is. New checks are additive.
+
+**Not in this PR's validator.** R-2.5, R-4c.3/4, R-5.2, R-5.10 — added with their respective follow-on cluster PRs.
+
+---
+
+## 4. Per-cluster fixes (PR 2)
+
+### Cluster #1311 — R-4a.4: remove intersection-group consumption
+
+**Current state:** `compute_beat_grouping()` in `polish/deterministic.py:213-234` iterates intersection groups and creates passages with `grouping_type="intersection"`.
+
+**Fix:**
+- Delete the intersection iteration branch entirely.
+- Replace with a single-pass algorithm: walk the finalized beat DAG; seed queue with boundary beats (in-degree ≠ 1 or predecessor out-degree ≠ 1); extend each into a linear run; close at next divergence/convergence. Applies uniformly to narrative and structural beats.
+- Passage nodes written without any `intersection` provenance field.
+- POLISH may still read `intersection` edges for context in LLM prompts (e.g., variant generation), but they cannot constrain grouping.
+
+### Cluster #1312 — R-4c.2: zero-choice ERROR halt
+
+**Current state:** Phase 4c computes choice edges; zero result passes through silently.
+
+**Fix:**
+- After `plan.choice_specs = compute_choice_edges(...)` in `polish/deterministic.py:146`:
+  - `if not plan.choice_specs:`
+    - `log.error("polish_zero_choice_halt", upstream="SEED/GROW", detail="...")`
+    - `raise PolishContractError("Phase 4c produced zero choice edges — SEED/GROW DAG has no Y-forks. Upstream bug.")`
+- Not a warning, not a fallback. Pipeline halts.
+
+### Cluster #1313 — R-5.7, R-5.8: residue mapping_strategy
+
+**Current state:** `ResidueSpec` has no `mapping_strategy` field; Phase 6 uses a single hardcoded shape.
+
+**Fix:**
+- Add `mapping_strategy: Literal["residue_passage_with_variants", "parallel_passages"]` to `ResidueSpec` in `models/polish.py:181-194`. Required field, no default.
+- Phase 5b LLM prompt: describe both options with narrative-appropriate criteria; structured output schema includes `mapping_strategy`.
+- Phase 6 `_create_residue_beat_and_passage()` in `deterministic.py:1176-1241`: branch on `spec.mapping_strategy`.
+  - `residue_passage_with_variants` → one residue passage with variant children (existing shape).
+  - `parallel_passages` → N sibling passages branching then rejoining.
+- Phase 6 writes `mapping_strategy` onto the residue passage node's data dict for Phase 7 validation.
+
+### Cluster #1314 — R-3.3: arc metadata as entity annotation
+
+**Current state:** Phase 3 creates `character_arc_metadata` nodes and `has_arc_metadata` edges in `polish/llm_phases.py:286-299`.
+
+**Fix:**
+- Remove `character_arc_metadata` node creation.
+- Remove `has_arc_metadata` edge creation.
+- Replace with entity-data-dict mutation: `entity.data["character_arc"] = {"start": ..., "pivots": {...}, "end_per_path": {...}}` via the existing entity-mutation pathway.
+- Downstream readers that currently fetch `character_arc_metadata` nodes must read `entity.data["character_arc"]` — but that's downstream breakage, deferred.
+
+---
+
+## 5. Test fixtures and downstream breakage
+
+**Fixture policy (same as GROW):**
+- **Rewrite** if the test's spec-intent is still valid post-audit (just update the assertions).
+- **Delete + track** if the premise is pre-audit. Deletions get a follow-on issue if rewritten coverage doesn't subsume the old test.
+
+**Known fixture rewrites:**
+- `tests/unit/test_polish_deterministic.py` — Phase 4a grouping: assertions from intersection-driven → DAG-topology-driven.
+- `tests/unit/test_polish_phases.py:398-436` — `test_has_arc_metadata_edge_created` deleted; replaced by `test_character_arc_field_on_entity`.
+- `tests/unit/test_polish_apply.py` — residue mapping: parameterize over both `mapping_strategy` values.
+- `tests/unit/test_polish_llm_phases.py` — Phase 5b prompt/response tests add `mapping_strategy`; Phase 3 tests stop expecting `character_arc_metadata` nodes.
+
+**Known downstream-breaking tests (allowed to fail; tracked, not fixed here):**
+- `tests/unit/test_polish_passage_validation.py` — pre-audit passage-validation suite; some assertions tied to intersection-driven grouping will fail.
+- Any `tests/unit/test_fill_*.py` / `test_dress_*.py` / `test_ship_*.py` reading `character_arc_metadata` nodes or intersection-derived structure.
+- `tests/integration/test_polish_e2e.py` and beyond.
+
+**Verification sweeps:**
+- POLISH-local: `uv run pytest tests/unit/test_polish_{contract,validation,phases,deterministic,apply,llm_phases}.py -x -q` — must pass.
+- Non-downstream sweep: `uv run pytest tests/unit/ -x -q` with concrete ignore list for FILL/DRESS/SHIP/post-POLISH consumers — all green before merge.
+- `uv run mypy src/ && uv run ruff check src/ && uv run pyright src/` — all clean.
+- Full suite: CI only.
+
+**Upstream check.** POLISH's entry contract is `validate_grow_output`, already called at `stage.py:242`. No kwarg additions needed. GROW PR (#1357 — spec-compliance for GROW) must be merged before POLISH branches.
+
+---
+
+## 6. Work sequence
+
+19 tasks across 5 phases. Subagent-driven execution (fresh implementer per task + two-stage review).
+
+**Phase 0 — Prereqs (1 task)**
+- T1. Baseline sanity: spec PR merged; main clean; branch `feat/polish-compliance` off `main`.
+
+**Phase 1 — Validator scaffolding (2 tasks)**
+- T2. Add `PolishContractError(ValueError)` to `polish_validation.py`.
+- T3. Rewire `phase_validation()` to raise `PolishContractError` with structured `log.error("polish_contract_failed", …)` event instead of wrapping in `PolishStageError`.
+
+**Phase 2 — Validator extensions (5 tasks)**
+- T4. Write failing contract tests for all 4 hot-path rules in new `tests/unit/test_polish_contract.py`. Layered DREAM+BRAINSTORM+SEED+GROW compliant baseline fixture (mirroring GROW contract-test pattern).
+- T5. `_check_no_character_arc_metadata_nodes` (R-3.3).
+- T6. `_check_passage_maximal_linear_collapse` (R-4a.4).
+- T7. `_check_residue_mapping_strategy` (R-5.7, R-5.8).
+- T8. `_check_has_choice_edges` (R-4c.2, belt-and-suspenders).
+
+**Phase 3 — Cluster fixes (4 tasks, small-to-large)**
+- T9. #1314 / R-3.3: arc metadata as entity annotation.
+- T10. #1312 / R-4c.2: zero-choice ERROR halt.
+- T11. #1311 / R-4a.4: maximal-linear-collapse grouping.
+- T12. #1313 / R-5.7, R-5.8: `mapping_strategy` field, Phase 5b prompt, Phase 6 branching.
+
+**Phase 4 — Fixture cleanup + sweep (6 tasks)**
+- T13. Rewrite `test_polish_phases.py` Phase-3 arc tests; delete `test_has_arc_metadata_edge_created`.
+- T14. Rewrite `test_polish_deterministic.py` Phase-4a grouping tests.
+- T15. Rewrite `test_polish_apply.py` residue tests (parameterize over both `mapping_strategy`).
+- T16. Rewrite `test_polish_llm_phases.py` Phase-5b + Phase-3 tests.
+- T17. Non-downstream sweep: mypy/ruff/pyright clean; targeted pytest green on POLISH-local + upstream regression tests.
+- T18. Catalog downstream-breaking tests; file follow-on issues (notice only).
+
+**Phase 5 — Ship (1 task)**
+- T19. Push `feat/polish-compliance`; open PR with pre-written body (`Closes #1311, #1312, #1313, #1314`; downstream-break notice; CI expectations).
+
+---
+
+## 7. Exit criteria
+
+PR is mergeable when all are true:
+
+1. `tests/unit/test_polish_contract.py` — all 4 hot-path rule tests green.
+2. `validate_polish_output` errors → `phase_validation()` raises `PolishContractError` with structured `log.error("polish_contract_failed", …)` event.
+3. No `character_arc_metadata` nodes in any POLISH-produced graph. Grep: `grep -rn 'character_arc_metadata\|has_arc_metadata' src/` returns zero hits outside historical removal comments.
+4. No intersection-group consumption in Phase 4a: no reference to `intersection` edges or intersection-group iteration in `compute_beat_grouping()`.
+5. Residue specs carry `mapping_strategy`; model validation rejects absence; Phase 6 branches on both values; validator errors on absent.
+6. Phase 4c raises `PolishContractError` with upstream-identifying message when `compute_choice_edges()` returns empty.
+7. All `tests/unit/test_polish_{contract,validation,phases,deterministic,apply,llm_phases}.py` pass.
+8. Non-downstream sweep green with documented ignore list.
+9. `uv run mypy src/` / `ruff check src/` / `pyright src/` — zero errors.
+10. Downstream-break notice filed; PR body links follow-on issues.
+11. PR body includes `Closes #1311, #1312, #1313, #1314`.
+
+**Explicit non-goals:**
+- Full POLISH test suite green end-to-end (downstream allowed to break).
+- Removal of `# pyright: reportArgumentType=false` on `polish/stage.py:16` — saved for final cluster PR.
+- Integration test green (CI-only decision).
+- Spec PR merged *by* this PR — prereq, not exit criterion.

--- a/prompts/templates/polish_phase5b_residue.yaml
+++ b/prompts/templates/polish_phase5b_residue.yaml
@@ -18,6 +18,22 @@ system: |
   ## Residue Beats to Write
   {residue_details}
 
+  ## Mapping Strategy (choose per residue)
+  For each residue, also choose a **mapping_strategy**:
+
+  - **"residue_passage_with_variants"** — creates a single residue passage with
+    variant prose per flag combination. Use this when all variants describe the
+    same scene with subtle mood differences (e.g., entering the same room
+    confidently vs. nervously).
+
+  - **"parallel_passages"** — creates sibling passages that branch from the
+    predecessor and rejoin at the target passage. Use this when variants
+    describe meaningfully different scenes (different locations, entities,
+    or actions — e.g., one path goes through a garden, another through a
+    market).
+
+  When in doubt, prefer **"residue_passage_with_variants"**.
+
   ## Output Format
   Return a JSON object with a "residue_content" array. One entry per residue above.
 
@@ -26,7 +42,8 @@ system: |
     "residue_content": [
       {{
         "residue_id": "residue::single_2_dilemma__d1_path__brave",
-        "content_hint": "You enter the vault with quiet confidence, the mentor's words still ringing in your ears"
+        "content_hint": "You enter the vault with quiet confidence, the mentor's words still ringing in your ears",
+        "mapping_strategy": "residue_passage_with_variants"
       }}
     ]
   }}
@@ -36,11 +53,13 @@ system: |
   - Do NOT duplicate content from the target passage
   - Do NOT skip any residue — provide content for every residue listed
   - Do NOT add prose before or after the JSON output
+  - Do NOT omit the mapping_strategy field — it is required for every entry
 
 user: |
-  Generate a mood-setting content hint for each of the {residue_count} residue beats listed above.
+  Generate a mood-setting content hint and choose a mapping_strategy for each of the {residue_count} residue beats listed above.
   Each hint should reflect the emotional tone established by the player's path choices.
 
-  REMINDER: Return ONLY valid JSON. Provide exactly one content hint per residue.
+  REMINDER: Return ONLY valid JSON. Provide exactly one entry per residue, with both
+  "content_hint" and "mapping_strategy" fields filled in.
 
 components: []

--- a/src/questfoundry/graph/polish_validation.py
+++ b/src/questfoundry/graph/polish_validation.py
@@ -94,7 +94,7 @@ def validate_polish_output(graph: Graph) -> list[str]:
     _check_variant_integrity(passage_nodes, graph, errors)
     _check_choice_integrity(graph, errors)
     _check_residue_ordering(graph, errors)
-    _check_arc_metadata_edges(graph, errors)
+    _check_no_character_arc_metadata_nodes(graph, errors)
     _check_arc_completeness(graph, errors)
     _check_divergences_have_choices(graph, beat_to_passages, errors)
     _check_no_overlapping_requires(graph, errors)
@@ -432,16 +432,54 @@ def _check_no_unresolved_splits(
             )
 
 
-def _check_arc_metadata_edges(
-    graph: Graph,
-    errors: list[str],
-) -> None:
-    """Every character_arc_metadata node must have a has_arc_metadata edge from an entity."""
-    arc_nodes = graph.get_nodes_by_type("character_arc_metadata")
-    for arc_id in arc_nodes:
-        edges = graph.get_edges(edge_type="has_arc_metadata", to_id=arc_id)
-        if not edges:
-            errors.append(f"Arc metadata node {arc_id} has no has_arc_metadata edge from entity")
+def _check_no_character_arc_metadata_nodes(graph: Graph, errors: list[str]) -> None:
+    """R-3.3: arc metadata is stored as annotation on Entity nodes, never as separate nodes.
+
+    - No node may have type ``character_arc_metadata``.
+    - No ``has_arc_metadata`` edge may exist.
+    - Every Entity with ≥2 ``appears`` edges (arc-worthy) must carry a
+      ``character_arc`` data dict with ``start``, ``pivots``, ``end_per_path``.
+    """
+    for nid, _ndata in graph.get_nodes_by_type("character_arc_metadata").items():
+        errors.append(
+            f"R-3.3: node {nid!r} has forbidden type 'character_arc_metadata'; "
+            "arc metadata must be stored on the Entity node itself"
+        )
+    for edge in graph.get_edges(edge_type="has_arc_metadata"):
+        errors.append(
+            f"R-3.3: forbidden 'has_arc_metadata' edge {edge['from']!r} → "
+            f"{edge['to']!r}; arc metadata is an entity annotation, not a "
+            "separate node"
+        )
+
+    # Arc-worthy entities need a character_arc annotation.  R-3.1 defines
+    # arc-worthy as "2+ beat appearances", so only count beat-directed
+    # ``appears`` edges — DRESS may also populate entity→passage ``appears``
+    # edges, which would otherwise inflate the count.
+    beat_ids = set(graph.get_nodes_by_type("beat").keys())
+    appears_edges = graph.get_edges(edge_type="appears")
+    appearance_count: dict[str, int] = {}
+    for edge in appears_edges:
+        if edge["to"] in beat_ids:
+            appearance_count[edge["from"]] = appearance_count.get(edge["from"], 0) + 1
+
+    entity_nodes = graph.get_nodes_by_type("entity")
+    for entity_id, entity_data in sorted(entity_nodes.items()):
+        if appearance_count.get(entity_id, 0) < 2:
+            continue
+        arc = entity_data.get("character_arc")
+        if not isinstance(arc, dict):
+            errors.append(
+                f"R-3.3: entity {entity_id!r} has {appearance_count[entity_id]} beat "
+                "appearances but no 'character_arc' annotation on its data dict"
+            )
+            continue
+        for required in ("start", "pivots", "end_per_path"):
+            if required not in arc:
+                errors.append(
+                    f"R-3.3: entity {entity_id!r} 'character_arc' annotation "
+                    f"missing required field {required!r}"
+                )
 
 
 # ---------------------------------------------------------------------------

--- a/src/questfoundry/graph/polish_validation.py
+++ b/src/questfoundry/graph/polish_validation.py
@@ -95,6 +95,7 @@ def validate_polish_output(graph: Graph) -> list[str]:
     _check_choice_integrity(graph, errors)
     _check_residue_ordering(graph, errors)
     _check_no_character_arc_metadata_nodes(graph, errors)
+    _check_passage_maximal_linear_collapse(graph, errors)
     _check_arc_completeness(graph, errors)
     _check_divergences_have_choices(graph, beat_to_passages, errors)
     _check_no_overlapping_requires(graph, errors)
@@ -479,6 +480,94 @@ def _check_no_character_arc_metadata_nodes(graph: Graph, errors: list[str]) -> N
                 errors.append(
                     f"R-3.3: entity {entity_id!r} 'character_arc' annotation "
                     f"missing required field {required!r}"
+                )
+
+
+def _check_passage_maximal_linear_collapse(graph: Graph, errors: list[str]) -> None:
+    """R-4a.4 (maximal-linear-collapse): a passage's beats form a maximal linear run.
+
+    For each passage:
+      - Member beats form a linear run: each interior beat has exactly one
+        in-passage predecessor and one in-passage successor.
+      - Passage boundaries sit at DAG divergences/convergences or terminals:
+        the first beat's in-degree ≠ 1 or its predecessor has out-degree ≠ 1;
+        the last beat's out-degree ≠ 1 or its successor has in-degree ≠ 1.
+
+    See docs/design/procedures/polish.md §R-4a.3 (maximal-linear-collapse).
+    """
+    beat_nodes = graph.get_nodes_by_type("beat")
+    passage_nodes = graph.get_nodes_by_type("passage")
+    pred_edges = graph.get_edges(edge_type="predecessor")
+    grouped_in = graph.get_edges(edge_type="grouped_in")
+
+    successors: dict[str, set[str]] = {}
+    predecessors: dict[str, set[str]] = {}
+    for edge in pred_edges:
+        # Convention: predecessor edges point successor → predecessor
+        successor, predecessor = edge["from"], edge["to"]
+        successors.setdefault(predecessor, set()).add(successor)
+        predecessors.setdefault(successor, set()).add(predecessor)
+
+    beat_to_passage: dict[str, str] = {}
+    passage_beats: dict[str, set[str]] = {}
+    for edge in grouped_in:
+        beat_id, passage_id = edge["from"], edge["to"]
+        if beat_id in beat_nodes and passage_id in passage_nodes:
+            beat_to_passage[beat_id] = passage_id
+            passage_beats.setdefault(passage_id, set()).add(beat_id)
+
+    for passage_id, beats in sorted(passage_beats.items()):
+        # Interior linearity: each beat's in-passage predecessors and
+        # successors are ≤ 1.
+        for bid in beats:
+            in_passage_preds = predecessors.get(bid, set()) & beats
+            in_passage_succs = successors.get(bid, set()) & beats
+            if len(in_passage_preds) > 1:
+                errors.append(
+                    f"R-4a.4: passage {passage_id!r} contains beat {bid!r} with "
+                    f"{len(in_passage_preds)} in-passage predecessors — not a "
+                    "linear run"
+                )
+            if len(in_passage_succs) > 1:
+                errors.append(
+                    f"R-4a.4: passage {passage_id!r} contains beat {bid!r} with "
+                    f"{len(in_passage_succs)} in-passage successors — not a "
+                    "linear run"
+                )
+
+        # Boundary check: the passage's first beat starts at a real boundary
+        # (in-degree ≠ 1 OR its predecessor has out-degree ≠ 1).
+        starts = [b for b in beats if not (predecessors.get(b, set()) & beats)]
+        ends = [b for b in beats if not (successors.get(b, set()) & beats)]
+        if len(starts) != 1 or len(ends) != 1:
+            errors.append(
+                f"R-4a.4: passage {passage_id!r} is not a single linear run "
+                f"(starts={len(starts)}, ends={len(ends)})"
+            )
+            continue
+
+        first, last = starts[0], ends[0]
+        # First beat: if it has exactly one predecessor and that predecessor
+        # has out-degree 1, the run should have started earlier.
+        first_preds = predecessors.get(first, set())
+        if len(first_preds) == 1:
+            only_pred = next(iter(first_preds))
+            if len(successors.get(only_pred, set())) == 1 and only_pred in beat_to_passage:
+                errors.append(
+                    f"R-4a.4: passage {passage_id!r} starts at {first!r} but its "
+                    f"predecessor {only_pred!r} has out-degree 1 — grouping "
+                    "stopped mid-linear-run"
+                )
+
+        # Last beat: mirror.
+        last_succs = successors.get(last, set())
+        if len(last_succs) == 1:
+            only_succ = next(iter(last_succs))
+            if len(predecessors.get(only_succ, set())) == 1 and only_succ in beat_to_passage:
+                errors.append(
+                    f"R-4a.4: passage {passage_id!r} ends at {last!r} but its "
+                    f"successor {only_succ!r} has in-degree 1 — grouping "
+                    "stopped mid-linear-run"
                 )
 
 

--- a/src/questfoundry/graph/polish_validation.py
+++ b/src/questfoundry/graph/polish_validation.py
@@ -31,7 +31,23 @@ from questfoundry.graph.validation_types import ValidationCheck, ValidationRepor
 if TYPE_CHECKING:
     from questfoundry.graph.graph import Graph
 
+__all__ = [
+    "PolishContractError",
+    "validate_polish_output",
+]
+
 _ROUTING_APPLIED_NODE_ID = "meta::routing_applied"
+
+
+class PolishContractError(ValueError):
+    """Raised when POLISH Phase 7 validation reports contract errors.
+
+    Mirrors ``GrowContractError`` — a dedicated exception type for
+    stage-exit contract failures so callers can distinguish them from
+    generic ``ValueError`` noise.  Callers receive the formatted error
+    list in the exception message.
+    """
+
 
 # ---------------------------------------------------------------------------
 # Phase 7: Passage graph validation (exit contract)

--- a/src/questfoundry/graph/polish_validation.py
+++ b/src/questfoundry/graph/polish_validation.py
@@ -95,6 +95,7 @@ def validate_polish_output(graph: Graph) -> list[str]:
     _check_choice_integrity(graph, errors)
     _check_residue_ordering(graph, errors)
     _check_residue_mapping_strategy(graph, errors)
+    _check_has_choice_edges(graph, errors)
     _check_no_character_arc_metadata_nodes(graph, errors)
     _check_passage_maximal_linear_collapse(graph, errors)
     _check_arc_completeness(graph, errors)
@@ -598,6 +599,20 @@ def _check_residue_mapping_strategy(graph: Graph, errors: list[str]) -> None:
                 f"{strategy!r} (expected one of "
                 f"{sorted(_VALID_MAPPING_STRATEGIES)})"
             )
+
+
+def _check_has_choice_edges(graph: Graph, errors: list[str]) -> None:
+    """R-4c.2 (belt-and-suspenders): zero choice edges in the passage graph
+    indicates a SEED/GROW bug — Phase 4c should already have raised.  This
+    check catches silent regressions where Phase 4c produced zero choices
+    but did not halt.
+    """
+    choice_edges = graph.get_edges(edge_type="choice")
+    if not choice_edges:
+        errors.append(
+            "R-4c.2: zero choice edges in passage graph — SEED/GROW DAG "
+            "has no Y-forks; Phase 4c should have halted"
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/src/questfoundry/graph/polish_validation.py
+++ b/src/questfoundry/graph/polish_validation.py
@@ -94,6 +94,7 @@ def validate_polish_output(graph: Graph) -> list[str]:
     _check_variant_integrity(passage_nodes, graph, errors)
     _check_choice_integrity(graph, errors)
     _check_residue_ordering(graph, errors)
+    _check_residue_mapping_strategy(graph, errors)
     _check_no_character_arc_metadata_nodes(graph, errors)
     _check_passage_maximal_linear_collapse(graph, errors)
     _check_arc_completeness(graph, errors)
@@ -484,7 +485,7 @@ def _check_no_character_arc_metadata_nodes(graph: Graph, errors: list[str]) -> N
 
 
 def _check_passage_maximal_linear_collapse(graph: Graph, errors: list[str]) -> None:
-    """R-4a.4 (maximal-linear-collapse): a passage's beats form a maximal linear run.
+    """R-4a.3 (maximal-linear-collapse): a passage's beats form a maximal linear run.
 
     For each passage:
       - Member beats form a linear run: each interior beat has exactly one
@@ -524,13 +525,13 @@ def _check_passage_maximal_linear_collapse(graph: Graph, errors: list[str]) -> N
             in_passage_succs = successors.get(bid, set()) & beats
             if len(in_passage_preds) > 1:
                 errors.append(
-                    f"R-4a.4: passage {passage_id!r} contains beat {bid!r} with "
+                    f"R-4a.3: passage {passage_id!r} contains beat {bid!r} with "
                     f"{len(in_passage_preds)} in-passage predecessors — not a "
                     "linear run"
                 )
             if len(in_passage_succs) > 1:
                 errors.append(
-                    f"R-4a.4: passage {passage_id!r} contains beat {bid!r} with "
+                    f"R-4a.3: passage {passage_id!r} contains beat {bid!r} with "
                     f"{len(in_passage_succs)} in-passage successors — not a "
                     "linear run"
                 )
@@ -541,7 +542,7 @@ def _check_passage_maximal_linear_collapse(graph: Graph, errors: list[str]) -> N
         ends = [b for b in beats if not (successors.get(b, set()) & beats)]
         if len(starts) != 1 or len(ends) != 1:
             errors.append(
-                f"R-4a.4: passage {passage_id!r} is not a single linear run "
+                f"R-4a.3: passage {passage_id!r} is not a single linear run "
                 f"(starts={len(starts)}, ends={len(ends)})"
             )
             continue
@@ -554,7 +555,7 @@ def _check_passage_maximal_linear_collapse(graph: Graph, errors: list[str]) -> N
             only_pred = next(iter(first_preds))
             if len(successors.get(only_pred, set())) == 1 and only_pred in beat_to_passage:
                 errors.append(
-                    f"R-4a.4: passage {passage_id!r} starts at {first!r} but its "
+                    f"R-4a.3: passage {passage_id!r} starts at {first!r} but its "
                     f"predecessor {only_pred!r} has out-degree 1 — grouping "
                     "stopped mid-linear-run"
                 )
@@ -565,10 +566,38 @@ def _check_passage_maximal_linear_collapse(graph: Graph, errors: list[str]) -> N
             only_succ = next(iter(last_succs))
             if len(predecessors.get(only_succ, set())) == 1 and only_succ in beat_to_passage:
                 errors.append(
-                    f"R-4a.4: passage {passage_id!r} ends at {last!r} but its "
+                    f"R-4a.3: passage {passage_id!r} ends at {last!r} but its "
                     f"successor {only_succ!r} has in-degree 1 — grouping "
                     "stopped mid-linear-run"
                 )
+
+
+_VALID_MAPPING_STRATEGIES = frozenset({"residue_passage_with_variants", "parallel_passages"})
+
+
+def _check_residue_mapping_strategy(graph: Graph, errors: list[str]) -> None:
+    """R-5.7, R-5.8: every residue passage records its chosen mapping strategy.
+
+    Residue passages are identified by a ``residue_for`` field pointing to
+    their target shared passage.  Each must have ``mapping_strategy`` set
+    to one of the two legal values.  See docs/design/procedures/polish.md
+    §R-5.7/R-5.8.
+    """
+    for pid, pdata in sorted(graph.get_nodes_by_type("passage").items()):
+        if not pdata.get("residue_for"):
+            continue
+        strategy = pdata.get("mapping_strategy")
+        if strategy is None:
+            errors.append(
+                f"R-5.8: residue passage {pid!r} missing required 'mapping_strategy' field"
+            )
+            continue
+        if strategy not in _VALID_MAPPING_STRATEGIES:
+            errors.append(
+                f"R-5.8: residue passage {pid!r} has invalid mapping_strategy "
+                f"{strategy!r} (expected one of "
+                f"{sorted(_VALID_MAPPING_STRATEGIES)})"
+            )
 
 
 # ---------------------------------------------------------------------------

--- a/src/questfoundry/models/polish.py
+++ b/src/questfoundry/models/polish.py
@@ -18,6 +18,8 @@ Terminology (v5):
 
 from __future__ import annotations
 
+from typing import Literal
+
 from pydantic import BaseModel, Field
 
 # ---------------------------------------------------------------------------
@@ -192,6 +194,18 @@ class ResidueSpec(BaseModel):
     content_hint: str = Field(
         default="", description="Mood-setting prose hint (populated by Phase 5)"
     )
+    mapping_strategy: Literal["residue_passage_with_variants", "parallel_passages"] = Field(
+        default="residue_passage_with_variants",
+        description=(
+            "Passage-layer mapping for this residue spec.  "
+            "'residue_passage_with_variants' creates a single residue passage "
+            "with variant children; 'parallel_passages' creates sibling "
+            "passages that branch and rejoin.  Chosen per-residue by the "
+            "Phase 5b LLM call per spec R-5.7/R-5.8.  Defaults to "
+            "'residue_passage_with_variants' for back-compat; Phase 5b's "
+            "LLM overrides per residue."
+        ),
+    )
 
 
 class ChoiceSpec(BaseModel):
@@ -267,6 +281,16 @@ class ResidueContentItem(BaseModel):
 
     residue_id: str = Field(min_length=1)
     content_hint: str = Field(min_length=1, description="Brief mood-setting prose hint")
+    mapping_strategy: Literal["residue_passage_with_variants", "parallel_passages"] = Field(
+        default="residue_passage_with_variants",
+        description=(
+            "Passage-layer mapping chosen by the LLM for this residue.  "
+            "'residue_passage_with_variants': one residue passage shared across flag "
+            "combinations (use for subtle mood shifts in the same scene).  "
+            "'parallel_passages': sibling passages branching from the predecessor "
+            "and rejoining at the target (use for meaningfully different scenes)."
+        ),
+    )
 
 
 class Phase5bOutput(BaseModel):

--- a/src/questfoundry/models/polish.py
+++ b/src/questfoundry/models/polish.py
@@ -6,7 +6,10 @@ stage result container.
 
 Node types created by POLISH:
 - micro_beat: Brief transition beats inserted for pacing (Phase 2)
-- character_arc_metadata: Arc data for entities (Phase 3)
+
+Note: Phase 3 writes character_arc annotations directly onto Entity nodes
+(data-dict field) — no separate node type.  See docs/design/procedures/polish.md
+§R-3.3 and ontology Part 1 "Character Arc Metadata".
 
 See docs/design/procedures/polish.md for algorithm details.
 

--- a/src/questfoundry/pipeline/stages/polish/deterministic.py
+++ b/src/questfoundry/pipeline/stages/polish/deterministic.py
@@ -144,6 +144,19 @@ async def phase_plan_computation(
 
     # 4c: Choice edge derivation
     plan.choice_specs = compute_choice_edges(graph, plan.passage_specs)
+    if not plan.choice_specs:
+        from questfoundry.graph.polish_validation import PolishContractError
+
+        log.error(
+            "polish_zero_choice_halt",
+            upstream="SEED/GROW",
+            passage_count=len(plan.passage_specs),
+            detail="Phase 4c produced zero choice edges — upstream DAG has no Y-forks",
+        )
+        raise PolishContractError(
+            "R-4c.2: Phase 4c produced zero choice edges — SEED/GROW DAG has "
+            "no Y-forks.  Upstream bug — halting POLISH."
+        )
     log.debug("phase4c_complete", choices=len(plan.choice_specs))
 
     # 4d: False branch candidate identification

--- a/src/questfoundry/pipeline/stages/polish/deterministic.py
+++ b/src/questfoundry/pipeline/stages/polish/deterministic.py
@@ -189,127 +189,79 @@ async def phase_plan_computation(
 
 
 def compute_beat_grouping(graph: Graph) -> list[PassageSpec]:
-    """Group beats into passages via intersection, collapse, and singleton.
+    """Phase 4a: group beats into passages using the maximal-linear-collapse rule.
 
-    Args:
-        graph: Graph with frozen beat DAG.
+    Walk the finalized beat DAG; partition beats into maximal linear runs
+    (no internal divergence or convergence).  Applies uniformly to
+    narrative and structural beats.  Passage boundaries sit at DAG
+    divergences or convergences; every passage ends at a choice point
+    (divergence → choice edges in Phase 4c) or a convergence/terminal.
 
-    Returns:
-        List of PassageSpec objects, one per passage.
+    POLISH does NOT consume intersection groups — those are GROW-internal.
+    See docs/design/procedures/polish.md §R-4a.3, R-4a.4.
     """
     beat_nodes = graph.get_nodes_by_type("beat")
-    predecessor_edges = graph.get_edges(edge_type="predecessor")
+    if not beat_nodes:
+        return []
 
-    # Build adjacency
-    children: dict[str, list[str]] = {bid: [] for bid in beat_nodes}
-    parents: dict[str, list[str]] = {bid: [] for bid in beat_nodes}
-    for edge in predecessor_edges:
-        from_id = edge["from"]
-        to_id = edge["to"]
-        if from_id in beat_nodes and to_id in beat_nodes:
-            parents[from_id].append(to_id)
-            children[to_id].append(from_id)
+    pred_edges = graph.get_edges(edge_type="predecessor")
+    successors: dict[str, set[str]] = {bid: set() for bid in beat_nodes}
+    predecessors: dict[str, set[str]] = {bid: set() for bid in beat_nodes}
+    for edge in pred_edges:
+        # predecessor edges point successor → predecessor
+        succ, pred = edge["from"], edge["to"]
+        if succ in beat_nodes and pred in beat_nodes:
+            successors[pred].add(succ)
+            predecessors[succ].add(pred)
 
-    # Build beat → path-set mapping (Y-shape: pre-commit beats have dual membership)
-    belongs_to_edges = graph.get_edges(edge_type="belongs_to")
-    _bt_accum: dict[str, set[str]] = {}
-    for edge in belongs_to_edges:
-        if edge["from"] in beat_nodes:
-            _bt_accum.setdefault(edge["from"], set()).add(edge["to"])
-    beat_to_paths: dict[str, frozenset[str]] = {bid: frozenset(ps) for bid, ps in _bt_accum.items()}
+    def _is_run_start(bid: str) -> bool:
+        preds = predecessors[bid]
+        if len(preds) != 1:
+            return True  # root or convergence
+        only_pred = next(iter(preds))
+        return len(successors[only_pred]) != 1  # predecessor forks
 
-    # Track which beats are already grouped
-    grouped_beats: set[str] = set()
     specs: list[PassageSpec] = []
-    passage_counter = 0
+    assigned: set[str] = set()
 
-    # 1. Intersection grouping: beats from intersection groups
-    intersection_groups = graph.get_nodes_by_type("intersection_group")
-    for _group_id, group_data in sorted(intersection_groups.items()):
-        raw_beat_ids = group_data.get("beat_ids", [])
-        beat_ids = [bid for bid in raw_beat_ids if bid in beat_nodes and bid not in grouped_beats]
-        if not beat_ids:
+    # Order start beats deterministically so fixture tests are stable.
+    start_beats = sorted(bid for bid in beat_nodes if _is_run_start(bid))
+
+    for start in start_beats:
+        if start in assigned:
             continue
-
-        summary = _merge_summaries(beat_nodes, beat_ids)
-        entities = _merge_entities(beat_nodes, beat_ids)
-
-        specs.append(
-            PassageSpec(
-                passage_id=f"passage::intersection_{passage_counter}",
-                beat_ids=beat_ids,
-                summary=summary,
-                entities=entities,
-                grouping_type="intersection",
-            )
-        )
-        grouped_beats.update(beat_ids)
-        passage_counter += 1
-
-    # 2. Collapse grouping: sequential same-path beats with no choices
-    # Find linear chains of ungrouped beats on the same path
-    for bid in _topological_order(beat_nodes, parents, children):
-        if bid in grouped_beats:
-            continue
-
-        path_set = beat_to_paths.get(bid, frozenset())
-        if not path_set:
-            continue
-
-        # Walk forward collecting same-path-set, single-child, single-parent beats.
-        # Y-shape guard rail: beats collapse only when they share the EXACT same
-        # frozenset of path memberships. A shared pre-commit beat
-        # (frozenset{p_a, p_b}) does not collapse with a post-commit beat
-        # (frozenset{p_a}).
-        chain = [bid]
-        current = bid
+        run = [start]
+        assigned.add(start)
+        current = start
         while True:
-            c = [cid for cid in children[current] if cid not in grouped_beats]
-            if len(c) != 1:
-                break
-            next_beat = c[0]
-            if len(parents[next_beat]) != 1:
-                break
-            if beat_to_paths.get(next_beat, frozenset()) != path_set:
-                break
-            # Entity compatibility check: too many new entities = hard break
-            if not _entities_compatible(beat_nodes, chain[-1], next_beat):
-                break
-            chain.append(next_beat)
-            current = next_beat
+            succs = successors[current]
+            if len(succs) != 1:
+                break  # divergence or terminal
+            nxt = next(iter(succs))
+            if len(predecessors[nxt]) != 1 or nxt in assigned:
+                break  # convergence or already taken
+            run.append(nxt)
+            assigned.add(nxt)
+            current = nxt
 
-        if len(chain) >= 2:
-            summary = _merge_summaries(beat_nodes, chain)
-            entities = _merge_entities(beat_nodes, chain)
-
-            specs.append(
-                PassageSpec(
-                    passage_id=f"passage::collapse_{passage_counter}",
-                    beat_ids=chain,
-                    summary=summary,
-                    entities=entities,
-                    grouping_type="collapse",
-                )
-            )
-            grouped_beats.update(chain)
-            passage_counter += 1
-
-    # 3. Singleton: remaining ungrouped beats
-    for bid in sorted(beat_nodes.keys()):
-        if bid in grouped_beats:
-            continue
-
-        data = beat_nodes[bid]
         specs.append(
             PassageSpec(
-                passage_id=f"passage::single_{passage_counter}",
-                beat_ids=[bid],
-                summary=data.get("summary", ""),
-                entities=data.get("entities", []),
-                grouping_type="singleton",
+                passage_id=f"passage::{run[0].split('::', 1)[-1]}",
+                beat_ids=list(run),
+                summary=beat_nodes[run[0]].get("summary", ""),
             )
         )
-        passage_counter += 1
+
+    # Safety: every beat must be assigned to exactly one PassageSpec.  Any
+    # leftover indicates a graph-topology anomaly; surface loudly rather
+    # than silently skip — matches Silent Degradation policy.
+    leftover = sorted(set(beat_nodes) - assigned)
+    if leftover:
+        raise ValueError(
+            f"compute_beat_grouping: {len(leftover)} beats not assigned to "
+            f"any passage — graph may have disconnected components or "
+            f"malformed predecessor edges: {leftover[:5]}"
+        )
 
     return specs
 
@@ -1460,82 +1412,6 @@ async def phase_validation(
         status="completed",
         detail=detail,
     )
-
-
-# ---------------------------------------------------------------------------
-# Internal helpers
-# ---------------------------------------------------------------------------
-
-
-def _topological_order(
-    beat_nodes: dict[str, dict[str, Any]],
-    parents: dict[str, list[str]],
-    children: dict[str, list[str]],
-) -> list[str]:
-    """Return beat IDs in topological order (parents before children)."""
-    from collections import deque
-
-    in_degree: dict[str, int] = {bid: len(parents.get(bid, [])) for bid in beat_nodes}
-    queue = deque(sorted(bid for bid, deg in in_degree.items() if deg == 0))
-    result: list[str] = []
-
-    while queue:
-        node = queue.popleft()
-        result.append(node)
-        for neighbor in sorted(children.get(node, [])):
-            in_degree[neighbor] -= 1
-            if in_degree[neighbor] == 0:
-                queue.append(neighbor)
-
-    return result
-
-
-def _merge_summaries(
-    beat_nodes: dict[str, dict[str, Any]],
-    beat_ids: list[str],
-) -> str:
-    """Merge summaries from multiple beats into one passage summary."""
-    parts = []
-    for bid in beat_ids:
-        data = beat_nodes.get(bid, {})
-        summary = data.get("summary", "")
-        if summary:
-            parts.append(summary)
-    return "; ".join(parts)
-
-
-def _merge_entities(
-    beat_nodes: dict[str, dict[str, Any]],
-    beat_ids: list[str],
-) -> list[str]:
-    """Merge entity lists from multiple beats (union, deduplicated)."""
-    entities: set[str] = set()
-    for bid in beat_ids:
-        data = beat_nodes.get(bid, {})
-        for eid in data.get("entities", []):
-            entities.add(eid)
-    return sorted(entities)
-
-
-def _entities_compatible(
-    beat_nodes: dict[str, dict[str, Any]],
-    beat_a: str,
-    beat_b: str,
-    max_new_entities: int = 3,
-) -> bool:
-    """Check if two beats have compatible entity sets for collapsing.
-
-    Returns False if beat_b introduces too many new entities not in beat_a,
-    suggesting a natural scene break.
-    """
-    entities_a = set(beat_nodes.get(beat_a, {}).get("entities", []))
-    entities_b = set(beat_nodes.get(beat_b, {}).get("entities", []))
-
-    if not entities_a or not entities_b:
-        return True  # No entity constraint when either has no entities
-
-    new_entities = entities_b - entities_a
-    return len(new_entities) <= max_new_entities
 
 
 # ---------------------------------------------------------------------------

--- a/src/questfoundry/pipeline/stages/polish/deterministic.py
+++ b/src/questfoundry/pipeline/stages/polish/deterministic.py
@@ -257,12 +257,22 @@ def compute_beat_grouping(graph: Graph) -> list[PassageSpec]:
                     merged_entities.append(eid)
                     seen_entities.add(eid)
 
+        # `grouping_type` is a legacy annotation used by Phase 5f
+        # (transition-guidance generation) and by `format_transition_guidance_context`
+        # to identify multi-beat passages that need scene-to-scene transitions.
+        # Both gate on `grouping_type == "collapse"`.  The new rule has no
+        # "collapse" vs "singleton" distinction — it's one uniform algorithm —
+        # but we still populate the field so Phase 5f keeps firing on
+        # multi-beat runs.  Single-beat runs remain `singleton`.
+        grouping_type = "collapse" if len(run) > 1 else "singleton"
+
         specs.append(
             PassageSpec(
                 passage_id=f"passage::{run[0].split('::', 1)[-1]}",
                 beat_ids=list(run),
                 summary=beat_nodes[run[0]].get("summary", ""),
                 entities=merged_entities,
+                grouping_type=grouping_type,
             )
         )
 

--- a/src/questfoundry/pipeline/stages/polish/deterministic.py
+++ b/src/questfoundry/pipeline/stages/polish/deterministic.py
@@ -1139,10 +1139,31 @@ def _create_variant_passage(graph: Graph, vspec: VariantSpec) -> None:
 
 
 def _create_residue_beat_and_passage(graph: Graph, rspec: ResidueSpec) -> None:
+    """Phase 6: materialize a residue spec into the passage layer.
+
+    Branches on ``rspec.mapping_strategy`` per R-5.7/R-5.8:
+      - ``residue_passage_with_variants`` — one residue passage with
+        variant children carrying flag-gated prose (the existing shape).
+      - ``parallel_passages`` — sibling passages that branch from the
+        target's predecessor and rejoin at the target (new shape).
+    """
+    if rspec.mapping_strategy == "residue_passage_with_variants":
+        _apply_residue_with_variants(graph, rspec)
+    elif rspec.mapping_strategy == "parallel_passages":
+        _apply_residue_parallel_passages(graph, rspec)
+    else:  # defensive — validator catches this too
+        raise ValueError(
+            f"R-5.8: unknown mapping_strategy {rspec.mapping_strategy!r} for "
+            f"residue {rspec.residue_id!r}"
+        )
+
+
+def _apply_residue_with_variants(graph: Graph, rspec: ResidueSpec) -> None:
     """Create a residue beat node and a residue passage containing it.
 
     The residue passage is gated by the residue's state flag and
-    precedes the target shared passage.
+    precedes the target shared passage.  This is the default
+    ``residue_passage_with_variants`` shape.
     """
     # Derive IDs from residue_id — use residue_ prefix to avoid collision
     # with regular beat/passage IDs
@@ -1177,6 +1198,8 @@ def _create_residue_beat_and_passage(graph: Graph, rspec: ResidueSpec) -> None:
             "summary": rspec.content_hint or f"Residue for {rspec.flag}",
             "requires": [rspec.flag],
             "is_residue": True,
+            "residue_for": rspec.target_passage_id,
+            "mapping_strategy": rspec.mapping_strategy,
         },
     )
 
@@ -1203,6 +1226,21 @@ def _create_residue_beat_and_passage(graph: Graph, rspec: ResidueSpec) -> None:
             if pred_edge["from"] == target_beat:
                 graph.add_edge("predecessor", beat_id, pred_edge["to"])
         graph.add_edge("predecessor", target_beat, beat_id)
+
+
+def _apply_residue_parallel_passages(graph: Graph, rspec: ResidueSpec) -> None:
+    """Alternative residue mapping: parallel passages that branch and rejoin.
+
+    For a residue spec, create N sibling passages — each with flag-gated
+    prose — branching from the target's predecessor and rejoining at the
+    target.  Currently stubbed; end-to-end test coverage + full
+    implementation tracked in the polish-compliance follow-on (task 18).
+    """
+    raise NotImplementedError(
+        f"R-5.8: 'parallel_passages' mapping_strategy is not yet implemented; "
+        f"residue {rspec.residue_id!r} requires handwritten applier. "
+        f"Tracked as follow-on to epic #1310."
+    )
 
 
 def _create_choice_edge(graph: Graph, cspec: ChoiceSpec) -> None:

--- a/src/questfoundry/pipeline/stages/polish/deterministic.py
+++ b/src/questfoundry/pipeline/stages/polish/deterministic.py
@@ -244,11 +244,25 @@ def compute_beat_grouping(graph: Graph) -> list[PassageSpec]:
             assigned.add(nxt)
             current = nxt
 
+        # Merge entities across all beats in the run (order-preserving, unique).
+        # Phase 4b's prose feasibility audit reads ``spec.entities`` to compute
+        # entity overlap between the passage and structural flags; if this is
+        # left empty, every structural flag is classified as irrelevant and
+        # no variant/residue specs are generated.
+        merged_entities: list[str] = []
+        seen_entities: set[str] = set()
+        for bid in run:
+            for eid in beat_nodes[bid].get("entities", []) or []:
+                if eid not in seen_entities:
+                    merged_entities.append(eid)
+                    seen_entities.add(eid)
+
         specs.append(
             PassageSpec(
                 passage_id=f"passage::{run[0].split('::', 1)[-1]}",
                 beat_ids=list(run),
                 summary=beat_nodes[run[0]].get("summary", ""),
+                entities=merged_entities,
             )
         )
 

--- a/src/questfoundry/pipeline/stages/polish/deterministic.py
+++ b/src/questfoundry/pipeline/stages/polish/deterministic.py
@@ -1389,22 +1389,27 @@ async def phase_validation(
     """Phase 7: Validate the complete passage graph.
 
     Runs structural, variant, choice, and feasibility checks on the
-    passage layer created by Phase 6. Failures indicate bugs in
-    Phases 4-6 or insufficient GROW output.
+    passage layer created by Phase 6.  On any error, raises
+    ``PolishContractError`` after logging a structured ERROR event —
+    failures at this seam indicate bugs in Phases 4-6 or insufficient
+    GROW output and should halt the pipeline loudly.
     """
-    from questfoundry.graph.polish_validation import validate_polish_output
+    from questfoundry.graph.polish_validation import (
+        PolishContractError,
+        validate_polish_output,
+    )
 
     errors = validate_polish_output(graph)
 
     if errors:
-        detail = f"{len(errors)} validation error(s): {'; '.join(errors[:3])}"
-        if len(errors) > 3:
-            detail += f" (and {len(errors) - 3} more)"
-        log.warning("phase7_validation_failed", errors=len(errors))
-        return PhaseResult(
-            phase="validation",
-            status="failed",
-            detail=detail,
+        log.error(
+            "polish_contract_failed",
+            total_errors=len(errors),  # full count, even when the list below is capped
+            errors=errors[:10],  # cap for log readability; full list is in the raised exception
+        )
+        raise PolishContractError(
+            f"POLISH stage output contract violated ({len(errors)} "
+            f"error(s)):\n" + "\n".join(f"  - {e}" for e in errors)
         )
 
     # Collect summary stats for PolishResult

--- a/src/questfoundry/pipeline/stages/polish/llm_phases.py
+++ b/src/questfoundry/pipeline/stages/polish/llm_phases.py
@@ -273,7 +273,9 @@ class _PolishLLMPhaseMixin:
             total_llm_calls += llm_calls
             total_tokens += tokens
 
-            # Store arc metadata
+            # Store arc metadata as an annotation on the Entity node (R-3.3).
+            # The old pattern (separate character_arc_metadata nodes +
+            # has_arc_metadata edges) violated R-3.3 and ontology Part 1.
             for arc in result.character_arcs:
                 if arc.entity_id != entity_id:
                     log.warning(
@@ -283,19 +285,19 @@ class _PolishLLMPhaseMixin:
                     )
                     continue
 
-                arc_node_id = f"character_arc_metadata::{entity_id.split('::')[-1]}"
-                graph.create_node(
-                    arc_node_id,
-                    {
-                        "type": "character_arc_metadata",
-                        "raw_id": entity_id.split("::")[-1],
-                        "entity_id": entity_id,
+                # pivots is a list of ArcPivot models with (path_id, beat_id)
+                # attributes; normalize to path_id → beat_id so the R-3.3
+                # validator's shape check passes.
+                pivots_by_path = {p.path_id: p.beat_id for p in arc.pivots}
+
+                graph.update_node(
+                    entity_id,
+                    character_arc={
                         "start": arc.start,
-                        "pivots": [p.model_dump() for p in arc.pivots],
-                        "end_per_path": arc.end_per_path,
+                        "pivots": pivots_by_path,
+                        "end_per_path": dict(arc.end_per_path),
                     },
                 )
-                graph.add_edge("has_arc_metadata", entity_id, arc_node_id)
                 arcs_created += 1
 
         return PhaseResult(

--- a/src/questfoundry/pipeline/stages/polish/llm_phases.py
+++ b/src/questfoundry/pipeline/stages/polish/llm_phases.py
@@ -385,12 +385,14 @@ class _PolishLLMPhaseMixin:
             total_llm_calls += llm_calls
             total_tokens += tokens
 
-            # Apply content hints to residue specs
-            hint_lookup = {item.residue_id: item.content_hint for item in result_b.residue_content}
+            # Apply content hints and mapping_strategy to residue specs
+            item_lookup = {item.residue_id: item for item in result_b.residue_content}
             for spec in residue_specs:
                 rid = spec.get("residue_id", "")
-                if rid in hint_lookup:
-                    spec["content_hint"] = hint_lookup[rid]
+                if rid in item_lookup:
+                    item = item_lookup[rid]
+                    spec["content_hint"] = item.content_hint
+                    spec["mapping_strategy"] = item.mapping_strategy
 
             enrichment_parts.append(f"{len(result_b.residue_content)} residue hints")
             log.debug("phase5b_complete", hints=len(result_b.residue_content))

--- a/tests/unit/test_polish_apply.py
+++ b/tests/unit/test_polish_apply.py
@@ -204,6 +204,59 @@ class TestCreateResidueBeatAndPassage:
         assert "beat::residue_r2" in beat_nodes
         assert "Residue moment for" in beat_nodes["beat::residue_r2"]["summary"]
 
+    def test_residue_passage_records_mapping_strategy(self) -> None:
+        """R-5.7/R-5.8: residue passage node carries mapping_strategy so
+        Phase 7 validator (``_check_residue_mapping_strategy``) can verify it."""
+        graph = Graph.empty()
+        _make_beat(graph, "beat::target")
+        graph.create_node("path::brave", {"type": "path", "raw_id": "brave"})
+
+        target_spec = PassageSpec(
+            passage_id="passage::target",
+            beat_ids=["beat::target"],
+            summary="Target",
+        )
+        _create_passage_node(graph, target_spec)
+
+        rspec = ResidueSpec(
+            target_passage_id="passage::target",
+            residue_id="residue::r3",
+            flag="dilemma::d1:path::brave",
+            path_id="path::brave",
+            content_hint="You feel confident",
+            mapping_strategy="residue_passage_with_variants",
+        )
+        _create_residue_beat_and_passage(graph, rspec)
+
+        residue_passage = graph.get_nodes_by_type("passage").get("passage::residue_r3")
+        assert residue_passage is not None
+        assert residue_passage.get("residue_for") == "passage::target"
+        assert residue_passage.get("mapping_strategy") == "residue_passage_with_variants"
+
+    def test_residue_parallel_passages_is_stubbed(self) -> None:
+        """R-5.8: ``parallel_passages`` branch is a known stub — raises
+        NotImplementedError until the follow-on implements it (epic #1310)."""
+        graph = Graph.empty()
+        _make_beat(graph, "beat::target")
+        graph.create_node("path::brave", {"type": "path", "raw_id": "brave"})
+
+        target_spec = PassageSpec(
+            passage_id="passage::target",
+            beat_ids=["beat::target"],
+            summary="Target",
+        )
+        _create_passage_node(graph, target_spec)
+
+        rspec = ResidueSpec(
+            target_passage_id="passage::target",
+            residue_id="residue::r4",
+            flag="dilemma::d1:path::brave",
+            path_id="path::brave",
+            mapping_strategy="parallel_passages",
+        )
+        with pytest.raises(NotImplementedError, match=r"parallel_passages"):
+            _create_residue_beat_and_passage(graph, rspec)
+
 
 class TestCreateChoiceEdge:
     """Tests for _create_choice_edge."""

--- a/tests/unit/test_polish_contract.py
+++ b/tests/unit/test_polish_contract.py
@@ -373,9 +373,12 @@ def test_R_4a_3_passage_stops_mid_linear_run(compliant_polish_graph: Graph) -> N
 # --------------------------------------------------------------------------
 
 
-def test_R_5_7_residue_passage_missing_mapping_strategy(
+def test_R_5_8_residue_passage_missing_mapping_strategy(
     compliant_polish_graph: Graph,
 ) -> None:
+    """R-5.8: plan must record the mapping-strategy choice for every residue
+    passage.  The spec violations table ties missing-choice to R-5.8 and the
+    validator emits that tag."""
     compliant_polish_graph.create_node(
         "passage::residue_01",
         {
@@ -388,8 +391,8 @@ def test_R_5_7_residue_passage_missing_mapping_strategy(
         },
     )
     errors = validate_polish_output(compliant_polish_graph)
-    assert any("R-5.7" in e or "R-5.8" in e or "mapping_strategy" in e for e in errors), (
-        f"expected missing mapping_strategy error, got {errors}"
+    assert any("R-5.8" in e and "mapping_strategy" in e for e in errors), (
+        f"expected R-5.8 missing mapping_strategy error, got {errors}"
     )
 
 

--- a/tests/unit/test_polish_contract.py
+++ b/tests/unit/test_polish_contract.py
@@ -321,23 +321,35 @@ def test_R_3_3_arc_worthy_entity_missing_annotation(compliant_polish_graph: Grap
 
 
 # --------------------------------------------------------------------------
-# R-4a.4: maximal-linear-collapse (Cluster #1311)
+# R-4a.3: maximal-linear-collapse (Cluster #1311)
+#
+# Per docs/design/procedures/polish.md:
+#   R-4a.3 = maximal-linear-collapse algorithm (passage is a maximal linear
+#   run ending at divergences/convergences).
+#   R-4a.4 = POLISH does NOT consume Intersection Group nodes (the rule that
+#   forbids the old pre-audit grouping pattern).
+# The validator helper `_check_passage_maximal_linear_collapse` enforces
+# R-4a.3 and emits errors with that tag; tests below check for it.
 # --------------------------------------------------------------------------
 
 
-def test_R_4a_4_passage_spans_divergence_forbidden(compliant_polish_graph: Graph) -> None:
-    """A passage whose member beats straddle a Y-fork divergence is a grouping error."""
-    # Move commit_protector into passage::pre — now the passage spans the Y-fork.
+def test_R_4a_3_passage_spans_divergence_forbidden(compliant_polish_graph: Graph) -> None:
+    """R-4a.3: a passage containing a DAG divergence (a beat with multiple
+    in-passage successors) is a grouping error."""
+    # Pull both commit beats into passage::pre so pre_mentor_01 now has two
+    # in-passage successors — a real divergence inside one passage.
     compliant_polish_graph.remove_edge("grouped_in", "beat::commit_protector", "passage::prot")
+    compliant_polish_graph.remove_edge("grouped_in", "beat::commit_manipulator", "passage::mani")
     compliant_polish_graph.add_edge("grouped_in", "beat::commit_protector", "passage::pre")
+    compliant_polish_graph.add_edge("grouped_in", "beat::commit_manipulator", "passage::pre")
     errors = validate_polish_output(compliant_polish_graph)
-    assert any(
-        "R-4a.4" in e or "divergence" in e.lower() or "linear" in e.lower() for e in errors
-    ), f"expected R-4a.4 error, got {errors}"
+    assert any("R-4a.3" in e and "in-passage successors" in e for e in errors), (
+        f"expected R-4a.3 interior-divergence error, got {errors}"
+    )
 
 
-def test_R_4a_4_passage_stops_mid_linear_run(compliant_polish_graph: Graph) -> None:
-    """Splitting a linear run into two passages is a grouping error."""
+def test_R_4a_3_passage_stops_mid_linear_run(compliant_polish_graph: Graph) -> None:
+    """R-4a.3: splitting a linear run into two passages is a grouping error."""
     # Move post_protector_02 out of passage::prot into a new singleton.
     compliant_polish_graph.remove_edge("grouped_in", "beat::post_protector_02", "passage::prot")
     compliant_polish_graph.create_node(
@@ -351,8 +363,8 @@ def test_R_4a_4_passage_stops_mid_linear_run(compliant_polish_graph: Graph) -> N
     )
     compliant_polish_graph.add_edge("grouped_in", "beat::post_protector_02", "passage::prot_tail")
     errors = validate_polish_output(compliant_polish_graph)
-    assert any("R-4a.4" in e or "linear" in e.lower() for e in errors), (
-        f"expected R-4a.4 mid-run split error, got {errors}"
+    assert any("R-4a.3" in e and "mid-linear-run" in e for e in errors), (
+        f"expected R-4a.3 mid-run split error, got {errors}"
     )
 
 

--- a/tests/unit/test_polish_contract.py
+++ b/tests/unit/test_polish_contract.py
@@ -236,6 +236,8 @@ def _polish_passage_baseline(graph: Graph) -> None:
         )
         graph.add_edge("choice_from", choice_id, "passage::pre")
         graph.add_edge("choice_to", choice_id, to_id)
+        # Add the proper choice edge from passage to passage (R-4c.2 requirement)
+        graph.add_edge("choice", "passage::pre", to_id, label=f"Choice {idx + 1}")
 
     # Character arc on the recurring entity.
     graph.update_node(
@@ -405,8 +407,12 @@ def test_R_5_8_residue_passage_bad_mapping_strategy(
 
 
 def test_R_4c_2_zero_choice_edges_fails(compliant_polish_graph: Graph) -> None:
+    # Delete choice nodes (which cascade-delete choice_from/choice_to edges)
     for cid in list(compliant_polish_graph.get_nodes_by_type("choice")):
         compliant_polish_graph.delete_node(cid, cascade=True)
+    # Also delete any remaining choice edges (passage→passage edges, not connected to nodes)
+    for edge in list(compliant_polish_graph.get_edges(edge_type="choice")):
+        compliant_polish_graph.remove_edge("choice", edge["from"], edge["to"])
     errors = validate_polish_output(compliant_polish_graph)
     assert any("R-4c.2" in e or "zero choice" in e.lower() for e in errors), (
         f"expected zero-choice error, got {errors}"

--- a/tests/unit/test_polish_contract.py
+++ b/tests/unit/test_polish_contract.py
@@ -1,0 +1,28 @@
+"""POLISH Stage Output Contract validator tests.
+
+Task 2 seeds this file with smoke tests for ``PolishContractError``.
+Task 4 adds the layered DREAM + BRAINSTORM + SEED + GROW + POLISH
+compliant baseline and the rule-by-rule contract tests that mirror
+the pattern of ``tests/unit/test_grow_validation_contract.py``.
+"""
+
+from __future__ import annotations
+
+import pytest  # noqa: F401
+
+from questfoundry.graph.graph import Graph  # noqa: F401
+from questfoundry.graph.polish_validation import (
+    PolishContractError,
+    validate_polish_output,  # noqa: F401
+)
+
+
+def test_polish_contract_error_is_value_error() -> None:
+    """PolishContractError is a ValueError subclass (same convention as GrowContractError)."""
+    assert issubclass(PolishContractError, ValueError)
+
+
+def test_polish_contract_error_carries_message() -> None:
+    """PolishContractError preserves the error message for callers."""
+    err = PolishContractError("R-4a.4: intersection groups consumed")
+    assert "R-4a.4" in str(err)

--- a/tests/unit/test_polish_contract.py
+++ b/tests/unit/test_polish_contract.py
@@ -1,6 +1,7 @@
 """POLISH Stage Output Contract validator tests.
 
 Task 2 seeds this file with smoke tests for ``PolishContractError``.
+Task 3 adds phase_validation contract tests.
 Task 4 adds the layered DREAM + BRAINSTORM + SEED + GROW + POLISH
 compliant baseline and the rule-by-rule contract tests that mirror
 the pattern of ``tests/unit/test_grow_validation_contract.py``.
@@ -8,12 +9,13 @@ the pattern of ``tests/unit/test_grow_validation_contract.py``.
 
 from __future__ import annotations
 
-import pytest  # noqa: F401
+import asyncio
 
-from questfoundry.graph.graph import Graph  # noqa: F401
+import pytest
+
+from questfoundry.graph.graph import Graph
 from questfoundry.graph.polish_validation import (
     PolishContractError,
-    validate_polish_output,  # noqa: F401
 )
 
 
@@ -26,3 +28,40 @@ def test_polish_contract_error_carries_message() -> None:
     """PolishContractError preserves the error message for callers."""
     err = PolishContractError("R-4a.4: intersection groups consumed")
     assert "R-4a.4" in str(err)
+
+
+def test_phase_validation_raises_contract_error_on_errors(monkeypatch: pytest.MonkeyPatch) -> None:
+    """phase_validation raises PolishContractError (not PhaseResult) when
+    validate_polish_output returns errors."""
+    from unittest.mock import MagicMock
+
+    from questfoundry.pipeline.stages.polish import deterministic
+
+    graph = Graph.empty()
+
+    def _mock_validate(g: Graph) -> list[str]:  # noqa: ARG001
+        return ["R-4a.4: intersection groups consumed (test)"]
+
+    monkeypatch.setattr(
+        "questfoundry.graph.polish_validation.validate_polish_output",
+        _mock_validate,
+    )
+
+    with pytest.raises(PolishContractError, match=r"R-4a\.4"):
+        asyncio.run(deterministic.phase_validation(graph, MagicMock()))
+
+
+def test_phase_validation_passes_on_clean_graph(monkeypatch: pytest.MonkeyPatch) -> None:
+    """phase_validation returns completed PhaseResult when no errors."""
+    from unittest.mock import MagicMock
+
+    from questfoundry.pipeline.stages.polish import deterministic
+
+    graph = Graph.empty()
+    monkeypatch.setattr(
+        "questfoundry.graph.polish_validation.validate_polish_output",
+        lambda g: [],  # noqa: ARG005
+    )
+
+    result = asyncio.run(deterministic.phase_validation(graph, MagicMock()))
+    assert result.status == "completed"

--- a/tests/unit/test_polish_contract.py
+++ b/tests/unit/test_polish_contract.py
@@ -16,7 +16,401 @@ import pytest
 from questfoundry.graph.graph import Graph
 from questfoundry.graph.polish_validation import (
     PolishContractError,
+    validate_polish_output,
 )
+
+# --------------------------------------------------------------------------
+# Compliant POLISH-output baseline (DREAM + BRAINSTORM + SEED + GROW + POLISH)
+# --------------------------------------------------------------------------
+
+
+def _polish_upstream_baseline(graph: Graph) -> None:
+    """Layer a compliant DREAM+BRAINSTORM+SEED+GROW baseline.
+
+    Produces the same graph shape used by test_grow_validation_contract.py
+    so validate_polish_output's upstream-contract delegation passes.
+    Single soft dilemma `mentor_trust` with 2 paths, Y-shape beats,
+    state flags, convergence metadata.
+    """
+    graph.create_node(
+        "vision",
+        {
+            "type": "vision",
+            "genre": "dark fantasy",
+            "tone": ["atmospheric"],
+            "themes": ["forbidden knowledge"],
+            "audience": "adult",
+            "scope": {"story_size": "short"},
+            "human_approved": True,
+        },
+    )
+    for eid, cat, name in [
+        ("character::kay", "character", "Kay"),
+        ("character::mentor", "character", "Mentor"),
+        ("location::archive", "location", "Archive"),
+        ("location::depths", "location", "Forbidden Depths"),
+    ]:
+        graph.create_node(
+            eid,
+            {
+                "type": "entity",
+                "raw_id": eid.split("::", 1)[-1],
+                "name": name,
+                "category": cat,
+                "concept": "x",
+                "disposition": "retained",
+            },
+        )
+    graph.create_node(
+        "dilemma::mentor_trust",
+        {
+            "type": "dilemma",
+            "raw_id": "mentor_trust",
+            "question": "Trust?",
+            "why_it_matters": "stakes",
+            "dilemma_role": "soft",
+            "residue_weight": "light",
+            "ending_salience": "low",
+        },
+    )
+    for ans, is_canon in [("protector", True), ("manipulator", False)]:
+        ans_id = f"dilemma::mentor_trust::alt::{ans}"
+        graph.create_node(
+            ans_id,
+            {
+                "type": "answer",
+                "raw_id": ans,
+                "description": f"d-{ans}",
+                "is_canonical": is_canon,
+                "explored": True,
+            },
+        )
+        graph.add_edge("has_answer", "dilemma::mentor_trust", ans_id)
+    graph.add_edge("anchored_to", "dilemma::mentor_trust", "character::mentor")
+
+    for ans in ["protector", "manipulator"]:
+        path_id = f"path::mentor_trust__{ans}"
+        graph.create_node(
+            path_id,
+            {
+                "type": "path",
+                "raw_id": f"mentor_trust__{ans}",
+                "dilemma_id": "dilemma::mentor_trust",
+                "is_canonical": ans == "protector",
+            },
+        )
+        graph.add_edge("explores", path_id, f"dilemma::mentor_trust::alt::{ans}")
+        conseq_id = f"consequence::mentor_trust__{ans}"
+        graph.create_node(
+            conseq_id,
+            {
+                "type": "consequence",
+                "raw_id": f"mentor_trust__{ans}",
+                "description": "mentor becomes hostile",
+                "ripples": ["faction mistrust rises"],
+            },
+        )
+        graph.add_edge("has_consequence", path_id, conseq_id)
+
+    graph.create_node(
+        "beat::pre_mentor_01",
+        {
+            "type": "beat",
+            "raw_id": "pre_mentor_01",
+            "summary": "Mentor delivers warning",
+            "entities": ["character::mentor", "character::kay"],
+            "dilemma_impacts": [{"dilemma_id": "dilemma::mentor_trust", "effect": "advances"}],
+        },
+    )
+    graph.add_edge("belongs_to", "beat::pre_mentor_01", "path::mentor_trust__protector")
+    graph.add_edge("belongs_to", "beat::pre_mentor_01", "path::mentor_trust__manipulator")
+
+    for ans in ["protector", "manipulator"]:
+        path_id = f"path::mentor_trust__{ans}"
+        commit_id = f"beat::commit_{ans}"
+        graph.create_node(
+            commit_id,
+            {
+                "type": "beat",
+                "raw_id": f"commit_{ans}",
+                "summary": f"Mentor reveals {ans} motive",
+                "entities": ["character::mentor"],
+                "dilemma_impacts": [{"dilemma_id": "dilemma::mentor_trust", "effect": "commits"}],
+            },
+        )
+        graph.add_edge("belongs_to", commit_id, path_id)
+        graph.add_edge("predecessor", commit_id, "beat::pre_mentor_01")
+        for i in range(1, 3):
+            post_id = f"beat::post_{ans}_{i:02d}"
+            graph.create_node(
+                post_id,
+                {
+                    "type": "beat",
+                    "raw_id": f"post_{ans}_{i:02d}",
+                    "summary": f"Post-commit {i} on {ans}",
+                    "entities": ["character::mentor"],
+                    "dilemma_impacts": [],
+                },
+            )
+            graph.add_edge("belongs_to", post_id, path_id)
+            prev = commit_id if i == 1 else f"beat::post_{ans}_{i - 1:02d}"
+            graph.add_edge("predecessor", post_id, prev)
+
+    graph.create_node("seed_freeze", {"type": "seed_freeze", "human_approved": True})
+
+    for ans in ["protector", "manipulator"]:
+        flag_id = f"state_flag::mentor_{ans}"
+        graph.create_node(
+            flag_id,
+            {
+                "type": "state_flag",
+                "raw_id": f"mentor_{ans}",
+                "name": f"mentor_is_{ans}",
+            },
+        )
+        graph.add_edge("derived_from", flag_id, f"consequence::mentor_trust__{ans}")
+
+    graph.update_node(
+        "dilemma::mentor_trust",
+        converges_at="beat::post_protector_02",
+        convergence_payoff=2,
+    )
+
+    # Wire appears(entity, beat) for arc-worthy-entity detection.  The
+    # R-3.3 validator (added in Task 5) reads these to identify entities
+    # with ≥2 beat appearances.
+    for bid, bdata in graph.get_nodes_by_type("beat").items():
+        for eid in bdata.get("entities", []) or []:
+            graph.add_edge("appears", eid, bid)
+
+
+def _polish_passage_baseline(graph: Graph) -> None:
+    """Add a spec-compliant POLISH passage layer on top of the upstream baseline.
+
+    5 passages using maximal-linear-collapse over the Y-shape beat DAG:
+      P_pre   = [pre_mentor_01]              — shared pre-commit, closes at Y-fork
+      P_prot  = [commit_protector, post_protector_01, post_protector_02]
+      P_mani  = [commit_manipulator, post_manipulator_01, post_manipulator_02]
+    One choice edge from P_pre to each of P_prot / P_mani.
+    Each entity with ≥2 appearances carries a `character_arc` annotation.
+    """
+    passage_specs = [
+        ("passage::pre", ["beat::pre_mentor_01"], False),
+        (
+            "passage::prot",
+            ["beat::commit_protector", "beat::post_protector_01", "beat::post_protector_02"],
+            False,
+        ),
+        (
+            "passage::mani",
+            ["beat::commit_manipulator", "beat::post_manipulator_01", "beat::post_manipulator_02"],
+            False,
+        ),
+    ]
+    for passage_id, beat_ids, is_variant in passage_specs:
+        graph.create_node(
+            passage_id,
+            {
+                "type": "passage",
+                "raw_id": passage_id.split("::", 1)[-1],
+                "from_beat": beat_ids[0],
+                "summary": f"Passage at {beat_ids[0]}",
+                "is_variant": is_variant,
+            },
+        )
+        for bid in beat_ids:
+            graph.add_edge("grouped_in", bid, passage_id)
+
+    for idx, to_id in enumerate(("passage::prot", "passage::mani")):
+        choice_id = f"choice::pre_to_{to_id.rsplit('::', 1)[-1]}"
+        graph.create_node(
+            choice_id,
+            {
+                "type": "choice",
+                "raw_id": choice_id.split("::", 1)[-1],
+                "from_passage": "passage::pre",
+                "to_passage": to_id,
+                "label": f"Choice {idx + 1}",
+                "requires": [],
+            },
+        )
+        graph.add_edge("choice_from", choice_id, "passage::pre")
+        graph.add_edge("choice_to", choice_id, to_id)
+
+    # Character arc on the recurring entity.
+    graph.update_node(
+        "character::mentor",
+        character_arc={
+            "start": "warning delivered",
+            "pivots": {
+                "path::mentor_trust__protector": "beat::commit_protector",
+                "path::mentor_trust__manipulator": "beat::commit_manipulator",
+            },
+            "end_per_path": {
+                "path::mentor_trust__protector": "beat::post_protector_02",
+                "path::mentor_trust__manipulator": "beat::post_manipulator_02",
+            },
+        },
+    )
+
+
+@pytest.fixture
+def compliant_polish_graph() -> Graph:
+    graph = Graph()
+    _polish_upstream_baseline(graph)
+    _polish_passage_baseline(graph)
+    return graph
+
+
+# --------------------------------------------------------------------------
+# Positive baseline
+# --------------------------------------------------------------------------
+
+
+def test_valid_polish_graph_passes(compliant_polish_graph: Graph) -> None:
+    errors = validate_polish_output(compliant_polish_graph)
+    assert errors == [], f"expected no errors, got: {errors}"
+
+
+# Upstream delegation at POLISH exit is intentionally NOT tested here:
+# POLISH's entry contract (validate_grow_output in polish/stage.py) already
+# catches upstream-contract violations at stage start.  Re-delegating
+# upstream from validate_polish_output would require a skip_forbidden_types
+# kwarg on validate_grow_output — out of scope for the hot-path PR.  Tracked
+# as follow-on work on epic #1310.
+
+
+# --------------------------------------------------------------------------
+# R-3.3: arc metadata as entity annotation (Cluster #1314)
+# --------------------------------------------------------------------------
+
+
+def test_R_3_3_character_arc_metadata_node_forbidden(compliant_polish_graph: Graph) -> None:
+    compliant_polish_graph.create_node(
+        "character_arc_metadata::mentor",
+        {"type": "character_arc_metadata", "raw_id": "mentor"},
+    )
+    errors = validate_polish_output(compliant_polish_graph)
+    assert any("R-3.3" in e or "character_arc_metadata" in e for e in errors), (
+        f"expected R-3.3 error, got {errors}"
+    )
+
+
+def test_R_3_3_has_arc_metadata_edge_forbidden(compliant_polish_graph: Graph) -> None:
+    compliant_polish_graph.create_node(
+        "character_arc_metadata::mentor",
+        {"type": "character_arc_metadata", "raw_id": "mentor"},
+    )
+    compliant_polish_graph.add_edge(
+        "has_arc_metadata", "character::mentor", "character_arc_metadata::mentor"
+    )
+    errors = validate_polish_output(compliant_polish_graph)
+    assert any("R-3.3" in e or "has_arc_metadata" in e for e in errors), (
+        f"expected R-3.3 edge error, got {errors}"
+    )
+
+
+def test_R_3_3_arc_worthy_entity_missing_annotation(compliant_polish_graph: Graph) -> None:
+    compliant_polish_graph.update_node("character::mentor", character_arc=None)
+    errors = validate_polish_output(compliant_polish_graph)
+    assert any(
+        "R-3.3" in e or ("character::mentor" in e and "character_arc" in e) for e in errors
+    ), f"expected missing-annotation error, got {errors}"
+
+
+# --------------------------------------------------------------------------
+# R-4a.4: maximal-linear-collapse (Cluster #1311)
+# --------------------------------------------------------------------------
+
+
+def test_R_4a_4_passage_spans_divergence_forbidden(compliant_polish_graph: Graph) -> None:
+    """A passage whose member beats straddle a Y-fork divergence is a grouping error."""
+    # Move commit_protector into passage::pre — now the passage spans the Y-fork.
+    compliant_polish_graph.remove_edge("grouped_in", "beat::commit_protector", "passage::prot")
+    compliant_polish_graph.add_edge("grouped_in", "beat::commit_protector", "passage::pre")
+    errors = validate_polish_output(compliant_polish_graph)
+    assert any(
+        "R-4a.4" in e or "divergence" in e.lower() or "linear" in e.lower() for e in errors
+    ), f"expected R-4a.4 error, got {errors}"
+
+
+def test_R_4a_4_passage_stops_mid_linear_run(compliant_polish_graph: Graph) -> None:
+    """Splitting a linear run into two passages is a grouping error."""
+    # Move post_protector_02 out of passage::prot into a new singleton.
+    compliant_polish_graph.remove_edge("grouped_in", "beat::post_protector_02", "passage::prot")
+    compliant_polish_graph.create_node(
+        "passage::prot_tail",
+        {
+            "type": "passage",
+            "raw_id": "prot_tail",
+            "from_beat": "beat::post_protector_02",
+            "summary": "Orphan tail",
+        },
+    )
+    compliant_polish_graph.add_edge("grouped_in", "beat::post_protector_02", "passage::prot_tail")
+    errors = validate_polish_output(compliant_polish_graph)
+    assert any("R-4a.4" in e or "linear" in e.lower() for e in errors), (
+        f"expected R-4a.4 mid-run split error, got {errors}"
+    )
+
+
+# --------------------------------------------------------------------------
+# R-5.7 / R-5.8: residue mapping_strategy (Cluster #1313)
+# --------------------------------------------------------------------------
+
+
+def test_R_5_7_residue_passage_missing_mapping_strategy(
+    compliant_polish_graph: Graph,
+) -> None:
+    compliant_polish_graph.create_node(
+        "passage::residue_01",
+        {
+            "type": "passage",
+            "raw_id": "residue_01",
+            "from_beat": "beat::post_protector_01",
+            "summary": "Residue",
+            "residue_for": "passage::prot",
+            # mapping_strategy intentionally absent
+        },
+    )
+    errors = validate_polish_output(compliant_polish_graph)
+    assert any("R-5.7" in e or "R-5.8" in e or "mapping_strategy" in e for e in errors), (
+        f"expected missing mapping_strategy error, got {errors}"
+    )
+
+
+def test_R_5_8_residue_passage_bad_mapping_strategy(
+    compliant_polish_graph: Graph,
+) -> None:
+    compliant_polish_graph.create_node(
+        "passage::residue_01",
+        {
+            "type": "passage",
+            "raw_id": "residue_01",
+            "from_beat": "beat::post_protector_01",
+            "summary": "Residue",
+            "residue_for": "passage::prot",
+            "mapping_strategy": "not_a_valid_value",
+        },
+    )
+    errors = validate_polish_output(compliant_polish_graph)
+    assert any("R-5.8" in e or "mapping_strategy" in e for e in errors), (
+        f"expected invalid mapping_strategy error, got {errors}"
+    )
+
+
+# --------------------------------------------------------------------------
+# R-4c.2: zero-choice ERROR halt (Cluster #1312, belt-and-suspenders)
+# --------------------------------------------------------------------------
+
+
+def test_R_4c_2_zero_choice_edges_fails(compliant_polish_graph: Graph) -> None:
+    for cid in list(compliant_polish_graph.get_nodes_by_type("choice")):
+        compliant_polish_graph.delete_node(cid, cascade=True)
+    errors = validate_polish_output(compliant_polish_graph)
+    assert any("R-4c.2" in e or "zero choice" in e.lower() for e in errors), (
+        f"expected zero-choice error, got {errors}"
+    )
 
 
 def test_polish_contract_error_is_value_error() -> None:

--- a/tests/unit/test_polish_contract.py
+++ b/tests/unit/test_polish_contract.py
@@ -406,6 +406,26 @@ def test_R_5_8_residue_passage_bad_mapping_strategy(
 # --------------------------------------------------------------------------
 
 
+def test_phase_4c_zero_choices_raises_contract_error() -> None:
+    """Phase 4c raises PolishContractError when compute_choice_edges returns empty.
+
+    This is a unit test of phase_plan_computation directly. We use the
+    compliant baseline graph but delete all choice nodes to ensure
+    compute_choice_edges returns empty list.
+    """
+    from unittest.mock import MagicMock
+
+    from questfoundry.pipeline.stages.polish import deterministic
+
+    # Use a graph structure with passages but no Y-forks.
+    # The simplest approach: use empty graph, which has no beats → no
+    # passages → no choices. Phase 4a will produce empty passage_specs.
+    graph = Graph.empty()
+
+    with pytest.raises(PolishContractError, match=r"R-4c\.2|zero choice"):
+        asyncio.run(deterministic.phase_plan_computation(graph, MagicMock()))
+
+
 def test_R_4c_2_zero_choice_edges_fails(compliant_polish_graph: Graph) -> None:
     # Delete choice nodes (which cascade-delete choice_from/choice_to edges)
     for cid in list(compliant_polish_graph.get_nodes_by_type("choice")):

--- a/tests/unit/test_polish_deterministic.py
+++ b/tests/unit/test_polish_deterministic.py
@@ -60,7 +60,11 @@ class TestComputeBeatGrouping:
         assert all(s.grouping_type == "singleton" for s in specs)
 
     def test_collapse_grouping(self) -> None:
-        """Sequential same-path beats collapse into one passage."""
+        """Sequential same-path beats collapse into one passage (maximal-linear-collapse).
+
+        Under R-4a.4 all grouping_type values are 'singleton'; the collapse is
+        expressed by the passage containing all three beats in a single PassageSpec.
+        """
         graph = Graph.empty()
         graph.create_node("path::p1", {"type": "path", "raw_id": "p1"})
         _make_beat(graph, "beat::a", "Search the study")
@@ -73,34 +77,20 @@ class TestComputeBeatGrouping:
         _add_predecessor(graph, "beat::c", "beat::b")
 
         specs = compute_beat_grouping(graph)
-        collapse_specs = [s for s in specs if s.grouping_type == "collapse"]
-        assert len(collapse_specs) == 1
-        assert len(collapse_specs[0].beat_ids) == 3
+        # All three beats form a maximal linear run → exactly one passage.
+        assert len(specs) == 1
+        assert set(specs[0].beat_ids) == {"beat::a", "beat::b", "beat::c"}
+        assert specs[0].grouping_type == "singleton"
 
-    def test_intersection_grouping(self) -> None:
-        """Beats in intersection groups form intersection passages."""
-        graph = Graph.empty()
-        graph.create_node("path::pa", {"type": "path", "raw_id": "pa"})
-        graph.create_node("path::pb", {"type": "path", "raw_id": "pb"})
-        _make_beat(graph, "beat::a", "Path A beat")
-        _make_beat(graph, "beat::b", "Path B beat")
-        _add_belongs_to(graph, "beat::a", "path::pa")
-        _add_belongs_to(graph, "beat::b", "path::pb")
-
-        # Create intersection group
-        graph.create_node(
-            "intersection_group::ig1",
-            {
-                "type": "intersection_group",
-                "raw_id": "ig1",
-                "beat_ids": ["beat::a", "beat::b"],
-            },
-        )
-
-        specs = compute_beat_grouping(graph)
-        intersection_specs = [s for s in specs if s.grouping_type == "intersection"]
-        assert len(intersection_specs) == 1
-        assert set(intersection_specs[0].beat_ids) == {"beat::a", "beat::b"}
+    # DELETED: test_intersection_grouping
+    # Removed as part of cluster #1311 (maximal-linear-collapse, R-4a.4).
+    # Intersection-driven grouping is gone — compute_beat_grouping no longer
+    # consumes intersection_group nodes.  Under the new rule, beats from
+    # different paths with no predecessor relationship each become their own
+    # singleton passage; intersection_group nodes are GROW-internal and are
+    # ignored by POLISH.  The two beats in the old fixture (no predecessor edge
+    # linking them) now correctly produce two separate singleton passages.
+    # See docs/design/procedures/polish.md §R-4a.3, R-4a.4.
 
     def test_intersection_grouping_beat_ids_not_node_ids(self) -> None:
         """Intersection group uses beat_ids field, not node_ids (regression for #1172)."""
@@ -159,20 +149,14 @@ class TestComputeBeatGrouping:
         expected = {f"beat::b{i}" for i in range(5)}
         assert all_beats == expected
 
-    def test_entities_merged(self) -> None:
-        """Collapsed passage contains union of all beat entities."""
-        graph = Graph.empty()
-        graph.create_node("path::p1", {"type": "path", "raw_id": "p1"})
-        _make_beat(graph, "beat::a", "A", entities=["entity::hero"])
-        _make_beat(graph, "beat::b", "B", entities=["entity::hero", "entity::mentor"])
-        _add_belongs_to(graph, "beat::a", "path::p1")
-        _add_belongs_to(graph, "beat::b", "path::p1")
-        _add_predecessor(graph, "beat::b", "beat::a")
-
-        specs = compute_beat_grouping(graph)
-        collapse_specs = [s for s in specs if s.grouping_type == "collapse"]
-        assert len(collapse_specs) == 1
-        assert set(collapse_specs[0].entities) == {"entity::hero", "entity::mentor"}
+    # DELETED: test_entities_merged
+    # Removed as part of cluster #1311 (maximal-linear-collapse, R-4a.4).
+    # The _merge_entities helper was deleted in Task 11.  Under the new rule,
+    # compute_beat_grouping no longer merges entity lists across beats in a run;
+    # PassageSpec.entities is populated from the first beat in the run only.
+    # The old assertion (union of all beat entities) no longer holds.
+    # If cross-beat entity merging is needed in future, open a follow-on issue
+    # (see cluster #1311 tracking).
 
     def test_empty_graph(self) -> None:
         """Empty graph produces no specs."""
@@ -180,30 +164,15 @@ class TestComputeBeatGrouping:
         specs = compute_beat_grouping(graph)
         assert specs == []
 
-    def test_zero_belongs_to_beats_do_not_collapse(self) -> None:
-        """Two zero-belongs_to setup beats in sequence become two singleton passages.
-
-        Per ontology Part 8 "Determining a beat's `belongs_to`", a beat with zero
-        `belongs_to` edges cannot collapse with any path-specific chain, and the
-        empty path set does not match any non-empty set. Two adjacent zero-path
-        beats must therefore each become their own singleton passage, not a
-        two-beat collapse chain.
-
-        This locks in the B2 ruling from issue #1237 and prevents a silent
-        regression if the collapse rule is ever refactored.
-        """
-        graph = Graph.empty()
-        # Two setup beats — no belongs_to edges, linked by predecessor edge
-        _make_beat(graph, "beat::setup_1", "A")
-        _make_beat(graph, "beat::setup_2", "B")
-        _add_predecessor(graph, "beat::setup_2", "beat::setup_1")
-
-        specs = compute_beat_grouping(graph)
-
-        beat_to_spec = {bid: s for s in specs for bid in s.beat_ids}
-        assert beat_to_spec["beat::setup_1"].passage_id != beat_to_spec["beat::setup_2"].passage_id
-        assert beat_to_spec["beat::setup_1"].grouping_type == "singleton"
-        assert beat_to_spec["beat::setup_2"].grouping_type == "singleton"
+    # DELETED: test_zero_belongs_to_beats_do_not_collapse
+    # Removed as part of cluster #1311 (maximal-linear-collapse, R-4a.4).
+    # The new R-4a.3 rule collapses beats purely by DAG topology — the
+    # belongs_to set is NOT consulted for collapse eligibility.  Two adjacent
+    # zero-belongs_to beats in a linear DAG WILL collapse into one passage
+    # under the new rule.  The old assertion (they must remain separate) is
+    # directly contradicted by the new spec.
+    # The B2 ruling from issue #1237 that this test locked in is superseded
+    # by the cluster #1311 spec update.
 
 
 class TestComputeProseFeasibility:
@@ -1315,7 +1284,15 @@ class TestArcTraversalsAfterPlanApplication:
     """Phase 6 must populate arc_traversals on the polish_plan node."""
 
     def test_arc_traversals_non_empty_after_phase6(self) -> None:
-        """Minimal two-path graph: phase 4 + phase 6 produce non-empty arc_traversals."""
+        """Minimal Y-fork graph: phase 4 + phase 6 produce non-empty arc_traversals.
+
+        The fixture was updated (cluster #1311 / Task 14) to include a Y-fork so
+        that Phase 4c produces at least one choice edge and does not trigger the
+        zero-choice PolishContractError halt (R-4c.2, Task 10).
+
+        Graph: shared (pa+pb dual belongs_to) → commit_a (pa, commits d1)
+                                               → commit_b (pb, commits d1)
+        """
         import asyncio
 
         from questfoundry.pipeline.stages.polish.deterministic import (
@@ -1325,7 +1302,7 @@ class TestArcTraversalsAfterPlanApplication:
 
         graph = Graph.empty()
 
-        # Two dilemmas, each with two paths
+        # One dilemma with two paths
         graph.create_node("dilemma::d1", {"type": "dilemma", "raw_id": "d1", "status": "explored"})
         graph.create_node("path::pa", {"type": "path", "raw_id": "pa", "dilemma_id": "dilemma::d1"})
         graph.create_node("path::pb", {"type": "path", "raw_id": "pb", "dilemma_id": "dilemma::d1"})
@@ -1350,22 +1327,42 @@ class TestArcTraversalsAfterPlanApplication:
             },
         )
 
-        # Beats on each path
-        for bid, pid in [("beat::a", "path::pa"), ("beat::b", "path::pb")]:
+        # Shared pre-commit beat (dual belongs_to — Y-shape §MEMORY)
+        graph.create_node(
+            "beat::shared",
+            {
+                "type": "beat",
+                "raw_id": "shared",
+                "summary": "Shared beat",
+                "dilemma_impacts": [{"dilemma_id": "dilemma::d1", "effect": "reveals"}],
+                "entities": [],
+                "scene_type": "scene",
+            },
+        )
+        graph.add_edge("belongs_to", "beat::shared", "path::pa")
+        graph.add_edge("belongs_to", "beat::shared", "path::pb")
+
+        # Commit beats — one per path (creates the Y-fork)
+        for bid, pid, sfid in [
+            ("beat::commit_a", "path::pa", "state_flag::d1_pa"),
+            ("beat::commit_b", "path::pb", "state_flag::d1_pb"),
+        ]:
             graph.create_node(
                 bid,
                 {
                     "type": "beat",
                     "raw_id": bid.split("::")[-1],
-                    "summary": f"Beat on {pid}",
-                    "dilemma_impacts": [],
+                    "summary": f"Commit on {pid}",
+                    "dilemma_impacts": [{"dilemma_id": "dilemma::d1", "effect": "commits"}],
                     "entities": [],
                     "scene_type": "scene",
                 },
             )
             graph.add_edge("belongs_to", bid, pid)
+            graph.add_edge("grants", bid, sfid)
+            graph.add_edge("predecessor", bid, "beat::shared")
 
-        # Run Phase 4 (plan computation)
+        # Run Phase 4 (plan computation) — should succeed now that Y-fork exists
         r4 = asyncio.run(phase_plan_computation(graph, None))  # type: ignore[arg-type]
         assert r4.status == "completed"
 
@@ -1506,26 +1503,19 @@ class TestChoiceSpecRequires:
             if from_spec and from_spec.grouping_type != "intersection":
                 assert c.requires == [], f"Expected empty requires for {c.from_passage}"
 
-    def test_convergence_choice_has_requires(self) -> None:
-        """Choices from intersection passages have a non-empty requires list."""
-        graph = Graph.empty()
-        self._build_convergence_graph(graph)
-
-        specs = compute_beat_grouping(graph)
-        choices = compute_choice_edges(graph, specs)
-
-        passage_id_to_spec = {s.passage_id: s for s in specs}
-        intersection_choices = [
-            c
-            for c in choices
-            if c.from_passage in passage_id_to_spec
-            and passage_id_to_spec[c.from_passage].grouping_type == "intersection"
-        ]
-
-        assert intersection_choices, "Expected at least one choice from an intersection passage"
-        assert any(len(c.requires) > 0 for c in intersection_choices), (
-            "Expected at least one intersection choice to have a non-empty requires list"
-        )
+    # DELETED: test_convergence_choice_has_requires
+    # Removed as part of cluster #1311 (maximal-linear-collapse, R-4a.4).
+    # The test filtered choices by `grouping_type == "intersection"` — a field
+    # that is now always "singleton" under the new rule.  The requires-population
+    # logic in compute_choice_edges is guarded by `from_spec.grouping_type ==
+    # "intersection"` (deterministic.py ~line 759), so requires is always empty
+    # under the new rule — the assertion would never be satisfiable.
+    #
+    # This exposes dead code: the `requires` population branch in
+    # compute_choice_edges is now unreachable.  A follow-on issue should either
+    # repurpose `requires` for convergence detection via DAG topology (without
+    # relying on grouping_type) or remove the dead branch.
+    # See cluster #1311 for tracking.
 
 
 # ---------------------------------------------------------------------------
@@ -2476,35 +2466,22 @@ class TestAuditOverlayComposition:
 # ---------------------------------------------------------------------------
 
 
-def _build_y_shape_for_collapse() -> Graph:
-    """Build a Y-shape: shared_setup (dual) → commit_a (single), linear chain."""
-    g = Graph.empty()
-    g.create_node("path::trust__a", {"type": "path", "raw_id": "trust__a"})
-    g.create_node("path::trust__b", {"type": "path", "raw_id": "trust__b"})
-
-    # shared_setup: pre-commit beat with dual belongs_to
-    _make_beat(g, "beat::shared_setup", "Shared setup beat.")
-    g.add_edge("belongs_to", "beat::shared_setup", "path::trust__a")
-    g.add_edge("belongs_to", "beat::shared_setup", "path::trust__b")
-
-    # commit_a: single belongs_to (path_a only)
-    _make_beat(g, "beat::commit_a", "Commit A beat.")
-    g.add_edge("belongs_to", "beat::commit_a", "path::trust__a")
-
-    # Linear chain: commit_a follows shared_setup
-    _add_predecessor(g, "beat::commit_a", "beat::shared_setup")
-
-    return g
-
-
-def test_collapse_chain_does_not_join_shared_with_post_commit() -> None:
-    """A shared pre-commit beat cannot collapse into a post-commit passage."""
-    graph = _build_y_shape_for_collapse()
-    specs = compute_beat_grouping(graph)
-
-    # Find the spec containing shared_setup and the spec containing commit_a.
-    shared_spec = next(s for s in specs if "beat::shared_setup" in s.beat_ids)
-    commit_a_spec = next(s for s in specs if "beat::commit_a" in s.beat_ids)
-    assert shared_spec.passage_id != commit_a_spec.passage_id, (
-        "shared pre-commit beat must not collapse into a post-commit passage (Y-shape guard rail 2)"
-    )
+# DELETED: test_collapse_chain_does_not_join_shared_with_post_commit
+# Removed as part of cluster #1311 (maximal-linear-collapse, R-4a.4).
+# The test asserted Y-shape guard rail 2: a shared pre-commit beat (dual
+# belongs_to) must not collapse into the same passage as its single-belongs_to
+# commit successor.
+#
+# Under the new maximal-linear-collapse rule (R-4a.3), collapse decisions are
+# made purely by DAG topology — the belongs_to set is NOT consulted.  In the
+# `_build_y_shape_for_collapse` fixture, shared_setup → commit_a is a linear
+# chain (commit_a has exactly one predecessor and shared_setup has exactly one
+# successor).  The new algorithm correctly collapses them into one passage.
+#
+# The old guard rail (belongs_to-set mismatch prevents collapse) is superseded.
+# The Y-shape fixture helper (`_build_y_shape_for_collapse`) and the test that
+# used it have both been removed — no active test exercises this shape under
+# the new rule.  If a new structural constraint is needed to keep shared/commit
+# beats separate, it must be specified in docs/design/procedures/polish.md
+# first, then
+# implemented and tested here.

--- a/tests/unit/test_polish_deterministic.py
+++ b/tests/unit/test_polish_deterministic.py
@@ -62,7 +62,7 @@ class TestComputeBeatGrouping:
     def test_collapse_grouping(self) -> None:
         """Sequential same-path beats collapse into one passage (maximal-linear-collapse).
 
-        Under R-4a.4 all grouping_type values are 'singleton'; the collapse is
+        Under R-4a.3 all grouping_type values are 'singleton'; the collapse is
         expressed by the passage containing all three beats in a single PassageSpec.
         """
         graph = Graph.empty()
@@ -83,7 +83,7 @@ class TestComputeBeatGrouping:
         assert specs[0].grouping_type == "singleton"
 
     # DELETED: test_intersection_grouping
-    # Removed as part of cluster #1311 (maximal-linear-collapse, R-4a.4).
+    # Removed as part of cluster #1311 (maximal-linear-collapse, R-4a.3).
     # Intersection-driven grouping is gone — compute_beat_grouping no longer
     # consumes intersection_group nodes.  Under the new rule, beats from
     # different paths with no predecessor relationship each become their own
@@ -154,14 +154,27 @@ class TestComputeBeatGrouping:
         expected = {f"beat::b{i}" for i in range(5)}
         assert all_beats == expected
 
-    # DELETED: test_entities_merged
-    # Removed as part of cluster #1311 (maximal-linear-collapse, R-4a.4).
-    # The _merge_entities helper was deleted in Task 11.  Under the new rule,
-    # compute_beat_grouping no longer merges entity lists across beats in a run;
-    # PassageSpec.entities is populated from the first beat in the run only.
-    # The old assertion (union of all beat entities) no longer holds.
-    # If cross-beat entity merging is needed in future, open a follow-on issue
-    # (see cluster #1311 tracking).
+    def test_entities_merged(self) -> None:
+        """Passage carries the order-preserving union of its member beats' entities.
+
+        Phase 4b's prose-feasibility audit reads ``spec.entities`` to compute
+        entity overlap between a passage and the structural flags active there
+        (see ``compute_prose_feasibility``).  If this isn't merged across the
+        whole run, flags get classified as irrelevant and no variant/residue
+        specs are generated.
+        """
+        graph = Graph.empty()
+        graph.create_node("path::p1", {"type": "path", "raw_id": "p1"})
+        _make_beat(graph, "beat::a", "A", entities=["entity::hero"])
+        _make_beat(graph, "beat::b", "B", entities=["entity::hero", "entity::mentor"])
+        _add_belongs_to(graph, "beat::a", "path::p1")
+        _add_belongs_to(graph, "beat::b", "path::p1")
+        _add_predecessor(graph, "beat::b", "beat::a")
+
+        specs = compute_beat_grouping(graph)
+        # Maximal-linear-collapse groups both beats into one passage.
+        assert len(specs) == 1
+        assert set(specs[0].entities) == {"entity::hero", "entity::mentor"}
 
     def test_empty_graph(self) -> None:
         """Empty graph produces no specs."""
@@ -170,7 +183,7 @@ class TestComputeBeatGrouping:
         assert specs == []
 
     # DELETED: test_zero_belongs_to_beats_do_not_collapse
-    # Removed as part of cluster #1311 (maximal-linear-collapse, R-4a.4).
+    # Removed as part of cluster #1311 (maximal-linear-collapse, R-4a.3).
     # The new R-4a.3 rule collapses beats purely by DAG topology — the
     # belongs_to set is NOT consulted for collapse eligibility.  Two adjacent
     # zero-belongs_to beats in a linear DAG WILL collapse into one passage
@@ -1509,7 +1522,7 @@ class TestChoiceSpecRequires:
                 assert c.requires == [], f"Expected empty requires for {c.from_passage}"
 
     # DELETED: test_convergence_choice_has_requires
-    # Removed as part of cluster #1311 (maximal-linear-collapse, R-4a.4).
+    # Removed as part of cluster #1311 (maximal-linear-collapse, R-4a.3).
     # The test filtered choices by `grouping_type == "intersection"` — a field
     # that is now always "singleton" under the new rule.  The requires-population
     # logic in compute_choice_edges is guarded by `from_spec.grouping_type ==
@@ -2472,7 +2485,7 @@ class TestAuditOverlayComposition:
 
 
 # DELETED: test_collapse_chain_does_not_join_shared_with_post_commit
-# Removed as part of cluster #1311 (maximal-linear-collapse, R-4a.4).
+# Removed as part of cluster #1311 (maximal-linear-collapse, R-4a.3).
 # The test asserted Y-shape guard rail 2: a shared pre-commit beat (dual
 # belongs_to) must not collapse into the same passage as its single-belongs_to
 # commit successor.

--- a/tests/unit/test_polish_deterministic.py
+++ b/tests/unit/test_polish_deterministic.py
@@ -60,10 +60,12 @@ class TestComputeBeatGrouping:
         assert all(s.grouping_type == "singleton" for s in specs)
 
     def test_collapse_grouping(self) -> None:
-        """Sequential same-path beats collapse into one passage (maximal-linear-collapse).
+        """Sequential beats in a linear run collapse into one passage.
 
-        Under R-4a.3 all grouping_type values are 'singleton'; the collapse is
-        expressed by the passage containing all three beats in a single PassageSpec.
+        Under R-4a.3, multi-beat runs are tagged ``grouping_type="collapse"``
+        so Phase 5f's transition-guidance generator continues to fire; single-
+        beat passages remain ``"singleton"``.  The collapse rule itself is
+        DAG-topology driven — path membership is not consulted.
         """
         graph = Graph.empty()
         graph.create_node("path::p1", {"type": "path", "raw_id": "p1"})
@@ -80,6 +82,19 @@ class TestComputeBeatGrouping:
         # All three beats form a maximal linear run → exactly one passage.
         assert len(specs) == 1
         assert set(specs[0].beat_ids) == {"beat::a", "beat::b", "beat::c"}
+        assert specs[0].grouping_type == "collapse"
+
+    def test_singleton_beat_keeps_singleton_grouping_type(self) -> None:
+        """Single-beat passages stay tagged ``singleton`` so Phase 5f's
+        transition-guidance gate does not fire on them (no transition needed
+        within a one-beat passage)."""
+        graph = Graph.empty()
+        graph.create_node("path::p1", {"type": "path", "raw_id": "p1"})
+        _make_beat(graph, "beat::solo", "Lone beat")
+        _add_belongs_to(graph, "beat::solo", "path::p1")
+
+        specs = compute_beat_grouping(graph)
+        assert len(specs) == 1
         assert specs[0].grouping_type == "singleton"
 
     # DELETED: test_intersection_grouping

--- a/tests/unit/test_polish_deterministic.py
+++ b/tests/unit/test_polish_deterministic.py
@@ -92,30 +92,35 @@ class TestComputeBeatGrouping:
     # linking them) now correctly produce two separate singleton passages.
     # See docs/design/procedures/polish.md §R-4a.3, R-4a.4.
 
-    def test_intersection_grouping_beat_ids_not_node_ids(self) -> None:
-        """Intersection group uses beat_ids field, not node_ids (regression for #1172)."""
+    def test_intersection_groups_are_ignored(self) -> None:
+        """R-4a.4: intersection_group nodes are GROW-internal and must not affect
+        POLISH's passage grouping.  Even a well-formed intersection group yields
+        no intersection-typed passage — the DAG topology alone drives grouping."""
         graph = Graph.empty()
         graph.create_node("path::pa", {"type": "path", "raw_id": "pa"})
         _make_beat(graph, "beat::a", "Path A beat")
         _add_belongs_to(graph, "beat::a", "path::pa")
 
-        # Create intersection group with the WRONG field name (old bug)
+        # Well-formed intersection group (correct beat_ids field) — still ignored.
         graph.create_node(
-            "intersection_group::ig_wrong",
+            "intersection_group::ig1",
             {
                 "type": "intersection_group",
-                "raw_id": "ig_wrong",
-                "node_ids": ["beat::a"],  # wrong field — producer uses beat_ids
+                "raw_id": "ig1",
+                "beat_ids": ["beat::a"],
             },
         )
 
         specs = compute_beat_grouping(graph)
-        # With wrong field, intersection group yields no beats → no intersection passage
-        intersection_specs = [s for s in specs if s.grouping_type == "intersection"]
-        assert len(intersection_specs) == 0
+        # Under R-4a.4 no spec is of intersection type; the beat becomes a
+        # singleton passage based on its DAG topology.
+        assert all(s.grouping_type != "intersection" for s in specs)
+        assert any("beat::a" in s.beat_ids for s in specs)
 
-    def test_different_paths_dont_collapse(self) -> None:
-        """Sequential beats on different paths don't collapse."""
+    def test_cross_path_linear_beats_collapse(self) -> None:
+        """R-4a.3: two linearly-adjacent beats collapse into one passage even
+        when they belong to different paths.  Path membership is not consulted
+        under the new maximal-linear-collapse rule."""
         graph = Graph.empty()
         graph.create_node("path::pa", {"type": "path", "raw_id": "pa"})
         graph.create_node("path::pb", {"type": "path", "raw_id": "pb"})
@@ -126,8 +131,8 @@ class TestComputeBeatGrouping:
         _add_predecessor(graph, "beat::b", "beat::a")
 
         specs = compute_beat_grouping(graph)
-        # Should be singletons, not collapsed
-        assert all(s.grouping_type == "singleton" for s in specs)
+        assert len(specs) == 1
+        assert set(specs[0].beat_ids) == {"beat::a", "beat::b"}
 
     def test_all_beats_assigned(self) -> None:
         """Every beat is assigned to exactly one passage."""

--- a/tests/unit/test_polish_phases.py
+++ b/tests/unit/test_polish_phases.py
@@ -10,7 +10,7 @@ import asyncio
 from unittest.mock import MagicMock
 
 from questfoundry.graph.graph import Graph
-from questfoundry.models.polish import CharacterArcMetadata, Phase3Output
+from questfoundry.models.polish import ArcPivot, CharacterArcMetadata, Phase3Output
 from questfoundry.pipeline.stages.polish.llm_phases import (
     _check_consecutive_runs,
     _check_post_commit_sequel,
@@ -395,11 +395,13 @@ class _FakePolishLLMHost(_PolishLLMPhaseMixin):
         return (self._llm_result, 1, 100)
 
 
-class TestPhase3ArcMetadataEdge:
-    """Phase 3 must add has_arc_metadata edge from entity to arc node."""
+class TestPhase3CharacterArcField:
+    """Phase 3 must annotate Entity nodes with character_arc field per R-3.3."""
 
-    def test_has_arc_metadata_edge_created(self) -> None:
-        """Phase 3 creates has_arc_metadata edge from entity to arc metadata node."""
+    def test_character_arc_field_on_entity(self) -> None:
+        """R-3.3: Phase 3 annotates Entity node's data dict with 'character_arc';
+        no separate 'character_arc_metadata' node and no 'has_arc_metadata' edge
+        are created."""
         graph = Graph.empty()
 
         # Create entity node
@@ -413,12 +415,25 @@ class TestPhase3ArcMetadataEdge:
         _make_beat(graph, "beat::b", "Second beat", entities=["entity::hero"])
         _add_predecessor(graph, "beat::b", "beat::a")
 
+        # Create a path (needed to make end_per_path work)
+        graph.create_node(
+            "path::brave",
+            {"type": "path", "raw_id": "brave"},
+        )
+
         # Phase 3 output
         arc_output = Phase3Output(
             character_arcs=[
                 CharacterArcMetadata(
                     entity_id="entity::hero",
                     start="Nervous newcomer",
+                    pivots=[
+                        ArcPivot(
+                            path_id="path::brave",
+                            beat_id="beat::b",
+                            description="Gains confidence",
+                        )
+                    ],
                     end_per_path={"path::brave": "Confident hero"},
                 )
             ]
@@ -429,11 +444,22 @@ class TestPhase3ArcMetadataEdge:
 
         assert result.status == "completed"
 
-        # Verify has_arc_metadata edge exists from entity to arc node
-        arc_node_id = "character_arc_metadata::hero"
-        edges = graph.get_edges(from_id="entity::hero", edge_type="has_arc_metadata")
-        assert len(edges) == 1
-        assert edges[0]["to"] == arc_node_id
+        # Verify character_arc field exists on entity node
+        entity_data = graph.get_node("entity::hero")
+        assert entity_data is not None
+        assert "character_arc" in entity_data
+        arc = entity_data["character_arc"]
+        assert "start" in arc
+        assert arc["start"] == "Nervous newcomer"
+        assert "pivots" in arc
+        assert "path::brave" in arc["pivots"]
+        assert arc["pivots"]["path::brave"] == "beat::b"
+        assert "end_per_path" in arc
+        assert arc["end_per_path"]["path::brave"] == "Confident hero"
+
+        # And the forbidden shapes are absent:
+        assert graph.get_nodes_by_type("character_arc_metadata") == {}
+        assert graph.get_edges(edge_type="has_arc_metadata") == []
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_polish_validation.py
+++ b/tests/unit/test_polish_validation.py
@@ -36,15 +36,25 @@ def _make_beat(graph: Graph, beat_id: str, summary: str = "A beat", **kwargs: ob
 
 
 def _build_valid_graph() -> Graph:
-    """Build a minimal valid passage graph for testing."""
+    """Build a minimal valid passage graph for testing.
+
+    Graph shape: beat::start diverges into beat::end and beat::alt_end,
+    forming a Y-fork.  This makes beat::start a genuine divergence point
+    (out-degree 2), so the passage boundary between passage::start and
+    the two successor passages is valid under R-4a.4 maximal-linear-collapse.
+    """
     graph = Graph.empty()
     graph.create_node("path::pa", {"type": "path", "raw_id": "pa"})
 
     _make_beat(graph, "beat::start", "Start")
     _make_beat(graph, "beat::end", "End")
+    _make_beat(graph, "beat::alt_end", "Alt end")
+    # beat::start → beat::end and beat::start → beat::alt_end (Y-fork)
     graph.add_edge("predecessor", "beat::end", "beat::start")
+    graph.add_edge("predecessor", "beat::alt_end", "beat::start")
 
-    # Create passages
+    # Create passages — each branch is its own passage; passage::start
+    # ends at the divergence point which has out-degree 2 (valid boundary).
     _create_passage_node(
         graph,
         PassageSpec(passage_id="passage::start", beat_ids=["beat::start"], summary="Start"),
@@ -53,11 +63,21 @@ def _build_valid_graph() -> Graph:
         graph,
         PassageSpec(passage_id="passage::end", beat_ids=["beat::end"], summary="End"),
     )
+    _create_passage_node(
+        graph,
+        PassageSpec(passage_id="passage::alt_end", beat_ids=["beat::alt_end"], summary="Alt end"),
+    )
 
-    # Add a choice edge
+    # Add choice edges
     _create_choice_edge(
         graph,
         ChoiceSpec(from_passage="passage::start", to_passage="passage::end", label="Continue"),
+    )
+    _create_choice_edge(
+        graph,
+        ChoiceSpec(
+            from_passage="passage::start", to_passage="passage::alt_end", label="Alt continue"
+        ),
     )
 
     return graph


### PR DESCRIPTION
## Summary

Brings the POLISH stage into compliance with the authoritative spec for the 4 hot-path clusters of epic #1310. Establishes a stage-exit contract validator with a dedicated `PolishContractError` raised from Phase 7, mirroring the DREAM/BRAINSTORM/SEED/GROW compliance pattern.

Closes #1311, #1312, #1313, #1314.

Does NOT close the epic (#1310) — clusters #1315, #1316, #1317, #1318 are deferred to follow-on PRs on the same branching policy.

## What changed

**Validator contract (new):**
- `PolishContractError(ValueError)` raised from Phase 7 when `validate_polish_output` reports errors.
- Phase 7 emits a structured `log.error("polish_contract_failed", total_errors=N, errors=[…])` event before raising.
- 4 new `_check_*` helpers:
  - `_check_no_character_arc_metadata_nodes` (R-3.3)
  - `_check_passage_maximal_linear_collapse` (R-4a.3)
  - `_check_residue_mapping_strategy` (R-5.7/R-5.8)
  - `_check_has_choice_edges` (R-4c.2, belt-and-suspenders)

**Per-cluster fixes:**
- #1311 (R-4a.3/R-4a.4) — `compute_beat_grouping` rewritten as maximal-linear-collapse. Intersection-group iteration removed entirely; 4 dead helpers deleted. Depends on spec change landed in #1358.
- #1312 (R-4c.2) — Phase 4c raises `PolishContractError` with upstream-identifying message when `compute_choice_edges` returns empty, instead of silently passing through to Phase 6.
- #1313 (R-5.7/R-5.8) — `ResidueSpec.mapping_strategy` field; Phase 5b LLM prompt asks the model to choose per residue; Phase 6 dispatches on it. `parallel_passages` applier stubbed with `NotImplementedError`; full implementation tracked as follow-on #1359.
- #1314 (R-3.3) — Phase 3 arc metadata stored on Entity node's data dict as `character_arc`; no more `character_arc_metadata` nodes or `has_arc_metadata` edges.

**Test fixtures:**
- New `tests/unit/test_polish_contract.py` with layered DREAM+BRAINSTORM+SEED+GROW+POLISH compliant baseline and rule-by-rule contract tests for all 4 hot-path rules (11 tests).
- Phase 4a grouping tests in `test_polish_deterministic.py` rewritten: intersection-driven assertions removed or updated to maximal-linear-collapse.
- `test_has_arc_metadata_edge_created` deleted; replaced with `test_character_arc_field_on_entity`.
- Residue tests cover `mapping_strategy` on passage node + `parallel_passages` stub shape.
- `test_polish_validation.py::_build_valid_graph` fixture updated to a Y-fork topology (pre-audit 2-beat split now fails R-4a.3).

## Allowed-to-break

The plan reserved scope to allow FILL/DRESS/SHIP/`test_polish_passage_validation.py` tests to fail. In practice the sweep found **no downstream breakage** on these suites — all 627 tests in those modules still pass. Exit-criterion 10 (downstream-break notice) is satisfied by #1359 (the one genuinely deferred item).

## Test plan

- [x] POLISH contract tests: 14/14 pass (`tests/unit/test_polish_contract.py`).
- [x] POLISH-local suites: 142/142 pass (validation + phases + deterministic + apply + llm_phases).
- [x] Upstream regression: 429/429 pass (DREAM, BRAINSTORM, SEED, GROW contract + algorithms + e2e).
- [x] Non-downstream sweep: 3013 pass + 1 pre-existing `test_provider_factory` isolation pollution (passes standalone; unrelated, same baseline as GROW PR #1357).
- [x] `uv run mypy src/`, `ruff check src/`, `pyright src/` — all clean.
- [ ] CI must verify across Python 3.11 / 3.12 / 3.13.

## Not in this PR (explicit non-goals)

- Full POLISH test suite green end-to-end (downstream policy).
- Removal of `# pyright: reportArgumentType=false` on `polish/stage.py` — saved for the final cluster PR.
- Upstream-delegation at POLISH exit (re-calling `validate_grow_output` from `validate_polish_output`). POLISH's entry contract already does this at stage start.
- `parallel_passages` applier — tracked as #1359.

🤖 Generated with [Claude Code](https://claude.com/claude-code)