### PR TITLE
feat(ship): HTML voice-document-driven CSS (closes #1335)

### DIFF
--- a/docs/design/procedures/fill.md
+++ b/docs/design/procedures/fill.md
@@ -49,7 +49,7 @@ FILL does NOT create, reorder, split, or merge beats or passages; does NOT add p
 
 R-1.1. Exactly one Voice Document node is created. Retries replace the previous node, not duplicate it.
 
-R-1.2. Voice Document fields include `pov`, `tense`, `register`, `sentence_rhythm`, `tone_words`, `avoid_words`, `avoid_patterns`, and optionally `pov_character` and `exemplar_passages`.
+R-1.2. Voice Document fields include `pov`, `tense`, `voice_register`, `sentence_rhythm`, `tone_words`, `avoid_words`, `avoid_patterns`, and optionally `pov_character` and `exemplar_passages`.
 
 R-1.3. `pov` ∈ {`first_person`, `second_person`, `third_person_limited`, `third_person_omniscient`}. When `pov` is limited, `pov_character` names the POV entity.
 
@@ -336,7 +336,7 @@ R-5.3. The cap is configurable but defaults to 2.
 ## Rule Index
 
 R-1.1: Exactly one Voice Document node; retries replace.
-R-1.2: Voice Document has required fields: pov, tense, register, rhythm, tone_words, avoid_words, avoid_patterns.
+R-1.2: Voice Document has required fields: pov, tense, voice_register, sentence_rhythm, tone_words, avoid_words, avoid_patterns.
 R-1.3: `pov` in permitted set; `pov_character` if limited.
 R-1.4: `tense` ∈ {past, present}.
 R-1.5: Voice Document has no graph edges.

--- a/src/questfoundry/export/base.py
+++ b/src/questfoundry/export/base.py
@@ -92,6 +92,7 @@ class ExportContext:
     cover: ExportIllustration | None = None
     codex_entries: list[ExportCodexEntry] = field(default_factory=list)
     art_direction: dict[str, Any] | None = None
+    voice: dict[str, Any] | None = None
     language: str = "en"
 
 

--- a/src/questfoundry/export/context.py
+++ b/src/questfoundry/export/context.py
@@ -82,6 +82,7 @@ def build_export_context(graph: Graph, project_name: str, *, language: str = "en
         cover=cover,
         codex_entries=_extract_codex_entries(graph),
         art_direction=_extract_art_direction(graph),
+        voice=_extract_voice(graph),
         language=language,
     )
 
@@ -341,6 +342,21 @@ def _extract_codex_entries(graph: Graph) -> list[ExportCodexEntry]:
                 )
             )
     return result
+
+
+def _extract_voice(graph: Graph) -> dict[str, Any] | None:
+    """Extract the FILL voice document for downstream presentation use.
+
+    Returns ``None`` when FILL has not produced a voice document yet
+    (R-3.3 styling falls back to defaults). When present, the dict
+    carries the VoiceDocument fields verbatim — exporters cherry-pick
+    what they need (HTML uses ``voice_register`` and ``sentence_rhythm``
+    for CSS class selection; other formats may ignore it entirely).
+    """
+    node = graph.get_node("voice::voice")
+    if not node:
+        return None
+    return {k: v for k, v in node.items() if k not in ("type", "raw_id")}
 
 
 def _extract_art_direction(graph: Graph) -> dict[str, Any] | None:

--- a/src/questfoundry/export/html_exporter.py
+++ b/src/questfoundry/export/html_exporter.py
@@ -35,9 +35,11 @@ HTML_FORMAT_VERSION = "1.0.0"
 # R-3.3 voice-document-driven CSS. Each register/rhythm value maps to a
 # body class plus a scoped rule block. Falls back to baseline styling
 # (no class added) when FILL hasn't produced a voice document.
-_VOICE_REGISTERS = ("formal", "conversational", "literary", "sparse")
-_VOICE_RHYTHMS = ("varied", "punchy", "flowing")
-
+#
+# The CSS dicts below are the SINGLE SOURCE OF TRUTH for the valid
+# register/rhythm values: _voice_body_class and _voice_css_block both
+# validate against dict membership so a class can never be emitted
+# without a matching scoped rule (or vice versa).
 _VOICE_REGISTER_CSS = {
     "formal": """body.register-formal .prose {
   font-family: 'EB Garamond', Garamond, Georgia, serif;
@@ -206,10 +208,10 @@ def _voice_body_class(voice: dict[str, Any] | None) -> str:
         return ""
     classes: list[str] = []
     register = voice.get("voice_register")
-    if register in _VOICE_REGISTERS:
+    if register in _VOICE_REGISTER_CSS:
         classes.append(f"register-{register}")
     rhythm = voice.get("sentence_rhythm")
-    if rhythm in _VOICE_RHYTHMS:
+    if rhythm in _VOICE_RHYTHM_CSS:
         classes.append(f"rhythm-{rhythm}")
     if not classes:
         return ""

--- a/src/questfoundry/export/html_exporter.py
+++ b/src/questfoundry/export/html_exporter.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 import html
 import json
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from questfoundry.export.i18n import get_ui_strings
 from questfoundry.export.metadata import ExportMetadata, build_export_metadata
@@ -31,6 +31,48 @@ log = get_logger(__name__)
 # Backward-compatible additive changes only; bump on shape changes
 # (new <head> meta block, breaking layout reshuffle, etc.).
 HTML_FORMAT_VERSION = "1.0.0"
+
+# R-3.3 voice-document-driven CSS. Each register/rhythm value maps to a
+# body class plus a scoped rule block. Falls back to baseline styling
+# (no class added) when FILL hasn't produced a voice document.
+_VOICE_REGISTERS = ("formal", "conversational", "literary", "sparse")
+_VOICE_RHYTHMS = ("varied", "punchy", "flowing")
+
+_VOICE_REGISTER_CSS = {
+    "formal": """body.register-formal .prose {
+  font-family: 'EB Garamond', Garamond, Georgia, serif;
+  text-align: justify;
+}""",
+    "conversational": """body.register-conversational .prose {
+  font-family: 'Georgia', 'Times New Roman', serif;
+  text-align: left;
+}""",
+    "literary": """body.register-literary .prose {
+  font-family: 'Iowan Old Style', 'Palatino Linotype', Palatino, serif;
+  text-align: justify;
+  font-feature-settings: "liga", "dlig";
+}""",
+    "sparse": """body.register-sparse .prose {
+  font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;
+  text-align: left;
+  letter-spacing: 0.01em;
+}""",
+}
+
+_VOICE_RHYTHM_CSS = {
+    "varied": """body.rhythm-varied .prose {
+  line-height: 1.7;
+  margin-bottom: 1.5em;
+}""",
+    "punchy": """body.rhythm-punchy .prose {
+  line-height: 1.45;
+  margin-bottom: 1em;
+}""",
+    "flowing": """body.rhythm-flowing .prose {
+  line-height: 1.85;
+  margin-bottom: 1.8em;
+}""",
+}
 
 
 class HtmlExporter:
@@ -114,6 +156,7 @@ class HtmlExporter:
             codex_html=codex_html,
             art_direction_meta=art_direction_meta,
             metadata=metadata,
+            voice=context.voice,
             cover_html=cover_html,
             language=context.language,
             ui=ui,
@@ -148,6 +191,49 @@ def _render_metadata_meta_tags(metadata: ExportMetadata) -> str:
         f'<meta name="qf-{key.replace("_", "-")}" content="{html.escape(value)}">'
         for key, value in sorted(metadata.to_dict().items())
     )
+
+
+def _voice_body_class(voice: dict[str, Any] | None) -> str:
+    """Return the ``class="..."`` attribute fragment for ``<body>`` (R-3.3).
+
+    Empty string when no voice document is present, so the page falls
+    back to baseline styling. Otherwise returns one or both of
+    ``register-<name>`` and ``rhythm-<name>``, validated against the
+    VoiceDocument literal sets so unknown values silently degrade
+    rather than emit unscoped classes.
+    """
+    if not voice:
+        return ""
+    classes: list[str] = []
+    register = voice.get("voice_register")
+    if register in _VOICE_REGISTERS:
+        classes.append(f"register-{register}")
+    rhythm = voice.get("sentence_rhythm")
+    if rhythm in _VOICE_RHYTHMS:
+        classes.append(f"rhythm-{rhythm}")
+    if not classes:
+        return ""
+    return f' class="{" ".join(classes)}"'
+
+
+def _voice_css_block(voice: dict[str, Any] | None) -> str:
+    """Return the voice-scoped CSS rule block to append to ``<style>``.
+
+    The rules are body-scoped (``body.register-formal .prose {...}``),
+    so they only activate when the matching class is present on
+    ``<body>`` — cheap to ship, zero impact when voice is absent or
+    its values fall outside the known set.
+    """
+    if not voice:
+        return ""
+    blocks: list[str] = []
+    register = voice.get("voice_register")
+    if register in _VOICE_REGISTER_CSS:
+        blocks.append(_VOICE_REGISTER_CSS[register])
+    rhythm = voice.get("sentence_rhythm")
+    if rhythm in _VOICE_RHYTHM_CSS:
+        blocks.append(_VOICE_RHYTHM_CSS[rhythm])
+    return "\n".join(blocks)
 
 
 def _render_passage_div(
@@ -234,6 +320,7 @@ def _build_html_document(
     metadata: ExportMetadata,
     codex_html: str = "",
     art_direction_meta: str = "",
+    voice: dict[str, Any] | None = None,
     cover_html: str = "",
     language: str = "en",
     ui: dict[str, str] | None = None,
@@ -244,11 +331,18 @@ def _build_html_document(
     export, so an HTML build without it would silently violate the spec.
     Make the parameter mandatory rather than defaulting to ``None`` so a
     forgotten argument fails at call time, not at audit time.
+
+    ``voice`` is optional (R-3.3): when present, voice-driven CSS
+    classes are added to ``<body>`` and matching scoped rule blocks
+    are appended to the embedded stylesheet. When absent, the page
+    falls back to baseline styling — no class added, no extra rules.
     """
     extra_meta_parts = [_render_metadata_meta_tags(metadata)]
     if art_direction_meta:
         extra_meta_parts.append(art_direction_meta)
     extra_meta = "\n" + "\n".join(extra_meta_parts)
+    body_class = _voice_body_class(voice)
+    voice_css = _voice_css_block(voice)
     codex_label = html.escape((ui or {}).get("codex", "Codex"))
     codex_button = (
         f'<button class="codex-toggle" id="codex-toggle">{codex_label}</button>'
@@ -376,9 +470,10 @@ h1 {{
   color: #a8d8ea;
   margin-bottom: 0.3em;
 }}
+{voice_css}
 </style>
 </head>
-<body>
+<body{body_class}>
 <h1>{html.escape(title)}</h1>
 {cover_html}
 {codex_button}

--- a/tests/unit/test_export_context.py
+++ b/tests/unit/test_export_context.py
@@ -518,3 +518,37 @@ class TestPartialDressWarning:
             ctx = build_export_context(g, "test")
         assert ctx.art_direction is None
         assert not _has_event(caplog, "art_direction_partial")
+
+
+class TestVoiceExtraction:
+    """R-3.3 prep: ExportContext exposes the FILL voice document so the
+    HTML exporter (and future format-specific styling) can react to it.
+    """
+
+    def test_voice_node_extracted(self) -> None:
+        g = _minimal_graph()
+        g.create_node(
+            "voice::voice",
+            {
+                "type": "voice",
+                "raw_id": "voice",
+                "story_title": "The Test",
+                "pov": "third_limited",
+                "tense": "past",
+                "voice_register": "literary",
+                "sentence_rhythm": "flowing",
+                "tone_words": ["wry"],
+            },
+        )
+        ctx = build_export_context(g, "test")
+        assert ctx.voice is not None
+        assert ctx.voice["voice_register"] == "literary"
+        assert ctx.voice["sentence_rhythm"] == "flowing"
+        # Internal-only fields stripped
+        assert "type" not in ctx.voice
+        assert "raw_id" not in ctx.voice
+
+    def test_no_voice_node_returns_none(self) -> None:
+        g = _minimal_graph()
+        ctx = build_export_context(g, "test")
+        assert ctx.voice is None

--- a/tests/unit/test_html_exporter.py
+++ b/tests/unit/test_html_exporter.py
@@ -385,6 +385,36 @@ class TestHtmlVoiceStyling:
         # No rhythm artifacts
         assert "rhythm-" not in content
 
+    def test_only_rhythm_present(self, tmp_path: Path) -> None:
+        """Symmetric to test_only_register_present: missing register field
+        doesn't break export — only rhythm class added.
+        """
+        ctx = _simple_context()
+        ctx.voice = {"sentence_rhythm": "punchy"}
+
+        result = HtmlExporter().export(ctx, tmp_path / "out")
+        content = result.read_text()
+
+        assert '<body class="rhythm-punchy">' in content
+        assert "body.rhythm-punchy .prose" in content
+        # No register artifacts
+        assert "register-" not in content
+
+    def test_all_unknown_values_no_body_class(self, tmp_path: Path) -> None:
+        """Both fields unknown → no class= attribute at all (not class="").
+
+        Pinning this behaviour: an empty class attribute would be valid
+        HTML but signals "voice was attempted" when in fact nothing
+        useful was applied.
+        """
+        ctx = _simple_context()
+        ctx.voice = {"voice_register": "shouty", "sentence_rhythm": "chaotic"}
+        result = HtmlExporter().export(ctx, tmp_path / "out")
+        content = result.read_text()
+
+        assert "<body>" in content
+        assert "<body class=" not in content
+
     def test_unknown_register_silently_ignored(self, tmp_path: Path) -> None:
         """Out-of-vocabulary register doesn't emit a body class.
 

--- a/tests/unit/test_html_exporter.py
+++ b/tests/unit/test_html_exporter.py
@@ -321,3 +321,99 @@ class TestHtmlExporter:
         content = result.read_text()
 
         assert 'lang="en"' in content
+
+
+# ---------------------------------------------------------------------------
+# R-3.3: voice-document-driven CSS
+# ---------------------------------------------------------------------------
+
+
+def _voice(register: str = "literary", rhythm: str = "flowing") -> dict[str, object]:
+    return {
+        "pov": "third_limited",
+        "tense": "past",
+        "voice_register": register,
+        "sentence_rhythm": rhythm,
+        "tone_words": ["wry"],
+    }
+
+
+class TestHtmlVoiceStyling:
+    """R-3.3: HTML uses voice-document-informed CSS/typography when available.
+
+    No voice → baseline (no body class, no extra rules).
+    Voice present → body carries register-* / rhythm-* classes and the
+    matching scoped CSS rule blocks are appended to <style>.
+    """
+
+    def test_no_voice_baseline_styling(self, tmp_path: Path) -> None:
+        ctx = _simple_context()
+        assert ctx.voice is None
+        result = HtmlExporter().export(ctx, tmp_path / "out")
+        content = result.read_text()
+
+        # body tag has no class attribute
+        assert "<body>" in content
+        assert "<body class=" not in content
+        # No voice CSS leaked into <style>
+        assert "register-" not in content
+        assert "rhythm-" not in content
+
+    def test_voice_register_and_rhythm_classes_applied(self, tmp_path: Path) -> None:
+        ctx = _simple_context()
+        ctx.voice = _voice(register="literary", rhythm="flowing")
+
+        result = HtmlExporter().export(ctx, tmp_path / "out")
+        content = result.read_text()
+
+        # body carries both classes
+        assert '<body class="register-literary rhythm-flowing">' in content
+        # Scoped rule blocks appear in <style>
+        assert "body.register-literary .prose" in content
+        assert "body.rhythm-flowing .prose" in content
+
+    def test_only_register_present(self, tmp_path: Path) -> None:
+        """Missing rhythm field doesn't break export — only register class added."""
+        ctx = _simple_context()
+        ctx.voice = {"voice_register": "sparse"}
+
+        result = HtmlExporter().export(ctx, tmp_path / "out")
+        content = result.read_text()
+
+        assert '<body class="register-sparse">' in content
+        assert "body.register-sparse .prose" in content
+        # No rhythm artifacts
+        assert "rhythm-" not in content
+
+    def test_unknown_register_silently_ignored(self, tmp_path: Path) -> None:
+        """Out-of-vocabulary register doesn't emit a body class.
+
+        Defensive: VoiceDocument's Literal type guarantees the value at
+        FILL time, but a hand-edited graph could carry anything.
+        Unknown values fall back to baseline rather than emitting an
+        unscoped CSS class.
+        """
+        ctx = _simple_context()
+        ctx.voice = {"voice_register": "shouty", "sentence_rhythm": "punchy"}
+
+        result = HtmlExporter().export(ctx, tmp_path / "out")
+        content = result.read_text()
+
+        # rhythm class present, register absent (no register-shouty)
+        assert '<body class="rhythm-punchy">' in content
+        assert "register-shouty" not in content
+
+    def test_each_register_value_has_distinct_css(self, tmp_path: Path) -> None:
+        """Sanity: registers don't all collapse to the same CSS rule."""
+        rendered = []
+        for register in ("formal", "conversational", "literary", "sparse"):
+            ctx = _simple_context()
+            ctx.voice = _voice(register=register)
+            out = HtmlExporter().export(ctx, tmp_path / register)
+            rendered.append(out.read_text())
+
+        # Each rendered HTML mentions its own register, not the others
+        for i, register in enumerate(("formal", "conversational", "literary", "sparse")):
+            assert f"register-{register}" in rendered[i]
+        # And the rendered docs differ
+        assert len(set(rendered)) == 4


### PR DESCRIPTION
## Summary

PR C of 5 for the SHIP spec-compliance milestone (epic #1331). Implements **R-3.3** — HTML export uses the FILL VoiceDocument to drive typography choices when available, falling back to baseline CSS when FILL hasn't run.

## What changed

- \`ExportContext.voice: dict[str, Any] | None\` exposes the FILL voice document to all exporters; \`_extract_voice()\` reads \`voice::voice\` and strips internal-only fields.
- \`html_exporter.py\` declares per-register and per-rhythm scoped CSS tables, and two helpers (\`_voice_body_class\` + \`_voice_css_block\`) turn the voice dict into:
  - A body-class attribute (\`<body class=\"register-literary rhythm-flowing\">\`)
  - Scoped rule blocks appended to the embedded stylesheet (\`body.register-literary .prose { ... }\`)
- Unknown register/rhythm values silently degrade to baseline rather than emitting unscoped classes — defensive for hand-edited graphs since the VoiceDocument Literal type only validates at FILL time.

## Why body-scoped classes (not inline styles)

- One CSS source of truth — easy to override in a custom stylesheet.
- Zero side effect when voice is absent: no class on body, no rules match.
- Cheap to extend (add a new register: declare a constant, no template surgery).

## Test plan

- [x] \`uv run pytest tests/unit/test_html_exporter.py tests/unit/test_export_context.py tests/unit/test_export_metadata.py tests/unit/test_ship_stage.py tests/unit/test_pdf_exporter.py tests/unit/test_twee_exporter.py tests/unit/test_json_exporter.py -q\` — 156/156 pass
- [x] \`uv run ruff check src/ tests/\` — clean
- [x] \`uv run mypy src/\` — clean
- [ ] CI green
- [ ] \`/pr-review-toolkit:review-pr\` clean before marking ready

## Remaining SHIP work

- PR D: Phase 4 export validation (R-4.1–R-4.4) — closes #1332 (biggest)
- PR E: cross-cutting test coverage (R-2.4 / R-3.1 / R-3.2) — closes #1338

🤖 Generated with [Claude Code](https://claude.com/claude-code)