### PR TITLE
feat(ship): codeword playability + partial-DRESS warnings (closes #1334, closes #1337)

### DIFF
--- a/docs/design/procedures/ship.md
+++ b/docs/design/procedures/ship.md
@@ -149,6 +149,8 @@ R-3.7. Illustration assets are copied into the export bundle (HTML/PDF) or refer
 
 R-3.8. If DRESS was skipped: exports degrade gracefully — no illustrations, no codex, no visual metadata. Core gameplay works.
 
+R-3.9. If DRESS *ran but produced an incomplete `art_direction` node* (one or more of the DRESS-required visual fields — `style`, `medium`, `palette`, `composition_notes`, `negative_defaults`, `aspect_ratio` — missing or blank): the export still proceeds (graceful degradation, like R-3.8), but SHIP logs a WARNING naming the missing fields. Partial DRESS is a recoverable degradation, not a silent one — the user must be told so they can rerun DRESS.
+
 **Violations:**
 
 | Symptom | Root cause | Broken rule |
@@ -157,6 +159,7 @@ R-3.8. If DRESS was skipped: exports degrade gracefully — no illustrations, no
 | JSON export renames `prose` to `text` between releases (non-backward-compatible) | Breaking change in schema | R-3.4 |
 | Gamebook pagination uses non-seeded random | Non-reproducible | R-3.5 |
 | Export with no metadata header | Missing provenance | R-3.6 |
+| Art direction has `style` but no `palette`; export proceeds with no warning | Partial DRESS silently shipped | R-3.9 |
 
 ### Output Contract
 
@@ -256,6 +259,7 @@ R-3.5: Gamebook pagination uses seeded random.
 R-3.6: Every export has deterministic metadata header.
 R-3.7: Illustration assets bundled or referenced by path.
 R-3.8: DRESS absence handled gracefully.
+R-3.9: Partial DRESS (incomplete `art_direction`) handled gracefully with WARNING naming missing fields.
 R-4.1: Every export file validated.
 R-4.2: Validation failure halts SHIP with ERROR.
 R-4.3: Validation is technical only (loadable, consistent).

--- a/src/questfoundry/export/context.py
+++ b/src/questfoundry/export/context.py
@@ -30,11 +30,12 @@ log = get_logger(__name__)
 # triggers a WARNING for human review.
 _CODEWORD_PLAYABILITY_THRESHOLD = 10
 
-# R-3.8 partial-DRESS check: art_direction nodes that are present but
+# R-3.9 partial-DRESS check: art_direction nodes that are present but
 # missing core visual fields produce silently degraded exports (e.g.
 # illustrations rendered without a palette). These are the fields the
 # DRESS Pydantic model declares as required; when any are absent or
 # blank we warn so the user can re-run DRESS rather than ship the gap.
+# (R-3.8 covers DRESS *skipped entirely*; R-3.9 covers DRESS *partial*.)
 _REQUIRED_ART_DIRECTION_FIELDS = (
     "style",
     "medium",
@@ -93,14 +94,18 @@ def _warn_codeword_playability(codewords: list[ExportCodeword]) -> None:
     """
     count = len(codewords)
     if count > _CODEWORD_PLAYABILITY_THRESHOLD:
+        # ExportContext is built once and reused across formats, so we cannot
+        # tell here whether gamebook is the actual target. Phrase the warning
+        # conditionally to avoid alarming Twee/HTML/JSON-only authors.
         log.warning(
             "codeword_count_exceeds_threshold",
             count=count,
             threshold=_CODEWORD_PLAYABILITY_THRESHOLD,
             detail=(
-                "Gamebook playability suffers above this threshold; consider "
-                "reducing soft dilemmas or routing more decisions through hard "
-                "dilemmas (R-1.7)."
+                "Gamebook playability suffers above this threshold if that "
+                "format is targeted; consider reducing soft dilemmas or "
+                "routing more decisions through hard dilemmas (R-1.7). "
+                "Digital-only exports (Twee/HTML/JSON) are unaffected."
             ),
         )
 
@@ -341,11 +346,12 @@ def _extract_codex_entries(graph: Graph) -> list[ExportCodexEntry]:
 def _extract_art_direction(graph: Graph) -> dict[str, Any] | None:
     """Extract art direction node if DRESS stage was run.
 
-    R-3.8: graceful degradation when DRESS is partial. If the node
+    R-3.9: graceful degradation when DRESS is partial. If the node
     exists but is missing required visual fields (e.g. style present,
     palette absent), warn so the user knows the export downstream will
     have visual gaps. We still return the partial dict — degrading is
-    valid, but it should not be silent.
+    valid, but it should not be silent. (R-3.8 covers DRESS skipped
+    entirely; that branch is the ``return None`` above.)
     """
     nodes = graph.get_nodes_by_type("art_direction")
     if not nodes:
@@ -357,8 +363,7 @@ def _extract_art_direction(graph: Graph) -> dict[str, Any] | None:
     missing = [
         field
         for field in _REQUIRED_ART_DIRECTION_FIELDS
-        if not extracted.get(field)
-        or (isinstance(extracted.get(field), str) and not str(extracted[field]).strip())
+        if not (value := extracted.get(field)) or (isinstance(value, str) and not value.strip())
     ]
     if missing:
         log.warning(
@@ -368,7 +373,7 @@ def _extract_art_direction(graph: Graph) -> dict[str, Any] | None:
             detail=(
                 "Art direction is present but missing required visual fields. "
                 "Illustrations and visual metadata will be partial; rerun DRESS "
-                "to fill the gaps (R-3.8)."
+                "to fill the gaps (R-3.9)."
             ),
         )
     return extracted

--- a/src/questfoundry/export/context.py
+++ b/src/questfoundry/export/context.py
@@ -24,6 +24,26 @@ if TYPE_CHECKING:
 
 log = get_logger(__name__)
 
+# R-1.7 playability threshold: gamebooks become unwieldy when the player
+# must track many codewords by hand. Spec phrases the bound as "typically
+# under 10," so projecting MORE than 10 (i.e. count > _CODEWORD_PLAYABILITY_THRESHOLD)
+# triggers a WARNING for human review.
+_CODEWORD_PLAYABILITY_THRESHOLD = 10
+
+# R-3.8 partial-DRESS check: art_direction nodes that are present but
+# missing core visual fields produce silently degraded exports (e.g.
+# illustrations rendered without a palette). These are the fields the
+# DRESS Pydantic model declares as required; when any are absent or
+# blank we warn so the user can re-run DRESS rather than ship the gap.
+_REQUIRED_ART_DIRECTION_FIELDS = (
+    "style",
+    "medium",
+    "palette",
+    "composition_notes",
+    "negative_defaults",
+    "aspect_ratio",
+)
+
 
 def build_export_context(graph: Graph, project_name: str, *, language: str = "en") -> ExportContext:
     """Extract player-facing data from the story graph.
@@ -48,19 +68,41 @@ def build_export_context(graph: Graph, project_name: str, *, language: str = "en
     _mark_start_and_endings(passages, choices)
 
     illustrations, cover = _extract_illustrations(graph)
+    codewords = _extract_codewords(graph)
+    _warn_codeword_playability(codewords)
 
     return ExportContext(
         title=project_name,
         passages=passages,
         choices=choices,
         entities=_extract_entities(graph),
-        codewords=_extract_codewords(graph),
+        codewords=codewords,
         illustrations=illustrations,
         cover=cover,
         codex_entries=_extract_codex_entries(graph),
         art_direction=_extract_art_direction(graph),
         language=language,
     )
+
+
+def _warn_codeword_playability(codewords: list[ExportCodeword]) -> None:
+    """Emit a R-1.7 playability WARNING when codeword count exceeds the threshold.
+
+    A WARNING (not an error) so the export still proceeds; downstream
+    decision is human-driven (rework state flags, switch format, accept).
+    """
+    count = len(codewords)
+    if count > _CODEWORD_PLAYABILITY_THRESHOLD:
+        log.warning(
+            "codeword_count_exceeds_threshold",
+            count=count,
+            threshold=_CODEWORD_PLAYABILITY_THRESHOLD,
+            detail=(
+                "Gamebook playability suffers above this threshold; consider "
+                "reducing soft dilemmas or routing more decisions through hard "
+                "dilemmas (R-1.7)."
+            ),
+        )
 
 
 def _extract_passages(graph: Graph) -> list[ExportPassage]:
@@ -297,10 +339,36 @@ def _extract_codex_entries(graph: Graph) -> list[ExportCodexEntry]:
 
 
 def _extract_art_direction(graph: Graph) -> dict[str, Any] | None:
-    """Extract art direction node if DRESS stage was run."""
+    """Extract art direction node if DRESS stage was run.
+
+    R-3.8: graceful degradation when DRESS is partial. If the node
+    exists but is missing required visual fields (e.g. style present,
+    palette absent), warn so the user knows the export downstream will
+    have visual gaps. We still return the partial dict — degrading is
+    valid, but it should not be silent.
+    """
     nodes = graph.get_nodes_by_type("art_direction")
     if not nodes:
         return None
     # There's typically one art_direction::main node
-    _node_id, data = next(iter(nodes.items()))
-    return {k: v for k, v in data.items() if k not in ("type", "raw_id")}
+    node_id, data = next(iter(nodes.items()))
+    extracted = {k: v for k, v in data.items() if k not in ("type", "raw_id")}
+
+    missing = [
+        field
+        for field in _REQUIRED_ART_DIRECTION_FIELDS
+        if not extracted.get(field)
+        or (isinstance(extracted.get(field), str) and not str(extracted[field]).strip())
+    ]
+    if missing:
+        log.warning(
+            "art_direction_partial",
+            node_id=node_id,
+            missing_fields=missing,
+            detail=(
+                "Art direction is present but missing required visual fields. "
+                "Illustrations and visual metadata will be partial; rerun DRESS "
+                "to fill the gaps (R-3.8)."
+            ),
+        )
+    return extracted

--- a/tests/unit/test_export_context.py
+++ b/tests/unit/test_export_context.py
@@ -360,3 +360,143 @@ class TestBuildExportContext:
         ctx = build_export_context(g, "test", language="nl")
 
         assert ctx.language == "nl"
+
+
+class TestCodewordPlayabilityWarning:
+    """R-1.7: codeword count > 10 must trigger a WARNING."""
+
+    @staticmethod
+    def _add_soft_dilemma_with_n_flags(g: Graph, n: int) -> None:
+        g.create_node(
+            "dilemma::wide",
+            {"type": "dilemma", "raw_id": "wide", "dilemma_role": "soft"},
+        )
+        for i in range(n):
+            g.create_node(
+                f"state_flag::flag_{i}",
+                {
+                    "type": "state_flag",
+                    "raw_id": f"flag_{i}",
+                    "dilemma_id": "dilemma::wide",
+                    "codeword_type": "granted",
+                },
+            )
+
+    def test_at_threshold_no_warning(self, caplog: pytest.LogCaptureFixture) -> None:
+        """Exactly 10 codewords sits at the limit — no warning yet."""
+        import logging
+
+        g = _minimal_graph()
+        self._add_soft_dilemma_with_n_flags(g, 10)
+
+        with caplog.at_level(logging.WARNING, logger="questfoundry.export.context"):
+            ctx = build_export_context(g, "test")
+
+        assert len(ctx.codewords) == 10
+        assert "codeword_count_exceeds_threshold" not in caplog.text
+
+    def test_above_threshold_warns(self, caplog: pytest.LogCaptureFixture) -> None:
+        """11 codewords exceeds the playability threshold — must warn (R-1.7)."""
+        import logging
+
+        g = _minimal_graph()
+        self._add_soft_dilemma_with_n_flags(g, 11)
+
+        with caplog.at_level(logging.WARNING, logger="questfoundry.export.context"):
+            ctx = build_export_context(g, "test")
+
+        assert len(ctx.codewords) == 11
+        assert "codeword_count_exceeds_threshold" in caplog.text
+        assert "'count': 11" in caplog.text
+
+    def test_zero_codewords_no_warning(self, caplog: pytest.LogCaptureFixture) -> None:
+        import logging
+
+        g = _minimal_graph()
+        with caplog.at_level(logging.WARNING, logger="questfoundry.export.context"):
+            ctx = build_export_context(g, "test")
+        assert ctx.codewords == []
+        assert "codeword_count_exceeds_threshold" not in caplog.text
+
+
+class TestPartialDressWarning:
+    """R-3.8: art_direction missing required fields must warn (graceful, not silent)."""
+
+    def test_complete_art_direction_no_warning(self, caplog: pytest.LogCaptureFixture) -> None:
+        import logging
+
+        g = _minimal_graph()
+        g.create_node(
+            "art_direction::main",
+            {
+                "type": "art_direction",
+                "style": "watercolor",
+                "medium": "digital painting",
+                "palette": ["blue", "gold"],
+                "composition_notes": "wide framing",
+                "negative_defaults": "no text overlays",
+                "aspect_ratio": "16:9",
+            },
+        )
+        with caplog.at_level(logging.WARNING, logger="questfoundry.export.context"):
+            ctx = build_export_context(g, "test")
+
+        assert ctx.art_direction is not None
+        assert "art_direction_partial" not in caplog.text
+
+    def test_missing_palette_warns(self, caplog: pytest.LogCaptureFixture) -> None:
+        import logging
+
+        g = _minimal_graph()
+        g.create_node(
+            "art_direction::main",
+            {
+                "type": "art_direction",
+                "style": "watercolor",
+                "medium": "digital painting",
+                # palette omitted
+                "composition_notes": "wide framing",
+                "negative_defaults": "no text overlays",
+                "aspect_ratio": "16:9",
+            },
+        )
+        with caplog.at_level(logging.WARNING, logger="questfoundry.export.context"):
+            ctx = build_export_context(g, "test")
+
+        # Partial data still propagates (graceful degradation)
+        assert ctx.art_direction is not None
+        assert "art_direction_partial" in caplog.text
+        assert "palette" in caplog.text
+
+    def test_blank_string_field_counts_as_missing(self, caplog: pytest.LogCaptureFixture) -> None:
+        """Whitespace-only style is as bad as missing — both warn."""
+        import logging
+
+        g = _minimal_graph()
+        g.create_node(
+            "art_direction::main",
+            {
+                "type": "art_direction",
+                "style": "   ",
+                "medium": "digital painting",
+                "palette": ["blue"],
+                "composition_notes": "wide framing",
+                "negative_defaults": "no text overlays",
+                "aspect_ratio": "16:9",
+            },
+        )
+        with caplog.at_level(logging.WARNING, logger="questfoundry.export.context"):
+            build_export_context(g, "test")
+
+        assert "art_direction_partial" in caplog.text
+        assert "style" in caplog.text
+
+    def test_no_art_direction_node_no_warning(self, caplog: pytest.LogCaptureFixture) -> None:
+        """DRESS skipped entirely → art_direction=None, no partial warning."""
+        import logging
+
+        g = _minimal_graph()
+        with caplog.at_level(logging.WARNING, logger="questfoundry.export.context"):
+            ctx = build_export_context(g, "test")
+        assert ctx.art_direction is None
+        assert "art_direction_partial" not in caplog.text

--- a/tests/unit/test_export_context.py
+++ b/tests/unit/test_export_context.py
@@ -2,10 +2,24 @@
 
 from __future__ import annotations
 
+import logging
+
 import pytest
 
 from questfoundry.export.context import build_export_context
 from questfoundry.graph.graph import Graph
+
+_CONTEXT_LOGGER = "questfoundry.export.context"
+
+
+def _has_event(caplog: pytest.LogCaptureFixture, event: str) -> bool:
+    """Return True if any captured record's message contains ``event``.
+
+    Mirrors the project convention (see test_polish_llm_phases.py et al.):
+    use ``caplog.records`` rather than ``caplog.text`` so the assertion
+    survives processor-chain or formatter changes in the structlog setup.
+    """
+    return any(event in str(r.message) for r in caplog.records)
 
 
 def _minimal_graph() -> Graph:
@@ -384,47 +398,38 @@ class TestCodewordPlayabilityWarning:
 
     def test_at_threshold_no_warning(self, caplog: pytest.LogCaptureFixture) -> None:
         """Exactly 10 codewords sits at the limit — no warning yet."""
-        import logging
-
         g = _minimal_graph()
         self._add_soft_dilemma_with_n_flags(g, 10)
 
-        with caplog.at_level(logging.WARNING, logger="questfoundry.export.context"):
+        with caplog.at_level(logging.WARNING, logger=_CONTEXT_LOGGER):
             ctx = build_export_context(g, "test")
 
         assert len(ctx.codewords) == 10
-        assert "codeword_count_exceeds_threshold" not in caplog.text
+        assert not _has_event(caplog, "codeword_count_exceeds_threshold")
 
     def test_above_threshold_warns(self, caplog: pytest.LogCaptureFixture) -> None:
         """11 codewords exceeds the playability threshold — must warn (R-1.7)."""
-        import logging
-
         g = _minimal_graph()
         self._add_soft_dilemma_with_n_flags(g, 11)
 
-        with caplog.at_level(logging.WARNING, logger="questfoundry.export.context"):
+        with caplog.at_level(logging.WARNING, logger=_CONTEXT_LOGGER):
             ctx = build_export_context(g, "test")
 
         assert len(ctx.codewords) == 11
-        assert "codeword_count_exceeds_threshold" in caplog.text
-        assert "'count': 11" in caplog.text
+        assert _has_event(caplog, "codeword_count_exceeds_threshold")
 
     def test_zero_codewords_no_warning(self, caplog: pytest.LogCaptureFixture) -> None:
-        import logging
-
         g = _minimal_graph()
-        with caplog.at_level(logging.WARNING, logger="questfoundry.export.context"):
+        with caplog.at_level(logging.WARNING, logger=_CONTEXT_LOGGER):
             ctx = build_export_context(g, "test")
         assert ctx.codewords == []
-        assert "codeword_count_exceeds_threshold" not in caplog.text
+        assert not _has_event(caplog, "codeword_count_exceeds_threshold")
 
 
 class TestPartialDressWarning:
-    """R-3.8: art_direction missing required fields must warn (graceful, not silent)."""
+    """R-3.9: art_direction missing required fields must warn (graceful, not silent)."""
 
     def test_complete_art_direction_no_warning(self, caplog: pytest.LogCaptureFixture) -> None:
-        import logging
-
         g = _minimal_graph()
         g.create_node(
             "art_direction::main",
@@ -438,15 +443,13 @@ class TestPartialDressWarning:
                 "aspect_ratio": "16:9",
             },
         )
-        with caplog.at_level(logging.WARNING, logger="questfoundry.export.context"):
+        with caplog.at_level(logging.WARNING, logger=_CONTEXT_LOGGER):
             ctx = build_export_context(g, "test")
 
         assert ctx.art_direction is not None
-        assert "art_direction_partial" not in caplog.text
+        assert not _has_event(caplog, "art_direction_partial")
 
     def test_missing_palette_warns(self, caplog: pytest.LogCaptureFixture) -> None:
-        import logging
-
         g = _minimal_graph()
         g.create_node(
             "art_direction::main",
@@ -460,18 +463,16 @@ class TestPartialDressWarning:
                 "aspect_ratio": "16:9",
             },
         )
-        with caplog.at_level(logging.WARNING, logger="questfoundry.export.context"):
+        with caplog.at_level(logging.WARNING, logger=_CONTEXT_LOGGER):
             ctx = build_export_context(g, "test")
 
         # Partial data still propagates (graceful degradation)
         assert ctx.art_direction is not None
-        assert "art_direction_partial" in caplog.text
-        assert "palette" in caplog.text
+        assert _has_event(caplog, "art_direction_partial")
+        assert _has_event(caplog, "palette")
 
     def test_blank_string_field_counts_as_missing(self, caplog: pytest.LogCaptureFixture) -> None:
         """Whitespace-only style is as bad as missing — both warn."""
-        import logging
-
         g = _minimal_graph()
         g.create_node(
             "art_direction::main",
@@ -485,18 +486,35 @@ class TestPartialDressWarning:
                 "aspect_ratio": "16:9",
             },
         )
-        with caplog.at_level(logging.WARNING, logger="questfoundry.export.context"):
+        with caplog.at_level(logging.WARNING, logger=_CONTEXT_LOGGER):
             build_export_context(g, "test")
 
-        assert "art_direction_partial" in caplog.text
-        assert "style" in caplog.text
+        assert _has_event(caplog, "art_direction_partial")
+        assert _has_event(caplog, "'style'")
+
+    def test_multiple_missing_fields_all_reported(self, caplog: pytest.LogCaptureFixture) -> None:
+        """When several fields are missing, the warning must list ALL of them.
+
+        Otherwise the user fixes one, reruns DRESS, hits the warning again
+        for the next field — fragile and unfriendly.
+        """
+        g = _minimal_graph()
+        # Only style + medium present; the other four fields all missing
+        g.create_node(
+            "art_direction::main",
+            {"type": "art_direction", "style": "ink", "medium": "digital"},
+        )
+        with caplog.at_level(logging.WARNING, logger=_CONTEXT_LOGGER):
+            build_export_context(g, "test")
+
+        assert _has_event(caplog, "art_direction_partial")
+        for missing in ("palette", "composition_notes", "negative_defaults", "aspect_ratio"):
+            assert _has_event(caplog, missing), f"missing field {missing!r} not in warning"
 
     def test_no_art_direction_node_no_warning(self, caplog: pytest.LogCaptureFixture) -> None:
-        """DRESS skipped entirely → art_direction=None, no partial warning."""
-        import logging
-
+        """DRESS skipped entirely → art_direction=None, no partial warning (R-3.8)."""
         g = _minimal_graph()
-        with caplog.at_level(logging.WARNING, logger="questfoundry.export.context"):
+        with caplog.at_level(logging.WARNING, logger=_CONTEXT_LOGGER):
             ctx = build_export_context(g, "test")
         assert ctx.art_direction is None
-        assert "art_direction_partial" not in caplog.text
+        assert not _has_event(caplog, "art_direction_partial")


### PR DESCRIPTION
## Summary

PR A of 5 for the SHIP spec-compliance milestone (epic #1331). Two small observability gaps fixed in \`export/context.py\`:

| # | Rule | Fix |
|---|---|---|
| #1334 | R-1.7 | WARNING when projected codeword count > 10 (gamebook playability threshold) |
| #1337 | R-3.8 | WARNING when \`art_direction\` is present but missing required visual fields — partial-DRESS is now graceful, not silent |

## Why these are bundled

Both warnings live in the same builder file, both are pure observability with no behavior change (export still proceeds), and neither needs new infrastructure. Splitting would be churn.

## Constants are explicit

- \`_CODEWORD_PLAYABILITY_THRESHOLD = 10\` — comment cites R-1.7 wording (\"typically under 10\").
- \`_REQUIRED_ART_DIRECTION_FIELDS\` — mirrors the DRESS Pydantic model's required fields so adding a required field there shows up here too.

## Test plan

- [x] \`uv run pytest tests/unit/test_export_context.py -x -q\` — 24/24 pass (8 new)
- [x] \`uv run pytest tests/unit/test_ship_stage.py tests/unit/test_*_exporter.py -q\` — 91/91 pass (no regressions)
- [x] \`uv run ruff check src/ tests/\` — clean
- [x] \`uv run mypy src/\` — clean

## Remaining SHIP work

- PR B: deterministic metadata headers (R-3.6) + PDF pagination map (R-3.5) — closes #1333, #1336
- PR C: HTML voice-document styling (R-3.3) — closes #1335
- PR D: Phase 4 export validation (R-4.1–R-4.4) — closes #1332
- PR E: cross-cutting test coverage (R-2.4 / R-3.1 / R-3.2) — closes #1338

🤖 Generated with [Claude Code](https://claude.com/claude-code)