### PR TITLE
fix(contract-chaining): wire upstream/downstream validators at every stage seam (closes #1347, closes #1348)

### DIFF
--- a/src/questfoundry/graph/dress_output_validation.py
+++ b/src/questfoundry/graph/dress_output_validation.py
@@ -11,6 +11,12 @@ Implements the DRESS §Stage Output Contract checks (from
 5. Every Entity has ≥1 CodexEntry with ``HasEntry`` edge.
 6. CodexEntry rank 1 is always visible (``visible_when == []``).
 
+Output-4 (brief field completeness + diegetic captions) is enforced
+inline during Phase 1 by ``apply_dress_brief()`` validation against
+the Pydantic ``IllustrationBrief`` model — re-checking it here would
+duplicate the per-brief checks that already raised at creation time.
+The numbering gap above is intentional, not an oversight.
+
 DRESS may be skipped entirely (Output-10), so an empty graph (no
 art_direction node) is treated as a *skipped* DRESS, not a contract
 violation. The validator returns no errors for skipped DRESS.

--- a/src/questfoundry/graph/dress_output_validation.py
+++ b/src/questfoundry/graph/dress_output_validation.py
@@ -1,0 +1,114 @@
+"""DRESS Stage Output Contract validator.
+
+Implements the DRESS §Stage Output Contract checks (from
+``docs/design/procedures/dress.md``):
+
+1. Exactly one ArtDirection node exists.
+2. Every Entity with ≥1 ``appears`` edge has an EntityVisual with
+   non-empty ``reference_prompt_fragment`` (R-1.3, R-1.4 — also
+   enforced at Phase 0 exit by ``validate_entity_visual_coverage``).
+3. Every Passage has an IllustrationBrief with a ``targets`` edge.
+5. Every Entity has ≥1 CodexEntry with ``HasEntry`` edge.
+6. CodexEntry rank 1 is always visible (``visible_when == []``).
+
+DRESS may be skipped entirely (Output-10), so an empty graph (no
+art_direction node) is treated as a *skipped* DRESS, not a contract
+violation. The validator returns no errors for skipped DRESS.
+
+Called at DRESS exit and at SHIP entry. Read-only — never mutates
+the graph.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from questfoundry.graph.context import strip_scope_prefix
+
+if TYPE_CHECKING:
+    from questfoundry.graph.graph import Graph
+
+
+def validate_dress_output(graph: Graph) -> list[str]:
+    """Return contract violations after DRESS completion. Empty = compliant.
+
+    DRESS may be skipped entirely (no art_direction node) — in that
+    case the validator returns ``[]`` so the SHIP entry contract still
+    passes for stories that opt out of illustrations.
+    """
+    art_direction_nodes = graph.get_nodes_by_type("art_direction")
+    if not art_direction_nodes:
+        # DRESS was skipped — Output-10 explicitly permits this.
+        return []
+
+    errors: list[str] = []
+
+    # Output-1: exactly one ArtDirection node.
+    if len(art_direction_nodes) > 1:
+        errors.append(
+            f"Output-1: exactly one ArtDirection node expected, found "
+            f"{len(art_direction_nodes)}: {sorted(art_direction_nodes)}"
+        )
+
+    # Output-2: every appearing entity has an EntityVisual with a
+    # non-empty reference_prompt_fragment. This mirrors
+    # validate_entity_visual_coverage() called at Phase 0 exit.
+    appears_edges = graph.get_edges(edge_type="appears")
+    appearing_entity_ids = {edge["from"] for edge in appears_edges}
+    for entity_id in sorted(appearing_entity_ids):
+        raw_id = strip_scope_prefix(entity_id)
+        ev_id = f"entity_visual::{raw_id}"
+        ev = graph.get_node(ev_id)
+        if ev is None:
+            errors.append(
+                f"Output-2: entity {entity_id!r} has appears edges but no "
+                f"EntityVisual ({ev_id!r} missing)"
+            )
+            continue
+        fragment = (ev.get("reference_prompt_fragment") or "").strip()
+        if not fragment:
+            errors.append(
+                f"Output-2: entity {entity_id!r} EntityVisual has empty reference_prompt_fragment"
+            )
+
+    # Output-3: every Passage has an IllustrationBrief with a targets edge.
+    passages = graph.get_nodes_by_type("passage")
+    targets_edges = graph.get_edges(edge_type="targets")
+    brief_targets = {edge["to"] for edge in targets_edges}
+    missing_briefs = sorted(pid for pid in passages if pid not in brief_targets)
+    if missing_briefs:
+        errors.append(
+            f"Output-3: {len(missing_briefs)} Passage(s) without an "
+            f"IllustrationBrief: "
+            f"{', '.join(repr(p) for p in missing_briefs[:5])}"
+            f"{' …' if len(missing_briefs) > 5 else ''}"
+        )
+
+    # Output-5: every Entity has ≥1 CodexEntry via HasEntry.
+    entities = graph.get_nodes_by_type("entity")
+    has_entry_edges = graph.get_edges(edge_type="HasEntry")
+    entities_with_codex = {edge["to"] for edge in has_entry_edges}
+    missing_codex = sorted(eid for eid in entities if eid not in entities_with_codex)
+    if missing_codex:
+        errors.append(
+            f"Output-5: {len(missing_codex)} Entity(ies) without a CodexEntry: "
+            f"{', '.join(repr(e) for e in missing_codex[:5])}"
+            f"{' …' if len(missing_codex) > 5 else ''}"
+        )
+
+    # Output-6: rank-1 codex entries must be unconditional (visible_when == []).
+    codex_entries = graph.get_nodes_by_type("codex_entry")
+    rank1_with_gates = sorted(
+        cid
+        for cid, data in codex_entries.items()
+        if data.get("rank") == 1 and data.get("visible_when")
+    )
+    if rank1_with_gates:
+        errors.append(
+            f"Output-6: {len(rank1_with_gates)} rank-1 CodexEntry(ies) with "
+            f"non-empty visible_when (must be unconditional): "
+            f"{', '.join(repr(c) for c in rank1_with_gates[:5])}"
+            f"{' …' if len(rank1_with_gates) > 5 else ''}"
+        )
+
+    return errors

--- a/src/questfoundry/graph/fill_output_validation.py
+++ b/src/questfoundry/graph/fill_output_validation.py
@@ -1,0 +1,85 @@
+"""FILL Stage Output Contract validator.
+
+Implements the FILL §Stage Output Contract checks (R from
+``docs/design/procedures/fill.md``):
+
+1. Voice Document singleton exists with all required fields populated.
+2. Every Passage has non-empty ``prose``.
+3. Entity base-state enriched with zero or more universal micro-details
+   (additive only).
+4. No new node types created or destroyed by FILL (structural validation
+   is upstream — POLISH owns DAG/passage shape).
+
+Called at FILL exit (from ``ShipStage._validate_fill_output`` cited
+indirectly by DRESS entry) and at DRESS entry. Read-only — never
+mutates the graph.
+
+Note that ``fill_validation.FillContractError`` already exists as the
+exception type for FILL escalations (R-2.14 / R-5.2). Output-contract
+violations reuse the same error type so callers only need to handle
+one exception family from FILL.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from questfoundry.graph.graph import Graph
+
+
+# Voice Document fields required to be present and non-empty after FILL
+# Phase 0. Mirrors the Pydantic VoiceDocument model in models/fill.py;
+# updating either the model or this list requires updating the other.
+# `story_title` lives on the same node but is added by FILL alongside the
+# VoiceDocument — not a VoiceDocument field — so it isn't validated here.
+_REQUIRED_VOICE_FIELDS = (
+    "pov",
+    "tense",
+    "voice_register",
+    "sentence_rhythm",
+    "tone_words",
+)
+
+
+def validate_fill_output(graph: Graph) -> list[str]:
+    """Return contract violations after FILL completion. Empty = compliant.
+
+    Pure read-only — never mutates the graph.
+    """
+    errors: list[str] = []
+
+    # Output-1: Voice Document singleton with required fields populated.
+    voice_node = graph.get_node("voice::voice")
+    if voice_node is None:
+        errors.append("Output-1: FILL must produce a Voice Document at `voice::voice` (none found)")
+    else:
+        missing = [
+            field
+            for field in _REQUIRED_VOICE_FIELDS
+            if not voice_node.get(field)
+            or (isinstance(voice_node.get(field), str) and not voice_node[field].strip())
+        ]
+        if missing:
+            errors.append(
+                f"Output-1: Voice Document missing required field(s): {', '.join(missing)}"
+            )
+
+    # Output-2: every Passage has non-empty prose.
+    passages = graph.get_nodes_by_type("passage")
+    if not passages:
+        errors.append("Output-2: FILL must produce at least one Passage (none found)")
+    else:
+        missing_prose = sorted(
+            pid
+            for pid, data in passages.items()
+            if not data.get("prose") or not str(data["prose"]).strip()
+        )
+        if missing_prose:
+            errors.append(
+                f"Output-2: {len(missing_prose)} Passage(s) without prose: "
+                f"{', '.join(repr(p) for p in missing_prose[:5])}"
+                f"{' …' if len(missing_prose) > 5 else ''}"
+            )
+
+    return errors

--- a/src/questfoundry/pipeline/stages/dress.py
+++ b/src/questfoundry/pipeline/stages/dress.py
@@ -315,6 +315,18 @@ class DressStage:
                 log.info("rewinding_graph", stage="dress", mutations=n)
             save_snapshot(graph, resolved_path, "dress")
 
+        # FILL Stage Output Contract — validate post-rewind so the
+        # check sees the base FILL state, not stale DRESS mutations
+        # from an earlier run (#1347).
+        from questfoundry.graph.fill_output_validation import validate_fill_output
+
+        entry_errors = validate_fill_output(graph)
+        if entry_errors:
+            raise DressStageError(
+                f"FILL output validation failed ({len(entry_errors)} "
+                f"error(s)):\n" + "\n".join(f"  - {e}" for e in entry_errors)
+            )
+
         phase_results: list[DressPhaseResult] = []
         total_llm_calls = 0
         total_tokens = 0
@@ -358,6 +370,18 @@ class DressStage:
             graph.save(resolved_path / "graph.db")
 
         if completed_normally:
+            # DRESS Stage Output Contract — validate before stamping
+            # last_stage so a malformed artifact is owned by DRESS,
+            # not discovered downstream at SHIP (#1348).
+            from questfoundry.graph.dress_output_validation import validate_dress_output
+
+            exit_errors = validate_dress_output(graph)
+            if exit_errors:
+                raise DressStageError(
+                    f"DRESS output contract violated ({len(exit_errors)} "
+                    f"error(s)):\n" + "\n".join(f"  - {e}" for e in exit_errors)
+                )
+
             graph.set_last_stage("dress")
             graph.save(resolved_path / "graph.db")
 

--- a/src/questfoundry/pipeline/stages/fill.py
+++ b/src/questfoundry/pipeline/stages/fill.py
@@ -416,6 +416,18 @@ class FillStage:
                 log.info("rewinding_graph", stage="fill", mutations=n)
             save_snapshot(graph, resolved_path, "fill")
 
+        # POLISH Stage Output Contract — validate post-rewind so the
+        # check sees the base POLISH state, not stale FILL mutations
+        # from an earlier run (#1347).
+        from questfoundry.graph.polish_validation import validate_polish_output
+
+        entry_errors = validate_polish_output(graph)
+        if entry_errors:
+            raise FillStageError(
+                f"POLISH output validation failed ({len(entry_errors)} "
+                f"error(s)):\n" + "\n".join(f"  - {e}" for e in entry_errors)
+            )
+
         phase_results: list[FillPhaseResult] = []
         total_llm_calls = 0
         total_tokens = 0
@@ -462,6 +474,21 @@ class FillStage:
                 on_phase_progress(phase_name, result.status, result.detail)
 
         if completed_normally:
+            # FILL Stage Output Contract — validate before stamping
+            # last_stage so a malformed artifact is owned by FILL, not
+            # discovered downstream (#1348). Escalations checked
+            # separately below — those are LLM-failure escalations and
+            # share FillStageError to keep the caller-side handling
+            # uniform.
+            from questfoundry.graph.fill_output_validation import validate_fill_output
+
+            exit_errors = validate_fill_output(graph)
+            if exit_errors:
+                raise FillStageError(
+                    f"FILL output contract violated ({len(exit_errors)} "
+                    f"error(s)):\n" + "\n".join(f"  - {e}" for e in exit_errors)
+                )
+
             graph.set_last_stage("fill")
             graph.save(resolved_path / "graph.db")
 

--- a/src/questfoundry/pipeline/stages/grow/stage.py
+++ b/src/questfoundry/pipeline/stages/grow/stage.py
@@ -308,6 +308,18 @@ class GrowStage(_LLMHelperMixin, _LLMPhaseMixin):
                 log.info("rewinding_graph", stage="grow", mutations=n)
             save_snapshot(graph, resolved_path, "grow")
 
+        # SEED Stage Output Contract — validate post-rewind so we
+        # check the base SEED state, not stale GROW mutations from a
+        # previous run (#1347).
+        from questfoundry.graph.seed_validation import validate_seed_output
+
+        entry_errors = validate_seed_output(graph)
+        if entry_errors:
+            raise GrowStageError(
+                f"SEED output validation failed ({len(entry_errors)} "
+                f"error(s)):\n" + "\n".join(f"  - {e}" for e in entry_errors)
+            )
+
         phase_results: list[GrowPhaseResult] = []
         total_llm_calls = 0
         total_tokens = 0

--- a/src/questfoundry/pipeline/stages/seed.py
+++ b/src/questfoundry/pipeline/stages/seed.py
@@ -31,6 +31,7 @@ from questfoundry.agents import (
 )
 from questfoundry.export.i18n import get_output_language_instruction
 from questfoundry.graph import Graph
+from questfoundry.graph.brainstorm_validation import validate_brainstorm_output
 from questfoundry.graph.context import strip_scope_prefix
 from questfoundry.graph.mutations import format_semantic_errors_as_content
 from questfoundry.graph.seed_pruning import compute_arc_count, prune_to_arc_limit
@@ -287,6 +288,18 @@ class SeedStage:
 
         total_llm_calls = 0
         total_tokens = 0
+
+        # BRAINSTORM Stage Output Contract: validate the upstream artifact
+        # before SEED phases consume it. Catches missing entities,
+        # incomplete dilemmas, and other contract violations at the seam
+        # rather than at the downstream-failure site (#1347).
+        entry_graph = Graph.load(resolved_path)
+        entry_errors = validate_brainstorm_output(entry_graph)
+        if entry_errors:
+            raise SeedStageError(
+                f"BRAINSTORM output validation failed ({len(entry_errors)} "
+                f"error(s)):\n" + "\n".join(f"  - {e}" for e in entry_errors)
+            )
 
         # Load brainstorm context from graph
         brainstorm_context = self._get_brainstorm_context(resolved_path)

--- a/src/questfoundry/pipeline/stages/seed.py
+++ b/src/questfoundry/pipeline/stages/seed.py
@@ -188,11 +188,15 @@ class SeedStage:
         """
         self.project_path = project_path
 
-    def _get_brainstorm_context(self, project_path: Path) -> str:
+    def _get_brainstorm_context(self, project_path: Path, *, graph: Graph | None = None) -> str:
         """Load and format brainstorm from graph.
 
         Args:
             project_path: Path to project directory.
+            graph: Pre-loaded graph to reuse. If None, loads from
+                ``project_path``. The keyword exists so ``execute()``
+                can avoid a second I/O round-trip when the graph is
+                already in hand from the entry-validation step.
 
         Returns:
             Formatted brainstorm context string.
@@ -200,7 +204,8 @@ class SeedStage:
         Raises:
             SeedStageError: If brainstorm not found in graph.
         """
-        graph = Graph.load(project_path)
+        if graph is None:
+            graph = Graph.load(project_path)
 
         # Check for entities (indicates brainstorm completed)
         # Get dilemma nodes from graph
@@ -289,20 +294,25 @@ class SeedStage:
         total_llm_calls = 0
         total_tokens = 0
 
+        # Load the graph once and reuse it for both the entry validation
+        # and the brainstorm-context build. The serialize-time graph load
+        # below is intentionally separate — it happens after a long
+        # discuss/summarize loop and may need to see fresh on-disk state.
+        graph = Graph.load(resolved_path)
+
         # BRAINSTORM Stage Output Contract: validate the upstream artifact
         # before SEED phases consume it. Catches missing entities,
         # incomplete dilemmas, and other contract violations at the seam
         # rather than at the downstream-failure site (#1347).
-        entry_graph = Graph.load(resolved_path)
-        entry_errors = validate_brainstorm_output(entry_graph)
+        entry_errors = validate_brainstorm_output(graph)
         if entry_errors:
             raise SeedStageError(
                 f"BRAINSTORM output validation failed ({len(entry_errors)} "
                 f"error(s)):\n" + "\n".join(f"  - {e}" for e in entry_errors)
             )
 
-        # Load brainstorm context from graph
-        brainstorm_context = self._get_brainstorm_context(resolved_path)
+        # Load brainstorm context from the same graph instance.
+        brainstorm_context = self._get_brainstorm_context(resolved_path, graph=graph)
         log.debug("seed_brainstorm_loaded", context_length=len(brainstorm_context))
 
         # Get language instruction (empty string for English)
@@ -350,8 +360,11 @@ class SeedStage:
         if unload_after_discuss is not None:
             await unload_after_discuss()
 
-        # Load graph once for summarize manifest and serialize validation
-        graph = Graph.load(resolved_path)
+        # Reuse the graph loaded for entry validation. Discuss runs LLM
+        # calls with research-only tools (corpus search, etc.) and does
+        # not mutate the graph, so the same in-memory instance is fresh
+        # enough for the summarize manifest and serialize validation
+        # that follow.
 
         # Outer loop: conversation-level retry for semantic errors
         # Each iteration runs summarize -> serialize; on semantic errors,

--- a/src/questfoundry/pipeline/stages/seed.py
+++ b/src/questfoundry/pipeline/stages/seed.py
@@ -31,7 +31,6 @@ from questfoundry.agents import (
 )
 from questfoundry.export.i18n import get_output_language_instruction
 from questfoundry.graph import Graph
-from questfoundry.graph.brainstorm_validation import validate_brainstorm_output
 from questfoundry.graph.context import strip_scope_prefix
 from questfoundry.graph.mutations import format_semantic_errors_as_content
 from questfoundry.graph.seed_pruning import compute_arc_count, prune_to_arc_limit
@@ -295,15 +294,17 @@ class SeedStage:
         total_tokens = 0
 
         # Load the graph once and reuse it for both the entry validation
-        # and the brainstorm-context build. The serialize-time graph load
-        # below is intentionally separate — it happens after a long
-        # discuss/summarize loop and may need to see fresh on-disk state.
+        # and the brainstorm-context build.
         graph = Graph.load(resolved_path)
 
         # BRAINSTORM Stage Output Contract: validate the upstream artifact
         # before SEED phases consume it. Catches missing entities,
         # incomplete dilemmas, and other contract violations at the seam
-        # rather than at the downstream-failure site (#1347).
+        # rather than at the downstream-failure site (#1347). The deferred
+        # local import matches the pattern used by GROW/FILL/DRESS/SHIP
+        # entry validators so test bypass uses an autouse fixture.
+        from questfoundry.graph.brainstorm_validation import validate_brainstorm_output
+
         entry_errors = validate_brainstorm_output(graph)
         if entry_errors:
             raise SeedStageError(

--- a/src/questfoundry/pipeline/stages/ship.py
+++ b/src/questfoundry/pipeline/stages/ship.py
@@ -82,21 +82,29 @@ class ShipStage:
         # Load graph
         graph = Graph.load(self._project_path)
 
-        # Validate passages have prose
+        # SHIP entry contract validation (#1347). Replaces the previous
+        # ad-hoc "passages have prose" check, which was a FILL-contract
+        # concern incorrectly checked at the DRESS→SHIP seam.
+        #
+        # We run BOTH validators because DRESS may have been skipped
+        # entirely (DRESS Output-10): validate_dress_output is
+        # permissive in that case, so we still need validate_fill_output
+        # to confirm prose presence and Voice Document completeness for
+        # opt-out projects.
+        from questfoundry.graph.dress_output_validation import validate_dress_output
+        from questfoundry.graph.fill_output_validation import validate_fill_output
+
+        entry_errors: list[str] = []
+        entry_errors.extend(validate_fill_output(graph))
+        entry_errors.extend(validate_dress_output(graph))
+        if entry_errors:
+            raise ShipStageError(
+                f"Pre-SHIP contract validation failed ({len(entry_errors)} "
+                f"error(s)):\n" + "\n".join(f"  - {e}" for e in entry_errors)
+            )
         passages = graph.get_nodes_by_type("passage")
         if not passages:
             raise ShipStageError("Graph contains no passages — nothing to export.")
-
-        missing_prose = [
-            pid
-            for pid, data in passages.items()
-            if not data.get("prose") or not str(data["prose"]).strip()
-        ]
-        if missing_prose:
-            raise ShipStageError(
-                f"{len(missing_prose)} passage(s) missing prose. "
-                f"Run FILL stage first. Examples: {missing_prose[:3]}"
-            )
 
         # Get story title and language from config
         voice = graph.get_node("voice::voice")

--- a/src/questfoundry/pipeline/stages/ship.py
+++ b/src/questfoundry/pipeline/stages/ship.py
@@ -102,9 +102,6 @@ class ShipStage:
                 f"Pre-SHIP contract validation failed ({len(entry_errors)} "
                 f"error(s)):\n" + "\n".join(f"  - {e}" for e in entry_errors)
             )
-        passages = graph.get_nodes_by_type("passage")
-        if not passages:
-            raise ShipStageError("Graph contains no passages — nothing to export.")
 
         # Get story title and language from config
         voice = graph.get_node("voice::voice")

--- a/tests/unit/test_contract_chaining.py
+++ b/tests/unit/test_contract_chaining.py
@@ -1,0 +1,228 @@
+"""Contract-chaining seam tests (#1346 / #1347 / #1348).
+
+Confirms that each stage exit and adjacent stage entry actually invokes
+the validate_<stage>_output() helper, halts loudly on contract violations
+with the right exception type, and lets clean inputs through.
+
+Per-stage tests bypass these validators with autouse fixtures so they can
+focus on stage mechanics. THIS file is where the seams themselves are
+tested — the contract-chaining audit's whole purpose was to prove that a
+malformed upstream artifact cannot silently flow downstream.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from unittest.mock import MagicMock
+
+import pytest
+
+from questfoundry.graph.dress_output_validation import validate_dress_output
+from questfoundry.graph.fill_output_validation import validate_fill_output
+from questfoundry.graph.graph import Graph
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+# ---------------------------------------------------------------------------
+# validate_fill_output (helper, called at FILL exit + DRESS entry + SHIP entry)
+# ---------------------------------------------------------------------------
+
+
+class TestValidateFillOutput:
+    def test_empty_graph_flags_voice_and_passages(self) -> None:
+        errors = validate_fill_output(Graph.empty())
+        assert any("Voice Document" in e for e in errors)
+        assert any("at least one Passage" in e for e in errors)
+
+    def test_voice_present_but_missing_required_field(self) -> None:
+        g = Graph.empty()
+        g.create_node(
+            "voice::voice",
+            {
+                "type": "voice",
+                "raw_id": "voice",
+                # tense omitted
+                "pov": "third_limited",
+                "voice_register": "literary",
+                "sentence_rhythm": "varied",
+                "tone_words": ["wry"],
+            },
+        )
+        g.create_node("passage::p1", {"type": "passage", "raw_id": "p1", "prose": "x"})
+        errors = validate_fill_output(g)
+        assert any("missing required field(s): tense" in e for e in errors)
+
+    def test_passage_with_blank_prose_flagged(self) -> None:
+        g = Graph.empty()
+        _add_minimal_voice(g)
+        g.create_node("passage::p1", {"type": "passage", "raw_id": "p1", "prose": "   "})
+        errors = validate_fill_output(g)
+        assert any("without prose" in e for e in errors)
+
+    def test_clean_graph_passes(self) -> None:
+        g = Graph.empty()
+        _add_minimal_voice(g)
+        g.create_node("passage::p1", {"type": "passage", "raw_id": "p1", "prose": "Hello."})
+        assert validate_fill_output(g) == []
+
+
+# ---------------------------------------------------------------------------
+# validate_dress_output (helper, called at DRESS exit + SHIP entry)
+# ---------------------------------------------------------------------------
+
+
+class TestValidateDressOutput:
+    def test_no_art_direction_treated_as_dress_skipped(self) -> None:
+        """DRESS Output-10: opt-out projects skip the contract entirely."""
+        g = Graph.empty()
+        # No art_direction node → DRESS skipped → empty errors
+        assert validate_dress_output(g) == []
+
+    def test_appearing_entity_without_visual_flagged(self) -> None:
+        g = Graph.empty()
+        g.create_node(
+            "art_direction::main",
+            {"type": "art_direction", "style": "ink", "palette": ["x"]},
+        )
+        g.create_node("entity::mentor", {"type": "entity", "raw_id": "mentor"})
+        g.create_node("passage::p1", {"type": "passage", "raw_id": "p1"})
+        g.add_edge("appears", "entity::mentor", "passage::p1")
+        # No EntityVisual for mentor
+        errors = validate_dress_output(g)
+        assert any("entity_visual::mentor" in e and "missing" in e for e in errors)
+
+    def test_passage_without_brief_flagged(self) -> None:
+        g = Graph.empty()
+        g.create_node("art_direction::main", {"type": "art_direction"})
+        g.create_node("passage::p1", {"type": "passage", "raw_id": "p1"})
+        # No IllustrationBrief for p1
+        errors = validate_dress_output(g)
+        assert any("without an IllustrationBrief" in e for e in errors)
+
+    def test_entity_without_codex_flagged(self) -> None:
+        g = Graph.empty()
+        g.create_node("art_direction::main", {"type": "art_direction"})
+        g.create_node("entity::mentor", {"type": "entity", "raw_id": "mentor"})
+        # Add brief so Output-3 passes
+        errors = validate_dress_output(g)
+        assert any("without a CodexEntry" in e for e in errors)
+
+    def test_rank1_with_visible_when_flagged(self) -> None:
+        g = Graph.empty()
+        g.create_node("art_direction::main", {"type": "art_direction"})
+        g.create_node(
+            "codex::leak",
+            {"type": "codex_entry", "rank": 1, "visible_when": ["state_flag::met"]},
+        )
+        errors = validate_dress_output(g)
+        assert any("rank-1" in e and "visible_when" in e for e in errors)
+
+
+# ---------------------------------------------------------------------------
+# Stage entry seams: each stage rejects malformed upstream artifacts loudly
+# ---------------------------------------------------------------------------
+
+
+class TestSeedEntryRejectsBadBrainstorm:
+    """SEED entry calls validate_brainstorm_output (#1347)."""
+
+    @pytest.mark.asyncio
+    async def test_seed_raises_on_empty_brainstorm(self, tmp_path: Path) -> None:
+        from pathlib import Path as _P
+
+        from questfoundry.pipeline.stages.seed import SeedStage, SeedStageError
+
+        g = Graph.empty()
+        g.set_last_stage("brainstorm")
+        g.save(tmp_path / "graph.db")
+
+        stage = SeedStage(project_path=tmp_path)
+        with pytest.raises(SeedStageError, match="BRAINSTORM output validation failed"):
+            await stage.execute(model=MagicMock(), user_prompt="x", project_path=_P(tmp_path))
+
+
+class TestGrowEntryRejectsBadSeed:
+    """GROW entry calls validate_seed_output (#1347)."""
+
+    @pytest.mark.asyncio
+    async def test_grow_raises_on_empty_seed(self, tmp_path: Path) -> None:
+        from questfoundry.pipeline.stages.grow import GrowStage, GrowStageError
+
+        g = Graph.empty()
+        g.set_last_stage("seed")  # but no paths/beats/entities → SEED contract violated
+        g.save(tmp_path / "graph.db")
+
+        stage = GrowStage(project_path=tmp_path)
+        with pytest.raises(GrowStageError, match="SEED output validation failed"):
+            await stage.execute(model=MagicMock(), user_prompt="x")
+
+
+class TestFillEntryRejectsBadPolish:
+    """FILL entry calls validate_polish_output (#1347)."""
+
+    @pytest.mark.asyncio
+    async def test_fill_raises_on_empty_polish(self, tmp_path: Path) -> None:
+        from questfoundry.pipeline.stages.fill import FillStage, FillStageError
+
+        g = Graph.empty()
+        g.set_last_stage("polish")  # but no passages → POLISH contract violated
+        g.save(tmp_path / "graph.db")
+
+        stage = FillStage(project_path=tmp_path)
+        with pytest.raises(FillStageError, match="POLISH output validation failed"):
+            await stage.execute(model=MagicMock(), user_prompt="x")
+
+
+class TestDressEntryRejectsBadFill:
+    """DRESS entry calls validate_fill_output (#1347)."""
+
+    @pytest.mark.asyncio
+    async def test_dress_raises_on_empty_fill(self, tmp_path: Path) -> None:
+        from questfoundry.pipeline.stages.dress import DressStage, DressStageError
+
+        g = Graph.empty()
+        g.set_last_stage("fill")  # but no voice/passages → FILL contract violated
+        g.save(tmp_path / "graph.db")
+
+        stage = DressStage(project_path=tmp_path)
+        with pytest.raises(DressStageError, match="FILL output validation failed"):
+            await stage.execute(model=MagicMock(), user_prompt="x")
+
+
+class TestShipEntryRejectsBadUpstream:
+    """SHIP entry runs both validate_fill_output and validate_dress_output (#1347)."""
+
+    def test_ship_raises_on_empty_fill(self, tmp_path: Path) -> None:
+        from questfoundry.pipeline.stages.ship import ShipStage, ShipStageError
+
+        project = tmp_path / "story"
+        project.mkdir()
+        g = Graph()
+        g.save(project / "graph.db")
+
+        stage = ShipStage(project)
+        with pytest.raises(ShipStageError, match="Pre-SHIP contract validation failed"):
+            stage.execute()
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _add_minimal_voice(g: Graph) -> None:
+    """Voice Document satisfying validate_fill_output's required-field set."""
+    g.create_node(
+        "voice::voice",
+        {
+            "type": "voice",
+            "raw_id": "voice",
+            "pov": "third_limited",
+            "tense": "past",
+            "voice_register": "literary",
+            "sentence_rhythm": "varied",
+            "tone_words": ["wry"],
+        },
+    )

--- a/tests/unit/test_contract_chaining.py
+++ b/tests/unit/test_contract_chaining.py
@@ -105,7 +105,9 @@ class TestValidateDressOutput:
         g = Graph.empty()
         g.create_node("art_direction::main", {"type": "art_direction"})
         g.create_node("entity::mentor", {"type": "entity", "raw_id": "mentor"})
-        # Add brief so Output-3 passes
+        # No passages → Output-3 is vacuously satisfied (no passages →
+        # no missing-brief check fires), so this assertion isolates the
+        # Output-5 (missing CodexEntry) error.
         errors = validate_dress_output(g)
         assert any("without a CodexEntry" in e for e in errors)
 

--- a/tests/unit/test_dress_stage.py
+++ b/tests/unit/test_dress_stage.py
@@ -123,6 +123,25 @@ def mock_phase0_output() -> DressPhase0Output:
     )
 
 
+@pytest.fixture(autouse=True)
+def _bypass_seam_validators(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Bypass DRESS's new FILL-output entry validator (#1347) and the
+    DRESS-output exit validator (#1348) for all tests in this file.
+    Test fixtures use minimal FILL graphs that don't satisfy the full
+    contracts; the seam-validation integration is exercised in
+    test_contract_chaining.py instead.
+    """
+    from questfoundry.graph import (
+        dress_output_validation as _dov,
+    )
+    from questfoundry.graph import (
+        fill_output_validation as _fov,
+    )
+
+    monkeypatch.setattr(_fov, "validate_fill_output", lambda _g: [])
+    monkeypatch.setattr(_dov, "validate_dress_output", lambda _g: [])
+
+
 # ---------------------------------------------------------------------------
 # Stage basics
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_fill_stage.py
+++ b/tests/unit/test_fill_stage.py
@@ -51,6 +51,25 @@ def mock_model() -> MagicMock:
     return MagicMock()
 
 
+@pytest.fixture(autouse=True)
+def _bypass_seam_validators(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Bypass FILL's new POLISH-output entry validator (#1347) and the
+    FILL-output exit validator (#1348) for all tests in this file. The
+    test fixtures use minimal POLISH graphs that don't satisfy the full
+    contracts on either side; the contract-chaining integration is
+    exercised in test_contract_chaining.py instead.
+    """
+    from questfoundry.graph import (
+        fill_output_validation as _fov,
+    )
+    from questfoundry.graph import (
+        polish_validation as _pv,
+    )
+
+    monkeypatch.setattr(_pv, "validate_polish_output", lambda _g: [])
+    monkeypatch.setattr(_fov, "validate_fill_output", lambda _g: [])
+
+
 class TestFillStageInit:
     def test_default_gate(self) -> None:
         stage = FillStage()

--- a/tests/unit/test_grow_algorithms.py
+++ b/tests/unit/test_grow_algorithms.py
@@ -2801,14 +2801,19 @@ class TestPhaseIntegrationEndToEnd:
         # validation so these tests exercise phase wiring rather than
         # contract compliance of the fixture graphs.
         #
-        # Two patches are needed:
+        # Three patches are needed:
         #  1. validate_grow_output — the exit-contract check in stage.execute()
-        #  2. run_all_checks — called by GROW's internal "validation" phase
+        #  2. validate_seed_output — the new entry-contract check (#1347)
+        #  3. run_all_checks — called by GROW's internal "validation" phase
         import questfoundry.pipeline.stages.grow.stage as grow_stage_mod
-        from questfoundry.graph import grow_validation as grow_validation
+        from questfoundry.graph import (
+            grow_validation,
+            seed_validation,
+        )
         from questfoundry.graph.grow_validation import ValidationCheck, ValidationReport
 
         monkeypatch.setattr(grow_stage_mod, "validate_grow_output", lambda _graph: [])
+        monkeypatch.setattr(seed_validation, "validate_seed_output", lambda _graph: [])
 
         def _mock_run_all_checks(_graph: Graph) -> ValidationReport:
             return ValidationReport(

--- a/tests/unit/test_grow_stage.py
+++ b/tests/unit/test_grow_stage.py
@@ -31,6 +31,20 @@ def tmp_project(tmp_path: Path) -> Path:
     return tmp_path
 
 
+@pytest.fixture(autouse=True)
+def _bypass_seed_entry_validator(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Bypass GROW's new SEED-output entry validator for all tests in this
+    file. ``tmp_project`` deliberately ships an empty SEED graph (no
+    paths/beats/entities) so the new contract enforcement at the
+    BRAINSTORM→SEED→GROW seam (#1347) would reject every test. The
+    integration of validate_seed_output is exercised in dedicated
+    tests in ``test_contract_chaining.py`` instead.
+    """
+    from questfoundry.graph import seed_validation as _sv
+
+    monkeypatch.setattr(_sv, "validate_seed_output", lambda _g: [])
+
+
 @pytest.fixture
 def mock_model() -> MagicMock:
     """Create a mock LLM model (unused by GROW but required by protocol)."""
@@ -69,9 +83,13 @@ class TestGrowStageExecute:
     async def test_execute_runs_all_phases(
         self, tmp_project: Path, mock_model: MagicMock, monkeypatch: pytest.MonkeyPatch
     ) -> None:
+        import questfoundry.graph.seed_validation as seed_val_mod
         import questfoundry.pipeline.stages.grow.stage as grow_stage_mod
 
         monkeypatch.setattr(grow_stage_mod, "validate_grow_output", lambda _g: [])
+        # Bypass the SEED-output entry validator (#1347) the same way:
+        # tmp_project's empty SEED graph won't satisfy the contract.
+        monkeypatch.setattr(seed_val_mod, "validate_seed_output", lambda _g: [])
         stage = GrowStage(project_path=tmp_project)
         result_dict, llm_calls, tokens = await stage.execute(model=mock_model, user_prompt="")
         assert llm_calls == 0

--- a/tests/unit/test_grow_stage.py
+++ b/tests/unit/test_grow_stage.py
@@ -83,13 +83,12 @@ class TestGrowStageExecute:
     async def test_execute_runs_all_phases(
         self, tmp_project: Path, mock_model: MagicMock, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        import questfoundry.graph.seed_validation as seed_val_mod
         import questfoundry.pipeline.stages.grow.stage as grow_stage_mod
 
+        # SEED entry validator already bypassed by the autouse
+        # _bypass_seed_entry_validator fixture; only the GROW exit
+        # validator needs per-test patching here.
         monkeypatch.setattr(grow_stage_mod, "validate_grow_output", lambda _g: [])
-        # Bypass the SEED-output entry validator (#1347) the same way:
-        # tmp_project's empty SEED graph won't satisfy the contract.
-        monkeypatch.setattr(seed_val_mod, "validate_seed_output", lambda _g: [])
         stage = GrowStage(project_path=tmp_project)
         result_dict, llm_calls, tokens = await stage.execute(model=mock_model, user_prompt="")
         assert llm_calls == 0

--- a/tests/unit/test_seed_stage.py
+++ b/tests/unit/test_seed_stage.py
@@ -68,7 +68,13 @@ async def test_execute_requires_brainstorm_in_graph() -> None:
     ):
         MockGraph.load.return_value = mock_graph
 
-        with pytest.raises(SeedStageError, match="SEED requires BRAINSTORM"):
+        # Now caught by the BRAINSTORM-output entry validator (#1347)
+        # rather than the legacy "SEED requires BRAINSTORM" sentinel,
+        # but the upshot is identical: SEED refuses to run on an empty
+        # graph.
+        with pytest.raises(
+            SeedStageError, match=r"BRAINSTORM output validation failed|SEED requires BRAINSTORM"
+        ):
             await stage.execute(
                 model=mock_model,
                 user_prompt="test",
@@ -94,6 +100,11 @@ async def test_execute_calls_all_three_phases() -> None:
 
     with (
         patch("questfoundry.pipeline.stages.seed.Graph") as MockGraph,
+        # Bypass the BRAINSTORM-output entry validator (#1347): the mock
+        # graph in this test isn't structurally rich enough to satisfy
+        # the real validator, and the test exists to exercise SEED's
+        # phase calls, not the seam-validation logic.
+        patch("questfoundry.pipeline.stages.seed.validate_brainstorm_output", return_value=[]),
         patch("questfoundry.pipeline.stages.seed.run_discuss_phase") as mock_discuss,
         patch("questfoundry.pipeline.stages.seed.summarize_seed_chunked") as mock_summarize,
         patch("questfoundry.pipeline.stages.seed.serialize_seed_as_function") as mock_serialize,
@@ -185,6 +196,11 @@ async def test_execute_emits_phase_progress() -> None:
 
     with (
         patch("questfoundry.pipeline.stages.seed.Graph") as MockGraph,
+        # Bypass the BRAINSTORM-output entry validator (#1347): mock
+        # graphs in this file are too thin for the real validator;
+        # SEED behavioural tests use simplified fixtures, not full
+        # contract-compliant ones.
+        patch("questfoundry.pipeline.stages.seed.validate_brainstorm_output", return_value=[]),
         patch("questfoundry.pipeline.stages.seed.run_discuss_phase") as mock_discuss,
         patch("questfoundry.pipeline.stages.seed.summarize_seed_chunked") as mock_summarize,
         patch("questfoundry.pipeline.stages.seed.serialize_seed_as_function") as mock_serialize,
@@ -235,6 +251,11 @@ async def test_execute_passes_brainstorm_context_to_discuss() -> None:
 
     with (
         patch("questfoundry.pipeline.stages.seed.Graph") as MockGraph,
+        # Bypass the BRAINSTORM-output entry validator (#1347): mock
+        # graphs in this file are too thin for the real validator;
+        # SEED behavioural tests use simplified fixtures, not full
+        # contract-compliant ones.
+        patch("questfoundry.pipeline.stages.seed.validate_brainstorm_output", return_value=[]),
         patch("questfoundry.pipeline.stages.seed.run_discuss_phase") as mock_discuss,
         patch("questfoundry.pipeline.stages.seed.summarize_seed_chunked") as mock_summarize,
         patch("questfoundry.pipeline.stages.seed.serialize_seed_as_function") as mock_serialize,
@@ -280,6 +301,11 @@ async def test_execute_uses_iterative_serialization() -> None:
 
     with (
         patch("questfoundry.pipeline.stages.seed.Graph") as MockGraph,
+        # Bypass the BRAINSTORM-output entry validator (#1347): mock
+        # graphs in this file are too thin for the real validator;
+        # SEED behavioural tests use simplified fixtures, not full
+        # contract-compliant ones.
+        patch("questfoundry.pipeline.stages.seed.validate_brainstorm_output", return_value=[]),
         patch("questfoundry.pipeline.stages.seed.run_discuss_phase") as mock_discuss,
         patch("questfoundry.pipeline.stages.seed.summarize_seed_chunked") as mock_summarize,
         patch("questfoundry.pipeline.stages.seed.serialize_seed_as_function") as mock_serialize,
@@ -320,6 +346,11 @@ async def test_execute_passes_graph_to_chunked_summarize() -> None:
 
     with (
         patch("questfoundry.pipeline.stages.seed.Graph") as MockGraph,
+        # Bypass the BRAINSTORM-output entry validator (#1347): mock
+        # graphs in this file are too thin for the real validator;
+        # SEED behavioural tests use simplified fixtures, not full
+        # contract-compliant ones.
+        patch("questfoundry.pipeline.stages.seed.validate_brainstorm_output", return_value=[]),
         patch("questfoundry.pipeline.stages.seed.run_discuss_phase") as mock_discuss,
         patch("questfoundry.pipeline.stages.seed.summarize_seed_chunked") as mock_summarize,
         patch("questfoundry.pipeline.stages.seed.serialize_seed_as_function") as mock_serialize,
@@ -362,6 +393,11 @@ async def test_execute_returns_artifact_as_dict() -> None:
 
     with (
         patch("questfoundry.pipeline.stages.seed.Graph") as MockGraph,
+        # Bypass the BRAINSTORM-output entry validator (#1347): mock
+        # graphs in this file are too thin for the real validator;
+        # SEED behavioural tests use simplified fixtures, not full
+        # contract-compliant ones.
+        patch("questfoundry.pipeline.stages.seed.validate_brainstorm_output", return_value=[]),
         patch("questfoundry.pipeline.stages.seed.run_discuss_phase") as mock_discuss,
         patch("questfoundry.pipeline.stages.seed.summarize_seed_chunked") as mock_summarize,
         patch("questfoundry.pipeline.stages.seed.serialize_seed_as_function") as mock_serialize,
@@ -580,6 +616,11 @@ async def test_outer_loop_retries_on_semantic_errors() -> None:
 
     with (
         patch("questfoundry.pipeline.stages.seed.Graph") as MockGraph,
+        # Bypass the BRAINSTORM-output entry validator (#1347): mock
+        # graphs in this file are too thin for the real validator;
+        # SEED behavioural tests use simplified fixtures, not full
+        # contract-compliant ones.
+        patch("questfoundry.pipeline.stages.seed.validate_brainstorm_output", return_value=[]),
         patch("questfoundry.pipeline.stages.seed.run_discuss_phase") as mock_discuss,
         patch("questfoundry.pipeline.stages.seed.summarize_seed_chunked") as mock_summarize,
         patch("questfoundry.pipeline.stages.seed.serialize_seed_as_function") as mock_serialize,
@@ -648,6 +689,11 @@ async def test_outer_loop_appends_feedback_to_messages() -> None:
 
     with (
         patch("questfoundry.pipeline.stages.seed.Graph") as MockGraph,
+        # Bypass the BRAINSTORM-output entry validator (#1347): mock
+        # graphs in this file are too thin for the real validator;
+        # SEED behavioural tests use simplified fixtures, not full
+        # contract-compliant ones.
+        patch("questfoundry.pipeline.stages.seed.validate_brainstorm_output", return_value=[]),
         patch("questfoundry.pipeline.stages.seed.run_discuss_phase") as mock_discuss,
         patch("questfoundry.pipeline.stages.seed.summarize_seed_chunked") as mock_summarize,
         patch("questfoundry.pipeline.stages.seed.serialize_seed_as_function") as mock_serialize,
@@ -711,6 +757,11 @@ async def test_outer_loop_respects_max_retries() -> None:
 
     with (
         patch("questfoundry.pipeline.stages.seed.Graph") as MockGraph,
+        # Bypass the BRAINSTORM-output entry validator (#1347): mock
+        # graphs in this file are too thin for the real validator;
+        # SEED behavioural tests use simplified fixtures, not full
+        # contract-compliant ones.
+        patch("questfoundry.pipeline.stages.seed.validate_brainstorm_output", return_value=[]),
         patch("questfoundry.pipeline.stages.seed.run_discuss_phase") as mock_discuss,
         patch("questfoundry.pipeline.stages.seed.summarize_seed_chunked") as mock_summarize,
         patch("questfoundry.pipeline.stages.seed.serialize_seed_as_function") as mock_serialize,
@@ -767,6 +818,11 @@ async def test_outer_loop_exhaustion_skips_convergence_analysis() -> None:
 
     with (
         patch("questfoundry.pipeline.stages.seed.Graph") as MockGraph,
+        # Bypass the BRAINSTORM-output entry validator (#1347): mock
+        # graphs in this file are too thin for the real validator;
+        # SEED behavioural tests use simplified fixtures, not full
+        # contract-compliant ones.
+        patch("questfoundry.pipeline.stages.seed.validate_brainstorm_output", return_value=[]),
         patch("questfoundry.pipeline.stages.seed.run_discuss_phase") as mock_discuss,
         patch("questfoundry.pipeline.stages.seed.summarize_seed_chunked") as mock_summarize,
         patch("questfoundry.pipeline.stages.seed.serialize_seed_as_function") as mock_serialize,
@@ -810,6 +866,11 @@ async def test_outer_loop_success_on_first_try() -> None:
 
     with (
         patch("questfoundry.pipeline.stages.seed.Graph") as MockGraph,
+        # Bypass the BRAINSTORM-output entry validator (#1347): mock
+        # graphs in this file are too thin for the real validator;
+        # SEED behavioural tests use simplified fixtures, not full
+        # contract-compliant ones.
+        patch("questfoundry.pipeline.stages.seed.validate_brainstorm_output", return_value=[]),
         patch("questfoundry.pipeline.stages.seed.run_discuss_phase") as mock_discuss,
         patch("questfoundry.pipeline.stages.seed.summarize_seed_chunked") as mock_summarize,
         patch("questfoundry.pipeline.stages.seed.serialize_seed_as_function") as mock_serialize,
@@ -859,6 +920,11 @@ async def test_low_arc_count_raises_seed_stage_error() -> None:
 
     with (
         patch("questfoundry.pipeline.stages.seed.Graph") as MockGraph,
+        # Bypass the BRAINSTORM-output entry validator (#1347): mock
+        # graphs in this file are too thin for the real validator;
+        # SEED behavioural tests use simplified fixtures, not full
+        # contract-compliant ones.
+        patch("questfoundry.pipeline.stages.seed.validate_brainstorm_output", return_value=[]),
         patch("questfoundry.pipeline.stages.seed.run_discuss_phase") as mock_discuss,
         patch("questfoundry.pipeline.stages.seed.summarize_seed_chunked") as mock_summarize,
         patch("questfoundry.pipeline.stages.seed.serialize_seed_as_function") as mock_serialize,
@@ -911,6 +977,11 @@ async def _run_seed_execute(stage: SeedStage, mock_artifact: SeedOutput, **execu
     mock_graph = _build_mock_graph_with_data()
     with (
         patch("questfoundry.pipeline.stages.seed.Graph") as MockGraph,
+        # Bypass the BRAINSTORM-output entry validator (#1347): mock
+        # graphs in this file are too thin for the real validator;
+        # SEED behavioural tests use simplified fixtures, not full
+        # contract-compliant ones.
+        patch("questfoundry.pipeline.stages.seed.validate_brainstorm_output", return_value=[]),
         patch("questfoundry.pipeline.stages.seed.run_discuss_phase") as mock_discuss,
         patch("questfoundry.pipeline.stages.seed.summarize_seed_chunked") as mock_summarize,
         patch("questfoundry.pipeline.stages.seed.serialize_seed_as_function") as mock_serialize,

--- a/tests/unit/test_seed_stage.py
+++ b/tests/unit/test_seed_stage.py
@@ -43,6 +43,21 @@ def test_seed_stage_name() -> None:
 # --- Execute Tests ---
 
 
+@pytest.fixture(autouse=True)
+def _bypass_brainstorm_entry_validator(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Bypass SEED's BRAINSTORM-output entry validator (#1347) for all
+    tests in this file. Test fixtures use thin mock graphs that don't
+    satisfy the full BRAINSTORM contract; the seam-validation
+    integration is exercised in test_contract_chaining.py instead.
+
+    Patches the source module so the deferred local import inside
+    ``SeedStage.execute()`` picks up the bypassed version at call time.
+    """
+    from questfoundry.graph import brainstorm_validation as _bv
+
+    monkeypatch.setattr(_bv, "validate_brainstorm_output", lambda _g: [])
+
+
 @pytest.mark.asyncio
 async def test_execute_requires_project_path() -> None:
     """Execute raises error when project_path is not provided."""
@@ -100,11 +115,8 @@ async def test_execute_calls_all_three_phases() -> None:
 
     with (
         patch("questfoundry.pipeline.stages.seed.Graph") as MockGraph,
-        # Bypass the BRAINSTORM-output entry validator (#1347): the mock
-        # graph in this test isn't structurally rich enough to satisfy
-        # the real validator, and the test exists to exercise SEED's
-        # phase calls, not the seam-validation logic.
-        patch("questfoundry.pipeline.stages.seed.validate_brainstorm_output", return_value=[]),
+        # BRAINSTORM-output entry validator bypass is provided by the
+        # autouse _bypass_brainstorm_entry_validator fixture above.
         patch("questfoundry.pipeline.stages.seed.run_discuss_phase") as mock_discuss,
         patch("questfoundry.pipeline.stages.seed.summarize_seed_chunked") as mock_summarize,
         patch("questfoundry.pipeline.stages.seed.serialize_seed_as_function") as mock_serialize,
@@ -196,11 +208,8 @@ async def test_execute_emits_phase_progress() -> None:
 
     with (
         patch("questfoundry.pipeline.stages.seed.Graph") as MockGraph,
-        # Bypass the BRAINSTORM-output entry validator (#1347): mock
-        # graphs in this file are too thin for the real validator;
-        # SEED behavioural tests use simplified fixtures, not full
-        # contract-compliant ones.
-        patch("questfoundry.pipeline.stages.seed.validate_brainstorm_output", return_value=[]),
+        # BRAINSTORM-output entry validator bypass is provided by the
+        # autouse _bypass_brainstorm_entry_validator fixture above.
         patch("questfoundry.pipeline.stages.seed.run_discuss_phase") as mock_discuss,
         patch("questfoundry.pipeline.stages.seed.summarize_seed_chunked") as mock_summarize,
         patch("questfoundry.pipeline.stages.seed.serialize_seed_as_function") as mock_serialize,
@@ -251,11 +260,8 @@ async def test_execute_passes_brainstorm_context_to_discuss() -> None:
 
     with (
         patch("questfoundry.pipeline.stages.seed.Graph") as MockGraph,
-        # Bypass the BRAINSTORM-output entry validator (#1347): mock
-        # graphs in this file are too thin for the real validator;
-        # SEED behavioural tests use simplified fixtures, not full
-        # contract-compliant ones.
-        patch("questfoundry.pipeline.stages.seed.validate_brainstorm_output", return_value=[]),
+        # BRAINSTORM-output entry validator bypass is provided by the
+        # autouse _bypass_brainstorm_entry_validator fixture above.
         patch("questfoundry.pipeline.stages.seed.run_discuss_phase") as mock_discuss,
         patch("questfoundry.pipeline.stages.seed.summarize_seed_chunked") as mock_summarize,
         patch("questfoundry.pipeline.stages.seed.serialize_seed_as_function") as mock_serialize,
@@ -301,11 +307,8 @@ async def test_execute_uses_iterative_serialization() -> None:
 
     with (
         patch("questfoundry.pipeline.stages.seed.Graph") as MockGraph,
-        # Bypass the BRAINSTORM-output entry validator (#1347): mock
-        # graphs in this file are too thin for the real validator;
-        # SEED behavioural tests use simplified fixtures, not full
-        # contract-compliant ones.
-        patch("questfoundry.pipeline.stages.seed.validate_brainstorm_output", return_value=[]),
+        # BRAINSTORM-output entry validator bypass is provided by the
+        # autouse _bypass_brainstorm_entry_validator fixture above.
         patch("questfoundry.pipeline.stages.seed.run_discuss_phase") as mock_discuss,
         patch("questfoundry.pipeline.stages.seed.summarize_seed_chunked") as mock_summarize,
         patch("questfoundry.pipeline.stages.seed.serialize_seed_as_function") as mock_serialize,
@@ -346,11 +349,8 @@ async def test_execute_passes_graph_to_chunked_summarize() -> None:
 
     with (
         patch("questfoundry.pipeline.stages.seed.Graph") as MockGraph,
-        # Bypass the BRAINSTORM-output entry validator (#1347): mock
-        # graphs in this file are too thin for the real validator;
-        # SEED behavioural tests use simplified fixtures, not full
-        # contract-compliant ones.
-        patch("questfoundry.pipeline.stages.seed.validate_brainstorm_output", return_value=[]),
+        # BRAINSTORM-output entry validator bypass is provided by the
+        # autouse _bypass_brainstorm_entry_validator fixture above.
         patch("questfoundry.pipeline.stages.seed.run_discuss_phase") as mock_discuss,
         patch("questfoundry.pipeline.stages.seed.summarize_seed_chunked") as mock_summarize,
         patch("questfoundry.pipeline.stages.seed.serialize_seed_as_function") as mock_serialize,
@@ -393,11 +393,8 @@ async def test_execute_returns_artifact_as_dict() -> None:
 
     with (
         patch("questfoundry.pipeline.stages.seed.Graph") as MockGraph,
-        # Bypass the BRAINSTORM-output entry validator (#1347): mock
-        # graphs in this file are too thin for the real validator;
-        # SEED behavioural tests use simplified fixtures, not full
-        # contract-compliant ones.
-        patch("questfoundry.pipeline.stages.seed.validate_brainstorm_output", return_value=[]),
+        # BRAINSTORM-output entry validator bypass is provided by the
+        # autouse _bypass_brainstorm_entry_validator fixture above.
         patch("questfoundry.pipeline.stages.seed.run_discuss_phase") as mock_discuss,
         patch("questfoundry.pipeline.stages.seed.summarize_seed_chunked") as mock_summarize,
         patch("questfoundry.pipeline.stages.seed.serialize_seed_as_function") as mock_serialize,
@@ -616,11 +613,8 @@ async def test_outer_loop_retries_on_semantic_errors() -> None:
 
     with (
         patch("questfoundry.pipeline.stages.seed.Graph") as MockGraph,
-        # Bypass the BRAINSTORM-output entry validator (#1347): mock
-        # graphs in this file are too thin for the real validator;
-        # SEED behavioural tests use simplified fixtures, not full
-        # contract-compliant ones.
-        patch("questfoundry.pipeline.stages.seed.validate_brainstorm_output", return_value=[]),
+        # BRAINSTORM-output entry validator bypass is provided by the
+        # autouse _bypass_brainstorm_entry_validator fixture above.
         patch("questfoundry.pipeline.stages.seed.run_discuss_phase") as mock_discuss,
         patch("questfoundry.pipeline.stages.seed.summarize_seed_chunked") as mock_summarize,
         patch("questfoundry.pipeline.stages.seed.serialize_seed_as_function") as mock_serialize,
@@ -689,11 +683,8 @@ async def test_outer_loop_appends_feedback_to_messages() -> None:
 
     with (
         patch("questfoundry.pipeline.stages.seed.Graph") as MockGraph,
-        # Bypass the BRAINSTORM-output entry validator (#1347): mock
-        # graphs in this file are too thin for the real validator;
-        # SEED behavioural tests use simplified fixtures, not full
-        # contract-compliant ones.
-        patch("questfoundry.pipeline.stages.seed.validate_brainstorm_output", return_value=[]),
+        # BRAINSTORM-output entry validator bypass is provided by the
+        # autouse _bypass_brainstorm_entry_validator fixture above.
         patch("questfoundry.pipeline.stages.seed.run_discuss_phase") as mock_discuss,
         patch("questfoundry.pipeline.stages.seed.summarize_seed_chunked") as mock_summarize,
         patch("questfoundry.pipeline.stages.seed.serialize_seed_as_function") as mock_serialize,
@@ -757,11 +748,8 @@ async def test_outer_loop_respects_max_retries() -> None:
 
     with (
         patch("questfoundry.pipeline.stages.seed.Graph") as MockGraph,
-        # Bypass the BRAINSTORM-output entry validator (#1347): mock
-        # graphs in this file are too thin for the real validator;
-        # SEED behavioural tests use simplified fixtures, not full
-        # contract-compliant ones.
-        patch("questfoundry.pipeline.stages.seed.validate_brainstorm_output", return_value=[]),
+        # BRAINSTORM-output entry validator bypass is provided by the
+        # autouse _bypass_brainstorm_entry_validator fixture above.
         patch("questfoundry.pipeline.stages.seed.run_discuss_phase") as mock_discuss,
         patch("questfoundry.pipeline.stages.seed.summarize_seed_chunked") as mock_summarize,
         patch("questfoundry.pipeline.stages.seed.serialize_seed_as_function") as mock_serialize,
@@ -818,11 +806,8 @@ async def test_outer_loop_exhaustion_skips_convergence_analysis() -> None:
 
     with (
         patch("questfoundry.pipeline.stages.seed.Graph") as MockGraph,
-        # Bypass the BRAINSTORM-output entry validator (#1347): mock
-        # graphs in this file are too thin for the real validator;
-        # SEED behavioural tests use simplified fixtures, not full
-        # contract-compliant ones.
-        patch("questfoundry.pipeline.stages.seed.validate_brainstorm_output", return_value=[]),
+        # BRAINSTORM-output entry validator bypass is provided by the
+        # autouse _bypass_brainstorm_entry_validator fixture above.
         patch("questfoundry.pipeline.stages.seed.run_discuss_phase") as mock_discuss,
         patch("questfoundry.pipeline.stages.seed.summarize_seed_chunked") as mock_summarize,
         patch("questfoundry.pipeline.stages.seed.serialize_seed_as_function") as mock_serialize,
@@ -866,11 +851,8 @@ async def test_outer_loop_success_on_first_try() -> None:
 
     with (
         patch("questfoundry.pipeline.stages.seed.Graph") as MockGraph,
-        # Bypass the BRAINSTORM-output entry validator (#1347): mock
-        # graphs in this file are too thin for the real validator;
-        # SEED behavioural tests use simplified fixtures, not full
-        # contract-compliant ones.
-        patch("questfoundry.pipeline.stages.seed.validate_brainstorm_output", return_value=[]),
+        # BRAINSTORM-output entry validator bypass is provided by the
+        # autouse _bypass_brainstorm_entry_validator fixture above.
         patch("questfoundry.pipeline.stages.seed.run_discuss_phase") as mock_discuss,
         patch("questfoundry.pipeline.stages.seed.summarize_seed_chunked") as mock_summarize,
         patch("questfoundry.pipeline.stages.seed.serialize_seed_as_function") as mock_serialize,
@@ -920,11 +902,8 @@ async def test_low_arc_count_raises_seed_stage_error() -> None:
 
     with (
         patch("questfoundry.pipeline.stages.seed.Graph") as MockGraph,
-        # Bypass the BRAINSTORM-output entry validator (#1347): mock
-        # graphs in this file are too thin for the real validator;
-        # SEED behavioural tests use simplified fixtures, not full
-        # contract-compliant ones.
-        patch("questfoundry.pipeline.stages.seed.validate_brainstorm_output", return_value=[]),
+        # BRAINSTORM-output entry validator bypass is provided by the
+        # autouse _bypass_brainstorm_entry_validator fixture above.
         patch("questfoundry.pipeline.stages.seed.run_discuss_phase") as mock_discuss,
         patch("questfoundry.pipeline.stages.seed.summarize_seed_chunked") as mock_summarize,
         patch("questfoundry.pipeline.stages.seed.serialize_seed_as_function") as mock_serialize,
@@ -977,11 +956,8 @@ async def _run_seed_execute(stage: SeedStage, mock_artifact: SeedOutput, **execu
     mock_graph = _build_mock_graph_with_data()
     with (
         patch("questfoundry.pipeline.stages.seed.Graph") as MockGraph,
-        # Bypass the BRAINSTORM-output entry validator (#1347): mock
-        # graphs in this file are too thin for the real validator;
-        # SEED behavioural tests use simplified fixtures, not full
-        # contract-compliant ones.
-        patch("questfoundry.pipeline.stages.seed.validate_brainstorm_output", return_value=[]),
+        # BRAINSTORM-output entry validator bypass is provided by the
+        # autouse _bypass_brainstorm_entry_validator fixture above.
         patch("questfoundry.pipeline.stages.seed.run_discuss_phase") as mock_discuss,
         patch("questfoundry.pipeline.stages.seed.summarize_seed_chunked") as mock_summarize,
         patch("questfoundry.pipeline.stages.seed.serialize_seed_as_function") as mock_serialize,

--- a/tests/unit/test_ship_stage.py
+++ b/tests/unit/test_ship_stage.py
@@ -27,6 +27,22 @@ def _create_project_with_graph(project_path: Path, *, with_prose: bool = True) -
 
     # Build a graph with passages and choices
     g = Graph()
+    # Voice Document — FILL Output-1 (the SHIP entry validator now
+    # checks for it; older tests pre-dated that contract enforcement).
+    g.create_node(
+        "voice::voice",
+        {
+            "type": "voice",
+            "raw_id": "voice",
+            # No story_title — keeps the test_project_name_from_config
+            # path exercising the config-name fallback in ShipStage.execute.
+            "pov": "third_limited",
+            "tense": "past",
+            "voice_register": "literary",
+            "sentence_rhythm": "varied",
+            "tone_words": ["wry"],
+        },
+    )
     g.create_node(
         "passage::intro",
         {
@@ -186,7 +202,11 @@ class TestShipStage:
         project.mkdir(parents=True)
 
         stage = ShipStage(project)
-        with pytest.raises(ShipStageError, match="no passages"):
+        # The pre-SHIP entry contract surfaces this as a FILL Output-2
+        # violation (no passage means FILL didn't produce its required
+        # output) — same defensive intent as the previous "no passages"
+        # check, just attributed to the right contract.
+        with pytest.raises(ShipStageError, match=r"at least one Passage|no passages"):
             stage.execute()
 
     def test_missing_prose_raises(self, tmp_path: Path) -> None:
@@ -194,7 +214,7 @@ class TestShipStage:
         _create_project_with_graph(project, with_prose=False)
 
         stage = ShipStage(project)
-        with pytest.raises(ShipStageError, match="missing prose"):
+        with pytest.raises(ShipStageError, match=r"without prose|missing prose"):
             stage.execute()
 
     def test_empty_graph_raises(self, tmp_path: Path) -> None:
@@ -213,7 +233,7 @@ class TestShipStage:
         g.save(project / "graph.db")
 
         stage = ShipStage(project)
-        with pytest.raises(ShipStageError, match="no passages"):
+        with pytest.raises(ShipStageError, match=r"at least one Passage|no passages"):
             stage.execute()
 
     def test_unknown_format_raises(self, tmp_path: Path) -> None:
@@ -241,7 +261,7 @@ class TestShipStage:
         g.save(project / "graph.db")
 
         stage = ShipStage(project)
-        with pytest.raises(ShipStageError, match="missing prose"):
+        with pytest.raises(ShipStageError, match=r"without prose|missing prose"):
             stage.execute()
 
     def test_project_name_from_config(self, tmp_path: Path) -> None:
@@ -262,6 +282,20 @@ class TestShipStage:
         project.mkdir(parents=True, exist_ok=True)
 
         g = Graph()
+        # Voice Document satisfying FILL Output-1 (no story_title so the
+        # config-name fallback path is what's exercised).
+        g.create_node(
+            "voice::voice",
+            {
+                "type": "voice",
+                "raw_id": "voice",
+                "pov": "third_limited",
+                "tense": "past",
+                "voice_register": "literary",
+                "sentence_rhythm": "varied",
+                "tone_words": ["wry"],
+            },
+        )
         g.create_node("passage::intro", {"type": "passage", "raw_id": "intro", "prose": "Hello."})
         g.save(project / "graph.db")
 
@@ -278,12 +312,10 @@ class TestShipStage:
         project = tmp_path / "my-story"
         _create_project_with_graph(project)
 
-        # Add a voice node with a generated story title
+        # Replace the fixture's title-less voice node with one carrying
+        # a generated story_title so SHIP picks it up.
         g = Graph.load(project)
-        g.create_node(
-            "voice::voice",
-            {"type": "voice", "raw_id": "voice", "story_title": "The Hollow Crown"},
-        )
+        g.update_node("voice::voice", story_title="The Hollow Crown")
         g.save(project / "graph.db")
 
         stage = ShipStage(project)
@@ -299,9 +331,9 @@ class TestShipStage:
         project = tmp_path / "my-story"
         _create_project_with_graph(project)
 
-        # Voice node exists but without story_title
+        # Fixture already creates a voice node without story_title; SHIP
+        # falls back to the config name.
         g = Graph.load(project)
-        g.create_node("voice::voice", {"type": "voice", "raw_id": "voice"})
         g.save(project / "graph.db")
 
         stage = ShipStage(project)
@@ -318,7 +350,7 @@ class TestShipStage:
         _create_project_with_graph(project)
 
         g = Graph.load(project)
-        g.create_node("voice::voice", {"type": "voice", "raw_id": "voice", "story_title": None})
+        g.update_node("voice::voice", story_title=None)
         g.save(project / "graph.db")
 
         stage = ShipStage(project)

--- a/tests/unit/test_ship_stage.py
+++ b/tests/unit/test_ship_stage.py
@@ -206,7 +206,7 @@ class TestShipStage:
         # violation (no passage means FILL didn't produce its required
         # output) — same defensive intent as the previous "no passages"
         # check, just attributed to the right contract.
-        with pytest.raises(ShipStageError, match=r"at least one Passage|no passages"):
+        with pytest.raises(ShipStageError, match="at least one Passage"):
             stage.execute()
 
     def test_missing_prose_raises(self, tmp_path: Path) -> None:
@@ -233,7 +233,7 @@ class TestShipStage:
         g.save(project / "graph.db")
 
         stage = ShipStage(project)
-        with pytest.raises(ShipStageError, match=r"at least one Passage|no passages"):
+        with pytest.raises(ShipStageError, match="at least one Passage"):
             stage.execute()
 
     def test_unknown_format_raises(self, tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

PR G of the cross-cutting cleanup — final cluster of the spec-compliance audit (epic #1346).

Per the audit, only **1 of 7 seams** (GROW→POLISH) explicitly validated the upstream contract on both sides. The other 6 used a \`last_stage\` sentinel, a narrow node-existence check, or — for DRESS→SHIP — the wrong-stage check (\"passages have prose\" is FILL's contract, not DRESS's). Investigation showed exit validation was already in place for DREAM/BRAINSTORM/SEED inside \`apply_*_mutations\` and for GROW/POLISH; only **FILL and DRESS** lacked exit validators because no validator helper existed.

## What changed

### New validators (#1348)

| File | Checks |
|---|---|
| \`graph/fill_output_validation.py\` | Voice Document presence + required fields; per-Passage non-empty prose |
| \`graph/dress_output_validation.py\` | ArtDirection singleton; EntityVisual coverage; Passage→IllustrationBrief coverage; Entity→CodexEntry coverage; rank-1 \`visible_when\` emptiness. Permissive when DRESS was skipped entirely (Output-10) |

### Entry-side wiring (#1347)

| Seam | Validator | Exception |
|---|---|---|
| BRAINSTORM→SEED | \`validate_brainstorm_output\` | \`SeedStageError\` |
| SEED→GROW | \`validate_seed_output\` | \`GrowStageError\` |
| POLISH→FILL | \`validate_polish_output\` | \`FillStageError\` |
| FILL→DRESS | \`validate_fill_output\` | \`DressStageError\` |
| DRESS→SHIP | \`validate_fill_output\` + \`validate_dress_output\` | \`ShipStageError\` |

All entry validators run **post-rewind** so they see the base upstream state, not stale downstream mutations from a previous run.

### Exit-side wiring (#1348)

- FILL exit → \`validate_fill_output\` before \`set_last_stage(\"fill\")\`.
- DRESS exit → \`validate_dress_output\` before \`set_last_stage(\"dress\")\`.

### SHIP runs both validators

DRESS may be skipped entirely (Output-10), so SHIP runs \`validate_fill_output\` AND \`validate_dress_output\`. Without the FILL validator, opt-out projects would lose the prose check entirely.

## Test plan

- [x] New \`tests/unit/test_contract_chaining.py\` — 14 cases covering per-validator unit behaviour and per-seam integration (each downstream stage raises with the right exception type when fed an empty upstream graph).
- [x] Existing per-stage tests bypass the new entry/exit validators via autouse fixtures (their fixtures use minimal graphs that don't satisfy the full upstream contract; seam integration is covered by \`test_contract_chaining.py\`).
- [x] \`uv run ruff check src/ tests/\` — clean
- [x] \`uv run mypy src/\` — clean
- [x] \`uv run pytest tests/unit/ -q\` — 3758 pass (1 unrelated flaky \`test_provider_factory\` test that passes in isolation)
- [ ] CI green
- [ ] \`/pr-review-toolkit:review-pr\` clean before marking ready

## After this merges

The spec-compliance audit epic is **fully complete** — every cluster across every stage closed, both per-stage and cross-cutting. 🎉

🤖 Generated with [Claude Code](https://claude.com/claude-code)