### PR TITLE
feat(ship): cross-cutting test coverage + IFID determinism fix (closes #1338)

### DIFF
--- a/src/questfoundry/export/twee_exporter.py
+++ b/src/questfoundry/export/twee_exporter.py
@@ -33,6 +33,15 @@ log = get_logger(__name__)
 # document shape changes (new passage type, removed field, etc.).
 TWEE_FORMAT_VERSION = "1.0.0"
 
+# Fixed UUID5 namespace for deriving Twee IFIDs deterministically from the
+# story title. R-2.4 mandates byte-identical exports for the same graph
+# state, so the IFID — which the IF Technology Foundation defines as a
+# stable identifier for the WORK, not the FILE — must not change between
+# runs. uuid.uuid4() (random) was the original choice and produced a
+# different identifier on every export. Generated once with uuid.uuid4()
+# and pasted here so the namespace itself is stable across machines.
+_QF_TWEE_IFID_NAMESPACE = uuid.UUID("4f0c8c5f-2e1c-4f44-8d1c-7a9c2f3d4e5f")
+
 
 class TweeExporter:
     """Export story as Twee 3 / SugarCube 2 format."""
@@ -137,7 +146,11 @@ def _story_header(
     language: str = "en",
 ) -> list[str]:
     """Generate Twee 3 story header passages."""
-    ifid = str(uuid.uuid4()).upper()
+    # Derive the IFID deterministically from the story title via
+    # uuid.uuid5(). Same title → same IFID across runs; required by
+    # R-2.4 byte-identical determinism and aligned with the IFTF
+    # convention that an IFID identifies the work, not the file.
+    ifid = str(uuid.uuid5(_QF_TWEE_IFID_NAMESPACE, title)).upper()
     header = [
         f":: StoryTitle\n{title}",
         "",

--- a/src/questfoundry/pipeline/stages/ship.py
+++ b/src/questfoundry/pipeline/stages/ship.py
@@ -50,6 +50,7 @@ class ShipStage:
         output_dir: Path | None = None,
         *,
         embed_assets: bool = False,
+        timestamp: str | None = None,
     ) -> Path:
         """Export the story graph to a playable format.
 
@@ -59,6 +60,11 @@ class ShipStage:
                 ``{project}/exports/{format}/``.
             embed_assets: Embed illustration assets as base64 data URLs
                 in HTML output. Ignored for non-HTML formats.
+            timestamp: Optional ISO 8601 string for the R-3.6 metadata
+                ``generation_timestamp``. Production runs leave this
+                ``None`` so the exporter stamps ``datetime.now(UTC)``
+                itself; tests pin a fixed value to assert R-2.4
+                byte-identical determinism without timestamp drift.
 
         Returns:
             Path to the main output file.
@@ -150,7 +156,7 @@ class ShipStage:
 
         # Export
         target_dir = output_dir or (self._project_path / "exports" / export_format)
-        output_file = exporter.export(context, target_dir)
+        output_file = exporter.export(context, target_dir, timestamp=timestamp)
 
         # Bundle illustration assets (non-fatal — export is valid without them)
         if context.illustrations and not (embed_assets and export_format == "html"):

--- a/tests/unit/test_export_metadata.py
+++ b/tests/unit/test_export_metadata.py
@@ -65,9 +65,10 @@ class TestGraphSnapshotHash:
         assert h1 != h2
 
     def test_changed_title_changes_hash(self) -> None:
+        from dataclasses import replace
+
         ctx_a = _ctx()
-        ctx_b = _ctx()
-        ctx_b.title = "different"
+        ctx_b = replace(ctx_a, title="different")
         assert compute_graph_snapshot_hash(ctx_a) != compute_graph_snapshot_hash(ctx_b)
 
 

--- a/tests/unit/test_export_metadata.py
+++ b/tests/unit/test_export_metadata.py
@@ -139,28 +139,12 @@ class TestTweeExporterMetadata:
         assert "pipeline_version:" in text
 
     def test_byte_identical_with_fixed_timestamp(self, tmp_path: Path) -> None:
-        # Twee header includes a random IFID, so we cannot expect full byte
-        # equality. But the metadata block itself MUST be deterministic.
+        # The IFID is now derived deterministically from the title
+        # (uuid.uuid5), so Twee meets the same byte-identical bar as
+        # JSON and HTML when the timestamp is pinned (R-2.4).
         out1 = TweeExporter().export(_ctx(), tmp_path / "a", timestamp=_FIXED_TS)
         out2 = TweeExporter().export(_ctx(), tmp_path / "b", timestamp=_FIXED_TS)
-
-        def _metadata_block(text: str) -> str:
-            """Extract the StoryMetadata block.
-
-            Read until the next Twee passage header (``::``) or a blank
-            line, instead of slicing a fixed line count — adding a fifth
-            metadata field would otherwise silently truncate the assertion.
-            """
-            lines = text.splitlines()
-            start = next(i for i, line in enumerate(lines) if ":: StoryMetadata" in line)
-            block = [lines[start]]
-            for line in lines[start + 1 :]:
-                if not line.strip() or line.startswith("::"):
-                    break
-                block.append(line)
-            return "\n".join(block)
-
-        assert _metadata_block(out1.read_text()) == _metadata_block(out2.read_text())
+        assert out1.read_bytes() == out2.read_bytes()
 
 
 class TestHtmlExporterMetadata:

--- a/tests/unit/test_ship_format_consistency.py
+++ b/tests/unit/test_ship_format_consistency.py
@@ -1,0 +1,228 @@
+"""R-3.1: same classified data drives every format.
+
+All four exporters consume a single ``ExportContext``. This test
+suite asserts that the player-facing counts (passages, choices,
+codewords, codex entries, illustrations) and structural facts
+(start passage id, ending passage ids, entity ids referenced from
+choice grants) are identical across formats — i.e. the formats
+cannot diverge in content beyond format-specific presentation.
+
+Cluster #1338 specifically called out the absence of this test:
+the implementation is correct (single source of truth in
+ExportContext) but tests were missing, so a future change that
+filtered passages in one exporter and not another would slip
+through unnoticed.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from typing import TYPE_CHECKING
+
+from questfoundry.export.base import (
+    ExportChoice,
+    ExportCodeword,
+    ExportCodexEntry,
+    ExportContext,
+    ExportEntity,
+    ExportPassage,
+)
+from questfoundry.export.html_exporter import HtmlExporter
+from questfoundry.export.json_exporter import JsonExporter
+from questfoundry.export.twee_exporter import TweeExporter
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+_FIXED_TS = "2026-04-24T00:00:00+00:00"
+
+
+def _multi_format_context() -> ExportContext:
+    """A non-trivial context with passages, choices, codewords, codex.
+
+    Ensures every exporter has something to render in every section
+    so the count comparisons are meaningful.
+    """
+    return ExportContext(
+        title="Cross-Format Test",
+        passages=[
+            ExportPassage(id="passage::start", prose="The gate opens.", is_start=True),
+            ExportPassage(id="passage::trial", prose="A choice appears."),
+            ExportPassage(id="passage::triumph", prose="Victory.", is_ending=True),
+            ExportPassage(id="passage::defeat", prose="Failure.", is_ending=True),
+        ],
+        choices=[
+            ExportChoice(
+                from_passage="passage::start",
+                to_passage="passage::trial",
+                label="Step inside",
+            ),
+            ExportChoice(
+                from_passage="passage::trial",
+                to_passage="passage::triumph",
+                label="Trust the mentor",
+                grants=["codeword::mentor_trusted"],
+            ),
+            ExportChoice(
+                from_passage="passage::trial",
+                to_passage="passage::defeat",
+                label="Refuse the mentor",
+                requires_codewords=["codeword::wary"],
+            ),
+        ],
+        entities=[
+            ExportEntity(
+                id="entity::mentor",
+                entity_type="character",
+                concept="A weathered guide.",
+            ),
+        ],
+        codewords=[
+            ExportCodeword(id="codeword::mentor_trusted", codeword_type="granted"),
+            ExportCodeword(id="codeword::wary", codeword_type="granted"),
+        ],
+        codex_entries=[
+            ExportCodexEntry(
+                entity_id="entity::mentor",
+                title="Mentor",
+                rank=1,
+                content="A figure encountered in the story.",
+            ),
+            ExportCodexEntry(
+                entity_id="entity::mentor",
+                title="Mentor's Secret",
+                rank=2,
+                visible_when=["codeword::mentor_trusted"],
+                content="They knew you all along.",
+            ),
+        ],
+    )
+
+
+def _twee_passage_count(text: str) -> int:
+    """Count `:: <name>` headers excluding SugarCube reserved infrastructure
+    and the Codex sidecar passage."""
+    reserved = {
+        "StoryTitle",
+        "StoryData",
+        "StoryInit",
+        "StoryArtDirection",
+        "StoryMetadata",
+        "Codex",
+    }
+    return sum(
+        1
+        for line in text.splitlines()
+        if (m := re.match(r"^::\s*(\S+)", line)) and m.group(1) not in reserved
+    )
+
+
+def _twee_choice_labels(text: str) -> set[str]:
+    """Collect every choice label from both Twee link forms."""
+    labels: set[str] = set()
+    # Plain [[label->target]]
+    for match in re.finditer(r"\[\[([^\]]+?)->[^\]]+\]\]", text):
+        labels.add(match.group(1).strip())
+    # <<link "label">>...
+    for match in re.finditer(r'<<link\s+"([^"]+)"\s*>>', text):
+        labels.add(match.group(1).strip())
+    return labels
+
+
+def _html_choice_labels(text: str) -> set[str]:
+    """Collect labels from <a class="choice" ...>label</a>."""
+    return {
+        m.group(1).strip()
+        for m in re.finditer(
+            r'<a class="choice"[^>]*>([^<]+)</a>',
+            text,
+        )
+    }
+
+
+class TestCrossFormatConsistency:
+    """Same context → same player-facing counts across formats (R-3.1)."""
+
+    def test_passage_counts_match(self, tmp_path: Path) -> None:
+        ctx = _multi_format_context()
+        json_path = JsonExporter().export(ctx, tmp_path / "j", timestamp=_FIXED_TS)
+        twee_path = TweeExporter().export(ctx, tmp_path / "t", timestamp=_FIXED_TS)
+        html_path = HtmlExporter().export(ctx, tmp_path / "h", timestamp=_FIXED_TS)
+
+        json_data = json.loads(json_path.read_text())
+        twee_text = twee_path.read_text()
+        html_text = html_path.read_text()
+
+        json_passages = len(json_data["passages"])
+        twee_passages = _twee_passage_count(twee_text)
+        html_passages = len(re.findall(r'<div class="passage" id="', html_text))
+
+        assert json_passages == twee_passages == html_passages == len(ctx.passages), (
+            f"passage count diverged: json={json_passages}, twee={twee_passages}, "
+            f"html={html_passages}, expected={len(ctx.passages)}"
+        )
+
+    def test_choice_labels_match(self, tmp_path: Path) -> None:
+        """Every choice label in the source ExportContext appears in
+        every format's output. R-3.2 (Twee verbatim) is exercised by
+        the Twee assertion; this test covers cross-format consistency.
+        """
+        ctx = _multi_format_context()
+        twee_path = TweeExporter().export(ctx, tmp_path / "t", timestamp=_FIXED_TS)
+        html_path = HtmlExporter().export(ctx, tmp_path / "h", timestamp=_FIXED_TS)
+        json_path = JsonExporter().export(ctx, tmp_path / "j", timestamp=_FIXED_TS)
+
+        expected_labels = {c.label for c in ctx.choices}
+
+        twee_labels = _twee_choice_labels(twee_path.read_text())
+        html_labels = _html_choice_labels(html_path.read_text())
+        json_labels = {c["label"] for c in json.loads(json_path.read_text())["choices"]}
+
+        assert json_labels == expected_labels
+        assert twee_labels == expected_labels
+        assert html_labels == expected_labels
+
+    def test_codex_entry_counts_match(self, tmp_path: Path) -> None:
+        ctx = _multi_format_context()
+        twee_path = TweeExporter().export(ctx, tmp_path / "t", timestamp=_FIXED_TS)
+        html_path = HtmlExporter().export(ctx, tmp_path / "h", timestamp=_FIXED_TS)
+        json_path = JsonExporter().export(ctx, tmp_path / "j", timestamp=_FIXED_TS)
+
+        json_codex = len(json.loads(json_path.read_text())["codex_entries"])
+        # Twee codex entries appear as `!! <title>` lines under the Codex passage.
+        twee_codex = sum(1 for line in twee_path.read_text().splitlines() if line.startswith("!! "))
+        # HTML codex entries are <div class="codex-entry">.
+        html_codex = len(re.findall(r'<div class="codex-entry"', html_path.read_text()))
+
+        assert json_codex == twee_codex == html_codex == len(ctx.codex_entries), (
+            f"codex entry count diverged: json={json_codex}, twee={twee_codex}, "
+            f"html={html_codex}, expected={len(ctx.codex_entries)}"
+        )
+
+    def test_metadata_snapshot_hash_consistent_across_formats(self, tmp_path: Path) -> None:
+        """Same ctx → same graph_snapshot_hash in every format's metadata
+        block. Already covered by test_export_metadata.py at the
+        metadata-module level; pinning here at the cross-format level
+        guards against an exporter accidentally reordering payload
+        before hash computation.
+        """
+        ctx = _multi_format_context()
+        json_meta = json.loads(
+            JsonExporter().export(ctx, tmp_path / "j", timestamp=_FIXED_TS).read_text()
+        )["_metadata"]
+        twee_text = TweeExporter().export(ctx, tmp_path / "t", timestamp=_FIXED_TS).read_text()
+        html_text = HtmlExporter().export(ctx, tmp_path / "h", timestamp=_FIXED_TS).read_text()
+
+        twee_hash = next(
+            line.split(": ", 1)[1].strip()
+            for line in twee_text.splitlines()
+            if line.startswith("graph_snapshot_hash:")
+        )
+        html_hash_match = re.search(
+            r'<meta name="qf-graph-snapshot-hash" content="([0-9a-f]{64})">', html_text
+        )
+        assert html_hash_match is not None
+        html_hash = html_hash_match.group(1)
+
+        assert json_meta["graph_snapshot_hash"] == twee_hash == html_hash

--- a/tests/unit/test_ship_format_consistency.py
+++ b/tests/unit/test_ship_format_consistency.py
@@ -29,6 +29,7 @@ from questfoundry.export.base import (
     ExportPassage,
 )
 from questfoundry.export.html_exporter import HtmlExporter
+from questfoundry.export.i18n import get_ui_strings
 from questfoundry.export.json_exporter import JsonExporter
 from questfoundry.export.twee_exporter import TweeExporter
 
@@ -100,22 +101,37 @@ def _multi_format_context() -> ExportContext:
     )
 
 
-def _twee_passage_count(text: str) -> int:
+_SUGARCUBE_RESERVED = {
+    "StoryTitle",
+    "StoryData",
+    "StoryInit",
+    "StoryArtDirection",
+    "StoryMetadata",
+}
+
+
+def _twee_passage_count(text: str, language: str = "en") -> int:
     """Count `:: <name>` headers excluding SugarCube reserved infrastructure
-    and the Codex sidecar passage."""
-    reserved = {
-        "StoryTitle",
-        "StoryData",
-        "StoryInit",
-        "StoryArtDirection",
-        "StoryMetadata",
-        "Codex",
-    }
-    return sum(
-        1
-        for line in text.splitlines()
-        if (m := re.match(r"^::\s*(\S+)", line)) and m.group(1) not in reserved
-    )
+    and the localised Codex sidecar passage.
+
+    A naive ``\\S+`` would miscount a passage like ``:: my adventure`` as
+    ``my``. The Twee header grammar puts the optional ``[tag]`` block
+    AND the optional ``{position/size}`` block (used by StoryMetadata
+    et al.) after a whitespace separator, so capture everything up to
+    the first ``[`` or ``{`` preceded by whitespace. The codex name
+    is i18n'd (``Codex`` / ``Kodex`` / …) so resolve it via
+    ``get_ui_strings()`` rather than hardcoding English.
+    """
+    reserved = _SUGARCUBE_RESERVED | {get_ui_strings(language)["codex"]}
+    count = 0
+    for line in text.splitlines():
+        match = re.match(r"^::\s*(.+?)(?:\s+[\[\{].*)?$", line)
+        if not match:
+            continue
+        name = match.group(1).strip()
+        if name and name not in reserved:
+            count += 1
+    return count
 
 
 def _twee_choice_labels(text: str) -> set[str]:
@@ -139,6 +155,30 @@ def _html_choice_labels(text: str) -> set[str]:
             text,
         )
     }
+
+
+def test_twee_passage_count_handles_spaces_in_names() -> None:
+    """Pin the latent fix: the helper must capture full passage names
+    even when they contain spaces (the previous \\S+ pattern stopped
+    at the first whitespace and would have undercounted)."""
+    text = (
+        ":: StoryTitle\nT\n\n"
+        ":: my adventure\nProse.\n\n"
+        ":: another story\nMore.\n\n"
+        ':: StoryArtDirection {"position":"0,0"}\nfoo: bar\n'
+    )
+    # Two real passages, StoryTitle + StoryArtDirection are SugarCube reserved
+    assert _twee_passage_count(text) == 2
+
+
+def test_twee_passage_count_excludes_localised_codex() -> None:
+    """German uses 'Kodex' for the codex sidecar — the helper must
+    treat that as reserved when language='de'."""
+    text = ":: StoryTitle\nT\n\n:: Start [start]\nBeginn.\n\n:: Kodex\nReferenz.\n"
+    # 1 navigable passage; Kodex is the i18n codex sidecar
+    assert _twee_passage_count(text, language="de") == 1
+    # Same text under English would count Kodex as a regular passage
+    assert _twee_passage_count(text, language="en") == 2
 
 
 class TestCrossFormatConsistency:

--- a/tests/unit/test_ship_stage.py
+++ b/tests/unit/test_ship_stage.py
@@ -373,3 +373,52 @@ class TestShipPhase4Validation:
         stage.execute(export_format="twee")
         stage.execute(export_format="json")
         stage.execute(export_format="html")
+
+
+class TestShipDeterminism:
+    """R-2.4: SHIP must not mutate the graph; running it twice on the
+    same graph must produce byte-identical output (modulo the metadata
+    generation_timestamp, which the test seam pins).
+    """
+
+    _FIXED_TS = "2026-04-24T00:00:00+00:00"
+
+    @pytest.mark.parametrize("export_format", ["twee", "json", "html"])
+    def test_two_runs_produce_byte_identical_output(
+        self, tmp_path: Path, export_format: str
+    ) -> None:
+        """Same project + same fixed timestamp → identical bytes.
+
+        Confirms SHIP itself is deterministic (no in-memory iteration
+        order leaking into output, no hidden randomness, no graph
+        mutation between runs).
+        """
+        project = tmp_path / "story"
+        _create_project_with_graph(project)
+
+        stage = ShipStage(project)
+        out1 = stage.execute(
+            export_format=export_format,
+            output_dir=tmp_path / f"{export_format}-1",
+            timestamp=self._FIXED_TS,
+        )
+        out2 = stage.execute(
+            export_format=export_format,
+            output_dir=tmp_path / f"{export_format}-2",
+            timestamp=self._FIXED_TS,
+        )
+        assert out1.read_bytes() == out2.read_bytes()
+
+    def test_graph_unchanged_after_ship(self, tmp_path: Path) -> None:
+        """SHIP is read-only: the graph file must be byte-identical
+        before and after a run.
+        """
+        project = tmp_path / "story"
+        _create_project_with_graph(project)
+        graph_path = project / "graph.db"
+        before = graph_path.read_bytes()
+
+        ShipStage(project).execute(export_format="json", timestamp=self._FIXED_TS)
+
+        after = graph_path.read_bytes()
+        assert before == after, "SHIP mutated graph.db (R-2.4 violation)"

--- a/tests/unit/test_twee_exporter.py
+++ b/tests/unit/test_twee_exporter.py
@@ -84,18 +84,26 @@ class TestTweeExporter:
 
     def test_ifid_differs_for_different_titles(self, tmp_path: Path) -> None:
         """A different story title should produce a different IFID — the
-        IFID identifies the work."""
+        IFID identifies the work.
+
+        Construct ``ctx_b`` directly rather than mutating a copy of
+        ``_simple_context()``: ``ExportContext`` is a plain dataclass
+        today but mutation here would silently break if it ever became
+        ``frozen=True``, and the construction style mirrors the rest
+        of the suite.
+        """
+        import re
+        from dataclasses import replace
+
         ctx_a = _simple_context()
-        ctx_b = _simple_context()
-        ctx_b.title = "Different Story"
+        ctx_b = replace(ctx_a, title="Different Story")
         out_a = TweeExporter().export(ctx_a, tmp_path / "a").read_text()
         out_b = TweeExporter().export(ctx_b, tmp_path / "b").read_text()
 
-        import re
-
-        ifid_a = re.search(r'"ifid":\s*"([0-9A-F-]{36})"', out_a).group(1)  # type: ignore[union-attr]
-        ifid_b = re.search(r'"ifid":\s*"([0-9A-F-]{36})"', out_b).group(1)  # type: ignore[union-attr]
-        assert ifid_a != ifid_b
+        ifid_a = re.search(r'"ifid":\s*"([0-9A-F-]{36})"', out_a)
+        ifid_b = re.search(r'"ifid":\s*"([0-9A-F-]{36})"', out_b)
+        assert ifid_a is not None and ifid_b is not None
+        assert ifid_a.group(1) != ifid_b.group(1)
 
     def test_start_passage(self, tmp_path: Path) -> None:
         exporter = TweeExporter()

--- a/tests/unit/test_twee_exporter.py
+++ b/tests/unit/test_twee_exporter.py
@@ -64,6 +64,39 @@ class TestTweeExporter:
         assert ":: StoryData" in content
         assert '"format": "SugarCube"' in content
 
+    def test_ifid_is_deterministic_per_title(self, tmp_path: Path) -> None:
+        """R-2.4: same story title → same IFID across runs.
+
+        Catches regression to ``uuid.uuid4()`` (which generated a fresh
+        IFID on every export and broke byte-identical determinism).
+        """
+        out1 = TweeExporter().export(_simple_context(), tmp_path / "a")
+        out2 = TweeExporter().export(_simple_context(), tmp_path / "b")
+        # Pull the IFID line from each output
+        import re
+
+        def _ifid(text: str) -> str:
+            m = re.search(r'"ifid":\s*"([0-9A-F-]{36})"', text)
+            assert m is not None, "IFID not found in StoryData"
+            return m.group(1)
+
+        assert _ifid(out1.read_text()) == _ifid(out2.read_text())
+
+    def test_ifid_differs_for_different_titles(self, tmp_path: Path) -> None:
+        """A different story title should produce a different IFID — the
+        IFID identifies the work."""
+        ctx_a = _simple_context()
+        ctx_b = _simple_context()
+        ctx_b.title = "Different Story"
+        out_a = TweeExporter().export(ctx_a, tmp_path / "a").read_text()
+        out_b = TweeExporter().export(ctx_b, tmp_path / "b").read_text()
+
+        import re
+
+        ifid_a = re.search(r'"ifid":\s*"([0-9A-F-]{36})"', out_a).group(1)  # type: ignore[union-attr]
+        ifid_b = re.search(r'"ifid":\s*"([0-9A-F-]{36})"', out_b).group(1)  # type: ignore[union-attr]
+        assert ifid_a != ifid_b
+
     def test_start_passage(self, tmp_path: Path) -> None:
         exporter = TweeExporter()
         result = exporter.export(_simple_context(), tmp_path / "out")
@@ -362,3 +395,70 @@ class TestTweeExporter:
 
         # German uses "Kodex"
         assert ":: Kodex" in content
+
+
+class TestTweeChoiceLabelVerbatim:
+    """R-3.2: Twee export preserves choice labels verbatim from POLISH.
+
+    The exporter does no escaping or rewriting of label text — both
+    the simple ``[[label->target]]`` form and the macro
+    ``<<link "label">>`` form must contain the label byte-for-byte
+    as it appeared in the ExportContext, including special characters
+    like em dashes, smart quotes, and apostrophes.
+    """
+
+    @staticmethod
+    def _ctx_with_label(label: str, *, with_grant: bool = False) -> ExportContext:
+        """Single-choice context where the choice carries ``label``.
+
+        ``with_grant=True`` forces the macro form (<<link>>) so we can
+        exercise the verbatim guarantee on both link-rendering paths.
+        """
+        return ExportContext(
+            title="Verbatim Test",
+            passages=[
+                ExportPassage(id="passage::start", prose="Start.", is_start=True),
+                ExportPassage(id="passage::end", prose="End.", is_ending=True),
+            ],
+            choices=[
+                ExportChoice(
+                    from_passage="passage::start",
+                    to_passage="passage::end",
+                    label=label,
+                    grants=["codeword::flag"] if with_grant else [],
+                ),
+            ],
+        )
+
+    def test_em_dash_preserved_in_simple_link_form(self, tmp_path: Path) -> None:
+        label = "Trust the mentor\u2014say nothing"
+        ctx = self._ctx_with_label(label)
+        out = TweeExporter().export(ctx, tmp_path / "out")
+        content = out.read_text()
+        # Simple form: [[label->target]]
+        assert f"[[{label}->end]]" in content
+
+    def test_em_dash_preserved_in_macro_link_form(self, tmp_path: Path) -> None:
+        label = "Trust the mentor\u2014say nothing"
+        ctx = self._ctx_with_label(label, with_grant=True)
+        out = TweeExporter().export(ctx, tmp_path / "out")
+        content = out.read_text()
+        # Macro form: <<link "label">>
+        assert f'<<link "{label}">>' in content
+
+    def test_smart_quotes_and_apostrophe_preserved(self, tmp_path: Path) -> None:
+        label = "It\u2019s the mentor\u2019s call \u201cnow\u201d"
+        ctx = self._ctx_with_label(label)
+        out = TweeExporter().export(ctx, tmp_path / "out")
+        assert label in out.read_text()
+
+    def test_label_bytes_preserved_exactly(self, tmp_path: Path) -> None:
+        """Catch-all: the entire label string must round-trip verbatim.
+        Pins R-3.2 against any future "helpful" cleanup (e.g. dash
+        normalisation, smart-quote folding).
+        """
+        label = "A \u2014 B \u2018C\u2019 D \u201cE\u201d F"
+        ctx = self._ctx_with_label(label)
+        out = TweeExporter().export(ctx, tmp_path / "out")
+        text = out.read_text(encoding="utf-8")
+        assert label in text, f"label round-trip failed: expected exactly {label!r} in output"


### PR DESCRIPTION
## Summary

PR E of 5 — final SHIP spec-compliance cluster (epic #1331). Closes the SHIP milestone.

The audit's #1338 brief was \"implementation correct, only regression tests missing\" for R-2.4 / R-3.1 / R-3.2. **Implementing the tests surfaced a real R-2.4 bug**: \`TweeExporter\` generated a fresh \`uuid.uuid4()\` IFID on every export, so two SHIP runs of the same project produced different bytes. Per CLAUDE.md docs-first the spec wins, so the code is fixed alongside the tests.

## What changed

| Rule | Test added | Implementation fix |
|---|---|---|
| **R-2.4** byte-identical determinism | \`TestShipDeterminism\` (parametrised twee/json/html) + \`test_graph_unchanged_after_ship\` + IFID determinism tests | \`ShipStage.execute(timestamp=...)\` seam + \`uuid.uuid5()\`-derived deterministic IFID |
| **R-3.1** cross-format consistency | \`TestCrossFormatConsistency\` (passage counts, codex counts, choice labels, snapshot hash all match) | none — already compliant |
| **R-3.2** Twee verbatim labels | \`TestTweeChoiceLabelVerbatim\` (em dash, smart quotes, both link forms) | none — already compliant |

## R-2.4 bug fix detail

The IFID change matters for the IF Technology Foundation convention: the IFID identifies *the work*, not *the file*. Generating a new IFID on every SHIP run was both a determinism violation (R-2.4) and a IFID-semantics violation. The new \`uuid.uuid5()\` derivation keys on the story title via a fixed namespace constant, so:

- Same title → same IFID across runs, machines, and Python versions
- Different titles → different IFIDs

Both behaviours pinned by tests.

## Test plan

- [x] \`uv run pytest tests/unit/test_ship_stage.py tests/unit/test_ship_format_consistency.py tests/unit/test_twee_exporter.py tests/unit/test_html_exporter.py tests/unit/test_json_exporter.py tests/unit/test_pdf_exporter.py tests/unit/test_export_validation.py tests/unit/test_export_metadata.py tests/unit/test_export_context.py -q\` — 202/202 pass
- [x] \`uv run ruff check src/ tests/\` — clean
- [x] \`uv run mypy src/\` — clean
- [ ] CI green
- [ ] \`/pr-review-toolkit:review-pr\` clean before marking ready

## SHIP milestone status after this merges

The spec-compliance audit epic is **complete** — every cluster across all 8 stages closed. 🎉

🤖 Generated with [Claude Code](https://claude.com/claude-code)