### PR TITLE
feat(ship): deterministic metadata headers + PDF pagination map (closes #1333, closes #1336)

### DIFF
--- a/src/questfoundry/export/base.py
+++ b/src/questfoundry/export/base.py
@@ -99,13 +99,24 @@ class Exporter(Protocol):
     """Protocol for story export format handlers."""
 
     format_name: str
+    format_version: str
 
-    def export(self, context: ExportContext, output_dir: Path) -> Path:
+    def export(
+        self,
+        context: ExportContext,
+        output_dir: Path,
+        *,
+        timestamp: str | None = None,
+    ) -> Path:
         """Export the story to the given output directory.
 
         Args:
             context: Extracted story data.
             output_dir: Directory to write output files.
+            timestamp: Optional ISO 8601 string used by the R-3.6 metadata
+                header. Tests inject a fixed value for deterministic
+                assertions; production callers should leave it ``None`` so
+                the exporter stamps ``datetime.now(UTC)`` itself.
 
         Returns:
             Path to the main output file.

--- a/src/questfoundry/export/html_exporter.py
+++ b/src/questfoundry/export/html_exporter.py
@@ -231,17 +231,24 @@ def _build_html_document(
     title: str,
     passages_html: str,
     start_id: str,
+    metadata: ExportMetadata,
     codex_html: str = "",
     art_direction_meta: str = "",
-    metadata: ExportMetadata | None = None,
     cover_html: str = "",
     language: str = "en",
     ui: dict[str, str] | None = None,
 ) -> str:
-    """Build the complete HTML document."""
-    metadata_meta = _render_metadata_meta_tags(metadata) if metadata else ""
-    extra_meta_parts = [m for m in (metadata_meta, art_direction_meta) if m]
-    extra_meta = ("\n" + "\n".join(extra_meta_parts)) if extra_meta_parts else ""
+    """Build the complete HTML document.
+
+    ``metadata`` is required: R-3.6 mandates a metadata header on every
+    export, so an HTML build without it would silently violate the spec.
+    Make the parameter mandatory rather than defaulting to ``None`` so a
+    forgotten argument fails at call time, not at audit time.
+    """
+    extra_meta_parts = [_render_metadata_meta_tags(metadata)]
+    if art_direction_meta:
+        extra_meta_parts.append(art_direction_meta)
+    extra_meta = "\n" + "\n".join(extra_meta_parts)
     codex_label = html.escape((ui or {}).get("codex", "Codex"))
     codex_button = (
         f'<button class="codex-toggle" id="codex-toggle">{codex_label}</button>'

--- a/src/questfoundry/export/html_exporter.py
+++ b/src/questfoundry/export/html_exporter.py
@@ -12,6 +12,7 @@ import json
 from typing import TYPE_CHECKING
 
 from questfoundry.export.i18n import get_ui_strings
+from questfoundry.export.metadata import ExportMetadata, build_export_metadata
 from questfoundry.observability.logging import get_logger
 
 if TYPE_CHECKING:
@@ -27,18 +28,31 @@ if TYPE_CHECKING:
 
 log = get_logger(__name__)
 
+# Backward-compatible additive changes only; bump on shape changes
+# (new <head> meta block, breaking layout reshuffle, etc.).
+HTML_FORMAT_VERSION = "1.0.0"
+
 
 class HtmlExporter:
     """Export story as a standalone HTML file."""
 
     format_name = "html"
+    format_version = HTML_FORMAT_VERSION
 
-    def export(self, context: ExportContext, output_dir: Path) -> Path:
+    def export(
+        self,
+        context: ExportContext,
+        output_dir: Path,
+        *,
+        timestamp: str | None = None,
+    ) -> Path:
         """Write story as a single playable HTML file.
 
         Args:
             context: Extracted story data.
             output_dir: Directory to write output files.
+            timestamp: Optional override for the metadata generation
+                timestamp (test seam for deterministic assertions).
 
         Returns:
             Path to the generated HTML file.
@@ -88,6 +102,10 @@ class HtmlExporter:
             alt_attr = "" if cap else html.escape(ui["cover_alt"])
             cover_html = f'<figure class="cover">\n  <img src="{html.escape(context.cover.asset_path)}" alt="{alt_attr}">{caption_tag}\n</figure>'
 
+        # R-3.6 metadata block — emitted as <meta name="qf-..."> tags
+        # in <head> for in-band provenance without affecting the page body.
+        metadata = build_export_metadata(context, HTML_FORMAT_VERSION, timestamp=timestamp)
+
         # Build the complete HTML document
         content = _build_html_document(
             title=context.title,
@@ -95,6 +113,7 @@ class HtmlExporter:
             start_id=_safe_id(start_id),
             codex_html=codex_html,
             art_direction_meta=art_direction_meta,
+            metadata=metadata,
             cover_html=cover_html,
             language=context.language,
             ui=ui,
@@ -117,6 +136,18 @@ class HtmlExporter:
 def _safe_id(passage_id: str) -> str:
     """Convert a passage ID to a safe HTML id attribute."""
     return passage_id.replace("::", "--").replace(" ", "_")
+
+
+def _render_metadata_meta_tags(metadata: ExportMetadata) -> str:
+    """Render the R-3.6 metadata block as HTML <meta> tags.
+
+    One tag per field, prefixed with ``qf-`` so they don't collide
+    with any spec-defined name attributes.
+    """
+    return "\n".join(
+        f'<meta name="qf-{key.replace("_", "-")}" content="{html.escape(value)}">'
+        for key, value in sorted(metadata.to_dict().items())
+    )
 
 
 def _render_passage_div(
@@ -202,12 +233,15 @@ def _build_html_document(
     start_id: str,
     codex_html: str = "",
     art_direction_meta: str = "",
+    metadata: ExportMetadata | None = None,
     cover_html: str = "",
     language: str = "en",
     ui: dict[str, str] | None = None,
 ) -> str:
     """Build the complete HTML document."""
-    extra_meta = f"\n{art_direction_meta}" if art_direction_meta else ""
+    metadata_meta = _render_metadata_meta_tags(metadata) if metadata else ""
+    extra_meta_parts = [m for m in (metadata_meta, art_direction_meta) if m]
+    extra_meta = ("\n" + "\n".join(extra_meta_parts)) if extra_meta_parts else ""
     codex_label = html.escape((ui or {}).get("codex", "Codex"))
     codex_button = (
         f'<button class="codex-toggle" id="codex-toggle">{codex_label}</button>'

--- a/src/questfoundry/export/json_exporter.py
+++ b/src/questfoundry/export/json_exporter.py
@@ -10,23 +10,38 @@ import json
 from dataclasses import asdict
 from typing import TYPE_CHECKING
 
+from questfoundry.export.metadata import build_export_metadata
+
 if TYPE_CHECKING:
     from pathlib import Path
 
     from questfoundry.export.base import ExportContext
+
+# Backward-compatible additive changes only (R-3.4): never rename or
+# remove fields; bump only when a NEW field appears or shape changes.
+JSON_FORMAT_VERSION = "1.0.0"
 
 
 class JsonExporter:
     """Export story as structured JSON."""
 
     format_name = "json"
+    format_version = JSON_FORMAT_VERSION
 
-    def export(self, context: ExportContext, output_dir: Path) -> Path:
+    def export(
+        self,
+        context: ExportContext,
+        output_dir: Path,
+        *,
+        timestamp: str | None = None,
+    ) -> Path:
         """Write story data as formatted JSON.
 
         Args:
             context: Extracted story data.
             output_dir: Directory to write output files.
+            timestamp: Optional override for the metadata generation
+                timestamp (test seam for deterministic assertions).
 
         Returns:
             Path to the generated story.json file.
@@ -34,7 +49,12 @@ class JsonExporter:
         output_dir.mkdir(parents=True, exist_ok=True)
         output_file = output_dir / "story.json"
 
-        data = asdict(context)
-        output_file.write_text(json.dumps(data, indent=2, ensure_ascii=False))
+        # R-3.6: emit a top-level "_metadata" key BEFORE the story payload
+        # so consumers see provenance first. Underscore-prefix keeps it
+        # visually separate from gameplay fields and (by convention)
+        # signals "tooling, not story content."
+        metadata = build_export_metadata(context, JSON_FORMAT_VERSION, timestamp=timestamp)
+        payload = {"_metadata": metadata.to_dict(), **asdict(context)}
+        output_file.write_text(json.dumps(payload, indent=2, ensure_ascii=False))
 
         return output_file

--- a/src/questfoundry/export/metadata.py
+++ b/src/questfoundry/export/metadata.py
@@ -1,0 +1,96 @@
+"""Deterministic metadata header shared across all SHIP exporters.
+
+Implements R-3.6: every export must carry a metadata block with
+``pipeline_version``, ``graph_snapshot_hash``, ``format_version``, and
+``generation_timestamp`` so downstream auditors can pin a delivered
+artefact to the exact source graph and code version that produced it.
+
+Each exporter declares its own ``format_version`` constant and embeds
+the metadata in a format-appropriate way (JSON top-level field, Twee
+metadata passage, HTML ``<meta>`` tags, PDF sidecar JSON).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import asdict, dataclass
+from datetime import UTC, datetime
+from importlib.metadata import PackageNotFoundError, version
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from questfoundry.export.base import ExportContext
+
+_PACKAGE_NAME = "questfoundry"
+_UNKNOWN_VERSION = "0.0.0+unknown"
+
+
+@dataclass(frozen=True)
+class ExportMetadata:
+    """R-3.6 metadata header carried by every SHIP export."""
+
+    pipeline_version: str
+    graph_snapshot_hash: str
+    format_version: str
+    generation_timestamp: str
+
+    def to_dict(self) -> dict[str, str]:
+        return asdict(self)
+
+
+def get_pipeline_version() -> str:
+    """Resolve the installed questfoundry version, or a stable sentinel.
+
+    Returns ``_UNKNOWN_VERSION`` when the package is not installed
+    (e.g. running from a checkout without ``pip install -e .``); the
+    sentinel is stable so the metadata block stays well-formed and
+    snapshot hashes remain reproducible across runs.
+    """
+    try:
+        return version(_PACKAGE_NAME)
+    except PackageNotFoundError:
+        return _UNKNOWN_VERSION
+
+
+def compute_graph_snapshot_hash(context: ExportContext) -> str:
+    """Deterministic content hash of the ExportContext.
+
+    Hashes a canonical JSON serialization of the context (sorted keys,
+    no whitespace) so the same graph produces the same hash across
+    runs, machines, and Python versions. Used to fingerprint the
+    source state of an export.
+    """
+    payload = json.dumps(
+        asdict(context),
+        sort_keys=True,
+        ensure_ascii=False,
+        separators=(",", ":"),
+    )
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+
+def build_export_metadata(
+    context: ExportContext,
+    format_version: str,
+    *,
+    timestamp: str | None = None,
+) -> ExportMetadata:
+    """Assemble an ``ExportMetadata`` for the given context and format.
+
+    Args:
+        context: Source ExportContext (its content drives the snapshot hash).
+        format_version: Per-exporter schema version (e.g. ``"1.0.0"``).
+        timestamp: Optional override for the generation timestamp; tests
+            inject a fixed value to make their assertions stable. Defaults
+            to ``datetime.now(UTC).isoformat()``.
+
+    Returns:
+        ExportMetadata with all four R-3.6 fields populated.
+    """
+    return ExportMetadata(
+        pipeline_version=get_pipeline_version(),
+        graph_snapshot_hash=compute_graph_snapshot_hash(context),
+        format_version=format_version,
+        generation_timestamp=timestamp or datetime.now(UTC).isoformat(),
+    )

--- a/src/questfoundry/export/pagination.py
+++ b/src/questfoundry/export/pagination.py
@@ -1,0 +1,56 @@
+"""Shared passage-numbering utility for gamebook-style exports.
+
+The PDF exporter used to own this directly. R-3.5 (gamebook PDF
+shuffles passages with a seeded RNG and renumbers) requires the
+mapping to be reproducible AND inspectable; R-3.6 / #1336 requires
+the ``passage_id → page_number`` map to be exported as metadata so
+authors can trace which passage became which page after a bug report.
+
+Living in a shared module lets the PDF exporter render the numbering
+and a sidecar writer surface the same map without recomputing.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import random
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from questfoundry.export.base import ExportPassage
+
+
+def compute_passage_numbering(passages: list[ExportPassage]) -> dict[str, int]:
+    """Map passage IDs to randomized section numbers (start passage = 1).
+
+    Uses a SHA256 of the sorted-and-joined passage IDs as the seed so
+    the shuffle is reproducible across runs and Python versions
+    (Python's built-in ``hash()`` is randomized per process).
+
+    Args:
+        passages: All passages destined for the export.
+
+    Returns:
+        Mapping from passage ID to its assigned 1-based section number.
+        Returns an empty dict for an empty list.
+    """
+    if not passages:
+        return {}
+
+    start_id = next((p.id for p in passages if p.is_start), passages[0].id)
+
+    other_ids = sorted(p.id for p in passages if p.id != start_id)
+
+    all_ids = sorted(p.id for p in passages)
+    id_string = "|".join(all_ids)
+    seed = int(hashlib.md5(id_string.encode()).hexdigest(), 16) % (2**32)
+    rng = random.Random(seed)
+
+    numbers = list(range(2, len(passages) + 1))
+    rng.shuffle(numbers)
+
+    numbering: dict[str, int] = {start_id: 1}
+    for pid, num in zip(other_ids, numbers, strict=True):
+        numbering[pid] = num
+
+    return numbering

--- a/src/questfoundry/export/pagination.py
+++ b/src/questfoundry/export/pagination.py
@@ -23,9 +23,11 @@ if TYPE_CHECKING:
 def compute_passage_numbering(passages: list[ExportPassage]) -> dict[str, int]:
     """Map passage IDs to randomized section numbers (start passage = 1).
 
-    Uses a SHA256 of the sorted-and-joined passage IDs as the seed so
-    the shuffle is reproducible across runs and Python versions
-    (Python's built-in ``hash()`` is randomized per process).
+    Uses an MD5 digest of the sorted-and-joined passage IDs as the
+    PRNG seed so the shuffle is reproducible across runs and Python
+    versions (Python's built-in ``hash()`` is randomized per process).
+    MD5 is used purely as a fast non-cryptographic content fingerprint
+    here — there is no security implication.
 
     Args:
         passages: All passages destined for the export.

--- a/src/questfoundry/export/pdf_exporter.py
+++ b/src/questfoundry/export/pdf_exporter.py
@@ -9,12 +9,13 @@ Requires the optional `pdf` dependency: `uv pip install questfoundry[pdf]`
 
 from __future__ import annotations
 
-import hashlib
 import html
-import random
+import json
 from typing import TYPE_CHECKING
 
 from questfoundry.export.i18n import get_ui_strings
+from questfoundry.export.metadata import build_export_metadata
+from questfoundry.export.pagination import compute_passage_numbering
 from questfoundry.observability.logging import get_logger
 
 if TYPE_CHECKING:
@@ -240,17 +241,35 @@ h1 {
 """
 
 
+PDF_FORMAT_VERSION = "1.0.0"
+
+
 class PdfExporter:
     """Export story as a gamebook-style PDF."""
 
     format_name = "pdf"
+    format_version = PDF_FORMAT_VERSION
 
-    def export(self, context: ExportContext, output_dir: Path) -> Path:
+    def export(
+        self,
+        context: ExportContext,
+        output_dir: Path,
+        *,
+        timestamp: str | None = None,
+    ) -> Path:
         """Write story as a gamebook PDF with numbered passages.
+
+        Also writes ``story.pdf.map.json`` next to the PDF: a sidecar
+        carrying both the R-3.6 metadata header and the R-3.5
+        ``passage_id → page_number`` map (#1336). The map lets authors
+        trace which passage became which page after a bug report; the
+        sidecar avoids forcing PDF readers to parse embedded JSON.
 
         Args:
             context: Extracted story data.
             output_dir: Directory to write output files.
+            timestamp: Optional override for the metadata generation
+                timestamp (test seam for deterministic assertions).
 
         Returns:
             Path to the generated PDF file.
@@ -268,7 +287,7 @@ class PdfExporter:
         output_file = output_dir / "story.pdf"
 
         # Build passage number mapping (randomized for spoiler prevention)
-        numbering = _build_passage_numbering(context.passages)
+        numbering = compute_passage_numbering(context.passages)
 
         # Build data structures
         choices_by_passage: dict[str, list[ExportChoice]] = {}
@@ -292,56 +311,28 @@ class PdfExporter:
         html_doc = HTML(string=html_content, base_url=str(project_root))
         html_doc.write_pdf(output_file)
 
+        # R-3.6 + #1336 sidecar: pipeline metadata + the page-number map
+        # next to the PDF for debugging and provenance.
+        metadata = build_export_metadata(context, PDF_FORMAT_VERSION, timestamp=timestamp)
+        sidecar = {
+            "_metadata": metadata.to_dict(),
+            "page_map": dict(sorted(numbering.items())),
+        }
+        sidecar_file = output_file.with_suffix(".pdf.map.json")
+        sidecar_file.write_text(
+            json.dumps(sidecar, indent=2, ensure_ascii=False),
+            encoding="utf-8",
+        )
+
         log.info(
             "pdf_export_complete",
             passages=len(context.passages),
             codewords=len(context.codewords),
             output=str(output_file),
+            sidecar=str(sidecar_file),
         )
 
         return output_file
-
-
-def _build_passage_numbering(passages: list[ExportPassage]) -> dict[str, int]:
-    """Map passage IDs to randomized section numbers.
-
-    Uses sorted IDs as seed for reproducible shuffling.
-    Same story = same numbers across exports.
-
-    Start passage always gets number 1 for reader convenience.
-
-    Args:
-        passages: List of passages to number.
-
-    Returns:
-        Mapping from passage ID to section number.
-    """
-    if not passages:
-        return {}
-
-    # Find start passage
-    start_id = next((p.id for p in passages if p.is_start), passages[0].id)
-
-    # Get other passage IDs (excluding start)
-    other_ids = sorted(p.id for p in passages if p.id != start_id)
-
-    # Create reproducible random seed from passage IDs using hashlib for cross-session determinism
-    # (Python's hash() is randomized per process via PYTHONHASHSEED)
-    all_ids = sorted(p.id for p in passages)
-    id_string = "|".join(all_ids)
-    seed = int(hashlib.md5(id_string.encode()).hexdigest(), 16) % (2**32)
-    rng = random.Random(seed)
-
-    # Assign numbers 2..N to other passages randomly
-    numbers = list(range(2, len(passages) + 1))
-    rng.shuffle(numbers)
-
-    # Build mapping: start=1, others=randomized
-    numbering: dict[str, int] = {start_id: 1}
-    for pid, num in zip(other_ids, numbers, strict=True):
-        numbering[pid] = num
-
-    return numbering
 
 
 def _render_html(

--- a/src/questfoundry/export/pdf_exporter.py
+++ b/src/questfoundry/export/pdf_exporter.py
@@ -313,16 +313,7 @@ class PdfExporter:
 
         # R-3.6 + #1336 sidecar: pipeline metadata + the page-number map
         # next to the PDF for debugging and provenance.
-        metadata = build_export_metadata(context, PDF_FORMAT_VERSION, timestamp=timestamp)
-        sidecar = {
-            "_metadata": metadata.to_dict(),
-            "page_map": dict(sorted(numbering.items())),
-        }
-        sidecar_file = output_file.with_suffix(".pdf.map.json")
-        sidecar_file.write_text(
-            json.dumps(sidecar, indent=2, ensure_ascii=False),
-            encoding="utf-8",
-        )
+        sidecar_file = _write_pdf_sidecar(output_file, context, numbering, timestamp=timestamp)
 
         log.info(
             "pdf_export_complete",
@@ -333,6 +324,32 @@ class PdfExporter:
         )
 
         return output_file
+
+
+def _write_pdf_sidecar(
+    pdf_path: Path,
+    context: ExportContext,
+    numbering: dict[str, int],
+    *,
+    timestamp: str | None = None,
+) -> Path:
+    """Write the ``story.pdf.map.json`` sidecar next to a rendered PDF.
+
+    Carries the R-3.6 metadata block plus the R-3.5 ``passage_id →
+    page_number`` map (#1336). Factored out so it can be exercised
+    without the optional WeasyPrint dependency installed.
+    """
+    metadata = build_export_metadata(context, PDF_FORMAT_VERSION, timestamp=timestamp)
+    sidecar = {
+        "_metadata": metadata.to_dict(),
+        "page_map": dict(sorted(numbering.items())),
+    }
+    sidecar_file = pdf_path.with_suffix(".pdf.map.json")
+    sidecar_file.write_text(
+        json.dumps(sidecar, indent=2, ensure_ascii=False),
+        encoding="utf-8",
+    )
+    return sidecar_file
 
 
 def _render_html(

--- a/src/questfoundry/export/twee_exporter.py
+++ b/src/questfoundry/export/twee_exporter.py
@@ -13,6 +13,7 @@ import uuid
 from typing import TYPE_CHECKING, Any
 
 from questfoundry.export.i18n import get_ui_strings
+from questfoundry.export.metadata import ExportMetadata, build_export_metadata
 from questfoundry.observability.logging import get_logger
 
 if TYPE_CHECKING:
@@ -28,18 +29,31 @@ if TYPE_CHECKING:
 
 log = get_logger(__name__)
 
+# Backward-compatible additive changes only; bump only when the Twee
+# document shape changes (new passage type, removed field, etc.).
+TWEE_FORMAT_VERSION = "1.0.0"
+
 
 class TweeExporter:
     """Export story as Twee 3 / SugarCube 2 format."""
 
     format_name = "twee"
+    format_version = TWEE_FORMAT_VERSION
 
-    def export(self, context: ExportContext, output_dir: Path) -> Path:
+    def export(
+        self,
+        context: ExportContext,
+        output_dir: Path,
+        *,
+        timestamp: str | None = None,
+    ) -> Path:
         """Write story as a .twee file.
 
         Args:
             context: Extracted story data.
             output_dir: Directory to write output files.
+            timestamp: Optional override for the metadata generation
+                timestamp (test seam for deterministic assertions).
 
         Returns:
             Path to the generated .twee file.
@@ -94,6 +108,13 @@ class TweeExporter:
         if context.art_direction:
             lines.extend(_render_art_direction_passage(context.art_direction))
             lines.append("")
+
+        # R-3.6 deterministic metadata block. SugarCube ignores unlinked
+        # passages, so this is safe sidecar storage of pipeline version,
+        # snapshot hash, format version, and timestamp.
+        metadata = build_export_metadata(context, TWEE_FORMAT_VERSION, timestamp=timestamp)
+        lines.extend(_render_metadata_passage(metadata))
+        lines.append("")
 
         content = "\n".join(lines)
         output_file.write_text(content, encoding="utf-8")
@@ -255,5 +276,15 @@ def _render_art_direction_passage(art_direction: dict[str, Any]) -> list[str]:
     for key, value in sorted(art_direction.items()):
         safe_key = _escape_sugarcube(str(key))
         safe_value = _escape_sugarcube(str(value))
+        lines.append(f"{safe_key}: {safe_value}")
+    return lines
+
+
+def _render_metadata_passage(metadata: ExportMetadata) -> list[str]:
+    """Render R-3.6 metadata header as an unlinked Twee passage."""
+    lines = [':: StoryMetadata {"position":"100,0","size":"100,100"}']
+    for key, value in sorted(metadata.to_dict().items()):
+        safe_key = _escape_sugarcube(key)
+        safe_value = _escape_sugarcube(value)
         lines.append(f"{safe_key}: {safe_value}")
     return lines

--- a/tests/unit/test_export_metadata.py
+++ b/tests/unit/test_export_metadata.py
@@ -1,0 +1,213 @@
+"""Tests for the deterministic export metadata header (R-3.6).
+
+Covers:
+
+- ``compute_graph_snapshot_hash`` is deterministic and changes when any
+  observable field of the ExportContext changes.
+- ``build_export_metadata`` populates all four R-3.6 fields and accepts
+  an injected timestamp for test stability.
+- Each exporter (JSON, Twee, HTML) embeds the metadata in the appropriate
+  format-specific shape, with the timestamp seam producing identical
+  output across two runs.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+
+import pytest
+
+from questfoundry.export.base import ExportContext, ExportPassage
+from questfoundry.export.html_exporter import HtmlExporter
+from questfoundry.export.json_exporter import JsonExporter
+from questfoundry.export.metadata import (
+    ExportMetadata,
+    build_export_metadata,
+    compute_graph_snapshot_hash,
+    get_pipeline_version,
+)
+from questfoundry.export.twee_exporter import TweeExporter
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+_FIXED_TS = "2026-04-24T00:00:00+00:00"
+
+
+def _ctx(prose: str = "Hello.") -> ExportContext:
+    """Minimal-but-real context: one start passage, no choices."""
+    return ExportContext(
+        title="test",
+        passages=[ExportPassage(id="passage::start", prose=prose, is_start=True)],
+        choices=[],
+    )
+
+
+# ---------------------------------------------------------------------------
+# metadata module
+# ---------------------------------------------------------------------------
+
+
+class TestGraphSnapshotHash:
+    def test_same_context_same_hash(self) -> None:
+        h1 = compute_graph_snapshot_hash(_ctx("A"))
+        h2 = compute_graph_snapshot_hash(_ctx("A"))
+        assert h1 == h2
+        # SHA256 hex
+        assert len(h1) == 64
+        assert all(c in "0123456789abcdef" for c in h1)
+
+    def test_changed_prose_changes_hash(self) -> None:
+        h1 = compute_graph_snapshot_hash(_ctx("A"))
+        h2 = compute_graph_snapshot_hash(_ctx("B"))
+        assert h1 != h2
+
+    def test_changed_title_changes_hash(self) -> None:
+        ctx_a = _ctx()
+        ctx_b = _ctx()
+        ctx_b.title = "different"
+        assert compute_graph_snapshot_hash(ctx_a) != compute_graph_snapshot_hash(ctx_b)
+
+
+class TestBuildExportMetadata:
+    def test_all_four_fields_populated(self) -> None:
+        meta = build_export_metadata(_ctx(), "1.2.3", timestamp=_FIXED_TS)
+        assert isinstance(meta, ExportMetadata)
+        assert meta.pipeline_version  # non-empty (sentinel or real)
+        assert len(meta.graph_snapshot_hash) == 64
+        assert meta.format_version == "1.2.3"
+        assert meta.generation_timestamp == _FIXED_TS
+
+    def test_to_dict_roundtrips(self) -> None:
+        meta = build_export_metadata(_ctx(), "1.0.0", timestamp=_FIXED_TS)
+        d = meta.to_dict()
+        assert set(d.keys()) == {
+            "pipeline_version",
+            "graph_snapshot_hash",
+            "format_version",
+            "generation_timestamp",
+        }
+        assert d["generation_timestamp"] == _FIXED_TS
+
+    def test_default_timestamp_is_iso8601_with_tz(self) -> None:
+        meta = build_export_metadata(_ctx(), "1.0.0")
+        # Just confirm the default produces an ISO-formatted string with timezone
+        assert "T" in meta.generation_timestamp
+        assert "+" in meta.generation_timestamp or meta.generation_timestamp.endswith("Z")
+
+    def test_pipeline_version_returns_string(self) -> None:
+        v = get_pipeline_version()
+        assert isinstance(v, str)
+        assert v
+
+
+# ---------------------------------------------------------------------------
+# Per-exporter metadata embedding
+# ---------------------------------------------------------------------------
+
+
+class TestJsonExporterMetadata:
+    def test_metadata_block_top_level(self, tmp_path: Path) -> None:
+        out = JsonExporter().export(_ctx(), tmp_path, timestamp=_FIXED_TS)
+        payload = json.loads(out.read_text())
+        assert "_metadata" in payload
+        meta = payload["_metadata"]
+        assert meta["format_version"] == JsonExporter.format_version
+        assert meta["generation_timestamp"] == _FIXED_TS
+        assert len(meta["graph_snapshot_hash"]) == 64
+        # Story payload still present
+        assert "passages" in payload
+
+    def test_byte_identical_with_fixed_timestamp(self, tmp_path: Path) -> None:
+        d1 = tmp_path / "a"
+        d2 = tmp_path / "b"
+        out1 = JsonExporter().export(_ctx(), d1, timestamp=_FIXED_TS)
+        out2 = JsonExporter().export(_ctx(), d2, timestamp=_FIXED_TS)
+        assert out1.read_bytes() == out2.read_bytes()
+
+
+class TestTweeExporterMetadata:
+    def test_metadata_passage_present(self, tmp_path: Path) -> None:
+        out = TweeExporter().export(_ctx(), tmp_path, timestamp=_FIXED_TS)
+        text = out.read_text()
+        assert ":: StoryMetadata" in text
+        assert f"generation_timestamp: {_FIXED_TS}" in text
+        assert f"format_version: {TweeExporter.format_version}" in text
+        assert "graph_snapshot_hash:" in text
+        assert "pipeline_version:" in text
+
+    def test_byte_identical_with_fixed_timestamp(self, tmp_path: Path) -> None:
+        # Twee header includes a random IFID, so we cannot expect full byte
+        # equality. But the metadata block itself MUST be deterministic.
+        out1 = TweeExporter().export(_ctx(), tmp_path / "a", timestamp=_FIXED_TS)
+        out2 = TweeExporter().export(_ctx(), tmp_path / "b", timestamp=_FIXED_TS)
+
+        def _metadata_block(text: str) -> str:
+            lines = text.splitlines()
+            start = next(i for i, line in enumerate(lines) if ":: StoryMetadata" in line)
+            return "\n".join(lines[start : start + 5])
+
+        assert _metadata_block(out1.read_text()) == _metadata_block(out2.read_text())
+
+
+class TestHtmlExporterMetadata:
+    def test_meta_tags_emitted(self, tmp_path: Path) -> None:
+        out = HtmlExporter().export(_ctx(), tmp_path, timestamp=_FIXED_TS)
+        text = out.read_text()
+        assert '<meta name="qf-format-version"' in text
+        assert f'content="{HtmlExporter.format_version}"' in text
+        assert '<meta name="qf-generation-timestamp"' in text
+        assert f'content="{_FIXED_TS}"' in text
+        assert '<meta name="qf-graph-snapshot-hash"' in text
+        assert '<meta name="qf-pipeline-version"' in text
+
+    def test_byte_identical_with_fixed_timestamp(self, tmp_path: Path) -> None:
+        out1 = HtmlExporter().export(_ctx(), tmp_path / "a", timestamp=_FIXED_TS)
+        out2 = HtmlExporter().export(_ctx(), tmp_path / "b", timestamp=_FIXED_TS)
+        assert out1.read_bytes() == out2.read_bytes()
+
+
+# ---------------------------------------------------------------------------
+# All exporters share a snapshot hash for the same context
+# ---------------------------------------------------------------------------
+
+
+def test_snapshot_hash_consistent_across_formats(tmp_path: Path) -> None:
+    """JSON, Twee, and HTML compute the SAME graph_snapshot_hash for one ctx."""
+    ctx = _ctx("Shared content.")
+
+    json_out = json.loads(
+        JsonExporter().export(ctx, tmp_path / "j", timestamp=_FIXED_TS).read_text()
+    )
+    twee_text = TweeExporter().export(ctx, tmp_path / "t", timestamp=_FIXED_TS).read_text()
+    html_text = HtmlExporter().export(ctx, tmp_path / "h", timestamp=_FIXED_TS).read_text()
+
+    json_hash = json_out["_metadata"]["graph_snapshot_hash"]
+    twee_hash_line = next(
+        line for line in twee_text.splitlines() if line.startswith("graph_snapshot_hash:")
+    )
+    twee_hash = twee_hash_line.split(": ", 1)[1].strip()
+
+    # Pull HTML hash from the meta tag
+    import re
+
+    html_hash_match = re.search(
+        r'<meta name="qf-graph-snapshot-hash" content="([0-9a-f]{64})">', html_text
+    )
+    assert html_hash_match is not None
+    html_hash = html_hash_match.group(1)
+
+    assert json_hash == twee_hash == html_hash
+
+
+# ---------------------------------------------------------------------------
+# fixture: confirm integration without weasyprint by exercising compute path
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("format_version", ["0.1.0", "1.0.0", "2.5.3"])
+def test_format_version_passed_through(format_version: str) -> None:
+    meta = build_export_metadata(_ctx(), format_version, timestamp=_FIXED_TS)
+    assert meta.format_version == format_version

--- a/tests/unit/test_export_metadata.py
+++ b/tests/unit/test_export_metadata.py
@@ -145,9 +145,20 @@ class TestTweeExporterMetadata:
         out2 = TweeExporter().export(_ctx(), tmp_path / "b", timestamp=_FIXED_TS)
 
         def _metadata_block(text: str) -> str:
+            """Extract the StoryMetadata block.
+
+            Read until the next Twee passage header (``::``) or a blank
+            line, instead of slicing a fixed line count — adding a fifth
+            metadata field would otherwise silently truncate the assertion.
+            """
             lines = text.splitlines()
             start = next(i for i, line in enumerate(lines) if ":: StoryMetadata" in line)
-            return "\n".join(lines[start : start + 5])
+            block = [lines[start]]
+            for line in lines[start + 1 :]:
+                if not line.strip() or line.startswith("::"):
+                    break
+                block.append(line)
+            return "\n".join(block)
 
         assert _metadata_block(out1.read_text()) == _metadata_block(out2.read_text())
 
@@ -211,3 +222,52 @@ def test_snapshot_hash_consistent_across_formats(tmp_path: Path) -> None:
 def test_format_version_passed_through(format_version: str) -> None:
     meta = build_export_metadata(_ctx(), format_version, timestamp=_FIXED_TS)
     assert meta.format_version == format_version
+
+
+# ---------------------------------------------------------------------------
+# PDF sidecar — exercised without WeasyPrint via the helper
+# ---------------------------------------------------------------------------
+
+
+def test_pdf_sidecar_written_without_weasyprint(tmp_path: Path) -> None:
+    """``_write_pdf_sidecar`` runs independently of WeasyPrint.
+
+    The sidecar is the R-3.6 + #1336 contract and must be testable on
+    machines that don't have the optional PDF dependency installed (CI
+    in particular). Touching ``_write_pdf_sidecar`` directly bypasses
+    ``write_pdf`` while still exercising the spec-relevant code path.
+    """
+    from questfoundry.export.pdf_exporter import (
+        PDF_FORMAT_VERSION,
+        _write_pdf_sidecar,
+    )
+
+    pdf_path = tmp_path / "story.pdf"
+    pdf_path.touch()  # the helper only needs the path, not the file
+    numbering = {"passage::start": 1, "passage::end": 2}
+
+    sidecar = _write_pdf_sidecar(pdf_path, _ctx(), numbering, timestamp=_FIXED_TS)
+
+    assert sidecar.name == "story.pdf.map.json"
+    data = json.loads(sidecar.read_text())
+    assert data["_metadata"]["format_version"] == PDF_FORMAT_VERSION
+    assert data["_metadata"]["generation_timestamp"] == _FIXED_TS
+    assert data["page_map"] == {"passage::start": 1, "passage::end": 2}
+
+
+def test_get_pipeline_version_falls_back_to_sentinel(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """If the package isn't installed, return a stable sentinel rather than
+    crashing. The sentinel keeps the metadata block well-formed and the
+    snapshot hash stable across checkout-only runs.
+    """
+    from importlib.metadata import PackageNotFoundError
+
+    import questfoundry.export.metadata as md
+
+    def _raise(_name: str) -> str:
+        raise PackageNotFoundError
+
+    monkeypatch.setattr(md, "version", _raise)
+    assert md.get_pipeline_version() == md._UNKNOWN_VERSION

--- a/tests/unit/test_pdf_exporter.py
+++ b/tests/unit/test_pdf_exporter.py
@@ -14,9 +14,9 @@ from questfoundry.export.base import (
     ExportIllustration,
     ExportPassage,
 )
+from questfoundry.export.pagination import compute_passage_numbering as _build_passage_numbering
 from questfoundry.export.pdf_exporter import (
     PdfExporter,
-    _build_passage_numbering,
     _format_codeword_name,
     _render_codeword_checklist,
     _render_codex,
@@ -521,3 +521,34 @@ class TestPdfExporter:
         exporter = PdfExporter()
         with pytest.raises(ImportError, match="WeasyPrint is required"):
             exporter.export(_simple_context(), tmp_path / "out")
+
+    @pytest.mark.skipif(
+        not _weasyprint_available(),
+        reason="WeasyPrint not installed (optional dependency)",
+    )
+    def test_writes_sidecar_map_with_metadata_and_pages(self, tmp_path: Path) -> None:
+        """R-3.6 + #1336: PDF run drops a story.pdf.map.json sidecar."""
+        import json
+
+        exporter = PdfExporter()
+        out = exporter.export(
+            _simple_context(), tmp_path / "out", timestamp="2026-04-24T00:00:00+00:00"
+        )
+
+        sidecar = out.with_suffix(".pdf.map.json")
+        assert sidecar.exists(), "PDF sidecar missing — #1336"
+
+        data = json.loads(sidecar.read_text())
+        assert "_metadata" in data
+        meta = data["_metadata"]
+        assert meta["format_version"] == PdfExporter.format_version
+        assert meta["generation_timestamp"] == "2026-04-24T00:00:00+00:00"
+        assert len(meta["graph_snapshot_hash"]) == 64
+
+        page_map = data["page_map"]
+        assert isinstance(page_map, dict)
+        # Every passage in the simple context appears in the map
+        for passage in _simple_context().passages:
+            assert passage.id in page_map
+        # Map values are 1-based ints
+        assert all(isinstance(v, int) and v >= 1 for v in page_map.values())

--- a/tests/unit/test_pdf_exporter.py
+++ b/tests/unit/test_pdf_exporter.py
@@ -131,16 +131,20 @@ class TestPassageNumbering:
         assert numbering == {"only": 1}
 
     def test_no_start_passage_uses_first(self) -> None:
-        """When no passage has is_start=True, first passage gets number 1."""
+        """When no passage has is_start=True, the first passage in list order
+        (NOT alphabetically first) gets number 1.
+        """
+        # Pass passages in non-alphabetical order so this test actually
+        # discriminates list-order behavior from sorted-order behavior.
         passages = [
+            ExportPassage(id="passage::gamma", prose="Gamma."),
             ExportPassage(id="passage::alpha", prose="Alpha."),
             ExportPassage(id="passage::beta", prose="Beta."),
-            ExportPassage(id="passage::gamma", prose="Gamma."),
         ]
         numbering = _build_passage_numbering(passages)
 
-        # First passage (alphabetically sorted) should be 1
-        assert numbering["passage::alpha"] == 1
+        # First in list order, NOT alphabetically first
+        assert numbering["passage::gamma"] == 1
         # All passages should have unique numbers
         assert len(set(numbering.values())) == 3
 


### PR DESCRIPTION
## Summary

PR B of 5 for the SHIP spec-compliance milestone (epic #1331). Two clusters bundled because they share infrastructure (the metadata header lands in the PDF sidecar that #1336 also produces):

| # | Rule | Fix |
|---|---|---|
| #1333 | R-3.6 | Every export carries a deterministic metadata block — \`pipeline_version\`, \`graph_snapshot_hash\` (SHA256 of canonical-JSON ExportContext), \`format_version\`, \`generation_timestamp\` |
| #1336 | R-3.5 | PDF runs now write a \`story.pdf.map.json\` sidecar carrying both the metadata block and the \`passage_id → page_number\` map |

## New modules

- \`export/metadata.py\` — \`ExportMetadata\` dataclass + \`build_export_metadata()\`. Falls back to a stable sentinel pipeline version when the package isn't installed (e.g. running from a checkout) so the snapshot hash stays reproducible.
- \`export/pagination.py\` — \`compute_passage_numbering()\` extracted from \`pdf_exporter.py\` for reuse.

## Per-format embedding

| Format | Where metadata lives |
|---|---|
| JSON | Top-level \`_metadata\` key |
| Twee | Unlinked \`:: StoryMetadata\` passage |
| HTML | One \`<meta name=\"qf-...\">\` tag per field in \`<head>\` |
| PDF | \`story.pdf.map.json\` sidecar |

Each exporter exposes a \`format_version\` class attribute (1.0.0 to start) and accepts a \`timestamp=\` kwarg for deterministic test assertions.

## Why a PDF sidecar (not embedded in JSON)

The audit suggested either embedding the page map in the JSON export OR a sidecar. Sidecar wins because:
1. Each format is exported independently; the user shouldn't have to also target JSON to debug a PDF.
2. The PDF is the format the map describes — keeping them adjacent matches the mental model.
3. JSON exports of stories that never went through PDF stay clean.

## Test plan

- [x] \`uv run pytest tests/unit/test_export_metadata.py tests/unit/test_pdf_exporter.py tests/unit/test_json_exporter.py tests/unit/test_twee_exporter.py tests/unit/test_html_exporter.py tests/unit/test_ship_stage.py tests/unit/test_export_context.py -q\` — 147/147 pass (incl. snapshot-hash-consistent-across-formats and byte-identical-with-fixed-timestamp)
- [x] \`uv run ruff check src/ tests/\` — clean
- [x] \`uv run mypy src/\` — clean
- [ ] CI green
- [ ] \`/pr-review-toolkit:review-pr\` clean before marking ready

## Remaining SHIP work

- PR C: HTML voice-document styling (R-3.3) — closes #1335
- PR D: Phase 4 export validation (R-4.1–R-4.4) — closes #1332
- PR E: cross-cutting test coverage (R-2.4 / R-3.1 / R-3.2) — closes #1338

🤖 Generated with [Claude Code](https://claude.com/claude-code)