### PR TITLE
fix(dress): generalise extra_repair_hints to _dress_llm_call (Cluster D-2)

### DIFF
--- a/src/questfoundry/pipeline/stages/dress.py
+++ b/src/questfoundry/pipeline/stages/dress.py
@@ -143,6 +143,36 @@ def _get_prompts_path() -> Path:
     return Path.cwd() / "prompts"
 
 
+def _build_dress_error_feedback(
+    error: Exception,
+    output_schema: type[BaseModel],
+    extra_repair_hints: list[str] | None = None,
+) -> str:
+    """Build the per-attempt repair feedback for `_dress_llm_call`.
+
+    Mirrors the SEED Phase-1 / FILL D-1 pattern: a generic Pydantic-error
+    description plus the expected field paths, optionally followed by
+    caller-supplied hint blocks (valid IDs, allowed enum values, schema
+    constraints) that the model would otherwise lose between the initial
+    system prompt and the retry message.
+
+    Per CLAUDE.md §6 / §repair-loop quality, retry feedback must echo the
+    *value* the model needs, not just the field name. The initial system
+    prompt's IDs and constraints are far back in context by retry time;
+    small models that drift on the first attempt need the constraint
+    re-stated in the same human-message they're correcting against.
+    """
+    expected = get_all_field_paths(output_schema)
+    parts = [
+        f"Your response failed validation:\n{error}",
+        f"\nExpected fields: {', '.join(expected)}",
+        "Please fix the errors and try again.",
+    ]
+    if extra_repair_hints:
+        parts.append("\n" + "\n\n".join(extra_repair_hints))
+    return "\n".join(parts)
+
+
 class DressStageError(ValueError):
     """Error raised when DRESS stage cannot proceed."""
 
@@ -525,6 +555,15 @@ class DressStage:
             entity_ids=entity_ids,
         )
 
+        # Re-echo the valid entity ID list on retry. The list appears in the
+        # initial system prompt via `entity_ids` but is far back in context by
+        # the time the repair feedback fires; without re-echoing, the model
+        # invents a different wrong ID on the second attempt instead of
+        # picking from the valid set.
+        serialize_repair_hints = [
+            "REMINDER — Valid entity IDs for `entity_visuals[].entity_id` "
+            f"(use ONLY these — raw IDs, no `entity::` prefix):\n{entity_ids}",
+        ]
         output, serialize_tokens = await serialize_to_artifact(
             model=self._serialize_model or model,
             brief=brief,
@@ -533,6 +572,7 @@ class DressStage:
             system_prompt=serialize_prompt,
             callbacks=self._callbacks,
             stage="dress",
+            extra_repair_hints=serialize_repair_hints,
         )
         total_llm_calls += 1
         total_tokens += serialize_tokens
@@ -588,6 +628,7 @@ class DressStage:
         *,
         creative: bool = False,
         strategy: StructuredOutputStrategy | None = None,
+        extra_repair_hints: list[str] | None = None,
     ) -> tuple[T, int, int]:
         """Call LLM with structured output and retry on validation failure.
 
@@ -602,6 +643,16 @@ class DressStage:
                 mood/caption diversity matters.
             strategy: Override the default structured output strategy for this
                 call. If None, uses the provider-level default.
+            extra_repair_hints: Optional caller-supplied hint blocks (e.g. valid
+                entity IDs, allowed priority range, state-flag list) appended to
+                the retry feedback verbatim. Per CLAUDE.md §6 / §repair-loop
+                quality, retry messages must echo the *value* the model needs,
+                not just the field name. The initial system prompt's IDs and
+                constraints are far back in context by retry time; small models
+                that drift on the first attempt need the constraint re-stated
+                in the same human-message they're correcting against. Mirrors
+                the SEED Phase-1 pattern (`agents/serialize.py`) and the FILL
+                D-1 enrichment (#1399).
 
         Returns:
             Tuple of (validated_result, llm_calls, tokens_used).
@@ -678,12 +729,7 @@ class DressStage:
                 )
 
                 if attempt < max_retries - 1:
-                    expected = get_all_field_paths(output_schema)
-                    error_msg = (
-                        f"Your response failed validation:\n{e}\n\n"
-                        f"Expected fields: {', '.join(expected)}\n"
-                        f"Please fix the errors and try again."
-                    )
+                    error_msg = _build_dress_error_feedback(e, output_schema, extra_repair_hints)
                     # Append error feedback to conversation history so the
                     # LLM can see what went wrong and fix it
                     messages.append(HumanMessage(content=error_msg))
@@ -782,6 +828,20 @@ class DressStage:
                 "output_language_instruction": self._lang_instruction,
             }
 
+            # Schema constraints the model routinely violates on retry —
+            # echo them in the repair feedback so the failure mode that
+            # produced the first miss is named explicitly when the model
+            # tries again. See `models/dress.py` IllustrationBrief Field
+            # validators for the source of truth.
+            brief_schema_hints = [
+                "REMINDER for each brief in this batch:",
+                "  - `priority` MUST be 1, 2, or 3 (1=must-have, 2=important, 3=nice-to-have)",
+                "  - `category` MUST be one of: `scene`, `portrait`, `vista`, "
+                "`item_detail`, `cover` (`cover` only for the story's title image)",
+                "  - `caption` MUST be 10-60 characters in the format "
+                "`[Subject] [action/state]` (diegetic; no meta-language)",
+            ]
+
             output, llm_calls, tokens = await self._dress_llm_call(
                 model,
                 "dress_brief_batch",
@@ -789,6 +849,7 @@ class DressStage:
                 BatchedBriefOutput,
                 creative=True,
                 strategy=StructuredOutputStrategy.JSON_MODE,
+                extra_repair_hints=brief_schema_hints,
             )
 
             # Extract per-item results
@@ -919,8 +980,21 @@ class DressStage:
                 "state_flags": state_flag_list or "No state flags defined.",
                 "output_language_instruction": self._lang_instruction,
             }
+            # Re-echo the state-flag list and the rank-1 invariant on retry —
+            # both appear in the system prompt initially but are far back in
+            # context by the time the retry feedback lands. See dress.md R-3.7.
+            codex_repair_hints = [
+                f"REMINDER — Available State Flags (use ONLY these in `visible_when`):\n"
+                f"{state_flag_list or 'No state flags defined.'}",
+                "REMINDER: Rank 1 entries MUST have empty `visible_when` "
+                "(always visible to player). Higher ranks gate on state flag IDs.",
+            ]
             output, llm_calls, tokens = await self._dress_llm_call(
-                model, "dress_codex_batch", context, BatchedCodexOutput
+                model,
+                "dress_codex_batch",
+                context,
+                BatchedCodexOutput,
+                extra_repair_hints=codex_repair_hints,
             )
 
             # Validate returned entity_ids match input chunk
@@ -1128,8 +1202,22 @@ class DressStage:
             "state_flags": state_flag_list or "No state flags defined.",
             "output_language_instruction": self._lang_instruction,
         }
+        # On retry the spoiler-warning text and state-flag list need to be
+        # re-stated so the model doesn't drift back into the leak shape on the
+        # second attempt of a regeneration that already followed a leak.
+        regen_repair_hints = [
+            f"REMINDER — Available State Flags (use ONLY these in `visible_when`):\n"
+            f"{state_flag_list or 'No state flags defined.'}",
+            f"REMINDER — Prior attempt leaked higher-tier content. Lower-rank "
+            f"entries MUST NOT disclose what higher-rank entries reveal:\n"
+            f"{leak_summary}",
+        ]
         output, calls, tokens = await self._dress_llm_call(
-            model, "dress_codex", context, DressPhase2Output
+            model,
+            "dress_codex",
+            context,
+            DressPhase2Output,
+            extra_repair_hints=regen_repair_hints,
         )
         return [e.model_dump() for e in output.entries], calls, tokens
 

--- a/src/questfoundry/pipeline/stages/dress.py
+++ b/src/questfoundry/pipeline/stages/dress.py
@@ -545,9 +545,13 @@ class DressStage:
         if self._unload_after_summarize is not None:
             await self._unload_after_summarize()
 
-        # Phase 3: Serialize
+        # Phase 3: Serialize.
+        # Backtick-wrap each ID per CLAUDE.md §9 rule 1 — small models drift
+        # less when IDs in LLM-facing text are unambiguously delimited. The
+        # value flows into both the initial system prompt (via {entity_ids})
+        # and the retry feedback hint built below.
         entity_ids = "\n".join(
-            f"- {edata.get('raw_id', strip_scope_prefix(eid))}" for eid, edata in entities.items()
+            f"- `{edata.get('raw_id', strip_scope_prefix(eid))}`" for eid, edata in entities.items()
         )
         serialize_template = loader.load("dress_serialize")
         serialize_prompt = serialize_template.system.format(

--- a/src/questfoundry/pipeline/stages/dress.py
+++ b/src/questfoundry/pipeline/stages/dress.py
@@ -148,20 +148,7 @@ def _build_dress_error_feedback(
     output_schema: type[BaseModel],
     extra_repair_hints: list[str] | None = None,
 ) -> str:
-    """Build the per-attempt repair feedback for `_dress_llm_call`.
-
-    Mirrors the SEED Phase-1 / FILL D-1 pattern: a generic Pydantic-error
-    description plus the expected field paths, optionally followed by
-    caller-supplied hint blocks (valid IDs, allowed enum values, schema
-    constraints) that the model would otherwise lose between the initial
-    system prompt and the retry message.
-
-    Per CLAUDE.md §6 / §repair-loop quality, retry feedback must echo the
-    *value* the model needs, not just the field name. The initial system
-    prompt's IDs and constraints are far back in context by retry time;
-    small models that drift on the first attempt need the constraint
-    re-stated in the same human-message they're correcting against.
-    """
+    """Build the per-attempt repair feedback for `_dress_llm_call`."""
     expected = get_all_field_paths(output_schema)
     parts = [
         f"Your response failed validation:\n{error}",
@@ -545,11 +532,7 @@ class DressStage:
         if self._unload_after_summarize is not None:
             await self._unload_after_summarize()
 
-        # Phase 3: Serialize.
-        # Backtick-wrap each ID per CLAUDE.md §9 rule 1 — small models drift
-        # less when IDs in LLM-facing text are unambiguously delimited. The
-        # value flows into both the initial system prompt (via {entity_ids})
-        # and the retry feedback hint built below.
+        # Phase 3: Serialize. Backtick-wrap IDs per CLAUDE.md §9 rule 1.
         entity_ids = "\n".join(
             f"- `{edata.get('raw_id', strip_scope_prefix(eid))}`" for eid, edata in entities.items()
         )
@@ -559,11 +542,7 @@ class DressStage:
             entity_ids=entity_ids,
         )
 
-        # Re-echo the valid entity ID list on retry. The list appears in the
-        # initial system prompt via `entity_ids` but is far back in context by
-        # the time the repair feedback fires; without re-echoing, the model
-        # invents a different wrong ID on the second attempt instead of
-        # picking from the valid set.
+        # Re-echo valid entity IDs on retry — system prompt is far back by then.
         serialize_repair_hints = [
             "REMINDER — Valid entity IDs for `entity_visuals[].entity_id` "
             f"(use ONLY these — raw IDs, no `entity::` prefix):\n{entity_ids}",
@@ -647,16 +626,8 @@ class DressStage:
                 mood/caption diversity matters.
             strategy: Override the default structured output strategy for this
                 call. If None, uses the provider-level default.
-            extra_repair_hints: Optional caller-supplied hint blocks (e.g. valid
-                entity IDs, allowed priority range, state-flag list) appended to
-                the retry feedback verbatim. Per CLAUDE.md §6 / §repair-loop
-                quality, retry messages must echo the *value* the model needs,
-                not just the field name. The initial system prompt's IDs and
-                constraints are far back in context by retry time; small models
-                that drift on the first attempt need the constraint re-stated
-                in the same human-message they're correcting against. Mirrors
-                the SEED Phase-1 pattern (`agents/serialize.py`) and the FILL
-                D-1 enrichment (#1399).
+            extra_repair_hints: Hint blocks appended verbatim to retry feedback
+                so caller-known IDs/constraints survive context drift.
 
         Returns:
             Tuple of (validated_result, llm_calls, tokens_used).
@@ -832,16 +803,12 @@ class DressStage:
                 "output_language_instruction": self._lang_instruction,
             }
 
-            # Schema constraints the model routinely violates on retry —
-            # echo them in the repair feedback so the failure mode that
-            # produced the first miss is named explicitly when the model
-            # tries again. See `models/dress.py` IllustrationBrief Field
-            # validators for the source of truth.
+            # Re-echo IllustrationBrief constraints on retry — system prompt is far back by then.
             brief_schema_hints = [
-                "REMINDER for each brief in this batch:",
-                "  - `priority` MUST be 1, 2, or 3 (1=must-have, 2=important, 3=nice-to-have)",
+                "REMINDER for each brief in this batch:\n"
+                "  - `priority` MUST be 1, 2, or 3 (1=must-have, 2=important, 3=nice-to-have)\n"
                 "  - `category` MUST be one of: `scene`, `portrait`, `vista`, "
-                "`item_detail`, `cover` (`cover` only for the story's title image)",
+                "`item_detail`, `cover` (`cover` only for the story's title image)\n"
                 "  - `caption` MUST be 10-60 characters in the format "
                 "`[Subject] [action/state]` (diegetic; no meta-language)",
             ]
@@ -984,9 +951,7 @@ class DressStage:
                 "state_flags": state_flag_list or "No state flags defined.",
                 "output_language_instruction": self._lang_instruction,
             }
-            # Re-echo the state-flag list and the rank-1 invariant on retry —
-            # both appear in the system prompt initially but are far back in
-            # context by the time the retry feedback lands. See dress.md R-3.7.
+            # Re-echo state flags and rank-1 invariant on retry (dress.md R-3.7).
             codex_repair_hints = [
                 f"REMINDER — Available State Flags (use ONLY these in `visible_when`):\n"
                 f"{state_flag_list or 'No state flags defined.'}",
@@ -1206,9 +1171,7 @@ class DressStage:
             "state_flags": state_flag_list or "No state flags defined.",
             "output_language_instruction": self._lang_instruction,
         }
-        # On retry the spoiler-warning text and state-flag list need to be
-        # re-stated so the model doesn't drift back into the leak shape on the
-        # second attempt of a regeneration that already followed a leak.
+        # Re-echo state flags and prior-leak summary on retry to prevent re-drift.
         regen_repair_hints = [
             f"REMINDER — Available State Flags (use ONLY these in `visible_when`):\n"
             f"{state_flag_list or 'No state flags defined.'}",

--- a/tests/unit/test_dress_stage.py
+++ b/tests/unit/test_dress_stage.py
@@ -792,6 +792,74 @@ class TestPhase4Generate:
         assert "0 images generated, 1 failed" in result.detail
 
 
+class TestBuildDressErrorFeedback:
+    """Tests for `_build_dress_error_feedback`.
+
+    Cluster D-2 plumbing: extra_repair_hints must reach the retry message
+    so DRESS templates that depend on the initial system prompt's IDs and
+    constraints can self-correct after the first attempt drifts.
+    """
+
+    def test_no_hints_legacy_output_unchanged(self) -> None:
+        """Callers that omit `extra_repair_hints` (the parameter default) get
+        the same generic feedback DRESS produced before this PR — no extra
+        block appended."""
+        from questfoundry.models.dress import DressPhase0Output
+        from questfoundry.pipeline.stages.dress import _build_dress_error_feedback
+
+        feedback = _build_dress_error_feedback(
+            ValueError("bad output"), DressPhase0Output, extra_repair_hints=None
+        )
+        assert "Your response failed validation" in feedback
+        assert "Expected fields" in feedback
+        assert "Please fix the errors" in feedback
+        # Legacy callers don't get any REMINDER block.
+        assert "REMINDER" not in feedback
+
+    def test_hints_appear_verbatim_in_feedback(self) -> None:
+        """A caller-supplied hint block appears literally in the retry
+        feedback so the LLM sees the constraint or ID list re-stated in the
+        same human-message it's correcting against. Closes the murder1 failure
+        shape generalised to DRESS — see audit DRESS §dress_serialize."""
+        from questfoundry.models.dress import DressPhase0Output
+        from questfoundry.pipeline.stages.dress import _build_dress_error_feedback
+
+        hints = [
+            "REMINDER — Valid entity IDs (use ONLY these): kay, marcus, archive",
+            "REMINDER — `priority` MUST be 1, 2, or 3.",
+        ]
+        feedback = _build_dress_error_feedback(
+            ValueError("bad output"), DressPhase0Output, extra_repair_hints=hints
+        )
+        for hint in hints:
+            assert hint in feedback
+
+    def test_hints_block_separated_from_generic_message(self) -> None:
+        """The hint block is positioned AFTER the generic Pydantic-error and
+        field-list lines so the model reads the failure first and the
+        corrective constraint last (closest to its retry context)."""
+        from questfoundry.models.dress import DressPhase0Output
+        from questfoundry.pipeline.stages.dress import _build_dress_error_feedback
+
+        feedback = _build_dress_error_feedback(
+            ValueError("bad output"),
+            DressPhase0Output,
+            extra_repair_hints=["REMINDER — Use only valid IDs."],
+        )
+        assert feedback.index("Please fix the errors") < feedback.index("REMINDER")
+
+    def test_empty_hints_list_omits_reminder_block(self) -> None:
+        """An empty (but non-None) list must not append a stray separator —
+        same falsy-guard semantics as `if extra_repair_hints:`."""
+        from questfoundry.models.dress import DressPhase0Output
+        from questfoundry.pipeline.stages.dress import _build_dress_error_feedback
+
+        feedback = _build_dress_error_feedback(
+            ValueError("bad output"), DressPhase0Output, extra_repair_hints=[]
+        )
+        assert "REMINDER" not in feedback
+
+
 class TestParseAspectRatio:
     """Tests for _parse_aspect_ratio helper."""
 

--- a/tests/unit/test_dress_stage.py
+++ b/tests/unit/test_dress_stage.py
@@ -800,21 +800,28 @@ class TestBuildDressErrorFeedback:
     constraints can self-correct after the first attempt drifts.
     """
 
-    def test_no_hints_legacy_output_unchanged(self) -> None:
+    def test_no_hints_legacy_output_byte_identical(self) -> None:
         """Callers that omit `extra_repair_hints` (the parameter default) get
-        the same generic feedback DRESS produced before this PR — no extra
-        block appended."""
+        the same generic feedback DRESS produced before this PR. Pinning the
+        EXACT string is the entire safety claim of the refactor — substring
+        checks would let a stray `\\n` or reorder slip through silently."""
+        from questfoundry.artifacts.validator import get_all_field_paths
         from questfoundry.models.dress import DressPhase0Output
         from questfoundry.pipeline.stages.dress import _build_dress_error_feedback
 
-        feedback = _build_dress_error_feedback(
-            ValueError("bad output"), DressPhase0Output, extra_repair_hints=None
+        error = ValueError("bad output")
+        expected = ", ".join(get_all_field_paths(DressPhase0Output))
+        # This is what the prior inline f-string produced verbatim:
+        # f"Your response failed validation:\n{e}\n\n"
+        # f"Expected fields: {', '.join(expected)}\n"
+        # f"Please fix the errors and try again."
+        legacy = (
+            f"Your response failed validation:\n{error}\n\n"
+            f"Expected fields: {expected}\n"
+            f"Please fix the errors and try again."
         )
-        assert "Your response failed validation" in feedback
-        assert "Expected fields" in feedback
-        assert "Please fix the errors" in feedback
-        # Legacy callers don't get any REMINDER block.
-        assert "REMINDER" not in feedback
+        feedback = _build_dress_error_feedback(error, DressPhase0Output, extra_repair_hints=None)
+        assert feedback == legacy
 
     def test_hints_appear_verbatim_in_feedback(self) -> None:
         """A caller-supplied hint block appears literally in the retry
@@ -858,6 +865,79 @@ class TestBuildDressErrorFeedback:
             ValueError("bad output"), DressPhase0Output, extra_repair_hints=[]
         )
         assert "REMINDER" not in feedback
+
+    @pytest.mark.asyncio
+    async def test_dress_llm_call_forwards_hints_into_retry_message(self) -> None:
+        """End-to-end: `_dress_llm_call` must actually plumb `extra_repair_hints`
+        through to the appended `HumanMessage` on retry. The unit tests above
+        cover the helper in isolation; this test guards against a regression
+        where someone drops the parameter forwarding inside `_dress_llm_call`
+        — the integration seam Cluster D-2 actually fixes."""
+        from langchain_core.messages import HumanMessage
+        from pydantic import BaseModel, Field, ValidationError
+
+        from questfoundry.pipeline.stages.dress import DressStage
+
+        class _Toy(BaseModel):
+            name: str = Field(min_length=1)
+
+        # First attempt: raise ValidationError. Second: return a valid result.
+        valid = _Toy(name="ok")
+        call_count = {"n": 0}
+        captured_messages: list[Any] = []
+
+        async def _ainvoke(messages: list[Any], config: Any = None) -> _Toy:  # noqa: ARG001
+            captured_messages.append(list(messages))  # snapshot the conversation
+            call_count["n"] += 1
+            if call_count["n"] == 1:
+                raise ValidationError.from_exception_data(
+                    "Toy",
+                    [
+                        {
+                            "type": "missing",
+                            "loc": ("name",),
+                            "msg": "Field required",
+                            "input": {},
+                        }
+                    ],
+                )
+            return valid
+
+        structured_model = MagicMock()
+        structured_model.ainvoke = _ainvoke
+
+        # Patch with_structured_output (used by _dress_llm_call line ~640) so
+        # we don't need a real LangChain provider.
+        stage = DressStage()
+        with (
+            patch(
+                "questfoundry.pipeline.stages.dress.with_structured_output",
+                return_value=structured_model,
+            ),
+            patch("questfoundry.prompts.loader.PromptLoader") as mock_loader,
+        ):
+            mock_template = MagicMock()
+            mock_template.system = "system text"
+            mock_template.user = None
+            mock_loader.return_value.load.return_value = mock_template
+
+            hints = ["REMINDER — must-be-present-in-retry"]
+            result, _calls, _tokens = await stage._dress_llm_call(
+                model=MagicMock(),
+                template_name="dummy",
+                context={},
+                output_schema=_Toy,
+                extra_repair_hints=hints,
+            )
+
+        assert result == valid
+        assert call_count["n"] == 2
+        # The retry conversation (second snapshot) must include the hint.
+        retry_messages = captured_messages[1]
+        retry_human_messages = [m for m in retry_messages if isinstance(m, HumanMessage)]
+        assert retry_human_messages, "expected an appended HumanMessage on retry"
+        retry_text = retry_human_messages[-1].content
+        assert "REMINDER — must-be-present-in-retry" in retry_text
 
 
 class TestParseAspectRatio:


### PR DESCRIPTION
## Summary

Phase 3 Cluster D-2 from the [prompt-vs-spec audit](docs/superpowers/reports/2026-04-25-prompt-spec-audit.md). Closes #1400. Generalises the SEED Phase-1 / FILL D-1 `extra_repair_hints` pattern to DRESS `_dress_llm_call`, paralleling #1399.

The prior generic repair message stripped IDs and constraints across all 8 DRESS templates — a 4B model retrying after the field-name-only feedback either invented another wrong value or repeated the same mistake (the murder1 failure shape generalised to DRESS).

## Changes

| File | Change |
|---|---|
| `src/questfoundry/pipeline/stages/dress.py` | New `_build_dress_error_feedback()` helper extracted for testability. `_dress_llm_call` accepts `extra_repair_hints: list[str] \| None = None` and appends them to the per-attempt retry feedback. Four call sites wired: `dress_serialize` (valid entity IDs), `_brief_batch` (priority 1-3 + category enum + caption format), `_codex_batch` (state flag list + rank-1 invariant), `_regenerate_codex_for_entity` (state flag list + prior-leak summary). |
| `tests/unit/test_dress_stage.py` | New `TestBuildDressErrorFeedback` (4 tests): legacy `None` produces unchanged output; supplied hints appear verbatim; hints sit after the generic message; empty list ≡ None. |

Diff: 2 files, +164/-8.

## Test plan

- [x] 174 DRESS tests pass (`uv run pytest tests/unit/test_dress*.py -x -q`)
- [x] mypy + ruff clean on `src/questfoundry/pipeline/stages/dress.py`
- [x] Default `extra_repair_hints=None` produces byte-identical legacy feedback (pinned by `test_no_hints_legacy_output_unchanged`)

## Out of scope

DRESS context-enrichment findings (entity-overlay enrichment in `format_entity_for_codex`, missing GOOD/BAD examples, bare-ID context blocks) — those land in **Cluster E** (long tail).

🤖 Generated with [Claude Code](https://claude.com/claude-code)