### PR TITLE
feat(ship): Phase 4 per-format export validation (closes #1332)

### DIFF
--- a/src/questfoundry/export/pdf_exporter.py
+++ b/src/questfoundry/export/pdf_exporter.py
@@ -344,7 +344,9 @@ def _write_pdf_sidecar(
         "_metadata": metadata.to_dict(),
         "page_map": dict(sorted(numbering.items())),
     }
-    sidecar_file = pdf_path.with_suffix(".pdf.map.json")
+    # Append the sidecar suffix via with_name; Path.with_suffix(".pdf.map.json")
+    # would warn under 3.12 and raise under 3.13 because of the multi-dot suffix.
+    sidecar_file = pdf_path.with_name(pdf_path.name + ".map.json")
     sidecar_file.write_text(
         json.dumps(sidecar, indent=2, ensure_ascii=False),
         encoding="utf-8",

--- a/src/questfoundry/export/validation.py
+++ b/src/questfoundry/export/validation.py
@@ -1,0 +1,320 @@
+"""Per-format export validation (SHIP Phase 4 / R-4.1 to R-4.4).
+
+A technical integrity check — not a quality check (R-4.3). Each
+validator parses the produced file and confirms internal consistency:
+every choice link resolves to a passage that actually exists, the
+file is loadable, the metadata block is present, etc.
+
+Validators raise :class:`ExportValidationError` on failure with a
+specific human-readable message naming the broken reference (R-4.4).
+``ShipStage._phase_4_validate()`` runs the validator matching the
+chosen format and re-raises as :class:`ShipStageError` so SHIP halts
+before delivering the bundle (R-4.2).
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from html.parser import HTMLParser
+from typing import TYPE_CHECKING
+
+from questfoundry.observability.logging import get_logger
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+    from pathlib import Path
+
+log = get_logger(__name__)
+
+
+class ExportValidationError(ValueError):
+    """Raised when a per-format integrity check fails (R-4.2 / R-4.4).
+
+    The message names the specific broken reference so the user can
+    fix the upstream cause without re-running the entire pipeline.
+    """
+
+
+# ---------------------------------------------------------------------------
+# Twee
+# ---------------------------------------------------------------------------
+
+# Top-of-line passage header, e.g. ":: Start [start]" or ":: castle".
+# We capture the bare name (first whitespace-or-bracket-delimited token).
+_TWEE_HEADER_RE = re.compile(r"^::\s*([^\s\[]+)")
+# Plain link form: [[label->target]] or [[target]].
+_TWEE_LINK_RE = re.compile(r"\[\[([^\]]+?)(?:->([^\]]+))?\]\]")
+# Macro form inside <<link>>: <<goto "target">>.
+_TWEE_GOTO_RE = re.compile(r'<<goto\s+"([^"]+)"\s*>>')
+
+# Twee headers that are SugarCube infrastructure, not navigable passages.
+_TWEE_RESERVED_HEADERS = {
+    "StoryTitle",
+    "StoryData",
+    "StoryInit",
+    "StoryArtDirection",
+    "StoryMetadata",
+}
+
+
+def validate_twee(path: Path) -> None:
+    """Verify Twee link reachability — every choice link target exists.
+
+    Raises:
+        ExportValidationError: If a link references an undefined passage,
+            or if the file lacks a ``Start`` passage.
+    """
+    text = path.read_text(encoding="utf-8")
+    passage_names: set[str] = set()
+    for line in text.splitlines():
+        match = _TWEE_HEADER_RE.match(line)
+        if match:
+            passage_names.add(match.group(1))
+
+    if not passage_names:
+        msg = f"Twee export {path.name} contains no passage headers (no `:: <name>` lines)"
+        raise ExportValidationError(msg)
+    if "Start" not in passage_names:
+        msg = f"Twee export {path.name} is missing a `:: Start` passage"
+        raise ExportValidationError(msg)
+
+    referenced: set[str] = set()
+    for match in _TWEE_LINK_RE.finditer(text):
+        # [[label->target]]: group(2) is target. [[target]]: group(2) is None.
+        target = match.group(2) or match.group(1)
+        referenced.add(target.strip())
+    for match in _TWEE_GOTO_RE.finditer(text):
+        referenced.add(match.group(1).strip())
+
+    broken = sorted(
+        ref for ref in referenced if ref not in passage_names and ref not in _TWEE_RESERVED_HEADERS
+    )
+    if broken:
+        msg = (
+            f"Twee export {path.name} has {len(broken)} broken link target(s): "
+            f"{', '.join(repr(b) for b in broken[:5])}"
+            f"{' …' if len(broken) > 5 else ''}. "
+            f"Each target must match a `:: <name>` header earlier in the file."
+        )
+        raise ExportValidationError(msg)
+
+
+# ---------------------------------------------------------------------------
+# JSON
+# ---------------------------------------------------------------------------
+
+# Required top-level keys. Schema is defined by ``json_exporter.JsonExporter``;
+# additive changes are allowed (R-3.4) so we only check the always-present set.
+_JSON_REQUIRED_KEYS = {"_metadata", "title", "passages", "choices"}
+_JSON_REQUIRED_METADATA_KEYS = {
+    "pipeline_version",
+    "graph_snapshot_hash",
+    "format_version",
+    "generation_timestamp",
+}
+
+
+def validate_json(path: Path) -> None:
+    """Verify JSON loadable, schema-shaped, and internally consistent.
+
+    Raises:
+        ExportValidationError: On parse failure, missing required keys,
+            or any choice referencing a passage id that is not in the
+            passages list.
+    """
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as e:
+        msg = f"JSON export {path.name} could not be parsed: {e}"
+        raise ExportValidationError(msg) from e
+
+    if not isinstance(data, dict):
+        msg = f"JSON export {path.name} top-level is not an object"
+        raise ExportValidationError(msg)
+
+    missing_keys = sorted(_JSON_REQUIRED_KEYS - data.keys())
+    if missing_keys:
+        msg = f"JSON export {path.name} missing required top-level key(s): {missing_keys}"
+        raise ExportValidationError(msg)
+
+    metadata = data["_metadata"]
+    if not isinstance(metadata, dict):
+        msg = f"JSON export {path.name} `_metadata` is not an object"
+        raise ExportValidationError(msg)
+    missing_meta = sorted(_JSON_REQUIRED_METADATA_KEYS - metadata.keys())
+    if missing_meta:
+        msg = (
+            f"JSON export {path.name} `_metadata` missing required key(s): {missing_meta}. "
+            f"R-3.6 requires every export to carry a complete provenance block."
+        )
+        raise ExportValidationError(msg)
+
+    passage_ids = {p["id"] for p in data["passages"] if isinstance(p, dict) and "id" in p}
+    broken = sorted(
+        c["to_passage"]
+        for c in data["choices"]
+        if isinstance(c, dict) and c.get("to_passage") not in passage_ids
+    )
+    if broken:
+        msg = (
+            f"JSON export {path.name} has {len(broken)} choice(s) targeting "
+            f"undefined passage(s): {', '.join(repr(b) for b in broken[:5])}"
+            f"{' …' if len(broken) > 5 else ''}."
+        )
+        raise ExportValidationError(msg)
+
+
+# ---------------------------------------------------------------------------
+# HTML
+# ---------------------------------------------------------------------------
+
+
+class _HtmlChoiceCollector(HTMLParser):
+    """Collect passage div ids and choice anchor data-target values.
+
+    Used to verify that every choice points at an existing passage div
+    without spinning up a headless browser (R-4.3 says technical
+    integrity, not visual rendering).
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.passage_ids: set[str] = set()
+        self.choice_targets: list[str] = []
+        self.has_body = False
+
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        if tag == "body":
+            self.has_body = True
+        if tag == "div":
+            attr_dict = dict(attrs)
+            if attr_dict.get("class") == "passage" and attr_dict.get("id"):
+                pid = attr_dict["id"]
+                if pid is not None:
+                    self.passage_ids.add(pid)
+        if tag == "a":
+            attr_dict = dict(attrs)
+            classes = (attr_dict.get("class") or "").split()
+            target = attr_dict.get("data-target")
+            if "choice" in classes and target:
+                self.choice_targets.append(target)
+
+
+def validate_html(path: Path) -> None:
+    """Verify HTML parses, has a body, and every choice resolves.
+
+    Raises:
+        ExportValidationError: If the file fails to parse, lacks a
+            ``<body>``, has no passage divs, or has a ``data-target``
+            attribute on a ``<a class="choice">`` that doesn't match
+            an existing passage div id.
+    """
+    text = path.read_text(encoding="utf-8")
+    parser = _HtmlChoiceCollector()
+    try:
+        parser.feed(text)
+    except Exception as e:  # html.parser is permissive; surface anything that escapes
+        msg = f"HTML export {path.name} failed to parse: {e}"
+        raise ExportValidationError(msg) from e
+
+    if not parser.has_body:
+        msg = f"HTML export {path.name} has no <body> element"
+        raise ExportValidationError(msg)
+    if not parser.passage_ids:
+        msg = f'HTML export {path.name} has no passage divs (`<div class="passage">`)'
+        raise ExportValidationError(msg)
+
+    broken = sorted({t for t in parser.choice_targets if t not in parser.passage_ids})
+    if broken:
+        msg = (
+            f"HTML export {path.name} has {len(broken)} choice(s) with broken "
+            f"data-target attribute(s): {', '.join(repr(b) for b in broken[:5])}"
+            f"{' …' if len(broken) > 5 else ''}. "
+            f"Each value must equal a passage div id."
+        )
+        raise ExportValidationError(msg)
+
+
+# ---------------------------------------------------------------------------
+# PDF
+# ---------------------------------------------------------------------------
+
+
+def validate_pdf(path: Path) -> None:
+    """Verify the PDF sidecar is present and the page map is internally consistent.
+
+    Per R-4.3 we check the sidecar (which carries every passage_id →
+    page_number assignment) rather than parsing PDF internals. The
+    sidecar is the canonical source of "turn to page X" targets, so
+    every value must be in the range ``1..N`` where N is the number
+    of distinct page numbers.
+
+    Raises:
+        ExportValidationError: Sidecar missing, malformed, or carrying
+            an out-of-range page number.
+    """
+    sidecar = path.with_suffix(".pdf.map.json")
+    if not sidecar.exists():
+        msg = (
+            f"PDF export {path.name} is missing its sidecar {sidecar.name} "
+            f"(required by R-3.6 + #1336 for provenance and pagination debugging)."
+        )
+        raise ExportValidationError(msg)
+
+    try:
+        data = json.loads(sidecar.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as e:
+        msg = f"PDF sidecar {sidecar.name} could not be parsed: {e}"
+        raise ExportValidationError(msg) from e
+
+    page_map = data.get("page_map")
+    if not isinstance(page_map, dict) or not page_map:
+        msg = f"PDF sidecar {sidecar.name} `page_map` is missing or empty"
+        raise ExportValidationError(msg)
+
+    pages = list(page_map.values())
+    n_pages = len(set(pages))
+    out_of_range = sorted(
+        f"{pid} → {pg}"
+        for pid, pg in page_map.items()
+        if not isinstance(pg, int) or pg < 1 or pg > n_pages
+    )
+    if out_of_range:
+        msg = (
+            f"PDF sidecar {sidecar.name} has {len(out_of_range)} page number(s) "
+            f"outside the valid range 1..{n_pages}: "
+            f"{', '.join(out_of_range[:5])}"
+            f"{' …' if len(out_of_range) > 5 else ''}."
+        )
+        raise ExportValidationError(msg)
+    if len(pages) != n_pages:
+        msg = (
+            f"PDF sidecar {sidecar.name} has duplicate page numbers — "
+            f"{len(pages)} entries, only {n_pages} distinct pages."
+        )
+        raise ExportValidationError(msg)
+
+
+# ---------------------------------------------------------------------------
+# Dispatch
+# ---------------------------------------------------------------------------
+
+VALIDATORS: dict[str, Callable[[Path], None]] = {
+    "twee": validate_twee,
+    "json": validate_json,
+    "html": validate_html,
+    "pdf": validate_pdf,
+}
+
+
+def validate_export(format_name: str, path: Path) -> None:
+    """Dispatch to the validator matching ``format_name``.
+
+    Raises:
+        ExportValidationError: Forwarded from the per-format validator.
+        KeyError: If ``format_name`` has no registered validator (a
+            programmer error — every supported format must have one).
+    """
+    validator = VALIDATORS[format_name]
+    validator(path)

--- a/src/questfoundry/export/validation.py
+++ b/src/questfoundry/export/validation.py
@@ -59,11 +59,19 @@ _TWEE_RESERVED_HEADERS = {
 
 
 def validate_twee(path: Path) -> None:
-    """Verify Twee link reachability — every choice link target exists.
+    """Verify Twee link reachability — every link target exists AND
+    every passage is reachable from ``Start`` via choice links.
+
+    The spec (Phase 4 Operations) requires both: ``Parse the Twee
+    file; verify every :: passage_id is reachable via choice links;
+    verify no broken links``. Codex/StoryArtDirection/StoryMetadata
+    passages are intentionally unlinked metadata sidecars (R-3.6 +
+    DRESS) and are exempt from the reachability check.
 
     Raises:
         ExportValidationError: If a link references an undefined passage,
-            or if the file lacks a ``Start`` passage.
+            if the file lacks a ``Start`` passage, or if a navigable
+            passage is defined but never reached from ``Start``.
     """
     text = path.read_text(encoding="utf-8")
     passage_names: set[str] = set()
@@ -79,14 +87,14 @@ def validate_twee(path: Path) -> None:
         msg = f"Twee export {path.name} is missing a `:: Start` passage"
         raise ExportValidationError(msg)
 
-    referenced: set[str] = set()
-    for match in _TWEE_LINK_RE.finditer(text):
-        # [[label->target]]: group(2) is target. [[target]]: group(2) is None.
-        target = match.group(2) or match.group(1)
-        referenced.add(target.strip())
-    for match in _TWEE_GOTO_RE.finditer(text):
-        referenced.add(match.group(1).strip())
+    # Build per-passage outbound link sets, scanning each passage body
+    # (everything between its `::` header and the next `::` header).
+    outlinks = _twee_outlinks_per_passage(text)
 
+    # Broken-target check: every referenced name must exist.
+    referenced: set[str] = set()
+    for targets in outlinks.values():
+        referenced.update(targets)
     broken = sorted(
         ref for ref in referenced if ref not in passage_names and ref not in _TWEE_RESERVED_HEADERS
     )
@@ -98,6 +106,63 @@ def validate_twee(path: Path) -> None:
             f"Each target must match a `:: <name>` header earlier in the file."
         )
         raise ExportValidationError(msg)
+
+    # Reachability BFS from Start. Passages defined as metadata
+    # sidecars (codex, art direction, story metadata) are intentionally
+    # unlinked — exclude them from the reachable-set requirement.
+    reachable = _bfs_reachable("Start", outlinks)
+    must_reach = {
+        name for name in passage_names if name not in _TWEE_RESERVED_HEADERS and name != "Codex"
+    }
+    orphans = sorted(must_reach - reachable)
+    if orphans:
+        msg = (
+            f"Twee export {path.name} has {len(orphans)} passage(s) defined but "
+            f"unreachable from `:: Start`: "
+            f"{', '.join(repr(o) for o in orphans[:5])}"
+            f"{' …' if len(orphans) > 5 else ''}. "
+            f"Every navigable passage must be reachable via choice links."
+        )
+        raise ExportValidationError(msg)
+
+
+def _twee_outlinks_per_passage(text: str) -> dict[str, set[str]]:
+    """Map each passage name to the set of names it links to.
+
+    Splits the file at `::` headers and scans each body for both link
+    forms ([[…]] and <<goto "…">>).
+    """
+    lines = text.splitlines()
+    headers: list[tuple[int, str]] = []  # (line index, name)
+    for i, line in enumerate(lines):
+        match = _TWEE_HEADER_RE.match(line)
+        if match:
+            headers.append((i, match.group(1)))
+
+    outlinks: dict[str, set[str]] = {}
+    for idx, (line_no, name) in enumerate(headers):
+        end = headers[idx + 1][0] if idx + 1 < len(headers) else len(lines)
+        body = "\n".join(lines[line_no + 1 : end])
+        targets: set[str] = set()
+        for match in _TWEE_LINK_RE.finditer(body):
+            targets.add((match.group(2) or match.group(1)).strip())
+        for match in _TWEE_GOTO_RE.finditer(body):
+            targets.add(match.group(1).strip())
+        outlinks[name] = targets
+    return outlinks
+
+
+def _bfs_reachable(start: str, outlinks: dict[str, set[str]]) -> set[str]:
+    """Standard BFS over the link graph starting at ``start``."""
+    seen: set[str] = {start}
+    frontier: list[str] = [start]
+    while frontier:
+        node = frontier.pop()
+        for target in outlinks.get(node, ()):
+            if target not in seen:
+                seen.add(target)
+                frontier.append(target)
+    return seen
 
 
 # ---------------------------------------------------------------------------
@@ -189,10 +254,9 @@ class _HtmlChoiceCollector(HTMLParser):
             self.has_body = True
         if tag == "div":
             attr_dict = dict(attrs)
-            if attr_dict.get("class") == "passage" and attr_dict.get("id"):
-                pid = attr_dict["id"]
-                if pid is not None:
-                    self.passage_ids.add(pid)
+            pid = attr_dict.get("id")
+            if attr_dict.get("class") == "passage" and pid:
+                self.passage_ids.add(pid)
         if tag == "a":
             attr_dict = dict(attrs)
             classes = (attr_dict.get("class") or "").split()
@@ -254,7 +318,9 @@ def validate_pdf(path: Path) -> None:
         ExportValidationError: Sidecar missing, malformed, or carrying
             an out-of-range page number.
     """
-    sidecar = path.with_suffix(".pdf.map.json")
+    # with_name (not with_suffix) — multi-dot suffix warns under Python 3.12
+    # and raises under 3.13. Mirror the construction in pdf_exporter._write_pdf_sidecar.
+    sidecar = path.with_name(path.name + ".map.json")
     if not sidecar.exists():
         msg = (
             f"PDF export {path.name} is missing its sidecar {sidecar.name} "
@@ -273,8 +339,13 @@ def validate_pdf(path: Path) -> None:
         msg = f"PDF sidecar {sidecar.name} `page_map` is missing or empty"
         raise ExportValidationError(msg)
 
+    # Valid range is 1..N where N is the total number of passages
+    # (entries in page_map). A bijective gamebook maps every passage
+    # to a distinct page number in that range; using len(set(values))
+    # would shrink N in the presence of duplicates and produce a
+    # confusing out-of-range message instead of the duplicate one.
     pages = list(page_map.values())
-    n_pages = len(set(pages))
+    n_pages = len(page_map)
     out_of_range = sorted(
         f"{pid} → {pg}"
         for pid, pg in page_map.items()
@@ -288,10 +359,10 @@ def validate_pdf(path: Path) -> None:
             f"{' …' if len(out_of_range) > 5 else ''}."
         )
         raise ExportValidationError(msg)
-    if len(pages) != n_pages:
+    if len(pages) != len(set(pages)):
         msg = (
             f"PDF sidecar {sidecar.name} has duplicate page numbers — "
-            f"{len(pages)} entries, only {n_pages} distinct pages."
+            f"{len(pages)} entries, only {len(set(pages))} distinct pages."
         )
         raise ExportValidationError(msg)
 

--- a/src/questfoundry/export/validation.py
+++ b/src/questfoundry/export/validation.py
@@ -103,7 +103,7 @@ def validate_twee(path: Path) -> None:
             f"Twee export {path.name} has {len(broken)} broken link target(s): "
             f"{', '.join(repr(b) for b in broken[:5])}"
             f"{' …' if len(broken) > 5 else ''}. "
-            f"Each target must match a `:: <name>` header earlier in the file."
+            f"Each target must match a `:: <name>` header in the file."
         )
         raise ExportValidationError(msg)
 

--- a/src/questfoundry/pipeline/stages/ship.py
+++ b/src/questfoundry/pipeline/stages/ship.py
@@ -13,6 +13,10 @@ from typing import TYPE_CHECKING
 from questfoundry.export import build_export_context, get_exporter
 from questfoundry.export.assets import bundle_assets
 from questfoundry.export.assets import embed_assets as embed_assets_data_urls
+from questfoundry.export.validation import (
+    ExportValidationError,
+    validate_export,
+)
 from questfoundry.graph.graph import Graph
 from questfoundry.observability.logging import get_logger
 from questfoundry.pipeline.config import ProjectConfigError, load_project_config
@@ -154,6 +158,30 @@ class ShipStage:
                 bundle_assets(context.illustrations, self._project_path, target_dir)
             except OSError as e:
                 log.warning("asset_bundling_failed", error=str(e))
+
+        # Phase 4: per-format validation (R-4.1 through R-4.4). Halt with ERROR
+        # before delivery if the file is broken — never present a
+        # half-exported bundle as final.
+        try:
+            validate_export(export_format, output_file)
+        except ExportValidationError as e:
+            log.error(
+                "ship_validation_failed",
+                format=export_format,
+                output=str(output_file),
+                error=str(e),
+            )
+            msg = (
+                f"SHIP Phase 4 validation failed for {export_format} export: {e} "
+                f"(R-4.2: validation failure halts SHIP — bundle not delivered)."
+            )
+            raise ShipStageError(msg) from e
+
+        log.info(
+            "ship_validation_passed",
+            format=export_format,
+            output=str(output_file),
+        )
 
         log.info(
             "ship_complete",

--- a/tests/unit/test_export_validation.py
+++ b/tests/unit/test_export_validation.py
@@ -249,7 +249,7 @@ class TestValidateHtml:
 
 class TestValidatePdf:
     def _write_sidecar(self, pdf_path: Path, page_map: dict[str, int]) -> None:
-        sidecar = pdf_path.with_suffix(".pdf.map.json")
+        sidecar = pdf_path.with_name(pdf_path.name + ".map.json")
         sidecar.write_text(
             json.dumps(
                 {
@@ -279,7 +279,7 @@ class TestValidatePdf:
     def test_unparseable_sidecar_raises(self, tmp_path: Path) -> None:
         pdf = tmp_path / "story.pdf"
         pdf.touch()
-        pdf.with_suffix(".pdf.map.json").write_text("{nope")
+        pdf.with_name(pdf.name + ".map.json").write_text("{nope")
         with pytest.raises(ExportValidationError, match="could not be parsed"):
             validate_pdf(pdf)
 

--- a/tests/unit/test_export_validation.py
+++ b/tests/unit/test_export_validation.py
@@ -1,0 +1,293 @@
+"""Tests for SHIP Phase 4 per-format validators (R-4.1 through R-4.4).
+
+Each validator receives a generated file, parses it, and raises
+ExportValidationError on internal-consistency failures (broken links,
+missing metadata, page numbers out of range, etc.). Tests cover both
+the happy path against real exporter output and forged broken files
+to confirm the failure mode is loud, specific, and structurally
+matches what R-4.4 mandates.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+
+import pytest
+
+from questfoundry.export.base import (
+    ExportChoice,
+    ExportContext,
+    ExportPassage,
+)
+from questfoundry.export.html_exporter import HtmlExporter
+from questfoundry.export.json_exporter import JsonExporter
+from questfoundry.export.twee_exporter import TweeExporter
+from questfoundry.export.validation import (
+    VALIDATORS,
+    ExportValidationError,
+    validate_export,
+    validate_html,
+    validate_json,
+    validate_pdf,
+    validate_twee,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _ctx() -> ExportContext:
+    return ExportContext(
+        title="Test",
+        passages=[
+            ExportPassage(id="passage::start", prose="Begin.", is_start=True),
+            ExportPassage(id="passage::end", prose="End.", is_ending=True),
+        ],
+        choices=[
+            ExportChoice(
+                from_passage="passage::start",
+                to_passage="passage::end",
+                label="Continue",
+            )
+        ],
+    )
+
+
+# ---------------------------------------------------------------------------
+# Twee
+# ---------------------------------------------------------------------------
+
+
+class TestValidateTwee:
+    def test_valid_export_passes(self, tmp_path: Path) -> None:
+        out = TweeExporter().export(_ctx(), tmp_path)
+        validate_twee(out)  # no exception
+
+    def test_broken_link_raises_with_target_name(self, tmp_path: Path) -> None:
+        twee = tmp_path / "story.twee"
+        twee.write_text(
+            ":: StoryTitle\nT\n\n:: Start [start]\nHello.\n[[Continue->ghost_passage]]\n",
+            encoding="utf-8",
+        )
+        with pytest.raises(ExportValidationError, match=r"ghost_passage"):
+            validate_twee(twee)
+
+    def test_no_passage_headers_raises(self, tmp_path: Path) -> None:
+        twee = tmp_path / "story.twee"
+        twee.write_text("This file has no headers at all.\n", encoding="utf-8")
+        with pytest.raises(ExportValidationError, match="no passage headers"):
+            validate_twee(twee)
+
+    def test_missing_start_raises(self, tmp_path: Path) -> None:
+        twee = tmp_path / "story.twee"
+        twee.write_text(":: somewhere\nHello.\n", encoding="utf-8")
+        with pytest.raises(ExportValidationError, match="missing a `:: Start`"):
+            validate_twee(twee)
+
+    def test_goto_macro_form_validated(self, tmp_path: Path) -> None:
+        """<<goto "target">> inside a <<link>> is a valid Twee link form."""
+        twee = tmp_path / "story.twee"
+        twee.write_text(
+            ':: Start [start]\nHello.\n<<link "Go">><<goto "missing_target">><</link>>\n',
+            encoding="utf-8",
+        )
+        with pytest.raises(ExportValidationError, match="missing_target"):
+            validate_twee(twee)
+
+    def test_reserved_headers_dont_count_as_broken(self, tmp_path: Path) -> None:
+        """A link to e.g. `StoryTitle` shouldn't be flagged — but no
+        real export does that. We test that referencing a reserved
+        header by name (unusual but possible) doesn't trip the check.
+        """
+        twee = tmp_path / "story.twee"
+        twee.write_text(
+            ":: StoryTitle\nT\n\n:: Start [start]\nHello.\n[[ToTitle->StoryTitle]]\n",
+            encoding="utf-8",
+        )
+        validate_twee(twee)
+
+
+# ---------------------------------------------------------------------------
+# JSON
+# ---------------------------------------------------------------------------
+
+
+class TestValidateJson:
+    def test_valid_export_passes(self, tmp_path: Path) -> None:
+        out = JsonExporter().export(_ctx(), tmp_path)
+        validate_json(out)
+
+    def test_unparseable_raises(self, tmp_path: Path) -> None:
+        bad = tmp_path / "story.json"
+        bad.write_text("{not json,", encoding="utf-8")
+        with pytest.raises(ExportValidationError, match="could not be parsed"):
+            validate_json(bad)
+
+    def test_missing_top_level_key_raises(self, tmp_path: Path) -> None:
+        bad = tmp_path / "story.json"
+        bad.write_text(json.dumps({"title": "x", "passages": [], "choices": []}))
+        with pytest.raises(ExportValidationError, match=r"_metadata"):
+            validate_json(bad)
+
+    def test_missing_metadata_field_raises(self, tmp_path: Path) -> None:
+        bad = tmp_path / "story.json"
+        bad.write_text(
+            json.dumps(
+                {
+                    "_metadata": {"pipeline_version": "x"},  # missing 3 of 4
+                    "title": "x",
+                    "passages": [],
+                    "choices": [],
+                }
+            )
+        )
+        with pytest.raises(ExportValidationError, match=r"_metadata.*missing"):
+            validate_json(bad)
+
+    def test_choice_to_undefined_passage_raises(self, tmp_path: Path) -> None:
+        bad = tmp_path / "story.json"
+        bad.write_text(
+            json.dumps(
+                {
+                    "_metadata": {
+                        "pipeline_version": "0.0.0",
+                        "graph_snapshot_hash": "deadbeef",
+                        "format_version": "1.0.0",
+                        "generation_timestamp": "2026-04-24T00:00:00+00:00",
+                    },
+                    "title": "x",
+                    "passages": [{"id": "passage::start"}],
+                    "choices": [{"from_passage": "passage::start", "to_passage": "passage::ghost"}],
+                }
+            )
+        )
+        with pytest.raises(ExportValidationError, match=r"passage::ghost"):
+            validate_json(bad)
+
+    def test_top_level_not_object_raises(self, tmp_path: Path) -> None:
+        bad = tmp_path / "story.json"
+        bad.write_text("[1, 2, 3]")
+        with pytest.raises(ExportValidationError, match="top-level is not an object"):
+            validate_json(bad)
+
+
+# ---------------------------------------------------------------------------
+# HTML
+# ---------------------------------------------------------------------------
+
+
+class TestValidateHtml:
+    def test_valid_export_passes(self, tmp_path: Path) -> None:
+        out = HtmlExporter().export(_ctx(), tmp_path)
+        validate_html(out)
+
+    def test_no_body_raises(self, tmp_path: Path) -> None:
+        bad = tmp_path / "story.html"
+        bad.write_text("<html><head></head></html>", encoding="utf-8")
+        with pytest.raises(ExportValidationError, match="no <body>"):
+            validate_html(bad)
+
+    def test_no_passage_divs_raises(self, tmp_path: Path) -> None:
+        bad = tmp_path / "story.html"
+        bad.write_text("<html><body><p>nothing here</p></body></html>", encoding="utf-8")
+        with pytest.raises(ExportValidationError, match="no passage divs"):
+            validate_html(bad)
+
+    def test_broken_choice_target_raises(self, tmp_path: Path) -> None:
+        bad = tmp_path / "story.html"
+        bad.write_text(
+            "<html><body>"
+            '<div class="passage" id="p1">hello</div>'
+            '<a class="choice" href="#" data-target="ghost">go</a>'
+            "</body></html>",
+            encoding="utf-8",
+        )
+        with pytest.raises(ExportValidationError, match="ghost"):
+            validate_html(bad)
+
+
+# ---------------------------------------------------------------------------
+# PDF (sidecar-only — no WeasyPrint required)
+# ---------------------------------------------------------------------------
+
+
+class TestValidatePdf:
+    def _write_sidecar(self, pdf_path: Path, page_map: dict[str, int]) -> None:
+        sidecar = pdf_path.with_suffix(".pdf.map.json")
+        sidecar.write_text(
+            json.dumps(
+                {
+                    "_metadata": {
+                        "pipeline_version": "0.0.0",
+                        "graph_snapshot_hash": "deadbeef",
+                        "format_version": "1.0.0",
+                        "generation_timestamp": "2026-04-24T00:00:00+00:00",
+                    },
+                    "page_map": page_map,
+                }
+            )
+        )
+
+    def test_valid_sidecar_passes(self, tmp_path: Path) -> None:
+        pdf = tmp_path / "story.pdf"
+        pdf.touch()
+        self._write_sidecar(pdf, {"passage::a": 1, "passage::b": 2})
+        validate_pdf(pdf)
+
+    def test_missing_sidecar_raises(self, tmp_path: Path) -> None:
+        pdf = tmp_path / "story.pdf"
+        pdf.touch()
+        with pytest.raises(ExportValidationError, match="missing its sidecar"):
+            validate_pdf(pdf)
+
+    def test_unparseable_sidecar_raises(self, tmp_path: Path) -> None:
+        pdf = tmp_path / "story.pdf"
+        pdf.touch()
+        pdf.with_suffix(".pdf.map.json").write_text("{nope")
+        with pytest.raises(ExportValidationError, match="could not be parsed"):
+            validate_pdf(pdf)
+
+    def test_empty_page_map_raises(self, tmp_path: Path) -> None:
+        pdf = tmp_path / "story.pdf"
+        pdf.touch()
+        self._write_sidecar(pdf, {})
+        with pytest.raises(ExportValidationError, match=r"page_map.*missing or empty"):
+            validate_pdf(pdf)
+
+    def test_out_of_range_page_raises(self, tmp_path: Path) -> None:
+        pdf = tmp_path / "story.pdf"
+        pdf.touch()
+        # 2 distinct pages but one entry points to page 99
+        self._write_sidecar(pdf, {"passage::a": 1, "passage::b": 99})
+        with pytest.raises(ExportValidationError, match=r"outside the valid range"):
+            validate_pdf(pdf)
+
+    def test_duplicate_page_numbers_raises(self, tmp_path: Path) -> None:
+        pdf = tmp_path / "story.pdf"
+        pdf.touch()
+        self._write_sidecar(pdf, {"passage::a": 1, "passage::b": 1})
+        with pytest.raises(ExportValidationError, match="duplicate page numbers"):
+            validate_pdf(pdf)
+
+
+# ---------------------------------------------------------------------------
+# Dispatch
+# ---------------------------------------------------------------------------
+
+
+class TestValidateExportDispatch:
+    def test_dispatches_to_correct_validator(self, tmp_path: Path) -> None:
+        out = JsonExporter().export(_ctx(), tmp_path)
+        validate_export("json", out)
+
+    def test_unknown_format_raises_keyerror(self, tmp_path: Path) -> None:
+        with pytest.raises(KeyError):
+            validate_export("xml", tmp_path / "story.xml")
+
+    def test_all_known_formats_have_validators(self) -> None:
+        """Every format the project exports must have a validator (R-4.1)."""
+        from questfoundry.export import _EXPORTERS
+
+        for name in _EXPORTERS:
+            assert name in VALIDATORS, f"format {name!r} is exportable but has no validator"

--- a/tests/unit/test_export_validation.py
+++ b/tests/unit/test_export_validation.py
@@ -95,6 +95,41 @@ class TestValidateTwee:
         with pytest.raises(ExportValidationError, match="missing_target"):
             validate_twee(twee)
 
+    def test_goto_macro_to_valid_target_passes(self, tmp_path: Path) -> None:
+        """Symmetric to test_goto_macro_form_validated: a <<goto>> targeting
+        a real passage must NOT trip the validator."""
+        twee = tmp_path / "story.twee"
+        twee.write_text(
+            ':: Start [start]\nHello.\n<<link "Go">><<goto "end">><</link>>\n\n:: end\nDone.\n',
+            encoding="utf-8",
+        )
+        validate_twee(twee)
+
+    def test_orphan_passage_unreachable_from_start_raises(self, tmp_path: Path) -> None:
+        """Spec: every passage must be reachable from Start via choice
+        links. A defined-but-unlinked passage is invalid even though
+        every link target exists.
+        """
+        twee = tmp_path / "story.twee"
+        twee.write_text(
+            ":: Start [start]\nHello.\n[[Continue->reachable]]\n\n"
+            ":: reachable\nFound.\n\n"
+            ":: orphan\nNobody links here.\n",
+            encoding="utf-8",
+        )
+        with pytest.raises(ExportValidationError, match="orphan"):
+            validate_twee(twee)
+
+    def test_codex_unlinked_passage_does_not_trip_reachability(self, tmp_path: Path) -> None:
+        """Codex is a metadata sidecar; SugarCube doesn't navigate to it
+        via choice links so it's exempt from the reachable-set check."""
+        twee = tmp_path / "story.twee"
+        twee.write_text(
+            ":: Start [start]\nHello.\n\n:: Codex\nReference info.\n",
+            encoding="utf-8",
+        )
+        validate_twee(twee)
+
     def test_reserved_headers_dont_count_as_broken(self, tmp_path: Path) -> None:
         """A link to e.g. `StoryTitle` shouldn't be flagged — but no
         real export does that. We test that referencing a reserved

--- a/tests/unit/test_ship_stage.py
+++ b/tests/unit/test_ship_stage.py
@@ -328,3 +328,48 @@ class TestShipStage:
 
         data = json.loads(result.read_text())
         assert data["title"] == "test-story"
+
+
+class TestShipPhase4Validation:
+    """R-4.1 through R-4.4: SHIP halts with ERROR before delivering a
+    bundle that fails per-format validation. The validator failure
+    message must be embedded in the raised ShipStageError so the user
+    can see exactly what's broken without spelunking through logs.
+    """
+
+    def test_validation_failure_halts_ship(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A validator that raises must surface as ShipStageError, not a
+        silently-delivered broken file (R-4.2).
+        """
+        from questfoundry.export.validation import ExportValidationError
+
+        project = tmp_path / "my-story"
+        _create_project_with_graph(project)
+
+        def _always_fail(_path: Path) -> None:
+            msg = "synthetic broken target: passage::ghost"
+            raise ExportValidationError(msg)
+
+        # Patch the dispatcher's table for the json validator
+        from questfoundry.export import validation as validation_module
+
+        monkeypatch.setitem(validation_module.VALIDATORS, "json", _always_fail)
+
+        stage = ShipStage(project)
+        with pytest.raises(ShipStageError, match="passage::ghost"):
+            stage.execute(export_format="json")
+
+    def test_valid_export_passes_phase_4(self, tmp_path: Path) -> None:
+        """End-to-end: a clean run from the test fixture must satisfy
+        Phase 4 validation without monkey-patching anything.
+        """
+        project = tmp_path / "my-story"
+        _create_project_with_graph(project)
+
+        stage = ShipStage(project)
+        # No exception = Phase 4 passed
+        stage.execute(export_format="twee")
+        stage.execute(export_format="json")
+        stage.execute(export_format="html")


### PR DESCRIPTION
## Summary

PR D of 5 for the SHIP spec-compliance milestone (epic #1331). The biggest cluster: implements Phase 4 (R-4.1 through R-4.4). Every exported file is validated post-export and any failure halts SHIP with ERROR before delivery — no more silently shipped broken bundles.

## What changed

### New module \`src/questfoundry/export/validation.py\`

| Validator | Checks |
|---|---|
| \`validate_twee\` | Every \`[[label->target]]\` and \`<<goto \"target\">>\` resolves to a \`:: <name>\` passage header; \`Start\` exists; SugarCube reserved headers excluded. |
| \`validate_json\` | Top-level keys present (\`_metadata\` / \`title\` / \`passages\` / \`choices\`); all four R-3.6 metadata fields present; every \`to_passage\` resolves. |
| \`validate_html\` | stdlib \`html.parser\` walk confirms \`<body>\` exists, at least one \`<div class=\"passage\">\`, every \`<a class=\"choice\" data-target=\"...\">\` resolves. (R-4.3 says technical, not visual — no headless browser dep.) |
| \`validate_pdf\` | Reads the \`story.pdf.map.json\` sidecar from PR B; \`page_map\` non-empty, every value in \`1..N\`, no duplicates. |

### \`ShipStage\` integration

Phase 4 runs after export + asset bundling. \`ExportValidationError\` → ERROR log + \`ShipStageError\` carrying both the spec-cited halt reason and the specific broken-reference message (R-4.4).

## Why no headless-browser HTML check

The spec wording mentions \"headless browser; verify starting passage renders\" but R-4.3 caps validation at \"loadable, internally consistent.\" A stdlib \`html.parser\` walk gives us:
- File is parseable (R-4.3 \"loadable\")
- \`<body>\` exists, passage divs exist (structural sanity)
- Every choice \`data-target\` resolves to a passage div id (R-4.4 broken-reference detection)

A headless browser would catch JS-runtime errors but adds a heavy dependency (Playwright/Selenium) and CI flakiness. If we ever need that, it slots in as a separate optional check.

## Test plan

- [x] \`uv run pytest tests/unit/test_export_validation.py tests/unit/test_ship_stage.py tests/unit/test_html_exporter.py tests/unit/test_twee_exporter.py tests/unit/test_json_exporter.py tests/unit/test_pdf_exporter.py tests/unit/test_export_context.py tests/unit/test_export_metadata.py -q\` — 185/185 pass
- [x] \`uv run ruff check src/ tests/\` — clean
- [x] \`uv run mypy src/\` — clean
- [x] \`TestValidateExportDispatch::test_all_known_formats_have_validators\` pins that every \`_EXPORTERS\` entry has a matching validator — adding a new format physically cannot skip Phase 4
- [ ] CI green
- [ ] \`/pr-review-toolkit:review-pr\` clean before marking ready

## Remaining SHIP work

- PR E: cross-cutting test coverage (R-2.4 / R-3.1 / R-3.2) — closes #1338 (final cluster)

🤖 Generated with [Claude Code](https://claude.com/claude-code)