### PR TITLE
fix(dress): codeword → state_flag terminology + add cover category (Cluster B)

### DIFF
--- a/prompts/templates/dress_brief.yaml
+++ b/prompts/templates/dress_brief.yaml
@@ -39,7 +39,7 @@ system: |
 
   **brief** (object):
   - priority: 1-3 (1=must-have, 2=important, 3=nice-to-have)
-  - category: One of "scene", "portrait", "vista", "item_detail"
+  - category: One of "scene", "portrait", "vista", "item_detail", "cover" (use "cover" only for the story's title/cover image)
   - subject: What the image depicts (concise description)
   - entities: List of entity IDs present in the image (raw IDs, no scope prefix)
   - caption: Short descriptive caption (10-60 chars). Format: "[Subject] [action/state]"

--- a/prompts/templates/dress_brief_batch.yaml
+++ b/prompts/templates/dress_brief_batch.yaml
@@ -35,7 +35,7 @@ system: |
 
   **brief** (object):
   - priority: 1-3 (1=must-have, 2=important, 3=nice-to-have)
-  - category: One of "scene", "portrait", "vista", "item_detail"
+  - category: One of "scene", "portrait", "vista", "item_detail", "cover" (use "cover" only for the story's title/cover image)
   - subject: What the image depicts (concise description)
   - entities: List of entity IDs present in the image (raw IDs, no scope prefix)
   - caption: Short descriptive caption (10-60 chars). Format: "[Subject] [action/state]"

--- a/prompts/templates/dress_codex.yaml
+++ b/prompts/templates/dress_codex.yaml
@@ -4,7 +4,9 @@ description: Generate codex entries for a single entity
 system: |
   You are creating encyclopedia (codex) entries for an entity in an interactive fiction story.
   Codex entries are player-facing — written in-world, revealing information as the player
-  unlocks codewords through gameplay.
+  accumulates state flags through gameplay. (SHIP later projects a subset of state flags
+  as player-visible "codewords" for the gamebook export, but DRESS gates internally on
+  state flag IDs — see dress.md R-3.7.)
 
   ## Creative Vision
   {vision_context}
@@ -12,8 +14,8 @@ system: |
   ## Entity Details
   {entity_details}
 
-  ## Available Codewords
-  {codewords}
+  ## Available State Flags
+  {state_flags}
 
   ## Output Schema
   Return a JSON object with:
@@ -21,23 +23,23 @@ system: |
   **entries** (list of objects):
   - title: Short display title for this entry (e.g., character name, location name, faction name)
   - rank: Display order (1 = base knowledge, higher = deeper revelation)
-  - visible_when: List of codeword IDs that must be unlocked to see this entry (empty for rank 1)
+  - visible_when: List of state flag IDs that must all be present to see this entry (empty for rank 1)
   - content: Diegetic text — written in the story's voice, not meta-commentary
 
   {output_language_instruction}
 
   ## Rules
   - Rank 1 entry MUST have empty visible_when (always visible to player)
-  - Higher rank entries should require relevant codewords
+  - Higher rank entries should require relevant state flags
   - Content must be diegetic — written as if it exists in the story world
   - Do NOT spoil future plot events — each tier reveals only what the player has earned
-  - Codeword IDs in visible_when MUST be from the available codewords list
+  - State flag IDs in visible_when MUST be from the Available State Flags list above
   - Each rank must be unique — no duplicate rank numbers
   - Return ONLY valid JSON. No prose before or after.
 
 user: |
   Create codex entries for this entity.
-  CRITICAL: Use ONLY codeword IDs from the available list. Rank 1 must have empty visible_when.
+  CRITICAL: Use ONLY state flag IDs from the Available State Flags list. Rank 1 must have empty visible_when.
   Return ONLY a valid JSON object with an entries field.
 
 components: []

--- a/prompts/templates/dress_codex_batch.yaml
+++ b/prompts/templates/dress_codex_batch.yaml
@@ -4,13 +4,15 @@ description: Generate codex entries for a batch of entities
 system: |
   You are creating encyclopedia (codex) entries for entities in an interactive fiction story.
   Codex entries are player-facing — written in-world, revealing information as the player
-  unlocks codewords through gameplay.
+  accumulates state flags through gameplay. (SHIP later projects a subset of state flags
+  as player-visible "codewords" for the gamebook export, but DRESS gates internally on
+  state flag IDs — see dress.md R-3.7.)
 
   ## Creative Vision
   {vision_context}
 
-  ## Available Codewords
-  {codewords}
+  ## Available State Flags
+  {state_flags}
 
   ## Output Schema
   Return a JSON object with an "entities" array. Each element must have:
@@ -20,17 +22,17 @@ system: |
   **entries** (list of objects):
   - title: Short display title for this entry (e.g., character name, location name, faction name)
   - rank: Display order (1 = base knowledge, higher = deeper revelation)
-  - visible_when: List of codeword IDs that must be unlocked to see this entry (empty for rank 1)
+  - visible_when: List of state flag IDs that must all be present to see this entry (empty for rank 1)
   - content: Diegetic text — written in the story's voice, not meta-commentary
 
   {output_language_instruction}
 
   ## Rules
   - Rank 1 entry MUST have empty visible_when (always visible to player)
-  - Higher rank entries should require relevant codewords
+  - Higher rank entries should require relevant state flags
   - Content must be diegetic — written as if it exists in the story world
   - Do NOT spoil future plot events — each tier reveals only what the player has earned
-  - Codeword IDs in visible_when MUST be from the available codewords list
+  - State flag IDs in visible_when MUST be from the Available State Flags list above
   - Each rank must be unique per entity — no duplicate rank numbers
   - Return ONLY valid JSON. No prose before or after.
 
@@ -39,7 +41,7 @@ user: |
   {entities_batch}
 
   Create codex entries for ALL {entity_count} entities listed above.
-  CRITICAL: Use ONLY codeword IDs from the available list. Rank 1 must have empty visible_when.
+  CRITICAL: Use ONLY state flag IDs from the Available State Flags list. Rank 1 must have empty visible_when.
   Return a JSON object with an "entities" array containing one element per entity.
 
 components: []

--- a/src/questfoundry/models/dress.py
+++ b/src/questfoundry/models/dress.py
@@ -79,7 +79,10 @@ class CodexEntry(BaseModel):
     """Player-facing encyclopedia entry for an entity.
 
     Multiple entries per entity enable spoiler graduation: players see
-    more as they unlock codewords. Linked to entity via HasEntry edge.
+    more as they accumulate state flags through gameplay. Linked to
+    entity via HasEntry edge. (SHIP later projects a subset of state
+    flags as player-visible "codewords" for the gamebook export, but
+    DRESS gates internally on state flag IDs — see dress.md R-3.7.)
     """
 
     title: str = Field(
@@ -89,7 +92,7 @@ class CodexEntry(BaseModel):
     rank: int = Field(ge=1, description="Display order (1 = base knowledge, higher = deeper)")
     visible_when: list[str] = Field(
         default_factory=list,
-        description="Codeword IDs that must all be present to unlock this tier",
+        description="State flag IDs that must all be present to unlock this tier (see dress.md R-3.7)",
     )
     content: str = Field(min_length=1, description="Diegetic content — in-world voice, no spoilers")
 

--- a/src/questfoundry/pipeline/stages/dress.py
+++ b/src/questfoundry/pipeline/stages/dress.py
@@ -916,7 +916,7 @@ class DressStage:
                 "vision_context": vision_ctx or "No creative vision available.",
                 "entities_batch": entities_batch,
                 "entity_count": str(len(chunk)),
-                "codewords": state_flag_list or "No codewords defined.",
+                "state_flags": state_flag_list or "No state flags defined.",
                 "output_language_instruction": self._lang_instruction,
             }
             output, llm_calls, tokens = await self._dress_llm_call(
@@ -1125,7 +1125,7 @@ class DressStage:
         context = {
             "vision_context": vision_ctx or "No creative vision available.",
             "entity_details": entity_details_with_warning,
-            "codewords": state_flag_list or "No codewords defined.",
+            "state_flags": state_flag_list or "No state flags defined.",
             "output_language_instruction": self._lang_instruction,
         }
         output, calls, tokens = await self._dress_llm_call(


### PR DESCRIPTION
## Summary

Phase 3 Cluster B from the [prompt-vs-spec audit](docs/superpowers/reports/2026-04-25-prompt-spec-audit.md). Closes #1394. Per `dress.md §R-3.7` and `story-graph-ontology.md §Part 8`, DRESS gates internally on state flag IDs — not codewords. The data flow already uses state flag nodes; only the prompt labels and one Pydantic docstring were wrong.

## Changes

| File | Change |
|---|---|
| `prompts/templates/dress_codex.yaml` | "Codeword" → "State Flag" labels throughout. Added a one-paragraph note explaining the SHIP projection so the historical naming makes sense. Renamed `{codewords}` template variable to `{state_flags}`. |
| `prompts/templates/dress_codex_batch.yaml` | Same treatment as `dress_codex.yaml`. |
| `prompts/templates/dress_brief.yaml` | `category` enum now lists all 5 `IllustrationCategory` values (added `"cover"`). |
| `prompts/templates/dress_brief_batch.yaml` | Same. |
| `src/questfoundry/models/dress.py` `CodexEntry` | Class + `visible_when` docstrings name "state flag IDs" explicitly and cite R-3.7. |
| `src/questfoundry/pipeline/stages/dress.py` | Two call sites updated from `"codewords": ...` → `"state_flags": ...` to match the renamed template variable. |

## Test plan

- [x] `grep -inE "codeword" prompts/templates/dress_*.yaml src/questfoundry/models/dress.py src/questfoundry/pipeline/stages/dress.py` returns only the three intentional occurrences in the SHIP-projection explanatory notes
- [x] Both brief prompts list all 5 `IllustrationCategory` values
- [x] 170 DRESS tests pass (`uv run pytest tests/unit/test_dress*.py -x -q`)
- [x] mypy + ruff clean

## Out of scope

Other DRESS audit findings — entity-overlay enrichment in `format_entity_for_codex()`, generic `_dress_llm_call` repair message, spoiler-direction rules absent from codex generation prompts — land in subsequent Cluster D / E PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)