### PR TITLE
fix(fill): echo Literal allowed values in repair feedback (Cluster D-1)

### DIFF
--- a/src/questfoundry/pipeline/stages/fill.py
+++ b/src/questfoundry/pipeline/stages/fill.py
@@ -778,7 +778,10 @@ class FillStage:
             for field_path in invalid_fields:
                 values = _get_literal_values_at_path(output_schema, field_path)
                 if values is not None:
-                    formatted = ", ".join(repr(v) for v in values)
+                    # Backtick-wrap each value for consistency with the SEED
+                    # repair-feedback pattern (serialize.py) and the prompts
+                    # themselves (CLAUDE.md §9 rule 1).
+                    formatted = ", ".join(f"`{v}`" for v in values)
                     literal_hints.append(f"Allowed values for `{field_path}`: {formatted}")
             if literal_hints:
                 parts.append("\n" + "\n".join(literal_hints))

--- a/src/questfoundry/pipeline/stages/fill.py
+++ b/src/questfoundry/pipeline/stages/fill.py
@@ -130,6 +130,76 @@ _STRUCTURAL_ERROR_TYPES = frozenset(
 )
 
 
+def _get_literal_values_at_path(
+    model_cls: type[BaseModel], field_path: str
+) -> tuple[Any, ...] | None:
+    """Walk a Pydantic model by dotted path and return the Literal values for that field.
+
+    Used by ``_build_error_feedback`` to echo allowed enum values on retry so
+    a small model that emits an out-of-set value (e.g. ``pov: "third person
+    limited"`` for the ``Literal["first_person", "second_person", ...]``
+    field) sees the valid set in the next attempt.
+
+    Args:
+        model_cls: The top-level Pydantic schema (e.g. FillPhase0Output).
+        field_path: Dotted path from `_classify_validation_error` (e.g.
+            ``"voice.pov"``).
+
+    Returns:
+        Tuple of allowed literal values if the field's annotation is a
+        ``Literal[...]`` (or a union containing one), else ``None``.
+    """
+    import types
+    import typing
+
+    # Strip list-index segments produced by Pydantic for list-typed errors
+    # (e.g. "passages.0.entity_updates.1.entity_id" -> "passages.entity_updates.entity_id"
+    # for schema traversal). Numeric segments map to "the item type", so we
+    # skip them and continue with the next named field.
+    parts = [p for p in field_path.split(".") if p and not p.isdigit()]
+
+    current_cls: type[BaseModel] | None = model_cls
+    annotation: Any = None
+    for i, part in enumerate(parts):
+        if current_cls is None:
+            return None
+        field_info = current_cls.model_fields.get(part)
+        if field_info is None:
+            return None
+        annotation = field_info.annotation
+
+        # Step into a nested BaseModel for the next segment, or into the item
+        # type of a list[BaseModel].
+        if i < len(parts) - 1:
+            inner: type[BaseModel] | None = None
+            args = getattr(annotation, "__args__", ())
+            if isinstance(annotation, type) and issubclass(annotation, BaseModel):
+                inner = annotation
+            else:
+                for arg in args:
+                    if isinstance(arg, type) and issubclass(arg, BaseModel):
+                        inner = arg
+                        break
+            current_cls = inner
+
+    if annotation is None:
+        return None
+
+    # Direct Literal[...]
+    if typing.get_origin(annotation) is typing.Literal:
+        return typing.get_args(annotation)
+    # Optional[Literal[...]] / Literal[...] | None
+    candidates: tuple[Any, ...] = ()
+    if hasattr(annotation, "__origin__"):
+        candidates = getattr(annotation, "__args__", ())
+    elif isinstance(annotation, types.UnionType):
+        candidates = annotation.__args__
+    for arg in candidates:
+        if typing.get_origin(arg) is typing.Literal:
+            return typing.get_args(arg)
+    return None
+
+
 def _classify_validation_error(
     error: Exception,
 ) -> tuple[str, list[str], list[str]]:
@@ -644,7 +714,9 @@ class FillStage:
                 )
 
                 if attempt < max_retries - 1:
-                    error_msg = self._build_error_feedback(e, output_schema, failure_type)
+                    error_msg = self._build_error_feedback(
+                        e, output_schema, failure_type, invalid_fields=invalid
+                    )
                     messages = list(base_messages)
                     messages.append(HumanMessage(content=error_msg))
 
@@ -658,6 +730,7 @@ class FillStage:
         error: Exception,
         output_schema: type[BaseModel],
         failure_type: str = "unknown",
+        invalid_fields: list[str] | None = None,
     ) -> str:
         """Build structured error feedback for LLM retry.
 
@@ -666,10 +739,19 @@ class FillStage:
         and fix only the structural issue. This prevents the model from
         rewriting good prose into something safer/shorter during retries.
 
+        For content failures on Literal fields (e.g.,
+        ``VoiceDocument.pov``), the feedback also echoes the allowed values
+        per CLAUDE.md §repair-loop quality. Without this, a 4B model that
+        outputs ``pov: "third person limited"`` sees only "value is not a
+        valid enumeration member" with no list of what IS valid — repair-loop
+        blindness, the murder1 failure shape generalised to FILL.
+
         Args:
             error: The validation error.
             output_schema: The expected schema.
             failure_type: Classification from _classify_validation_error.
+            invalid_fields: Dotted field paths flagged as content failures by
+                _classify_validation_error. Used to look up Literal values.
 
         Returns:
             Formatted error feedback string.
@@ -687,6 +769,19 @@ class FillStage:
             )
         else:
             parts.append("\nPlease fix the errors and try again.")
+
+        # Per CLAUDE.md §6 / §repair-loop quality: echo allowed Literal values
+        # for any invalid Literal-typed field so the model can self-correct
+        # instead of guessing again.
+        if invalid_fields:
+            literal_hints: list[str] = []
+            for field_path in invalid_fields:
+                values = _get_literal_values_at_path(output_schema, field_path)
+                if values is not None:
+                    formatted = ", ".join(repr(v) for v in values)
+                    literal_hints.append(f"Allowed values for `{field_path}`: {formatted}")
+            if literal_hints:
+                parts.append("\n" + "\n".join(literal_hints))
 
         return "\n".join(parts)
 

--- a/src/questfoundry/pipeline/stages/fill.py
+++ b/src/questfoundry/pipeline/stages/fill.py
@@ -22,7 +22,7 @@ import re
 from collections.abc import Awaitable, Callable
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, TypeVar
+from typing import TYPE_CHECKING, Any, Literal, TypeVar, get_args, get_origin
 
 from langchain_core.messages import HumanMessage, SystemMessage
 from pydantic import BaseModel, ValidationError
@@ -140,18 +140,20 @@ def _get_literal_values_at_path(
     limited"`` for the ``Literal["first_person", "second_person", ...]``
     field) sees the valid set in the next attempt.
 
+    Only direct ``Literal[...]`` fields are recognised. ``Optional[Literal[...]]``
+    is intentionally not supported — no current FILL field uses that shape and
+    YAGNI per CLAUDE.md (don't add code for hypothetical future requirements).
+    Add a test case alongside any future field that needs the union form.
+
     Args:
         model_cls: The top-level Pydantic schema (e.g. FillPhase0Output).
         field_path: Dotted path from `_classify_validation_error` (e.g.
             ``"voice.pov"``).
 
     Returns:
-        Tuple of allowed literal values if the field's annotation is a
-        ``Literal[...]`` (or a union containing one), else ``None``.
+        Tuple of allowed literal values if the field's annotation is a direct
+        ``Literal[...]``, else ``None``.
     """
-    import types
-    import typing
-
     # Strip list-index segments produced by Pydantic for list-typed errors
     # (e.g. "passages.0.entity_updates.1.entity_id" -> "passages.entity_updates.entity_id"
     # for schema traversal). Numeric segments map to "the item type", so we
@@ -182,22 +184,9 @@ def _get_literal_values_at_path(
                         break
             current_cls = inner
 
-    if annotation is None:
+    if annotation is None or get_origin(annotation) is not Literal:
         return None
-
-    # Direct Literal[...]
-    if typing.get_origin(annotation) is typing.Literal:
-        return typing.get_args(annotation)
-    # Optional[Literal[...]] / Literal[...] | None
-    candidates: tuple[Any, ...] = ()
-    if hasattr(annotation, "__origin__"):
-        candidates = getattr(annotation, "__args__", ())
-    elif isinstance(annotation, types.UnionType):
-        candidates = annotation.__args__
-    for arg in candidates:
-        if typing.get_origin(arg) is typing.Literal:
-            return typing.get_args(arg)
-    return None
+    return get_args(annotation)
 
 
 def _classify_validation_error(
@@ -772,8 +761,11 @@ class FillStage:
 
         # Per CLAUDE.md §6 / §repair-loop quality: echo allowed Literal values
         # for any invalid Literal-typed field so the model can self-correct
-        # instead of guessing again.
-        if invalid_fields:
+        # instead of guessing again. Skipped on structural failures because
+        # those carry the "fix ONLY the structural issue" instruction above —
+        # appending enum hints alongside that would contradict it for the
+        # mixed missing-field-AND-bad-Literal case.
+        if invalid_fields and failure_type != "structural":
             literal_hints: list[str] = []
             for field_path in invalid_fields:
                 values = _get_literal_values_at_path(output_schema, field_path)

--- a/tests/unit/test_fill_stage.py
+++ b/tests/unit/test_fill_stage.py
@@ -1359,6 +1359,7 @@ class TestBuildErrorFeedback:
             assert f"`{v}`" in feedback
 
     def test_literal_field_failure_lists_allowed_voice_register_values(self) -> None:
+        """`voice.voice_register` content failure echoes the four valid registers."""
         from questfoundry.models.fill import FillPhase0Output
 
         try:
@@ -1474,6 +1475,20 @@ class TestBuildErrorFeedback:
 
         assert _get_literal_values_at_path(FillPhase0Output, "voice.no_such_field") is None
         assert _get_literal_values_at_path(FillPhase0Output, "no_such_root") is None
+
+    def test_get_literal_values_at_path_walks_list_of_basemodel(self) -> None:
+        """The helper must step through `list[NestedModel]` annotations to reach
+        a Literal field on the inner model. `BatchedExpandOutput.blueprints` is
+        `list[ExpandBlueprint]`, and `ExpandBlueprint.opening_move` is the
+        Literal we want to surface on a `blueprints.0.opening_move` failure.
+        Without this branch the helper would bail at `blueprints` and the
+        repair message would silently omit the valid set — exactly the
+        repair-loop blindness this PR is fixing."""
+        from questfoundry.models.fill import BatchedExpandOutput
+        from questfoundry.pipeline.stages.fill import _get_literal_values_at_path
+
+        result = _get_literal_values_at_path(BatchedExpandOutput, "blueprints.0.opening_move")
+        assert result == ("dialogue", "action", "sensory_image", "internal_thought")
 
     def test_non_literal_content_failure_omits_literal_hint(self) -> None:
         """A `min_length=1` violation on a non-Literal field must not crash and

--- a/tests/unit/test_fill_stage.py
+++ b/tests/unit/test_fill_stage.py
@@ -7,6 +7,7 @@ from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from pydantic import ValidationError
 
 from questfoundry.graph.graph import Graph
 from questfoundry.models.fill import (
@@ -1321,6 +1322,113 @@ class TestBuildErrorFeedback:
         feedback = FillStage._build_error_feedback(error, FillPhase1Output, "content")
         assert "fix the errors" in feedback.lower()
         assert "keep" not in feedback.lower() or "prose" not in feedback.lower()
+
+    def test_literal_field_failure_lists_allowed_pov_values(self) -> None:
+        """A `voice.pov` content failure must echo the four valid Literal values
+        so a 4B model can self-correct on retry. Closes the FILL repair-gap
+        finding from the 2026-04-25 prompt-vs-spec audit."""
+        from questfoundry.models.fill import FillPhase0Output
+
+        try:
+            FillPhase0Output.model_validate(
+                {
+                    "voice": {
+                        "pov": "third person limited",  # bad — has spaces
+                        "pov_character": "kay",
+                        "tense": "past",
+                        "voice_register": "literary",
+                        "sentence_rhythm": "varied",
+                        "tone_words": ["dark"],
+                    },
+                    "story_title": "The Tower",
+                }
+            )
+            raise AssertionError("expected ValidationError")
+        except ValidationError as exc:
+            feedback = FillStage._build_error_feedback(
+                exc, FillPhase0Output, "content", invalid_fields=["voice.pov"]
+            )
+
+        assert "Allowed values for `voice.pov`:" in feedback
+        for v in (
+            "first_person",
+            "second_person",
+            "third_person_limited",
+            "third_person_omniscient",
+        ):
+            assert f"'{v}'" in feedback
+
+    def test_literal_field_failure_lists_allowed_voice_register_values(self) -> None:
+        from questfoundry.models.fill import FillPhase0Output
+
+        try:
+            FillPhase0Output.model_validate(
+                {
+                    "voice": {
+                        "pov": "third_person_omniscient",
+                        "pov_character": "",
+                        "tense": "past",
+                        "voice_register": "terse",  # bad
+                        "sentence_rhythm": "varied",
+                        "tone_words": ["dark"],
+                    },
+                    "story_title": "T",
+                }
+            )
+            raise AssertionError("expected ValidationError")
+        except ValidationError as exc:
+            feedback = FillStage._build_error_feedback(
+                exc,
+                FillPhase0Output,
+                "content",
+                invalid_fields=["voice.voice_register"],
+            )
+
+        assert "Allowed values for `voice.voice_register`:" in feedback
+        for v in ("formal", "conversational", "literary", "sparse"):
+            assert f"'{v}'" in feedback
+
+    def test_structural_failure_does_not_invoke_literal_lookup(self) -> None:
+        """Missing-field structural failures should not trigger Literal echoing —
+        the model needs to add the field, not pick a value for it."""
+        error = ValueError("missing field")
+        feedback = FillStage._build_error_feedback(
+            error,
+            FillPhase1Output,
+            "structural",
+            invalid_fields=None,
+        )
+        assert "Allowed values for" not in feedback
+
+    def test_non_literal_content_failure_omits_literal_hint(self) -> None:
+        """A `min_length=1` violation on a non-Literal field must not crash and
+        must not append a spurious Allowed-values line."""
+        from questfoundry.models.fill import FillPhase0Output
+
+        try:
+            FillPhase0Output.model_validate(
+                {
+                    "voice": {
+                        "pov": "third_person_omniscient",
+                        "pov_character": "",
+                        "tense": "past",
+                        "voice_register": "literary",
+                        "sentence_rhythm": "varied",
+                        "tone_words": [],  # bad — min_length=1
+                    },
+                    "story_title": "T",
+                }
+            )
+            raise AssertionError("expected ValidationError")
+        except ValidationError as exc:
+            feedback = FillStage._build_error_feedback(
+                exc,
+                FillPhase0Output,
+                "content",
+                invalid_fields=["voice.tone_words"],
+            )
+
+        assert "Allowed values for" not in feedback
 
 
 class TestTwoStepFill:

--- a/tests/unit/test_fill_stage.py
+++ b/tests/unit/test_fill_stage.py
@@ -1388,17 +1388,92 @@ class TestBuildErrorFeedback:
         for v in ("formal", "conversational", "literary", "sparse"):
             assert f"`{v}`" in feedback
 
-    def test_structural_failure_does_not_invoke_literal_lookup(self) -> None:
-        """Missing-field structural failures should not trigger Literal echoing —
-        the model needs to add the field, not pick a value for it."""
+    def test_literal_field_failure_lists_allowed_sentence_rhythm_values(self) -> None:
+        """`voice.sentence_rhythm` content failure echoes the three valid rhythms."""
+        from questfoundry.models.fill import FillPhase0Output
+
+        try:
+            FillPhase0Output.model_validate(
+                {
+                    "voice": {
+                        "pov": "third_person_omniscient",
+                        "pov_character": "",
+                        "tense": "past",
+                        "voice_register": "literary",
+                        "sentence_rhythm": "syncopated",  # bad
+                        "tone_words": ["dark"],
+                    },
+                    "story_title": "T",
+                }
+            )
+            raise AssertionError("expected ValidationError")
+        except ValidationError as exc:
+            feedback = FillStage._build_error_feedback(
+                exc,
+                FillPhase0Output,
+                "content",
+                invalid_fields=["voice.sentence_rhythm"],
+            )
+
+        assert "Allowed values for `voice.sentence_rhythm`:" in feedback
+        for v in ("varied", "punchy", "flowing"):
+            assert f"`{v}`" in feedback
+
+    def test_structural_failure_skips_literal_hints_even_with_invalid_fields(self) -> None:
+        """When `_classify_validation_error` returns ('structural', missing, invalid)
+        with a non-empty `invalid` list (mixed missing-field-AND-bad-Literal case),
+        `_build_error_feedback` must NOT emit Allowed-values hints — they would
+        contradict the "fix ONLY the structural issue" instruction. Closes the
+        ambiguity flagged in the #1399 review."""
         error = ValueError("missing field")
         feedback = FillStage._build_error_feedback(
             error,
             FillPhase1Output,
             "structural",
+            invalid_fields=["passage.passage_id"],  # non-empty even on structural
+        )
+        assert "Allowed values for" not in feedback
+        assert "fix only" in feedback.lower()
+
+    def test_none_invalid_fields_omits_literal_hints(self) -> None:
+        """Legacy callers that omit `invalid_fields` (the parameter default) get
+        identical pre-PR feedback output — no Allowed-values block appended."""
+        error = ValueError("min_length")
+        feedback = FillStage._build_error_feedback(
+            error,
+            FillPhase1Output,
+            "content",
             invalid_fields=None,
         )
         assert "Allowed values for" not in feedback
+
+    def test_get_literal_values_at_path_strips_list_index_segments(self) -> None:
+        """The helper must skip numeric segments produced by Pydantic for
+        list-typed validation errors (e.g. `passages.0.entity_updates.1.entity_id`).
+        Without index-stripping the schema walk would bail at "0" and miss the
+        nested Literal lookup entirely."""
+        from questfoundry.models.fill import FillPhase0Output
+        from questfoundry.pipeline.stages.fill import _get_literal_values_at_path
+
+        # voice.pov is Literal — accessed via the bare path
+        direct = _get_literal_values_at_path(FillPhase0Output, "voice.pov")
+        assert direct is not None
+        assert "first_person" in direct
+
+        # Same field with an interleaved spurious numeric segment must resolve
+        # identically (no Pydantic field is named "0" / "1" so the strip is
+        # the only thing keeping the walk alive).
+        with_indices = _get_literal_values_at_path(FillPhase0Output, "voice.0.pov")
+        assert with_indices == direct
+
+    def test_get_literal_values_at_path_returns_none_for_missing_field(self) -> None:
+        """A path that doesn't resolve in the schema returns None silently —
+        downstream code already handles the None branch as 'no hint to append'."""
+        from questfoundry.models.fill import FillPhase0Output
+        from questfoundry.pipeline.stages.fill import _get_literal_values_at_path
+
+        assert _get_literal_values_at_path(FillPhase0Output, "voice.no_such_field") is None
+        assert _get_literal_values_at_path(FillPhase0Output, "no_such_root") is None
 
     def test_non_literal_content_failure_omits_literal_hint(self) -> None:
         """A `min_length=1` violation on a non-Literal field must not crash and

--- a/tests/unit/test_fill_stage.py
+++ b/tests/unit/test_fill_stage.py
@@ -1356,7 +1356,7 @@ class TestBuildErrorFeedback:
             "third_person_limited",
             "third_person_omniscient",
         ):
-            assert f"'{v}'" in feedback
+            assert f"`{v}`" in feedback
 
     def test_literal_field_failure_lists_allowed_voice_register_values(self) -> None:
         from questfoundry.models.fill import FillPhase0Output
@@ -1386,7 +1386,7 @@ class TestBuildErrorFeedback:
 
         assert "Allowed values for `voice.voice_register`:" in feedback
         for v in ("formal", "conversational", "literary", "sparse"):
-            assert f"'{v}'" in feedback
+            assert f"`{v}`" in feedback
 
     def test_structural_failure_does_not_invoke_literal_lookup(self) -> None:
         """Missing-field structural failures should not trigger Literal echoing —

--- a/tests/unit/test_fill_stage.py
+++ b/tests/unit/test_fill_stage.py
@@ -1425,13 +1425,21 @@ class TestBuildErrorFeedback:
         with a non-empty `invalid` list (mixed missing-field-AND-bad-Literal case),
         `_build_error_feedback` must NOT emit Allowed-values hints — they would
         contradict the "fix ONLY the structural issue" instruction. Closes the
-        ambiguity flagged in the #1399 review."""
+        ambiguity flagged in the #1399 review.
+
+        Uses `BatchedExpandOutput` + `blueprints.0.opening_move` (a real Literal
+        field) so the test actually exercises the `failure_type != "structural"`
+        guard. With a non-Literal path, `_get_literal_values_at_path` would return
+        None regardless and the guard could be silently removed without breaking
+        the test."""
+        from questfoundry.models.fill import BatchedExpandOutput
+
         error = ValueError("missing field")
         feedback = FillStage._build_error_feedback(
             error,
-            FillPhase1Output,
+            BatchedExpandOutput,
             "structural",
-            invalid_fields=["passage.passage_id"],  # non-empty even on structural
+            invalid_fields=["blueprints.0.opening_move"],  # IS Literal — guard matters
         )
         assert "Allowed values for" not in feedback
         assert "fix only" in feedback.lower()


### PR DESCRIPTION
## Summary

Phase 3 Cluster D-1 from the [prompt-vs-spec audit](docs/superpowers/reports/2026-04-25-prompt-spec-audit.md). Closes #1398. Generalises the SEED Phase-1 `extra_repair_hints` pattern (PR #1384) to FILL `_build_error_feedback`.

When a Voice Document content failure fires on a Literal field (`pov`, `voice_register`, `sentence_rhythm`), the prior repair feedback named the field but did NOT echo the allowed values. A 4B model that emitted `pov: "third person limited"` saw "value is not a valid enumeration member" with no list of what IS valid — repair-loop blindness, the murder1 failure shape generalised to FILL.

## Changes

| File | Change |
|---|---|
| `src/questfoundry/pipeline/stages/fill.py` | New `_get_literal_values_at_path()` helper walks the schema by dotted path, returns Literal values (or None). `_build_error_feedback` now accepts `invalid_fields: list[str] \| None` and appends "Allowed values for `field.path`: ..." per-Literal field. Sole call site updated. |
| `tests/unit/test_fill_stage.py` | 4 new tests: pov + voice_register Literal echoing; structural failure skips lookup; non-Literal content failure (`min_length` violation) doesn't crash or add spurious lines. |

Diff: 2 files, +204/-1.

## Test plan

- [x] 140 FILL tests pass (`uv run pytest tests/unit/test_fill_stage.py tests/unit/test_fill_models.py -x -q`)
- [x] mypy + ruff clean on `src/questfoundry/pipeline/stages/fill.py`
- [x] Behaviour-preserving for non-Literal failures (`min_length`, missing fields, etc.)

## Out of scope

DRESS `_dress_llm_call` repair-feedback enrichment lands in **Cluster D-2** — separate stage code, different message format, independent review surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)