### PR TITLE
fix(dress): include entity overlays in codex generation context (Cluster E-2)

### DIFF
--- a/src/questfoundry/graph/dress_context.py
+++ b/src/questfoundry/graph/dress_context.py
@@ -237,9 +237,12 @@ def format_entity_for_codex(graph: Graph, entity_id: str) -> str:
         if not flags or not details:
             continue
         flag_str = ", ".join(f"`{f}`" for f in flags)
-        # str(v) defends against future schema additions where details values
-        # become list/dict — without it Python repr would leak into LLM-facing
-        # text, violating CLAUDE.md §9 rule 1.
+        # `!s` coerces to str, guaranteeing a render path for any value type
+        # (consistent, non-crashing) — note that for list/dict this still
+        # delegates to __repr__ and emits bracket-format. Current overlay
+        # schema is string-only (story-graph-ontology.md §entity overlays);
+        # if non-string values are added, prefer an explicit per-type
+        # formatter rather than relying on this fallback.
         detail_str = "; ".join(f"{k}: {v!s}" for k, v in details.items())
         overlay_lines.append(f"- When {flag_str}: {detail_str}")
     if overlay_lines:

--- a/src/questfoundry/graph/dress_context.py
+++ b/src/questfoundry/graph/dress_context.py
@@ -227,6 +227,23 @@ def format_entity_for_codex(graph: Graph, entity_id: str) -> str:
         if features:
             lines.append(f"**Features:** {', '.join(features)}")
 
+    # Path-specific overlays (per dress.md R-3.8: codex generation must see
+    # the full Entity description — base plus overlays — so spoiler-graduated
+    # tiers can surface path-specific arcs the base concept doesn't capture).
+    overlay_lines: list[str] = []
+    for overlay in entity.get("overlays") or []:
+        flags = overlay.get("when") or []
+        details = overlay.get("details") or {}
+        if not flags or not details:
+            continue
+        flag_str = ", ".join(f"`{f}`" for f in flags)
+        detail_str = "; ".join(f"{k}: {v}" for k, v in details.items())
+        overlay_lines.append(f"- When {flag_str}: {detail_str}")
+    if overlay_lines:
+        lines.append("")
+        lines.append("### Overlays (path-specific arcs)")
+        lines.extend(overlay_lines)
+
     # Related state flags — uses substring matching as a heuristic:
     # a state flag is "related" if the entity's raw_id appears in the
     # state flag's trigger text or raw_id (case-insensitive). This is

--- a/src/questfoundry/graph/dress_context.py
+++ b/src/questfoundry/graph/dress_context.py
@@ -237,7 +237,10 @@ def format_entity_for_codex(graph: Graph, entity_id: str) -> str:
         if not flags or not details:
             continue
         flag_str = ", ".join(f"`{f}`" for f in flags)
-        detail_str = "; ".join(f"{k}: {v}" for k, v in details.items())
+        # str(v) defends against future schema additions where details values
+        # become list/dict — without it Python repr would leak into LLM-facing
+        # text, violating CLAUDE.md §9 rule 1.
+        detail_str = "; ".join(f"{k}: {v!s}" for k, v in details.items())
         overlay_lines.append(f"- When {flag_str}: {detail_str}")
     if overlay_lines:
         lines.append("")

--- a/tests/unit/test_dress_context.py
+++ b/tests/unit/test_dress_context.py
@@ -162,6 +162,68 @@ class TestFormatEntityForCodex:
 
         assert format_entity_for_codex(dress_graph, "character::nonexistent") == ""
 
+    def test_includes_overlays_when_present(self, dress_graph: Graph) -> None:
+        """Entities with path-specific overlays MUST surface them per dress.md
+        R-3.8: codex generation needs the full Entity description (base +
+        overlays) so spoiler-graduated tiers can capture path-specific arcs
+        the base concept doesn't reveal."""
+        from questfoundry.graph.dress_context import format_entity_for_codex
+
+        # Add an overlay to aldric — two state flags trigger a different demeanor.
+        dress_graph.update_node(
+            "character::aldric",
+            overlays=[
+                {
+                    "when": ["state_flag::met_aldric", "state_flag::trusted_aldric"],
+                    "details": {
+                        "demeanor": "warm and forthcoming",
+                        "voice": "softer, conspiratorial",
+                    },
+                },
+                {
+                    "when": ["state_flag::betrayed_aldric"],
+                    "details": {"demeanor": "cold and guarded"},
+                },
+            ],
+        )
+
+        result = format_entity_for_codex(dress_graph, "character::aldric")
+        assert "### Overlays (path-specific arcs)" in result
+        # Both overlays present, with backtick-wrapped state flag IDs (CLAUDE.md §9).
+        assert "`state_flag::met_aldric`" in result
+        assert "`state_flag::trusted_aldric`" in result
+        assert "`state_flag::betrayed_aldric`" in result
+        # Detail key:value pairs rendered.
+        assert "demeanor: warm and forthcoming" in result
+        assert "voice: softer, conspiratorial" in result
+        assert "demeanor: cold and guarded" in result
+
+    def test_omits_overlays_section_when_none(self, dress_graph: Graph) -> None:
+        """Entities with no overlays MUST NOT emit an empty `### Overlays`
+        header — the section is conditional, not always present."""
+        from questfoundry.graph.dress_context import format_entity_for_codex
+
+        # `aldric` in the fixture has no overlays.
+        result = format_entity_for_codex(dress_graph, "character::aldric")
+        assert "### Overlays" not in result
+
+    def test_skips_overlays_with_missing_when_or_details(self, dress_graph: Graph) -> None:
+        """Malformed overlays (missing `when` or `details`) MUST be skipped
+        silently — same defensive pattern used in polish_context.py."""
+        from questfoundry.graph.dress_context import format_entity_for_codex
+
+        dress_graph.update_node(
+            "character::aldric",
+            overlays=[
+                {"when": [], "details": {"demeanor": "evasive"}},  # no flags
+                {"when": ["state_flag::met_aldric"], "details": {}},  # no details
+            ],
+        )
+
+        result = format_entity_for_codex(dress_graph, "character::aldric")
+        # Both malformed overlays skipped → no Overlays section emitted.
+        assert "### Overlays" not in result
+
 
 class TestFormatEntitiesBatchForCodex:
     def test_formats_multiple_entities(self, dress_graph: Graph) -> None:

--- a/tests/unit/test_dress_context.py
+++ b/tests/unit/test_dress_context.py
@@ -224,6 +224,49 @@ class TestFormatEntityForCodex:
         # Both malformed overlays skipped → no Overlays section emitted.
         assert "### Overlays" not in result
 
+    def test_skips_malformed_overlay_but_renders_valid_sibling(self, dress_graph: Graph) -> None:
+        """A list mixing one valid overlay and one malformed entry MUST render
+        the valid one and silently drop the malformed one — the section header
+        still appears because at least one overlay survived."""
+        from questfoundry.graph.dress_context import format_entity_for_codex
+
+        dress_graph.update_node(
+            "character::aldric",
+            overlays=[
+                {"when": [], "details": {"demeanor": "skipped"}},  # malformed
+                {
+                    "when": ["state_flag::met_aldric"],
+                    "details": {"demeanor": "warm and forthcoming"},
+                },
+            ],
+        )
+
+        result = format_entity_for_codex(dress_graph, "character::aldric")
+        assert "### Overlays (path-specific arcs)" in result
+        assert "warm and forthcoming" in result
+        assert "skipped" not in result  # malformed entry not rendered
+
+    def test_overlay_details_non_string_values_str_cast(self, dress_graph: Graph) -> None:
+        """If a future schema change makes a `details` value a list/dict, the
+        renderer must `str()`-cast it rather than leak Python repr into
+        LLM-facing text (CLAUDE.md §9 rule 1)."""
+        from questfoundry.graph.dress_context import format_entity_for_codex
+
+        dress_graph.update_node(
+            "character::aldric",
+            overlays=[
+                {
+                    "when": ["state_flag::met_aldric"],
+                    "details": {"speech_tics": ["umm", "well"]},
+                },
+            ],
+        )
+
+        result = format_entity_for_codex(dress_graph, "character::aldric")
+        # The list is rendered via str() — consistent with how Python prints
+        # lists, just guaranteed not to leak via __repr__ side-channels.
+        assert "speech_tics: ['umm', 'well']" in result
+
 
 class TestFormatEntitiesBatchForCodex:
     def test_formats_multiple_entities(self, dress_graph: Graph) -> None:
@@ -249,6 +292,31 @@ class TestFormatEntitiesBatchForCodex:
         from questfoundry.graph.dress_context import format_entities_batch_for_codex
 
         assert format_entities_batch_for_codex(dress_graph, []) == ""
+
+    def test_batch_includes_overlays_per_entity(self, dress_graph: Graph) -> None:
+        """The batch formatter delegates to `format_entity_for_codex`, so the
+        overlay enrichment from this PR must surface in the batch output too.
+        Pinning this guards against future refactors that might bypass the
+        single-entity formatter."""
+        from questfoundry.graph.dress_context import format_entities_batch_for_codex
+
+        dress_graph.update_node(
+            "character::aldric",
+            overlays=[
+                {
+                    "when": ["state_flag::met_aldric"],
+                    "details": {"demeanor": "warm"},
+                },
+            ],
+        )
+
+        result = format_entities_batch_for_codex(
+            dress_graph, ["character::protagonist", "character::aldric"]
+        )
+        # Overlay block from aldric appears in the batch output.
+        assert "### Overlays (path-specific arcs)" in result
+        assert "`state_flag::met_aldric`" in result
+        assert "demeanor: warm" in result
 
 
 class TestGetPassageEntityIds:

--- a/tests/unit/test_dress_context.py
+++ b/tests/unit/test_dress_context.py
@@ -247,9 +247,13 @@ class TestFormatEntityForCodex:
         assert "skipped" not in result  # malformed entry not rendered
 
     def test_overlay_details_non_string_values_str_cast(self, dress_graph: Graph) -> None:
-        """If a future schema change makes a `details` value a list/dict, the
-        renderer must `str()`-cast it rather than leak Python repr into
-        LLM-facing text (CLAUDE.md §9 rule 1)."""
+        """The renderer must `!s`-coerce non-string `details` values so it
+        always has a render path (no crash, consistent output). Note: for
+        list/dict values `str()` delegates to `__repr__`, so this test pins
+        the bracket-format repr — that's the documented behaviour, see the
+        comment in `dress_context.py` directing future maintainers toward
+        an explicit per-type formatter if the schema admits non-string
+        values."""
         from questfoundry.graph.dress_context import format_entity_for_codex
 
         dress_graph.update_node(

--- a/tests/unit/test_dress_context.py
+++ b/tests/unit/test_dress_context.py
@@ -267,8 +267,9 @@ class TestFormatEntityForCodex:
         )
 
         result = format_entity_for_codex(dress_graph, "character::aldric")
-        # The list is rendered via str() — consistent with how Python prints
-        # lists, just guaranteed not to leak via __repr__ side-channels.
+        # `str()` delegates to `__repr__` for lists, so bracket-format is the
+        # expected output here. See the docstring above for why this is the
+        # documented behaviour rather than a leak.
         assert "speech_tics: ['umm', 'well']" in result
 
 


### PR DESCRIPTION
## Summary

Phase 3 Cluster E-2 from the [prompt-vs-spec audit](docs/superpowers/reports/2026-04-25-prompt-spec-audit.md). Closes #1404.

`format_entity_for_codex()` previously included concept, entity type, visual profile, and related state flags — but not the entity's overlays. Spec [dress.md R-3.8](docs/design/procedures/dress.md) requires "full Entity description (base + overlays)". For entities with path-specific overlays (e.g., `mentor_aligned` vs `mentor_hostile`), codex generation was writing entries blind to the entity's path-specific arc — exactly what the spoiler-graduation tier system is supposed to surface.

## Changes

| File | Change |
|---|---|
| `src/questfoundry/graph/dress_context.py` | New `### Overlays (path-specific arcs)` section in `format_entity_for_codex()`. Emits per-overlay `when` state flags (backtick-wrapped per CLAUDE.md §9 rule 1) and `details` key:value pairs. Section omitted when entity has no overlays. Malformed overlays (empty `when` or `details`) skipped silently — defensive pattern from `polish_context.py:235-243`. `format_entities_batch_for_codex()` inherits via delegation. |
| `tests/unit/test_dress_context.py` | 3 new tests covering present / absent / malformed overlay branches. |

Diff: 2 files, +79.

## Test plan

- [x] 178 DRESS tests pass (`uv run pytest tests/unit/test_dress_context.py tests/unit/test_dress_stage.py tests/unit/test_dress_models.py -x -q`)
- [x] mypy + ruff clean on `src/questfoundry/graph/dress_context.py`

## Out of scope

Other Cluster E items — bare-ID context blocks across other `format_*_context()` outputs, missing GOOD/BAD examples — are subsequent narrow PRs (E-3, E-4, …) or a single sweep PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)