### PR TITLE
fix(silent-degradation): topo-sort cycles raise + FILL LLM failures escalate (closes #1344, closes #1345)

### DIFF
--- a/src/questfoundry/graph/algorithms.py
+++ b/src/questfoundry/graph/algorithms.py
@@ -336,7 +336,14 @@ def _topological_sort_subset(
     """Topologically sort a subset of beats using successor edges.
 
     Uses Kahn's algorithm restricted to beats in ``beat_set``.
-    Falls back to sorted order if cycles are detected.
+
+    Raises:
+        PipelineInvariantError: If the subgraph contains a cycle. A cycle
+            in the beat DAG is a structural-invariant violation per
+            CLAUDE.md §Anti-Patterns and POLISH R-4c.1; producing a
+            sorted-by-id fallback would silently corrupt downstream
+            beat ordering. Callers must fix the upstream cycle, not
+            tolerate it.
     """
     if not beat_set:
         return []
@@ -363,9 +370,17 @@ def _topological_sort_subset(
 
                     bisect.insort(queue_sorted, child)
 
-    # Cycle fallback: if not all beats were emitted, append remaining sorted
     if len(result) < len(beat_set):
-        remaining = sorted(beat_set - set(result))
-        result.extend(remaining)
+        from questfoundry.graph.invariants import PipelineInvariantError
+
+        unprocessed = sorted(beat_set - set(result))
+        msg = (
+            f"Beat DAG cycle detected in topological sort: "
+            f"{len(unprocessed)} beat(s) could not be ordered: "
+            f"{', '.join(repr(b) for b in unprocessed[:5])}"
+            f"{' …' if len(unprocessed) > 5 else ''}. "
+            f"This is a structural invariant violation — fix the cycle upstream."
+        )
+        raise PipelineInvariantError(msg)
 
     return result

--- a/src/questfoundry/graph/algorithms.py
+++ b/src/questfoundry/graph/algorithms.py
@@ -12,6 +12,7 @@ from itertools import product
 from typing import TYPE_CHECKING, Any
 
 from questfoundry.graph.context import normalize_scoped_id
+from questfoundry.graph.invariants import PipelineInvariantError
 from questfoundry.observability.logging import get_logger
 
 if TYPE_CHECKING:
@@ -371,8 +372,6 @@ def _topological_sort_subset(
                     bisect.insort(queue_sorted, child)
 
     if len(result) < len(beat_set):
-        from questfoundry.graph.invariants import PipelineInvariantError
-
         unprocessed = sorted(beat_set - set(result))
         msg = (
             f"Beat DAG cycle detected in topological sort: "

--- a/src/questfoundry/graph/grow_algorithms.py
+++ b/src/questfoundry/graph/grow_algorithms.py
@@ -309,8 +309,17 @@ def topological_sort_beats(
         queue = sorted(queue + new_ready, key=_sort_key)
 
     if len(result) != len(beat_set):
-        remaining = beat_set - set(result)
-        raise ValueError(f"Cycle detected in beat subset: {sorted(remaining)}")
+        from questfoundry.graph.invariants import PipelineInvariantError
+
+        remaining = sorted(beat_set - set(result))
+        msg = (
+            f"Beat DAG cycle detected during topological sort: "
+            f"{len(remaining)} beat(s) could not be ordered: "
+            f"{', '.join(repr(b) for b in remaining[:5])}"
+            f"{' …' if len(remaining) > 5 else ''}. "
+            f"This is a structural invariant violation — fix the cycle upstream."
+        )
+        raise PipelineInvariantError(msg)
 
     return result
 

--- a/src/questfoundry/graph/grow_algorithms.py
+++ b/src/questfoundry/graph/grow_algorithms.py
@@ -667,15 +667,17 @@ def enumerate_arcs(graph: Graph, *, max_arc_count: int | None = None) -> list[Ar
         all_beats.update(beats)
 
     reference_positions: dict[str, int] | None = None
-    try:
-        global_sequence = topological_sort_beats(
-            graph,
-            list(all_beats),
-            priority_beats=shared,
-        )
-        reference_positions = {bid: idx for idx, bid in enumerate(global_sequence)}
-    except ValueError:
-        pass  # Fallback: no reference if global beat set has cycles
+    # A cycle in the beat DAG is a structural-invariant violation per
+    # CLAUDE.md §Anti-Patterns; both call sites below now propagate the
+    # ValueError to the phase runner instead of degrading silently to
+    # sorted-by-id order. The previous fallbacks shipped wrong narrative
+    # order to downstream POLISH/FILL with no surfaced signal.
+    global_sequence = topological_sort_beats(
+        graph,
+        list(all_beats),
+        priority_beats=shared,
+    )
+    reference_positions = {bid: idx for idx, bid in enumerate(global_sequence)}
 
     # Cartesian product of paths
     arcs: list[Arc] = []
@@ -689,15 +691,12 @@ def enumerate_arcs(graph: Graph, *, max_arc_count: int | None = None) -> list[Ar
         for pid in path_combo:
             beat_set.update(path_beat_sets.get(pid, set()))
 
-        try:
-            sequence = topological_sort_beats(
-                graph,
-                list(beat_set),
-                priority_beats=shared,
-                reference_positions=reference_positions,
-            )
-        except ValueError:
-            sequence = sorted(beat_set)  # Fallback for cycles
+        sequence = topological_sort_beats(
+            graph,
+            list(beat_set),
+            priority_beats=shared,
+            reference_positions=reference_positions,
+        )
 
         arcs.append(
             Arc(
@@ -2626,15 +2625,12 @@ def _get_path_beats_ordered(
     beats = path_beats_map.get(path_id, [])
     if not beats:
         return []
-    try:
-        return topological_sort_beats(graph, beats)
-    except ValueError:
-        log.warning(
-            "interleave_path_cycle_fallback",
-            path_id=path_id,
-            beats=beats,
-        )
-        return sorted(beats)  # Fallback to alphabetical on cycle (should not happen)
+    # Cycle on the per-path beat subgraph is a structural-invariant
+    # violation — the comment used to read "should not happen", but the
+    # fallback was shipping degraded order to interleave anyway. Per
+    # CLAUDE.md §Anti-Patterns we now propagate the failure so the phase
+    # runner halts and the bug is visible.
+    return topological_sort_beats(graph, beats)
 
 
 def _commits_beats_for_dilemma(

--- a/src/questfoundry/graph/invariants.py
+++ b/src/questfoundry/graph/invariants.py
@@ -51,12 +51,12 @@ def assert_predecessor_dag_acyclic(graph: Graph, phase_name: str) -> None:
 
     beat_ids = list(beat_nodes.keys())
 
+    # topological_sort_beats raises PipelineInvariantError on cycle detection.
+    # Wrap to attribute the failure to the specific phase that introduced it.
     try:
         topological_sort_beats(graph, beat_ids)
-    except ValueError as exc:
-        # topological_sort_beats raises ValueError on cycle detection
-        raise PipelineInvariantError(
-            f"Cycle detected in predecessor DAG after phase '{phase_name}': {exc}"
-        ) from exc
+    except PipelineInvariantError as exc:
+        msg = f"Cycle detected in predecessor DAG after phase '{phase_name}': {exc}"
+        raise PipelineInvariantError(msg) from exc
 
     log.debug("predecessor_dag_acyclic", phase=phase_name, beats=len(beat_ids))

--- a/src/questfoundry/models/fill.py
+++ b/src/questfoundry/models/fill.py
@@ -249,17 +249,23 @@ class FillEscalation(BaseModel):
     ``FillContractError`` at stage exit if any were recorded.
     """
 
-    kind: Literal["missing_entity", "unresolved_review_flags"] = Field(
-        description="What kind of escalation this is."
-    )
+    kind: Literal[
+        "missing_entity",
+        "unresolved_review_flags",
+        "voice_research_failed",
+        "blueprint_validation_failed",
+        "entity_extract_failed",
+    ] = Field(description="What kind of escalation this is.")
     passage_id: str = Field(
         description="Passage where the escalation was raised. Empty string if not passage-scoped."
     )
     detail: str = Field(
         description="Human-readable description of the specific violation.",
     )
-    upstream_stage: Literal["SEED", "GROW", "POLISH"] = Field(
-        description="Which upstream stage owns the fix.",
+    upstream_stage: Literal["SEED", "GROW", "POLISH", "FILL"] = Field(
+        description="Which stage owns the fix. ``FILL`` for self-owned failures "
+        "(LLM call failures during voice research, blueprint validation, or "
+        "entity extraction — rerun FILL or adjust provider settings).",
     )
 
 

--- a/src/questfoundry/pipeline/stages/fill.py
+++ b/src/questfoundry/pipeline/stages/fill.py
@@ -890,8 +890,9 @@ class FillStage:
                     kind="voice_research_failed",
                     passage_id="",
                     detail=(
-                        f"Voice research LLM call failed: {exc!r}. Prose generation "
-                        f"will proceed with no research notes — quality may degrade."
+                        f"Voice research LLM call failed: {exc!r}. FILL will exit "
+                        f"with FillContractError at stage end; rerun FILL or fix "
+                        f"the provider configuration to proceed."
                     ),
                     upstream_stage="FILL",
                 )
@@ -1409,7 +1410,12 @@ class FillStage:
                         total_llm_calls += ex_calls
                         total_tokens += ex_tokens
                         entity_updates = extract_out.entity_updates
-                    except (ValidationError, ValueError, RuntimeError) as exc:
+                    except Exception as exc:
+                        # Catch broadly (matching the voice-research and
+                        # blueprint-validation sites above): transport-level
+                        # failures (httpx.TimeoutException, asyncio.TimeoutError,
+                        # provider-specific exceptions) must escalate too, not
+                        # propagate unhandled and crash the per-passage loop.
                         # Per-passage and bounded — escalate (option 2 of audit
                         # recommendation, #1345). Without entity updates the
                         # entity state diverges from the generated prose; the

--- a/src/questfoundry/pipeline/stages/fill.py
+++ b/src/questfoundry/pipeline/stages/fill.py
@@ -870,7 +870,12 @@ class FillStage:
         total_llm_calls = 0
         total_tokens = 0
 
-        # Phase 0a: Research voice guidance (graceful degradation on failure)
+        # Phase 0a: Research voice guidance.
+        # Voice research is degradation, not corruption: prose is still
+        # generatable without the research notes. We escalate (option 2 of
+        # the audit recommendation, #1345) rather than raising so the
+        # whole stage's failure picture surfaces at exit; FillContractError
+        # then halts SHIP with the full set of issues.
         research_notes = ""
         try:
             research_notes, research_calls, research_tokens = await self._phase_0a_voice_research(
@@ -878,8 +883,19 @@ class FillStage:
             )
             total_llm_calls += research_calls
             total_tokens += research_tokens
-        except Exception:
-            log.warning("voice_research_failed", exc_info=True)
+        except Exception as exc:
+            log.error("voice_research_failed", exc_info=True)
+            self._escalations.append(
+                FillEscalation(
+                    kind="voice_research_failed",
+                    passage_id="",
+                    detail=(
+                        f"Voice research LLM call failed: {exc!r}. Prose generation "
+                        f"will proceed with no research notes — quality may degrade."
+                    ),
+                    upstream_stage="FILL",
+                )
+            )
 
         context = {
             "dream_vision": format_dream_vision(graph),
@@ -1174,13 +1190,29 @@ class FillStage:
                 full_pid = f"passage::{clean_id}"
                 if not graph.has_node(full_pid):
                     continue
-                # Validate blueprint before persisting
+                # Validate blueprint before persisting. Failure is per-passage
+                # and bounded — escalate (option 2 of audit recommendation,
+                # #1345) so the full set surfaces at stage exit instead of
+                # the user discovering each broken passage one-by-one in
+                # downstream phases.
                 try:
                     validated = ExpandBlueprint.model_validate(bp_dict)
                     graph.update_node(full_pid, blueprint=validated.model_dump())
                     blueprints_created += 1
-                except Exception:
-                    log.warning("blueprint_validation_failed", passage_id=full_pid)
+                except Exception as exc:
+                    log.error("blueprint_validation_failed", passage_id=full_pid, exc_info=True)
+                    self._escalations.append(
+                        FillEscalation(
+                            kind="blueprint_validation_failed",
+                            passage_id=full_pid,
+                            detail=(
+                                f"ExpandBlueprint validation failed: {exc!r}. "
+                                f"Passage will fall back to default expansion — "
+                                f"likely produces lower-quality prose."
+                            ),
+                            upstream_stage="FILL",
+                        )
+                    )
                     continue
 
         log.info(
@@ -1377,11 +1409,27 @@ class FillStage:
                         total_llm_calls += ex_calls
                         total_tokens += ex_tokens
                         entity_updates = extract_out.entity_updates
-                    except (ValidationError, ValueError, RuntimeError):
-                        log.warning(
+                    except (ValidationError, ValueError, RuntimeError) as exc:
+                        # Per-passage and bounded — escalate (option 2 of audit
+                        # recommendation, #1345). Without entity updates the
+                        # entity state diverges from the generated prose; the
+                        # user must see this at stage exit, not silently.
+                        log.error(
                             "entity_extract_failed",
                             passage_id=passage_id,
                             exc_info=True,
+                        )
+                        self._escalations.append(
+                            FillEscalation(
+                                kind="entity_extract_failed",
+                                passage_id=passage_id,
+                                detail=(
+                                    f"Two-step entity extraction failed: {exc!r}. "
+                                    f"Entity state diverges from generated prose "
+                                    f"for this passage."
+                                ),
+                                upstream_stage="FILL",
+                            )
                         )
             else:
                 entity_updates = passage_output.entity_updates

--- a/tests/unit/test_algorithms.py
+++ b/tests/unit/test_algorithms.py
@@ -748,8 +748,13 @@ class TestComputeArcTraversalsDilemmaIdNormalization:
         assert result == {"p1": ["beat::b1"]}
 
 
-class TestComputeArcTraversalsCycleFallback:
-    """Tests for cycle detection fallback in _topological_sort_subset."""
+class TestComputeArcTraversalsCyclicBeatsExcluded:
+    """Cyclic beats are unreachable from roots and the walk-based
+    ``compute_arc_traversals`` simply doesn't visit them — so the
+    fact that ``_topological_sort_subset`` would now raise on a
+    cyclic subset (#1344) doesn't fire here. GROW validates the
+    DAG is acyclic, so cycles should not occur in production at all.
+    """
 
     def test_cyclic_predecessors_excluded_from_walk(self) -> None:
         """Beats in a cycle have no root entry point and are not reached by the walk.

--- a/tests/unit/test_algorithms.py
+++ b/tests/unit/test_algorithms.py
@@ -775,6 +775,34 @@ class TestComputeArcTraversalsCycleFallback:
         assert result == {"p1": []}
 
 
+class TestTopologicalSortSubsetRaisesOnCycle:
+    """Direct cycle in the subset must raise PipelineInvariantError (#1344).
+
+    Production callers filter to reachable beats before calling, so this
+    raise primarily catches programmer error in future callers — but the
+    behaviour must be loud either way per CLAUDE.md §Anti-Patterns.
+    """
+
+    def test_cyclic_subset_raises(self) -> None:
+        from questfoundry.graph.algorithms import _topological_sort_subset
+        from questfoundry.graph.invariants import PipelineInvariantError
+
+        # 3-node cycle a → b → c → a, all in subset
+        beat_set = {"a", "b", "c"}
+        successors = {"a": ["b"], "b": ["c"], "c": ["a"]}
+        with pytest.raises(PipelineInvariantError, match="cycle detected"):
+            _topological_sort_subset(beat_set, successors)
+
+    def test_acyclic_subset_returns_topo_order(self) -> None:
+        """Sanity: clean subset still produces a valid topological order."""
+        from questfoundry.graph.algorithms import _topological_sort_subset
+
+        beat_set = {"a", "b", "c"}
+        successors = {"a": ["b"], "b": ["c"], "c": []}
+        result = _topological_sort_subset(beat_set, successors)
+        assert result.index("a") < result.index("b") < result.index("c")
+
+
 # ---------------------------------------------------------------------------
 # compute_passage_traversals tests
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_fill_stage.py
+++ b/tests/unit/test_fill_stage.py
@@ -1907,6 +1907,74 @@ class TestEntityUpdateEscalation:
             await stage.execute(mock_model, "", interactive=False)
 
 
+class TestFillSilentDegradationEscalations:
+    """#1345: LLM failures inside FILL must escalate, not log-and-shrug.
+
+    The previous code caught broad ``Exception`` at three sites
+    (voice research / blueprint validation / entity extraction) and
+    logged WARNING — the stage reported success with degraded output.
+    Each failure mode now collects a FillEscalation so FillContractError
+    surfaces at stage exit (R-2.14, R-5.2).
+    """
+
+    def test_voice_research_failed_kind_accepted(self) -> None:
+        from questfoundry.models.fill import FillEscalation
+
+        e = FillEscalation(
+            kind="voice_research_failed",
+            passage_id="",
+            detail="LLM call timed out",
+            upstream_stage="FILL",
+        )
+        assert e.kind == "voice_research_failed"
+        assert e.upstream_stage == "FILL"
+
+    def test_blueprint_validation_failed_kind_accepted(self) -> None:
+        from questfoundry.models.fill import FillEscalation
+
+        e = FillEscalation(
+            kind="blueprint_validation_failed",
+            passage_id="passage::intro",
+            detail="ExpandBlueprint validation failed: ValidationError(...)",
+            upstream_stage="FILL",
+        )
+        assert e.kind == "blueprint_validation_failed"
+
+    def test_entity_extract_failed_kind_accepted(self) -> None:
+        from questfoundry.models.fill import FillEscalation
+
+        e = FillEscalation(
+            kind="entity_extract_failed",
+            passage_id="passage::trial",
+            detail="Two-step extraction failed: RuntimeError(...)",
+            upstream_stage="FILL",
+        )
+        assert e.kind == "entity_extract_failed"
+
+    def test_self_owned_FILL_upstream_stage_accepted(self) -> None:
+        """FillEscalation.upstream_stage now accepts ``FILL`` for
+        self-owned failures (LLM call drops, schema bugs)."""
+        from pydantic import ValidationError as PydanticValidationError
+
+        from questfoundry.models.fill import FillEscalation
+
+        # Sanity: FILL is allowed
+        FillEscalation(
+            kind="voice_research_failed",
+            passage_id="",
+            detail="x",
+            upstream_stage="FILL",
+        )
+        # And a junk value still rejected
+        with pytest.raises(PydanticValidationError):
+            FillEscalation(
+                kind="voice_research_failed",
+                passage_id="",
+                detail="x",
+                upstream_stage="DREAM",  # type: ignore[arg-type]
+            )
+
+
 class TestReviewCycleEscalation:
     """R-5.2: unresolved review flags after the final cycle become escalations."""
 

--- a/tests/unit/test_grow_algorithms.py
+++ b/tests/unit/test_grow_algorithms.py
@@ -272,14 +272,23 @@ class TestTopologicalSortBeats:
         # No direct edge between a and c in subset, so alphabetical
         assert result == ["beat::a", "beat::c"]
 
-    def test_cycle_raises_value_error(self) -> None:
+    def test_cycle_raises_pipeline_invariant_error(self) -> None:
+        """Cycle in the beat DAG raises PipelineInvariantError (#1344).
+
+        Was previously a bare ``ValueError`` — promoted to
+        ``PipelineInvariantError`` so the two topo-sort implementations
+        raise the same exception type and any phase runner that
+        catches "cycle in beat DAG" only needs one ``except`` clause.
+        """
+        from questfoundry.graph.invariants import PipelineInvariantError
+
         graph = Graph.empty()
         graph.create_node("beat::a", {"type": "beat"})
         graph.create_node("beat::b", {"type": "beat"})
         graph.add_edge("predecessor", "beat::b", "beat::a")
         graph.add_edge("predecessor", "beat::a", "beat::b")
 
-        with pytest.raises(ValueError, match="Cycle detected"):
+        with pytest.raises(PipelineInvariantError, match="cycle detected"):
             topological_sort_beats(graph, ["beat::a", "beat::b"])
 
     def test_branching_structure(self) -> None:
@@ -908,6 +917,37 @@ class TestEnumerateArcs:
         # Different arcs should have different final beats (ending differentiation)
         final_beats = {arc.sequence[-1] for arc in arcs}
         assert len(final_beats) > 1, f"All arcs share the same final beat: {final_beats}"
+
+
+class TestEnumerateArcsCyclePropagation:
+    """#1344 follow-up: enumerate_arcs used to swallow cycle errors with
+    `except ValueError: pass` (global beat set) and
+    `except ValueError: sequence = sorted(beat_set)` (per-arc beat set).
+    Both fallbacks were removed; the underlying topo-sort exception
+    must propagate so the GROW phase runner halts.
+    """
+
+    def test_cycle_in_global_beat_set_propagates(self) -> None:
+        """A cycle spanning beats reachable from multiple paths must
+        raise PipelineInvariantError out of enumerate_arcs."""
+        from questfoundry.graph.grow_algorithms import enumerate_arcs
+        from questfoundry.graph.invariants import PipelineInvariantError
+
+        graph = Graph.empty()
+        graph.create_node(
+            "dilemma::d1", {"type": "dilemma", "raw_id": "d1", "answers": [{"id": "a"}]}
+        )
+        graph.create_node("path::p1", {"type": "path", "raw_id": "p1", "dilemma_id": "dilemma::d1"})
+        graph.create_node("beat::a", {"type": "beat", "summary": "A"})
+        graph.create_node("beat::b", {"type": "beat", "summary": "B"})
+        graph.add_edge("belongs_to", "beat::a", "path::p1")
+        graph.add_edge("belongs_to", "beat::b", "path::p1")
+        # Cycle in the per-arc beat set: a → b → a
+        graph.add_edge("predecessor", "beat::a", "beat::b")
+        graph.add_edge("predecessor", "beat::b", "beat::a")
+
+        with pytest.raises(PipelineInvariantError, match="cycle detected"):
+            enumerate_arcs(graph)
 
 
 # ---------------------------------------------------------------------------
@@ -2948,9 +2988,17 @@ class TestGetPathBeatSequence:
             "beat::mentor_commits_alt",
         ]
 
-    def test_cycle_raises_value_error(self) -> None:
-        """Cycle in path beat dependencies raises ValueError."""
+    def test_cycle_raises_pipeline_invariant_error(self) -> None:
+        """Cycle in path beat dependencies raises PipelineInvariantError (#1344).
+
+        Was a bare ``ValueError`` and the fallback in
+        ``_get_path_beats_ordered`` swallowed it into a sorted-by-id
+        result. The fallback was removed and the type was promoted to
+        ``PipelineInvariantError`` for consistency with
+        ``_topological_sort_subset``.
+        """
         from questfoundry.graph.grow_algorithms import get_path_beat_sequence
+        from questfoundry.graph.invariants import PipelineInvariantError
 
         graph = Graph.empty()
         graph.create_node("path::t1", {"type": "path", "raw_id": "t1"})
@@ -2962,7 +3010,7 @@ class TestGetPathBeatSequence:
         graph.add_edge("predecessor", "beat::a", "beat::b")
         graph.add_edge("predecessor", "beat::b", "beat::a")
 
-        with pytest.raises(ValueError, match="Cycle detected"):
+        with pytest.raises(PipelineInvariantError, match="cycle detected"):
             get_path_beat_sequence(graph, "path::t1")
 
 


### PR DESCRIPTION
## Summary

PR F of the post-audit cross-cutting cleanup (epic #1343, silent-degradation). Two clusters, both replacing \"log WARNING and continue with degraded output\" with loud failure paths per CLAUDE.md §Anti-Patterns.

## #1344 — Topo-sort cycle silent fallback

| Site | Before | After |
|---|---|---|
| \`graph/algorithms.py::_topological_sort_subset\` | Appended cyclic beats sorted-by-id to the result | Raises \`PipelineInvariantError\` listing unprocessed beats |
| \`graph/grow_algorithms.py\` (2 sites in \`enumerate_arcs\`) | \`except ValueError: pass\` / \`= sorted(beat_set)\` | Let \`topological_sort_beats\` propagate |
| \`graph/grow_algorithms.py::_get_path_beats_ordered\` | Logged WARNING and returned sorted fallback | Let it propagate (the \"should not happen\" comment was right) |

## #1345 — FILL LLM-failure silent continuation

Extended \`FillEscalation\` with three new kinds and a \`FILL\` self-owned upstream stage:

| Site | Cluster | Behaviour |
|---|---|---|
| \`fill.py:882\` voice research | option 2 (escalate) | log ERROR + append \`voice_research_failed\` escalation |
| \`fill.py:1199\` blueprint validation | option 2 (per-passage, bounded) | log ERROR + append \`blueprint_validation_failed\` per failing passage |
| \`fill.py:1418\` entity extraction | option 2 (per-passage, bounded) | log ERROR + append \`entity_extract_failed\` per failing passage |

Existing stage-exit logic raises \`FillContractError\` when escalations are non-empty, so the failure surfaces loudly without losing per-passage granularity.

## Test plan

- [x] \`uv run pytest tests/unit/test_fill_stage.py tests/unit/test_algorithms.py tests/unit/test_grow_algorithms.py tests/unit/test_fill_models.py -q\` — 448/448 pass
- [x] \`uv run ruff check src/ tests/\` — clean
- [x] \`uv run mypy src/\` — clean
- [ ] CI green

## Remaining cross-cutting work

- PR G: contract-chaining (#1346) — wire \`validate_<stage>_output()\` helpers + entry/exit calls across 6 of 7 stage seams.

🤖 Generated with [Claude Code](https://claude.com/claude-code)