### PR TITLE
ci(claude-review): allow claude[bot] to trigger reviews

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -46,5 +46,12 @@ jobs:
           # in the job's GitHub Step Summary.
           track_progress: true
           display_report: true
+          # The action's safety check refuses bot-initiated runs by default.
+          # claude[bot] pushes commits when a `[Fix this →]` link is clicked
+          # from a previous review comment — those pushes trigger a
+          # `pull_request` synchronize event with `actor=claude[bot]`, which
+          # we DO want reviewed. Explicit allowlist so future fix-link cycles
+          # keep flowing through review without manual re-runs.
+          allowed_bots: 'claude'
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options


### PR DESCRIPTION
## Summary

Adds `allowed_bots: 'claude'` to `.github/workflows/claude-code-review.yml` so the review workflow runs on pushes initiated by `claude[bot]` — specifically the auto-fix commits that land when someone clicks a `[Fix this →]` link from a prior review comment.

## Background

`anthropics/claude-code-action@v1` upgraded its safety check to refuse runs from non-human actors:

```
Workflow initiated by non-human actor: claude (type: Bot).
Add bot to allowed_bots list or use '*' to allow all bots.
```

This breaks the auto-fix → re-review feedback loop: the bot pushes a fix, but the workflow refuses to evaluate it. First observed on PR #1373 ([failed run](https://github.com/pvliesdonk/questfoundry/actions/runs/24876754779/job/72844540828)).

## Why specifically `claude` and not `*`

Allowlisting only `claude` keeps the safety check active against arbitrary other bots (dependabot, renovate, third-party integrations) that we don't want spending Claude review budget. Only the official Anthropic bot needs the bypass.

## Test plan

- [ ] Once merged, confirm review re-runs on the next `claude[bot]` push (visible the first time someone clicks a `[Fix this →]` link after this change lands).

🤖 Generated with [Claude Code](https://claude.com/claude-code)