### PR TITLE
fix(fill): inject valid_entity_ids into revision context (Cluster E-1)

### DIFF
--- a/prompts/templates/fill_phase3_revision.yaml
+++ b/prompts/templates/fill_phase3_revision.yaml
@@ -22,6 +22,10 @@ system: |
   ## Extended Sliding Window
   {extended_window}
 
+  ## Valid Entity IDs
+  Use ONLY these IDs in `entity_updates[].entity_id` (raw IDs, no scope prefix):
+  {valid_entity_ids}
+
   ## Revision Guidance by Issue Type
 
   - **voice_drift**: Match register, rhythm, and tone to surrounding passages.

--- a/src/questfoundry/pipeline/stages/fill.py
+++ b/src/questfoundry/pipeline/stages/fill.py
@@ -749,6 +749,8 @@ class FillStage:
             failure_type: Classification from _classify_validation_error.
             invalid_fields: Dotted field paths flagged as content failures by
                 _classify_validation_error. Used to look up Literal values.
+            extra_repair_hints: Hint blocks appended verbatim after the standard
+                error text so caller-known IDs/constraints survive context drift.
 
         Returns:
             Formatted error feedback string.

--- a/src/questfoundry/pipeline/stages/fill.py
+++ b/src/questfoundry/pipeline/stages/fill.py
@@ -608,6 +608,7 @@ class FillStage:
         max_retries: int = 3,
         *,
         creative: bool = False,
+        extra_repair_hints: list[str] | None = None,
     ) -> tuple[T, int, int]:
         """Call LLM with structured output and retry on validation failure.
 
@@ -704,7 +705,11 @@ class FillStage:
 
                 if attempt < max_retries - 1:
                     error_msg = self._build_error_feedback(
-                        e, output_schema, failure_type, invalid_fields=invalid
+                        e,
+                        output_schema,
+                        failure_type,
+                        invalid_fields=invalid,
+                        extra_repair_hints=extra_repair_hints,
                     )
                     messages = list(base_messages)
                     messages.append(HumanMessage(content=error_msg))
@@ -720,6 +725,7 @@ class FillStage:
         output_schema: type[BaseModel],
         failure_type: str = "unknown",
         invalid_fields: list[str] | None = None,
+        extra_repair_hints: list[str] | None = None,
     ) -> str:
         """Build structured error feedback for LLM retry.
 
@@ -777,6 +783,12 @@ class FillStage:
                     literal_hints.append(f"Allowed values for `{field_path}`: {formatted}")
             if literal_hints:
                 parts.append("\n" + "\n".join(literal_hints))
+
+        # Caller-supplied hint blocks (valid IDs etc.) — appended verbatim so
+        # the model sees the constraint re-stated in the same human-message
+        # it's correcting against. Mirrors the DRESS Cluster D-2 plumbing.
+        if extra_repair_hints:
+            parts.append("\n" + "\n\n".join(extra_repair_hints))
 
         return "\n".join(parts)
 
@@ -1966,6 +1978,18 @@ class FillStage:
                 for i, f in enumerate(flags)
             )
 
+            # Valid entity IDs for any entity_updates the revision proposes.
+            # Per CLAUDE.md §6 the model must see this list explicitly; without
+            # it phantom IDs are caught only at stage exit (see escalation
+            # handler below) instead of being prevented at the call.
+            valid_entity_id_list = sorted(
+                enode.get("raw_id", strip_scope_prefix(eid))
+                for eid, enode in graph.get_nodes_by_type("entity").items()
+            )
+            valid_entity_ids = (
+                "\n".join(f"- `{rid}`" for rid in valid_entity_id_list) or "(no entities defined)"
+            )
+
             context = {
                 "voice_document": voice_context,
                 "passage_id": passage.get("raw_id", passage_id),
@@ -1977,8 +2001,15 @@ class FillStage:
                     if arc_id
                     else ""
                 ),
+                "valid_entity_ids": valid_entity_ids,
                 "output_language_instruction": self._lang_instruction,
             }
+
+            # Re-echo on retry so the constraint survives context drift.
+            revision_repair_hints = [
+                "REMINDER — Valid entity IDs for `entity_updates[].entity_id` "
+                f"(use ONLY these — raw IDs, no scope prefix):\n{valid_entity_ids}",
+            ]
 
             output, llm_calls, tokens = await self._fill_llm_call(
                 model,
@@ -1986,6 +2017,7 @@ class FillStage:
                 context,
                 FillPhase1Output,
                 creative=True,
+                extra_repair_hints=revision_repair_hints,
             )
 
             if output.passage.prose:

--- a/src/questfoundry/pipeline/stages/fill.py
+++ b/src/questfoundry/pipeline/stages/fill.py
@@ -624,6 +624,8 @@ class FillStage:
             creative: Use the discuss-phase model (creative temperature) instead
                 of the serialize model. Enable for prose generation where lexical
                 diversity matters.
+            extra_repair_hints: Hint blocks appended verbatim to retry feedback
+                so caller-known IDs/constraints survive context drift.
 
         Returns:
             Tuple of (validated_result, llm_calls, tokens_used).
@@ -1950,6 +1952,21 @@ class FillStage:
             if node:
                 passage_data[passage_id] = node
 
+        # Valid entity IDs (raw, sorted, backtick-wrapped per CLAUDE.md §9 rule 1).
+        # Hoisted out of the per-passage closure since entities don't change
+        # during revision — matches the pre-computation pattern above.
+        valid_entity_id_list = sorted(
+            enode.get("raw_id", strip_scope_prefix(eid))
+            for eid, enode in graph.get_nodes_by_type("entity").items()
+        )
+        valid_entity_ids = (
+            "\n".join(f"- `{rid}`" for rid in valid_entity_id_list) or "(no entities defined)"
+        )
+        revision_repair_hints = [
+            "REMINDER — Valid entity IDs for `entity_updates[].entity_id` "
+            f"(use ONLY these — raw IDs, no scope prefix):\n{valid_entity_ids}",
+        ]
+
         # Each passage's revision chain is independent of other passages,
         # but flags within one passage must be sequential (chained).
         passage_items = list(flagged_passages.items())
@@ -1978,18 +1995,6 @@ class FillStage:
                 for i, f in enumerate(flags)
             )
 
-            # Valid entity IDs for any entity_updates the revision proposes.
-            # Per CLAUDE.md §6 the model must see this list explicitly; without
-            # it phantom IDs are caught only at stage exit (see escalation
-            # handler below) instead of being prevented at the call.
-            valid_entity_id_list = sorted(
-                enode.get("raw_id", strip_scope_prefix(eid))
-                for eid, enode in graph.get_nodes_by_type("entity").items()
-            )
-            valid_entity_ids = (
-                "\n".join(f"- `{rid}`" for rid in valid_entity_id_list) or "(no entities defined)"
-            )
-
             context = {
                 "voice_document": voice_context,
                 "passage_id": passage.get("raw_id", passage_id),
@@ -2004,12 +2009,6 @@ class FillStage:
                 "valid_entity_ids": valid_entity_ids,
                 "output_language_instruction": self._lang_instruction,
             }
-
-            # Re-echo on retry so the constraint survives context drift.
-            revision_repair_hints = [
-                "REMINDER — Valid entity IDs for `entity_updates[].entity_id` "
-                f"(use ONLY these — raw IDs, no scope prefix):\n{valid_entity_ids}",
-            ]
 
             output, llm_calls, tokens = await self._fill_llm_call(
                 model,

--- a/tests/unit/test_fill_stage.py
+++ b/tests/unit/test_fill_stage.py
@@ -1104,6 +1104,64 @@ class TestPhase3Revision:
         assert result.llm_calls == 0
 
     @pytest.mark.asyncio
+    async def test_revision_context_and_hints_carry_valid_entity_ids(self) -> None:
+        """The revision call MUST inject `valid_entity_ids` into the prompt
+        context AND pass it as `extra_repair_hints` so the constraint survives
+        context drift on retry. Closes the FILL §fill_phase3_revision audit
+        finding (CLAUDE.md §6 Valid ID Injection)."""
+        graph = _make_reviewed_graph()
+        graph.create_node(
+            "entity::kay",
+            {"type": "entity", "raw_id": "kay", "concept": "A wanderer"},
+        )
+        graph.update_node(
+            "passage::p1",
+            review_flags=[
+                {"passage_id": "p1", "issue": "Voice drift", "issue_type": "voice_drift"}
+            ],
+        )
+        stage = FillStage()
+
+        captured_context: dict[str, Any] = {}
+        captured_hints: list[str] | None = None
+
+        async def mock_llm_call(
+            model: MagicMock,  # noqa: ARG001
+            template_name: str,  # noqa: ARG001
+            context: dict,
+            output_schema: type,  # noqa: ARG001
+            max_retries: int = 3,  # noqa: ARG001
+            *,
+            creative: bool = False,  # noqa: ARG001
+            extra_repair_hints: list[str] | None = None,
+            **kwargs: object,  # noqa: ARG001
+        ) -> tuple:
+            nonlocal captured_context, captured_hints
+            captured_context = context
+            captured_hints = extra_repair_hints
+            return (
+                FillPhase1Output(
+                    passage=FillPassageOutput(passage_id="p1", prose="Revised prose.")
+                ),
+                1,
+                300,
+            )
+
+        stage._fill_llm_call = mock_llm_call  # type: ignore[method-assign]
+        await stage._phase_3_revision(graph, MagicMock())
+
+        # Context contains the prompt-injection variable used by
+        # fill_phase3_revision.yaml's `## Valid Entity IDs` section.
+        assert "valid_entity_ids" in captured_context
+        valid_ids_text = captured_context["valid_entity_ids"]
+        assert "kay" in valid_ids_text  # raw_id of the entity in _make_reviewed_graph
+        assert "`kay`" in valid_ids_text  # backtick-wrapped per CLAUDE.md §9 rule 1
+
+        # Same constraint also flows as a retry hint so it survives context drift.
+        assert captured_hints is not None
+        assert any("Valid entity IDs" in h and "`kay`" in h for h in captured_hints)
+
+    @pytest.mark.asyncio
     async def test_multiple_flags_batched(self) -> None:
         """Multiple flags on same passage should be batched into one LLM call."""
         graph = _make_reviewed_graph()
@@ -1483,6 +1541,45 @@ class TestBuildErrorFeedback:
 
         assert _get_literal_values_at_path(FillPhase0Output, "voice.no_such_field") is None
         assert _get_literal_values_at_path(FillPhase0Output, "no_such_root") is None
+
+    def test_extra_repair_hints_appended_to_feedback(self) -> None:
+        """Caller-supplied hints (e.g. valid entity IDs) appear verbatim in
+        the retry feedback. Mirrors the SEED Phase-1 / DRESS D-2 plumbing."""
+        from questfoundry.models.fill import FillPhase1Output
+
+        hints = [
+            "REMINDER — Valid entity IDs (use ONLY these): `kay`, `marcus`",
+        ]
+        feedback = FillStage._build_error_feedback(
+            ValueError("missing field"),
+            FillPhase1Output,
+            "structural",
+            invalid_fields=None,
+            extra_repair_hints=hints,
+        )
+        assert "REMINDER — Valid entity IDs" in feedback
+        assert "`kay`" in feedback and "`marcus`" in feedback
+
+    def test_extra_repair_hints_default_none_byte_identical(self) -> None:
+        """Legacy callers that omit `extra_repair_hints` get the same feedback
+        the previous build produced. Pinning byte-equality keeps the new
+        parameter from silently changing legacy retry behaviour."""
+        from questfoundry.models.fill import FillPhase1Output
+
+        with_hints_none = FillStage._build_error_feedback(
+            ValueError("min_length"),
+            FillPhase1Output,
+            "content",
+            invalid_fields=None,
+            extra_repair_hints=None,
+        )
+        without_param = FillStage._build_error_feedback(
+            ValueError("min_length"),
+            FillPhase1Output,
+            "content",
+            invalid_fields=None,
+        )
+        assert with_hints_none == without_param
 
     def test_get_literal_values_at_path_walks_list_of_basemodel(self) -> None:
         """The helper must step through `list[NestedModel]` annotations to reach

--- a/tests/unit/test_fill_stage.py
+++ b/tests/unit/test_fill_stage.py
@@ -1154,12 +1154,56 @@ class TestPhase3Revision:
         # fill_phase3_revision.yaml's `## Valid Entity IDs` section.
         assert "valid_entity_ids" in captured_context
         valid_ids_text = captured_context["valid_entity_ids"]
-        assert "kay" in valid_ids_text  # raw_id of the entity in _make_reviewed_graph
+        assert "kay" in valid_ids_text  # raw_id of the entity created above
         assert "`kay`" in valid_ids_text  # backtick-wrapped per CLAUDE.md §9 rule 1
 
         # Same constraint also flows as a retry hint so it survives context drift.
         assert captured_hints is not None
         assert any("Valid entity IDs" in h and "`kay`" in h for h in captured_hints)
+
+    @pytest.mark.asyncio
+    async def test_revision_with_zero_entities_uses_fallback_string(self) -> None:
+        """When the graph has flagged passages but zero entity nodes, the
+        `valid_entity_ids` injection must fall back to a non-empty placeholder
+        rather than rendering as an empty block (which would confuse small
+        models reading `## Valid Entity IDs\\n\\n` with no content)."""
+        graph = _make_reviewed_graph()
+        # Intentionally NO entity nodes — fixture doesn't create any.
+        graph.update_node(
+            "passage::p1",
+            review_flags=[
+                {"passage_id": "p1", "issue": "Voice drift", "issue_type": "voice_drift"}
+            ],
+        )
+        stage = FillStage()
+
+        captured_context: dict[str, Any] = {}
+
+        async def mock_llm_call(
+            model: MagicMock,  # noqa: ARG001
+            template_name: str,  # noqa: ARG001
+            context: dict,
+            output_schema: type,  # noqa: ARG001
+            max_retries: int = 3,  # noqa: ARG001
+            *,
+            creative: bool = False,  # noqa: ARG001
+            extra_repair_hints: list[str] | None = None,  # noqa: ARG001
+            **kwargs: object,  # noqa: ARG001
+        ) -> tuple:
+            nonlocal captured_context
+            captured_context = context
+            return (
+                FillPhase1Output(
+                    passage=FillPassageOutput(passage_id="p1", prose="Revised prose.")
+                ),
+                1,
+                300,
+            )
+
+        stage._fill_llm_call = mock_llm_call  # type: ignore[method-assign]
+        await stage._phase_3_revision(graph, MagicMock())
+
+        assert captured_context["valid_entity_ids"] == "(no entities defined)"
 
     @pytest.mark.asyncio
     async def test_multiple_flags_batched(self) -> None:


### PR DESCRIPTION
## Summary

Phase 3 Cluster E-1 (first slice of the long-tail context-enrichment cluster) from the [prompt-vs-spec audit](docs/superpowers/reports/2026-04-25-prompt-spec-audit.md). Closes #1402.

The revision prompt's output schema includes `entity_updates[].entity_id` but the runtime context dict had no `valid_entity_ids`. The model was asked to output entity IDs without seeing which IDs are valid. The escalation handler caught phantom IDs at stage exit but the phantom was preventable per CLAUDE.md §6.

## Changes

| File | Change |
|---|---|
| `src/questfoundry/pipeline/stages/fill.py` | `_fill_llm_call` + `_build_error_feedback` now accept `extra_repair_hints` (mirrors the DRESS D-2 plumbing from #1401). `_revise_passage` computes valid entity IDs (raw, sorted, backtick-wrapped) and threads them into BOTH the prompt context AND the retry hints. |
| `prompts/templates/fill_phase3_revision.yaml` | New `## Valid Entity IDs` section after the sliding window block. |
| `tests/unit/test_fill_stage.py` | 3 new tests: byte-identical legacy behaviour, hint propagation through `_build_error_feedback`, and revision context/hint plumbing end-to-end. |

Diff: 3 files, +134/-1.

## Test plan

- [x] 357 FILL tests pass (`uv run pytest tests/unit/test_fill_stage.py tests/unit/test_fill_models.py tests/unit/test_fill_context.py -x -q`)
- [x] mypy + ruff clean on `src/questfoundry/pipeline/stages/fill.py`
- [x] Default `extra_repair_hints=None` produces byte-identical legacy feedback (pinned)

## Out of scope

Other Cluster E items — DRESS `format_entity_for_codex()` overlay enrichment, bare-ID context blocks across other `format_*_context()` functions, missing GOOD/BAD examples — are subsequent narrow PRs (E-2, E-3, …).

🤖 Generated with [Claude Code](https://claude.com/claude-code)