### PR TITLE
docs(grow,polish,ontology): GROW Phase 4 → POLISH spec migration

### DIFF
--- a/docs/design/procedures/fill.md
+++ b/docs/design/procedures/fill.md
@@ -20,7 +20,7 @@ FILL does NOT create, reorder, split, or merge beats or passages; does NOT add p
 8. Variant passages exist for every passage with incompatible heavy-residue state combinations, with `variant_of` edges and satisfiable `requires`.
 9. Residue beat passages exist wherever light-residue mood-bridging is needed; passage-layer mapping (residue-passage-with-variants or parallel-passages) is recorded.
 10. False-branch passages exist where Phase 5 approved diamond or sidetrack patterns; false-branch beats have `role: "false_branch_beat"`, zero `belongs_to`, zero `dilemma_impacts`.
-11. Character arc metadata is annotated on every entity with 2+ beat appearances (start, pivots per path, end per path).
+11. Character arc metadata is annotated on every entity with 2+ beat appearances (`start`, `pivots` per path, `end_per_path`, AND `arcs_per_path` per audit Q6 / POLISH Phase 3 extended).
 12. Every passage has a prose feasibility annotation (clean / annotated / residue / variant). No `structural split` passages unresolved.
 13. No prose exists — `passage.prose` is empty until FILL.
 14. No cycles in the passage graph.
@@ -314,7 +314,7 @@ R-5.3. The cap is configurable but defaults to 2.
 - **Context Enrichment:** Every prose-generation LLM call must receive the Voice Document, full entity details (name, appearance, personality, active overlays from state flags), character arc metadata for every entity in the passage, sliding window of preceding prose, lookahead at convergence points, shadows for active dilemmas. Bare Passage summaries are insufficient. → CLAUDE.md §Context Enrichment Principle (CRITICAL)
 - **Prompt Context Formatting:** Entity details, state flag lists, sliding windows, character arc metadata must be formatted as human-readable text with explanatory headers. Never interpolate Python objects. → CLAUDE.md §Prompt Context Formatting (CRITICAL)
 - **Valid ID Injection:** LLM calls do not generate IDs (prose is unconstrained); however, entity micro-detail updates must reference existing Entity IDs. Provide the valid Entity ID list when asking for updates. → CLAUDE.md §Valid ID Injection Principle
-- **Silent Degradation:** Persistent quality failures after 2 cycles must escalate upstream — do not ship silently-low-quality prose. The `fill_hard_transition_detected` warning — a runtime log signature emitted when FILL encounters a cross-dilemma seam that GROW's Phase 5 did not cover with a transition beat (→ grow.md §Phase 5: Transition Beat Insertion) — must surface in logs and flag for human review, not be suppressed. → CLAUDE.md §Silent Degradation
+- **Silent Degradation:** Persistent quality failures after 2 cycles must escalate upstream — do not ship silently-low-quality prose. The `fill_hard_transition_detected` warning — a runtime log signature emitted when FILL encounters a cross-dilemma seam that GROW's Phase 4c did not cover with a transition beat (→ grow.md §Phase 4c — Transition Beat Insertion) — must surface in logs and flag for human review, not be suppressed. → CLAUDE.md §Silent Degradation
 - **Small Model Prompt Bias:** If voice drifts or scene structure breaks on small models, fix the prompt (stronger voice reinforcement, explicit scene-type guidance, concrete exemplars) before blaming the model. → CLAUDE.md §Small Model Prompt Bias (CRITICAL)
 
 ## Cross-References

--- a/docs/design/procedures/fill.md
+++ b/docs/design/procedures/fill.md
@@ -24,6 +24,9 @@ FILL does NOT create, reorder, split, or merge beats or passages; does NOT add p
 12. Every passage has a prose feasibility annotation (clean / annotated / residue / variant). No `structural split` passages unresolved.
 13. No prose exists — `passage.prose` is empty until FILL.
 14. No cycles in the passage graph.
+15. Every beat has `atmospheric_detail` populated (or a WARNING was logged for partial coverage from POLISH Phase 5e).
+16. Every multi-beat path has `path_theme` and `path_mood` populated (or a WARNING was logged for per-path Phase 5f failure).
+17. Gap beats from POLISH Phase 1a carry `is_gap_beat: True`, traceability fields (`bridges_from`, `bridges_to`, `transition_style`), and structural-beat invariants.
 
 ---
 

--- a/docs/design/procedures/fill.md
+++ b/docs/design/procedures/fill.md
@@ -20,13 +20,14 @@ FILL does NOT create, reorder, split, or merge beats or passages; does NOT add p
 8. Variant passages exist for every passage with incompatible heavy-residue state combinations, with `variant_of` edges and satisfiable `requires`.
 9. Residue beat passages exist wherever light-residue mood-bridging is needed; passage-layer mapping (residue-passage-with-variants or parallel-passages) is recorded.
 10. False-branch passages exist where Phase 5 approved diamond or sidetrack patterns; false-branch beats have `role: "false_branch_beat"`, zero `belongs_to`, zero `dilemma_impacts`.
-11. Character arc metadata is annotated on every entity with 2+ beat appearances (`start`, `pivots` per path, `end_per_path`, AND `arcs_per_path` per audit Q6 / POLISH Phase 3 extended).
+11. Character arc metadata is annotated on every entity with 2+ beat appearances: `start`, `pivots` per path, `end_per_path`, and `arcs_per_path` (see POLISH §Phase 3 §Output Contract for the full schema).
 12. Every passage has a prose feasibility annotation (clean / annotated / residue / variant). No `structural split` passages unresolved.
 13. No prose exists — `passage.prose` is empty until FILL.
 14. No cycles in the passage graph.
 15. Every beat has `atmospheric_detail` populated (or a WARNING was logged for partial coverage from POLISH Phase 5e).
 16. Every multi-beat path has `path_theme` and `path_mood` populated (or a WARNING was logged for per-path Phase 5f failure).
-17. Gap beats from POLISH Phase 1a carry `is_gap_beat: True`, traceability fields (`bridges_from`, `bridges_to`, `transition_style`), and structural-beat invariants.
+17. Gap beats from POLISH Phase 1a carry `is_gap_beat: True`, `role: gap_beat`, single `belongs_to` to their path, and traceability fields (`bridges_from`, `bridges_to`, `transition_style`).
+18. Every beat has `scene_type`, `narrative_function`, and `exit_mood` populated (or a WARNING was logged for partial coverage from GROW Phase 4b; FILL falls back per R-4b.1).
 
 ---
 

--- a/docs/design/procedures/grow.md
+++ b/docs/design/procedures/grow.md
@@ -565,6 +565,7 @@ R-8.4. Pruning never deletes a beat that has `belongs_to` to an explored Path �
 14. No orphan beats (all reachable from root by at least one arc).
 15. Setup beats from SEED persist (structural, zero `belongs_to`, zero `dilemma_impacts`) — GROW does not add to or remove from them.
 16. Epilogue beats from SEED persist (structural, zero `belongs_to`, zero `dilemma_impacts`) — GROW does not add to or remove from them.
+17. Every beat has `scene_type`, `narrative_function`, and `exit_mood` populated by Phase 4b. Partial coverage (LLM missed some beats) emits a WARNING; downstream consumers handle absent fields via the R-4b.1 fallback (default `scene_type` to `"scene"`).
 
 ## Implementation Constraints
 

--- a/docs/design/procedures/grow.md
+++ b/docs/design/procedures/grow.md
@@ -31,7 +31,7 @@ GROW does NOT create Passage nodes, Choice edges, variant passages, residue beat
 
 ## Phase 1: Import and Validate
 
-**Purpose:** Read SEED's output, verify every contract item, and build the starting beat DAG from the per-dilemma Y-shaped scaffolds. No new ordering edges across dilemmas yet — that comes in Phase 4.
+**Purpose:** Read SEED's output, verify every contract item, and build the starting beat DAG from the per-dilemma Y-shaped scaffolds. No new ordering edges across dilemmas yet — that comes in Phase 4a.
 
 ### Input Contract
 
@@ -90,7 +90,7 @@ R-1.6. Intra-path `predecessor` edges form no cycles.
 
 ## Phase 2: Intersection Detection
 
-**Purpose:** Identify beats from different Dilemmas that co-occur in the same scene, and declare that co-occurrence as Intersection Group nodes. Intersection groups are consumed within GROW to inform beat placement in Phase 4 — they are NOT a handoff artifact to POLISH. POLISH makes its own passage grouping assessment from the finalized DAG.
+**Purpose:** Identify beats from different Dilemmas that co-occur in the same scene, and declare that co-occurrence as Intersection Group nodes. Intersection groups are consumed within GROW to inform beat placement in Phase 4a — they are NOT a handoff artifact to POLISH. POLISH makes its own passage grouping assessment from the finalized DAG.
 
 ### Input Contract
 
@@ -139,7 +139,7 @@ R-2.8. Intersection rejection due to the invariant is logged at INFO with the ca
 
 | Symptom | Root cause | Broken rule |
 |---------|-----------|-------------|
-| `passage_dag_cycles` validation failure in Phase 8 | A `predecessor` edge was dropped silently during arc enumeration because the invariant was not checked | R-2.7 |
+| `passage_dag_cycles` validation failure in Phase 7 | A `predecessor` edge was dropped silently during arc enumeration because the invariant was not checked | R-2.7 |
 | All intersection candidates rejected with no log entries | Silent rejection without explanation | R-2.8 |
 
 ### Output Contract
@@ -222,90 +222,136 @@ R-3.7. After Phase 3 completes, applying all surviving temporal hints to the bas
 
 | Symptom | Root cause | Broken rule |
 |---------|-----------|-------------|
-| `interleave_cycle_skipped` log entry appears after GROW | Cyclic hint slipped through Phase 3 and was dropped in Phase 4 — this is a pipeline ERROR, not a warning. Any occurrence of this log signature indicates a hard failure and must halt the pipeline per the Silent Degradation policy | R-3.7 |
+| `interleave_cycle_skipped` log entry appears after GROW | Cyclic hint slipped through Phase 3 and was dropped in Phase 4a — this is a pipeline ERROR, not a warning. Any occurrence of this log signature indicates a hard failure and must halt the pipeline per the Silent Degradation policy | R-3.7 |
 
 ### Output Contract
 
 1. Surviving temporal-hint set applied to base DAG is acyclic.
 2. Each drop (mandatory or swap) is logged at INFO with rationale.
-3. No `interleave_cycle_skipped` outcomes possible in Phase 4.
+3. No `interleave_cycle_skipped` outcomes possible in Phase 4a.
 
 ---
 
-## Phase 4: Interleave
+## Phase 4: DAG Assembly and Annotation
+
+**Purpose:** Combine per-dilemma scaffolds into a single beat DAG with structural annotations. Three sub-phases:
+
+- **4a Interleave** — create cross-dilemma ordering edges (existing).
+- **4b Scene Types Annotation** — tag every beat with scene/sequel + narrative function + exit mood. Foundation annotation that POLISH Phase 2 pacing depends on.
+- **4c Transition Beat Insertion** — insert bridge beats at cross-dilemma hard cuts (no shared entity, no shared location). Was previously labeled "Phase 5" in this spec; absorbed into Phase 4 as a sub-phase since it is part of structural DAG assembly.
+
+This phase produces a structurally complete and minimally annotated beat DAG. Narrative-quality concerns (rhythm correction, narrative gap filling, sensory annotation, thematic context) are POLISH's responsibility per the structural-vs-narrative boundary (see audit doc 2026-04-21-grow-phase-4-sub-phases-audit.md).
+
+### 4a — Interleave
 
 **Purpose:** Apply cross-dilemma ordering edges to weave the per-dilemma Y-shapes into a single DAG. Use the Dilemma ordering relationships (`wraps`/`concurrent`/`serial`) plus the surviving temporal hints from Phase 3. No cycles possible — Phase 3 guaranteed acyclicity.
 
-### Input Contract
+#### Input Contract
 
 1. Phase 3 Output Contract satisfied.
 
-### Operations
+#### Operations
 
-#### Cross-Dilemma Ordering Edge Creation
+##### Cross-Dilemma Ordering Edge Creation
 
 **What:** Add `predecessor` edges between beats of different Dilemmas according to `wraps`/`concurrent`/`serial` plus temporal hints. Each edge reflects "beat X must come before beat Y in any arc that traverses both."
 
 **Rules:**
 
-R-4.1. `serial` Dilemmas: the last beat of Dilemma A precedes the first beat of Dilemma B.
+R-4a.1. `serial` Dilemmas: the last beat of Dilemma A precedes the first beat of Dilemma B.
 
-R-4.2. `wraps` Dilemmas (A wraps B): A's introduction beats precede B's introduction beats; B's final beats precede A's commit beats.
+R-4a.2. `wraps` Dilemmas (A wraps B): A's introduction beats precede B's introduction beats; B's final beats precede A's commit beats.
 
-R-4.3. `concurrent` Dilemmas: no mandatory ordering from the relationship itself; interleaving is governed by temporal hints and heuristics.
+R-4a.3. `concurrent` Dilemmas: no mandatory ordering from the relationship itself; interleaving is governed by temporal hints and heuristics.
 
-R-4.4. Temporal hints that survived Phase 3 are applied as `predecessor` edges.
+R-4a.4. Temporal hints that survived Phase 3 are applied as `predecessor` edges.
 
-R-4.5. No cycles are introduced. If a cycle would be introduced, the input from Phase 3 was faulty — this is a hard failure, not a silent skip.
+R-4a.5. No cycles are introduced. If a cycle would be introduced, the input from Phase 3 was faulty — this is a hard failure, not a silent skip.
 
 **Violations:**
 
 | Symptom | Root cause | Broken rule |
 |---------|-----------|-------------|
-| Beat cycle exists after Phase 4 | Either Phase 3's acyclicity guarantee failed, or Phase 4 introduced a new edge that closed a cycle | R-4.5 |
-| `interleave_cycle_skipped` outcome | Silent degradation — pipeline failure, not warning | R-4.5 (and R-3.7) |
+| Beat cycle exists after Phase 4a | Either Phase 3's acyclicity guarantee failed, or Phase 4a introduced a new edge that closed a cycle | R-4a.5 |
+| `interleave_cycle_skipped` outcome | Silent degradation — pipeline failure, not warning | R-4a.5 (and R-3.7) |
 
-### Output Contract
+#### Output Contract
 
 1. The beat DAG is acyclic.
 2. Cross-dilemma `predecessor` edges reflect Dilemma ordering relationships and surviving temporal hints.
 3. No edges are silently dropped.
 
----
+### 4b — Scene Types Annotation
 
-## Phase 5: Transition Beat Insertion
+**Purpose:** Tag every beat in the assembled DAG with `scene_type`, `narrative_function`, and `exit_mood`. These fields are foundation annotations consumed by POLISH (Phase 2 pacing detection), FILL (prose pacing derivation, narrative context), and DRESS (illustration priority).
 
-**Purpose:** Where a cross-dilemma `predecessor` edge connects two beats with no shared entities and no shared location, insert a Transition Beat between them — a short structural bridge that carries no dilemma relationship (zero `belongs_to`, zero `dilemma_impacts`). → ontology §Part 1: Transition beat.
+#### Input Contract
 
-### Input Contract
+1. Phase 4a Output Contract satisfied (interleaved DAG complete).
+2. All beat nodes have summaries populated by SEED.
 
-1. Phase 4 Output Contract satisfied.
+#### Operations
 
-### Operations
+##### Single-Pass Beat Classification
 
-#### Cross-Dilemma Seam Detection and Bridging
-
-**What:** For each cross-dilemma `predecessor` edge, check whether the two beats share any entities or location. If both overlaps are zero, this is a hard transition — the narrative jumps between unrelated scenes. Insert a Transition Beat drafted by the LLM (1–2 sentences referencing entities/locations from both sides). The original edge is replaced by two edges: earlier → transition → later.
+**What:** For all beat nodes in the graph, a single LLM call produces tags per beat. Each tag includes the three field values. Invalid beat IDs in the LLM response are skipped with an INFO log noting the unknown beat ID.
 
 **Rules:**
 
-R-5.1. Transition Beats carry zero `dilemma_impacts` and zero `belongs_to` edges. They are structural beats, traversed by every arc that reaches them via the predecessor chain.
+R-4b.1. Every beat receives `scene_type ∈ {scene, sequel, micro_beat}`. Partial coverage (LLM tags only some beats) MUST emit a WARNING; downstream consumers fall back to `"scene"` if the field is absent.
 
-R-5.2. Transition Beats are inserted only at cross-dilemma seams with zero entity/location overlap. Seams with partial overlap are left alone; POLISH may add micro-beats for rhythm later.
+R-4b.2. Every beat receives `narrative_function ∈ {introduce, develop, complicate, confront, resolve}`.
 
-R-5.3. Each Transition Beat references entities and/or locations from both sides of the seam in its summary (bridging concrete anchors).
+R-4b.3. Every beat receives `exit_mood`: a 2–40 character free-form descriptor of the emotional handoff to the next beat.
 
-R-5.4. The LLM call that drafts the transition summary receives full context for both bridging beats (summaries, entities, locations).
+R-4b.4. Phase 4b is a single LLM call covering all beats; per-beat retries are not used. On overall LLM failure, the phase MUST return failed status (no silent default).
 
 **Violations:**
 
 | Symptom | Root cause | Broken rule |
 |---------|-----------|-------------|
-| Transition Beat has `belongs_to` edge | Wrongly assigned path membership to a structural beat | R-5.1 |
-| Transition Beat inserted at a seam with shared mentor entity | R-5.2 — not a hard transition | R-5.2 |
-| Transition Beat summary mentions only one side's entities | Bridge not bridging | R-5.3 |
+| Beat without `scene_type` | Partial LLM coverage; missing WARNING | R-4b.1 |
+| `scene_type` outside the enum | Schema validator missing | R-4b.1 |
+| `exit_mood` empty string | Length constraint not enforced | R-4b.3 |
 
-### Output Contract
+#### Output Contract
+
+1. Every beat has `scene_type`, `narrative_function`, `exit_mood` populated. Partial coverage produces a WARNING.
+2. No graph mutations beyond the three field updates per beat.
+
+### 4c — Transition Beat Insertion
+
+**Purpose:** Where a cross-dilemma `predecessor` edge connects two beats with no shared entities and no shared location, insert a Transition Beat between them — a short structural bridge that carries no dilemma relationship (zero `belongs_to`, zero `dilemma_impacts`). → ontology §Part 1: Transition beat.
+
+#### Input Contract
+
+1. Phase 4b Output Contract satisfied.
+
+#### Operations
+
+##### Cross-Dilemma Seam Detection and Bridging
+
+**What:** For each cross-dilemma `predecessor` edge, check whether the two beats share any entities or location. If both overlaps are zero, this is a hard transition — the narrative jumps between unrelated scenes. Insert a Transition Beat drafted by the LLM (1–2 sentences referencing entities/locations from both sides). The original edge is replaced by two edges: earlier → transition → later.
+
+**Rules:**
+
+R-4c.1. Transition Beats carry zero `dilemma_impacts` and zero `belongs_to` edges. They are structural beats, traversed by every arc that reaches them via the predecessor chain.
+
+R-4c.2. Transition Beats are inserted only at cross-dilemma seams with zero entity/location overlap. Seams with partial overlap are left alone; POLISH may add micro-beats for rhythm later.
+
+R-4c.3. Each Transition Beat references entities and/or locations from both sides of the seam in its summary (bridging concrete anchors).
+
+R-4c.4. The LLM call that drafts the transition summary receives full context for both bridging beats (summaries, entities, locations).
+
+**Violations:**
+
+| Symptom | Root cause | Broken rule |
+|---------|-----------|-------------|
+| Transition Beat has `belongs_to` edge | Wrongly assigned path membership to a structural beat | R-4c.1 |
+| Transition Beat inserted at a seam with shared mentor entity | R-4c.2 — not a hard transition | R-4c.2 |
+| Transition Beat summary mentions only one side's entities | Bridge not bridging | R-4c.3 |
+
+#### Output Contract
 
 1. Every cross-dilemma `predecessor` edge with zero entity/location overlap has a Transition Beat inserted.
 2. Every Transition Beat has zero `belongs_to` and zero `dilemma_impacts`.
@@ -313,13 +359,13 @@ R-5.4. The LLM call that drafts the transition summary receives full context for
 
 ---
 
-## Phase 6: State Flag Derivation and Entity Overlay Activation
+## Phase 5: State Flag Derivation and Entity Overlay Activation
 
 **Purpose:** Derive State Flag nodes from Path Consequences, and activate Entity Overlays on the entities those consequences affect.
 
 ### Input Contract
 
-1. Phase 5 Output Contract satisfied.
+1. Phase 4c Output Contract satisfied.
 
 ### Operations
 
@@ -329,21 +375,21 @@ R-5.4. The LLM call that drafts the transition summary receives full context for
 
 **Rules:**
 
-R-6.1. Every State Flag node has a `derived_from` edge to exactly one Consequence. State flags created ad hoc (without a Consequence source) are forbidden — they are dilemma flags in the ontology's taxonomy and must be derivable.
+R-5.1. Every State Flag node has a `derived_from` edge to exactly one Consequence. State flags created ad hoc (without a Consequence source) are forbidden — they are dilemma flags in the ontology's taxonomy and must be derivable.
 
-R-6.2. State flag names express world state, not player actions. → ontology §Part 8: State Flags ≠ Player Choices.
+R-5.2. State flag names express world state, not player actions. → ontology §Part 8: State Flags ≠ Player Choices.
 
-R-6.3. State flags are associated with the commit beat of their source path: the flag is "active" on any arc that traverses that commit beat.
+R-5.3. State flags are associated with the commit beat of their source path: the flag is "active" on any arc that traverses that commit beat.
 
-R-6.4. Every Consequence produces at least one State Flag.
+R-5.4. Every Consequence produces at least one State Flag.
 
 **Violations:**
 
 | Symptom | Root cause | Broken rule |
 |---------|-----------|-------------|
-| State Flag node has no `derived_from` edge | Ad hoc creation — no source consequence | R-6.1 |
-| State flag named `player_chose_distrust` | Action-phrased instead of world-state-phrased | R-6.2 |
-| Consequence has no associated State Flag | Derivation skipped | R-6.4 |
+| State Flag node has no `derived_from` edge | Ad hoc creation — no source consequence | R-5.1 |
+| State flag named `player_chose_distrust` | Action-phrased instead of world-state-phrased | R-5.2 |
+| Consequence has no associated State Flag | Derivation skipped | R-5.4 |
 
 #### Entity Overlay Activation
 
@@ -351,21 +397,21 @@ R-6.4. Every Consequence produces at least one State Flag.
 
 **Rules:**
 
-R-6.5. Overlays are stored as an embedded list on the Entity node. Each overlay is a dict with `when` (list of state flag IDs) and `details` (property changes).
+R-5.5. Overlays are stored as an embedded list on the Entity node. Each overlay is a dict with `when` (list of state flag IDs) and `details` (property changes).
 
-R-6.6. The Entity remains one node. Overlays do not create second entities or variant entities.
+R-5.6. The Entity remains one node. Overlays do not create second entities or variant entities.
 
-R-6.7. Overlays may be composed — if multiple state flags affect the same entity, multiple overlays apply on arcs where their flags are all active.
+R-5.7. Overlays may be composed — if multiple state flags affect the same entity, multiple overlays apply on arcs where their flags are all active.
 
-R-6.8. Hard and soft Dilemmas both produce overlays. For hard Dilemmas, the state flag activates overlays even though the passage graph is structurally separate.
+R-5.8. Hard and soft Dilemmas both produce overlays. For hard Dilemmas, the state flag activates overlays even though the passage graph is structurally separate.
 
 **Violations:**
 
 | Symptom | Root cause | Broken rule |
 |---------|-----------|-------------|
-| Two Entity nodes: `character::mentor` and `character::mentor__hostile` | Overlay implemented as separate entity | R-6.6 |
-| Overlay has `when: []` | No activation condition — always-on | R-6.5 |
-| Hard Dilemma produces no overlay | Skipped because "hard paths don't rejoin" — but overlays still needed for FILL | R-6.8 |
+| Two Entity nodes: `character::mentor` and `character::mentor__hostile` | Overlay implemented as separate entity | R-5.6 |
+| Overlay has `when: []` | No activation condition — always-on | R-5.5 |
+| Hard Dilemma produces no overlay | Skipped because "hard paths don't rejoin" — but overlays still needed for FILL | R-5.8 |
 
 ### Output Contract
 
@@ -377,13 +423,13 @@ R-6.8. Hard and soft Dilemmas both produce overlays. For hard Dilemmas, the stat
 
 ---
 
-## Phase 7: Convergence Metadata Population
+## Phase 6: Convergence Metadata Population
 
 **Purpose:** For each soft Dilemma, compute the `converges_at` beat ID and `convergence_payoff` count from the finalized DAG topology. Hard Dilemmas leave both fields null.
 
 ### Input Contract
 
-1. Phase 6 Output Contract satisfied.
+1. Phase 5 Output Contract satisfied.
 
 ### Operations
 
@@ -393,21 +439,21 @@ R-6.8. Hard and soft Dilemmas both produce overlays. For hard Dilemmas, the stat
 
 **Rules:**
 
-R-7.1. `converges_at` is computed from DAG reachability — not declared. It is the first shared beat after both paths' post-commit chains.
+R-6.1. `converges_at` is computed from DAG reachability — not declared. It is the first shared beat after both paths' post-commit chains.
 
-R-7.2. `convergence_payoff` is the minimum count of path-exclusive beats (including commit) per path before convergence.
+R-6.2. `convergence_payoff` is the minimum count of path-exclusive beats (including commit) per path before convergence.
 
-R-7.3. Hard Dilemmas have `converges_at: null` and `convergence_payoff: null`. Paths never rejoin.
+R-6.3. Hard Dilemmas have `converges_at: null` and `convergence_payoff: null`. Paths never rejoin.
 
-R-7.4. If a soft Dilemma has no structural convergence beat (e.g., paths lead to different endings), this is a classification error — the Dilemma should be hard. Halt with error identifying the Dilemma.
+R-6.4. If a soft Dilemma has no structural convergence beat (e.g., paths lead to different endings), this is a classification error — the Dilemma should be hard. Halt with error identifying the Dilemma.
 
 **Violations:**
 
 | Symptom | Root cause | Broken rule |
 |---------|-----------|-------------|
-| Hard Dilemma has `converges_at` set | Mis-applied to hard role | R-7.3 |
-| Soft Dilemma has `converges_at: null` but paths do rejoin in DAG | Computation skipped | R-7.1 |
-| Soft Dilemma's paths never rejoin and GROW proceeds | Should have halted with classification error | R-7.4 |
+| Hard Dilemma has `converges_at` set | Mis-applied to hard role | R-6.3 |
+| Soft Dilemma has `converges_at: null` but paths do rejoin in DAG | Computation skipped | R-6.1 |
+| Soft Dilemma's paths never rejoin and GROW proceeds | Should have halted with classification error | R-6.4 |
 
 ### Output Contract
 
@@ -417,13 +463,13 @@ R-7.4. If a soft Dilemma has no structural convergence beat (e.g., paths lead to
 
 ---
 
-## Phase 8: Arc Validation
+## Phase 7: Arc Validation
 
 **Purpose:** Enumerate all valid arc traversals of the DAG (one combination of path choices per arc) and verify completeness, reachability, and dilemma resolution. Arcs are COMPUTED, not stored — the enumeration is a validation utility.
 
 ### Input Contract
 
-1. Phase 7 Output Contract satisfied.
+1. Phase 6 Output Contract satisfied.
 
 ### Operations
 
@@ -433,42 +479,42 @@ R-7.4. If a soft Dilemma has no structural convergence beat (e.g., paths lead to
 
 **Rules:**
 
-R-8.1. Arc traversal starts at the DAG root and walks `predecessor` successors. At each Y-fork, the traversal follows the successor matching the arc's selected path for that Dilemma.
+R-7.1. Arc traversal starts at the DAG root and walks `predecessor` successors. At each Y-fork, the traversal follows the successor matching the arc's selected path for that Dilemma.
 
-R-8.2. Arcs are computed on demand, not stored as graph nodes. If materialized for debugging, they must use the `materialized_` prefix.
+R-7.2. Arcs are computed on demand, not stored as graph nodes. If materialized for debugging, they must use the `materialized_` prefix.
 
-R-8.3. Every computed arc reaches a terminal beat (no dead ends).
+R-7.3. Every computed arc reaches a terminal beat (no dead ends).
 
-R-8.4. Every arc traverses exactly one commit beat per explored Dilemma.
+R-7.4. Every arc traverses exactly one commit beat per explored Dilemma.
 
-R-8.5. Every beat in the graph is reachable from the root via at least one arc. Unreachable beats are pruning candidates (Phase 9) — not errors at this stage, but logged at INFO.
+R-7.5. Every beat in the graph is reachable from the root via at least one arc. Unreachable beats are pruning candidates (Phase 8) — not errors at this stage, but logged at INFO.
 
-R-8.6. No cycles in `predecessor` edges.
+R-7.6. No cycles in `predecessor` edges.
 
 **Violations:**
 
 | Symptom | Root cause | Broken rule |
 |---------|-----------|-------------|
-| Arc traversal reaches a beat with no outgoing edges before a terminal passage | Missing successor edge — interleave created a gap | R-8.3 |
-| Arc traverses two commit beats of the same Dilemma | Interleave placed both per-path commits in one arc's path | R-8.4 |
-| Arc node materialized without `materialized_` prefix | Violates arc-as-derived rule | R-8.2 |
+| Arc traversal reaches a beat with no outgoing edges before a terminal passage | Missing successor edge — interleave created a gap | R-7.3 |
+| Arc traverses two commit beats of the same Dilemma | Interleave placed both per-path commits in one arc's path | R-7.4 |
+| Arc node materialized without `materialized_` prefix | Violates arc-as-derived rule | R-7.2 |
 
 ### Output Contract
 
 1. Every arc is complete (reaches terminal).
 2. Every arc contains exactly one commit per explored Dilemma.
 3. No cycles in `predecessor` edges.
-4. Unreachable beats are logged (for Phase 9 pruning).
+4. Unreachable beats are logged (for Phase 8 pruning).
 
 ---
 
-## Phase 9: Pruning
+## Phase 8: Pruning
 
 **Purpose:** Remove unreachable beats and orphan edges. Freeze the DAG.
 
 ### Input Contract
 
-1. Phase 8 Output Contract satisfied.
+1. Phase 7 Output Contract satisfied.
 
 ### Operations
 
@@ -478,20 +524,20 @@ R-8.6. No cycles in `predecessor` edges.
 
 **Rules:**
 
-R-9.1. A beat is prunable if no computed arc reaches it.
+R-8.1. A beat is prunable if no computed arc reaches it.
 
-R-9.2. Pruning deletes the beat node and all edges incident on it.
+R-8.2. Pruning deletes the beat node and all edges incident on it.
 
-R-9.3. Every pruning decision is logged at INFO with the beat ID and reason.
+R-8.3. Every pruning decision is logged at INFO with the beat ID and reason.
 
-R-9.4. Pruning never deletes a beat that has `belongs_to` to an explored Path — such a beat should always be reachable; if it isn't, that is a structural bug to halt on, not a pruning target.
+R-8.4. Pruning never deletes a beat that has `belongs_to` to an explored Path — such a beat should always be reachable; if it isn't, that is a structural bug to halt on, not a pruning target.
 
 **Violations:**
 
 | Symptom | Root cause | Broken rule |
 |---------|-----------|-------------|
-| Post-commit beat pruned as "unreachable" | Structural bug masked by pruning; should halt instead | R-9.4 |
-| Pruning removes a beat with no log entry | Silent deletion | R-9.3 |
+| Post-commit beat pruned as "unreachable" | Structural bug masked by pruning; should halt instead | R-8.4 |
+| Pruning removes a beat with no log entry | Silent deletion | R-8.3 |
 
 ### Output Contract
 
@@ -522,8 +568,8 @@ R-9.4. Pruning never deletes a beat that has `belongs_to` to an explored Path �
 
 ## Implementation Constraints
 
-- **Silent Degradation:** `interleave_cycle_skipped` is a pipeline failure, not a warning. All cycles must be resolved in Phase 3 before Phase 4 applies edges. Similarly, all-intersections-rejected is a failure — log at ERROR and halt, do not produce degraded output. → CLAUDE.md §Silent Degradation (CRITICAL)
-- **Context Enrichment:** Intersection detection LLM call (Phase 2), swap-pair resolution (Phase 3), and transition drafting (Phase 5) must receive full beat context — summaries, entity references, location, `flexibility` annotations, dilemma question, `why_it_matters`. Bare ID listings are insufficient. → CLAUDE.md §Context Enrichment Principle (CRITICAL)
+- **Silent Degradation:** `interleave_cycle_skipped` is a pipeline failure, not a warning. All cycles must be resolved in Phase 3 before Phase 4a applies edges. Similarly, all-intersections-rejected is a failure — log at ERROR and halt, do not produce degraded output. → CLAUDE.md §Silent Degradation (CRITICAL)
+- **Context Enrichment:** Intersection detection LLM call (Phase 2), swap-pair resolution (Phase 3), and transition drafting (Phase 4c) must receive full beat context — summaries, entity references, location, `flexibility` annotations, dilemma question, `why_it_matters`. Bare ID listings are insufficient. → CLAUDE.md §Context Enrichment Principle (CRITICAL)
 - **Valid ID Injection:** Every LLM call that references dilemma IDs, path IDs, beat IDs, entity IDs must receive an explicit `### Valid IDs` section listing every valid value. → CLAUDE.md §Valid ID Injection Principle
 - **Prompt Context Formatting:** Beat lists, entity lists, intersection candidate clusters must be formatted as human-readable text (bulleted, headed, backtick-wrapped IDs). Never Python repr. → CLAUDE.md §Prompt Context Formatting (CRITICAL)
 - **Small Model Prompt Bias:** If intersection clustering or transition drafting underperforms, fix the prompt before blaming the model. → CLAUDE.md §Small Model Prompt Bias (CRITICAL)
@@ -568,37 +614,41 @@ R-3.4: Swap pairs resolved by LLM with context.
 R-3.5: LLM drops exactly one hint per swap pair.
 R-3.6: Swap resolutions logged.
 R-3.7: After Phase 3, surviving hints + base DAG are acyclic (hard invariant).
-R-4.1: Serial: last beat of A precedes first beat of B.
-R-4.2: Wraps: A's intros precede B's; B's finals precede A's commits.
-R-4.3: Concurrent: no mandatory ordering from relationship alone.
-R-4.4: Surviving temporal hints applied as edges.
-R-4.5: No cycles in Phase 4 output; no silent skip.
-R-5.1: Transition Beats have zero `belongs_to` and zero `dilemma_impacts`.
-R-5.2: Transition Beats only at zero-overlap cross-dilemma seams.
-R-5.3: Transition summary references both sides' entities/locations.
-R-5.4: Drafting LLM receives full context for both bridging beats.
-R-6.1: Every State Flag has `derived_from` to a Consequence.
-R-6.2: Flag names are world-state, not player-action.
-R-6.3: Flags associated with their source path's commit beat.
-R-6.4: Every Consequence produces ≥1 State Flag.
-R-6.5: Overlays embedded on Entity nodes (not separate nodes).
-R-6.6: Entity remains one node; no variant entities.
-R-6.7: Overlays compose when multiple flags affect the same entity.
-R-6.8: Hard and soft Dilemmas both produce overlays.
-R-7.1: `converges_at` computed from DAG reachability.
-R-7.2: `convergence_payoff` is min exclusive-beat count per path.
-R-7.3: Hard Dilemmas have both fields null.
-R-7.4: Soft Dilemma without structural convergence → halt (classification error).
-R-8.1: Arc traversal walks `predecessor` successors; follows path at forks.
-R-8.2: Arcs computed, not stored (materialized uses `materialized_` prefix).
-R-8.3: Every arc reaches a terminal beat.
-R-8.4: Every arc has exactly one commit per explored Dilemma.
-R-8.5: Unreachable beats logged at INFO for pruning.
-R-8.6: No cycles in `predecessor` edges.
-R-9.1: Prunable beats have no reaching arc.
-R-9.2: Pruning deletes the beat and incident edges.
-R-9.3: Every pruning decision logged.
-R-9.4: Path-member beats that are unreachable are structural bugs, not pruning targets.
+R-4a.1: Serial: last beat of A precedes first beat of B.
+R-4a.2: Wraps: A's intros precede B's; B's finals precede A's commits.
+R-4a.3: Concurrent: no mandatory ordering from relationship alone.
+R-4a.4: Surviving temporal hints applied as edges.
+R-4a.5: No cycles in Phase 4a output; no silent skip.
+R-4b.1: Every beat receives `scene_type ∈ {scene, sequel, micro_beat}`; partial coverage emits WARNING.
+R-4b.2: Every beat receives `narrative_function ∈ {introduce, develop, complicate, confront, resolve}`.
+R-4b.3: Every beat receives `exit_mood` (2–40 character descriptor).
+R-4b.4: Phase 4b is single LLM call; failure halts (no silent default).
+R-4c.1: Transition Beats have zero `belongs_to` and zero `dilemma_impacts`.
+R-4c.2: Transition Beats only at zero-overlap cross-dilemma seams.
+R-4c.3: Transition summary references both sides' entities/locations.
+R-4c.4: Drafting LLM receives full context for both bridging beats.
+R-5.1: Every State Flag has `derived_from` to a Consequence.
+R-5.2: Flag names are world-state, not player-action.
+R-5.3: Flags associated with their source path's commit beat.
+R-5.4: Every Consequence produces ≥1 State Flag.
+R-5.5: Overlays embedded on Entity nodes (not separate nodes).
+R-5.6: Entity remains one node; no variant entities.
+R-5.7: Overlays compose when multiple flags affect the same entity.
+R-5.8: Hard and soft Dilemmas both produce overlays.
+R-6.1: `converges_at` computed from DAG reachability.
+R-6.2: `convergence_payoff` is min exclusive-beat count per path.
+R-6.3: Hard Dilemmas have both fields null.
+R-6.4: Soft Dilemma without structural convergence → halt (classification error).
+R-7.1: Arc traversal walks `predecessor` successors; follows path at forks.
+R-7.2: Arcs computed, not stored (materialized uses `materialized_` prefix).
+R-7.3: Every arc reaches a terminal beat.
+R-7.4: Every arc has exactly one commit per explored Dilemma.
+R-7.5: Unreachable beats logged at INFO for pruning.
+R-7.6: No cycles in `predecessor` edges.
+R-8.1: Prunable beats have no reaching arc.
+R-8.2: Pruning deletes the beat and incident edges.
+R-8.3: Every pruning decision logged.
+R-8.4: Path-member beats that are unreachable are structural bugs, not pruning targets.
 
 ---
 
@@ -609,24 +659,27 @@ R-9.4: Path-member beats that are unreachable are structural bugs, not pruning t
 | 1 | Import and Validate | Automated (halt on violation) |
 | 2 | Intersection Detection | Required — approve/reject/modify intersection proposals |
 | 3 | Temporal Hint Resolution | Automated + LLM (swap pairs only) |
-| 4 | Interleave | Automated |
-| 5 | Transition Beat Insertion | Automated (LLM drafts; human may review post-hoc) |
-| 6 | State Flag and Overlay Activation | Required — review overlay details |
-| 7 | Convergence Metadata | Automated |
-| 8 | Arc Validation | Required — review validation report; fix or abort |
-| 9 | Pruning | Automated |
+| 4a | Interleave | Automated |
+| 4b | Scene Types Annotation | Automated (LLM tags per beat) |
+| 4c | Transition Beat Insertion | Automated (LLM drafts; human may review post-hoc) |
+| 5 | State Flag and Overlay Activation | Required — review overlay details |
+| 6 | Convergence Metadata | Automated |
+| 7 | Arc Validation | Required — review validation report; fix or abort |
+| 8 | Pruning | Automated |
 
 ## Iteration Control
 
-**Forward flow:** 1 → 2 → 3 → 4 → 5 → 6 → 7 → 8 → 9.
+**Forward flow:** 1 → 2 → 3 → 4a → 4b → 4c → 5 → 6 → 7 → 8.
 
 **Backward loops:**
 
 | From | To | Trigger |
 |------|-----|---------|
 | 2 | 1 | Validation rejection (SEED bug) — abort to SEED |
-| 8 | 2 | Arc validation fails on intersection-caused inconsistency — re-run intersections with tighter candidacy |
-| 8 | 5 | Arc validation fails on transition placement — re-run with adjusted seams |
+| 7 | 2 | Arc validation fails on intersection-caused inconsistency — re-run intersections with tighter candidacy |
+| 7 | 4c | Arc validation fails on transition placement — re-run with adjusted seams |
+
+**Note on Phase 4 sub-phase re-entry:** A backward loop targeting 4c re-runs only transition insertion; newly-inserted transition beats will lack `scene_type` / `narrative_function` / `exit_mood` annotations from 4b. Consumers handle the missing annotations via R-4b.1's partial-coverage fallback (WARNING + default to `"scene"`). If full re-annotation is needed, loop back to 4a so the entire Phase 4 wrapper re-runs.
 
 **Abort to SEED:**
 
@@ -643,16 +696,16 @@ R-9.4: Path-member beats that are unreachable are structural bugs, not pruning t
 | 1 | Cycle in SEED `predecessor` hints | Topological sort | Halt — fix in SEED |
 | 2 | Cross-dilemma `belongs_to` attempted | R-2.5 check | Halt — SEED or GROW bug |
 | 2 | All intersection candidates rejected | Silent degradation check | Halt ERROR (not warning) |
-| 3 | Hint cycles slip through (`interleave_cycle_skipped`) | Phase 4 detection | Halt — Phase 3 invariant violated |
-| 5 | Transition drafting LLM fails | LLM timeout/error | Retry once; if still failing, insert placeholder transition beat and log WARNING |
-| 7 | Soft dilemma has no convergence beat | R-7.4 check | Halt — classification error in SEED |
-| 8 | Arc has dead end | Reachability check | Re-run Phase 2 (intersection) or abort to SEED |
+| 3 | Hint cycles slip through (`interleave_cycle_skipped`) | Phase 4a detection | Halt — Phase 3 invariant violated |
+| 4c | Transition drafting LLM fails | LLM timeout/error | Retry once; if still failing, insert placeholder transition beat and log WARNING |
+| 6 | Soft dilemma has no convergence beat | R-6.4 check | Halt — classification error in SEED |
+| 7 | Arc has dead end | Reachability check | Re-run Phase 2 (intersection) or abort to SEED |
 
 ## Context Management
 
 **Standard (≥128k context):** Full DREAM + BRAINSTORM + SEED output + intermediate DAG state per phase. Context consumption peaks in Phase 2 (intersection clustering across all candidate beats).
 
-**Constrained (~32k context):** Phase 2 batches candidates by cluster signal (location overlap first, then shared entity, then temporal) rather than single-call clustering. Phase 5 drafts transitions per-seam rather than all at once.
+**Constrained (~32k context):** Phase 2 batches candidates by cluster signal (location overlap first, then shared entity, then temporal) rather than single-call clustering. Phase 4c drafts transitions per-seam rather than all at once.
 
 ## Worked Example
 
@@ -675,29 +728,33 @@ Candidate: pre-commit beat of `mentor_trust` and pre-commit beat of `archive_nat
 
 No temporal hints in this run; acyclicity trivially holds.
 
-### Phase 4
+### Phase 4a
 
 Cross-dilemma `predecessor` edges added per `concurrent` interleaving heuristic.
 
-### Phase 5
+### Phase 4b
+
+Each beat tagged with `scene_type`, `narrative_function`, and `exit_mood` from a single LLM call.
+
+### Phase 4c
 
 One cross-dilemma seam between `mentor_trust` post-commit and `archive_nature` pre-commit has no shared entity/location. LLM drafts: "Kay steps out of the reading room into the courtyard, thoughts of the mentor receding as the archive looms." Transition Beat inserted.
 
-### Phase 6
+### Phase 5
 
 Consequences of `mentor_trust__protector` and `mentor_trust__manipulator` each produce one State Flag (`mentor_protective_ally`, `mentor_hostile_adversary`). Overlays added to `character::mentor` node.
 
-### Phase 7
+### Phase 6
 
 `dilemma::mentor_trust`: `converges_at` = the first shared beat after both paths' post-commit chains. `convergence_payoff` = 3 (commit + 2 post-commit per path).
 
 `dilemma::archive_nature`: hard, only canonical path — both fields null.
 
-### Phase 8
+### Phase 7
 
 2 arcs (`mentor_trust` has 2 explored paths × `archive_nature` has only the canonical path = 2 arcs). Each validated: complete, reaches terminal, exactly one commit beat per explored Dilemma.
 
-### Phase 9
+### Phase 8
 
 No unreachable beats. Freeze.
 

--- a/docs/design/procedures/polish.md
+++ b/docs/design/procedures/polish.md
@@ -26,6 +26,7 @@ POLISH does NOT change the branching topology set by SEED and GROW (Y-shape fork
 14. No orphan beats (all reachable from root by at least one arc).
 15. Setup beats from SEED persist (structural, zero `belongs_to`, zero `dilemma_impacts`) — GROW does not add to or remove from them.
 16. Epilogue beats from SEED persist (structural, zero `belongs_to`, zero `dilemma_impacts`) — GROW does not add to or remove from them.
+17. Every beat has `scene_type`, `narrative_function`, and `exit_mood` populated by GROW Phase 4b (or a WARNING was logged for partial coverage; downstream phases fall back per R-4b.1).
 
 ---
 
@@ -599,13 +600,13 @@ R-7.12. Validation failure halts POLISH with ERROR — partial output is not del
 8. Variant passages exist for every passage with incompatible heavy-residue state combinations, with `variant_of` edges and satisfiable `requires`.
 9. Residue beat passages exist wherever light-residue mood-bridging is needed; passage-layer mapping (residue-passage-with-variants or parallel-passages) is recorded.
 10. False-branch passages exist where Phase 5 approved diamond or sidetrack patterns; false-branch beats have `role: "false_branch_beat"`, zero `belongs_to`, zero `dilemma_impacts`.
-11. Character arc metadata is annotated on every entity with 2+ beat appearances (`start`, `pivots` per path, `end_per_path`, AND `arcs_per_path` per audit Q6 / Phase 3 extended).
+11. Character arc metadata is annotated on every entity with 2+ beat appearances: `start`, `pivots` per path, `end_per_path`, and `arcs_per_path` (see Phase 3 §Output Contract for the full schema).
 12. Every passage has a prose feasibility annotation (clean / annotated / residue / variant). No `structural split` passages unresolved.
 13. No prose exists — `passage.prose` is empty until FILL.
 14. No cycles in the passage graph.
 15. Every beat has `atmospheric_detail` populated (10–200 characters describing sensory environment), or a WARNING was logged for partial Phase 5e coverage.
 16. Every multi-beat path has `path_theme` (10–200 characters) and `path_mood` (2–50 characters) populated, or a WARNING was logged for per-path Phase 5f failure.
-17. Gap beats inserted by Phase 1a carry `is_gap_beat: True`, `role: gap_beat`, `created_by: "POLISH"`, zero `dilemma_impacts`, and traceability fields (`bridges_from`, `bridges_to`, `transition_style`).
+17. Gap beats inserted by Phase 1a carry `is_gap_beat: True`, `role: gap_beat`, `created_by: "POLISH"`, zero `dilemma_impacts`, single `belongs_to` to their path, and traceability fields (`bridges_from`, `bridges_to`, `transition_style`).
 
 ## Implementation Constraints
 

--- a/docs/design/procedures/polish.md
+++ b/docs/design/procedures/polish.md
@@ -599,10 +599,13 @@ R-7.12. Validation failure halts POLISH with ERROR — partial output is not del
 8. Variant passages exist for every passage with incompatible heavy-residue state combinations, with `variant_of` edges and satisfiable `requires`.
 9. Residue beat passages exist wherever light-residue mood-bridging is needed; passage-layer mapping (residue-passage-with-variants or parallel-passages) is recorded.
 10. False-branch passages exist where Phase 5 approved diamond or sidetrack patterns; false-branch beats have `role: "false_branch_beat"`, zero `belongs_to`, zero `dilemma_impacts`.
-11. Character arc metadata is annotated on every entity with 2+ beat appearances (start, pivots per path, end per path).
+11. Character arc metadata is annotated on every entity with 2+ beat appearances (`start`, `pivots` per path, `end_per_path`, AND `arcs_per_path` per audit Q6 / Phase 3 extended).
 12. Every passage has a prose feasibility annotation (clean / annotated / residue / variant). No `structural split` passages unresolved.
 13. No prose exists — `passage.prose` is empty until FILL.
 14. No cycles in the passage graph.
+15. Every beat has `atmospheric_detail` populated (10–200 characters describing sensory environment), or a WARNING was logged for partial Phase 5e coverage.
+16. Every multi-beat path has `path_theme` (10–200 characters) and `path_mood` (2–50 characters) populated, or a WARNING was logged for per-path Phase 5f failure.
+17. Gap beats inserted by Phase 1a carry `is_gap_beat: True`, `role: gap_beat`, `created_by: "POLISH"`, zero `dilemma_impacts`, and traceability fields (`bridges_from`, `bridges_to`, `transition_style`).
 
 ## Implementation Constraints
 

--- a/docs/design/procedures/polish.md
+++ b/docs/design/procedures/polish.md
@@ -263,7 +263,7 @@ R-4a.4. POLISH does NOT consume Intersection Group nodes as a constraint on grou
 
 R-4a.5. (Subsumed by R-4a.3.) The prior allowance for optional multi-path grouping is now automatic: multi-path chains that are linear in the DAG are collapsed by the topology rule; those separated by divergences or convergences are in different passages by topology.
 
-**Notes on structural beats.** Residue and false-branch beats are created by POLISH in Phase 6 *after* Phase 4a completes; their passage placement is governed by Phase 6 creation rules (R-6.x), not Phase 4a. Micro-beats (Phase 2, from POLISH) and transition beats (from GROW) are already in the DAG at Phase 4a and are grouped uniformly by R-4a.3. No sub-type-specific grouping rules are needed in Phase 4a.
+**Notes on structural beats.** Residue and false-branch beats are created by POLISH in Phase 6 *after* Phase 4a completes; their passage placement is governed by Phase 6 creation rules (R-6.x), not Phase 4a. Micro-beats (Phase 2, from POLISH), gap beats (Phase 1a, from POLISH), and transition beats (from GROW) are already in the DAG at Phase 4a and are grouped uniformly by R-4a.3. No sub-type-specific grouping rules are needed in Phase 4a.
 
 **Violations:**
 

--- a/docs/design/procedures/polish.md
+++ b/docs/design/procedures/polish.md
@@ -440,12 +440,52 @@ R-5.13. Each variant has a distinct summary reflecting its flag combination.
 
 R-5.14. Variant passages share the same beats (via `grouped_in`) but have different prose.
 
+#### 5e — Atmospheric Annotation
+
+**What:** For every beat in the frozen DAG, produce an `atmospheric_detail` string (10–200 characters) describing the sensory environment: sight, sound, smell, texture. Environment, not character emotion. A single LLM call produces details for all beats. Absorbed from old GROW 4d per audit Q1: sensory grounding is prose-prep, not structural.
+
+**Rules:**
+
+R-5e.1. Every beat receives `atmospheric_detail` populated by Phase 5e. Partial coverage (LLM details only some beats) MUST log a WARNING; FILL falls back to scene-blueprint sensory data when `atmospheric_detail` is absent.
+
+R-5e.2. `atmospheric_detail` describes ENVIRONMENT (sight/sound/smell/texture/light/temperature/etc.), not character interiority. This separation is enforced by the LLM prompt; the spec does not mandate prose-content checks.
+
+R-5e.3. Phase 5e runs after Beat DAG Freeze, so transition beats inserted by GROW Phase 4c receive `atmospheric_detail` like any other beat (auto-fixes the transition-beat-atmospheric gap noted in the audit Q3).
+
+**Violations:**
+
+| Symptom | Root cause | Broken rule |
+|---------|-----------|-------------|
+| Beat without `atmospheric_detail` and no WARNING | Partial coverage detection skipped | R-5e.1 |
+| Transition beat without `atmospheric_detail` | Phase 5e ran before transition-beat creation, OR transition beats excluded from coverage | R-5e.3 |
+
+#### 5f — Path Thematic Annotation
+
+**What:** For each path, produce a `path_theme` (10–200 characters) and `path_mood` (2–50 characters) summarizing the path's emotional through-line and tonal palette. One LLM call per path; the LLM consumes the full beat sequence with their summaries, scene types, narrative functions, and exit moods. Absorbed from old GROW 4e per audit Q1: per-path narrative identity is prose-prep, not structural.
+
+**Rules:**
+
+R-5f.1. Every path with 2+ beats receives `path_theme` and `path_mood`. Paths with fewer than 2 beats are skipped (no narrative arc to summarize).
+
+R-5f.2. `path_theme` is the path's emotional through-line / "controlling idea" (McKee). `path_mood` is its tonal palette. Both are LLM-generated free-form strings; the spec does not enforce specific vocabularies.
+
+R-5f.3. Per-path LLM failures MUST log at WARNING and leave the path's fields unpopulated. FILL and DRESS handle missing fields by falling back to path description / dilemma question text.
+
+**Violations:**
+
+| Symptom | Root cause | Broken rule |
+|---------|-----------|-------------|
+| Multi-beat path without `path_theme` and no WARNING | Per-path failure detection skipped | R-5f.3 |
+| `path_mood` exceeds 50 characters | Schema length not enforced | R-5f.2 |
+
 ### Output Contract
 
 1. All ChoiceSpecs have labels.
 2. All ResidueSpecs have content and a passage-layer mapping choice.
 3. All FalseBranchCandidates have a decision (skip / diamond / sidetrack).
 4. All VariantSpecs have summaries.
+5. Every beat has `atmospheric_detail` populated (or a WARNING logged for partial coverage).
+6. Every multi-beat path has `path_theme` and `path_mood` populated (or a WARNING logged for per-path failure).
 
 ---
 
@@ -649,6 +689,12 @@ R-5.11: False-branch choice edges may grant cosmetic state flags.
 R-5.12: False branches never affect dilemma-driven branching.
 R-5.13: Variants have distinct summaries per flag combination.
 R-5.14: Variants share beats via `grouped_in`; differ in prose only.
+R-5e.1: Every beat receives `atmospheric_detail`; partial coverage emits WARNING.
+R-5e.2: `atmospheric_detail` describes environment, not interiority.
+R-5e.3: Phase 5e runs after Beat DAG Freeze; transition beats receive `atmospheric_detail`.
+R-5f.1: Multi-beat paths receive `path_theme` and `path_mood`; <2-beat paths skipped.
+R-5f.2: `path_theme` (controlling idea) and `path_mood` (tonal palette) are free-form LLM strings.
+R-5f.3: Per-path LLM failure → WARNING + leave unpopulated; consumers fall back.
 R-6.1: Phase 6 runs in a single transaction.
 R-6.2: Application order: passages → variants → residue beats → residue passages → choices → false branches.
 R-6.3: Any step failure rolls back.
@@ -774,6 +820,8 @@ User reviews. Approves.
 - Residue content for 2 spec: one variant per path.
 - False branch decision: `diamond` pattern for the opening stretch.
 - Variant summary for the climax passage: two versions.
+- **5e:** atmospheric_detail populated for all 14 beats (including the gap and micro beats from Phases 1a/2 and the transition beat from GROW 4c).
+- **5f:** path_theme and path_mood populated for both `mentor_trust` paths and the `archive_nature` canonical path.
 
 ### Phase 6
 

--- a/docs/design/procedures/polish.md
+++ b/docs/design/procedures/polish.md
@@ -72,13 +72,56 @@ R-1.5. Sections with fewer than 3 beats are not reordered (not worth the LLM cal
 
 ---
 
+## Phase 1a: Narrative Gap Insertion
+
+**Purpose:** Detect structural narrative jumps in path beat sequences (e.g., a path goes setup → climax with no development beat) and insert bridging gap beats to smooth abrupt narrative leaps. Absorbed from old GROW 4b per audit Q1 resolution: gap insertion is narrative-craft work (improves how the story reads), not structural skeleton (which dilemmas exist).
+
+### Input Contract
+
+1. Phase 1 Output Contract satisfied.
+2. Beats carry `scene_type` annotation (populated by GROW Phase 4b).
+
+### Operations
+
+#### Gap Detection and Insertion
+
+**What:** For each path with 2+ beats, the LLM is given the beat sequence (with truncated summaries and scene-type tags). It identifies missing intermediate beats and proposes new beats to insert at specified positions. POLISH validates each proposal (referenced beat IDs exist, ordering is correct) and inserts gap beats with the appropriate predecessor edges and `belongs_to` to the path.
+
+**Rules:**
+
+R-1a.1. Inserted gap beats carry `is_gap_beat: True` and `role: gap_beat` and `created_by: "POLISH"`.
+
+R-1a.2. Inserted gap beats carry zero `dilemma_impacts`. They are structural transition beats; they MUST NOT advance any dilemma. This matches the structural-beat invariant for all POLISH-created beats (R-2.1, R-5.10, etc.).
+
+R-1a.3. Inserted gap beats record traceability fields: `bridges_from` (the earlier beat ID), `bridges_to` (the later beat ID), `transition_style` (free-form descriptor).
+
+R-1a.4. Per-path cap: maximum 2 gap beats inserted per path per Phase 1a invocation.
+
+R-1a.5. Invalid LLM proposals (bad beat IDs, ordering violations) MUST log at WARNING and skip the proposal; do not silently accept.
+
+**Violations:**
+
+| Symptom | Root cause | Broken rule |
+|---------|-----------|-------------|
+| Gap beat with non-empty `dilemma_impacts` | Structural-beat invariant violated | R-1a.2 |
+| Gap beat without `bridges_from` / `bridges_to` | Traceability missing | R-1a.3 |
+| 3+ gap beats on one path | Cap not enforced | R-1a.4 |
+| Phase 1a accepts a proposal referencing non-existent `before_beat` ID | Validation skipped | R-1a.5 |
+
+### Output Contract
+
+1. Zero or more gap beats added to the graph. Each carries `is_gap_beat=True`, zero `dilemma_impacts`, `belongs_to` to its path, predecessor edges placing it between `bridges_from` and `bridges_to`, and `created_by: "POLISH"`.
+2. Path beat sequences may be longer than at Phase 1a's start; original (non-gap) beats are unmodified.
+
+---
+
 ## Phase 2: Pacing Micro-Beat Injection
 
 **Purpose:** Flag pacing issues (too many scenes or sequels in a row; no sequel after a commit beat) and insert micro-beats to smooth rhythm. Micro-beats are structural beats that carry no dilemma relationship.
 
 ### Input Contract
 
-1. Phase 1 Output Contract satisfied.
+1. Phase 1a Output Contract satisfied.
 
 ### Operations
 
@@ -519,6 +562,11 @@ R-1.2: Reordered sequence preserves beat set exactly.
 R-1.3: Reordering preserves hard constraints (commit timing, cross-section edges).
 R-1.4: Invalid proposal → original order + WARNING; never silent accept.
 R-1.5: Sections <3 beats not reordered.
+R-1a.1: Gap beats have `is_gap_beat: True`, `role: gap_beat`, `created_by: "POLISH"`.
+R-1a.2: Gap beats carry zero `dilemma_impacts` (structural-beat invariant).
+R-1a.3: Gap beats record traceability: `bridges_from`, `bridges_to`, `transition_style`.
+R-1a.4: Per-path cap: max 2 gap beats per Phase 1a invocation.
+R-1a.5: Invalid LLM proposals → WARNING + skip; never silent accept.
 R-2.1: Micro-beats have `role: micro_beat`, zero `dilemma_impacts`, zero `belongs_to`.
 R-2.2: Micro-beats inserted only in linear sections.
 R-2.3: Micro-beats carry surrounding entity references.
@@ -588,6 +636,7 @@ R-7.12: Validation failure halts POLISH; no partial output.
 | Phase | Gate | Decision |
 |-------|------|----------|
 | 1 | Beat Reordering | Automated (WARNING on invalid proposals) |
+| 1a | Narrative Gap Insertion | Automated (WARNING on invalid proposals) |
 | 2 | Pacing Micro-beats | Automated |
 | 3 | Character Arc Synthesis | Automated |
 | — | Beat DAG Freeze | Required — user reviews finalized beat DAG before passage layer |
@@ -600,7 +649,7 @@ The single human gate is between Phase 3 (beat DAG freeze) and Phase 4 (plan com
 
 ## Iteration Control
 
-**Forward flow:** 1 → 2 → 3 → [freeze gate] → 4 → 5 → 6 → 7.
+**Forward flow:** 1 → 1a → 2 → 3 → [freeze gate] → 4 → 5 → 6 → 7.
 
 **Backward loops:**
 
@@ -613,6 +662,7 @@ The single human gate is between Phase 3 (beat DAG freeze) and Phase 4 (plan com
 **Maximum iterations:**
 
 - Phase 1 reordering: at most 1 proposal per section; invalid fallbacks to original.
+- Phase 1a gap insertion: at most 1 LLM call per path; per-path cap of 2 gap beats per R-1a.4.
 - Phase 2 micro-beats: at most 1 proposal per pacing flag.
 - Phase 4: deterministic, single pass.
 - Phase 5 LLM enrichment: at most 2 retries per LLM call (per CLAUDE.md §Validation & Repair Loop).
@@ -623,6 +673,7 @@ The single human gate is between Phase 3 (beat DAG freeze) and Phase 4 (plan com
 | Phase | Failure | Detection | Recovery |
 |-------|---------|-----------|----------|
 | 1 | Invalid reordering | R-1.4 validation | Keep original + WARNING |
+| 1a | Invalid gap-beat proposal | R-1a.5 validation | Skip proposal + WARNING |
 | 2 | Micro-beat wrongly has `belongs_to` | R-2.1 check | Halt; fix in Phase 2 logic |
 | 4a | Beat grouped into two passages | R-4a.1 check | Plan bug — re-run Phase 4 |
 | 4c | Zero choice edges | R-4c.2 check | Halt ERROR; fix in SEED (Y-shape) or GROW (DAG) |
@@ -653,6 +704,10 @@ Phase 4b's prose feasibility audit needs to know which state flags are *structur
 ### Phase 1
 
 One linear section of 4 beats in `mentor_trust`'s post-commit chain. LLM proposes reordering two beats for better scene-sequel rhythm. Validation passes; edges updated.
+
+### Phase 1a
+
+LLM inspects each path's beat sequence. On the `manipulator` path, it flags a leap from setup to confrontation with no rising-tension beat between; proposes one gap beat (`bridges_from`/`bridges_to` set, `transition_style: "rising suspicion"`). The other path passes without insertion. Per-path cap (R-1a.4) not approached.
 
 ### Phase 2
 

--- a/docs/design/procedures/polish.md
+++ b/docs/design/procedures/polish.md
@@ -180,7 +180,7 @@ R-2.8. Phase 2 MUST NOT introduce new monotonous runs while breaking existing on
 
 ## Phase 3: Character Arc Synthesis
 
-**Purpose:** For each entity appearing in 2+ beats, synthesize explicit arc metadata — start, pivot(s) per path, end per path — that FILL uses to maintain prose consistency.
+**Purpose:** For each entity appearing in 2+ beats, synthesize explicit arc metadata — start, pivots per path, end per path, AND per-path positional trajectory data — that FILL uses to maintain prose consistency. The per-path positional data (`arcs_per_path`) was previously produced by old GROW 4f and is now consolidated here per audit Q6 resolution: a single source of truth on Entity nodes, indexed for FILL's per-passage positional context.
 
 ### Input Contract
 
@@ -204,6 +204,12 @@ R-3.4. Arc metadata is working data for FILL. POLISH does not write prose based 
 
 R-3.5. The LLM receives full context for each entity: beat summaries in order, dilemma questions, path descriptions, overlay details.
 
+R-3.6. The character_arc annotation includes `arcs_per_path: list[{path_id: str, arc_type: str, arc_line: str, pivot_beat: str}]`, one entry per path on which the entity is arc-worthy. Single LLM call produces both the existing fields (start, pivots, end_per_path) and `arcs_per_path` together, ensuring internal consistency.
+
+R-3.7. `arc_type` is determined deterministically by the entity's category: character → "transformation", location → "atmosphere", object → "significance", faction → "relationship". The LLM does not choose `arc_type`; POLISH derives it from the entity node and validates the LLM output matches.
+
+R-3.8. For each `path_id` present in both `pivots` and `arcs_per_path`, the values MUST agree: `pivots[path_id]` (the entity-scoped pivot beat for that path) MUST equal the `pivot_beat` of the matching `arcs_per_path` entry. POLISH enforces this at synthesis time (single LLM call producing both, validated together).
+
 **Violations:**
 
 | Symptom | Root cause | Broken rule |
@@ -211,11 +217,15 @@ R-3.5. The LLM receives full context for each entity: beat summaries in order, d
 | Entity with 5 beat appearances has no arc metadata | Phase 3 skipped this entity | R-3.1 |
 | Arc metadata stored as separate `CharacterArc` nodes | Should be entity annotation | R-3.3 |
 | LLM call for arc synthesis receives bare entity IDs | Context enrichment missing | R-3.5 |
+| `arcs_per_path` missing for an entity with 2+ appearances on a path | Phase 3 partial coverage | R-3.6 |
+| `arc_type` does not match the entity's category | Validation gap | R-3.7 |
+| `pivots[path_id] != arcs_per_path[*].pivot_beat` for the same path | Internal-consistency check skipped | R-3.8 |
 
 ### Output Contract
 
 1. Every entity with 2+ beat appearances has arc metadata annotation (start, pivots per path, end per path).
 2. No separate CharacterArc nodes created.
+3. `arcs_per_path` populated alongside the existing fields, with `arc_type` matching entity category and `pivot_beat` agreeing with `pivots[path_id]` for each path.
 
 ---
 
@@ -601,6 +611,9 @@ R-3.2: Arc metadata: start, pivots per path, end_per_path.
 R-3.3: Arc metadata is entity annotation, not separate node.
 R-3.4: POLISH does not write prose from arc metadata.
 R-3.5: Arc-synthesis LLM receives full context.
+R-3.6: character_arc includes `arcs_per_path[]`; produced in same LLM call as start/pivots/end_per_path.
+R-3.7: `arc_type` derived from entity category (character/location/object/faction).
+R-3.8: `pivots[path_id]` MUST equal `arcs_per_path[*].pivot_beat` for the same path.
 R-4a.1: Every beat in exactly one Passage.
 R-4a.2: (Removed — linear runs may span different `belongs_to` sets; path-membership uniformity within a passage is not required.)
 R-4a.3: Maximal-linear-collapse — a passage is a maximal run of beats with no internal divergence or convergence.
@@ -739,7 +752,7 @@ Pacing flag: 3 action beats with no sequel in `archive_nature` path. LLM propose
 
 ### Phase 3
 
-`character::mentor` appears in 8 beats. Arc metadata: start = "cryptic authority figure"; pivot on protector path = commit beat (mentor confesses); pivot on manipulator path = post-commit reveal; end_per_path populated. Annotated on entity node.
+`character::mentor` appears in 8 beats. Arc metadata: start = "cryptic authority figure"; pivot on protector path = commit beat (mentor confesses); pivot on manipulator path = post-commit reveal; end_per_path populated. The same LLM call also produces `arcs_per_path` for the mentor — one entry per path with `arc_type: "transformation"` (derived from the character category), an `arc_line` summarizing trajectory, and `pivot_beat` equal to the corresponding `pivots[path_id]`. Annotated on entity node.
 
 ### Beat DAG Freeze — Human Gate
 

--- a/docs/design/procedures/polish.md
+++ b/docs/design/procedures/polish.md
@@ -150,10 +150,31 @@ R-2.5. Micro-beats have `created_by: POLISH` for stage-attribution tracking.
 | Micro-beat inserted at a Y-fork boundary (changes topology) | Branching altered | R-2.2 |
 | Micro-beat has `created_by: GROW` | Attribution wrong | R-2.5 |
 
+#### Pacing-Run Detection
+
+**What:** In the same Phase 2 invocation, deterministically detect runs of 3+ consecutive beats with the same `scene_type` along any path (the "monotonous run" condition). For each detected run, propose a correction beat of the opposite type (insert a sequel between scenes, or a scene between sequels) to break the monotony. Implementation may share its LLM call with the micro-beat detection above.
+
+(Absorbed from old GROW 4c. Per audit Q1, pacing rhythm correction is narrative work — POLISH territory.)
+
+**Rules:**
+
+R-2.6. Phase 2 detects runs of 3+ consecutive same-`scene_type` beats per path and inserts correction beats of the opposite type to break the run. Detection is deterministic; the correction-beat content is LLM-generated.
+
+R-2.7. Correction beats carry `is_gap_beat: True`, `role: micro_beat`, zero `dilemma_impacts`, `created_by: "POLISH"`. They are structurally indistinguishable from pacing micro-beats; the `is_gap_beat` flag distinguishes their origin (pacing-run correction vs. pacing-flag micro-beat insertion).
+
+R-2.8. Phase 2 MUST NOT introduce new monotonous runs while breaking existing ones. If a candidate correction beat would extend a run on the opposite side of the insertion point, the proposal is rejected.
+
+**Violations:**
+
+| Symptom | Root cause | Broken rule |
+|---------|-----------|-------------|
+| 4+ consecutive same-`scene_type` beats remain after Phase 2 | Pacing-run detection skipped or correction failed | R-2.6 |
+
 ### Output Contract
 
 1. Zero or more micro-beats added, each within a linear section with correct role/attribution.
 2. Branching topology unchanged.
+3. Zero or more pacing-run correction beats added (`is_gap_beat: True`, `role: micro_beat`, opposite `scene_type` of the run they break).
 
 ---
 
@@ -572,6 +593,9 @@ R-2.2: Micro-beats inserted only in linear sections.
 R-2.3: Micro-beats carry surrounding entity references.
 R-2.4: Pacing flags: 3+ scenes-in-a-row, 3+ sequels-in-a-row, no sequel after commit.
 R-2.5: Micro-beats have `created_by: POLISH`.
+R-2.6: Phase 2 detects 3+ same-`scene_type` runs per path and inserts opposite-type correction beats.
+R-2.7: Correction beats have `is_gap_beat: True`, `role: micro_beat`, zero `dilemma_impacts`, `created_by: "POLISH"`.
+R-2.8: Phase 2 MUST NOT introduce new monotonous runs.
 R-3.1: Arc-worthy entities have 2+ beat appearances.
 R-3.2: Arc metadata: start, pivots per path, end_per_path.
 R-3.3: Arc metadata is entity annotation, not separate node.
@@ -711,7 +735,7 @@ LLM inspects each path's beat sequence. On the `manipulator` path, it flags a le
 
 ### Phase 2
 
-Pacing flag: 3 action beats with no sequel in `archive_nature` path. LLM proposes a brief reflection micro-beat; inserted with `role: micro_beat`.
+Pacing flag: 3 action beats with no sequel in `archive_nature` path. LLM proposes a brief reflection micro-beat; inserted with `role: micro_beat`. Pacing-run detection finds a separate run of 3 consecutive sequels in `mentor_trust`'s post-commit chain on the protector path; LLM proposes a brief scene-type correction beat (`is_gap_beat: True`, `role: micro_beat`, opposite `scene_type`) to break the monotony.
 
 ### Phase 3
 

--- a/docs/design/story-graph-ontology.md
+++ b/docs/design/story-graph-ontology.md
@@ -191,6 +191,10 @@ A per-entity summary of how a character changes across the story, synthesized by
 
 Character arc metadata is stored as an annotation on entity nodes — it describes the entity's trajectory on each path (start → pivot → end). It is working data for FILL: when the prose writer encounters the mentor in a mid-story scene, they need to know where the mentor has been and where the mentor is going. Without it, the writer sees individual beats in isolation and risks inconsistency.
 
+**Per-path arc trajectories** — `arcs_per_path: list[{path_id: str, arc_type: str, arc_line: str, pivot_beat: str}]`. Populated by POLISH Phase 3 (Character Arc Synthesis, extended). One entry per path on which this entity is arc-worthy. `arc_type` is determined by the entity's category: character → "transformation", location → "atmosphere", object → "significance", faction → "relationship". `arc_line` is a concise A → B → C trajectory. `pivot_beat` is the beat at which the entity's trajectory turns. Consumed by FILL for per-passage positional context (pre-pivot / at-pivot / post-pivot).
+
+The full `character_arc` annotation contains `start`, `pivots`, `end_per_path`, AND `arcs_per_path`. The `pivots` field (entity-scoped per-path map: `dict[path_id → beat_id]`) and `arcs_per_path[*].pivot_beat` (path-scoped record) MUST agree for the same `path_id` — they describe the same pivot from different indexing angles. POLISH Phase 3 enforces this by producing both in a single LLM call.
+
 **Working.** Created by POLISH, consumed by FILL. Not exported.
 
 ### Scene Blueprint

--- a/docs/design/story-graph-ontology.md
+++ b/docs/design/story-graph-ontology.md
@@ -87,6 +87,12 @@ An answer that is not actively lived by the player is a **shadow** — the road 
 
 Neither kind requires a dedicated node type. Context builders surface both so FILL has the narrative weight of unexplored alternatives.
 
+#### Path Annotations
+
+**Path theme** — `path_theme: str` (10–200 characters). Populated by POLISH Phase 5f. Per-path emotional through-line / "controlling idea" (McKee). In branching fiction, different answers to the same dilemma should produce qualitatively different narrative experiences; `path_theme` is the path's answer to "what is this journey's emotional identity?" Consumed by FILL (narrative context, choice consequence labels) and DRESS (illustration `path_undertone`).
+
+**Path mood** — `path_mood: str` (2–50 characters). Populated by POLISH Phase 5f. Tonal palette for the path as a whole (e.g., "melancholic", "frenetic", "tense-then-resolved"). Distinct from beat-level `exit_mood` which describes per-beat handoff feeling — `path_mood` is the path's macro-tone. Consumed by FILL and DRESS for tonal framing.
+
 **Working.** Consumed by GROW.
 
 ### Beat

--- a/docs/design/story-graph-ontology.md
+++ b/docs/design/story-graph-ontology.md
@@ -103,18 +103,31 @@ A narrative beat directly advances a dilemma. It carries **dilemma impacts** (wh
 
 #### Structural Beats
 
-A structural beat serves the DAG without advancing any dilemma. It carries zero `dilemma_impacts` and zero `belongs_to` edges. Every arc that reaches a structural beat via the predecessor chain traverses it — it belongs to no path but is walked through naturally. Six sub-types:
+A structural beat serves the DAG without advancing any dilemma. It carries zero `dilemma_impacts` and zero `belongs_to` edges. Every arc that reaches a structural beat via the predecessor chain traverses it — it belongs to no path but is walked through naturally. Seven sub-types:
 
 - **Setup beat** (SEED) — world-building before any dilemma is introduced. Establishes context without serving a dilemma.
 - **Epilogue beat** (SEED) — shared narrative resolution after all dilemmas have committed and converged. Wraps up the story as a whole rather than any single dilemma. Distinct from a Setup beat in timing and purpose — Setup opens, Epilogue closes — even though both carry zero `belongs_to`.
 - **Transition beat** (GROW) — atmospheric bridge between cross-dilemma scenes that share no entities or location.
 - **Micro-beat** (POLISH) — brief moment added for pacing within a linear section.
+- **Gap beat** (POLISH) — bridge beat inserted by POLISH Phase 1a (Narrative Gap Insertion) to smooth abrupt narrative leaps in a path's beat sequence. Carries `is_gap_beat=True` and traceability fields (`bridges_from`, `bridges_to`, `transition_style`). Zero `dilemma_impacts`; single `belongs_to` to its path.
 - **Residue beat** (POLISH) — mood-setter placed before a shared beat. Carries state-flag-specific prose hints; only shown to players holding the relevant flag. Has no `dilemma_impacts` but is flag-dependent.
 - **False branch beat** (POLISH) — a beat on a cosmetic fork-rejoin structure that gives the player the experience of choice without dilemma consequence. A diamond pattern uses one beat per arm; a sidetrack may use several beats on its detour arm. Carries no dilemma relationship. The surrounding choice edges may optionally grant cosmetic state flags (flags unrelated to any dilemma, used later by residue beats or prose variation for flavor).
 
+#### Beat Annotations
+
+**Scene-type annotation** — `scene_type ∈ {scene, sequel, micro_beat}`. Populated by GROW Phase 4b. Encodes Scene/Sequel rhythm (Swain): `scene` = active conflict (goal → conflict → disaster); `sequel` = reactive processing (emotion → thought → decision); `micro_beat` = brief transition. Consumed by POLISH Phase 2 for pacing detection and by FILL for prose intensity / target length derivation.
+
+**Narrative function** — `narrative_function ∈ {introduce, develop, complicate, confront, resolve}`. Populated by GROW Phase 4b. The beat's role in story structure (Freytag-style, compressed to beat level). Consumed by FILL for prose pacing and by DRESS for illustration priority.
+
+**Exit mood** — `exit_mood: str` (2–40 characters). Populated by GROW Phase 4b. Free-form descriptor of the emotional state the beat hands off to its successor. Consumed by FILL for narrative-context generation; informs reader-affect transitions between beats.
+
+**Atmospheric detail** — `atmospheric_detail: str` (10–200 characters). Populated by POLISH Phase 5e. Sensory environment description (sight, sound, smell, texture) — environment, not character emotion. Consumed by FILL for sensory grounding when no scene blueprint supersedes.
+
+**Gap-beat traceability** — `is_gap_beat: bool`, `transition_style: str`, `bridges_from: str | None`, `bridges_to: str | None`. Populated by POLISH Phase 1a (Narrative Gap Insertion) on POLISH-created bridge beats. `bridges_from` and `bridges_to` reference the IDs of the beats this gap beat sits between. `transition_style` is a free-form descriptor (e.g., "smooth", "cut") that informs FILL's transition-context. `is_gap_beat=True` excludes the beat from intersection candidate generation.
+
 #### Beat Lifecycle
 
-SEED creates the initial narrative beats (the Y-shaped scaffold per dilemma) plus setup beats (opening world-building) and epilogue beats (post-all-dilemmas wrap-up) as needed. GROW combines all per-dilemma scaffolds into a single beat DAG, adding transition beats for structural continuity. Once GROW has combined all dilemmas, **beats are never removed** and the **dilemma topology is frozen** — the forks and convergences driven by dilemmas cannot change. POLISH operates within that frozen topology, adding micro-beats, residue beats, and false branch beats. At the end of POLISH, one or more beats are grouped into a passage. Throughout this lifecycle, a beat's identity — what happens — remains stable. The metadata around it evolves.
+SEED creates the initial narrative beats (the Y-shaped scaffold per dilemma) plus setup beats (opening world-building) and epilogue beats (post-all-dilemmas wrap-up) as needed. GROW combines all per-dilemma scaffolds into a single beat DAG, adding transition beats for structural continuity. Once GROW has combined all dilemmas, **beats are never removed** and the **dilemma topology is frozen** — the forks and convergences driven by dilemmas cannot change. POLISH operates within that frozen topology, adding micro-beats, gap beats, residue beats, and false branch beats. At the end of POLISH, one or more beats are grouped into a passage. Throughout this lifecycle, a beat's identity — what happens — remains stable. The metadata around it evolves.
 
 **Working.** Beats are not exported. They are the authoring abstraction. The player sees passages.
 

--- a/docs/design/story-graph-ontology.md
+++ b/docs/design/story-graph-ontology.md
@@ -343,9 +343,9 @@ Beats are not cloned per reachable state — each beat is one node with one set 
 
 ### Total Order Per Arc
 
-The DAG defines a partial order. Each arc (a specific combination of path choices) defines a **total order** — the exact sequence of beats a player on that arc experiences. This total order is computed by **walking the DAG** from the root beat, following `predecessor` edges forward. At each Y-shape fork (where a shared beat has successors on different paths of the same dilemma), the traversal follows the successor matching the arc's selected path for that dilemma. Beats that are not on any dilemma fork branch — setup, epilogue, transition, and micro-beats — are traversed naturally as the walk passes through them. False branch beats follow their own cosmetic-fork choice; residue beats are flag-gated and shown only to players holding the corresponding flag.
+The DAG defines a partial order. Each arc (a specific combination of path choices) defines a **total order** — the exact sequence of beats a player on that arc experiences. This total order is computed by **walking the DAG** from the root beat, following `predecessor` edges forward. At each Y-shape fork (where a shared beat has successors on different paths of the same dilemma), the traversal follows the successor matching the arc's selected path for that dilemma. Beats that are not on any dilemma fork branch — setup, epilogue, transition, and micro-beats — are traversed naturally as the walk passes through them. False branch beats follow their own cosmetic-fork choice; residue beats are flag-gated and shown only to players holding the corresponding flag. Gap beats carry a single `belongs_to` to one path and appear in the total order only for arcs traversing that path.
 
-This is a DAG walk, not a collection-by-membership operation. The `belongs_to` edges define which path a beat furthers narratively (the Y-shape from SEED), but the arc traversal follows the `predecessor` DAG structure that GROW built. Beats without `belongs_to` edges (all structural beat sub-types: setup, epilogue, transition, micro-beat, residue, false branch) are included whenever the walk reaches them — they sit on the predecessor chain between path-member beats and are traversed like any other node.
+This is a DAG walk, not a collection-by-membership operation. The `belongs_to` edges define which path a beat furthers narratively (the Y-shape from SEED), but the arc traversal follows the `predecessor` DAG structure that GROW built. Beats without `belongs_to` edges (setup, epilogue, transition, micro-beat, residue, false branch — all structural sub-types except gap beats) are included whenever the walk reaches them; they sit on the predecessor chain between path-member beats and are traversed like any other node. Gap beats are the structural exception: they carry a single `belongs_to` and appear only on arcs traversing that path.
 
 Arcs are not stored as graph nodes. They are **computed traversals** of the DAG. Any stage that needs an arc's beat sequence computes it on demand from the DAG structure. Diagnostic tools may snapshot pre-computed arc sequences for inspection, but pipeline stages must never read arcs from stored nodes — they traverse the DAG.
 
@@ -646,11 +646,12 @@ Intersection beats participate in scenes with beats from other paths, but they s
 
 #### Determining a beat's `belongs_to`
 
-A beat's `belongs_to` edges are a **narrative** statement: "this beat furthers the narrative of this dilemma." They are not a graph-shape statement about which path chains reach the beat. Three beat categories cover every legal beat:
+A beat's `belongs_to` edges are a **narrative** statement: "this beat furthers the narrative of this dilemma." They are not a graph-shape statement about which path chains reach the beat. Four beat categories cover every legal beat:
 
 1. **Shared pre-commit** — the beat sets up the dilemma's tension for both possible answers. Two `belongs_to` edges, one to each explored path of the dilemma.
 2. **Commit and exclusive post-commit** — the beat locks in or plays out one answer's consequences. One `belongs_to` edge to the answer's path.
-3. **Structural beats** (setup, epilogue, transition, micro-beat, residue beat, false branch beat) — the beat furthers no dilemma's narrative. Zero `belongs_to` edges. Examples: a world-setup opening beat before any dilemma is introduced; a transition beat that bridges between unrelated scenes; a closing epilogue beat after the final dilemma has committed and converged.
+3. **Zero-`belongs_to` structural beats** (setup, epilogue, transition, micro-beat, residue beat, false branch beat) — the beat furthers no dilemma's narrative. Zero `belongs_to` edges. Examples: a world-setup opening beat before any dilemma is introduced; a transition beat that bridges between unrelated scenes; a closing epilogue beat after the final dilemma has committed and converged.
+4. **Path-specific structural beats** (gap beat only) — the beat bridges a narrative seam within one path's beat sequence without advancing any dilemma. One `belongs_to` edge to that path. Zero `dilemma_impacts`. Created by POLISH Phase 1a; structurally indistinguishable from category 2 by `belongs_to` count, distinguished by zero `dilemma_impacts` and `is_gap_beat=True`.
 
 Cross-dilemma co-occurrence (a scene that serves two dilemmas at once) is **not** represented as a beat belonging to two dilemmas. It is represented as two distinct beats (one per dilemma) linked by an `intersection_group`. This preserves guard rail 1 below (no cross-dilemma dual `belongs_to`).
 
@@ -665,7 +666,7 @@ For residue and false-branch beats, passage placement is governed by the Phase 6
 Guard rails:
 
 1. **Same-dilemma constraint.** A beat with two `belongs_to` edges must reference two paths that belong to the same dilemma. Cross-dilemma multi-`belongs_to` is a hard-convergence violation.
-2. **Pre-commit only.** Only beats before the dilemma's commit may have two `belongs_to` edges. The commit beat itself has one (it is the first beat exclusive to its path). Post-commit beats of a dilemma have exactly one `belongs_to` edge; beats that serve no dilemma have zero (see "Determining a beat's `belongs_to`" above, category 3).
+2. **Pre-commit only.** Only beats before the dilemma's commit may have two `belongs_to` edges. The commit beat itself has one (it is the first beat exclusive to its path). Post-commit beats of a dilemma have exactly one `belongs_to` edge; beats that serve no dilemma have zero (see "Determining a beat's `belongs_to`" above, category 3) — gap beats are the structural exception, carrying exactly one `belongs_to` despite serving no dilemma (category 4).
 3. **Same-dilemma pre-commit exclusion.** An intersection group must not contain two pre-commit beats of the same dilemma (identified by identical dual `belongs_to` path sets). Such beats are already sequentially ordered in the dilemma's pre-commit chain; grouping them into an intersection implies simultaneity, contradicting the chain ordering. Cross-dilemma pre-commit co-occurrence IS the intended use of intersection groups and remains allowed.
 
 ### Beat Ordering ≠ Temporal Position Relative to Commits
@@ -754,7 +755,7 @@ Vision and Voice Document are singleton nodes with no incoming or outgoing edges
 | `anchored_to` | Dilemma → Entity | BRAINSTORM | Entities central to this dilemma |
 | `explores` | Path → Answer | SEED | Which answer this path develops |
 | `has_consequence` | Path → Consequence | SEED | Narrative outcomes of this path |
-| `belongs_to` | Beat → Path | SEED | Which path this beat serves. Pre-commit beats have two edges (both paths in the dilemma); post-commit beats have one. |
+| `belongs_to` | Beat → Path | SEED, POLISH | Which path this beat serves. Pre-commit beats have two edges (both paths in the dilemma); post-commit beats have one; gap beats (POLISH Phase 1a) have one to their bridging path. |
 | `flexibility` | Beat → Entity | SEED | Substitutable entity. Carries a `role` property on the edge itself (e.g., `role: "mentor"` when the spy could play the mentor role). Working — consumed by GROW. |
 | `predecessor` | Beat → Beat | GROW | Ordering in the beat DAG (B comes after A) |
 | `intersection` | Beat → Intersection Group | GROW | This beat participates in this co-occurrence group |

--- a/docs/design/story-graph-ontology.md
+++ b/docs/design/story-graph-ontology.md
@@ -109,13 +109,13 @@ A narrative beat directly advances a dilemma. It carries **dilemma impacts** (wh
 
 #### Structural Beats
 
-A structural beat serves the DAG without advancing any dilemma. It carries zero `dilemma_impacts` and zero `belongs_to` edges. Every arc that reaches a structural beat via the predecessor chain traverses it — it belongs to no path but is walked through naturally. Seven sub-types:
+A structural beat serves the DAG without advancing any dilemma. It carries zero `dilemma_impacts`. Most structural sub-types also carry zero `belongs_to` edges and are traversed by every arc that reaches them via the predecessor chain. Gap beats (POLISH Phase 1a) are the sole exception: they carry a single `belongs_to` to one path so they appear only on arcs traversing that path. Seven sub-types:
 
 - **Setup beat** (SEED) — world-building before any dilemma is introduced. Establishes context without serving a dilemma.
 - **Epilogue beat** (SEED) — shared narrative resolution after all dilemmas have committed and converged. Wraps up the story as a whole rather than any single dilemma. Distinct from a Setup beat in timing and purpose — Setup opens, Epilogue closes — even though both carry zero `belongs_to`.
 - **Transition beat** (GROW) — atmospheric bridge between cross-dilemma scenes that share no entities or location.
 - **Micro-beat** (POLISH) — brief moment added for pacing within a linear section.
-- **Gap beat** (POLISH) — bridge beat inserted by POLISH Phase 1a (Narrative Gap Insertion) to smooth abrupt narrative leaps in a path's beat sequence. Carries `is_gap_beat=True` and traceability fields (`bridges_from`, `bridges_to`, `transition_style`). Zero `dilemma_impacts`; single `belongs_to` to its path.
+- **Gap beat** (POLISH) — bridge beat inserted by POLISH Phase 1a (Narrative Gap Insertion) to smooth abrupt narrative leaps in a path's beat sequence. Carries `is_gap_beat=True`, `role: gap_beat`, and traceability fields (`bridges_from`, `bridges_to`, `transition_style`). Zero `dilemma_impacts`; single `belongs_to` to its path.
 - **Residue beat** (POLISH) — mood-setter placed before a shared beat. Carries state-flag-specific prose hints; only shown to players holding the relevant flag. Has no `dilemma_impacts` but is flag-dependent.
 - **False branch beat** (POLISH) — a beat on a cosmetic fork-rejoin structure that gives the player the experience of choice without dilemma consequence. A diamond pattern uses one beat per arm; a sidetrack may use several beats on its detour arm. Carries no dilemma relationship. The surrounding choice edges may optionally grant cosmetic state flags (flags unrelated to any dilemma, used later by residue beats or prose variation for flavor).
 
@@ -129,7 +129,7 @@ A structural beat serves the DAG without advancing any dilemma. It carries zero 
 
 **Atmospheric detail** — `atmospheric_detail: str` (10–200 characters). Populated by POLISH Phase 5e. Sensory environment description (sight, sound, smell, texture) — environment, not character emotion. Consumed by FILL for sensory grounding when no scene blueprint supersedes.
 
-**Gap-beat traceability** — `is_gap_beat: bool`, `transition_style: str`, `bridges_from: str | None`, `bridges_to: str | None`. Populated by POLISH Phase 1a (Narrative Gap Insertion) on POLISH-created bridge beats. `bridges_from` and `bridges_to` reference the IDs of the beats this gap beat sits between. `transition_style` is a free-form descriptor (e.g., "smooth", "cut") that informs FILL's transition-context. `is_gap_beat=True` excludes the beat from intersection candidate generation.
+**Gap-beat traceability** — `is_gap_beat: bool`, `role: "gap_beat"`, `transition_style: str`, `bridges_from: str | None`, `bridges_to: str | None`. Populated by POLISH Phase 1a (Narrative Gap Insertion) on POLISH-created bridge beats. `bridges_from` and `bridges_to` reference the IDs of the beats this gap beat sits between. `transition_style` is a free-form descriptor (e.g., "smooth", "cut") that informs FILL's transition-context. The `role` field distinguishes gap beats from pacing-correction beats (POLISH Phase 2 R-2.7), which share `is_gap_beat=True` but have `role: "micro_beat"`. `is_gap_beat=True` excludes the beat from intersection candidate generation if intersection detection is re-derived during a backward loop from GROW Phase 7.
 
 #### Beat Lifecycle
 
@@ -642,7 +642,7 @@ Intersection beats participate in scenes with beats from other paths, but they s
 
 **Same-dilemma pre-commit multi-`belongs_to` is permitted.** A pre-commit beat — one that occurs before the dilemma's commit point — belongs to both paths of its own dilemma. This is structurally correct: every player experiences pre-commit beats regardless of which path they will later choose. Pre-commit beats have two `belongs_to` edges (one to each path in the dilemma); post-commit beats have exactly one. Cross-dilemma multi-`belongs_to` remains forbidden.
 
-**Zero-`belongs_to` beats.** Beats that are not part of any dilemma's Y-shape — all structural beat sub-types (setup, epilogue, transition, micro-beat, residue beat, false branch beat) — have no `belongs_to` edges. They sit on the DAG between path-member beats and do not "belong to" any path. Setup, epilogue, transition, and micro-beats are traversed by every arc that reaches them via the predecessor chain; residue beats are flag-gated and shown only to players holding the corresponding flag; false branch beats are traversed by players who take the cosmetic fork's corresponding choice. See "Total Order Per Arc" in Part 3.
+**Zero-`belongs_to` beats.** Most structural beat sub-types (setup, epilogue, transition, micro-beat, residue beat, false branch beat) have no `belongs_to` edges. They sit on the DAG between path-member beats and do not "belong to" any path. Setup, epilogue, transition, and micro-beats are traversed by every arc that reaches them via the predecessor chain; residue beats are flag-gated and shown only to players holding the corresponding flag; false branch beats are traversed by players who take the cosmetic fork's corresponding choice. **Gap beats** (POLISH Phase 1a) are the structural exception: they carry a single `belongs_to` to one path because they bridge narrative seams within that path's specific beat sequence. See "Total Order Per Arc" in Part 3.
 
 #### Determining a beat's `belongs_to`
 

--- a/docs/superpowers/plans/2026-04-23-grow-phase-4-spec-migration.md
+++ b/docs/superpowers/plans/2026-04-23-grow-phase-4-spec-migration.md
@@ -1,0 +1,798 @@
+# GROW Phase 4 → POLISH Spec Migration Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Update authoritative specs (story-graph-ontology.md, grow.md, polish.md, fill.md) to reflect the structural-vs-narrative GROW/POLISH boundary determined by the audit at `docs/superpowers/specs/2026-04-21-grow-phase-4-sub-phases-audit.md`.  No code changes — code migration follows in a separate plan.
+
+**Architecture:** Spec-only PR.  Three target documents get edits ordered so that downstream files reference fields already defined upstream.  Ontology first (defines the new fields with stage attribution), then grow.md (Phase 4 collapses to 3 sub-phases), then polish.md (absorbs 5 sub-phases as new POLISH phases), then fill.md (cross-reference updates).
+
+**Tech Stack:** Markdown only.  No tests.  Validation is human review (rules numbered uniquely, cross-references resolve, no orphan fields).
+
+**Audit reference:** `docs/superpowers/specs/2026-04-21-grow-phase-4-sub-phases-audit.md` — read the "Final design" section before starting.
+
+**Branch:** `docs/grow-phase-4-audit` (already created; audit doc committed).  All spec edits land here.  Single PR.
+
+---
+
+## File Structure
+
+| File | Responsibility | Lines added (approx) |
+|---|---|---|
+| `docs/design/story-graph-ontology.md` | Field definitions for the 10 new fields with stage attribution | ~80 |
+| `docs/design/procedures/grow.md` | Phase 4 collapses to 3 sub-phases (4a/4b/4c); old "Phase 5: Transition Beat Insertion" becomes Phase 4c; later phases renumbered | ~60 net (mostly relabeling) |
+| `docs/design/procedures/polish.md` | 5 new sub-phases absorbed (1a Narrative Gap Insertion; 2 extended; 3 extended; 5e Atmospheric; 5f Path Thematic) | ~150 |
+| `docs/design/procedures/fill.md` | Cross-reference updates — fields it consumes now populated by POLISH (formerly GROW) | ~10 |
+
+---
+
+## Naming conventions used in this plan
+
+- **GROW Phase 4** post-migration: 4a Interleave, 4b Scene Types Annotation, 4c Transition Beat Insertion.
+- **POLISH** sub-phase names: keep existing 1/2/3/4/5/6/7 numbering; add **Phase 1a: Narrative Gap Insertion** as a new sub-phase between current Phase 1 and Phase 2; extend Phase 2 (pacing absorbs from old GROW 4c); extend Phase 3 (entity arcs absorbs from old GROW 4f); add **Phase 5e: Atmospheric Annotation** and **Phase 5f: Path Thematic Annotation** as new LLM Enrichment sub-phases.
+- **Field stage attribution**: every new ontology field is annotated with `(populated by GROW)` or `(populated by POLISH)` so consumers know when the field becomes available.
+- **Rule numbers**: GROW Phase 4 rules use R-4a.* / R-4b.* / R-4c.*.  POLISH new rules use R-1a.* / R-2.6+ / R-3.6+ / R-5e.* / R-5f.* — pick the next available number after the existing range in each phase.
+
+---
+
+## Task 1: Baseline sanity
+
+**Files:** None (verification only).
+
+- [ ] **Step 1: Confirm branch state**
+
+```bash
+cd /mnt/code/questfoundry
+git status
+git log --oneline -3
+```
+Expected: on `docs/grow-phase-4-audit`, last commit is `0db3df67 docs(audit): resolve Q1-Q7 in GROW Phase 4 sub-phase audit`.
+
+- [ ] **Step 2: Read the audit doc**
+
+Open `docs/superpowers/specs/2026-04-21-grow-phase-4-sub-phases-audit.md`.  Read the "Resolutions" and "Final design" sections in full.  These are the load-bearing decisions this plan implements.
+
+- [ ] **Step 3: No commit — proceed to Task 2**
+
+---
+
+## Task 2: Ontology — add Beat fields populated by GROW
+
+**Files:**
+- Modify: `docs/design/story-graph-ontology.md` Beat section (line 92+)
+
+- [ ] **Step 1: Locate the Beat section**
+
+The Beat section starts at `docs/design/story-graph-ontology.md:92` (`### Beat`).  Find the field listing within that section.  The existing fields include `summary`, `entity references`, `dilemma_impacts`, `belongs_to`, intersection groupings, state flag associations.
+
+- [ ] **Step 2: Add the three GROW-populated annotation fields**
+
+Insert this block in the Beat section's field listing, after the existing `dilemma_impacts` description and before `belongs_to`.  Use the same prose style as surrounding field descriptions (typically a paragraph per field):
+
+```markdown
+**Scene-type annotation** — `scene_type ∈ {scene, sequel, micro_beat}`.  Populated by GROW Phase 4b.  Encodes Scene/Sequel rhythm (Swain): `scene` = active conflict (goal → conflict → disaster); `sequel` = reactive processing (emotion → thought → decision); `micro_beat` = brief transition.  Consumed by POLISH Phase 2 for pacing detection and by FILL for prose intensity / target length derivation.
+
+**Narrative function** — `narrative_function ∈ {introduce, develop, complicate, confront, resolve}`.  Populated by GROW Phase 4b.  The beat's role in story structure (Freytag-style, compressed to beat level).  Consumed by FILL for prose pacing and by DRESS for illustration priority.
+
+**Exit mood** — `exit_mood: str` (2–40 characters).  Populated by GROW Phase 4b.  Free-form descriptor of the emotional state the beat hands off to its successor.  Consumed by FILL for narrative-context generation; informs reader-affect transitions between beats.
+```
+
+- [ ] **Step 3: Add the four POLISH-populated annotation fields**
+
+Insert this block immediately after the GROW-populated block (still within the Beat section's field listing):
+
+```markdown
+**Atmospheric detail** — `atmospheric_detail: str` (10–200 characters).  Populated by POLISH Phase 5e.  Sensory environment description (sight, sound, smell, texture) — environment, not character emotion.  Consumed by FILL for sensory grounding when no scene blueprint supersedes.
+
+**Gap-beat traceability** — `is_gap_beat: bool`, `transition_style: str`, `bridges_from: str | None`, `bridges_to: str | None`.  Populated by POLISH Phase 1a (Narrative Gap Insertion) on POLISH-created bridge beats.  `bridges_from` and `bridges_to` reference the IDs of the beats this gap beat sits between.  `transition_style` is a free-form descriptor (e.g., "smooth", "cut") that informs FILL's transition-context.  `is_gap_beat=True` excludes the beat from intersection candidate generation.
+```
+
+- [ ] **Step 4: Update Beat sub-type list (if present)**
+
+If the Beat section enumerates sub-types (setup beat / commit beat / post-commit / transition beat / micro-beat / etc.), add **gap beat** as a POLISH-created structural sub-type with zero `dilemma_impacts` and zero `belongs_to` (matching the existing structural-beat pattern).  If no such enumeration exists, skip this step.
+
+- [ ] **Step 5: Run a quick rule-number cross-check**
+
+```bash
+grep -nE 'R-4[abc]\.|R-1a\.|R-5[ef]\.' docs/design/story-graph-ontology.md
+```
+Expected: empty (the ontology shouldn't reference procedure-rule numbers; it's a separate document).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add docs/design/story-graph-ontology.md
+git commit -m "docs(ontology): add Beat annotation fields populated by GROW and POLISH
+
+Adds scene_type / narrative_function / exit_mood (GROW Phase 4b),
+atmospheric_detail (POLISH Phase 5e), and gap-beat traceability
+fields (POLISH Phase 1a) to the Beat section.
+
+Per the GROW Phase 4 sub-phase audit
+(docs/superpowers/specs/2026-04-21-grow-phase-4-sub-phases-audit.md),
+these fields are foundation annotations that consumers (FILL, POLISH,
+DRESS) read but the ontology never formally defined.  Each field is
+annotated with the stage that populates it so consumers can reason
+about availability.
+
+Part of completing the GROW→POLISH migration started in epics
+#990 / #1057."
+```
+
+---
+
+## Task 3: Ontology — add Path fields populated by POLISH
+
+**Files:**
+- Modify: `docs/design/story-graph-ontology.md` Path section (line 75+)
+
+- [ ] **Step 1: Locate the Path section**
+
+The Path section starts at `docs/design/story-graph-ontology.md:75` (`### Path`).  Find its field listing.
+
+- [ ] **Step 2: Add the two POLISH-populated path-level annotation fields**
+
+Insert this block in the Path section's field listing:
+
+```markdown
+**Path theme** — `path_theme: str` (10–200 characters).  Populated by POLISH Phase 5f.  Per-path emotional through-line / "controlling idea" (McKee).  In branching fiction, different answers to the same dilemma should produce qualitatively different narrative experiences; `path_theme` is the path's answer to "what is this journey's emotional identity?"  Consumed by FILL (narrative context, choice consequence labels) and DRESS (illustration `path_undertone`).
+
+**Path mood** — `path_mood: str` (2–50 characters).  Populated by POLISH Phase 5f.  Tonal palette for the path as a whole (e.g., "melancholic", "frenetic", "tense-then-resolved").  Distinct from beat-level `exit_mood` which describes per-beat handoff feeling — `path_mood` is the path's macro-tone.  Consumed by FILL and DRESS for tonal framing.
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/design/story-graph-ontology.md
+git commit -m "docs(ontology): add Path theme/mood fields populated by POLISH
+
+Adds path_theme and path_mood to the Path section.  Both populated by
+POLISH Phase 5f (new sub-phase absorbed from the migration of old GROW
+4e).  Consumers: FILL (narrative context, choice labels), DRESS
+(illustration tonal framing).
+
+Part of the GROW→POLISH migration completion."
+```
+
+---
+
+## Task 4: Ontology — extend Entity arc data for per-path positional info
+
+**Files:**
+- Modify: `docs/design/story-graph-ontology.md` Entity section (line 33+) and/or Character Arc Metadata section (search for "Character Arc Metadata" anchor — Part 1).
+
+- [ ] **Step 1: Find the existing character_arc / Character Arc Metadata definition**
+
+```bash
+grep -n 'character_arc\|Character Arc Metadata' docs/design/story-graph-ontology.md
+```
+The current shape (per POLISH spec R-3.2): `start: str`, `pivots: dict[path_id → beat_id]`, `end_per_path: dict[path_id → str]`.  Stored as a `character_arc` annotation on the Entity node (per R-3.3).
+
+- [ ] **Step 2: Extend the Character Arc Metadata definition**
+
+In the existing definition, add the per-path positional list field absorbed from the migration of old GROW 4f:
+
+```markdown
+**Per-path arc trajectories** — `arcs_per_path: list[{path_id: str, arc_type: str, arc_line: str, pivot_beat: str}]`.  Populated by POLISH Phase 3 (Character Arc Synthesis, extended).  One entry per path on which this entity is arc-worthy.  `arc_type` is determined by the entity's category: character → "transformation", location → "atmosphere", object → "significance", faction → "relationship".  `arc_line` is a concise A → B → C trajectory.  `pivot_beat` is the beat at which the entity's trajectory turns.  Consumed by FILL for per-passage positional context (pre-pivot / at-pivot / post-pivot).
+```
+
+The full `character_arc` annotation now contains: `start`, `pivots`, `end_per_path`, AND `arcs_per_path`.  Note in the description that `pivots` (existing, entity-scoped per-path map) and `arcs_per_path[*].pivot_beat` (new, path-scoped record) MUST agree for the same `path_id` — they describe the same pivot from different indexing angles.  POLISH Phase 3 enforces this by producing both in a single LLM call.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/design/story-graph-ontology.md
+git commit -m "docs(ontology): extend character_arc with per-path positional trajectories
+
+Per audit Q6 resolution (B): POLISH Phase 3 absorbs old GROW 4f.
+character_arc gains arcs_per_path[] with arc_type/arc_line/pivot_beat
+per path, populated alongside the existing start/pivots/end_per_path.
+
+One source of truth on Entity nodes; consumers index by entity_id
+or by (entity_id, path_id) as needed.  Internal consistency: pivots
+and arcs_per_path[*].pivot_beat must agree per path."
+```
+
+---
+
+## Task 5: GROW — restructure Phase 4 into sub-phases 4a/4b/4c
+
+**Files:**
+- Modify: `docs/design/procedures/grow.md` Phase 4 section (line 235+) and Phase 5 section (line 276+)
+
+- [ ] **Step 1: Read current Phase 4 and Phase 5**
+
+Read `docs/design/procedures/grow.md:235-315`.  Note:
+- Current Phase 4 ("Interleave") is the single sub-phase covering cross-dilemma ordering edge creation.
+- Current Phase 5 ("Transition Beat Insertion") describes 4g's behavior (insert bridge beats at hard cuts).
+
+- [ ] **Step 2: Rewrite Phase 4 header with sub-phase structure**
+
+Replace the Phase 4 section's heading and intro with:
+
+```markdown
+## Phase 4: DAG Assembly and Annotation
+
+**Purpose:** Combine per-dilemma scaffolds into a single beat DAG with structural annotations.  Three sub-phases:
+
+- **4a Interleave** — create cross-dilemma ordering edges (existing).
+- **4b Scene Types Annotation** — tag every beat with scene/sequel + narrative function + exit mood.  Foundation annotation that POLISH Phase 2 pacing depends on.
+- **4c Transition Beat Insertion** — insert bridge beats at cross-dilemma hard cuts (no shared entity, no shared location).  Was previously labeled "Phase 5" in this spec; absorbed into Phase 4 as a sub-phase since it is part of structural DAG assembly.
+
+This phase produces a structurally complete and minimally annotated beat DAG.  Narrative-quality concerns (rhythm correction, narrative gap filling, sensory annotation, thematic context) are POLISH's responsibility per the structural-vs-narrative boundary (see audit doc 2026-04-21-grow-phase-4-sub-phases-audit.md).
+
+### 4a — Interleave
+```
+
+(Keep the existing Phase 4 Operations content as the body of the new "4a — Interleave" subsection.  Existing rules R-4.1, R-4.2, etc. become R-4a.1, R-4a.2 — renumber by prefix.)
+
+- [ ] **Step 3: Add the new 4b Scene Types Annotation sub-phase**
+
+After the 4a sub-section, add:
+
+```markdown
+### 4b — Scene Types Annotation
+
+**Purpose:** Tag every beat in the assembled DAG with `scene_type`, `narrative_function`, and `exit_mood`.  These fields are foundation annotations consumed by POLISH (Phase 2 pacing detection), FILL (prose pacing derivation, narrative context), and DRESS (illustration priority).
+
+#### Input Contract
+
+1. Phase 4a Output Contract satisfied (interleaved DAG complete).
+2. All beat nodes have summaries populated by SEED.
+
+#### Operations
+
+##### Single-Pass Beat Classification
+
+**What:** For all beat nodes in the graph, a single LLM call produces tags per beat.  Each tag includes the three field values.  Invalid beat IDs in the LLM response are silently skipped with an INFO log.
+
+**Rules:**
+
+R-4b.1. Every beat receives `scene_type ∈ {scene, sequel, micro_beat}`.  Partial coverage (LLM tags only some beats) MUST emit a WARNING; downstream consumers fall back to `"scene"` if the field is absent.
+
+R-4b.2. Every beat receives `narrative_function ∈ {introduce, develop, complicate, confront, resolve}`.
+
+R-4b.3. Every beat receives `exit_mood`: a 2–40 character free-form descriptor of the emotional handoff to the next beat.
+
+R-4b.4. Phase 4b is a single LLM call covering all beats; per-beat retries are not used.  On overall LLM failure, the phase MUST return failed status (no silent default).
+
+**Violations:**
+
+| Symptom | Root cause | Broken rule |
+|---------|-----------|-------------|
+| Beat without `scene_type` | Partial LLM coverage; missing WARNING | R-4b.1 |
+| `scene_type` outside the enum | Schema validator missing | R-4b.1 |
+| `exit_mood` empty string | Length constraint not enforced | R-4b.3 |
+
+#### Output Contract
+
+1. Every beat has `scene_type`, `narrative_function`, `exit_mood` populated.  Partial coverage produces a WARNING.
+2. No graph mutations beyond the three field updates per beat.
+```
+
+- [ ] **Step 4: Replace current Phase 5 with 4c Transition Beat Insertion**
+
+Move the existing Phase 5 section (currently `## Phase 5: Transition Beat Insertion`) to be a `### 4c — Transition Beat Insertion` subsection under Phase 4.  Renumber the existing Phase 5 rules to R-4c.* (e.g., R-5.1 → R-4c.1).  Keep all other content (purpose, input contract, operations, output contract) verbatim.
+
+- [ ] **Step 5: Renumber the remaining grow.md phases**
+
+Old Phase 6 → new Phase 5.  Old Phase 7 → new Phase 6.  Old Phase 8 → new Phase 7.  Old Phase 9 → new Phase 8.
+
+For each renumbered phase:
+1. Update the section heading.
+2. Renumber any rules referencing the phase number (e.g., R-6.1 → R-5.1).
+3. Update internal cross-references in the same file.
+
+Run after this step:
+```bash
+grep -nE 'R-[6-9]\.' docs/design/procedures/grow.md
+```
+Expected: empty (no rules referencing phases 6–9 anymore).
+
+```bash
+grep -nE 'Phase [6-9]' docs/design/procedures/grow.md
+```
+Expected: empty.
+
+- [ ] **Step 6: Update Rule Index section**
+
+In the Rule Index section of grow.md, update:
+- Old R-4.* entries → R-4a.*
+- Add R-4b.1 through R-4b.4 entries.
+- Old R-5.* entries → R-4c.*
+- Old R-6.* through R-9.* entries → R-5.* through R-8.*
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add docs/design/procedures/grow.md
+git commit -m "docs(grow): collapse Phase 4 into 3 sub-phases; absorb old Phase 5
+
+Phase 4 now has three sub-phases: 4a Interleave (existing),
+4b Scene Types Annotation (new — documents the LLM-tagging code
+that was previously undocumented), 4c Transition Beat Insertion
+(absorbed from old Phase 5 since it is part of structural DAG
+assembly, not a separate phase).
+
+Old Phase 5 → 4c.  Old Phases 6/7/8/9 renumbered to 5/6/7/8.
+Rule indices updated.
+
+Per audit doc 2026-04-21-grow-phase-4-sub-phases-audit.md.  Part
+of completing the GROW→POLISH migration (epics #990 / #1057).
+
+5 other Phase 4 sub-phases (narrative_gaps, pacing_gaps,
+atmospheric, path_arcs, entity_arcs) move to POLISH in the next
+commit per the structural-vs-narrative boundary."
+```
+
+---
+
+## Task 6: POLISH — add Phase 1a Narrative Gap Insertion
+
+**Files:**
+- Modify: `docs/design/procedures/polish.md` between Phase 1 (line 32) and Phase 2 (line 75)
+
+- [ ] **Step 1: Locate the insertion point**
+
+After `Phase 1: Beat Reordering` finishes (around line 75 just before `## Phase 2: Pacing Micro-Beat Injection`), insert a new top-level section.
+
+Note: this is a new sub-phase in POLISH's pre-Beat-DAG-Freeze section.  We use "Phase 1a" rather than renumbering Phase 2 onward, to minimize churn in existing rule numbers.
+
+- [ ] **Step 2: Add the Phase 1a section**
+
+Insert verbatim:
+
+```markdown
+## Phase 1a: Narrative Gap Insertion
+
+**Purpose:** Detect structural narrative jumps in path beat sequences (e.g., a path goes setup → climax with no development beat) and insert bridging gap beats to smooth abrupt narrative leaps.  Absorbed from old GROW 4b per audit Q1 resolution: gap insertion is narrative-craft work (improves how the story reads), not structural skeleton (which dilemmas exist).
+
+### Input Contract
+
+1. Phase 1 Output Contract satisfied (beat reorderings applied).
+2. Beats carry `scene_type` annotation (populated by GROW Phase 4b).
+
+### Operations
+
+#### Gap Detection and Insertion
+
+**What:** For each path with 2+ beats, the LLM is given the beat sequence (with truncated summaries and scene-type tags).  It identifies missing intermediate beats and proposes new beats to insert at specified positions.  POLISH validates each proposal (referenced beat IDs exist, ordering is correct) and inserts gap beats with the appropriate predecessor edges and `belongs_to` to the path.
+
+**Rules:**
+
+R-1a.1. Inserted gap beats carry `is_gap_beat: True` and `role: gap_beat` and `created_by: "POLISH"`.
+
+R-1a.2. Inserted gap beats carry zero `dilemma_impacts`.  They are structural transition beats; they MUST NOT advance any dilemma.  This matches the structural-beat invariant for all POLISH-created beats (R-2.1, R-5.10, etc.).
+
+R-1a.3. Inserted gap beats record traceability fields: `bridges_from` (the earlier beat ID), `bridges_to` (the later beat ID), `transition_style` (free-form descriptor).
+
+R-1a.4. Per-path cap: maximum 2 gap beats inserted per path per Phase 1a invocation.
+
+R-1a.5. Invalid LLM proposals (bad beat IDs, ordering violations) MUST log at WARNING and skip the proposal; do not silently accept.
+
+**Violations:**
+
+| Symptom | Root cause | Broken rule |
+|---------|-----------|-------------|
+| Gap beat with non-empty `dilemma_impacts` | Structural-beat invariant violated | R-1a.2 |
+| Gap beat without `bridges_from` / `bridges_to` | Traceability missing | R-1a.3 |
+| 3+ gap beats on one path | Cap not enforced | R-1a.4 |
+| Phase 1a accepts a proposal referencing non-existent `before_beat` ID | Validation skipped | R-1a.5 |
+
+### Output Contract
+
+1. Zero or more gap beats added to the graph.  Each carries `is_gap_beat=True`, zero `dilemma_impacts`, `belongs_to` to its path, predecessor edges placing it between `bridges_from` and `bridges_to`, and `created_by: "POLISH"`.
+2. Path beat sequences may be longer than at Phase 1a's start; original (non-gap) beats are unmodified.
+```
+
+- [ ] **Step 3: Update POLISH Rule Index for the new R-1a.* entries**
+
+In the Rule Index section of polish.md (search for "Rule Index"), insert R-1a.1 through R-1a.5 entries at the appropriate position.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docs/design/procedures/polish.md
+git commit -m "docs(polish): add Phase 1a Narrative Gap Insertion
+
+New POLISH sub-phase absorbed from old GROW 4b (narrative_gaps).
+Gap beats are structural (zero dilemma_impacts, role=gap_beat,
+created_by=POLISH) — matching the existing POLISH structural-beat
+pattern.  Rules R-1a.1 through R-1a.5 added.
+
+Per audit doc Q1 resolution: gap insertion is narrative work
+(improves prose readability), not structural skeleton, so it
+belongs in POLISH not GROW.  Auto-resolves Q4 (gap beats with
+dilemma_impacts) via the POLISH structural-beat rule."
+```
+
+---
+
+## Task 7: POLISH — extend Phase 2 Pacing Micro-Beat Injection to absorb pacing_gaps
+
+**Files:**
+- Modify: `docs/design/procedures/polish.md` Phase 2 section (line 75+)
+
+- [ ] **Step 1: Read the current Phase 2 section**
+
+Read `docs/design/procedures/polish.md:75-117`.  Note current rules R-2.1 through R-2.5.
+
+- [ ] **Step 2: Extend the Phase 2 Operations to include pacing_gaps detection**
+
+In the Phase 2 "Operations" subsection, after the existing micro-beat detection description, append:
+
+```markdown
+##### Pacing-Run Detection
+
+**What:** In the same Phase 2 invocation, deterministically detect runs of 3+ consecutive beats with the same `scene_type` along any path (the "monotonous run" condition).  For each detected run, propose a correction beat of the opposite type (insert a sequel between scenes, or a scene between sequels) to break the monotony.  Implementation may share its LLM call with the micro-beat detection above.
+
+(Absorbed from old GROW 4c.  Per audit Q1, pacing rhythm correction is narrative work — POLISH territory.)
+```
+
+- [ ] **Step 3: Add pacing-run rules**
+
+After R-2.5, add:
+
+```markdown
+R-2.6. Phase 2 detects runs of 3+ consecutive same-`scene_type` beats per path and inserts correction beats of the opposite type to break the run.  Detection is deterministic; the correction-beat content is LLM-generated.
+
+R-2.7. Correction beats carry `is_gap_beat: True`, `role: micro_beat`, zero `dilemma_impacts`, `created_by: "POLISH"`.  They are structurally indistinguishable from pacing micro-beats; the `is_gap_beat` flag distinguishes their origin (pacing-run correction vs. pacing-flag micro-beat insertion).
+
+R-2.8. Phase 2 MUST NOT introduce new monotonous runs while breaking existing ones.  If a candidate correction beat would extend a run on the opposite side of the insertion point, the proposal is rejected.
+```
+
+Update the Violations table with one new row:
+
+```markdown
+| 4+ consecutive same-`scene_type` beats remain after Phase 2 | Pacing-run detection skipped or correction failed | R-2.6 |
+```
+
+- [ ] **Step 4: Update Rule Index for R-2.6 / R-2.7 / R-2.8**
+
+In polish.md's Rule Index, add the three new R-2.* entries at the appropriate position.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add docs/design/procedures/polish.md
+git commit -m "docs(polish): extend Phase 2 with pacing-run correction (was GROW 4c)
+
+Per audit Q1, pacing-run correction is narrative work (rhythm
+prep), not structural — belongs in POLISH not GROW.  Same
+trigger as POLISH Phase 2's existing pacing micro-beat injection
+(3+ consecutive same scene_type), so consolidated into Phase 2
+as a second sub-operation rather than a new phase.
+
+R-2.6 through R-2.8 added."
+```
+
+---
+
+## Task 8: POLISH — extend Phase 3 Character Arc Synthesis to absorb entity_arcs
+
+**Files:**
+- Modify: `docs/design/procedures/polish.md` Phase 3 section (line 117+)
+
+- [ ] **Step 1: Read the current Phase 3 section**
+
+Read `docs/design/procedures/polish.md:117-158`.  Existing rules R-3.1 through R-3.5 cover entity arc-worthiness, the start/pivots/end_per_path structure, and entity-annotation storage.
+
+- [ ] **Step 2: Extend Phase 3 Purpose**
+
+Update the Phase 3 Purpose paragraph to mention the per-path positional data:
+
+```markdown
+**Purpose:** For each entity appearing in 2+ beats, synthesize explicit arc metadata — start, pivots per path, end per path, AND per-path positional trajectory data — that FILL uses to maintain prose consistency.  The per-path positional data (`arcs_per_path`) was previously produced by old GROW 4f and is now consolidated here per audit Q6 resolution: a single source of truth on Entity nodes, indexed for FILL's per-passage positional context.
+```
+
+- [ ] **Step 3: Add R-3.6 through R-3.8 for the new positional data**
+
+After R-3.5, add:
+
+```markdown
+R-3.6. The character_arc annotation includes `arcs_per_path: list[{path_id: str, arc_type: str, arc_line: str, pivot_beat: str}]`, one entry per path on which the entity is arc-worthy.  Single LLM call produces both the existing fields (start, pivots, end_per_path) and `arcs_per_path` together, ensuring internal consistency.
+
+R-3.7. `arc_type` is determined deterministically by the entity's category: character → "transformation", location → "atmosphere", object → "significance", faction → "relationship".  The LLM does not choose `arc_type`; POLISH derives it from the entity node and validates the LLM output matches.
+
+R-3.8. For each `path_id` present in both `pivots` and `arcs_per_path`, the values MUST agree: `pivots[path_id]` (the entity-scoped pivot beat for that path) MUST equal the `pivot_beat` of the matching `arcs_per_path` entry.  POLISH enforces this at synthesis time (single LLM call producing both, validated together).
+```
+
+Update Violations table:
+
+```markdown
+| `arcs_per_path` missing for an entity with 2+ appearances on a path | Phase 3 partial coverage | R-3.6 |
+| `arc_type` does not match the entity's category | Validation gap | R-3.7 |
+| `pivots[path_id] != arcs_per_path[*].pivot_beat` for the same path | Internal-consistency check skipped | R-3.8 |
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docs/design/procedures/polish.md
+git commit -m "docs(polish): extend Phase 3 to absorb per-path positional arc data (was GROW 4f)
+
+Per audit Q6 resolution (B): POLISH Phase 3 absorbs old GROW 4f
+content.  Phase 3 now produces the existing start/pivots/end_per_path
+structure AND a new per-path positional list (arcs_per_path) in a
+single LLM call, ensuring internal consistency by construction.
+
+R-3.6 through R-3.8 added: arcs_per_path field, deterministic
+arc_type derivation by entity category, and the single-LLM-call
+consistency rule that pivots[path_id] == arcs_per_path[*].pivot_beat
+for the same path."
+```
+
+---
+
+## Task 9: POLISH — add Phase 5e Atmospheric Annotation
+
+**Files:**
+- Modify: `docs/design/procedures/polish.md` Phase 5 section (line 281+)
+
+- [ ] **Step 1: Locate Phase 5 sub-phase area**
+
+Phase 5 (LLM Enrichment) currently has sub-phases 5a (choice labels), 5b (residue content), 5c (false branch decisions), 5d (variant summaries).  Add 5e and 5f after the existing sub-phases.
+
+- [ ] **Step 2: Add Phase 5e Atmospheric Annotation**
+
+Insert after the existing sub-phases in Phase 5:
+
+```markdown
+#### 5e — Atmospheric Annotation
+
+**What:** For every beat in the frozen DAG, produce an `atmospheric_detail` string (10–200 characters) describing the sensory environment: sight, sound, smell, texture.  Environment, not character emotion.  A single LLM call produces details for all beats.  Absorbed from old GROW 4d per audit Q1: sensory grounding is prose-prep, not structural.
+
+**Rules:**
+
+R-5e.1. Every beat receives `atmospheric_detail` populated by Phase 5e.  Partial coverage (LLM details only some beats) MUST log a WARNING; FILL falls back to scene-blueprint sensory data when `atmospheric_detail` is absent.
+
+R-5e.2. `atmospheric_detail` describes ENVIRONMENT (sight/sound/smell/texture/light/temperature/etc.), not character interiority.  This separation is enforced by the LLM prompt; the spec does not mandate prose-content checks.
+
+R-5e.3. Phase 5e runs after Beat DAG Freeze, so transition beats inserted by GROW Phase 4c receive `atmospheric_detail` like any other beat (auto-fixes the transition-beat-atmospheric gap noted in the audit Q3).
+
+**Violations:**
+
+| Symptom | Root cause | Broken rule |
+|---------|-----------|-------------|
+| Beat without `atmospheric_detail` and no WARNING | Partial coverage detection skipped | R-5e.1 |
+| Transition beat without `atmospheric_detail` | Phase 5e ran before transition-beat creation, OR transition beats excluded from coverage | R-5e.3 |
+```
+
+- [ ] **Step 3: Add Phase 5f Path Thematic Annotation**
+
+After 5e:
+
+```markdown
+#### 5f — Path Thematic Annotation
+
+**What:** For each path, produce a `path_theme` (10–200 characters) and `path_mood` (2–50 characters) summarizing the path's emotional through-line and tonal palette.  One LLM call per path; the LLM consumes the full beat sequence with their summaries, scene types, narrative functions, and exit moods.  Absorbed from old GROW 4e per audit Q1: per-path narrative identity is prose-prep, not structural.
+
+**Rules:**
+
+R-5f.1. Every path with 2+ beats receives `path_theme` and `path_mood`.  Paths with fewer than 2 beats are skipped (no narrative arc to summarize).
+
+R-5f.2. `path_theme` is the path's emotional through-line / "controlling idea" (McKee).  `path_mood` is its tonal palette.  Both are LLM-generated free-form strings; the spec does not enforce specific vocabularies.
+
+R-5f.3. Per-path LLM failures MUST log at WARNING and leave the path's fields unpopulated.  FILL and DRESS handle missing fields by falling back to path description / dilemma question text.
+
+**Violations:**
+
+| Symptom | Root cause | Broken rule |
+|---------|-----------|-------------|
+| Multi-beat path without `path_theme` and no WARNING | Per-path failure detection skipped | R-5f.3 |
+| `path_mood` exceeds 50 characters | Schema length not enforced | R-5f.2 |
+```
+
+- [ ] **Step 4: Update Rule Index**
+
+In polish.md Rule Index, add R-5e.1 through R-5e.3 and R-5f.1 through R-5f.3 entries.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add docs/design/procedures/polish.md
+git commit -m "docs(polish): add Phase 5e Atmospheric Annotation + Phase 5f Path Thematic Annotation
+
+Two new POLISH Phase 5 (LLM Enrichment) sub-phases absorbed from old
+GROW 4d (atmospheric) and 4e (path_arcs).  Per audit Q1, both are
+narrative-prep concerns (sensory grounding for prose; per-path tonal
+identity for FILL/DRESS), not structural.
+
+R-5e.1 through R-5e.3 + R-5f.1 through R-5f.3 added.
+
+R-5e.3 documents that running atmospheric annotation after Beat DAG
+Freeze auto-fixes the transition-beat atmospheric gap from audit Q3:
+GROW 4c transition beats now receive atmospheric_detail like any
+other beat."
+```
+
+---
+
+## Task 10: FILL — update cross-references for migrated fields
+
+**Files:**
+- Modify: `docs/design/procedures/fill.md` — anywhere consumed fields are described as "populated by GROW"
+
+- [ ] **Step 1: Find FILL references to the migrated fields**
+
+```bash
+grep -nE 'GROW.*atmospheric_detail|GROW.*path_theme|GROW.*path_mood|GROW.*entity_arcs|GROW.*scene_type|GROW.*narrative_function|GROW.*exit_mood|GROW.*is_gap_beat' docs/design/procedures/fill.md
+```
+
+For each hit:
+- If the field is still GROW-populated post-migration (`scene_type`, `narrative_function`, `exit_mood`), leave it alone.
+- If the field is now POLISH-populated (`atmospheric_detail`, `path_theme`, `path_mood`, `arcs_per_path`, `is_gap_beat` traceability), update the reference to say "populated by POLISH".
+
+- [ ] **Step 2: Update the Stage Input Contract for FILL (if it lists field sources)**
+
+Read fill.md's Stage Input Contract section (search for `## Stage Input Contract`).  If it enumerates the fields FILL expects from upstream stages, ensure the migrated fields are listed under POLISH outputs (not GROW outputs).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/design/procedures/fill.md
+git commit -m "docs(fill): update cross-references for migrated POLISH fields
+
+After the GROW Phase 4 sub-phase migration to POLISH (per audit doc
+2026-04-21-grow-phase-4-sub-phases-audit.md), these fields are now
+populated by POLISH rather than GROW:
+
+- atmospheric_detail (POLISH Phase 5e)
+- path_theme, path_mood (POLISH Phase 5f)
+- character_arc.arcs_per_path (POLISH Phase 3, extended)
+- gap-beat traceability fields (POLISH Phase 1a)
+
+FILL still reads the same fields; only the source attribution
+changes."
+```
+
+---
+
+## Task 11: Self-review pass
+
+**Files:** None (verification only).
+
+- [ ] **Step 1: Verify rule numbering uniqueness**
+
+```bash
+grep -nE '^R-[0-9]+[a-z]?\.[0-9]+:' docs/design/procedures/grow.md docs/design/procedures/polish.md docs/design/procedures/fill.md | sort -u | wc -l
+grep -nE '^R-[0-9]+[a-z]?\.[0-9]+:' docs/design/procedures/grow.md docs/design/procedures/polish.md docs/design/procedures/fill.md | awk -F: '{print $1 ":" $3}' | sort | uniq -d
+```
+First command: count of unique rule lines.  Second: should print nothing (no duplicate rule numbers within a file).
+
+- [ ] **Step 2: Verify cross-references resolve**
+
+```bash
+grep -nE 'Phase [0-9]+[a-z]?' docs/design/procedures/grow.md
+grep -nE 'Phase [0-9]+[a-z]?' docs/design/procedures/polish.md
+```
+Manually verify every "Phase N" reference matches an actual section heading in the same file.
+
+- [ ] **Step 3: Verify ontology field stage-attribution is consistent**
+
+```bash
+grep -nE 'populated by (GROW|POLISH)' docs/design/story-graph-ontology.md
+```
+For each match, confirm the cited stage and phase number actually populate the field per the procedure spec.  Cross-check against grow.md / polish.md sub-phase content.
+
+- [ ] **Step 4: Verify no orphan field definitions**
+
+For each new ontology field added in Tasks 2–4, confirm at least one consumer in fill.md or polish.md or another procedure doc references it.
+
+- [ ] **Step 5: No commit — checks only.  If anything is wrong, fix it inline and re-run the relevant prior task's commit step.**
+
+---
+
+## Task 12: Push branch and open PR
+
+**Files:** None (git operations only).
+
+- [ ] **Step 1: Verify branch state**
+
+```bash
+git status
+git log --oneline origin/main..HEAD
+```
+Expected: clean tree; ~10 commits on the branch (audit doc + 10 spec edit commits + maybe self-review fixups).
+
+- [ ] **Step 2: Push**
+
+```bash
+git push -u origin docs/grow-phase-4-audit
+```
+
+- [ ] **Step 3: Open the PR**
+
+```bash
+gh pr create --base main --title 'docs(grow,polish,ontology): GROW Phase 4 → POLISH spec migration' --body "$(cat <<'EOF'
+## Summary
+
+Spec-only PR completing the GROW→POLISH migration that started in epics #990 / #1057 but didn't move five sub-phases that should have moved.  Surfaced via FILL spec audit follow-on #1365.
+
+Audit doc: \`docs/superpowers/specs/2026-04-21-grow-phase-4-sub-phases-audit.md\`.  Read its "Final design" section first.
+
+Closes #1365.
+
+## What changed
+
+**Principle (audit Q1):** GROW = structure (load-bearing skeleton).  POLISH = narrative (rhythm, pacing, prose-readiness).  Pacing/atmospheric/thematic work is narrative-prep, so POLISH territory.
+
+**GROW Phase 4** collapses to 3 sub-phases:
+- 4a Interleave (existing)
+- 4b Scene Types Annotation (NEW — documents the LLM-tagging code that was previously undocumented)
+- 4c Transition Beat Insertion (absorbed from old Phase 5)
+
+Old Phase 5 → 4c.  Old Phases 6/7/8/9 renumbered to 5/6/7/8.
+
+**POLISH** absorbs 5 sub-phases from old GROW Phase 4:
+- new **Phase 1a** Narrative Gap Insertion (was GROW 4b)
+- **Phase 2** extended with pacing-run correction (was GROW 4c)
+- **Phase 3** extended to absorb per-path entity arc data (was GROW 4f) per audit Q6 resolution B
+- new **Phase 5e** Atmospheric Annotation (was GROW 4d)
+- new **Phase 5f** Path Thematic Annotation (was GROW 4e)
+
+**Ontology** gains stage-attributed field definitions for ~10 fields previously undocumented:
+- Beat: scene_type, narrative_function, exit_mood (GROW); atmospheric_detail, gap-beat traceability fields (POLISH)
+- Path: path_theme, path_mood (POLISH)
+- Entity: character_arc.arcs_per_path (POLISH Phase 3, extended)
+
+**FILL** cross-references updated for fields whose populator changed (GROW → POLISH).
+
+## No code changes
+
+Pure spec PR.  Code migration follows in a separate plan PR — moving 5 sub-phase implementations from GROW to POLISH is substantial work that warrants its own scoping.  Per CLAUDE.md §Design Doc Authority, spec lands first; code follows.
+
+## Cross-effects
+
+- **Audit Q3 (transition-beat atmospheric gap)** auto-fixed by the migration: POLISH Phase 5e (atmospheric) runs after GROW Phase 4c (transition beat creation), so transition beats receive atmospheric_detail naturally.
+- **Audit Q4 (gap beats with dilemma_impacts)** auto-resolved: POLISH-created beats inherit POLISH's structural-only rule (R-1a.2 explicit, R-2.7 explicit).
+- **Audit Q5 (4e/4f ordering bug)** moot: both move to POLISH; Q6 collapses 4f content into Phase 3.
+
+## Test plan
+
+- [ ] Spec docs render correctly in GitHub preview.
+- [ ] Rule numbers unique within each procedure doc (verified via Task 11 self-review).
+- [ ] All "Phase N" references resolve to actual section headings.
+- [ ] All "populated by GROW" / "populated by POLISH" attributions agree between ontology and procedure docs.
+- [ ] No orphan ontology field definitions (every new field has at least one cited consumer).
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 4: Report PR URL to user**
+
+Post the PR URL.  Note that this is the FIRST of two PRs (this spec PR; code migration follows after this lands).
+
+---
+
+## Verification Checklist (run after Task 11)
+
+- [ ] All 10 ontology field additions are present in `story-graph-ontology.md` with stage attribution.
+- [ ] grow.md Phase 4 has 3 sub-phases (4a/4b/4c).
+- [ ] grow.md old Phase 5 is gone (folded into 4c).
+- [ ] grow.md phases beyond Phase 4 renumbered (no Phase 6–9 remain).
+- [ ] polish.md has new Phase 1a section.
+- [ ] polish.md Phase 2 has R-2.6/R-2.7/R-2.8.
+- [ ] polish.md Phase 3 has R-3.6/R-3.7/R-3.8.
+- [ ] polish.md Phase 5 has 5e and 5f sub-phases.
+- [ ] fill.md cross-references updated for migrated fields.
+- [ ] All rule numbers unique within each file.
+- [ ] No "Phase N" reference is unresolved.
+
+---
+
+## Self-Review Notes
+
+**Spec coverage** (against audit doc § Final design):
+
+- ✅ "GROW Phase 4 collapses to 3 sub-phases" → Task 5
+- ✅ "POLISH absorbs 5 sub-phases" → Tasks 6, 7, 8, 9 (covers all 5)
+- ✅ "Ontology field placements" (10 fields) → Tasks 2, 3, 4
+- ✅ FILL cross-references → Task 10
+- ✅ Self-review → Task 11
+- ✅ PR creation → Task 12
+
+**Placeholder scan:** none — every spec-text addition is provided in full.  No "TBD" or "TODO" or "fill in" instructions.
+
+**Type / naming consistency:** All field names match across tasks (`scene_type`, `narrative_function`, `exit_mood`, `atmospheric_detail`, `is_gap_beat`, `transition_style`, `bridges_from`, `bridges_to`, `path_theme`, `path_mood`, `arcs_per_path`).  Phase labels match across tasks (Phase 4a/4b/4c in grow; Phase 1a/2/3/5e/5f in polish).  Rule prefixes match (R-4a/R-4b/R-4c/R-5/.../R-8 in grow; R-1a/R-2.6+/R-3.6+/R-5e/R-5f in polish).

--- a/docs/superpowers/specs/2026-04-21-grow-phase-4-sub-phases-audit.md
+++ b/docs/superpowers/specs/2026-04-21-grow-phase-4-sub-phases-audit.md
@@ -1,0 +1,225 @@
+# GROW Phase 4 Sub-Phases — Design-Space Audit
+
+**Date:** 2026-04-21
+**Triggered by:** Follow-on #1365 — surfaced during FILL spec PR #1364 review when reviewer noted `narrative_function` / `scene_type` absent from authoritative ontology.
+**Scope:** Audit all seven `_phase_4*` sub-phases in GROW code vs. what `docs/design/procedures/grow.md` and `docs/design/story-graph-ontology.md` describe.
+**Goal:** Arrive at a correct and complete spec — not optimized for smallest PR.  Delivery structure is decided only after spec correctness is settled.
+**Not a final spec.** This is the analysis doc.  Final spec updates (ontology + grow.md + possibly minor POLISH/FILL cross-refs) follow after the design questions are resolved.
+
+---
+
+## Situation
+
+The grow.md spec has **one** Phase 4 ("Interleave" — cross-dilemma ordering edges).  The code has **seven** Phase 4 sub-phases:
+
+| Code name | Priority | Produces |
+|---|---|---|
+| `interleave_beats` | 3 | cross-dilemma predecessor edges |
+| `scene_types` (4a) | 4 | `scene_type`, `narrative_function`, `exit_mood` on beats |
+| `narrative_gaps` (4b) | 4 | NEW gap beats with `is_gap_beat=True` |
+| `pacing_gaps` (4c) | 5 | NEW correction beats |
+| `atmospheric` (4d) | 6 | `atmospheric_detail` on beats |
+| `path_arcs` (4e) | 7 | `path_theme`, `path_mood` on paths |
+| `entity_arcs` (4f) | 8 | `entity_arcs` list on paths |
+| `transition_gaps` (4g) | 8 | NEW transition beats with `role=transition_beat` |
+
+Seven of these (all except `interleave_beats`) are undocumented in grow.md.  Many of the fields they write are absent from `story-graph-ontology.md`.
+
+## Per-sub-phase audit
+
+### 4a — `scene_types` (llm_phases.py:600)
+
+- **Writes**: `scene_type ∈ {scene, sequel, micro_beat}`, `narrative_function ∈ {introduce, develop, complicate, confront, resolve}`, `exit_mood` (2–40 char free-form) on every beat.
+- **Theory**: Scene/Sequel (Swain) + Freytag compressed to beat level + emotional-transfer principle.
+- **Read by**: FILL derive_pacing (intensity + length), FILL narrative context / voice / transitions, POLISH Phase 2 pacing detection, DRESS illustration priority, 4c, 4e.
+- **Verdict**: **Load-bearing.** Most-consumed annotation in the pipeline.  Cannot remove.
+- **Issues**: Ontology gap.  Silent partial-coverage (LLM classifies some, not all; fallback `"scene"` everywhere).  No semantic validator for completeness.  Dead `scene_type == "climax"/"transition"` branches in DRESS (llm_phases.py → dress.py:1562).
+
+### 4b — `narrative_gaps` (llm_phases.py:686)
+
+- **Writes**: NEW beat nodes with `is_gap_beat=True`, `transition_style`, `bridges_from`, `bridges_to`; may carry non-empty `dilemma_impacts`.  Edges inserted to place the beat in its path's DAG sequence.
+- **Theory**: Story skeleton / scene economy — setup/climax cannot be immediately adjacent without transitional development.
+- **Read by**: all downstream (they are regular beats); FILL uses `is_gap_beat`/`transition_style` for gap-labeled context.  `is_gap_beat=True` excludes beats from intersection candidate generation.
+- **Verdict**: **Load-bearing but scope-questionable.**  Gap beats are structurally tracked and consumed.
+- **Issues**:
+  - **Scope**: gap beats with non-empty `dilemma_impacts` are narrative beats invented mid-pipeline by GROW.  The ontology's clean split (structural beats = zero impacts) is blurred.  Is this intentional?
+  - Partially overlaps POLISH Phase 2's "insert-beat-to-fix-missing-sequel" logic, though the triggers differ.
+  - Shared schema + helper with 4c (`Phase4bOutput`, `_validate_and_insert_gaps`).
+  - Max-per-path cap is a prompt instruction, not a code invariant.
+  - Counterintuitive field naming (`after_beat` = earlier; `before_beat` = later).
+
+### 4c — `pacing_gaps` (llm_phases.py:791)
+
+- **Writes**: NEW correction beats (same mechanism as 4b) to break up runs of 3+ same `scene_type`.
+- **Theory**: Scene-Sequel rhythm applied at sequence scale — 3+ scenes exhausts the reader; 3+ sequels stagnates.
+- **Read by**: all downstream.
+- **Verdict**: **Drift candidate.**  Pacing rhythm is POLISH Phase 2's declared domain (polish.md R-2.4, same trigger condition).  Whether 4c is "intentional coarse pre-pass" or "accidental duplication" is not documented.
+- **Issues**:
+  - GROW's overview says it does NOT do POLISH-level work; 4c is POLISH-level work.
+  - No loop: 4c's own insertions could create new 3+ runs; not re-checked within GROW.
+  - LLM is not validated to correct the *flagged* run (could insert beats elsewhere).
+
+### 4d — `atmospheric` (llm_phases.py:937)
+
+- **Writes**: `atmospheric_detail` (10–200 char free-form) on every beat.
+- **Theory**: Sensory immediacy / "fictional dream" (Gardner) / show-don't-tell.  Environment detail, not character emotion.
+- **Read by**: FILL `format_atmospheric_detail()`.  Suppressed when scene blueprints exist (FILL's own pre-prose planning).
+- **Verdict**: **Drift candidate (low urgency).**  The single consumer is FILL, and FILL has its own blueprint mechanism that supersedes.  Prose-writing concern that moved upstream.
+- **Issues**:
+  - No semantic validator (partial coverage undetected).
+  - Transition beats from 4g never receive `atmospheric_detail` (4d runs before 4g).  Systematic gap.
+  - Blueprint-suppression is silent and inline.
+  - Ontology gap.
+
+### 4e — `path_arcs` (llm_phases.py:1017)
+
+- **Writes**: `path_theme`, `path_mood` on each path node.
+- **Theory**: Per-path emotional through-line / "controlling idea" (McKee).  Branching fiction needs qualitatively different narrative experiences per path, not just different facts.
+- **Read by**: FILL narrative context + choice consequence labels; DRESS illustration `path_undertone`; context_compact display.
+- **Verdict**: **Load-bearing with a live bug.**
+- **Issues**:
+  - **Live bug**: 4e (priority=7) reads `path.entity_arcs` — a field written by 4f (priority=8, runs AFTER).  That context block is always empty.
+  - `PathMiniArc.path_id` is validated by the schema but ignored in code; wasted LLM token budget + schema complexity.
+  - Ontology gap (`path_theme`, `path_mood` nowhere in design docs).
+  - No semantic validator.
+  - `path_mood` (2–50 char) semantically overlaps `exit_mood` (2–40 char from 4a).  No formal relationship.
+
+### 4f — `entity_arcs` (llm_phases.py:1166)
+
+- **Writes**: `entity_arcs` list on each path node: `[{entity_id, arc_type, arc_line, pivot_beat}]`.  `arc_type` is deterministic lookup by entity category (character→"transformation", location→"atmosphere", object→"significance", faction→"relationship").
+- **Theory**: Character arc theory (McKee/Vogler/Truby) — entities have a trajectory; pivot is the turning point.  Category-appropriate arc kinds.
+- **Read by**: FILL per-passage positional context (pre/at/post-pivot); FILL entity introduction framing; `enumerate_arcs` deterministic phase depends on it.
+- **Verdict**: **Load-bearing.**
+- **Issues**:
+  - Dependency ordering problem from 4e (fix ordering, not this phase).
+  - Partial overlap with POLISH Phase 3 (Character Arc Synthesis) which produces `{start, pivots, end_per_path}` per entity.  Two arc-synthesis operations feed FILL; no formal reconciliation.
+  - `arc_type` vocabulary is in code only (grow_algorithms.py:2523); not in ontology.
+  - `entity_arcs` exists in the deprecated 00-spec.md but not in the authoritative ontology.
+  - Shared-beat pivot allowed with only INFO log (prompt says "PREFER path-specific").
+
+### 4g — `transition_gaps` (llm_phases.py:1350)
+
+- **Writes**: NEW beats with `role="transition_beat"`, `scene_type="micro_beat"`, zero `dilemma_impacts`, zero `belongs_to`.  Replaces one predecessor edge with a two-edge chain through the new beat.
+- **Theory**: Scene-transition craft — hard cuts (no shared entity or location across a cross-dilemma edge) need a brief bridge.
+- **Read by**: POLISH residue-beat placement (filters `role=="transition_beat"`), grow_validation R-5.1, seed_validation forbidden-type list.
+- **Verdict**: **Load-bearing.  Also the phase grow.md's existing "Phase 5" already refers to.**
+- **Issues**:
+  - **Spec numbering mismatch**: grow.md's "Phase 5: Transition Beat Insertion" IS this code-phase `transition_gaps` (priority=8 under the 4x group).  No code phase is actually numbered 5.
+  - `transition_id` format (`"earlier|later"`) is a raw-string convention with no doc; LLM hallucination produces `phase4g_no_bridges_matched` with no recovery.
+  - Bridge `entities` from LLM not validated against entity node set; phantom IDs can enter.
+  - Transition beats never get `atmospheric_detail` (sequencing: 4d runs before 4g).
+
+## Cross-cutting findings
+
+### Live bugs (not just spec gaps)
+
+1. **4e/4f ordering**: 4e reads `entity_arcs` but 4f writes it, and 4f runs later.  The prompt variable is always empty.  Either fix by `depends_on=["entity_arcs"]` on 4e (and accept 4e runs post-enumerate_arcs) or strip the empty read from 4e's template.
+2. **Transition beat atmospheric gap**: 4g creates beats AFTER 4d, so transition beats systematically lack `atmospheric_detail`.  FILL gets no sensory anchor for bridge prose.
+3. **Dead DRESS branches**: `dress.py:1562` checks `scene_type == "climax"` and `scene_type == "transition"` — neither is a valid 4a value.  Always false.
+
+### Silent degradations
+
+- 4a partial coverage → downstream `.get("scene_type", "scene")` fallback.  No warning on LLM missing beats.
+- 4d partial coverage → FILL silently skips atmospheric.  No warning.
+- 4d / 4e / 4g have no semantic validators.  4a, 4b, 4c, 4f do.
+- `phase4g_no_bridges_matched` logs WARNING but no retry.
+
+### Ontology gap summary (fields written that aren't in `story-graph-ontology.md`)
+
+**Beat**: `scene_type`, `narrative_function`, `exit_mood`, `atmospheric_detail`, `is_gap_beat`, `transition_style`, `bridges_from`, `bridges_to`.
+**Path**: `path_theme`, `path_mood`, `entity_arcs` (fully), `arc_type` vocabulary.
+
+### Spec gap summary (things the code does that grow.md doesn't describe)
+
+All seven sub-phases except `interleave_beats`.  Failure modes for sub-phase LLM failures.  Dependency chain for the 4x cluster.  Relationship between 4b/4c gap-beat creation and the ontology's structural-beat vs. narrative-beat distinction.
+
+## Design questions (require narrative-craft / project-intent judgment)
+
+Each resolution below shapes the final spec.  Ordered by consequence.
+
+### Q1 — Scope boundary between GROW and POLISH
+
+4b (gap beats) and 4c (pacing corrections) do work POLISH's spec claims as its own.  POLISH Phase 2 injects micro-beats for pacing; POLISH Phase 1 reorders beats; POLISH Phase 6 creates residue / false-branch beats.  If GROW also modifies the beat DAG structurally, we have two stages doing structural mutation.
+
+**Options:**
+- **A.** Keep as-is.  Document 4b/4c in grow.md as "coarse pre-pass"; document the intentional layering with POLISH Phase 1 ("fine reorder") and POLISH Phase 2 ("residual pacing").
+- **B.** Move 4b/4c to POLISH.  GROW's Phase 4 becomes only: interleave, scene_types, atmospheric, path_arcs, entity_arcs, transition_gaps.  POLISH Phase 2 absorbs pacing correction; a new POLISH phase absorbs narrative gap detection.  Larger refactor.
+- **C.** Keep 4b/4c in GROW but remove their ability to create `dilemma_impacts` on gap beats — they become purely structural insertions (like transition beats).  Keeps the stage boundary but narrows their scope.
+
+### Q2 — Is 4d (atmospheric) a GROW concern or a FILL concern?
+
+Sensory detail is a prose-writing concern.  4d writes one free-form 200-char string per beat.  The only consumer is FILL, and FILL has scene blueprints that supersede it when present.
+
+**Options:**
+- **A.** Keep in GROW.  Document as pre-prose planning for consumers that don't use blueprints.
+- **B.** Move to FILL's planning phase (Phase 1 Voice or a new sub-phase).  Blueprint and atmospheric detail live together in FILL.
+- **C.** Remove (drift).  Rely on FILL's blueprint mechanism.  Consumer code falls back gracefully.
+
+### Q3 — Transition beat atmospheric gap
+
+4g creates transition beats after 4d runs, so they never get `atmospheric_detail`.
+
+**Options:**
+- **A.** 4g also drafts an `atmospheric_detail` for each transition beat it creates (extend 4g's LLM output schema).
+- **B.** Move 4d to run after 4g.  But 4g depends on 4e/4f, creating a new ordering.
+- **C.** Accept the gap.  Transition beats are brief bridges; FILL handles "no atmospheric detail" gracefully.
+- **D.** (If Q2 → B/C) irrelevant.
+
+### Q4 — gap beats with `dilemma_impacts`
+
+4b's prompt allows the LLM to assign `advances/reveals/complicates` to gap beats.  This makes them narrative beats invented by GROW, contradicting the ontology split (structural = zero impacts).
+
+**Options:**
+- **A.** Keep: gap beats are real story beats advancing real dilemmas.  The ontology is wrong; update it to allow structural→narrative promotion in GROW.
+- **B.** Narrow: 4b gap beats must have zero `dilemma_impacts`.  They are purely structural bridges.  Rename to `bridge beats` or similar to distinguish from dilemma-bearing beats.
+
+### Q5 — Fix the 4e/4f ordering bug
+
+4e reads `entity_arcs` but 4f writes it later.  The context block is always empty.
+
+**Options:**
+- **A.** Swap: 4e depends on 4f.  4e runs at priority 9+.  Accept it runs post-`enumerate_arcs` (still works — enumerate_arcs doesn't read path_theme).
+- **B.** Strip the empty read: delete `entity_arcs` from 4e's context + prompt template.  Simpler.
+- **C.** Merge 4e and 4f into one path-level annotation phase.  Single LLM call per path produces both theme/mood and entity arcs together.
+
+### Q6 — 4f vs POLISH Phase 3 redundancy
+
+4f (GROW) writes path-level arc data for FILL per-passage positional tracking.  POLISH Phase 3 writes entity-level arc data (start/pivots/end) for FILL cross-passage entity consistency.  Both feed FILL.  No formal reconciliation.
+
+**Options:**
+- **A.** Keep both.  Document as intentionally complementary: 4f = positional, Phase 3 = cross-passage identity.  Codify in ontology that they must not contradict (POLISH Phase 3 pivots must match 4f's `pivot_beat` for the same entity-path pair).
+- **B.** Collapse into one.  POLISH Phase 3 absorbs 4f; GROW stops writing `entity_arcs`.
+- **C.** Collapse the other way.  4f absorbs POLISH Phase 3.  Unlikely — POLISH already has Phase 3 in spec.
+
+### Q7 — `exit_mood` (beat) vs `path_mood` (path) relationship
+
+Both are mood descriptors.  Different granularity, independently LLM-generated, no defined relationship.
+
+**Options:**
+- **A.** Keep both, independent.  Document both in ontology with explicit "these do not need to agree" note.
+- **B.** Derive `path_mood` from the sequence of `exit_mood` on the path's terminal beats (deterministic aggregation).  Remove `path_mood` from LLM output.
+- **C.** Remove one.  Likely candidate: `path_mood` — less load-bearing than beat-level `exit_mood`, overlaps `path_theme`.
+
+## Path forward
+
+After resolving Q1–Q7, the final spec work consists of:
+
+1. **Ontology updates** — add all Beat and Path fields to `story-graph-ontology.md` with types, value constraints, population rule, and (where applicable) consumer list.  Size: ~60–100 lines depending on how thorough.
+2. **grow.md phase structure rewrite** — expand the single "Phase 4: Interleave" into Phase 4 + sub-phases 4a–4f (or however many survive Q1–Q7).  Document dependencies, LLM vs deterministic, failure modes, rules.  Size: ~150–250 lines depending on decisions.
+3. **Renumber "Phase 5: Transition Beat Insertion"** to match code's `transition_gaps` (currently labeled 4g).  Either number it 4g in the spec, or move it to Phase 5 in code priority order (which requires priority re-sort).
+4. **Cross-stage cross-references** — POLISH Phase 2 should reference 4c if they're intentionally layered (Q1).  FILL's derive_pacing / atmospheric / arc-context functions should cite the GROW sub-phase that populates their inputs.
+5. **Code fixes** — separate PR(s): fix 4e/4f ordering bug, remove dead DRESS branches, potentially add semantic validators to 4d/4e/4g.
+
+### Delivery structure (to be decided AFTER the design questions are resolved)
+
+Candidate breakdowns, listed for later discussion:
+
+- **One big PR** (ontology + grow.md + cross-refs).  Simplest end-state; biggest review surface.
+- **Spec update + code cleanup** (two PRs): spec first, then bug fixes.
+- **Structured by decision** (Q1 → scope, Q2 → 4d, …): one PR per resolved question.  Most granular, highest overhead.
+
+---
+
+## Next step
+
+Resolve Q1 through Q7 with the human.  Once resolved, this doc becomes the brief for the spec-writing plan, which then produces ontology + grow.md updates in a plan document.

--- a/docs/superpowers/specs/2026-04-21-grow-phase-4-sub-phases-audit.md
+++ b/docs/superpowers/specs/2026-04-21-grow-phase-4-sub-phases-audit.md
@@ -220,6 +220,87 @@ Candidate breakdowns, listed for later discussion:
 
 ---
 
-## Next step
+## Resolutions (2026-04-23)
 
-Resolve Q1 through Q7 with the human.  Once resolved, this doc becomes the brief for the spec-writing plan, which then produces ontology + grow.md updates in a plan document.
+### Q1 — Structural vs narrative principle (RESOLVED)
+
+The GROW/POLISH boundary is **structural vs narrative**, not DAG-layer vs passage-layer.  GROW makes the structure (load-bearing skeleton: forks, convergences, dilemma scaffolding, intersection coordination, foundation annotation).  POLISH prepares the narrative (rhythm, pacing, prose-readiness, sensory grounding, thematic context).
+
+**Historical context:** POLISH used to be part of GROW.  The split (epic #990 / cleanup #1057) didn't move everything correctly.  The 5 sub-phases below are leftover GROW phases that should have moved to POLISH but didn't.  **This work completes that migration.**
+
+**Resolution per sub-phase:**
+
+| Sub-phase | Verdict | Stage |
+|---|---|---|
+| 4a `scene_types` | Foundation annotation (POLISH Phase 2 pacing depends on `scene_type`) | **GROW** |
+| 4b `narrative_gaps` | Narrative gap filling | **POLISH** |
+| 4c `pacing_gaps` | Pure rhythm correction | **POLISH** |
+| 4d `atmospheric` | Sensory annotation for prose | **POLISH** |
+| 4e `path_arcs` | Per-path narrative context | **POLISH** |
+| 4f `entity_arcs` | Per-entity narrative context (see Q6 resolution) | **POLISH** |
+| 4g `transition_gaps` | Bridge structural seams (cross-dilemma hard cuts) | **GROW** |
+
+GROW Phase 4 collapses to 3 sub-phases: `interleave_beats` + `scene_types` + `transition_gaps`.  POLISH absorbs 5 sub-phases.
+
+### Q2 — 4d location (RESOLVED via Q1)
+
+POLISH.
+
+### Q3 — Transition beat `atmospheric_detail` gap (AUTO-RESOLVED via Q1)
+
+`atmospheric` moves to POLISH.  POLISH's atmospheric pass runs **after** GROW completes (including 4g transition beat creation), so transition beats receive `atmospheric_detail` naturally.  Bug eliminated by the migration.
+
+### Q4 — gap beats with `dilemma_impacts` (AUTO-RESOLVED via Q1)
+
+Gap and pacing-correction beats move to POLISH (sub-phases absorbed from 4b / 4c).  POLISH's existing rule (R-2.1: micro-beats have zero `dilemma_impacts`; residue and false-branch beats also zero) extends to these new POLISH-created beats.  All POLISH-created beats are structural by virtue of being POLISH-created.
+
+### Q5 — 4e/4f ordering bug (AUTO-RESOLVED via Q1)
+
+Both phases move to POLISH; the ordering can be re-derived in the new stage (and Q6's resolution removes 4f's content into POLISH Phase 3, eliminating the dependency entirely).
+
+### Q6 — 4f vs POLISH Phase 3 redundancy (RESOLVED)
+
+**B: POLISH Phase 3 absorbs 4f.**  Phase 3 is the spec'd authority and 4f is migration leftover.  Phase 3 is extended to also produce per-path positional data (current 4f content): `[{entity_id, arc_type, arc_line, pivot_beat}]` per path joins the existing `{start, pivots, end_per_path}` structure on the entity node.  FILL builds positional context by indexing into the entity-node arc data.  Eliminates the redundancy entirely; one source of truth on entity nodes; fewer LLM calls.
+
+### Q7 — `exit_mood` (beat) vs `path_mood` (path) (RESOLVED)
+
+**A: Keep both, independent.**  They are genuinely different narrative-craft concepts at different scales.  `exit_mood` is reader-affect at the handoff between beats (Swain-adjacent); `path_mood` is the path's tonal identity (consumed by FILL/DRESS for tonal framing).  No formal relationship enforced.  POLISH may consult `exit_mood` sequence as one input when generating `path_mood`, but the LLM has freedom.
+
+---
+
+## Final design
+
+### Stage responsibilities (post-migration)
+
+**GROW Phase 4** (3 sub-phases):
+1. `interleave_beats` (existing, deterministic) — cross-dilemma ordering edges.
+2. `scene_types` — annotate beats with `scene_type`, `narrative_function`, `exit_mood`.  Foundation annotation that POLISH Phase 2 depends on.
+3. `transition_gaps` — insert bridge beats at cross-dilemma hard cuts (no shared entity/location).  Structural seam smoothing.  Currently labeled "Phase 5" in grow.md spec but priority=8 in code; renumber for consistency.
+
+**POLISH** absorbs:
+- `narrative_gaps` (was 4b) — insert beats to fix narrative jumps.  Likely a new POLISH sub-phase or fold into Phase 1 (Beat Reordering).
+- `pacing_gaps` (was 4c) — insert correction beats for 3+ same-`scene_type` runs.  Fold into POLISH Phase 2 (Pacing Micro-Beat Injection); the trigger is identical.
+- `atmospheric` (was 4d) — `atmospheric_detail` per beat.  New POLISH sub-phase.
+- `path_arcs` (was 4e) — `path_theme`, `path_mood` per path.  New POLISH sub-phase.
+- `entity_arcs` content (was 4f) — absorbed into POLISH Phase 3 (Character Arc Synthesis).  Phase 3 extends to produce per-path positional data on entity nodes.
+
+### Ontology field placements
+
+**Beat** (populated by **GROW**): `scene_type`, `narrative_function`, `exit_mood`.
+**Beat** (populated by **POLISH**): `atmospheric_detail`; gap-beat traceability fields (`is_gap_beat`, `transition_style`, `bridges_from`, `bridges_to`).
+**Path** (populated by **POLISH**): `path_theme`, `path_mood`.
+**Entity** (populated by **POLISH** Phase 3, extended): per-entity arc data including `start`, `pivots`, `end_per_path`, AND per-path positional list (absorbed from 4f).
+
+All fields need formal definition in `story-graph-ontology.md` with type, value constraints, population stage, and consumers.
+
+## Path forward
+
+This audit has produced a clear final design.  Three categories of work follow:
+
+1. **Spec updates** — grow.md (Phase 4 restructure), polish.md (absorb 5 sub-phases), story-graph-ontology.md (~10 field additions with stage attribution).
+2. **Code migration** — move 5 sub-phase implementations from GROW to POLISH; consolidate `pacing_gaps` into POLISH Phase 2; consolidate 4f content into POLISH Phase 3; delete dead DRESS branches; add missing semantic validators.
+3. **Audit-side bookkeeping** — close #1365 by reference to this doc; potentially split into smaller follow-on issues for each migration step.
+
+The **spec updates** must come first per CLAUDE.md §Design Doc Authority — the spec describes the target state, code follows.
+
+Proceed via `superpowers:writing-plans` to produce a detailed implementation plan for the spec updates.


### PR DESCRIPTION
## Summary

Spec-only PR completing the GROW→POLISH migration that started in epics #990 / #1057 but didn't move five sub-phases that should have moved.  Surfaced via FILL spec audit follow-on #1365.

Audit doc: `docs/superpowers/specs/2026-04-21-grow-phase-4-sub-phases-audit.md`.  Read its "Final design" section first.

Closes #1365.

## What changed

**Principle (audit Q1):** GROW = structure (load-bearing skeleton).  POLISH = narrative (rhythm, pacing, prose-readiness).  Pacing/atmospheric/thematic work is narrative-prep, so POLISH territory.

**GROW Phase 4** collapses to 3 sub-phases:
- 4a Interleave (existing)
- 4b Scene Types Annotation (NEW — documents the LLM-tagging code that was previously undocumented)
- 4c Transition Beat Insertion (absorbed from old Phase 5)

Old Phase 5 → 4c.  Old Phases 6/7/8/9 renumbered to 5/6/7/8.

**POLISH** absorbs 5 sub-phases from old GROW Phase 4:
- new **Phase 1a** Narrative Gap Insertion (was GROW 4b in code)
- **Phase 2** extended with pacing-run correction (was GROW 4c in code)
- **Phase 3** extended to absorb per-path entity arc data (was GROW 4f in code) per audit Q6 resolution B
- new **Phase 5e** Atmospheric Annotation (was GROW 4d in code)
- new **Phase 5f** Path Thematic Annotation (was GROW 4e in code)

**Ontology** gains stage-attributed field definitions for ~10 fields previously undocumented:
- Beat: scene_type, narrative_function, exit_mood (GROW); atmospheric_detail, gap-beat traceability fields (POLISH)
- Path: path_theme, path_mood (POLISH)
- Entity: character_arc.arcs_per_path (POLISH Phase 3, extended)

**FILL** cross-references updated for fields whose populator changed (GROW → POLISH).  Stage Input Contract extended with items 15/16/17 mirroring POLISH's new Stage Output Contract items.

## No code changes

Pure spec PR.  Code migration follows in a separate plan PR — moving 5 sub-phase implementations from GROW to POLISH is substantial work that warrants its own scoping.  Per CLAUDE.md §Design Doc Authority, spec lands first; code follows.

## Cross-effects

- **Audit Q3 (transition-beat atmospheric gap)** auto-fixed by the migration: POLISH Phase 5e (atmospheric) runs after GROW Phase 4c (transition beat creation), so transition beats receive atmospheric_detail naturally.
- **Audit Q4 (gap beats with dilemma_impacts)** auto-resolved: POLISH-created beats inherit POLISH's structural-only rule (R-1a.2 explicit, R-2.7 explicit).
- **Audit Q5 (4e/4f ordering bug)** moot: both move to POLISH; Q6 collapses 4f content into Phase 3.

## Test plan

- [ ] Spec docs render correctly in GitHub preview.
- [ ] Rule numbers unique within each procedure doc (verified via Task 11 self-review — all clean).
- [ ] All "Phase N" references resolve to actual section headings (verified).
- [ ] All "populated by GROW" / "populated by POLISH" attributions agree between ontology and procedure docs (verified — 8 fields have stage attribution).
- [ ] No orphan ontology field definitions (every new field has at least one cited consumer — verified).

🤖 Generated with [Claude Code](https://claude.com/claude-code)