### PR TITLE
feat(prompts): prompt-engineer subagent + murder1 SEED repair-feedback fix

### DIFF
--- a/.claude/agents/prompt-engineer.md
+++ b/.claude/agents/prompt-engineer.md
@@ -1,0 +1,160 @@
+---
+name: prompt-engineer
+description: Reviews QuestFoundry LLM prompts for spec accuracy, repair-loop quality, small-model resilience, schema alignment, and terminology drift. Spawn one per prompt audit task or invoke inline when editing a single prompt template.
+tools: Glob, Grep, LS, Read, NotebookRead, WebFetch, TodoWrite, WebSearch
+model: sonnet
+color: cyan
+---
+
+You are the QuestFoundry prompt-engineer. You review prompt templates
+in `prompts/templates/` for adherence to the authoritative design
+docs and resilience under small-model conditions (the production
+default is `qwen3:4b-instruct-32k` on Ollama).
+
+## When you are dispatched
+
+Two invocation modes:
+
+1. **Stage audit** — you receive a stage name (e.g. `seed`) plus the
+   list of prompt files for that stage. Read every prompt, the
+   stage's procedure doc, the relevant ontology sections, and the
+   stage's Pydantic models. Produce findings grouped by severity.
+2. **Inline review** — you receive a single prompt file diff (or a
+   draft new prompt). Produce a same-shape review for that one file.
+
+Either way, your output is a Markdown findings block (see "Output
+shape" below). You do NOT edit files; the dispatching controller
+applies fixes after reading your findings.
+
+## Authoritative inputs
+
+Always start by reading the relevant slice of these docs:
+
+- `docs/design/how-branching-stories-work.md` — narrative model.
+- `docs/design/story-graph-ontology.md` — graph schema. Part 8
+  (Y-shape guard rails) is load-bearing for SEED/GROW/POLISH
+  prompts.
+- `docs/design/procedures/<stage>.md` — algorithm spec for the
+  stage you are auditing.
+- `src/questfoundry/models/<stage>.py` — Pydantic models for that
+  stage's structured outputs.
+- `CLAUDE.md` §6 / §7 / §8 / §9 / §10 — the project-specific prompt
+  rules you must enforce.
+
+If a constraint a prompt encodes is NOT in the spec, that is a
+spec gap, not a prompt fix. Surface it as a `spec-gap` finding
+and recommend updating the spec first per CLAUDE.md
+§Design Doc Authority.
+
+## Audit dimensions
+
+Score each prompt on five axes. Each finding cites the dimension
+that triggered it:
+
+| Dimension | Tag | What you look for |
+|---|---|---|
+| Spec accuracy | `drift` | Field renamed in spec but old name in prompt; deprecated phase name; wrong rule citation |
+| Repair-loop quality | `repair-gap` | Validation feedback that names a missing field but does NOT echo the expected value. Example: "Beats missing `also_belongs_to`" without saying what value to use. Small models lose the constraint-to-value mapping across long context. |
+| Small-model resilience | `sm-fragile` | Implicit instructions, no concrete examples, ambiguous constraint phrasing, no sandwich repetition (critical instructions only at the start) |
+| Schema alignment | `schema-skew` | Prompt describes fields the Pydantic model doesn't have, or omits required ones, or names them differently |
+| Drift markers | `terminology` | "codeword" where spec says "state_flag", "passage_from" where spec says "grouped_in", "Codeword" class name, deprecated POLISH/GROW field references |
+
+## Severity rubric
+
+- **hard** — known cause of pipeline halt or contract violation. Block on this before merge.
+- **soft** — degraded output quality but pipeline survives. Fix in same epic if cheap; defer if not.
+- **info** — noted, no action required this round.
+
+A `repair-gap` that names but doesn't echo the expected value is
+**always at least soft**, and **hard** if the validator that emits
+the message is on the contract path (FillContractError,
+DressStageError, GrowStageError, etc.).
+
+## Required reading: small-model failure modes
+
+You assume the production model is small (`qwen3:4b`). The failure
+modes you care about most:
+
+1. **Constraint-to-value mapping loss** — the prompt says
+   "use the sibling path id from the dilemma section above," but
+   3000 tokens later the model has forgotten which sibling. Echo
+   the value at point of use.
+2. **Optional vs required confusion** — Pydantic's `Optional`
+   reads as "ignore this" to a 4B model. Mark required fields
+   "MUST" with the literal word; optional fields say "may omit".
+3. **Implicit instruction loss** — instructions buried in
+   docstring-style prose are dropped. Hoist constraints to a
+   "Rules" section with bullets.
+4. **Schema-name collision with prose** — a field named
+   `description` collides with the natural-language word. Use
+   distinctive identifiers in the schema and in the prompt.
+5. **Repair-loop blindness** — the model doesn't re-read the
+   system prompt on retry; only the new user-message is fresh
+   context. Repair feedback must be self-contained.
+
+## Reference patterns to enforce
+
+Citations from CLAUDE.md (the source of truth — re-read before
+each audit, don't paraphrase from memory):
+
+- **§6 Valid ID Injection** — every prompt that references IDs
+  ships an explicit "valid IDs" list. Phantom-ID prevention.
+- **§7 Defensive Prompt Patterns** — every constrained section
+  has a `GOOD:` and a `BAD:` example.
+- **§8 Context Enrichment** — bare ID listings are insufficient;
+  every ontologically relevant field comes through.
+- **§9 Prompt Context Formatting** — never interpolate Python
+  objects; always explicitly format. No `[…]`, no
+  `<EnumClass.VALUE: 1>`.
+- **§10 Small Model Bias** — the prompt is the suspect, not the
+  model.
+
+You may consult the public web for prompt-engineering guidance
+(e.g. promptingguide.ai, the OpenAI/Anthropic docs) when a
+specific pattern question comes up. Do NOT rely on memory for
+QuestFoundry-specific rules — those live in CLAUDE.md and the
+design docs.
+
+## Output shape
+
+Return Markdown with this structure (one block per audited
+prompt; for stage audits, repeat the block per file):
+
+```
+### `<prompt_filename>`
+
+**Verdict:** clean | drift | mixed
+
+**Findings:**
+
+- **[hard|soft|info] [tag]** — One-line summary
+  - Where: line range or section name
+  - Spec citation: `<doc>#<section>` or `CLAUDE.md §X`
+  - Recommended fix: concrete wording (3–5 lines max). When
+    rewriting a repair-loop message, show the new message
+    verbatim, including the echoed value template.
+
+(empty findings list = clean prompt; still emit the verdict line.)
+```
+
+For stage audits, end with a one-paragraph stage summary:
+
+```
+### Stage summary: <stage>
+
+- Prompts audited: N
+- Hard findings: H
+- Soft findings: S
+- Spec gaps surfaced: G (each linked to a recommended spec edit)
+- Recommended PR split: <one PR | per-cluster split | TBD>
+```
+
+## What you do NOT do
+
+- You do not edit any file. The controller applies fixes after
+  reading your findings.
+- You do not file GitHub issues. The controller does that after
+  the audit doc is complete.
+- You do not ship prompts. The controller opens fix PRs.
+- You do not rewrite a prompt wholesale. You point at the broken
+  bits and propose the wording for them.

--- a/docs/superpowers/reports/2026-04-25-prompt-engineer-smoke-test.md
+++ b/docs/superpowers/reports/2026-04-25-prompt-engineer-smoke-test.md
@@ -1,0 +1,108 @@
+# prompt-engineer subagent smoke test (2026-04-25)
+
+**Target:** `prompts/templates/serialize_seed_sections.yaml` (per-path-beats / shared-beats sections)
+**Failure under test:** murder1 SEED halt — repair feedback didn't echo expected `also_belongs_to` value.
+
+## PASS criteria
+
+1. Identified the murder1 repair-gap with severity `hard`.
+2. Proposed concrete repair-message wording that echoes the sibling path id template per beat.
+3. Cited CLAUDE.md §9 or §10 AND the Y-shape Part 8 guard rail.
+
+**Result: PASS on all three.** The subagent also surfaced 5 bonus findings (sandwich-pattern issues, schema-skew with `[bracket]` interpolation, terminology overlap between `effect: "commits"` and "commit beat") that will fold into the SEED stage audit (Task 8).
+
+## Subagent output
+
+### `prompts/templates/serialize_seed_sections.yaml`
+
+**Verdict:** mixed
+
+**Findings:**
+
+---
+
+- **[hard] [repair-gap]** — Validator names missing `also_belongs_to` beats but does NOT echo the expected sibling path ID value; small model retries fail 3/3
+  - Where: `src/questfoundry/models/seed.py` lines 758–769 (`_require_also_belongs_to`), which feeds into `serialize.py` `_build_error_feedback` (lines 478–493). The repair feedback delivered to the model reads: *"Beats missing `also_belongs_to`: `shared_setup_dilemma_garden_key_hides_or_opens_01`, `shared_setup_dilemma_garden_key_hides_or_opens_02`. Please fix these issues and try again."* It does **not** tell the model *what value* to set.
+  - Spec citation: `story-graph-ontology.md §Part 8` guard rail 2 (pre-commit only); `seed.md §R-3.6`; `CLAUDE.md §9` (never let repair feedback send generic "Missing items" — describe the specific problem and the fix); `CLAUDE.md §10` (small-model repair-loop blindness: the model does not re-read the system prompt on retry — only the new user-message is fresh context).
+  - Root cause: The system prompt in `shared_beats_prompt` tells the model what `also_belongs_to` must be (`{also_belongs_to}`) near the top of the call, but the repair message delivered 3000+ tokens later (on retry) only names the field, not the value. qwen3:4b has lost the constraint-to-value mapping by that point. Every retry sees the same incomplete feedback and produces the same mistake.
+  - Recommended fix — replace the body of `_require_also_belongs_to` in `src/questfoundry/models/seed.py` with a version that carries the sibling path id per-beat. Because the validator runs after construction it does not yet know the expected sibling id from the call context, so the fix must be in one of two places (pick the nearest):
+
+    **Option A (preferred) — enrich the per-beat error at the Pydantic layer.** The validator already knows each beat's `path_id`; it should derive the expected sibling by consulting the beat's own `path_id` structural pattern and echo it. Since the validator cannot know the dilemma's two explored path IDs without extra context, pass them in via a class-var on a per-call subclass or via a closure model. The new error string for each offending beat should be:
+
+    ```
+    Beat `{beat_id}` is missing `also_belongs_to`. Set it to the sibling path of this
+    dilemma. Your two explored paths for dilemma `{dilemma_id}` are:
+      - primary (path_id):      `{primary_path_id}`
+      - sibling (also_belongs_to): `{sibling_path_id}`
+    Every shared pre-commit beat MUST have `also_belongs_to: "{sibling_path_id}"`.
+    ```
+
+    **Option B (simpler short-term) — enrich the repair feedback in the serializer.** In `_serialize_shared_beats_for_dilemma` (`serialize.py`), after `serialize_to_artifact` raises, intercept the `ValidationError`, find the `also_belongs_to`-missing beats, and re-raise with an augmented message that injects `primary_path_id` and `sibling_path_id` (which are already in scope at lines 1194–1195). The new user-message sent to the model on retry must say, verbatim per beat:
+
+    ```
+    Beat `shared_setup_dilemma_garden_key_hides_or_opens_01` is missing `also_belongs_to`.
+    You MUST set it to: `path::garden_key_hides_or_opens__opens`
+    (The two explored paths are `path::garden_key_hides_or_opens__hides` [path_id]
+    and `path::garden_key_hides_or_opens__opens` [also_belongs_to].
+    Every shared beat needs BOTH.)
+
+    Beat `shared_setup_dilemma_garden_key_hides_or_opens_02` is missing `also_belongs_to`.
+    You MUST set it to: `path::garden_key_hides_or_opens__opens`
+    ```
+
+    Either option satisfies the requirement; Option B can be shipped faster without touching the Pydantic model.
+
+---
+
+- **[soft] [sm-fragile]** — `per_path_beats_prompt`: the "DO NOT set `also_belongs_to`" rule for post-commit beats appears only in the "What NOT to Do" list and in the schema example (`"also_belongs_to": null`) but is **not** sandwiched — never repeated at the end of the prompt. Small models drop tail rules from a 60-line prompt.
+  - Where: `per_path_beats_prompt`, section "What NOT to Do". The FINAL VERIFICATION block checks `path_id` and `dilemma_impacts` but does NOT re-check `also_belongs_to: null`.
+  - Spec citation: `seed.md §R-3.7`; `CLAUDE.md §10` small-model implicit instruction loss.
+  - Recommended fix: add to the FINAL VERIFICATION block:
+    ```
+    3. `also_belongs_to` is null for EVERY beat (these are post-commit beats,
+       single-membership ONLY — never set also_belongs_to here)
+    ```
+
+---
+
+- **[soft] [sm-fragile]** — `shared_beats_prompt`: the `also_belongs_to` constraint bullet (line 659) is the 7th bullet in Generation Requirements. Small models read early bullets more reliably than mid-list bullets.
+  - Where: `shared_beats_prompt`, "Generation Requirements" section, line 659.
+  - Spec citation: `CLAUDE.md §10` small-model failure modes; `seed.md §R-3.6`.
+  - Recommended fix: hoist the `also_belongs_to` constraint to be bullet #1 (before `effect` restrictions) so it is the first rule encountered:
+    ```
+    1. MUST have `also_belongs_to` = `{also_belongs_to}` — THIS IS REQUIRED, not optional.
+       Without it the beat is rejected by the Y-shape guard rail.
+    ```
+
+---
+
+- **[soft] [schema-skew]** — `per_path_beats_prompt` schema example uses square-bracket placeholder notation (`"dilemma::[other_dilemma_id]"`) which violates `CLAUDE.md §9` ("Never interpolate Python objects… No `[…]`") and could leak as literal text if the model copies the template literally.
+  - Where: `per_path_beats_prompt`, schema example temporal_hint block.
+  - Spec citation: `CLAUDE.md §9` (no square-bracket interpolation); `seed.md §R-3.13`.
+  - Recommended fix: replace with a format comment that makes clear it is a placeholder:
+    ```json
+    "temporal_hint": {
+      "relative_to": "dilemma::another_dilemma_id",
+      "position": "before_commit"
+    }
+    ```
+    Add the explicit note: *"Replace `dilemma::another_dilemma_id` with an ACTUAL dilemma ID from your manifest — NOT a template placeholder."*
+
+---
+
+- **[soft] [schema-skew]** — `shared_beats_prompt` schema example uses `{{double-brace}}` escaping for the JSON example while the surrounding prompt text uses `{single-brace}` for template variables. Correct now under `.format()`; could break if the template engine ever changes.
+  - Where: `shared_beats_prompt` schema block.
+  - Spec citation: `CLAUDE.md §9` (formatting must be verified in `llm_calls.jsonl`).
+  - Recommended fix: add a comment in the YAML above the block: `# Double-braces below are .format() escapes — rendered as single braces in the prompt`.
+
+---
+
+- **[info] [terminology]** — Word "commit" used both as field value (`"effect: commits"`) and as beat-category concept ("commit beat") in same sentences. For qwen3:4b, distinguishing field value from concept can cause confusion. Not a hard finding; flagging for completeness.
+  - Where: `per_path_beats_prompt`, throughout.
+  - Recommended fix: none required this round.
+
+---
+
+## Implementation decision
+
+For Task 3, **Option B** is the right choice: enrich the repair feedback at the serialize.py layer where the path ids are in scope, rather than restructuring the Pydantic validator. Faster to ship, doesn't touch the model, and the regression test pins the behaviour at the boundary the model actually sees.

--- a/src/questfoundry/agents/serialize.py
+++ b/src/questfoundry/agents/serialize.py
@@ -208,6 +208,7 @@ async def serialize_to_artifact(
     semantic_validator: SemanticValidator | None = None,
     semantic_error_class: type[SemanticErrorFormatter] | None = None,
     stage: str = "unknown",
+    extra_repair_hints: list[str] | None = None,
 ) -> tuple[T, int]:
     """Serialize a brief into a structured artifact.
 
@@ -230,6 +231,13 @@ async def serialize_to_artifact(
             for formatting semantic validation errors. Required if semantic_validator
             is provided.
         stage: Pipeline stage name for tracing metadata (e.g., "dream", "seed").
+        extra_repair_hints: Optional caller-supplied reminder strings appended to
+            the validation-failure feedback message on every retry attempt. Used
+            to echo expected values for constraint-to-value mappings the model
+            loses across long context (e.g. SEED shared-beats `also_belongs_to`
+            sibling path id). Per CLAUDE.md §10, the model does not re-read the
+            system prompt on retry — only the new user-message — so the hint
+            must be self-contained.
 
     Returns:
         Tuple of (validated_artifact, tokens_used).
@@ -378,7 +386,7 @@ async def serialize_to_artifact(
 
                 # Add error feedback for retry
                 if attempt < max_retries:
-                    error_feedback = _build_error_feedback(last_errors)
+                    error_feedback = _build_error_feedback(last_errors, extra_repair_hints)
                     messages.append(HumanMessage(content=error_feedback))
 
             except (KeyboardInterrupt, asyncio.CancelledError):
@@ -475,22 +483,31 @@ def _format_validation_errors(error: ValidationError) -> list[str]:
     return errors
 
 
-def _build_error_feedback(errors: list[str]) -> str:
+def _build_error_feedback(errors: list[str], extra_hints: list[str] | None = None) -> str:
     """Build error feedback message for retry.
 
     Args:
         errors: List of validation error messages.
+        extra_hints: Optional caller-supplied hints appended after the
+            generic feedback. Used to echo expected values for
+            constraint-to-value mappings the model loses across long
+            context (e.g. SEED shared-beats `also_belongs_to` value
+            template — see CLAUDE.md §10 small-model repair-loop
+            blindness).
 
     Returns:
         Formatted feedback message for the model.
     """
     error_list = "\n".join(f"  - {e}" for e in errors)
-    return (
+    base = (
         "The output had validation errors:\n"
         f"{error_list}\n\n"
         "Please fix these issues and try again. "
         "Ensure all required fields are present and have valid values."
     )
+    if extra_hints:
+        return base + "\n\n" + "\n\n".join(extra_hints)
+    return base
 
 
 # Required prompt keys for SEED section serialization
@@ -1211,6 +1228,21 @@ async def _serialize_shared_beats_for_dilemma(
         sibling_path_id=sibling_path_id,
     )
 
+    # Per-attempt repair hint — the validator's `also_belongs_to`-missing
+    # error names the field but doesn't echo the value, and small models
+    # (qwen3:4b production default) lose the constraint-to-value mapping
+    # across retry attempts (CLAUDE.md §10 small-model repair-loop
+    # blindness — the model doesn't re-read the system prompt on retry).
+    # The hint is dilemma-specific so it always applies to this call.
+    also_belongs_to_hint = (
+        f"REMINDER for shared pre-commit beats of dilemma `{prefixed_dilemma_id}`:\n"
+        f"  - `path_id` MUST be `{primary_path_id}`\n"
+        f"  - `also_belongs_to` MUST be `{sibling_path_id}`\n"
+        f'Add `also_belongs_to: "{sibling_path_id}"` to EVERY beat in this output. '
+        f"Without it the beat is rejected by the Y-shape guard rail "
+        f"(Story Graph Ontology Part 8)."
+    )
+
     result, tokens = await serialize_to_artifact(
         model=model,
         brief=brief,
@@ -1220,6 +1252,7 @@ async def _serialize_shared_beats_for_dilemma(
         system_prompt=prompt,
         callbacks=callbacks,
         stage="seed",
+        extra_repair_hints=[also_belongs_to_hint],
     )
 
     beats = result.model_dump().get("initial_beats", [])

--- a/tests/unit/test_serialize.py
+++ b/tests/unit/test_serialize.py
@@ -380,6 +380,38 @@ class TestHelperFunctions:
         assert "count" in feedback
         assert "fix" in feedback.lower()
 
+    def test_build_error_feedback_appends_extra_hints(self) -> None:
+        """Caller-supplied repair hints land after the generic feedback.
+
+        Regression for the murder1 SEED halt: the model needs the expected
+        sibling path id template echoed alongside the validation error so
+        small models (qwen3:4b) can recover from constraint-to-value
+        mapping loss across long context. See CLAUDE.md §10.
+        """
+        errors = ["beats.0.also_belongs_to: Field required"]
+        hint = (
+            "REMINDER for shared pre-commit beats of dilemma `dilemma::x`:\n"
+            "  - `path_id` MUST be `path::x__a`\n"
+            "  - `also_belongs_to` MUST be `path::x__b`"
+        )
+
+        feedback = _build_error_feedback(errors, extra_hints=[hint])
+
+        # Generic feedback still present
+        assert "validation errors" in feedback.lower()
+        assert "beats.0.also_belongs_to" in feedback
+        # Hint appended verbatim — sibling path id ECHOED (not just named)
+        assert "path::x__b" in feedback
+        assert "REMINDER" in feedback
+
+    def test_build_error_feedback_no_hints_unchanged(self) -> None:
+        """Without extra_hints, the output is identical to the legacy form."""
+        errors = ["x: required"]
+        without = _build_error_feedback(errors)
+        with_empty = _build_error_feedback(errors, extra_hints=None)
+        with_empty_list = _build_error_feedback(errors, extra_hints=[])
+        assert without == with_empty == with_empty_list
+
 
 class TestSerializationError:
     """Test SerializationError exception."""


### PR DESCRIPTION
## Summary

Phase 1 of the prompt-vs-spec audit (spec at \`docs/superpowers/specs/2026-04-25-prompt-spec-audit-design.md\`, plan at \`docs/superpowers/plans/2026-04-25-prompt-spec-audit.md\`).

Three commits:

1. **New \`prompt-engineer\` subagent** (\`.claude/agents/prompt-engineer.md\`) — recreates the subagent referenced extensively in CLAUDE.md §6/§7/§8/§9/§10 but missing from this repo. Knowledge body covers prompt-engineering fundamentals (sandwich pattern, repair-loop quality, structured-output specifics), small-model failure modes (constraint-to-value mapping loss, optional/required confusion, repair-loop blindness), and QuestFoundry-specific patterns. Five audit dimensions: drift / repair-gap / sm-fragile / schema-skew / terminology.

2. **Smoke test record** (\`docs/superpowers/reports/2026-04-25-prompt-engineer-smoke-test.md\`) — proves the subagent identifies the murder1 SEED halt root cause and proposes actionable fix wording. Subagent passed all three smoke-test criteria (hard repair-gap finding, verbatim fix wording with sibling path id echoed, CLAUDE.md §9/§10 + Y-shape Part 8 citation) and surfaced 5 bonus findings that fold into the SEED stage audit (Task 8).

3. **Murder1 SEED fix** — \`_build_error_feedback\` and \`serialize_to_artifact\` accept optional caller-supplied \`extra_repair_hints\`. \`_serialize_shared_beats_for_dilemma\` uses this to echo the primary and sibling path ids verbatim on every retry. Small Ollama models can now recover from \`also_belongs_to\` validation failures within the repair loop instead of failing 3/3.

## Test plan

- [x] New \`test_build_error_feedback_appends_extra_hints\` pins the new behaviour (sibling path id appears verbatim in feedback)
- [x] New \`test_build_error_feedback_no_hints_unchanged\` confirms callers that don't use the new kwarg get byte-identical legacy output
- [x] Existing 116 serialize tests still pass
- [x] mypy + ruff clean
- [ ] CI green
- [ ] Re-run murder1 SEED stage manually after merge to confirm the failure mode is gone

## Next phases

- Phase 2: per-stage audit pass (Tasks 5–14) — appends findings to \`docs/superpowers/reports/2026-04-25-prompt-spec-audit.md\`
- Phase 3: per-stage fix PRs (Tasks 15–16) — demand-driven by Phase 2 findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)