### PR TITLE
feat(grow→polish): migrate narrative_gaps to POLISH Phase 1a (PR A of #1368)

### DIFF
--- a/prompts/templates/polish_phase1a_narrative_gaps.yaml
+++ b/prompts/templates/polish_phase1a_narrative_gaps.yaml
@@ -1,0 +1,94 @@
+name: polish_phase1a_narrative_gaps
+description: Identify missing beats in path sequences (POLISH Phase 1a, Narrative Gap Insertion)
+
+system: |
+  You are analyzing path beat sequences to find narrative gaps --
+  places where the story jumps too abruptly between beats.
+
+  ## Beat Ordering (CRITICAL — read this first)
+  after_beat = the EARLIER beat (the new beat goes AFTER it)
+  before_beat = the LATER beat (the new beat goes BEFORE it)
+
+  The new beat is inserted BETWEEN after_beat and before_beat.
+  after_beat MUST appear earlier in the path sequence than before_beat.
+
+  Example: if a path has beats #1 beat::setup, #2 beat::climax:
+    CORRECT: after_beat = "beat::setup", before_beat = "beat::climax"
+    WRONG:   after_beat = "beat::climax", before_beat = "beat::setup"
+
+  ## What is a Narrative Gap?
+  A gap occurs when a path's beat sequence lacks a natural transition:
+  - Setup → climax (missing development/escalation)
+  - Decision → consequence (missing reaction/processing)
+  - Introduction → commitment (missing exploration)
+
+  ## Gap Detection Checklist
+  1. Jump in narrative intensity? (setup to climax with nothing between)
+  2. Missing emotional transition? (big decision to next action without reflection)
+  3. Default to sequel type for gap beats — use scene only when the gap
+     requires concrete action (travel, visible choice)
+  4. Gap beats should be concise transitions, not major story events
+  5. Maximum 2 gap beats per path
+
+  ## Path → Dilemma mapping (use these dilemma_id values)
+  {path_dilemma_map}
+
+  ## Valid dilemma IDs
+  {valid_dilemma_ids}
+
+  ## Path Sequences (in execution order)
+  {path_sequences}
+
+  ## What NOT to Do
+  - Do NOT propose gaps for paths with only 1-2 beats
+  - Do NOT propose gaps between beats that already flow naturally
+  - Do NOT use IDs not listed in the Valid IDs section
+  - Do NOT swap after_beat and before_beat — after_beat is ALWAYS earlier
+  - Do NOT add prose before or after the JSON output
+
+  ## Valid IDs
+  Valid path_ids: {valid_path_ids}
+  Valid beat_ids (for after_beat/before_beat): {valid_beat_ids}
+
+  ## Output Format
+  Return a JSON object with a "gaps" array. Each gap has:
+  - path_id: the path (prefixed form, e.g., "path::dilemma__answer")
+  - after_beat: the EARLIER beat (or null for start of path)
+  - before_beat: the LATER beat (or null for end of path)
+  - summary: concise description of the gap beat (1 sentence)
+  - scene_type: scene | sequel | micro_beat (default: sequel)
+  - dilemma_impacts: list of how this beat affects dilemmas (may be empty)
+    Each item: {{"dilemma_id": "<id>", "effect": "<advances|reveals|commits|complicates>", "note": "<explanation>"}}
+    Effect values:
+      advances    = moves the dilemma closer to resolution (tension builds)
+      reveals     = discloses new information about the dilemma
+      commits     = a character makes an irreversible choice about the dilemma
+      complicates = adds a new obstacle or contradiction to the dilemma
+
+  If no gaps are needed, return an empty gaps array.
+
+  Example (do not copy these IDs):
+  {{
+    "gaps": [
+      {{
+        "path_id": "path::dilemma__answer",
+        "after_beat": "beat::setup_01",
+        "before_beat": "beat::climax_01",
+        "summary": "Hero reflects on the stakes before the confrontation",
+        "scene_type": "sequel",
+        "dilemma_impacts": [
+          {{"dilemma_id": "dilemma::trust_or_betray", "effect": "advances", "note": "Hero weighs loyalty against self-interest before the confrontation forces a choice"}}
+        ]
+      }}
+    ]
+  }}
+
+user: |
+  Analyze the path sequences above and propose gap beats where needed.
+
+  REMINDER: Return ONLY a valid JSON object. Use ONLY IDs from the Valid IDs section.
+  REMINDER: after_beat is the EARLIER beat, before_beat is the LATER beat. Do NOT reverse them.
+  REMINDER: Include dilemma_impacts for each gap beat using ONLY valid dilemma_ids listed above. Valid effect values: advances, reveals, commits, complicates.
+  Maximum 2 gap beats per path.
+
+components: []

--- a/src/questfoundry/graph/gap_insertion.py
+++ b/src/questfoundry/graph/gap_insertion.py
@@ -29,7 +29,11 @@ log = get_logger(__name__)
 
 @dataclass
 class GapInsertionReport:
-    """Summary of gap insertion validation and results."""
+    """Summary of gap insertion validation and results.
+
+    The invariant ``inserted + total_invalid == len(gaps)`` holds: every
+    proposal either lands or contributes to one of the rejection counts.
+    """
 
     inserted: int = 0
     invalid_path_id: int = 0
@@ -38,6 +42,7 @@ class GapInsertionReport:
     invalid_beat_order: int = 0
     beat_not_in_sequence: int = 0
     anchor_wrong_path: int = 0
+    cycle_skipped: int = 0
 
     @property
     def total_invalid(self) -> int:
@@ -48,6 +53,7 @@ class GapInsertionReport:
             + self.invalid_beat_order
             + self.beat_not_in_sequence
             + self.anchor_wrong_path
+            + self.cycle_skipped
         )
 
 
@@ -107,7 +113,8 @@ def validate_and_insert_gaps(
             prefixed = f"beat::{beat_id}"
             if prefixed in valid_beat_set:
                 log.info(
-                    f"{phase_name}_unprefixed_beat_id",
+                    "gap_unprefixed_beat_id",
+                    phase=phase_name,
                     beat_id=beat_id,
                     prefixed=prefixed,
                 )
@@ -118,22 +125,23 @@ def validate_and_insert_gaps(
         prefixed_pid = gap.path_id if gap.path_id.startswith("path::") else f"path::{gap.path_id}"
         if prefixed_pid != gap.path_id:
             log.info(
-                f"{phase_name}_unprefixed_path_id",
+                "gap_unprefixed_path_id",
+                phase=phase_name,
                 path_id=gap.path_id,
                 prefixed=prefixed_pid,
             )
         if prefixed_pid not in valid_path_set:
-            log.info(f"{phase_name}_invalid_path_id", path_id=gap.path_id)
+            log.info("gap_invalid_path_id", phase=phase_name, path_id=gap.path_id)
             report.invalid_path_id += 1
             continue
         after_beat = _normalize_beat_id(gap.after_beat)
         before_beat = _normalize_beat_id(gap.before_beat)
         if after_beat and after_beat not in valid_beat_set:
-            log.info(f"{phase_name}_invalid_after_beat", beat_id=after_beat)
+            log.info("gap_invalid_after_beat", phase=phase_name, beat_id=after_beat)
             report.invalid_after_beat += 1
             continue
         if before_beat and before_beat not in valid_beat_set:
-            log.info(f"{phase_name}_invalid_before_beat", beat_id=before_beat)
+            log.info("gap_invalid_before_beat", phase=phase_name, beat_id=before_beat)
             report.invalid_before_beat += 1
             continue
         # Validate path membership: anchors must belong to the gap's path.
@@ -144,7 +152,8 @@ def validate_and_insert_gaps(
             }
             if prefixed_pid not in after_paths:
                 log.info(
-                    f"{phase_name}_anchor_wrong_path",
+                    "gap_anchor_wrong_path",
+                    phase=phase_name,
                     after_beat=after_beat,
                     path_id=prefixed_pid,
                 )
@@ -156,7 +165,8 @@ def validate_and_insert_gaps(
             }
             if prefixed_pid not in before_paths:
                 log.info(
-                    f"{phase_name}_anchor_wrong_path",
+                    "gap_anchor_wrong_path",
+                    phase=phase_name,
                     before_beat=before_beat,
                     path_id=prefixed_pid,
                 )
@@ -170,14 +180,15 @@ def validate_and_insert_gaps(
                 before_idx = sequence.index(before_beat)
                 if after_idx >= before_idx:
                     log.info(
-                        f"{phase_name}_invalid_beat_order",
+                        "gap_invalid_beat_order",
+                        phase=phase_name,
                         after_beat=after_beat,
                         before_beat=before_beat,
                     )
                     report.invalid_beat_order += 1
                     continue
             except ValueError:
-                log.info(f"{phase_name}_beat_not_in_sequence", path_id=gap.path_id)
+                log.info("gap_beat_not_in_sequence", phase=phase_name, path_id=gap.path_id)
                 report.beat_not_in_sequence += 1
                 continue
 
@@ -203,6 +214,7 @@ def validate_and_insert_gaps(
                 before_beat=before_beat,
                 path_id=prefixed_pid,
             )
+            report.cycle_skipped += 1
             continue
 
         new_beat_id = insert_gap_beat(

--- a/src/questfoundry/graph/gap_insertion.py
+++ b/src/questfoundry/graph/gap_insertion.py
@@ -1,0 +1,228 @@
+"""Shared gap-beat insertion validation.
+
+Used by:
+
+- POLISH Phase 1a (Narrative Gap Insertion) — moved from GROW per the
+  spec migration in PR #1366 (structural-vs-narrative principle: gap
+  insertion is narrative-prep work).
+- GROW Phase 4c (Pacing Gaps) — temporary co-tenant; moves to POLISH
+  Phase 2 in the next migration PR (issue #1368).
+
+Both callers produce the same kind of `GapProposal` and need the same
+validation + insertion logic. This module is the single source of truth.
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+from questfoundry.observability.logging import get_logger
+
+if TYPE_CHECKING:
+    from questfoundry.graph.graph import Graph
+    from questfoundry.models.grow import GapProposal
+
+log = get_logger(__name__)
+
+
+@dataclass
+class GapInsertionReport:
+    """Summary of gap insertion validation and results."""
+
+    inserted: int = 0
+    invalid_path_id: int = 0
+    invalid_after_beat: int = 0
+    invalid_before_beat: int = 0
+    invalid_beat_order: int = 0
+    beat_not_in_sequence: int = 0
+    anchor_wrong_path: int = 0
+
+    @property
+    def total_invalid(self) -> int:
+        return (
+            self.invalid_path_id
+            + self.invalid_after_beat
+            + self.invalid_before_beat
+            + self.invalid_beat_order
+            + self.beat_not_in_sequence
+            + self.anchor_wrong_path
+        )
+
+
+def validate_and_insert_gaps(
+    graph: Graph,
+    gaps: list[GapProposal],
+    valid_path_ids: set[str] | dict[str, Any],
+    valid_beat_ids: set[str] | dict[str, Any],
+    phase_name: str,
+) -> GapInsertionReport:
+    """Validate gap proposals and insert valid ones into the graph.
+
+    Checks path_id prefixing, beat ID existence, ordering, and cycle
+    safety before inserting each gap beat. A cycle check runs before
+    every insertion: if inserting the gap beat would close a cycle in
+    the predecessor DAG, the gap is skipped with a log message.
+
+    Args:
+        graph: Graph to insert beats into.
+        gaps: List of GapProposal instances from LLM output.
+        valid_path_ids: Set or dict of valid path IDs.
+        valid_beat_ids: Set or dict of valid beat IDs.
+        phase_name: Phase name for log event prefixing.
+
+    Returns:
+        Report with counts of inserted and invalid gaps.
+    """
+    from questfoundry.graph.grow_algorithms import (
+        _would_create_cycle,
+        get_path_beat_sequence,
+        insert_gap_beat,
+    )
+
+    report = GapInsertionReport()
+    valid_path_set = (
+        set(valid_path_ids.keys()) if isinstance(valid_path_ids, dict) else set(valid_path_ids)
+    )
+    valid_beat_set = (
+        set(valid_beat_ids.keys()) if isinstance(valid_beat_ids, dict) else set(valid_beat_ids)
+    )
+
+    # Build the successors dict (prerequisite → dependents) for cycle detection.
+    # predecessor(A, B) means B comes before A; successors[B] contains A.
+    # We keep this in sync after each successful insertion.
+    beat_set: set[str] = set(graph.get_nodes_by_type("beat").keys())
+    successors: dict[str, set[str]] = defaultdict(set)
+    for edge in graph.get_edges(from_id=None, to_id=None, edge_type="predecessor"):
+        # edge["from"] requires edge["to"] → edge["to"] is a prereq of edge["from"]
+        successors[edge["to"]].add(edge["from"])
+
+    def _normalize_beat_id(beat_id: str | None) -> str | None:
+        if not beat_id:
+            return None
+        if beat_id in valid_beat_set:
+            return beat_id
+        if not beat_id.startswith("beat::"):
+            prefixed = f"beat::{beat_id}"
+            if prefixed in valid_beat_set:
+                log.info(
+                    f"{phase_name}_unprefixed_beat_id",
+                    beat_id=beat_id,
+                    prefixed=prefixed,
+                )
+                return prefixed
+        return beat_id
+
+    for gap in gaps:
+        prefixed_pid = gap.path_id if gap.path_id.startswith("path::") else f"path::{gap.path_id}"
+        if prefixed_pid != gap.path_id:
+            log.info(
+                f"{phase_name}_unprefixed_path_id",
+                path_id=gap.path_id,
+                prefixed=prefixed_pid,
+            )
+        if prefixed_pid not in valid_path_set:
+            log.info(f"{phase_name}_invalid_path_id", path_id=gap.path_id)
+            report.invalid_path_id += 1
+            continue
+        after_beat = _normalize_beat_id(gap.after_beat)
+        before_beat = _normalize_beat_id(gap.before_beat)
+        if after_beat and after_beat not in valid_beat_set:
+            log.info(f"{phase_name}_invalid_after_beat", beat_id=after_beat)
+            report.invalid_after_beat += 1
+            continue
+        if before_beat and before_beat not in valid_beat_set:
+            log.info(f"{phase_name}_invalid_before_beat", beat_id=before_beat)
+            report.invalid_before_beat += 1
+            continue
+        # Validate path membership: anchors must belong to the gap's path.
+        # A beat belongs to a path if it has a belongs_to edge pointing to it.
+        if after_beat:
+            after_paths = {
+                e["to"] for e in graph.get_edges(edge_type="belongs_to", from_id=after_beat)
+            }
+            if prefixed_pid not in after_paths:
+                log.info(
+                    f"{phase_name}_anchor_wrong_path",
+                    after_beat=after_beat,
+                    path_id=prefixed_pid,
+                )
+                report.anchor_wrong_path += 1
+                continue
+        if before_beat:
+            before_paths = {
+                e["to"] for e in graph.get_edges(edge_type="belongs_to", from_id=before_beat)
+            }
+            if prefixed_pid not in before_paths:
+                log.info(
+                    f"{phase_name}_anchor_wrong_path",
+                    before_beat=before_beat,
+                    path_id=prefixed_pid,
+                )
+                report.anchor_wrong_path += 1
+                continue
+        # Validate ordering: after_beat must come before before_beat
+        if after_beat and before_beat:
+            sequence = get_path_beat_sequence(graph, prefixed_pid)
+            try:
+                after_idx = sequence.index(after_beat)
+                before_idx = sequence.index(before_beat)
+                if after_idx >= before_idx:
+                    log.info(
+                        f"{phase_name}_invalid_beat_order",
+                        after_beat=after_beat,
+                        before_beat=before_beat,
+                    )
+                    report.invalid_beat_order += 1
+                    continue
+            except ValueError:
+                log.info(f"{phase_name}_beat_not_in_sequence", path_id=gap.path_id)
+                report.beat_not_in_sequence += 1
+                continue
+
+        # Cycle prevention: if after_beat and before_beat are both given,
+        # check whether inserting the gap would create a cycle.
+        # The gap insertion adds predecessor(gap, after_beat) and
+        # predecessor(before_beat, gap). A cycle forms if after_beat is
+        # already a transitive successor of before_beat — i.e. inserting
+        # gap closes a circle: before_beat → gap → after_beat → ... → before_beat.
+        # This is equivalent to asking: is after_beat reachable from
+        # before_beat via the current successors graph?
+        # _would_create_cycle(before_beat, after_beat, ...) returns True iff
+        # after_beat is reachable from before_beat, which is exactly that case.
+        if (
+            after_beat
+            and before_beat
+            and _would_create_cycle(before_beat, after_beat, successors, beat_set)
+        ):
+            log.info(
+                "gap_skipped_would_create_cycle",
+                phase=phase_name,
+                after_beat=after_beat,
+                before_beat=before_beat,
+                path_id=prefixed_pid,
+            )
+            continue
+
+        new_beat_id = insert_gap_beat(
+            graph,
+            path_id=prefixed_pid,
+            after_beat=after_beat,
+            before_beat=before_beat,
+            summary=gap.summary,
+            scene_type=gap.scene_type,
+            dilemma_impacts=[i.model_dump() for i in gap.dilemma_impacts],
+        )
+        report.inserted += 1
+
+        # Update successors and beat_set to reflect the newly inserted beat.
+        # predecessor(new_beat, after_beat) → after_beat is prereq of new_beat
+        # predecessor(before_beat, new_beat) → new_beat is prereq of before_beat
+        beat_set.add(new_beat_id)
+        if after_beat:
+            successors[after_beat].add(new_beat_id)
+        if before_beat:
+            successors[new_beat_id].add(before_beat)
+
+    return report

--- a/src/questfoundry/graph/grow_algorithms.py
+++ b/src/questfoundry/graph/grow_algorithms.py
@@ -2383,6 +2383,9 @@ def insert_gap_beat(
     summary: str,
     scene_type: str,
     dilemma_impacts: list[dict[str, Any]] | None = None,
+    *,
+    role: str = "gap_beat",
+    created_by: str = "POLISH",
 ) -> str:
     """Insert a new gap beat into the graph between existing beats.
 
@@ -2401,6 +2404,12 @@ def insert_gap_beat(
         summary: Summary text for the new beat.
         scene_type: Scene type tag for the new beat.
         dilemma_impacts: List of dilemma impact dicts (dilemma_id, effect, note).
+        role: Beat role tag. Defaults to ``"gap_beat"`` (POLISH Phase 1a per
+            spec R-1a.1). Pacing-correction beats override this with
+            ``"micro_beat"`` per POLISH Phase 2 R-2.7.
+        created_by: Stage that created this beat. Defaults to ``"POLISH"``
+            since both narrative-gap insertion and pacing-correction
+            insertion are POLISH responsibilities post-migration.
 
     Returns:
         The new beat's node ID.
@@ -2441,7 +2450,9 @@ def insert_gap_beat(
     # Infer transition style based on context
     transition_style = _infer_transition_style(after_node, before_node)
 
-    # Create the beat node with enriched context
+    # Create the beat node with enriched context.
+    # ``role`` and ``created_by`` are required by spec R-1a.1 (narrative gaps)
+    # and R-2.7 (pacing-correction); FILL's structural-beat handling reads them.
     graph.create_node(
         beat_id,
         {
@@ -2451,6 +2462,8 @@ def insert_gap_beat(
             "scene_type": scene_type,
             "paths": [path_id.removeprefix("path::")],
             "is_gap_beat": True,
+            "role": role,
+            "created_by": created_by,
             # Enrichment fields for transition handling
             "entities": entities,
             "location": location,

--- a/src/questfoundry/pipeline/stages/grow/llm_helper.py
+++ b/src/questfoundry/pipeline/stages/grow/llm_helper.py
@@ -1,13 +1,20 @@
 """LLM call helper and validation utilities for the GROW stage.
 
-Provides _LLMHelperMixin with _grow_llm_call(), error feedback formatting,
-and gap-beat insertion validation.  GrowStage inherits this mixin so all
-LLM phase methods can call ``self._grow_llm_call(...)`` directly.
+Provides _LLMHelperMixin with _grow_llm_call() and error feedback
+formatting. GrowStage inherits this mixin so LLM phase methods can call
+``self._grow_llm_call(...)`` directly.
+
+``GapInsertionReport`` and ``_validate_and_insert_gaps`` are re-exports
+of the free function ``validate_and_insert_gaps`` from
+``questfoundry.graph.gap_insertion``. The shared module is the home for
+gap-insertion logic now that the narrative_gaps phase has moved to
+POLISH (PR for issue #1368). The thin delegation here keeps existing
+test call sites (``stage._validate_and_insert_gaps(...)``) working
+without changes.
 """
 
 from __future__ import annotations
 
-from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
 from langchain_core.messages import HumanMessage, SystemMessage
@@ -15,6 +22,7 @@ from pydantic import BaseModel, ValidationError
 
 from questfoundry.agents.serialize import extract_tokens
 from questfoundry.artifacts.validator import get_all_field_paths
+from questfoundry.graph.gap_insertion import GapInsertionReport, validate_and_insert_gaps
 from questfoundry.graph.graph import Graph  # noqa: TC001 - used at runtime
 from questfoundry.graph.mutations import GrowValidationError  # noqa: TC001 - used at runtime
 from questfoundry.observability.tracing import traceable
@@ -37,29 +45,8 @@ if TYPE_CHECKING:
 
     from questfoundry.models.grow import GapProposal
 
-
-@dataclass
-class GapInsertionReport:
-    """Summary of gap insertion validation and results."""
-
-    inserted: int = 0
-    invalid_path_id: int = 0
-    invalid_after_beat: int = 0
-    invalid_before_beat: int = 0
-    invalid_beat_order: int = 0
-    beat_not_in_sequence: int = 0
-    anchor_wrong_path: int = 0
-
-    @property
-    def total_invalid(self) -> int:
-        return (
-            self.invalid_path_id
-            + self.invalid_after_beat
-            + self.invalid_before_beat
-            + self.invalid_beat_order
-            + self.beat_not_in_sequence
-            + self.anchor_wrong_path
-        )
+# Re-exported for back-compat with existing imports.
+__all__ = ["GapInsertionReport", "_LLMHelperMixin"]
 
 
 class _LLMHelperMixin:
@@ -247,175 +234,5 @@ class _LLMHelperMixin:
         valid_beat_ids: set[str] | dict[str, Any],
         phase_name: str,
     ) -> GapInsertionReport:
-        """Validate gap proposals and insert valid ones into the graph.
-
-        Checks path_id prefixing, beat ID existence, ordering, and cycle
-        safety before inserting each gap beat.  A cycle check is performed
-        before every insertion: if inserting the gap beat would close a cycle
-        in the predecessor DAG, the gap is skipped with a warning.
-
-        Args:
-            graph: Graph to insert beats into.
-            gaps: List of GapProposal instances from LLM output.
-            valid_path_ids: Set or dict of valid path IDs.
-            valid_beat_ids: Set or dict of valid beat IDs.
-            phase_name: Phase name for log event prefixing.
-
-        Returns:
-            Report with counts of inserted and invalid gaps.
-        """
-        from collections import defaultdict
-
-        from questfoundry.graph.grow_algorithms import (
-            _would_create_cycle,
-            get_path_beat_sequence,
-            insert_gap_beat,
-        )
-
-        report = GapInsertionReport()
-        valid_path_set = (
-            set(valid_path_ids.keys()) if isinstance(valid_path_ids, dict) else set(valid_path_ids)
-        )
-        valid_beat_set = (
-            set(valid_beat_ids.keys()) if isinstance(valid_beat_ids, dict) else set(valid_beat_ids)
-        )
-
-        # Build the successors dict (prerequisite → dependents) for cycle detection.
-        # predecessor(A, B) means B comes before A; successors[B] contains A.
-        # We keep this in sync after each successful insertion.
-        beat_set: set[str] = set(graph.get_nodes_by_type("beat").keys())
-        successors: dict[str, set[str]] = defaultdict(set)
-        for edge in graph.get_edges(from_id=None, to_id=None, edge_type="predecessor"):
-            # edge["from"] requires edge["to"] → edge["to"] is a prereq of edge["from"]
-            successors[edge["to"]].add(edge["from"])
-
-        def _normalize_beat_id(beat_id: str | None) -> str | None:
-            if not beat_id:
-                return None
-            if beat_id in valid_beat_set:
-                return beat_id
-            if not beat_id.startswith("beat::"):
-                prefixed = f"beat::{beat_id}"
-                if prefixed in valid_beat_set:
-                    log.info(
-                        f"{phase_name}_unprefixed_beat_id",
-                        beat_id=beat_id,
-                        prefixed=prefixed,
-                    )
-                    return prefixed
-            return beat_id
-
-        for gap in gaps:
-            prefixed_pid = (
-                gap.path_id if gap.path_id.startswith("path::") else f"path::{gap.path_id}"
-            )
-            if prefixed_pid != gap.path_id:
-                log.info(
-                    f"{phase_name}_unprefixed_path_id",
-                    path_id=gap.path_id,
-                    prefixed=prefixed_pid,
-                )
-            if prefixed_pid not in valid_path_set:
-                log.info(f"{phase_name}_invalid_path_id", path_id=gap.path_id)
-                report.invalid_path_id += 1
-                continue
-            after_beat = _normalize_beat_id(gap.after_beat)
-            before_beat = _normalize_beat_id(gap.before_beat)
-            if after_beat and after_beat not in valid_beat_set:
-                log.info(f"{phase_name}_invalid_after_beat", beat_id=after_beat)
-                report.invalid_after_beat += 1
-                continue
-            if before_beat and before_beat not in valid_beat_set:
-                log.info(f"{phase_name}_invalid_before_beat", beat_id=before_beat)
-                report.invalid_before_beat += 1
-                continue
-            # Validate path membership: anchors must belong to the gap's path.
-            # A beat belongs to a path if it has a belongs_to edge pointing to it.
-            if after_beat:
-                after_paths = {
-                    e["to"] for e in graph.get_edges(edge_type="belongs_to", from_id=after_beat)
-                }
-                if prefixed_pid not in after_paths:
-                    log.info(
-                        f"{phase_name}_anchor_wrong_path",
-                        after_beat=after_beat,
-                        path_id=prefixed_pid,
-                    )
-                    report.anchor_wrong_path += 1
-                    continue
-            if before_beat:
-                before_paths = {
-                    e["to"] for e in graph.get_edges(edge_type="belongs_to", from_id=before_beat)
-                }
-                if prefixed_pid not in before_paths:
-                    log.info(
-                        f"{phase_name}_anchor_wrong_path",
-                        before_beat=before_beat,
-                        path_id=prefixed_pid,
-                    )
-                    report.anchor_wrong_path += 1
-                    continue
-            # Validate ordering: after_beat must come before before_beat
-            if after_beat and before_beat:
-                sequence = get_path_beat_sequence(graph, prefixed_pid)
-                try:
-                    after_idx = sequence.index(after_beat)
-                    before_idx = sequence.index(before_beat)
-                    if after_idx >= before_idx:
-                        log.info(
-                            f"{phase_name}_invalid_beat_order",
-                            after_beat=after_beat,
-                            before_beat=before_beat,
-                        )
-                        report.invalid_beat_order += 1
-                        continue
-                except ValueError:
-                    log.info(f"{phase_name}_beat_not_in_sequence", path_id=gap.path_id)
-                    report.beat_not_in_sequence += 1
-                    continue
-
-            # Cycle prevention: if after_beat and before_beat are both given,
-            # check whether inserting the gap would create a cycle.
-            # The gap insertion adds predecessor(gap, after_beat) and
-            # predecessor(before_beat, gap).  A cycle forms if after_beat is
-            # already a transitive successor of before_beat — i.e. inserting
-            # gap closes a circle: before_beat → gap → after_beat → ... → before_beat.
-            # This is equivalent to asking: is after_beat reachable from
-            # before_beat via the current successors graph?
-            # _would_create_cycle(before_beat, after_beat, ...) returns True iff
-            # after_beat is reachable from before_beat, which is exactly that case.
-            if (
-                after_beat
-                and before_beat
-                and _would_create_cycle(before_beat, after_beat, successors, beat_set)
-            ):
-                log.info(
-                    "gap_skipped_would_create_cycle",
-                    phase=phase_name,
-                    after_beat=after_beat,
-                    before_beat=before_beat,
-                    path_id=prefixed_pid,
-                )
-                continue
-
-            new_beat_id = insert_gap_beat(
-                graph,
-                path_id=prefixed_pid,
-                after_beat=after_beat,
-                before_beat=before_beat,
-                summary=gap.summary,
-                scene_type=gap.scene_type,
-                dilemma_impacts=[i.model_dump() for i in gap.dilemma_impacts],
-            )
-            report.inserted += 1
-
-            # Update successors and beat_set to reflect the newly inserted beat.
-            # predecessor(new_beat, after_beat) → after_beat is prereq of new_beat
-            # predecessor(before_beat, new_beat) → new_beat is prereq of before_beat
-            beat_set.add(new_beat_id)
-            if after_beat:
-                successors[after_beat].add(new_beat_id)
-            if before_beat:
-                successors[new_beat_id].add(before_beat)
-
-        return report
+        """Thin delegation to the shared free function (see module docstring)."""
+        return validate_and_insert_gaps(graph, gaps, valid_path_ids, valid_beat_ids, phase_name)

--- a/src/questfoundry/pipeline/stages/grow/llm_phases.py
+++ b/src/questfoundry/pipeline/stages/grow/llm_phases.py
@@ -683,112 +683,12 @@ class _LLMPhaseMixin:
             tokens_used=tokens,
         )
 
-    @grow_phase(name="narrative_gaps", depends_on=["scene_types"], priority=4)
-    async def _phase_4b_narrative_gaps(self, graph: Graph, model: BaseChatModel) -> GrowPhaseResult:
-        """Phase 4b: Detect narrative gaps in path beat sequences.
+    # NOTE: GROW Phase 4b (narrative_gaps) was MOVED to POLISH Phase 1a
+    # per the spec migration in PR #1366. The implementation lives in
+    # ``polish/llm_phases.py``. The shared gap-insertion helper lives in
+    # ``graph/gap_insertion.py``. See issue #1368 for the migration epic.
 
-        For each path, traces the beat sequence and asks the LLM
-        to identify missing beats (e.g., a path jumps from setup
-        to climax without a development beat).
-
-        Preconditions:
-        - Scene types assigned (Phase 4a complete).
-        - Paths have 2+ beats with requires-based ordering.
-
-        Postconditions:
-        - Gap beats inserted into the graph with requires edges.
-        - New beats have belongs_to edges linking them to their path.
-        - Beat summaries provided by LLM for each gap.
-
-        Invariants:
-        - Only paths with 2+ beats assessed.
-        - Inserted beats placed between valid before/after beat pairs.
-        - Invalid proposals (bad IDs, wrong ordering) silently rejected.
-        """
-        from questfoundry.graph.grow_algorithms import get_path_beat_sequence
-        from questfoundry.models.grow import Phase4bOutput
-
-        path_nodes = graph.get_nodes_by_type("path")
-        if not path_nodes:
-            return GrowPhaseResult(
-                phase="narrative_gaps",
-                status="completed",
-                detail="No paths to check for gaps",
-            )
-
-        # Build path sequences with truncated summaries
-        path_sequences: list[str] = []
-        valid_beat_ids: set[str] = set()
-        for pid in sorted(path_nodes.keys()):
-            sequence = get_path_beat_sequence(graph, pid)
-            if len(sequence) < 2:
-                continue
-            beat_list: list[str] = []
-            for bid in sequence:
-                node = graph.get_node(bid)
-                summary = truncate_summary(node.get("summary", ""), 80) if node else ""
-                scene_type = node.get("scene_type", "untagged") if node else "untagged"
-                beat_list.append(f"    {bid} [{scene_type}]: {summary}")
-                valid_beat_ids.add(bid)
-            raw_pid = path_nodes[pid].get("raw_id", pid)
-            path_sequences.append(f"  Path: {raw_pid} ({pid})\n" + "\n".join(beat_list))
-
-        if not path_sequences:
-            return GrowPhaseResult(
-                phase="narrative_gaps",
-                status="completed",
-                detail="No paths with 2+ beats to check",
-            )
-
-        path_dilemma_map_text, valid_dilemma_ids_text = _build_path_dilemma_context(
-            graph, path_nodes
-        )
-
-        context = {
-            "path_sequences": "\n\n".join(path_sequences),
-            "valid_path_ids": ", ".join(sorted(path_nodes.keys())),
-            "valid_beat_ids": ", ".join(sorted(valid_beat_ids)),
-            "path_dilemma_map": path_dilemma_map_text,
-            "valid_dilemma_ids": valid_dilemma_ids_text,
-        }
-
-        from questfoundry.graph.grow_validators import validate_phase4_output
-
-        validator = partial(
-            validate_phase4_output,
-            valid_path_ids=set(path_nodes.keys()),
-            valid_beat_ids=valid_beat_ids,
-            graph=graph,
-        )
-        try:
-            result, llm_calls, tokens = await self._grow_llm_call(  # type: ignore[attr-defined]
-                model=model,
-                template_name="grow_phase4b_narrative_gaps",
-                context=context,
-                output_schema=Phase4bOutput,
-                semantic_validator=validator,
-            )
-        except GrowStageError as e:
-            return GrowPhaseResult(
-                phase="narrative_gaps",
-                status="failed",
-                detail=str(e),
-            )
-
-        # Validate and insert gap beats
-        report = self._validate_and_insert_gaps(  # type: ignore[attr-defined]
-            graph, result.gaps, path_nodes, valid_beat_ids, "phase4b"
-        )
-
-        return GrowPhaseResult(
-            phase="narrative_gaps",
-            status="completed",
-            detail=f"Inserted {report.inserted} gap beats from {len(result.gaps)} proposals",
-            llm_calls=llm_calls,
-            tokens_used=tokens,
-        )
-
-    @grow_phase(name="pacing_gaps", depends_on=["narrative_gaps"], priority=5)
+    @grow_phase(name="pacing_gaps", depends_on=["scene_types"], priority=5)
     async def _phase_4c_pacing_gaps(self, graph: Graph, model: BaseChatModel) -> GrowPhaseResult:
         """Phase 4c: Detect and fix pacing issues (3+ same scene_type in a row).
 

--- a/src/questfoundry/pipeline/stages/grow/llm_phases.py
+++ b/src/questfoundry/pipeline/stages/grow/llm_phases.py
@@ -696,8 +696,8 @@ class _LLMPhaseMixin:
         to propose correction beats for any violations found.
 
         Preconditions:
-        - Narrative gaps resolved (Phase 4b complete).
-        - Beats have scene_type tags from Phase 4a.
+        - Beats have scene_type tags from Phase 4a (the only direct
+          dependency since narrative_gaps moved to POLISH per #1368).
 
         Postconditions:
         - Pacing violations (3+ consecutive same scene_type) corrected.

--- a/src/questfoundry/pipeline/stages/polish/llm_phases.py
+++ b/src/questfoundry/pipeline/stages/polish/llm_phases.py
@@ -191,8 +191,6 @@ class _PolishLLMPhaseMixin:
           ``role: gap_beat``, ``created_by: "POLISH"``.
         - Per-path cap: maximum 2 gap beats per path.
         """
-        from functools import partial
-
         from questfoundry.graph.gap_insertion import validate_and_insert_gaps
         from questfoundry.graph.grow_algorithms import get_path_beat_sequence
         from questfoundry.models.grow import Phase4bOutput
@@ -251,10 +249,11 @@ class _PolishLLMPhaseMixin:
             "valid_dilemma_ids": valid_dilemma_ids_text,
         }
 
-        # The LLM call uses POLISH's helper (no semantic_validator support
-        # currently — invalid IDs in the response are caught by
-        # validate_and_insert_gaps at insertion time).
-        _ = partial  # keep for future semantic-validator support
+        # The LLM call uses POLISH's helper. POLISH's _polish_llm_call has no
+        # semantic_validator parameter, so invalid IDs in the response are
+        # caught by validate_and_insert_gaps at insertion time instead of
+        # forcing a retry. If retry-on-invalid-IDs becomes important, add
+        # semantic_validator support to _polish_llm_call (mirroring GROW's).
         result, llm_calls, tokens = await self._polish_llm_call(  # type: ignore[attr-defined]
             model=model,
             template_name="polish_phase1a_narrative_gaps",

--- a/src/questfoundry/pipeline/stages/polish/llm_phases.py
+++ b/src/questfoundry/pipeline/stages/polish/llm_phases.py
@@ -172,7 +172,120 @@ class _PolishLLMPhaseMixin:
             tokens_used=total_tokens,
         )
 
-    @polish_phase(name="pacing", depends_on=["beat_reordering"], priority=1)
+    @polish_phase(name="narrative_gaps", depends_on=["beat_reordering"], priority=1)
+    async def _phase_1a_narrative_gaps(self, graph: Graph, model: BaseChatModel) -> PhaseResult:
+        """Phase 1a: Narrative Gap Insertion.
+
+        For each path with 2+ beats, the LLM identifies missing
+        intermediate beats (e.g., a path goes setup → climax with no
+        development beat) and proposes new beats to insert at specified
+        positions. Insertion validates IDs, ordering, and cycle safety.
+
+        Per the structural-vs-narrative migration (PR #1366), this is
+        narrative-prep work — POLISH territory, not GROW. See
+        ``docs/design/procedures/polish.md`` §Phase 1a for the spec.
+
+        Postconditions:
+        - Gap beats inserted into the graph with predecessor edges,
+          ``belongs_to`` to their path, ``is_gap_beat=True``,
+          ``role: gap_beat``, ``created_by: "POLISH"``.
+        - Per-path cap: maximum 2 gap beats per path.
+        """
+        from functools import partial
+
+        from questfoundry.graph.gap_insertion import validate_and_insert_gaps
+        from questfoundry.graph.grow_algorithms import get_path_beat_sequence
+        from questfoundry.models.grow import Phase4bOutput
+
+        path_nodes = graph.get_nodes_by_type("path")
+        if not path_nodes:
+            log.info("phase1a_no_paths", detail="No paths to check for gaps")
+            return PhaseResult(
+                phase="narrative_gaps",
+                status="skipped",
+                detail="No paths to check for gaps",
+            )
+
+        # Build path sequences with truncated summaries (matches GROW Phase 4b's
+        # original context shape so the prompt can be migrated verbatim).
+        path_sequences: list[str] = []
+        valid_beat_ids: set[str] = set()
+        for pid in sorted(path_nodes.keys()):
+            sequence = get_path_beat_sequence(graph, pid)
+            if len(sequence) < 2:
+                continue
+            beat_list: list[str] = []
+            for bid in sequence:
+                node = graph.get_node(bid)
+                summary = (node.get("summary", "") or "")[:80] if node else ""
+                scene_type = node.get("scene_type", "untagged") if node else "untagged"
+                beat_list.append(f"    {bid} [{scene_type}]: {summary}")
+                valid_beat_ids.add(bid)
+            raw_pid = path_nodes[pid].get("raw_id", pid)
+            path_sequences.append(f"  Path: {raw_pid} ({pid})\n" + "\n".join(beat_list))
+
+        if not path_sequences:
+            log.info("phase1a_no_multibeat_paths", detail="No paths with 2+ beats")
+            return PhaseResult(
+                phase="narrative_gaps",
+                status="skipped",
+                detail="No paths with 2+ beats to check",
+            )
+
+        # Path → dilemma map for the prompt's Valid IDs section.
+        # Matches the helper used by GROW Phase 4b/4c (kept in grow llm_phases
+        # while pacing_gaps still lives there; will move with PR C).
+        from questfoundry.pipeline.stages.grow.llm_phases import (
+            _build_path_dilemma_context,
+        )
+
+        path_dilemma_map_text, valid_dilemma_ids_text = _build_path_dilemma_context(
+            graph, path_nodes
+        )
+
+        context = {
+            "path_sequences": "\n\n".join(path_sequences),
+            "valid_path_ids": ", ".join(sorted(path_nodes.keys())),
+            "valid_beat_ids": ", ".join(sorted(valid_beat_ids)),
+            "path_dilemma_map": path_dilemma_map_text,
+            "valid_dilemma_ids": valid_dilemma_ids_text,
+        }
+
+        # The LLM call uses POLISH's helper (no semantic_validator support
+        # currently — invalid IDs in the response are caught by
+        # validate_and_insert_gaps at insertion time).
+        _ = partial  # keep for future semantic-validator support
+        result, llm_calls, tokens = await self._polish_llm_call(  # type: ignore[attr-defined]
+            model=model,
+            template_name="polish_phase1a_narrative_gaps",
+            context=context,
+            output_schema=Phase4bOutput,
+        )
+
+        # Validate proposals and insert gap beats.
+        report = validate_and_insert_gaps(
+            graph,
+            result.gaps,
+            valid_path_ids=set(path_nodes.keys()),
+            valid_beat_ids=valid_beat_ids,
+            phase_name="phase1a",
+        )
+
+        log.info(
+            "phase1a_complete",
+            inserted=report.inserted,
+            invalid=report.total_invalid,
+            proposals=len(result.gaps),
+        )
+        return PhaseResult(
+            phase="narrative_gaps",
+            status="completed",
+            detail=f"Inserted {report.inserted} gap beats from {len(result.gaps)} proposals",
+            llm_calls=llm_calls,
+            tokens_used=tokens,
+        )
+
+    @polish_phase(name="pacing", depends_on=["narrative_gaps"], priority=1)
     async def _phase_2_pacing(self, graph: Graph, model: BaseChatModel) -> PhaseResult:
         """Phase 2: Pacing & Micro-beat Injection.
 

--- a/tests/unit/test_grow_registry.py
+++ b/tests/unit/test_grow_registry.py
@@ -216,11 +216,11 @@ class TestGrowPhaseDecorator:
 class TestGlobalRegistry:
     """Tests for the global registry populated by actual GROW phases."""
 
-    def test_global_registry_has_18_phases(self) -> None:
-        """All GROW phases are registered (18 after transition_gaps added)."""
+    def test_global_registry_has_17_phases(self) -> None:
+        """All GROW phases are registered (17 after narrative_gaps moved to POLISH per #1368)."""
         registry = get_registry()
-        assert len(registry) == 18, (
-            f"Expected 18 phases, got {len(registry)}: {registry.phase_names}"
+        assert len(registry) == 17, (
+            f"Expected 17 phases, got {len(registry)}: {registry.phase_names}"
         )
 
     def test_global_registry_validates(self) -> None:
@@ -230,7 +230,7 @@ class TestGlobalRegistry:
         assert errors == [], f"Registry validation errors: {errors}"
 
     def test_global_registry_execution_order_matches_expected(self) -> None:
-        """Execution order matches the current phase structure (18 phases)."""
+        """Execution order matches the current phase structure (17 phases)."""
         expected = [
             "validate_dag",
             "intersections",
@@ -238,7 +238,7 @@ class TestGlobalRegistry:
             "resolve_temporal_hints",
             "interleave_beats",
             "scene_types",
-            "narrative_gaps",
+            # narrative_gaps moved to POLISH Phase 1a per PR #1366 / issue #1368
             "pacing_gaps",
             "atmospheric",
             "path_arcs",

--- a/tests/unit/test_grow_stage.py
+++ b/tests/unit/test_grow_stage.py
@@ -215,10 +215,10 @@ class TestGrowStageExecute:
 
 class TestGrowStagePhaseOrder:
     def test_phase_order_returns_correct_count(self) -> None:
-        """18 phases; transition_gaps added in Phase 4g."""
+        """17 phases after narrative_gaps moved to POLISH (PR for #1368)."""
         stage = GrowStage()
         phases = stage._phase_order()
-        assert len(phases) == 18
+        assert len(phases) == 17
 
     def test_phase_order_names(self) -> None:
         stage = GrowStage()
@@ -230,7 +230,7 @@ class TestGrowStagePhaseOrder:
             "resolve_temporal_hints",
             "interleave_beats",
             "scene_types",
-            "narrative_gaps",
+            # narrative_gaps moved to POLISH Phase 1a per PR #1366 / issue #1368
             "pacing_gaps",
             "atmospheric",
             "path_arcs",
@@ -1124,107 +1124,11 @@ class TestValidateAndInsertGaps:
         assert len(gap_beats) == 1
 
 
-class TestPhase4bNarrativeGaps:
-    @pytest.mark.asyncio
-    async def test_phase_4b_inserts_gap_beats(self) -> None:
-        """Phase 4b inserts gap beats from LLM proposals."""
-        from questfoundry.models.grow import GapProposal, Phase4bOutput
-        from tests.fixtures.grow_fixtures import make_single_dilemma_graph
-
-        graph = make_single_dilemma_graph()
-        stage = GrowStage()
-
-        phase4b_output = Phase4bOutput(
-            gaps=[
-                GapProposal(
-                    path_id="path::mentor_trust_canonical",
-                    after_beat="beat::mentor_meet",
-                    before_beat="beat::mentor_commits_canonical",
-                    summary="Hero reflects on mentor's words",
-                    scene_type="sequel",
-                ),
-            ]
-        )
-
-        mock_structured = AsyncMock()
-        mock_structured.ainvoke = AsyncMock(return_value=phase4b_output)
-        mock_model = MagicMock()
-        mock_model.with_structured_output = MagicMock(return_value=mock_structured)
-
-        result = await stage._phase_4b_narrative_gaps(graph, mock_model)
-
-        assert result.status == "completed"
-        assert result.llm_calls == 1
-        assert "1" in result.detail
-
-        # Verify gap beat was inserted
-        beat_nodes = graph.get_nodes_by_type("beat")
-        gap_beats = [bid for bid in beat_nodes if "gap" in bid]
-        assert len(gap_beats) == 1
-
-    @pytest.mark.asyncio
-    async def test_phase_4b_skips_invalid_path(self) -> None:
-        """Phase 4b skips gap proposals with invalid path IDs."""
-        from questfoundry.models.grow import GapProposal, Phase4bOutput
-        from tests.fixtures.grow_fixtures import make_single_dilemma_graph
-
-        graph = make_single_dilemma_graph()
-        stage = GrowStage()
-
-        phase4b_output = Phase4bOutput(
-            gaps=[
-                GapProposal(
-                    path_id="path::nonexistent",
-                    after_beat="beat::opening",
-                    before_beat="beat::mentor_meet",
-                    summary="Invalid path gap",
-                    scene_type="sequel",
-                ),
-            ]
-        )
-
-        mock_structured = AsyncMock()
-        mock_structured.ainvoke = AsyncMock(return_value=phase4b_output)
-        mock_model = MagicMock()
-        mock_model.with_structured_output = MagicMock(return_value=mock_structured)
-
-        result = await stage._phase_4b_narrative_gaps(graph, mock_model)
-
-        assert result.status == "completed"
-        assert "0" in result.detail
-
-    @pytest.mark.asyncio
-    async def test_phase_4b_no_paths(self) -> None:
-        """Phase 4b returns completed when no paths exist."""
-        from questfoundry.graph.graph import Graph
-
-        graph = Graph.empty()
-        stage = GrowStage()
-        mock_model = MagicMock()
-
-        result = await stage._phase_4b_narrative_gaps(graph, mock_model)
-
-        assert result.status == "completed"
-        assert "No paths" in result.detail
-        assert result.llm_calls == 0
-
-    @pytest.mark.asyncio
-    async def test_phase_4b_single_beat_paths_skipped(self) -> None:
-        """Phase 4b skips paths with only 1 beat (no sequence to gap-check)."""
-        from questfoundry.graph.graph import Graph
-
-        graph = Graph.empty()
-        graph.create_node("path::short", {"type": "path", "raw_id": "short"})
-        graph.create_node("beat::only", {"type": "beat", "summary": "Lone beat"})
-        graph.add_edge("belongs_to", "beat::only", "path::short")
-
-        stage = GrowStage()
-        mock_model = MagicMock()
-
-        result = await stage._phase_4b_narrative_gaps(graph, mock_model)
-
-        assert result.status == "completed"
-        assert "No paths with 2+ beats" in result.detail
+# NOTE: TestPhase4bNarrativeGaps was MOVED to tests/unit/test_polish_llm_phases.py
+# as TestPolishPhase1aNarrativeGaps when GROW's narrative_gaps phase migrated to
+# POLISH per PR #1366 / issue #1368. The same behaviors (insert valid gap, skip
+# invalid path, no-paths early-return, single-beat-path skip) are covered there
+# against the POLISH implementation.
 
 
 class TestPhase4cPacingGaps:

--- a/tests/unit/test_polish_llm_phases.py
+++ b/tests/unit/test_polish_llm_phases.py
@@ -2,11 +2,16 @@
 
 from __future__ import annotations
 
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
 from questfoundry.graph.graph import Graph
 from questfoundry.pipeline.stages.polish.llm_phases import (
     _detect_duplicate_labels_in_passage,
     _detect_pacing_flags,
 )
+from questfoundry.pipeline.stages.polish.stage import PolishStage
 
 
 def _make_beat(graph: Graph, beat_id: str, summary: str, **kwargs: object) -> None:
@@ -164,3 +169,113 @@ def test_detect_duplicate_labels_multiple_collisions_sorted() -> None:
     ]
     collisions = _detect_duplicate_labels_in_passage(specs)
     assert [c["from_passage"] for c in collisions] == ["passage::p1", "passage::p2"]
+
+
+# ---------------------------------------------------------------------------
+# Phase 1a Narrative Gap Insertion (migrated from GROW Phase 4b per PR #1366)
+# ---------------------------------------------------------------------------
+
+
+class TestPolishPhase1aNarrativeGaps:
+    """POLISH Phase 1a — Narrative Gap Insertion.
+
+    Migrated from ``tests/unit/test_grow_stage.py::TestPhase4bNarrativeGaps``
+    when the implementation moved per the structural-vs-narrative migration
+    (issue #1368). Behavior is identical; only the host stage changed.
+    """
+
+    @pytest.mark.asyncio
+    async def test_phase_1a_inserts_gap_beats(self) -> None:
+        """Phase 1a inserts gap beats from LLM proposals."""
+        from questfoundry.models.grow import GapProposal, Phase4bOutput
+        from tests.fixtures.grow_fixtures import make_single_dilemma_graph
+
+        graph = make_single_dilemma_graph()
+        stage = PolishStage()
+
+        phase_output = Phase4bOutput(
+            gaps=[
+                GapProposal(
+                    path_id="path::mentor_trust_canonical",
+                    after_beat="beat::mentor_meet",
+                    before_beat="beat::mentor_commits_canonical",
+                    summary="Hero reflects on mentor's words",
+                    scene_type="sequel",
+                ),
+            ]
+        )
+
+        mock_structured = AsyncMock()
+        mock_structured.ainvoke = AsyncMock(return_value=phase_output)
+        mock_model = MagicMock()
+        mock_model.with_structured_output = MagicMock(return_value=mock_structured)
+
+        result = await stage._phase_1a_narrative_gaps(graph, mock_model)
+
+        assert result.status == "completed"
+        assert result.llm_calls == 1
+        assert "1" in result.detail
+
+        beat_nodes = graph.get_nodes_by_type("beat")
+        gap_beats = [bid for bid in beat_nodes if "gap" in bid]
+        assert len(gap_beats) == 1
+
+    @pytest.mark.asyncio
+    async def test_phase_1a_skips_invalid_path(self) -> None:
+        """Phase 1a skips gap proposals with invalid path IDs."""
+        from questfoundry.models.grow import GapProposal, Phase4bOutput
+        from tests.fixtures.grow_fixtures import make_single_dilemma_graph
+
+        graph = make_single_dilemma_graph()
+        stage = PolishStage()
+
+        phase_output = Phase4bOutput(
+            gaps=[
+                GapProposal(
+                    path_id="path::nonexistent",
+                    after_beat="beat::opening",
+                    before_beat="beat::mentor_meet",
+                    summary="Invalid path gap",
+                    scene_type="sequel",
+                ),
+            ]
+        )
+
+        mock_structured = AsyncMock()
+        mock_structured.ainvoke = AsyncMock(return_value=phase_output)
+        mock_model = MagicMock()
+        mock_model.with_structured_output = MagicMock(return_value=mock_structured)
+
+        result = await stage._phase_1a_narrative_gaps(graph, mock_model)
+
+        assert result.status == "completed"
+        assert "0" in result.detail
+
+    @pytest.mark.asyncio
+    async def test_phase_1a_no_paths(self) -> None:
+        """Phase 1a returns skipped when no paths exist."""
+        graph = Graph.empty()
+        stage = PolishStage()
+        mock_model = MagicMock()
+
+        result = await stage._phase_1a_narrative_gaps(graph, mock_model)
+
+        assert result.status == "skipped"
+        assert "No paths" in result.detail
+        assert result.llm_calls == 0
+
+    @pytest.mark.asyncio
+    async def test_phase_1a_single_beat_paths_skipped(self) -> None:
+        """Phase 1a skips paths with only 1 beat (no sequence to gap-check)."""
+        graph = Graph.empty()
+        graph.create_node("path::short", {"type": "path", "raw_id": "short"})
+        graph.create_node("beat::only", {"type": "beat", "summary": "Lone beat"})
+        graph.add_edge("belongs_to", "beat::only", "path::short")
+
+        stage = PolishStage()
+        mock_model = MagicMock()
+
+        result = await stage._phase_1a_narrative_gaps(graph, mock_model)
+
+        assert result.status == "skipped"
+        assert "No paths with 2+ beats" in result.detail


### PR DESCRIPTION
## Summary

First of three migration PRs (per issue #1368) implementing the code half of the GROW→POLISH spec migration that landed in PR #1366.

GROW Phase 4b (`narrative_gaps`) is narrative-prep work, not structural skeleton, so per the structural-vs-narrative principle it belongs in POLISH. The spec (`docs/design/procedures/polish.md` §Phase 1a) already documents the new home.

## What changed

- **New shared graph module** `src/questfoundry/graph/gap_insertion.py`: `GapInsertionReport` + `validate_and_insert_gaps()` free function. Single source of truth for gap insertion now that two stages need it (PR C will move pacing_gaps too, then GROW won't import this anymore).
- **GROW**: `_phase_4b_narrative_gaps` removed. `_validate_and_insert_gaps` now thin-delegates to the free function (back-compat for existing test call sites). `pacing_gaps.depends_on` updated to `["scene_types"]` (was `["narrative_gaps"]`).
- **POLISH**: `_phase_1a_narrative_gaps` added with `@polish_phase(name="narrative_gaps", depends_on=["beat_reordering"], priority=1)`. `pacing.depends_on` updated to `["narrative_gaps"]`.
- **Prompt**: `prompts/templates/polish_phase1a_narrative_gaps.yaml` (verbatim body from grow_phase4b_narrative_gaps.yaml). Old GROW template stays for pacing_gaps until PR C.
- **Tests**: `TestPhase4bNarrativeGaps` removed from `test_grow_stage.py` (with NOTE pointing to new location). Equivalent `TestPolishPhase1aNarrativeGaps` added to `test_polish_llm_phases.py`. Phase-count assertions updated 18 → 17.

## Test plan

- [x] 3566 unit tests pass (`uv run pytest tests/unit/ -x -q`)
- [x] mypy clean
- [x] ruff check + ruff format clean
- [x] GROW phase order assertion updated (`narrative_gaps` removed from expected sequence)
- [x] POLISH phase order — `narrative_gaps` slot reserved between `beat_reordering` and `pacing` via `depends_on`
- [ ] Manual: confirm a real run with paths still produces gap beats (deferred)

## Future PRs in #1368

- **PR B**: `atmospheric` → POLISH Phase 5e + `path_arcs` → POLISH Phase 5f
- **PR C**: `pacing_gaps` → POLISH Phase 2 extension + `entity_arcs` → POLISH Phase 3 extension. Cleans up the temporary `_validate_and_insert_gaps` delegation when GROW no longer needs it.

Refs #1368.

🤖 Generated with [Claude Code](https://claude.com/claude-code)