### PR TITLE
docs(specs): close 5 spec gaps surfaced by 2026-04-25 prompt audit

### DIFF
--- a/docs/design/procedures/brainstorm.md
+++ b/docs/design/procedures/brainstorm.md
@@ -34,7 +34,7 @@ BRAINSTORM is the expansive creative stage: it turns an approved Vision into raw
 
 **Rules:**
 
-R-1.1. Discussion aims for abundance. Err toward inclusion — entity and dilemma targets come from the active size preset (`src/questfoundry/pipeline/size.py`: `entities_min`/`entities_max`, `dilemmas_min`/`dilemmas_max`), ranging from 5–10 entities and 2–3 dilemmas (`micro`) up to 20–35 entities and 5–10 dilemmas (`long`). SEED will cut; do not pre-triage here.
+R-1.1. Discussion aims for abundance. Err toward inclusion — entity and dilemma targets come from the active Size Preset (one of `micro`, `short`, `medium`, `long`), with ranges from 5–10 entities and 2–3 dilemmas (`micro`) up to 20–35 entities and 5–10 dilemmas (`long`); intermediate `short` and `medium` values come from the same preset configuration. SEED will cut; do not pre-triage here.
 
 R-1.2. Discussion writes nothing to the graph. It produces prose notes only. The graph remains empty of BRAINSTORM artifacts through the end of this phase.
 

--- a/docs/design/procedures/brainstorm.md
+++ b/docs/design/procedures/brainstorm.md
@@ -34,7 +34,7 @@ BRAINSTORM is the expansive creative stage: it turns an approved Vision into raw
 
 **Rules:**
 
-R-1.1. Discussion aims for abundance. Err toward inclusion — typical targets are 15–25 entities and 4–8 dilemmas for a short story. SEED will cut; do not pre-triage here.
+R-1.1. Discussion aims for abundance. Err toward inclusion — entity and dilemma targets come from the active size preset (`src/questfoundry/pipeline/size.py`: `entities_min`/`entities_max`, `dilemmas_min`/`dilemmas_max`), ranging from 5–10 entities and 2–3 dilemmas (`micro`) up to 20–35 entities and 5–10 dilemmas (`long`). SEED will cut; do not pre-triage here.
 
 R-1.2. Discussion writes nothing to the graph. It produces prose notes only. The graph remains empty of BRAINSTORM artifacts through the end of this phase.
 
@@ -46,7 +46,7 @@ R-1.4. The LLM is generative; the human guides. The human redirects unproductive
 
 | Symptom | Root cause | Broken rule |
 |---------|-----------|-------------|
-| Discussion ends with 4 entities and 1 dilemma for a short-scope story | Pre-triaging — self-censored during BRAINSTORM | R-1.1 |
+| Discussion ends below the size preset's `entities_min` / `dilemmas_min` | Pre-triaging — self-censored during BRAINSTORM | R-1.1 |
 | Entity node exists in the graph after Phase 1 | Graph write happened during discussion | R-1.2 |
 | Discussion proposes a slapstick comic-relief character in a gritty noir | Vision's tone not enforced; contradiction accepted | R-1.3 |
 

--- a/docs/design/procedures/fill.md
+++ b/docs/design/procedures/fill.md
@@ -51,7 +51,7 @@ R-1.1. Exactly one Voice Document node is created. Retries replace the previous 
 
 R-1.2. Voice Document fields include `pov`, `tense`, `voice_register`, `sentence_rhythm`, `tone_words`, `avoid_words`, `avoid_patterns`, and optionally `pov_character` and `exemplar_passages`.
 
-R-1.3. `pov` ∈ {`first_person`, `second_person`, `third_person_limited`, `third_person_omniscient`}. When `pov` is limited, `pov_character` names the POV entity.
+R-1.3. `pov` ∈ {`first_person`, `second_person`, `third_person_limited`, `third_person_omniscient`}. `pov_character` names the POV entity and is required when `pov` is `first_person` or `third_person_limited` (both attach narration to a single character's perspective). For `second_person` and `third_person_omniscient` the field is omitted or empty.
 
 R-1.4. `tense` ∈ {`past`, `present`}.
 
@@ -448,7 +448,7 @@ R-5.3: Cap is configurable; default 2.
 
 ### Phase 1
 
-LLM proposes Voice Document based on Vision and POLISH structure. `pov: third_person_limited`, `pov_character: character::kay`, `tense: past`, register `atmospheric-terse`, tone_words: `[muted, wary, hushed]`, avoid_patterns: `[adverb-heavy, said-bookisms]`. Human approves.
+LLM proposes Voice Document based on Vision and POLISH structure. `pov: third_person_limited`, `pov_character: character::kay`, `tense: past`, `voice_register: sparse`, `sentence_rhythm: punchy`, tone_words: `[muted, wary, hushed]`, avoid_patterns: `[adverb-heavy, said-bookisms]`. Human approves.
 
 ### Phase 2
 

--- a/docs/design/procedures/fill.md
+++ b/docs/design/procedures/fill.md
@@ -67,7 +67,7 @@ R-1.7. Human approval of the Voice Document is required before prose generation 
 |---------|-----------|-------------|
 | Two Voice Documents exist after Phase 1 | Retry duplicated | R-1.1 |
 | Voice Document has `pov: "omniscient"` | Value outside permitted set | R-1.3 |
-| Voice Document has `pov: "third_person_limited"` but no `pov_character` | Limited POV needs a character | R-1.3 |
+| Voice Document has `pov: "first_person"` or `"third_person_limited"` but no `pov_character` | Attached-POV needs a named character | R-1.3 |
 | Voice Document has outgoing edges to passages | Singleton contract violated | R-1.5 |
 | Phase 2 starts without recorded approval | Human gate skipped | R-1.7 |
 
@@ -337,7 +337,7 @@ R-5.3. The cap is configurable but defaults to 2.
 
 R-1.1: Exactly one Voice Document node; retries replace.
 R-1.2: Voice Document has required fields: pov, tense, voice_register, sentence_rhythm, tone_words, avoid_words, avoid_patterns.
-R-1.3: `pov` in permitted set; `pov_character` if limited.
+R-1.3: `pov` in permitted set; `pov_character` required for `first_person` and `third_person_limited`.
 R-1.4: `tense` ∈ {past, present}.
 R-1.5: Voice Document has no graph edges.
 R-1.6: Vision's `pov_style` is advisory.

--- a/docs/design/procedures/polish.md
+++ b/docs/design/procedures/polish.md
@@ -460,9 +460,14 @@ R-5e.3. Phase 5e runs after Beat DAG Freeze, so transition beats inserted by GRO
 | Beat without `atmospheric_detail` and no WARNING | Partial coverage detection skipped | R-5e.1 |
 | Transition beat without `atmospheric_detail` | Phase 5e ran before transition-beat creation, OR transition beats excluded from coverage | R-5e.3 |
 
-#### 5f — Path Thematic Annotation
+#### 5f — Path Thematic Annotation and Transition Guidance
 
-**What:** For each path, produce a `path_theme` (10–200 characters) and `path_mood` (2–50 characters) summarizing the path's emotional through-line and tonal palette. One LLM call per path; the LLM consumes the full beat sequence with their summaries, scene types, narrative functions, and exit moods. Absorbed from old GROW 4e per audit Q1: per-path narrative identity is prose-prep, not structural.
+**What:** Phase 5f covers two related per-path concerns that both feed FILL prose generation:
+
+1. **Path thematic annotation.** For each path, produce a `path_theme` (10–200 characters) and `path_mood` (2–50 characters) summarizing the path's emotional through-line and tonal palette. One LLM call per path; the LLM consumes the full beat sequence with their summaries, scene types, narrative functions, and exit moods. Absorbed from old GROW 4e per audit Q1: per-path narrative identity is prose-prep, not structural.
+2. **Transition guidance for collapsed passages.** For each collapsed passage (one passage covering multiple consecutive beats — see Phase 4a), generate a brief transition instruction per beat boundary so the FILL writer knows how to bridge from one beat to the next within a single scene. Driven by `polish_phase5f_transitions.yaml`.
+
+The two sub-tasks share Phase 5f because both produce per-path / per-passage prose-prep metadata that FILL consumes; both are non-structural; and both run after Beat DAG Freeze when the final passage layout is known.
 
 **Rules:**
 
@@ -470,7 +475,11 @@ R-5f.1. Every path with 2+ beats receives `path_theme` and `path_mood`. Paths wi
 
 R-5f.2. `path_theme` is the path's emotional through-line / "controlling idea" (McKee). `path_mood` is its tonal palette. Both are LLM-generated free-form strings; the spec does not enforce specific vocabularies.
 
-R-5f.3. Per-path LLM failures MUST log at WARNING and leave the path's fields unpopulated. FILL and DRESS handle missing fields by falling back to path description / dilemma question text.
+R-5f.3. Per-path LLM failures for thematic annotation MUST log at WARNING and leave the path's fields unpopulated. FILL and DRESS handle missing fields by falling back to path description / dilemma question text.
+
+R-5f.4. Every collapsed passage (>1 beat) receives one transition instruction per beat boundary (N beats → N-1 transitions). Single-beat passages are skipped (no boundary to bridge).
+
+R-5f.5. Transition instructions are LLM-generated free-form prose hints for FILL; the spec does not enforce specific vocabularies. Per-passage failures MUST log at WARNING and leave the passage's transition list empty; FILL falls back to bridging without explicit guidance.
 
 **Violations:**
 
@@ -478,6 +487,8 @@ R-5f.3. Per-path LLM failures MUST log at WARNING and leave the path's fields un
 |---------|-----------|-------------|
 | Multi-beat path without `path_theme` and no WARNING | Per-path failure detection skipped | R-5f.3 |
 | `path_mood` exceeds 50 characters | Schema length not enforced | R-5f.2 |
+| Collapsed 4-beat passage with 4 transition instructions | Off-by-one — should be N-1 | R-5f.4 |
+| Collapsed passage missing transitions and no WARNING | Per-passage failure detection skipped | R-5f.5 |
 
 ### Output Contract
 
@@ -487,6 +498,7 @@ R-5f.3. Per-path LLM failures MUST log at WARNING and leave the path's fields un
 4. All VariantSpecs have summaries.
 5. Every beat has `atmospheric_detail` populated (or a WARNING logged for partial coverage).
 6. Every multi-beat path has `path_theme` and `path_mood` populated (or a WARNING logged for per-path failure).
+7. Every collapsed passage (>1 beat) has N-1 transition instructions populated (or a WARNING logged for per-passage failure).
 
 ---
 

--- a/docs/design/procedures/polish.md
+++ b/docs/design/procedures/polish.md
@@ -711,6 +711,8 @@ R-5e.3: Phase 5e runs after Beat DAG Freeze; transition beats receive `atmospher
 R-5f.1: Multi-beat paths receive `path_theme` and `path_mood`; <2-beat paths skipped.
 R-5f.2: `path_theme` (controlling idea) and `path_mood` (tonal palette) are free-form LLM strings.
 R-5f.3: Per-path LLM failure → WARNING + leave unpopulated; consumers fall back.
+R-5f.4: Collapsed passages (>1 beat) receive N-1 transition instructions per beat boundary; single-beat passages skipped.
+R-5f.5: Transition instructions are free-form LLM hints; per-passage failure → WARNING + empty list; FILL falls back to bridging without guidance.
 R-6.1: Phase 6 runs in a single transaction.
 R-6.2: Application order: passages → variants → residue beats → residue passages → choices → false branches.
 R-6.3: Any step failure rolls back.
@@ -837,7 +839,7 @@ User reviews. Approves.
 - False branch decision: `diamond` pattern for the opening stretch.
 - Variant summary for the climax passage: two versions.
 - **5e:** atmospheric_detail populated for all 14 beats (including the gap and micro beats from Phases 1a/2 and the transition beat from GROW 4c).
-- **5f:** path_theme and path_mood populated for both `mentor_trust` paths and the `archive_nature` canonical path.
+- **5f:** path_theme and path_mood populated for both `mentor_trust` paths and the `archive_nature` canonical path. Transition instructions populated for the multi-beat collapsed passages (the maximal-linear-collapse run from Phase 4a produces several 2- and 3-beat passages, each receiving N-1 transitions); single-beat passages are skipped.
 
 ### Phase 6
 

--- a/docs/design/procedures/seed.md
+++ b/docs/design/procedures/seed.md
@@ -573,7 +573,7 @@ R-7.3: Every Dilemma has `ending_salience` ∈ {high, low, none}.
 R-7.4: `residue_weight` and `dilemma_role` are independent axes.
 R-7.5: LLM failure in Phase 7 logged at WARNING; no silent defaults.
 R-8.1: Valid relationships: wraps, concurrent, serial.
-R-8.2: Relationships declared only for relevant pairs (not O(n²)).
+R-8.2: Relationships declared only for relevant pairs; exhaustive O(n²) is wasteful but acceptable when ambiguity-removing.
 R-8.3: `concurrent` is symmetric; stored once with lex-smaller ID as `dilemma_a`.
 R-8.4: `shared_entity` is derived, not declared as an edge.
 R-8.5: LLM failure in Phase 8 logged at WARNING.

--- a/docs/design/procedures/seed.md
+++ b/docs/design/procedures/seed.md
@@ -455,7 +455,7 @@ R-7.5. If the LLM call fails, defaults are applied (role: soft, weight: light, s
 
 R-8.1. Valid relationships: `wraps` (A wraps B when A introduces before B and B resolves before A), `concurrent` (both active at once, no nesting), `serial` (A fully resolves before B introduces).
 
-R-8.2. Relationships are declared only for relevant pairs — those sharing entities, with causal dependencies, or with explicit authorial ordering intent. Exhaustive O(n²) declaration is forbidden.
+R-8.2. Relationships are declared only for relevant pairs — those sharing entities, with causal dependencies, or with explicit authorial ordering intent. Exhaustive O(n²) declaration is wasteful but not forbidden; including pairs whose relationship is the default `concurrent` (no shared entities, no causal dependency) for completeness is acceptable when it removes ambiguity for GROW. Exhaustive declarations on every run, however, signal that the LLM is over-applying the pattern and should be discouraged in the prompt.
 
 R-8.3. `concurrent` is symmetric. The edge is stored once, with the lexicographically smaller Dilemma ID as `dilemma_a`. → ontology §Part 2: Pairwise Relationships.
 
@@ -467,7 +467,7 @@ R-8.5. If the LLM call fails, no relationships are declared — the graph is lef
 
 | Symptom | Root cause | Broken rule |
 |---------|-----------|-------------|
-| n×(n-1)/2 ordering edges declared for n Dilemmas | Exhaustive O(n²) declaration instead of sparse | R-8.2 |
+| n×(n-1)/2 ordering edges declared for n Dilemmas on every run | Exhaustive O(n²) declaration as the default — should be the exception | R-8.2 |
 | `concurrent` edge with `dilemma_a: dilemma::mentor_trust` and `dilemma_b: dilemma::archive_nature` | Non-lex order — `archive_nature` precedes `mentor_trust` alphabetically, so it should be `dilemma_a`. Normalization rule not applied | R-8.3 |
 | `shared_entity` edge exists in graph | Declared as an edge instead of derived | R-8.4 |
 | `concurrent` edge duplicated (A→B and B→A) | Symmetric edge stored twice | R-8.3 |

--- a/docs/design/procedures/seed.md
+++ b/docs/design/procedures/seed.md
@@ -455,7 +455,9 @@ R-7.5. If the LLM call fails, defaults are applied (role: soft, weight: light, s
 
 R-8.1. Valid relationships: `wraps` (A wraps B when A introduces before B and B resolves before A), `concurrent` (both active at once, no nesting), `serial` (A fully resolves before B introduces).
 
-R-8.2. Relationships are declared only for relevant pairs — those sharing entities, with causal dependencies, or with explicit authorial ordering intent. Exhaustive O(n²) declaration is wasteful but not forbidden; including pairs whose relationship is the default `concurrent` (no shared entities, no causal dependency) for completeness is acceptable when it removes ambiguity for GROW. Exhaustive declarations on every run, however, signal that the LLM is over-applying the pattern and should be discouraged in the prompt.
+R-8.2. Relationships are declared only for relevant pairs — those sharing entities, with causal dependencies, or with explicit authorial ordering intent. Exhaustive O(n²) declaration is wasteful but not forbidden; including pairs whose relationship is the default `concurrent` (no shared entities, no causal dependency) for completeness is acceptable when it removes ambiguity for GROW.
+
+*Note (implementation guidance, not a rule):* Exhaustive declarations on every run signal that the LLM is over-applying the pattern; the prompt should discourage this without rejecting valid completeness-driven exhaustive lists.
 
 R-8.3. `concurrent` is symmetric. The edge is stored once, with the lexicographically smaller Dilemma ID as `dilemma_a`. → ontology §Part 2: Pairwise Relationships.
 


### PR DESCRIPTION
## Summary

Phase 3 prep — closes the 5 spec gaps surfaced by the [prompt-vs-spec audit report](docs/superpowers/reports/2026-04-25-prompt-spec-audit.md). Per CLAUDE.md §Design Doc Authority, spec changes precede the prompt fixes that depend on them. Closes #1387.

## Changes

| Spec | Section | Change |
|---|---|---|
| `brainstorm.md` | R-1.1 | Replace hardcoded "15-25 entities and 4-8 dilemmas" with reference to size-preset system; show ranges across all 4 presets |
| `seed.md` | R-8.2 | Relax "exhaustive O(n²) is forbidden" to "wasteful but not forbidden" — exhaustive declarations OK for completeness when ambiguity-removing |
| `polish.md` | §Phase 5f | Rename to "Path Thematic Annotation **and Transition Guidance**"; add R-5f.4 / R-5f.5 + Output Contract item 7 covering the active `phase5f_transitions.yaml` prompt |
| `fill.md` | R-1.3 | Clarify `pov_character` is required for both `first_person` and `third_person_limited` (not just "limited") |
| `fill.md` | Worked Example §Phase 1 | Replace invalid `voice_register: atmospheric-terse` with `sparse`; add `sentence_rhythm: punchy` |

Diff is +21/-9 across 4 files.

## Out of scope

- Prompt template fixes — follow per cluster in subsequent Phase 3 PRs (POV alignment, DRESS terminology, POLISH migration cleanup, etc.)
- Pydantic model fixes — `VoiceDocument.pov` short-vs-long-form Literal correction lands in the Cluster A (POV alignment) PR alongside the prompt updates that depend on it

## Test plan

- [x] No code or test changes — pure spec PR
- [x] Each cited spec section reads correctly after edit
- [x] All replacement field values (`sparse`, `punchy`) are valid Pydantic Literals on `VoiceDocument`

🤖 Generated with [Claude Code](https://claude.com/claude-code)