### PR TITLE
fix(polish): close hard findings in phase1a, phase2, phase5a (Cluster C)

### DIFF
--- a/prompts/templates/polish_phase1a_narrative_gaps.yaml
+++ b/prompts/templates/polish_phase1a_narrative_gaps.yaml
@@ -2,8 +2,16 @@ name: polish_phase1a_narrative_gaps
 description: Identify missing beats in path sequences (POLISH Phase 1a, Narrative Gap Insertion)
 
 system: |
-  You are analyzing path beat sequences to find narrative gaps --
-  places where the story jumps too abruptly between beats.
+  You are POLISH Phase 1a (Narrative Gap Insertion). Your job is to scan
+  each path's beat sequence for narrative gaps and propose inserting
+  *structural transition beats* — gap beats — that bridge abrupt jumps.
+
+  Per polish.md R-1a.2, gap beats are STRUCTURAL ONLY. They MUST NOT
+  advance, reveal, commit, or complicate any dilemma. The
+  `dilemma_impacts` field is intentionally absent from the output schema
+  below — do not invent it. If you find yourself wanting to record a
+  dilemma effect, the beat is not a gap beat and does not belong in this
+  phase's output.
 
   ## Beat Ordering (CRITICAL — read this first)
   after_beat = the EARLIER beat (the new beat goes AFTER it)
@@ -30,16 +38,16 @@ system: |
   4. Gap beats should be concise transitions, not major story events
   5. Maximum 2 gap beats per path
 
-  ## Path → Dilemma mapping (use these dilemma_id values)
+  ## Path → Dilemma mapping (FOR REFERENCE ONLY — do not use in output)
+  This is shown so you can recognise which dilemmas a path explores
+  while reading its sequence. Gap beats do not reference dilemmas.
   {path_dilemma_map}
-
-  ## Valid dilemma IDs
-  {valid_dilemma_ids}
 
   ## Path Sequences (in execution order)
   {path_sequences}
 
   ## What NOT to Do
+  - Do NOT include `dilemma_impacts` in any gap beat (R-1a.2 — gap beats are structural)
   - Do NOT propose gaps for paths with only 1-2 beats
   - Do NOT propose gaps between beats that already flow naturally
   - Do NOT use IDs not listed in the Valid IDs section
@@ -57,13 +65,11 @@ system: |
   - before_beat: the LATER beat (or null for end of path)
   - summary: concise description of the gap beat (1 sentence)
   - scene_type: scene | sequel | micro_beat (default: sequel)
-  - dilemma_impacts: list of how this beat affects dilemmas (may be empty)
-    Each item: {{"dilemma_id": "<id>", "effect": "<advances|reveals|commits|complicates>", "note": "<explanation>"}}
-    Effect values:
-      advances    = moves the dilemma closer to resolution (tension builds)
-      reveals     = discloses new information about the dilemma
-      commits     = a character makes an irreversible choice about the dilemma
-      complicates = adds a new obstacle or contradiction to the dilemma
+
+  Note: POLISH code automatically adds `is_gap_beat: True`, `role: "gap_beat"`,
+  `created_by: "POLISH"`, and zero `dilemma_impacts` to every accepted beat
+  (per R-1a.1). You do not include those fields — they are not part of this
+  schema.
 
   If no gaps are needed, return an empty gaps array.
 
@@ -75,10 +81,7 @@ system: |
         "after_beat": "beat::setup_01",
         "before_beat": "beat::climax_01",
         "summary": "Hero reflects on the stakes before the confrontation",
-        "scene_type": "sequel",
-        "dilemma_impacts": [
-          {{"dilemma_id": "dilemma::trust_or_betray", "effect": "advances", "note": "Hero weighs loyalty against self-interest before the confrontation forces a choice"}}
-        ]
+        "scene_type": "sequel"
       }}
     ]
   }}
@@ -88,7 +91,7 @@ user: |
 
   REMINDER: Return ONLY a valid JSON object. Use ONLY IDs from the Valid IDs section.
   REMINDER: after_beat is the EARLIER beat, before_beat is the LATER beat. Do NOT reverse them.
-  REMINDER: Include dilemma_impacts for each gap beat using ONLY valid dilemma_ids listed above. Valid effect values: advances, reveals, commits, complicates.
+  REMINDER: Gap beats carry NO `dilemma_impacts` (R-1a.2). The field is not in the schema.
   Maximum 2 gap beats per path.
 
 components: []

--- a/prompts/templates/polish_phase2_pacing.yaml
+++ b/prompts/templates/polish_phase2_pacing.yaml
@@ -2,8 +2,19 @@ name: polish_phase2_pacing
 description: Propose micro-beat insertions to fix pacing issues
 
 system: |
-  You are a pacing consultant for a branching story. The story has
+  You are POLISH Phase 2 (Pacing Run Correction). The story has
   pacing issues — stretches of beats that need breathing room.
+
+  ## Division of responsibility (per polish.md R-2.6 / R-2.7)
+  Run detection is done by code, not by you: POLISH walks each path and
+  flags 3+ consecutive same-`scene_type` beats and post-commit beats that
+  lack a sequel. Those flags are listed under "Pacing Issues Detected"
+  below as `consecutive_scene`, `consecutive_sequel`, and
+  `no_sequel_after_commit`. Your job is to propose ONE correction
+  micro-beat per flagged issue (per R-2.7), choosing the OPPOSITE
+  scene_type from the run that triggered the flag — sequel-style
+  reflection for `consecutive_scene`, action-style for
+  `consecutive_sequel`, and processing-style for `no_sequel_after_commit`.
 
   ## What Are Micro-beats?
   Brief transition moments that don't advance the plot:

--- a/prompts/templates/polish_phase2_pacing.yaml
+++ b/prompts/templates/polish_phase2_pacing.yaml
@@ -35,8 +35,7 @@ system: |
   - For "consecutive_scene": Insert a reflection/transition micro-beat
   - For "consecutive_sequel": Insert an action/event micro-beat
   - For "no_sequel_after_commit": Insert a processing/reaction micro-beat
-  - Not every flag needs a micro-beat — skip if the pacing feels natural
-  - Maximum 1 micro-beat per pacing issue
+  - Exactly 1 micro-beat per flagged pacing issue (per R-2.7) — do not skip flagged runs and do not insert extras
 
   ## Valid Entity IDs
   Valid entity_ids (use ONLY these): {valid_entity_ids}

--- a/prompts/templates/polish_phase5a_choice_labels.yaml
+++ b/prompts/templates/polish_phase5a_choice_labels.yaml
@@ -17,6 +17,10 @@ system: |
   ## Choices to Label
   {choice_details}
 
+  ## Valid IDs
+  Valid passage IDs (use ONLY these for from_passage / to_passage):
+  {valid_passage_ids}
+
   ## Output Format
   Return a JSON object with a "choice_labels" array. One entry per choice above.
 
@@ -35,6 +39,7 @@ system: |
   - Do NOT use meta-language ("Choose option A", "Select path 2")
   - Do NOT make labels longer than 15 words
   - Do NOT skip any choice — provide a label for every choice listed
+  - Do NOT invent passage IDs — every from_passage / to_passage MUST appear in the Valid passage IDs list above
   - Do NOT add prose before or after the JSON output
 
 user: |

--- a/src/questfoundry/graph/context.py
+++ b/src/questfoundry/graph/context.py
@@ -24,9 +24,16 @@ def build_path_dilemma_context(
 ) -> tuple[str, str]:
     """Build path-to-dilemma mapping text and valid dilemma ID text for LLM context.
 
-    Used by gap-insertion phases (POLISH Phase 1a, GROW Phase 4c historically)
-    to give the LLM the dilemma context it needs when proposing gap or
-    correction beats with `dilemma_impacts`.
+    Two callers, two uses:
+
+    - POLISH Phase 1a (narrative gap insertion) consumes the
+      `path_dilemma_map_text` return value as **reference-only context** so
+      the LLM can recognise which dilemmas a path explores while reading
+      the sequence. Per polish.md R-1a.2 gap beats are structural and do
+      NOT carry `dilemma_impacts`, so Phase 1a discards the
+      `valid_dilemma_ids_text` element.
+    - GROW Phase 4c (historically) used both elements to help the LLM
+      propose correction beats that DO carry `dilemma_impacts`.
 
     Args:
         graph: The graph store to query for dilemma nodes.

--- a/src/questfoundry/graph/polish_context.py
+++ b/src/questfoundry/graph/polish_context.py
@@ -305,10 +305,25 @@ def format_choice_label_context(
             f"     To: {to_id} ({to_summary}){grants_str}"
         )
 
+    # Valid passage IDs: every passage_id referenced by any ChoiceSpec, sorted
+    # for determinism. Per CLAUDE.md §6 the LLM must receive an explicit Valid
+    # IDs list rather than be expected to derive IDs from the choice details
+    # block — small models otherwise invent or mangle passage IDs and Phase 6
+    # fails to wire choice edges.
+    valid_passage_ids = sorted(
+        {
+            pid
+            for spec in choice_specs
+            for pid in (spec.get("from_passage", ""), spec.get("to_passage", ""))
+            if pid
+        }
+    )
+
     return {
         "choice_details": "\n".join(choice_lines),
         "story_context": story_context,
         "choice_count": str(len(choice_specs)),
+        "valid_passage_ids": ", ".join(valid_passage_ids),
     }
 
 

--- a/src/questfoundry/models/grow.py
+++ b/src/questfoundry/models/grow.py
@@ -268,7 +268,14 @@ class Phase4fOutput(BaseModel):
 
 
 class GapProposal(BaseModel):
-    """Phase 4b/4c: Proposes new beats to fill structural gaps."""
+    """POLISH Phase 1a (Narrative Gap Insertion): proposes new beats to fill
+    structural transitions between adjacent beats. Per polish.md R-1a.2, gap
+    beats are STRUCTURAL ONLY — they MUST NOT carry `dilemma_impacts`. The
+    field below is retained as an empty default for back-compat with the
+    prior GROW Phase 4b/4c shape; a model_validator rejects any non-empty
+    value so an LLM that ignores the prompt fails validation immediately
+    rather than producing a beat that violates R-1a.2 downstream.
+    """
 
     path_id: str = Field(min_length=1)
     after_beat: str | None = Field(
@@ -281,7 +288,25 @@ class GapProposal(BaseModel):
     )
     summary: str = Field(min_length=1)
     scene_type: Literal["scene", "sequel", "micro_beat"] = "sequel"
-    dilemma_impacts: list[DilemmaImpact] = Field(default_factory=list)
+    dilemma_impacts: list[DilemmaImpact] = Field(
+        default_factory=list,
+        description=(
+            "MUST be empty per polish.md R-1a.2 — gap beats are structural "
+            "transition beats and cannot advance, reveal, commit, or "
+            "complicate any dilemma."
+        ),
+    )
+
+    @model_validator(mode="after")
+    def _no_dilemma_impacts(self) -> GapProposal:
+        if self.dilemma_impacts:
+            raise ValueError(
+                "Gap beats MUST NOT carry dilemma_impacts (polish.md R-1a.2). "
+                "Gap beats are structural transition beats only — they cannot "
+                "advance, reveal, commit, or complicate any dilemma. Remove the "
+                "dilemma_impacts entries from this gap proposal."
+            )
+        return self
 
 
 class Phase4bOutput(BaseModel):

--- a/src/questfoundry/pipeline/stages/polish/llm_phases.py
+++ b/src/questfoundry/pipeline/stages/polish/llm_phases.py
@@ -236,16 +236,18 @@ class _PolishLLMPhaseMixin:
         # pacing_gaps moved to POLISH).
         from questfoundry.graph.context import build_path_dilemma_context
 
-        path_dilemma_map_text, valid_dilemma_ids_text = build_path_dilemma_context(
-            graph, path_nodes
-        )
+        # Phase 1a no longer accepts dilemma_impacts in its output (R-1a.2 — gap
+        # beats are structural). The path → dilemma map is still shown for context
+        # so the LLM can recognise which dilemmas a path explores while reading the
+        # sequence, but valid_dilemma_ids is no longer injected (gap beats can't
+        # reference dilemmas).
+        path_dilemma_map_text, _ = build_path_dilemma_context(graph, path_nodes)
 
         context = {
             "path_sequences": "\n\n".join(path_sequences),
             "valid_path_ids": ", ".join(sorted(path_nodes.keys())),
             "valid_beat_ids": ", ".join(sorted(valid_beat_ids)),
             "path_dilemma_map": path_dilemma_map_text,
-            "valid_dilemma_ids": valid_dilemma_ids_text,
         }
 
         # The LLM call uses POLISH's helper. POLISH's _polish_llm_call has no

--- a/tests/unit/test_grow_models.py
+++ b/tests/unit/test_grow_models.py
@@ -301,6 +301,23 @@ class TestGapProposal:
         with pytest.raises(ValidationError, match="summary"):
             GapProposal(path_id="t1", summary="")
 
+    def test_dilemma_impacts_rejected_per_r_1a_2(self) -> None:
+        # Per polish.md R-1a.2, gap beats are structural and must carry zero
+        # dilemma_impacts. The validator rejects any non-empty value so an
+        # LLM that ignores the prompt fails fast.
+        with pytest.raises(ValidationError, match=r"R-1a\.2"):
+            GapProposal(
+                path_id="t1",
+                summary="A transition beat.",
+                dilemma_impacts=[
+                    {  # type: ignore[list-item]
+                        "dilemma_id": "dilemma::trust",
+                        "effect": "advances",
+                        "note": "test",
+                    }
+                ],
+            )
+
 
 class TestOverlayProposal:
     def test_valid_proposal(self) -> None:

--- a/tests/unit/test_polish_phase5_context.py
+++ b/tests/unit/test_polish_phase5_context.py
@@ -43,12 +43,30 @@ class TestFormatChoiceLabelContext:
         assert "choice_details" in ctx
         assert "Start" in ctx["choice_details"]
         assert "End" in ctx["choice_details"]
+        # valid_passage_ids must be populated for the prompt's Valid IDs section
+        # (CLAUDE.md §6) — sorted, comma-joined union of from/to passage IDs.
+        assert ctx["valid_passage_ids"] == "p1, p2"
 
     def test_empty_choices(self) -> None:
         graph = Graph.empty()
         ctx = format_choice_label_context(graph, [], [])
         assert ctx["choice_count"] == "0"
         assert ctx["choice_details"] == ""
+        # Empty input → empty Valid IDs string (still present so the template
+        # placeholder always renders).
+        assert ctx["valid_passage_ids"] == ""
+
+    def test_valid_passage_ids_dedups_and_sorts(self) -> None:
+        # Same passage appearing as both `from` and `to` across multiple choices
+        # should be deduplicated; output is sorted for determinism.
+        graph = Graph.empty()
+        choice_specs = [
+            {"from_passage": "p2", "to_passage": "p3"},
+            {"from_passage": "p1", "to_passage": "p2"},
+            {"from_passage": "p2", "to_passage": "p3"},
+        ]
+        ctx = format_choice_label_context(graph, choice_specs, [])
+        assert ctx["valid_passage_ids"] == "p1, p2, p3"
 
     def test_story_context_from_dream(self) -> None:
         graph = Graph.empty()


### PR DESCRIPTION
## Summary

Phase 3 Cluster C from the [prompt-vs-spec audit](docs/superpowers/reports/2026-04-25-prompt-spec-audit.md). Closes #1396. 5 hard findings concentrated in 3 POLISH prompt files; folded into one PR since the audit's "~4 PRs" estimate over-fragmented work that's tightly related and shares review context.

## Changes

| File | Hard findings closed | Change |
|---|---|---|
| `prompts/templates/polish_phase1a_narrative_gaps.yaml` | 3 | System block now identifies as POLISH Phase 1a and states R-1a.2 up front; `dilemma_impacts` removed from schema, example, and user-message reminder; new schema note explains code-set fields (`is_gap_beat`, `role`, `created_by`); path-dilemma map reframed as reference-only. |
| `src/questfoundry/pipeline/stages/polish/llm_phases.py` | — | Dropped unused `valid_dilemma_ids` from phase1a context dict (template no longer references it). |
| `src/questfoundry/models/grow.py` `GapProposal` | — (defensive) | New `_no_dilemma_impacts` model_validator rejects any non-empty `dilemma_impacts` with spec-citing error. Belt-and-braces with the prompt change. |
| `prompts/templates/polish_phase2_pacing.yaml` | 1 | System block identifies as POLISH Phase 2 and explains R-2.6/R-2.7 division of responsibility (code detects runs, LLM proposes correction beats with opposite scene_type). |
| `prompts/templates/polish_phase5a_choice_labels.yaml` | 1 | New `### Valid IDs` section listing valid passage IDs; "What NOT to Do" rule forbidding invented passage IDs. |
| `src/questfoundry/graph/polish_context.py` | — | `format_choice_label_context` now derives `valid_passage_ids` from ChoiceSpecs. |
| `tests/unit/test_grow_models.py` | — | New `test_dilemma_impacts_rejected_per_r_1a_2` pins the validator. |

Diff: 7 files, +103/-25.

## Test plan

- [x] `polish_phase1a_narrative_gaps.yaml` no longer instructs the LLM to set `dilemma_impacts`; system opener identifies POLISH; schema notes the auto-set fields
- [x] `polish_phase2_pacing.yaml` clarifies R-2.6 detection-by-code and R-2.7 LLM responsibility
- [x] `polish_phase5a_choice_labels.yaml` has explicit Valid passage IDs section
- [x] 428 POLISH + grow_models tests pass (`uv run pytest tests/unit/test_polish*.py tests/unit/test_grow_models.py -x -q`)
- [x] mypy + ruff clean
- [x] All existing `GapProposal(...)` constructions across the test suite use the default empty `dilemma_impacts` — none break

## Out of scope

- POLISH soft findings (~22) — bare-ID context blocks, missing GOOD/BAD examples — land in **Cluster E** (context enrichment)
- POLISH phase identity drift in other migrated phases — `grep "GROW Phase" prompts/templates/polish_*.yaml` returns zero hits, so the only mislabel was phase1a (now fixed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)