### PR TITLE
fix(fill): align VoiceDocument.pov with fill.md R-1.3 (Cluster A)

### DIFF
--- a/docs/design/procedures/fill.md
+++ b/docs/design/procedures/fill.md
@@ -448,7 +448,7 @@ R-5.3: Cap is configurable; default 2.
 
 ### Phase 1
 
-LLM proposes Voice Document based on Vision and POLISH structure. `pov: third_person_limited`, `pov_character: character::kay`, `tense: past`, `voice_register: sparse`, `sentence_rhythm: punchy`, tone_words: `[muted, wary, hushed]`, avoid_patterns: `[adverb-heavy, said-bookisms]`. Human approves.
+LLM proposes Voice Document based on Vision and POLISH structure. `pov: third_person_limited`, `pov_character: kay` (raw character ID — not the scoped form `character::kay` and not the display name `Kay`), `tense: past`, `voice_register: sparse`, `sentence_rhythm: punchy`, tone_words: `[muted, wary, hushed]`, avoid_patterns: `[adverb-heavy, said-bookisms]`. Human approves.
 
 ### Phase 2
 

--- a/docs/design/procedures/fill.md
+++ b/docs/design/procedures/fill.md
@@ -51,7 +51,7 @@ R-1.1. Exactly one Voice Document node is created. Retries replace the previous 
 
 R-1.2. Voice Document fields include `pov`, `tense`, `voice_register`, `sentence_rhythm`, `tone_words`, `avoid_words`, `avoid_patterns`, and optionally `pov_character` and `exemplar_passages`.
 
-R-1.3. `pov` ∈ {`first_person`, `second_person`, `third_person_limited`, `third_person_omniscient`}. `pov_character` names the POV entity and is required when `pov` is `first_person` or `third_person_limited` (both attach narration to a single character's perspective). For `second_person` and `third_person_omniscient` the field is omitted or empty.
+R-1.3. `pov` ∈ {`first_person`, `second_person`, `third_person_limited`, `third_person_omniscient`}. `pov_character` names the POV entity by its raw character ID (e.g. `kay`, not the scoped form `character::kay` and not the display name `Kay`) and is required when `pov` is `first_person` or `third_person_limited` (both attach narration to a single character's perspective). For `second_person` and `third_person_omniscient` the field is omitted or empty.
 
 R-1.4. `tense` ∈ {`past`, `present`}.
 

--- a/prompts/templates/fill_phase0_discuss.yaml
+++ b/prompts/templates/fill_phase0_discuss.yaml
@@ -44,8 +44,8 @@ system: |
   - If no protagonist is defined, discuss options with the user (interactive) or choose the most prominent character (autonomous)
 
   ### POV Character Naming (CRITICAL)
-  GOOD: Use an exact character name from the valid characters list: "Kay", "Marcus"
-  BAD: Invent a new character: "Mila", "the reader as Alex", "your character named Sam"
+  GOOD: Use an exact raw_id from the valid characters list: `kay`, `marcus` (lowercase, no `character::` prefix)
+  BAD: Capitalized display name (`"Kay"`), scoped form (`"character::kay"`), or an invented name (`"Mila"`, `"the reader as Alex"`)
 
   ### Voice Decisions to Make
   1. **POV**: first_person, second_person, third_person_limited, or third_person_omniscient?

--- a/prompts/templates/fill_phase0_discuss.yaml
+++ b/prompts/templates/fill_phase0_discuss.yaml
@@ -7,7 +7,7 @@ system: |
   HOW the story will be told: POV, tense, register, and voice characteristics.
 
   ## Task Contract
-  Stage: FILL (5 of 6: DREAM → BRAINSTORM → SEED → GROW → FILL → SHIP)
+  Stage: FILL (6 of 8: DREAM → BRAINSTORM → SEED → GROW → POLISH → FILL → DRESS → SHIP)
   Deliverables: POV choice, tense choice, voice register decisions
   Completion: when voice decisions are established
 
@@ -38,7 +38,7 @@ system: |
   ## Guidelines
 
   ### POV Character Selection (CRITICAL)
-  - For first-person or third-limited POV, the POV character MUST be one of the valid characters listed above
+  - For first_person or third_person_limited POV, the POV character MUST be one of the valid characters listed above
   - Do NOT invent characters like "Mila", "the reader", or other names not in the valid characters list
   - If the creative vision specifies a protagonist, confirm it matches an actual character entity
   - If no protagonist is defined, discuss options with the user (interactive) or choose the most prominent character (autonomous)
@@ -48,8 +48,8 @@ system: |
   BAD: Invent a new character: "Mila", "the reader as Alex", "your character named Sam"
 
   ### Voice Decisions to Make
-  1. **POV**: first, second, third_limited, or third_omniscient?
-     - If first/third_limited: which character from the valid list?
+  1. **POV**: first_person, second_person, third_person_limited, or third_person_omniscient?
+     - If first_person or third_person_limited: which character from the valid list?
   2. **Tense**: past or present?
   3. **Register**: formal, conversational, literary, or sparse?
   4. **Tone**: What 3-5 adjectives capture the voice? (derived from the creative vision's themes)

--- a/prompts/templates/fill_phase0_voice.yaml
+++ b/prompts/templates/fill_phase0_voice.yaml
@@ -25,8 +25,8 @@ system: |
 
   Create a voice document with these fields:
 
-  - **pov**: Point of view. One of: first, second, third_limited, third_omniscient
-  - **pov_character**: Whose perspective (required for first/third_limited, empty for omniscient/second)
+  - **pov**: Point of view. One of: first_person, second_person, third_person_limited, third_person_omniscient
+  - **pov_character**: POV character (entity ID). REQUIRED for first_person and third_person_limited (both attach narration to a single character). Empty string for second_person and third_person_omniscient.
   - **tense**: One of: past, present
   - **voice_register**: One of: formal, conversational, literary, sparse
   - **sentence_rhythm**: One of: varied, punchy, flowing
@@ -36,8 +36,8 @@ system: |
 
   ## Guidelines
 
-  - Match POV and tense to genre conventions (fantasy often uses third_limited past;
-    horror can use second present; literary fiction varies)
+  - Match POV and tense to genre conventions (fantasy often uses third_person_limited past;
+    horror can use second_person present; literary fiction varies)
   - The register should match the DREAM tone — dark stories need literary or sparse,
     not conversational
   - Tone words should be distilled from DREAM themes, not generic
@@ -74,7 +74,7 @@ user: |
   Based on the creative vision and story structure above, propose a voice document.
 
   CRITICAL REMINDERS:
-  - Match POV/tense to genre conventions (fantasy → third_limited past; horror → second present)
+  - Match POV/tense to genre conventions (fantasy → third_person_limited past; horror → second_person present)
   - voice_register must match DREAM tone — dark stories need literary or sparse, NOT conversational
   - tone_words must be distilled from DREAM themes, not generic filler
   - avoid_words and avoid_patterns should target the genre's common pitfalls

--- a/prompts/templates/fill_phase0_voice.yaml
+++ b/prompts/templates/fill_phase0_voice.yaml
@@ -26,7 +26,7 @@ system: |
   Create a voice document with these fields:
 
   - **pov**: Point of view. One of: first_person, second_person, third_person_limited, third_person_omniscient
-  - **pov_character**: POV character (entity ID). REQUIRED for first_person and third_person_limited (both attach narration to a single character). Empty string for second_person and third_person_omniscient.
+  - **pov_character**: Raw character ID from the valid characters list (e.g. `kay`, not `character::kay` and not the display name `Kay`). REQUIRED for first_person and third_person_limited (both attach narration to a single character). Empty string for second_person and third_person_omniscient.
   - **tense**: One of: past, present
   - **voice_register**: One of: formal, conversational, literary, sparse
   - **sentence_rhythm**: One of: varied, punchy, flowing

--- a/src/questfoundry/models/fill.py
+++ b/src/questfoundry/models/fill.py
@@ -60,11 +60,17 @@ class VoiceDocument(BaseModel):
     )
 
     @model_validator(mode="after")
-    def _check_pov_character_required(self) -> VoiceDocument:
-        if self.pov in ("first_person", "third_person_limited") and not self.pov_character:
+    def _check_pov_character(self) -> VoiceDocument:
+        if self.pov in ("first_person", "third_person_limited") and not self.pov_character.strip():
             raise ValueError(
                 f"pov_character is required when pov is {self.pov!r}; "
-                "set it to the entity ID whose perspective the prose follows. See fill.md R-1.3."
+                "set it to the raw character ID whose perspective the prose follows. "
+                "See fill.md R-1.3."
+            )
+        if self.pov in ("second_person", "third_person_omniscient") and self.pov_character.strip():
+            raise ValueError(
+                f"pov_character must be empty when pov is {self.pov!r}; "
+                "narration is not attached to a single character. See fill.md R-1.3."
             )
         return self
 

--- a/src/questfoundry/models/fill.py
+++ b/src/questfoundry/models/fill.py
@@ -40,6 +40,7 @@ class VoiceDocument(BaseModel):
             "POV character (required for first_person and third_person_limited; "
             "empty for second_person and third_person_omniscient). See fill.md R-1.3."
         ),
+        json_schema_extra={"strip_whitespace": True},
     )
     tense: Literal["past", "present"] = Field(description="Narrative tense")
     voice_register: Literal["formal", "conversational", "literary", "sparse"] = Field(
@@ -59,15 +60,25 @@ class VoiceDocument(BaseModel):
         description="Patterns to avoid (e.g. adverb-heavy, said-bookisms)",
     )
 
+    @model_validator(mode="before")
+    @classmethod
+    def _strip_pov_character_whitespace(cls, data: Any) -> Any:
+        """Strip whitespace from pov_character before the bidirectional check."""
+        if isinstance(data, dict) and isinstance(data.get("pov_character"), str):
+            data["pov_character"] = data["pov_character"].strip()
+        return data
+
     @model_validator(mode="after")
     def _check_pov_character(self) -> VoiceDocument:
-        if self.pov in ("first_person", "third_person_limited") and not self.pov_character.strip():
+        # `pov_character` has already been whitespace-stripped by the before-validator,
+        # so a truthiness check suffices here.
+        if self.pov in ("first_person", "third_person_limited") and not self.pov_character:
             raise ValueError(
                 f"pov_character is required when pov is {self.pov!r}; "
                 "set it to the raw character ID whose perspective the prose follows. "
                 "See fill.md R-1.3."
             )
-        if self.pov in ("second_person", "third_person_omniscient") and self.pov_character.strip():
+        if self.pov in ("second_person", "third_person_omniscient") and self.pov_character:
             raise ValueError(
                 f"pov_character must be empty when pov is {self.pov!r}; "
                 "narration is not attached to a single character. See fill.md R-1.3."

--- a/src/questfoundry/models/fill.py
+++ b/src/questfoundry/models/fill.py
@@ -31,12 +31,15 @@ class VoiceDocument(BaseModel):
     DREAM's high-level vision doesn't specify.
     """
 
-    pov: Literal["first", "second", "third_limited", "third_omniscient"] = Field(
-        description="Narrative point of view"
-    )
+    pov: Literal[
+        "first_person", "second_person", "third_person_limited", "third_person_omniscient"
+    ] = Field(description="Narrative point of view")
     pov_character: str = Field(
-        default="",  # Empty string valid for omniscient/second POV
-        description="Whose perspective (for limited POVs). Empty string for omniscient/second.",
+        default="",
+        description=(
+            "POV character (required for first_person and third_person_limited; "
+            "empty for second_person and third_person_omniscient). See fill.md R-1.3."
+        ),
     )
     tense: Literal["past", "present"] = Field(description="Narrative tense")
     voice_register: Literal["formal", "conversational", "literary", "sparse"] = Field(
@@ -55,6 +58,15 @@ class VoiceDocument(BaseModel):
         default_factory=list,
         description="Patterns to avoid (e.g. adverb-heavy, said-bookisms)",
     )
+
+    @model_validator(mode="after")
+    def _check_pov_character_required(self) -> VoiceDocument:
+        if self.pov in ("first_person", "third_person_limited") and not self.pov_character:
+            raise ValueError(
+                f"pov_character is required when pov is {self.pov!r}; "
+                "set it to the entity ID whose perspective the prose follows. See fill.md R-1.3."
+            )
+        return self
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_contract_chaining.py
+++ b/tests/unit/test_contract_chaining.py
@@ -44,7 +44,7 @@ class TestValidateFillOutput:
                 "type": "voice",
                 "raw_id": "voice",
                 # tense omitted
-                "pov": "third_limited",
+                "pov": "third_person_limited",
                 "voice_register": "literary",
                 "sentence_rhythm": "varied",
                 "tone_words": ["wry"],
@@ -221,7 +221,7 @@ def _add_minimal_voice(g: Graph) -> None:
         {
             "type": "voice",
             "raw_id": "voice",
-            "pov": "third_limited",
+            "pov": "third_person_limited",
             "tense": "past",
             "voice_register": "literary",
             "sentence_rhythm": "varied",

--- a/tests/unit/test_export_context.py
+++ b/tests/unit/test_export_context.py
@@ -533,7 +533,7 @@ class TestVoiceExtraction:
                 "type": "voice",
                 "raw_id": "voice",
                 "story_title": "The Test",
-                "pov": "third_limited",
+                "pov": "third_person_limited",
                 "tense": "past",
                 "voice_register": "literary",
                 "sentence_rhythm": "flowing",

--- a/tests/unit/test_fill_context.py
+++ b/tests/unit/test_fill_context.py
@@ -437,13 +437,13 @@ class TestFormatVoiceContext:
             {
                 "type": "voice",
                 "raw_id": "main",
-                "pov": "third_limited",
+                "pov": "third_person_limited",
                 "tense": "past",
                 "voice_register": "literary",
             },
         )
         result = format_voice_context(fill_graph)
-        assert "pov: third_limited" in result
+        assert "pov: third_person_limited" in result
         assert "tense: past" in result
         assert "voice_register: literary" in result
         # Should not include graph metadata
@@ -609,14 +609,14 @@ class TestFormatPovContext:
             {
                 "type": "vision",
                 "genre": "mystery",
-                "pov_style": "first",
+                "pov_style": "first_person",
                 "protagonist_defined": True,
             },
         )
 
         result = format_pov_context(g)
 
-        assert "**Suggested POV:** first" in result
+        assert "**Suggested POV:** first_person" in result
         assert "**Protagonist:** Defined" in result
 
     def test_protagonist_defined_without_pov(self) -> None:

--- a/tests/unit/test_fill_models.py
+++ b/tests/unit/test_fill_models.py
@@ -140,6 +140,19 @@ class TestVoiceDocument:
                 tone_words=["dark"],
             )
 
+    def test_pov_character_padding_is_stripped(self) -> None:
+        # Whitespace around a real ID is stripped on construction so downstream
+        # consumers never see "  kay  " in the stored value.
+        doc = VoiceDocument(
+            pov="first_person",
+            pov_character="  kay  ",
+            tense="past",
+            voice_register="literary",
+            sentence_rhythm="varied",
+            tone_words=["dark"],
+        )
+        assert doc.pov_character == "kay"
+
     def test_second_person_rejects_non_empty_pov_character(self) -> None:
         # Per fill.md R-1.3: pov_character must be empty for second_person.
         with pytest.raises(ValidationError, match="pov_character must be empty"):

--- a/tests/unit/test_fill_models.py
+++ b/tests/unit/test_fill_models.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import Literal
+
 import pytest
 from pydantic import ValidationError
 
@@ -29,26 +31,26 @@ from questfoundry.models.pipeline import PhaseResult
 class TestVoiceDocument:
     def test_minimal_creation(self) -> None:
         doc = VoiceDocument(
-            pov="third_limited",
-            pov_character="",  # Required but can be empty for omniscient
+            pov="third_person_limited",
+            pov_character="kay",  # Required for first_person and third_person_limited per R-1.3
             tense="past",
             voice_register="literary",
             sentence_rhythm="varied",
             tone_words=["atmospheric"],
         )
-        assert doc.pov == "third_limited"
+        assert doc.pov == "third_person_limited"
         assert doc.tense == "past"
         assert doc.voice_register == "literary"
         assert doc.sentence_rhythm == "varied"
         assert doc.tone_words == ["atmospheric"]
-        assert doc.pov_character == ""
+        assert doc.pov_character == "kay"
         assert doc.avoid_words == []
         assert doc.avoid_patterns == []
 
     def test_pov_character_defaults_to_empty(self) -> None:
         """pov_character defaults to empty string when not provided."""
         doc = VoiceDocument(
-            pov="third_omniscient",
+            pov="third_person_omniscient",
             tense="past",
             voice_register="literary",
             sentence_rhythm="varied",
@@ -60,7 +62,7 @@ class TestVoiceDocument:
 
     def test_full_creation(self) -> None:
         doc = VoiceDocument(
-            pov="first",
+            pov="first_person",
             pov_character="kay",
             tense="present",
             voice_register="conversational",
@@ -73,16 +75,58 @@ class TestVoiceDocument:
         assert len(doc.avoid_words) == 2
 
     def test_all_pov_values(self) -> None:
-        for pov in ("first", "second", "third_limited", "third_omniscient"):
+        # Per fill.md R-1.3: pov_character required for first_person and third_person_limited;
+        # empty for second_person and third_person_omniscient.
+        cases: list[
+            tuple[
+                Literal[
+                    "first_person",
+                    "second_person",
+                    "third_person_limited",
+                    "third_person_omniscient",
+                ],
+                str,
+            ]
+        ] = [
+            ("first_person", "kay"),
+            ("second_person", ""),
+            ("third_person_limited", "kay"),
+            ("third_person_omniscient", ""),
+        ]
+        for pov, pov_character in cases:
             doc = VoiceDocument(
                 pov=pov,
-                pov_character="",  # Required
+                pov_character=pov_character,
                 tense="past",
                 voice_register="literary",
                 sentence_rhythm="varied",
                 tone_words=["dark"],
             )
             assert doc.pov == pov
+
+    def test_first_person_requires_pov_character(self) -> None:
+        # Per fill.md R-1.3: pov_character is required for first_person.
+        with pytest.raises(ValidationError, match="pov_character is required"):
+            VoiceDocument(
+                pov="first_person",
+                pov_character="",
+                tense="past",
+                voice_register="literary",
+                sentence_rhythm="varied",
+                tone_words=["dark"],
+            )
+
+    def test_third_person_limited_requires_pov_character(self) -> None:
+        # Per fill.md R-1.3: pov_character is required for third_person_limited.
+        with pytest.raises(ValidationError, match="pov_character is required"):
+            VoiceDocument(
+                pov="third_person_limited",
+                pov_character="",
+                tense="past",
+                voice_register="literary",
+                sentence_rhythm="varied",
+                tone_words=["dark"],
+            )
 
     def test_invalid_pov_rejected(self) -> None:
         with pytest.raises(ValidationError):
@@ -98,8 +142,8 @@ class TestVoiceDocument:
     def test_invalid_tense_rejected(self) -> None:
         with pytest.raises(ValidationError):
             VoiceDocument(
-                pov="first",
-                pov_character="",
+                pov="first_person",
+                pov_character="kay",
                 tense="future",  # type: ignore[arg-type]
                 voice_register="literary",
                 sentence_rhythm="varied",
@@ -109,8 +153,8 @@ class TestVoiceDocument:
     def test_empty_tone_words_rejected(self) -> None:
         with pytest.raises(ValidationError):
             VoiceDocument(
-                pov="first",
-                pov_character="",
+                pov="first_person",
+                pov_character="kay",
                 tense="past",
                 voice_register="literary",
                 sentence_rhythm="varied",
@@ -120,8 +164,8 @@ class TestVoiceDocument:
     def test_all_register_values(self) -> None:
         for reg in ("formal", "conversational", "literary", "sparse"):
             doc = VoiceDocument(
-                pov="first",
-                pov_character="",
+                pov="first_person",
+                pov_character="kay",
                 tense="past",
                 voice_register=reg,
                 sentence_rhythm="varied",
@@ -132,8 +176,8 @@ class TestVoiceDocument:
     def test_all_rhythm_values(self) -> None:
         for rhythm in ("varied", "punchy", "flowing"):
             doc = VoiceDocument(
-                pov="first",
-                pov_character="",
+                pov="first_person",
+                pov_character="kay",
                 tense="past",
                 voice_register="literary",
                 sentence_rhythm=rhythm,
@@ -268,21 +312,21 @@ class TestReviewFlag:
 class TestFillPhase0Output:
     def test_wraps_voice_document(self) -> None:
         voice = VoiceDocument(
-            pov="third_limited",
-            pov_character="",
+            pov="third_person_limited",
+            pov_character="kay",
             tense="past",
             voice_register="literary",
             sentence_rhythm="varied",
             tone_words=["atmospheric"],
         )
         output = FillPhase0Output(voice=voice, story_title="The Hollow Crown")
-        assert output.voice.pov == "third_limited"
+        assert output.voice.pov == "third_person_limited"
         assert output.story_title == "The Hollow Crown"
 
     def test_empty_title_rejected(self) -> None:
         voice = VoiceDocument(
-            pov="first",
-            pov_character="",
+            pov="first_person",
+            pov_character="kay",
             tense="past",
             voice_register="sparse",
             sentence_rhythm="punchy",
@@ -293,8 +337,8 @@ class TestFillPhase0Output:
 
     def test_whitespace_only_title_rejected(self) -> None:
         voice = VoiceDocument(
-            pov="first",
-            pov_character="",
+            pov="first_person",
+            pov_character="kay",
             tense="past",
             voice_register="sparse",
             sentence_rhythm="punchy",

--- a/tests/unit/test_fill_models.py
+++ b/tests/unit/test_fill_models.py
@@ -128,6 +128,42 @@ class TestVoiceDocument:
                 tone_words=["dark"],
             )
 
+    def test_whitespace_pov_character_rejected_for_attached_pov(self) -> None:
+        # A whitespace-only pov_character is treated as empty per R-1.3.
+        with pytest.raises(ValidationError, match="pov_character is required"):
+            VoiceDocument(
+                pov="first_person",
+                pov_character="   ",
+                tense="past",
+                voice_register="literary",
+                sentence_rhythm="varied",
+                tone_words=["dark"],
+            )
+
+    def test_second_person_rejects_non_empty_pov_character(self) -> None:
+        # Per fill.md R-1.3: pov_character must be empty for second_person.
+        with pytest.raises(ValidationError, match="pov_character must be empty"):
+            VoiceDocument(
+                pov="second_person",
+                pov_character="kay",
+                tense="past",
+                voice_register="literary",
+                sentence_rhythm="varied",
+                tone_words=["dark"],
+            )
+
+    def test_third_person_omniscient_rejects_non_empty_pov_character(self) -> None:
+        # Per fill.md R-1.3: pov_character must be empty for third_person_omniscient.
+        with pytest.raises(ValidationError, match="pov_character must be empty"):
+            VoiceDocument(
+                pov="third_person_omniscient",
+                pov_character="kay",
+                tense="past",
+                voice_register="literary",
+                sentence_rhythm="varied",
+                tone_words=["dark"],
+            )
+
     def test_invalid_pov_rejected(self) -> None:
         with pytest.raises(ValidationError):
             VoiceDocument(

--- a/tests/unit/test_fill_stage.py
+++ b/tests/unit/test_fill_stage.py
@@ -100,7 +100,7 @@ def _mock_implemented_phases(stage: FillStage) -> None:
             {
                 "type": "voice",
                 "raw_id": "voice",
-                "pov": "third_limited",
+                "pov": "third_person_limited",
                 "tense": "past",
                 "voice_register": "literary",
                 "sentence_rhythm": "varied",
@@ -216,7 +216,7 @@ class TestFillStageExecute:
         g.set_last_stage(last_stage)
         g.create_node(
             "voice::voice",
-            {"type": "voice", "raw_id": "voice", "pov": "third_limited", "tense": "past"},
+            {"type": "voice", "raw_id": "voice", "pov": "third_person_limited", "tense": "past"},
         )
         g.create_node("arc::spine", {"type": "arc", "raw_id": "spine", "arc_type": "spine"})
         g.save(tmp_path / "graph.db")
@@ -247,7 +247,7 @@ class TestFillStageExecute:
         with g.mutation_context(stage="fill", phase="voice"):
             g.create_node(
                 "voice::voice",
-                {"type": "voice", "raw_id": "voice", "pov": "first", "tense": "present"},
+                {"type": "voice", "raw_id": "voice", "pov": "first_person", "tense": "present"},
             )
         g.set_last_stage("fill")
         g.save(tmp_path / "graph.db")
@@ -430,7 +430,8 @@ def _make_voice_output() -> FillPhase0Output:
     """Create a valid FillPhase0Output for mocking."""
     return FillPhase0Output(
         voice=VoiceDocument(
-            pov="third_limited",
+            pov="third_person_limited",
+            pov_character="kay",
             tense="past",
             voice_register="literary",
             sentence_rhythm="varied",
@@ -476,7 +477,7 @@ class TestPhase0Voice:
         # Voice node should be created in graph with story_title
         voice_node = graph.get_node("voice::voice")
         assert voice_node is not None
-        assert voice_node["pov"] == "third_limited"
+        assert voice_node["pov"] == "third_person_limited"
         assert voice_node["tense"] == "past"
         assert voice_node["voice_register"] == "literary"
         assert voice_node["story_title"] == "The Hollow Crown"
@@ -663,7 +664,7 @@ def _make_prose_graph() -> Graph:
         {
             "type": "voice",
             "raw_id": "voice",
-            "pov": "third_limited",
+            "pov": "third_person_limited",
             "tense": "past",
             "voice_register": "literary",
             # R-1.7 stamp — Phase 1a's entry assertion requires this. Tests
@@ -1432,7 +1433,7 @@ class TestTwoStepFill:
             {
                 "type": "voice",
                 "raw_id": "voice",
-                "pov": "third_limited",
+                "pov": "third_person_limited",
                 "tense": "past",
                 "voice_register": "literary",
             },
@@ -1817,7 +1818,7 @@ class TestVoiceApprovalStamp:
             {
                 "type": "voice",
                 "raw_id": "voice",
-                "pov": "third_limited",
+                "pov": "third_person_limited",
                 "tense": "past",
             },
         )

--- a/tests/unit/test_fill_stage.py
+++ b/tests/unit/test_fill_stage.py
@@ -504,7 +504,7 @@ class TestPhase0Voice:
                 stage,
                 "_phase_0a_voice_research",
                 new_callable=AsyncMock,
-                return_value=("Use third_limited past for fantasy.", 2, 300),
+                return_value=("Use third_person_limited past for fantasy.", 2, 300),
             ),
             patch.object(stage, "_fill_llm_call", mock_llm_call),
         ):
@@ -517,7 +517,7 @@ class TestPhase0Voice:
         assert "grow_summary" in context
         assert "scene_types_summary" in context
         assert "research_notes" in context
-        assert "Use third_limited past for fantasy." in context["research_notes"]
+        assert "Use third_person_limited past for fantasy." in context["research_notes"]
 
     @pytest.mark.asyncio
     async def test_includes_research_metrics(self) -> None:
@@ -630,12 +630,12 @@ class TestPhase0aVoiceResearch:
             patch(
                 "questfoundry.agents.summarize_discussion",
                 new_callable=AsyncMock,
-                return_value=("Use third_limited past for dark fantasy.", 200),
+                return_value=("Use third_person_limited past for dark fantasy.", 200),
             ),
         ):
             brief, calls, tokens = await stage._phase_0a_voice_research(graph, MagicMock())
 
-        assert brief == "Use third_limited past for dark fantasy."
+        assert brief == "Use third_person_limited past for dark fantasy."
         assert calls == 4  # 3 discuss + 1 summarize
         assert tokens == 800  # 600 + 200
 

--- a/tests/unit/test_html_exporter.py
+++ b/tests/unit/test_html_exporter.py
@@ -330,7 +330,7 @@ class TestHtmlExporter:
 
 def _voice(register: str = "literary", rhythm: str = "flowing") -> dict[str, object]:
     return {
-        "pov": "third_limited",
+        "pov": "third_person_limited",
         "tense": "past",
         "voice_register": register,
         "sentence_rhythm": rhythm,

--- a/tests/unit/test_ship_stage.py
+++ b/tests/unit/test_ship_stage.py
@@ -36,7 +36,7 @@ def _create_project_with_graph(project_path: Path, *, with_prose: bool = True) -
             "raw_id": "voice",
             # No story_title — keeps the test_project_name_from_config
             # path exercising the config-name fallback in ShipStage.execute.
-            "pov": "third_limited",
+            "pov": "third_person_limited",
             "tense": "past",
             "voice_register": "literary",
             "sentence_rhythm": "varied",
@@ -289,7 +289,7 @@ class TestShipStage:
             {
                 "type": "voice",
                 "raw_id": "voice",
-                "pov": "third_limited",
+                "pov": "third_person_limited",
                 "tense": "past",
                 "voice_register": "literary",
                 "sentence_rhythm": "varied",


### PR DESCRIPTION
## Summary

Phase 3 Cluster A from the [prompt-vs-spec audit](docs/superpowers/reports/2026-04-25-prompt-spec-audit.md). Closes #1390. Per CLAUDE.md §Design Doc Authority, the spec (`fill.md §R-1.3`, merged in #1388) is the source of truth.

`dream.py` already uses long forms; `fill.py` was the outlier. Cluster A brings the FILL Pydantic model and its two phase0 prompts into alignment with the spec, and adds the `pov_character` enforcement validator that R-1.3 calls for.

## Changes

| File | Change |
|---|---|
| `src/questfoundry/models/fill.py` | `VoiceDocument.pov` Literal: short → long forms. Added `_check_pov_character_required` model_validator (R-1.3). |
| `prompts/templates/fill_phase0_voice.yaml` | POV value list + genre-convention examples → long forms; tightened `pov_character` description. |
| `prompts/templates/fill_phase0_discuss.yaml` | POV decision-list + selection rules → long forms. Pipeline stage counter "5 of 6" → "6 of 8" (folds in the FILL info finding while we're in this file). |
| 7 test files (~30 occurrences) | Mechanical rename. Added `pov_character="kay"` to test fixtures using `first_person` / `third_person_limited` to satisfy the new validator. Added 2 positive-failure tests for the validator. |

## Test plan

- [x] `grep -nE 'pov="(first\|second\|third_limited\|third_omniscient)"' src/ tests/` returns nothing matching POV usage
- [x] 434 tests across FILL-touched test files pass (`uv run pytest tests/unit/test_fill_*.py tests/unit/test_export_context.py tests/unit/test_ship_stage.py tests/unit/test_html_exporter.py tests/unit/test_contract_chaining.py -x -q`)
- [x] `uv run mypy src/questfoundry/models/fill.py` clean
- [x] `uv run ruff check` clean on all changed Python files
- [ ] CI green

## Out of scope

Other FILL audit findings — shadow context omission in `fill_phase1_prose_only.yaml`, missing `narrative_function` injection in `fill_phase1_prose.yaml`, generic `_build_error_feedback` message — land in subsequent Cluster D / E PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)