### PR TITLE
fix(polish): backtick-wrap state flag IDs in overlay rendering (E-3)

### DIFF
--- a/src/questfoundry/graph/dress_context.py
+++ b/src/questfoundry/graph/dress_context.py
@@ -237,13 +237,13 @@ def format_entity_for_codex(graph: Graph, entity_id: str) -> str:
         if not flags or not details:
             continue
         flag_str = ", ".join(f"`{f}`" for f in flags)
-        # `!s` coerces to str, guaranteeing a render path for any value type
-        # (consistent, non-crashing) — note that for list/dict this still
-        # delegates to __repr__ and emits bracket-format. Current overlay
-        # schema is string-only (story-graph-ontology.md §entity overlays);
-        # if non-string values are added, prefer an explicit per-type
-        # formatter rather than relying on this fallback.
-        detail_str = "; ".join(f"{k}: {v!s}" for k, v in details.items())
+        # Format list values explicitly to avoid leaking Python repr
+        # (brackets/quotes) into LLM-facing text per CLAUDE.md §9 rule 1.
+        # Sorted for deterministic output across runs.
+        detail_str = "; ".join(
+            f"{k}: {', '.join(map(str, v)) if isinstance(v, list) else v}"
+            for k, v in sorted(details.items())
+        )
         overlay_lines.append(f"- When {flag_str}: {detail_str}")
     if overlay_lines:
         lines.append("")

--- a/src/questfoundry/graph/polish_context.py
+++ b/src/questfoundry/graph/polish_context.py
@@ -241,7 +241,8 @@ def format_entity_arc_context(
             # `!s` coerces to str so any value type renders without crashing
             # (matches the dress_context.py overlay renderer); for list/dict
             # this still delegates to __repr__ — current overlay schema is
-            # string-only.
+            # string-only. If non-string values are added, prefer an explicit
+            # per-type formatter rather than relying on this fallback.
             detail_str = "; ".join(f"{k}: {v!s}" for k, v in details.items())
             overlay_lines.append(f"  - When {flag_str}: {truncate_summary(detail_str, 80)}")
 

--- a/src/questfoundry/graph/polish_context.py
+++ b/src/questfoundry/graph/polish_context.py
@@ -238,12 +238,13 @@ def format_entity_arc_context(
         if flags and details:
             # Backtick-wrap flag IDs per CLAUDE.md §9 rule 1.
             flag_str = ", ".join(f"`{f}`" for f in flags)
-            # `!s` coerces to str so any value type renders without crashing
-            # (matches the dress_context.py overlay renderer); for list/dict
-            # this still delegates to __repr__ — current overlay schema is
-            # string-only. If non-string values are added, prefer an explicit
-            # per-type formatter rather than relying on this fallback.
-            detail_str = "; ".join(f"{k}: {v!s}" for k, v in details.items())
+            # Format list values explicitly to avoid leaking Python repr
+            # (brackets/quotes) into LLM-facing text per CLAUDE.md §9 rule 1.
+            # Sorted for deterministic output across runs.
+            detail_str = "; ".join(
+                f"{k}: {', '.join(map(str, v)) if isinstance(v, list) else v}"
+                for k, v in sorted(details.items())
+            )
             overlay_lines.append(f"  - When {flag_str}: {truncate_summary(detail_str, 80)}")
 
     overlay_text = "\n".join(overlay_lines) if overlay_lines else "  (no overlays)"

--- a/src/questfoundry/graph/polish_context.py
+++ b/src/questfoundry/graph/polish_context.py
@@ -236,8 +236,13 @@ def format_entity_arc_context(
         flags = overlay.get("when") or []
         details = overlay.get("details") or {}
         if flags and details:
-            flag_str = ", ".join(flags)
-            detail_str = "; ".join(f"{k}: {v}" for k, v in details.items())
+            # Backtick-wrap flag IDs per CLAUDE.md §9 rule 1.
+            flag_str = ", ".join(f"`{f}`" for f in flags)
+            # `!s` coerces to str so any value type renders without crashing
+            # (matches the dress_context.py overlay renderer); for list/dict
+            # this still delegates to __repr__ — current overlay schema is
+            # string-only.
+            detail_str = "; ".join(f"{k}: {v!s}" for k, v in details.items())
             overlay_lines.append(f"  - When {flag_str}: {truncate_summary(detail_str, 80)}")
 
     overlay_text = "\n".join(overlay_lines) if overlay_lines else "  (no overlays)"

--- a/tests/unit/test_dress_context.py
+++ b/tests/unit/test_dress_context.py
@@ -246,14 +246,9 @@ class TestFormatEntityForCodex:
         assert "warm and forthcoming" in result
         assert "skipped" not in result  # malformed entry not rendered
 
-    def test_overlay_details_non_string_values_str_cast(self, dress_graph: Graph) -> None:
-        """The renderer must `!s`-coerce non-string `details` values so it
-        always has a render path (no crash, consistent output). Note: for
-        list/dict values `str()` delegates to `__repr__`, so this test pins
-        the bracket-format repr — that's the documented behaviour, see the
-        comment in `dress_context.py` directing future maintainers toward
-        an explicit per-type formatter if the schema admits non-string
-        values."""
+    def test_overlay_list_values_render_human_readable(self, dress_graph: Graph) -> None:
+        """List-valued details render as comma-joined strings (e.g. `umm, well`)
+        — never as Python repr (`['umm', 'well']`) per CLAUDE.md §9 rule 1."""
         from questfoundry.graph.dress_context import format_entity_for_codex
 
         dress_graph.update_node(
@@ -267,10 +262,31 @@ class TestFormatEntityForCodex:
         )
 
         result = format_entity_for_codex(dress_graph, "character::aldric")
-        # `str()` delegates to `__repr__` for lists, so bracket-format is the
-        # expected output here. See the docstring above for why this is the
-        # documented behaviour rather than a leak.
-        assert "speech_tics: ['umm', 'well']" in result
+        assert "speech_tics: umm, well" in result
+        # Belt-and-braces: explicitly assert the bracket-format is GONE.
+        assert "['umm', 'well']" not in result
+
+    def test_overlay_details_sorted_for_determinism(self, dress_graph: Graph) -> None:
+        """Detail keys MUST be iterated in sorted order so the rendered string
+        is byte-identical across runs regardless of dict insertion order."""
+        from questfoundry.graph.dress_context import format_entity_for_codex
+
+        dress_graph.update_node(
+            "character::aldric",
+            overlays=[
+                {
+                    "when": ["state_flag::met_aldric"],
+                    # Inserted in non-alphabetical order intentionally.
+                    "details": {"voice": "soft", "demeanor": "warm"},
+                },
+            ],
+        )
+
+        result = format_entity_for_codex(dress_graph, "character::aldric")
+        # `demeanor` sorts before `voice` alphabetically.
+        d_idx = result.index("demeanor: warm")
+        v_idx = result.index("voice: soft")
+        assert d_idx < v_idx
 
 
 class TestFormatEntitiesBatchForCodex:

--- a/tests/unit/test_polish_context.py
+++ b/tests/unit/test_polish_context.py
@@ -171,7 +171,37 @@ class TestFormatEntityArcContext:
         ctx = format_entity_arc_context(graph, "entity::npc", ["beat::b1"])
 
         assert "hostile" in ctx["overlay_data"]
-        assert "dilemma::d1:path::p1" in ctx["overlay_data"]
+        # Flag IDs are backtick-wrapped per CLAUDE.md §9 rule 1 — matches the
+        # DRESS overlay renderer (closes #1406).
+        assert "`dilemma::d1:path::p1`" in ctx["overlay_data"]
+
+    def test_entity_overlay_details_non_string_values_str_cast(self) -> None:
+        """Same `!s`-coerce pattern as the DRESS overlay renderer: any value
+        type renders consistently. Note that for list/dict, `str()` delegates
+        to `__repr__` (bracket-format) — that's the documented behaviour."""
+        graph = Graph.empty()
+        graph.create_node("path::p1", {"type": "path", "raw_id": "p1"})
+        graph.create_node(
+            "entity::npc",
+            {
+                "type": "entity",
+                "raw_id": "npc",
+                "name": "NPC",
+                "overlays": [
+                    {
+                        "when": ["state_flag::met_npc"],
+                        "details": {"speech_tics": ["umm", "well"]},
+                    }
+                ],
+            },
+        )
+        _make_beat(graph, "beat::b1", "Meet NPC", entities=["entity::npc"])
+        graph.add_edge("belongs_to", "beat::b1", "path::p1")
+
+        ctx = format_entity_arc_context(graph, "entity::npc", ["beat::b1"])
+        # `str()` on a list delegates to `__repr__` — see the comment in
+        # `polish_context.py` for the documented bracket-format behaviour.
+        assert "speech_tics: ['umm', 'well']" in ctx["overlay_data"]
 
     def test_entity_not_found(self) -> None:
         """Missing entity returns empty fields gracefully."""

--- a/tests/unit/test_polish_context.py
+++ b/tests/unit/test_polish_context.py
@@ -175,10 +175,10 @@ class TestFormatEntityArcContext:
         # DRESS overlay renderer (closes #1406).
         assert "`dilemma::d1:path::p1`" in ctx["overlay_data"]
 
-    def test_entity_overlay_details_non_string_values_str_cast(self) -> None:
-        """Same `!s`-coerce pattern as the DRESS overlay renderer: any value
-        type renders consistently. Note that for list/dict, `str()` delegates
-        to `__repr__` (bracket-format) — that's the documented behaviour."""
+    def test_entity_overlay_list_values_render_human_readable(self) -> None:
+        """List-valued details render as comma-joined strings (e.g. `umm, well`)
+        — never as Python repr (`['umm', 'well']`) per CLAUDE.md §9 rule 1.
+        Pinned because this is exactly the bracket-format the rule forbids."""
         graph = Graph.empty()
         graph.create_node("path::p1", {"type": "path", "raw_id": "p1"})
         graph.create_node(
@@ -199,9 +199,38 @@ class TestFormatEntityArcContext:
         graph.add_edge("belongs_to", "beat::b1", "path::p1")
 
         ctx = format_entity_arc_context(graph, "entity::npc", ["beat::b1"])
-        # `str()` on a list delegates to `__repr__` — see the comment in
-        # `polish_context.py` for the documented bracket-format behaviour.
-        assert "speech_tics: ['umm', 'well']" in ctx["overlay_data"]
+        assert "speech_tics: umm, well" in ctx["overlay_data"]
+        # Belt-and-braces: explicitly assert the bracket-format is GONE.
+        assert "['umm', 'well']" not in ctx["overlay_data"]
+
+    def test_entity_overlay_details_sorted_for_determinism(self) -> None:
+        """Detail keys MUST be iterated in sorted order so the rendered string
+        is byte-identical across runs regardless of dict insertion order."""
+        graph = Graph.empty()
+        graph.create_node("path::p1", {"type": "path", "raw_id": "p1"})
+        graph.create_node(
+            "entity::npc",
+            {
+                "type": "entity",
+                "raw_id": "npc",
+                "name": "NPC",
+                "overlays": [
+                    {
+                        "when": ["state_flag::met_npc"],
+                        # Inserted in non-alphabetical order intentionally.
+                        "details": {"voice": "soft", "demeanor": "warm"},
+                    }
+                ],
+            },
+        )
+        _make_beat(graph, "beat::b1", "Meet NPC", entities=["entity::npc"])
+        graph.add_edge("belongs_to", "beat::b1", "path::p1")
+
+        ctx = format_entity_arc_context(graph, "entity::npc", ["beat::b1"])
+        # `demeanor` sorts before `voice` alphabetically.
+        d_idx = ctx["overlay_data"].index("demeanor: warm")
+        v_idx = ctx["overlay_data"].index("voice: soft")
+        assert d_idx < v_idx
 
     def test_entity_not_found(self) -> None:
         """Missing entity returns empty fields gracefully."""


### PR DESCRIPTION
## Summary

Phase 3 Cluster E-3. Closes #1406. Started as a small backtick-consistency fix in `polish_context.py`; expanded to fix a CLAUDE.md §9 rule 1 violation gemini-code-assist caught in commit `482abcbe`.

## Changes

| File | Change |
|---|---|
| `src/questfoundry/graph/polish_context.py` | Backtick-wrap state flag IDs in overlay rendering (closes #1406). Replace `!s` coercion with explicit `list` handler — `', '.join(map(str, v))` — to satisfy CLAUDE.md §9 rule 1. Sort `details.items()` for deterministic output. |
| `src/questfoundry/graph/dress_context.py` | Same `!s` → explicit list handler + sort fix on the DRESS sibling. The two renderers were intentionally aligned in #1405; gemini's finding applies equally to both, so fixing only one would re-break the alignment. |
| `tests/unit/test_polish_context.py` | Updated overlay-with-backticks assertion. Replaced the bracket-format test with a human-readable assertion (`umm, well` not `['umm', 'well']`). New test pinning sort determinism. |
| `tests/unit/test_dress_context.py` | Same updates on the DRESS side. |

Diff: 4 files, +78/-32.

## Why both renderers

The previous claude-review accepted the bracket-format `['umm', 'well']` as "documented behaviour"; gemini correctly flagged that documenting a §9 violation doesn't make it not a violation. The DRESS PR (#1405) shipped the same bug — fixing only one of the two intentionally-aligned twin renderers would re-break the alignment the previous PR established. Belt-and-braces "bracket format is GONE" assertions added to both sides.

## Test plan

- [x] 43 tests across polish + dress context suites pass
- [x] mypy + ruff clean
- [x] Existing overlay tests with string-only details still pass (substring-match assertions are order-independent)

🤖 Generated with [Claude Code](https://claude.com/claude-code)