### PR TITLE
feat(dress): codex spoiler-direction enforcement + retry loop (closes #1329)

### DIFF
--- a/prompts/templates/dress_codex_spoiler_check.yaml
+++ b/prompts/templates/dress_codex_spoiler_check.yaml
@@ -1,0 +1,53 @@
+name: dress_codex_spoiler_check
+description: Check whether lower-ranked codex entries leak content gated behind higher-ranked tiers (R-3.6)
+
+system: |
+  You are auditing codex entries for an interactive fiction story.
+
+  Codex entries for one entity are tiered. Tier 1 is always visible. Higher
+  tiers (rank 2, 3, ...) are unlocked as the player progresses, gated by
+  state flags. The intent is **spoiler graduation**: each tier reveals
+  more than the previous, in a controlled order.
+
+  **Your task:** Detect whether any **lower-ranked** entry leaks information
+  whose reveal is supposed to be gated behind a **higher-ranked** entry.
+  The direction matters — rank 1 may be deliberately vague; rank 2+ may
+  fully reveal. The violation is when rank 1 (or any lower rank) prematurely
+  discloses what a higher-rank entry was meant to be the moment of revelation.
+
+  ## Examples
+
+  **Leak (rank 1 → rank 2):**
+  - rank 1: "A traveling scholar who secretly knows your true identity."
+  - rank 2 (gated by `met_aldric`): "Aldric is the traitor who betrayed your mentor."
+  - Verdict: rank 1 leaks the deception angle. The reveal "this trusted figure
+    is hiding a major secret about you" is what rank 2 was supposed to deliver.
+
+  **No leak:**
+  - rank 1: "A traveling scholar who offers guidance to weary travelers."
+  - rank 2 (gated by `met_aldric`): "Aldric is the traitor who betrayed your mentor."
+  - Verdict: rank 1 stays in deliberately vague public-knowledge territory.
+
+  ## Output Schema
+
+  Return a JSON object with:
+  - **has_leak** (bool): true if any lower-ranked entry leaks higher-ranked content
+  - **leaks** (list of objects, possibly empty): each with:
+    - lower_rank (int ≥ 1): the rank that disclosed too much
+    - higher_rank (int ≥ 2): the rank whose reveal was leaked
+    - leaked_content (string): short paraphrase of what was leaked
+  - **reason** (string): brief overall explanation; empty string if no leak
+
+  Return ONLY valid JSON. No prose before or after.
+
+user: |
+  ## Entity
+  {entity_id}
+
+  ## Codex Entries (ordered by rank)
+  {entries_block}
+
+  Audit these entries. Does any lower-ranked entry leak content gated behind a
+  higher-ranked tier? Return a JSON object matching the schema.
+
+components: []

--- a/src/questfoundry/models/__init__.py
+++ b/src/questfoundry/models/__init__.py
@@ -43,6 +43,8 @@ from questfoundry.models.dress import (
     Illustration,
     IllustrationBrief,
     IllustrationCategory,
+    SpoilerCheckResult,
+    SpoilerLeak,
 )
 from questfoundry.models.fill import (
     BatchedExpandOutput,
@@ -246,6 +248,8 @@ __all__ = [
     "Scope",
     "SeedOutput",
     "SharedBeatsSection",
+    "SpoilerCheckResult",
+    "SpoilerLeak",
     "SpokeLabelUpdate",
     "StateFlag",
     "TemporalHint",

--- a/src/questfoundry/models/dress.py
+++ b/src/questfoundry/models/dress.py
@@ -233,6 +233,39 @@ class BatchedCodexOutput(BaseModel):
     entities: list[BatchedCodexItem] = Field(min_length=1)
 
 
+class SpoilerLeak(BaseModel):
+    """One spoiler-direction violation between two ranks of one entity."""
+
+    lower_rank: int = Field(
+        ge=1,
+        description="Rank of the entry that prematurely discloses information",
+    )
+    higher_rank: int = Field(
+        ge=2,
+        description="Rank of the entry whose reveal was leaked",
+    )
+    leaked_content: str = Field(
+        min_length=1,
+        description="Short quote or paraphrase of the leaked information",
+    )
+
+
+class SpoilerCheckResult(BaseModel):
+    """Result of an LLM spoiler check on one entity's codex entries (R-3.6)."""
+
+    has_leak: bool = Field(
+        description="True if any lower-ranked entry leaks higher-ranked content",
+    )
+    leaks: list[SpoilerLeak] = Field(
+        default_factory=list,
+        description="Detected spoiler violations (empty if has_leak is False)",
+    )
+    reason: str = Field(
+        default="",
+        description="Brief LLM explanation; populated when has_leak is True",
+    )
+
+
 # ---------------------------------------------------------------------------
 # Stage result
 # ---------------------------------------------------------------------------

--- a/src/questfoundry/models/dress.py
+++ b/src/questfoundry/models/dress.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 
 from typing import Literal
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
 
 from questfoundry.models.pipeline import PhaseResult
 
@@ -248,6 +248,21 @@ class SpoilerLeak(BaseModel):
         min_length=1,
         description="Short quote or paraphrase of the leaked information",
     )
+
+    @model_validator(mode="after")
+    def _check_rank_ordering(self) -> SpoilerLeak:
+        # R-3.6's spoiler direction is strictly low → high. An LLM that
+        # returns lower_rank ≥ higher_rank has either inverted the
+        # arguments or invented a self-referential leak; either way the
+        # downstream retry feedback would be nonsensical, so reject at
+        # validation time so the LLM repair loop fixes it.
+        if self.lower_rank >= self.higher_rank:
+            msg = (
+                f"SpoilerLeak: lower_rank ({self.lower_rank}) must be "
+                f"strictly less than higher_rank ({self.higher_rank})"
+            )
+            raise ValueError(msg)
+        return self
 
 
 class SpoilerCheckResult(BaseModel):

--- a/src/questfoundry/pipeline/stages/dress.py
+++ b/src/questfoundry/pipeline/stages/dress.py
@@ -1604,26 +1604,36 @@ def _format_entries_for_spoiler_check(entries: list[dict[str, Any]]) -> str:
     return "\n\n".join(lines)
 
 
+_FALLBACK_DESCRIPTORS: dict[str, str] = {
+    "character": "a figure encountered in the story",
+    "location": "a place encountered in the story",
+    "object": "an object encountered in the story",
+    "item": "an object encountered in the story",
+    "faction": "a group encountered in the story",
+}
+_FALLBACK_DESCRIPTOR_DEFAULT = "an element of the story"
+
+
 def _minimal_rank_one_codex(graph: Graph, entity_id: str) -> list[dict[str, Any]]:
     """Build a deliberately vague rank-1-only fallback codex entry.
 
     Used when spoiler retries are exhausted. Per spec, retry exhaustion
     must produce a minimal codex with WARNING — never a silent gap.
-    The fallback uses the entity's display name and a generic
-    description so the entry exists, validates, and reveals nothing the
-    player has not already encountered.
+    The fallback uses the entity's display name and an entity-type
+    appropriate descriptor so the entry stays diegetic (R-3.4) for
+    locations, items, and factions as well as characters.
     """
     raw_id = strip_scope_prefix(entity_id)
     entity_node = graph.get_node(entity_id) or {}
     title = entity_node.get("name") or entity_node.get("title") or raw_id
+    entity_type = entity_node.get("entity_type", "character")
+    descriptor = _FALLBACK_DESCRIPTORS.get(entity_type, _FALLBACK_DESCRIPTOR_DEFAULT)
     return [
         {
             "title": title,
             "rank": 1,
             "visible_when": [],
-            "content": (
-                f"{title} — a figure encountered in the story. Further details are not yet known."
-            ),
+            "content": f"{title} — {descriptor}. Further details are not yet known.",
         }
     ]
 

--- a/src/questfoundry/pipeline/stages/dress.py
+++ b/src/questfoundry/pipeline/stages/dress.py
@@ -42,6 +42,7 @@ from questfoundry.graph.dress_context import (
     format_all_entity_visuals,
     format_art_direction_context,
     format_entities_batch_for_codex,
+    format_entity_for_codex,
     format_passages_batch_for_briefs,
     format_vision_and_entities,
 )
@@ -61,7 +62,9 @@ from questfoundry.models.dress import (
     BatchedBriefOutput,
     BatchedCodexOutput,
     DressPhase0Output,
+    DressPhase2Output,
     DressPhaseResult,
+    SpoilerCheckResult,
 )
 from questfoundry.observability.logging import get_logger
 from questfoundry.observability.tracing import traceable
@@ -107,6 +110,12 @@ _VALID_ASPECT_RATIOS = {"1:1", "16:9", "9:16", "3:2", "2:3"}
 # reprioritization. Spec calls this `priority: skip` (string); see
 # tracking note in map_score_to_priority for the drift.
 _BRIEF_SKIP_PRIORITY = 99
+
+# Per-entity codex regeneration cap per spec R-3.6: at most 2 retries after
+# the original batch attempt for any one entity whose entries leak content
+# gated behind a higher tier. After exhaustion, fall back to a minimal
+# rank-1-only entry with WARNING (no silent gap).
+_CODEX_SPOILER_RETRIES = 2
 
 
 def _parse_aspect_ratio(raw: str) -> str:
@@ -913,12 +922,40 @@ class DressStage:
             on_connectivity_error=self._on_connectivity_error,
         )
 
+        spoiler_retries = 0
+        spoiler_fallbacks = 0
+
         for batch_result in results:
             if batch_result is None:
                 log.warning("codex_batch_failed", detail="batch returned no results")
                 continue
             for entity_id, entry_dicts in batch_result:
-                errs = validate_dress_codex_entries(graph, entity_id, entry_dicts)
+                # R-3.6: per-entity spoiler-direction check. If a lower tier
+                # leaks higher-tier content, regenerate this entity's entries
+                # alone (max _CODEX_SPOILER_RETRIES). On exhaustion, fall back
+                # to a minimal rank-1-only codex with a WARNING — never ship
+                # silently leaking spoilers.
+                (
+                    final_entries,
+                    retries,
+                    fallback,
+                    retry_calls,
+                    retry_tokens,
+                ) = await self._enforce_codex_spoiler_safety(
+                    graph,
+                    model,
+                    entity_id,
+                    entry_dicts,
+                    vision_ctx=vision_ctx,
+                    state_flag_list=state_flag_list,
+                )
+                spoiler_retries += retries
+                if fallback:
+                    spoiler_fallbacks += 1
+                total_llm_calls += retry_calls
+                total_tokens += retry_tokens
+
+                errs = validate_dress_codex_entries(graph, entity_id, final_entries)
                 if errs:
                     validation_warnings += 1
                     log.warning(
@@ -926,14 +963,16 @@ class DressStage:
                         entity_id=entity_id,
                         errors=errs,
                     )
-                apply_dress_codex(graph, entity_id, entry_dicts)
-                codex_created += len(entry_dicts)
+                apply_dress_codex(graph, entity_id, final_entries)
+                codex_created += len(final_entries)
 
         log.info(
             "codex_phase_complete",
             entries_created=codex_created,
             entities=len(entities),
             warnings=validation_warnings,
+            spoiler_retries=spoiler_retries,
+            spoiler_fallbacks=spoiler_fallbacks,
         )
 
         return DressPhaseResult(
@@ -943,6 +982,132 @@ class DressStage:
             llm_calls=total_llm_calls,
             tokens_used=total_tokens,
         )
+
+    # -------------------------------------------------------------------------
+    # Phase 2 helpers: spoiler-direction enforcement (R-3.6)
+    # -------------------------------------------------------------------------
+
+    async def _enforce_codex_spoiler_safety(
+        self,
+        graph: Graph,
+        model: BaseChatModel,
+        entity_id: str,
+        entries: list[dict[str, Any]],
+        *,
+        vision_ctx: str,
+        state_flag_list: str,
+    ) -> tuple[list[dict[str, Any]], int, bool, int, int]:
+        """Enforce R-3.6 spoiler-direction safety on one entity's entries.
+
+        Runs an LLM spoiler check; on detected leak, regenerates the
+        entity's entries alone (max ``_CODEX_SPOILER_RETRIES``).  If
+        every retry still leaks, returns a minimal rank-1-only fallback
+        with WARNING logged.
+
+        Returns:
+            ``(final_entries, retries_used, used_fallback, llm_calls, tokens)``.
+        """
+        current = entries
+        retries_used = 0
+        total_calls = 0
+        total_tokens = 0
+
+        for attempt in range(_CODEX_SPOILER_RETRIES + 1):
+            check, calls, tokens = await self._spoiler_check(model, entity_id, current)
+            total_calls += calls
+            total_tokens += tokens
+            if not check.has_leak:
+                return current, retries_used, False, total_calls, total_tokens
+
+            log.warning(
+                "codex_spoiler_leak_detected",
+                entity_id=entity_id,
+                attempt=attempt + 1,
+                leaks=[leak.model_dump() for leak in check.leaks],
+                reason=check.reason,
+            )
+
+            if attempt == _CODEX_SPOILER_RETRIES:
+                break
+
+            retries_used += 1
+            regen_entries, regen_calls, regen_tokens = await self._regenerate_codex_for_entity(
+                graph,
+                model,
+                entity_id,
+                vision_ctx=vision_ctx,
+                state_flag_list=state_flag_list,
+                prior_leak=check,
+            )
+            total_calls += regen_calls
+            total_tokens += regen_tokens
+            current = regen_entries
+
+        # Retries exhausted; spec mandates a rank-1-only fallback with WARNING
+        # rather than a silent gap.
+        fallback = _minimal_rank_one_codex(graph, entity_id)
+        log.warning(
+            "codex_spoiler_retry_exhausted",
+            entity_id=entity_id,
+            retries=_CODEX_SPOILER_RETRIES,
+            fallback_entries=len(fallback),
+        )
+        return fallback, retries_used, True, total_calls, total_tokens
+
+    async def _spoiler_check(
+        self,
+        model: BaseChatModel,
+        entity_id: str,
+        entries: list[dict[str, Any]],
+    ) -> tuple[SpoilerCheckResult, int, int]:
+        """Ask the LLM whether any lower-ranked entry leaks higher-rank content."""
+        entries_block = _format_entries_for_spoiler_check(entries)
+        context = {
+            "entity_id": entity_id,
+            "entries_block": entries_block,
+        }
+        return await self._dress_llm_call(
+            model,
+            "dress_codex_spoiler_check",
+            context,
+            SpoilerCheckResult,
+        )
+
+    async def _regenerate_codex_for_entity(
+        self,
+        graph: Graph,
+        model: BaseChatModel,
+        entity_id: str,
+        *,
+        vision_ctx: str,
+        state_flag_list: str,
+        prior_leak: SpoilerCheckResult,
+    ) -> tuple[list[dict[str, Any]], int, int]:
+        """Regenerate one entity's codex after a detected spoiler leak."""
+        entity_details = format_entity_for_codex(graph, entity_id)
+        leak_summary = (
+            "\n".join(
+                f"- rank {leak.lower_rank} leaked content gated behind rank "
+                f"{leak.higher_rank}: {leak.leaked_content}"
+                for leak in prior_leak.leaks
+            )
+            or "Prior attempt leaked higher-tier content."
+        )
+        # Append the prior-leak description to entity details so the model
+        # has the concrete failure mode to avoid this round.
+        entity_details_with_warning = (
+            f"{entity_details}\n\n## Prior attempt leaked spoilers — DO NOT REPEAT\n{leak_summary}"
+        )
+        context = {
+            "vision_context": vision_ctx or "No creative vision available.",
+            "entity_details": entity_details_with_warning,
+            "codewords": state_flag_list or "No codewords defined.",
+            "output_language_instruction": self._lang_instruction,
+        }
+        output, calls, tokens = await self._dress_llm_call(
+            model, "dress_codex", context, DressPhase2Output
+        )
+        return [e.model_dump() for e in output.entries], calls, tokens
 
     # -------------------------------------------------------------------------
     # Phase 3: Human Review Gate
@@ -1409,6 +1574,58 @@ class DressStage:
             status="completed",
             detail=f"{generated} images generated, {failed} failed",
         )
+
+
+# -------------------------------------------------------------------------
+# Codex spoiler-check helpers
+# -------------------------------------------------------------------------
+
+
+def _format_entries_for_spoiler_check(entries: list[dict[str, Any]]) -> str:
+    """Render codex entries as a numbered, rank-ordered block for the LLM.
+
+    The spoiler-check prompt needs human-readable entries (per CLAUDE.md
+    §Prompt Context Formatting). Sort by rank ascending so the model
+    audits low → high in the same direction the player would unlock them.
+    """
+    sorted_entries = sorted(entries, key=lambda e: e.get("rank", 0))
+    lines: list[str] = []
+    for entry in sorted_entries:
+        rank = entry.get("rank", "?")
+        title = entry.get("title", "(no title)")
+        gates = entry.get("visible_when") or []
+        gate_text = (
+            "always visible"
+            if not gates
+            else "gated by " + ", ".join(f"`{strip_scope_prefix(g)}`" for g in gates)
+        )
+        content = (entry.get("content") or "").strip() or "(no content)"
+        lines.append(f"### Rank {rank} — {title} ({gate_text})\n{content}")
+    return "\n\n".join(lines)
+
+
+def _minimal_rank_one_codex(graph: Graph, entity_id: str) -> list[dict[str, Any]]:
+    """Build a deliberately vague rank-1-only fallback codex entry.
+
+    Used when spoiler retries are exhausted. Per spec, retry exhaustion
+    must produce a minimal codex with WARNING — never a silent gap.
+    The fallback uses the entity's display name and a generic
+    description so the entry exists, validates, and reveals nothing the
+    player has not already encountered.
+    """
+    raw_id = strip_scope_prefix(entity_id)
+    entity_node = graph.get_node(entity_id) or {}
+    title = entity_node.get("name") or entity_node.get("title") or raw_id
+    return [
+        {
+            "title": title,
+            "rank": 1,
+            "visible_when": [],
+            "content": (
+                f"{title} — a figure encountered in the story. Further details are not yet known."
+            ),
+        }
+    ]
 
 
 # -------------------------------------------------------------------------

--- a/tests/unit/test_dress_stage.py
+++ b/tests/unit/test_dress_stage.py
@@ -21,9 +21,12 @@ from questfoundry.models.dress import (
     CodexEntry,
     DressPhase0Output,
     DressPhase1Output,
+    DressPhase2Output,
     DressPhaseResult,
     EntityVisualWithId,
     IllustrationBrief,
+    SpoilerCheckResult,
+    SpoilerLeak,
 )
 from questfoundry.pipeline.stages.dress import (
     DressStage,
@@ -205,6 +208,54 @@ class TestDressStageResume:
 
 
 # ---------------------------------------------------------------------------
+# Shared mock helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_dispatch_mock(
+    *,
+    brief_output: Any = None,
+    codex_batch_output: BatchedCodexOutput | None = None,
+    spoiler_result: SpoilerCheckResult | None = None,
+    codex_retry_output: DressPhase2Output | None = None,
+) -> Any:
+    """Build a side_effect that dispatches by template name.
+
+    Phase 2 now issues a per-entity spoiler-check call after every batch
+    (R-3.6). Tests that previously enumerated a fixed call list as side
+    effects break when the new call slots in. This helper routes by
+    ``template_name`` so the test stays declarative.
+
+    Default ``spoiler_result`` is "no leak" so existing tests keep
+    passing without changes to their assertions.
+    """
+    safe = spoiler_result or SpoilerCheckResult(has_leak=False, leaks=[], reason="")
+
+    async def _dispatch(
+        _model: Any,
+        template_name: str,
+        _context: dict[str, Any],
+        _schema: type,
+        **_kwargs: Any,
+    ) -> tuple:
+        if template_name == "dress_codex_spoiler_check":
+            return (safe, 1, 25)
+        if template_name == "dress_codex_batch":
+            assert codex_batch_output is not None, "codex_batch_output not provided"
+            return (codex_batch_output, 1, 50)
+        if template_name == "dress_codex":
+            assert codex_retry_output is not None, "codex_retry_output not provided"
+            return (codex_retry_output, 1, 50)
+        if template_name in {"dress_brief", "dress_brief_batch"}:
+            assert brief_output is not None, "brief_output not provided"
+            return (brief_output, 1, 50)
+        msg = f"Unexpected template_name in dispatch mock: {template_name}"
+        raise AssertionError(msg)
+
+    return _dispatch
+
+
+# ---------------------------------------------------------------------------
 # Phase 0: Art Direction
 # ---------------------------------------------------------------------------
 
@@ -270,12 +321,10 @@ class TestPhase0ArtDirection:
                 stage,
                 "_dress_llm_call",
                 new_callable=AsyncMock,
-                # Phase 1: 1 passage (per-passage call).
-                # Phase 2: 1 batch with both entities (batch size 4).
-                side_effect=[
-                    (mock_brief_output, 1, 50),  # Phase 1: opening passage
-                    (mock_codex_out, 1, 50),  # Phase 2: batch of 2 entities
-                ],
+                side_effect=_make_dispatch_mock(
+                    brief_output=mock_brief_output,
+                    codex_batch_output=mock_codex_out,
+                ),
             ),
         ):
             await stage.execute(MagicMock(), "Establish art direction")
@@ -1416,12 +1465,13 @@ class TestPhase2Codex:
             stage,
             "_dress_llm_call",
             new_callable=AsyncMock,
-            return_value=(mock_output, 1, 150),
+            side_effect=_make_dispatch_mock(codex_batch_output=mock_output),
         ):
             result = await stage._phase_2_codex(g, MagicMock())
 
         assert result.status == "completed"
-        assert result.llm_calls == 1
+        # 1 batch call + 1 spoiler-check call per entity (R-3.6)
+        assert result.llm_calls == 2
         assert g.get_node("codex::protagonist_rank1") is not None
         assert g.get_node("codex::protagonist_rank2") is not None
 
@@ -1472,6 +1522,8 @@ class TestPhase2Codex:
 
         calls: list[dict[str, Any]] = []
 
+        batch_calls: list[dict[str, Any]] = []
+
         async def _mock_llm_call(
             _model: Any,
             _template: str,
@@ -1480,6 +1532,10 @@ class TestPhase2Codex:
             **_kwargs: Any,
         ) -> tuple:
             calls.append(_context)
+            if _template == "dress_codex_spoiler_check":
+                return (SpoilerCheckResult(has_leak=False, leaks=[], reason=""), 1, 25)
+            # dress_codex_batch
+            batch_calls.append(_context)
             # Parse entity IDs from batch context (each starts with "## Entity: <raw_id>")
             import re
 
@@ -1491,8 +1547,9 @@ class TestPhase2Codex:
         with patch.object(stage, "_dress_llm_call", side_effect=_mock_llm_call):
             result = await stage._phase_2_codex(g, MagicMock())
 
-        assert len(calls) == 2  # 4 + 1
-        assert result.llm_calls == 2
+        assert len(batch_calls) == 2  # 4 + 1 batches
+        # 2 batch calls + 5 spoiler-check calls (one per entity)
+        assert result.llm_calls == 7
         # All 5 entities should have codex entries
         for i in range(5):
             assert g.get_node(f"codex::e{i}_rank1") is not None
@@ -1524,7 +1581,7 @@ class TestPhase2Codex:
             stage,
             "_dress_llm_call",
             new_callable=AsyncMock,
-            return_value=(wrong_output, 1, 100),
+            side_effect=_make_dispatch_mock(codex_batch_output=wrong_output),
         ):
             result = await stage._phase_2_codex(g, MagicMock())
 
@@ -1551,12 +1608,221 @@ class TestPhase2Codex:
             stage,
             "_dress_llm_call",
             new_callable=AsyncMock,
-            return_value=(mock_output, 1, 150),
+            side_effect=_make_dispatch_mock(codex_batch_output=mock_output),
         ):
             result = await stage._phase_2_codex(g, MagicMock())
 
         assert result.status == "completed"
         assert g.get_node("codex::protagonist_rank1") is not None
+
+
+# ---------------------------------------------------------------------------
+# Phase 2: spoiler-direction enforcement (R-3.6)
+# ---------------------------------------------------------------------------
+
+
+class TestPhase2CodexSpoilerEnforcement:
+    """R-3.6: lower-tier entries must not leak higher-tier reveals.
+
+    Detection is an LLM call after each batch; on leak, the entity is
+    regenerated alone (max 2 retries); on retry exhaustion, fall back
+    to a minimal rank-1-only codex with a WARNING.
+    """
+
+    @pytest.mark.asyncio()
+    async def test_clean_first_attempt_no_retry(self) -> None:
+        """No leak detected → no retry, original entries persist."""
+        g = Graph()
+        g.create_node(
+            "entity::protagonist",
+            {"type": "entity", "raw_id": "protagonist", "entity_type": "character"},
+        )
+        stage = DressStage()
+        original = _make_codex_output("entity::protagonist")
+        with patch.object(
+            stage,
+            "_dress_llm_call",
+            new_callable=AsyncMock,
+            side_effect=_make_dispatch_mock(codex_batch_output=original),
+        ):
+            result = await stage._phase_2_codex(g, MagicMock())
+
+        assert result.status == "completed"
+        # Original rank-1 content (from _make_codex_output) survived
+        rank1 = g.get_node("codex::protagonist_rank1")
+        assert rank1 is not None
+        assert rank1["content"] == "A young scholar of the old academy."
+        assert g.get_node("codex::protagonist_rank2") is not None
+
+    @pytest.mark.asyncio()
+    async def test_leak_triggers_single_retry_then_clean(self) -> None:
+        """Leak → 1 retry → clean. Replaced content lands on graph."""
+        g = Graph()
+        g.create_node(
+            "entity::protagonist",
+            {"type": "entity", "raw_id": "protagonist", "entity_type": "character"},
+        )
+        stage = DressStage()
+        original = _make_codex_output("entity::protagonist")
+        clean_retry = DressPhase2Output(
+            entries=[
+                CodexEntry(
+                    title="Protagonist",
+                    rank=1,
+                    visible_when=[],
+                    content="A figure encountered early on. Vague.",
+                ),
+                CodexEntry(
+                    title="Protagonist's Secret",
+                    rank=2,
+                    visible_when=["met_aldric"],
+                    content="Now revealed: the deeper truth.",
+                ),
+            ]
+        )
+        # First spoiler check leaks; after retry, second spoiler check is clean.
+        leaks_then_clean = [
+            SpoilerCheckResult(
+                has_leak=True,
+                leaks=[
+                    SpoilerLeak(
+                        lower_rank=1,
+                        higher_rank=2,
+                        leaked_content="rank-1 already reveals rank-2 content",
+                    )
+                ],
+                reason="rank 1 leaked the secret",
+            ),
+            SpoilerCheckResult(has_leak=False, leaks=[], reason=""),
+        ]
+
+        async def _dispatch(
+            _model: Any,
+            template_name: str,
+            _context: dict[str, Any],
+            _schema: type,
+            **_kwargs: Any,
+        ) -> tuple:
+            if template_name == "dress_codex_batch":
+                return (original, 1, 50)
+            if template_name == "dress_codex":
+                return (clean_retry, 1, 50)
+            if template_name == "dress_codex_spoiler_check":
+                return (leaks_then_clean.pop(0), 1, 25)
+            msg = f"Unexpected template: {template_name}"
+            raise AssertionError(msg)
+
+        with patch.object(stage, "_dress_llm_call", side_effect=_dispatch):
+            result = await stage._phase_2_codex(g, MagicMock())
+
+        assert result.status == "completed"
+        # Retry content landed (replaced original)
+        rank1 = g.get_node("codex::protagonist_rank1")
+        assert rank1 is not None
+        assert "Vague" in rank1["content"]
+
+    @pytest.mark.asyncio()
+    async def test_retry_exhausted_falls_back_to_rank1_only(self) -> None:
+        """3 leaks (initial + 2 retries) → minimal rank-1-only fallback."""
+        g = Graph()
+        g.create_node(
+            "entity::protagonist",
+            {
+                "type": "entity",
+                "raw_id": "protagonist",
+                "entity_type": "character",
+                "name": "The Wandering Scholar",
+            },
+        )
+        stage = DressStage()
+        original = _make_codex_output("entity::protagonist")
+        leaky_retry = DressPhase2Output(
+            entries=[
+                CodexEntry(
+                    title="Still Leaky",
+                    rank=1,
+                    visible_when=[],
+                    content="Still leaks the rank-2 secret.",
+                ),
+                CodexEntry(
+                    title="Secret",
+                    rank=2,
+                    visible_when=["met_aldric"],
+                    content="The secret.",
+                ),
+            ]
+        )
+        always_leak = SpoilerCheckResult(
+            has_leak=True,
+            leaks=[SpoilerLeak(lower_rank=1, higher_rank=2, leaked_content="leak")],
+            reason="persistent leak",
+        )
+
+        async def _dispatch(
+            _model: Any,
+            template_name: str,
+            _context: dict[str, Any],
+            _schema: type,
+            **_kwargs: Any,
+        ) -> tuple:
+            if template_name == "dress_codex_batch":
+                return (original, 1, 50)
+            if template_name == "dress_codex":
+                return (leaky_retry, 1, 50)
+            if template_name == "dress_codex_spoiler_check":
+                return (always_leak, 1, 25)
+            msg = f"Unexpected template: {template_name}"
+            raise AssertionError(msg)
+
+        with patch.object(stage, "_dress_llm_call", side_effect=_dispatch):
+            result = await stage._phase_2_codex(g, MagicMock())
+
+        assert result.status == "completed"
+        # Fallback wrote ONLY a rank-1 entry; rank-2 absent
+        assert g.get_node("codex::protagonist_rank1") is not None
+        assert g.get_node("codex::protagonist_rank2") is None
+        rank1 = g.get_node("codex::protagonist_rank1")
+        # Fallback uses entity name when present
+        assert "The Wandering Scholar" in rank1["title"]
+        assert rank1["visible_when"] == []
+
+
+def test_format_entries_for_spoiler_check_orders_by_rank() -> None:
+    from questfoundry.pipeline.stages.dress import _format_entries_for_spoiler_check
+
+    entries = [
+        {"rank": 2, "title": "Hidden", "visible_when": ["state_flag::met"], "content": "Deep."},
+        {"rank": 1, "title": "Surface", "visible_when": [], "content": "Shallow."},
+    ]
+    rendered = _format_entries_for_spoiler_check(entries)
+    # Rank 1 must appear before Rank 2 in the rendered block
+    assert rendered.index("Rank 1") < rendered.index("Rank 2")
+    assert "always visible" in rendered
+    assert "gated by `met`" in rendered
+
+
+def test_minimal_rank_one_codex_uses_entity_name() -> None:
+    from questfoundry.pipeline.stages.dress import _minimal_rank_one_codex
+
+    g = Graph()
+    g.create_node(
+        "entity::aldric",
+        {"type": "entity", "raw_id": "aldric", "name": "Aldric the Scribe"},
+    )
+    fallback = _minimal_rank_one_codex(g, "entity::aldric")
+    assert len(fallback) == 1
+    assert fallback[0]["rank"] == 1
+    assert fallback[0]["visible_when"] == []
+    assert "Aldric the Scribe" in fallback[0]["title"]
+
+
+def test_minimal_rank_one_codex_falls_back_to_raw_id() -> None:
+    from questfoundry.pipeline.stages.dress import _minimal_rank_one_codex
+
+    g = Graph()
+    fallback = _minimal_rank_one_codex(g, "entity::missing")
+    # No node, no name → use raw id as title
+    assert fallback[0]["title"] == "missing"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_dress_stage.py
+++ b/tests/unit/test_dress_stage.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 from typing import TYPE_CHECKING, Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -1537,8 +1538,6 @@ class TestPhase2Codex:
             # dress_codex_batch
             batch_calls.append(_context)
             # Parse entity IDs from batch context (each starts with "## Entity: <raw_id>")
-            import re
-
             raw_ids = re.findall(r"## Entity: (\S+)", _context["entities_batch"])
             eids = [f"entity::{raw_id}" for raw_id in raw_ids]
             return (_make_batch_output(eids), 1, 100)
@@ -1786,6 +1785,136 @@ class TestPhase2CodexSpoilerEnforcement:
         assert "The Wandering Scholar" in rank1["title"]
         assert rank1["visible_when"] == []
 
+    @pytest.mark.asyncio()
+    async def test_mixed_outcomes_within_one_batch(self) -> None:
+        """One batch with three entities: clean, retry-then-clean, exhausted.
+
+        Exercises the per-entity sequencing inside a single batch and
+        confirms the three outcomes coexist without cross-contamination.
+        """
+        g = Graph()
+        for raw_id in ("alpha", "beta", "gamma"):
+            g.create_node(
+                f"entity::{raw_id}",
+                {
+                    "type": "entity",
+                    "raw_id": raw_id,
+                    "entity_type": "character",
+                    "name": raw_id.capitalize(),
+                },
+            )
+        stage = DressStage()
+
+        batch = BatchedCodexOutput(
+            entities=[
+                BatchedCodexItem(
+                    entity_id=f"entity::{raw_id}",
+                    entries=[
+                        CodexEntry(
+                            title=raw_id, rank=1, visible_when=[], content="Original rank 1."
+                        ),
+                        CodexEntry(
+                            title=f"{raw_id} Secret",
+                            rank=2,
+                            visible_when=["state_flag::known"],
+                            content="Original rank 2.",
+                        ),
+                    ],
+                )
+                for raw_id in ("alpha", "beta", "gamma")
+            ]
+        )
+        clean_retry = DressPhase2Output(
+            entries=[
+                CodexEntry(
+                    title="Beta",
+                    rank=1,
+                    visible_when=[],
+                    content="Replaced rank 1 — vague.",
+                ),
+                CodexEntry(
+                    title="Beta Secret",
+                    rank=2,
+                    visible_when=["state_flag::known"],
+                    content="Replaced rank 2.",
+                ),
+            ]
+        )
+        leaky_retry = DressPhase2Output(
+            entries=[
+                CodexEntry(
+                    title="Gamma",
+                    rank=1,
+                    visible_when=[],
+                    content="Still leaks.",
+                ),
+                CodexEntry(
+                    title="Gamma Secret",
+                    rank=2,
+                    visible_when=["state_flag::known"],
+                    content="Persistent leak.",
+                ),
+            ]
+        )
+        clean = SpoilerCheckResult(has_leak=False, leaks=[], reason="")
+        leak = SpoilerCheckResult(
+            has_leak=True,
+            leaks=[SpoilerLeak(lower_rank=1, higher_rank=2, leaked_content="leak")],
+            reason="leak",
+        )
+        # alpha: clean
+        # beta: leak → retry → clean (3 spoiler checks total: alpha clean, beta leak, beta clean,
+        #   then gamma block follows)
+        # gamma: leak → retry → leak → retry → leak (3 spoiler checks for gamma)
+        # Sequence: alpha-check(clean), beta-check(leak), beta-recheck(clean),
+        #           gamma-check(leak), gamma-recheck(leak), gamma-recheck(leak)
+        spoiler_sequence = [clean, leak, clean, leak, leak, leak]
+
+        async def _dispatch(
+            _model: Any,
+            template_name: str,
+            context: dict[str, Any],
+            _schema: type,
+            **_kwargs: Any,
+        ) -> tuple:
+            if template_name == "dress_codex_batch":
+                return (batch, 1, 50)
+            if template_name == "dress_codex":
+                # Pick the right per-entity retry output by inspecting the
+                # injected entity_details (which contains the raw id).
+                if "beta" in context.get("entity_details", ""):
+                    return (clean_retry, 1, 50)
+                return (leaky_retry, 1, 50)
+            if template_name == "dress_codex_spoiler_check":
+                return (spoiler_sequence.pop(0), 1, 25)
+            msg = f"Unexpected template: {template_name}"
+            raise AssertionError(msg)
+
+        with patch.object(stage, "_dress_llm_call", side_effect=_dispatch):
+            result = await stage._phase_2_codex(g, MagicMock())
+
+        assert result.status == "completed"
+
+        # alpha: original entries kept (rank 1 + rank 2)
+        alpha_r1 = g.get_node("codex::alpha_rank1")
+        assert alpha_r1 is not None
+        assert alpha_r1["content"] == "Original rank 1."
+        assert g.get_node("codex::alpha_rank2") is not None
+
+        # beta: retry replaced both ranks
+        beta_r1 = g.get_node("codex::beta_rank1")
+        assert beta_r1 is not None
+        assert "Replaced rank 1" in beta_r1["content"]
+        assert g.get_node("codex::beta_rank2") is not None
+
+        # gamma: rank-1-only fallback (rank 2 dropped)
+        gamma_r1 = g.get_node("codex::gamma_rank1")
+        assert gamma_r1 is not None
+        assert "Further details are not yet known" in gamma_r1["content"]
+        assert g.get_node("codex::gamma_rank2") is None
+        # Sequence fully consumed: 6 spoiler checks issued
+        assert spoiler_sequence == []
+
 
 def test_format_entries_for_spoiler_check_orders_by_rank() -> None:
     from questfoundry.pipeline.stages.dress import _format_entries_for_spoiler_check
@@ -1823,6 +1952,52 @@ def test_minimal_rank_one_codex_falls_back_to_raw_id() -> None:
     fallback = _minimal_rank_one_codex(g, "entity::missing")
     # No node, no name → use raw id as title
     assert fallback[0]["title"] == "missing"
+
+
+def test_minimal_rank_one_codex_uses_entity_type_descriptor() -> None:
+    """Fallback content is diegetic for non-character entities (R-3.4)."""
+    from questfoundry.pipeline.stages.dress import _minimal_rank_one_codex
+
+    g = Graph()
+    g.create_node(
+        "entity::cliff_pass",
+        {"type": "entity", "raw_id": "cliff_pass", "name": "Cliff Pass", "entity_type": "location"},
+    )
+    g.create_node(
+        "entity::sword",
+        {"type": "entity", "raw_id": "sword", "name": "Old Sword", "entity_type": "object"},
+    )
+    g.create_node(
+        "entity::guild",
+        {"type": "entity", "raw_id": "guild", "name": "The Guild", "entity_type": "faction"},
+    )
+    g.create_node(
+        "entity::weird",
+        {"type": "entity", "raw_id": "weird", "name": "Weirdness", "entity_type": "concept"},
+    )
+
+    assert "a place encountered" in _minimal_rank_one_codex(g, "entity::cliff_pass")[0]["content"]
+    assert "an object encountered" in _minimal_rank_one_codex(g, "entity::sword")[0]["content"]
+    assert "a group encountered" in _minimal_rank_one_codex(g, "entity::guild")[0]["content"]
+    # Unknown entity_type falls back to the generic descriptor
+    assert "an element of the story" in _minimal_rank_one_codex(g, "entity::weird")[0]["content"]
+
+
+def test_spoiler_leak_rejects_inverted_rank_ordering() -> None:
+    """Pydantic must reject lower_rank ≥ higher_rank — direction matters in R-3.6."""
+    from pydantic import ValidationError
+
+    # lower == higher
+    with pytest.raises(ValidationError, match=r"lower_rank.*must be strictly less than"):
+        SpoilerLeak(lower_rank=2, higher_rank=2, leaked_content="x")
+
+    # lower > higher
+    with pytest.raises(ValidationError, match=r"lower_rank.*must be strictly less than"):
+        SpoilerLeak(lower_rank=3, higher_rank=2, leaked_content="x")
+
+    # Valid case still works
+    leak = SpoilerLeak(lower_rank=1, higher_rank=2, leaked_content="x")
+    assert leak.lower_rank == 1
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Implements DRESS spec **R-3.6** — the last open DRESS audit cluster. A lower-ranked codex entry must not prematurely disclose content gated behind a higher-ranked tier; violations now trigger an LLM-driven retry loop (max 2) and, if still leaking, a minimal rank-1-only fallback with a WARNING.

## Changes

- **New models** in \`models/dress.py\`: \`SpoilerCheckResult\` and \`SpoilerLeak\` describe a structured spoiler-check verdict (has_leak + per-pair leaks + overall reason).
- **New prompt** \`prompts/templates/dress_codex_spoiler_check.yaml\`: instructs the LLM to audit one entity's tiered entries for low→high spoiler leakage. The user message renders entries rank-ordered with their gating state-flags so the model audits in unlock order.
- **Phase 2 codex** in \`stages/dress.py\` now wraps each per-entity result returned by the batch in \`_enforce_codex_spoiler_safety()\`:
  1. Run \`_spoiler_check\` (LLM call) on the entity's entries.
  2. If clean — keep entries.
  3. If leak — regenerate via the existing single-entity \`dress_codex\` template with the prior leak summary appended to the entity context, so the model has the concrete failure to avoid. Repeat up to \`_CODEX_SPOILER_RETRIES = 2\`.
  4. If retries exhaust — \`_minimal_rank_one_codex()\` writes a deliberately vague rank-1-only fallback (uses entity name when available, else raw id) and a WARNING is logged.
- **Observability**: \`codex_phase_complete\` INFO event now carries \`spoiler_retries\` and \`spoiler_fallbacks\` counts.
- **Tests** are restructured around a \`_make_dispatch_mock()\` helper that routes \`_dress_llm_call\` by template_name. Existing assertions still pass because the helper defaults to \"no leak.\" New \`TestPhase2CodexSpoilerEnforcement\` covers clean / single-retry / exhausted-fallback paths, plus unit coverage for the two new module-level helpers.

## Spec compliance

R-3.6 requires:
- ✅ LLM validation checks for spoiler ordering
- ✅ Violations trigger retry (max 2 per entity)
- ✅ Retry exhaustion produces a minimal rank-1-only codex with WARNING (per CLAUDE.md §Silent Degradation)

## Test plan

- [x] \`uv run pytest tests/unit/test_dress_stage.py tests/unit/test_dress_mutations.py tests/unit/test_dress_models.py\` — 171/171 pass
- [x] \`uv run ruff check src/ tests/\` — clean
- [x] \`uv run mypy src/\` — clean
- [ ] CI green
- [ ] \`/pr-review-toolkit:review-pr\` clean before marking ready

🤖 Generated with [Claude Code](https://claude.com/claude-code)