### PR TITLE
fix(polish): enrich Phase 3 arc context blocks (Cluster E-4)

### DIFF
--- a/prompts/templates/polish_phase3_arcs.yaml
+++ b/prompts/templates/polish_phase3_arcs.yaml
@@ -16,9 +16,16 @@ system: |
   {overlay_data}
 
   ## Beats Featuring This Entity (in story order)
+  Format: `- <beat_id> (path: <path_id>) [<scene_type>]: <summary>` —
+  pre-commit beats list both paths of their dilemma and end with
+  `(shared pre-commit)`. Beats with `dilemma_effects=[…]` carry those
+  effects on their listed dilemmas.
   {beat_appearances}
 
-  ## Paths in This Story
+  ## Paths Where This Entity Appears
+  Subset of the story's paths — only those reached via at least one
+  beat the entity is in. The `pivots` and `arcs_per_path` arrays below
+  MUST use IDs from this list.
   {path_ids}
 
   ## Arc Structure

--- a/prompts/templates/polish_phase3_arcs.yaml
+++ b/prompts/templates/polish_phase3_arcs.yaml
@@ -16,11 +16,11 @@ system: |
   {overlay_data}
 
   ## Beats Featuring This Entity (in story order)
-  Format: `- `<beat_id>` (path: `<path_id>`) [<scene_type>]: <summary>` —
-  beat and path IDs are backtick-wrapped (CLAUDE.md §9 rule 1, matches
-  the Valid IDs section below). Pre-commit beats list both paths of
-  their dilemma and end with `(shared pre-commit)`. Beats with
-  `dilemma_effects=[…]` carry those effects on their listed dilemmas.
+  Format per line: `<beat_id>` (path: `<path_id>`) [<scene_type>]: <summary>
+  Beat and path IDs are backtick-wrapped (matches the Valid IDs section
+  below). Pre-commit beats list both paths of their dilemma and end
+  with `(shared pre-commit)`. Beats with `dilemma_effects=[…]` carry
+  those effects on their listed dilemmas.
   {beat_appearances}
 
   ## Paths Where This Entity Appears

--- a/prompts/templates/polish_phase3_arcs.yaml
+++ b/prompts/templates/polish_phase3_arcs.yaml
@@ -16,10 +16,11 @@ system: |
   {overlay_data}
 
   ## Beats Featuring This Entity (in story order)
-  Format: `- <beat_id> (path: <path_id>) [<scene_type>]: <summary>` —
-  pre-commit beats list both paths of their dilemma and end with
-  `(shared pre-commit)`. Beats with `dilemma_effects=[…]` carry those
-  effects on their listed dilemmas.
+  Format: `- `<beat_id>` (path: `<path_id>`) [<scene_type>]: <summary>` —
+  beat and path IDs are backtick-wrapped (CLAUDE.md §9 rule 1, matches
+  the Valid IDs section below). Pre-commit beats list both paths of
+  their dilemma and end with `(shared pre-commit)`. Beats with
+  `dilemma_effects=[…]` carry those effects on their listed dilemmas.
   {beat_appearances}
 
   ## Paths Where This Entity Appears

--- a/src/questfoundry/graph/polish_context.py
+++ b/src/questfoundry/graph/polish_context.py
@@ -183,7 +183,6 @@ def format_entity_arc_context(
     """
     beat_nodes = graph.get_nodes_by_type("beat")
     entity_nodes = graph.get_nodes_by_type("entity")
-    path_nodes = graph.get_nodes_by_type("path")
 
     # Entity info
     entity_data = entity_nodes.get(entity_id, {})
@@ -270,8 +269,12 @@ def format_entity_arc_context(
 
     # Render each ID list with a `(none)` fallback when empty so the prompt
     # never receives a bare empty injection. Matches `anchored_text` above.
+    # `valid_path_ids` is scoped to the entity's paths (paths_seen) — the
+    # Phase 3 prompt constrains `pivots` / `arcs_per_path` to this set, and
+    # showing the broader story-wide list previously confused models into
+    # inventing arcs for paths the entity never appears in (closes #1410).
     path_ids_text = ", ".join(f"`{p}`" for p in sorted(paths_seen)) or "(none)"
-    valid_path_ids_text = ", ".join(f"`{p}`" for p in sorted(path_nodes.keys())) or "(none)"
+    valid_path_ids_text = path_ids_text
     valid_beat_ids_text = ", ".join(f"`{b}`" for b in sorted(beat_appearances)) or "(none)"
 
     return {

--- a/src/questfoundry/graph/polish_context.py
+++ b/src/questfoundry/graph/polish_context.py
@@ -214,13 +214,17 @@ def format_entity_arc_context(
             effects = [imp.get("effect", "?") for imp in impacts]
             impact_str = f" dilemma_effects=[{', '.join(effects)}]"
 
+        # Backtick-wrap IDs per CLAUDE.md §9 rule 1 — consistent with the
+        # other ID lists this context dict produces, so a model matching beat
+        # IDs against `valid_beat_ids` doesn't have to mentally strip backticks.
         if not path_set:
             path_label = "unknown"
         elif len(path_set) == 1:
-            (path_label,) = path_set
+            (only_path,) = path_set
+            path_label = f"`{only_path}`"
         else:
-            path_label = ", ".join(sorted(path_set)) + " (shared pre-commit)"
-        line = f"  - {bid} (path: {path_label}) [{scene_type}]: {summary}{impact_str}"
+            path_label = ", ".join(f"`{p}`" for p in sorted(path_set)) + " (shared pre-commit)"
+        line = f"  - `{bid}` (path: {path_label}) [{scene_type}]: {summary}{impact_str}"
         beat_items.append(ContextItem(id=bid, text=line))
 
     if config:

--- a/src/questfoundry/graph/polish_context.py
+++ b/src/questfoundry/graph/polish_context.py
@@ -256,7 +256,10 @@ def format_entity_arc_context(
         if edge["from"] == entity_id:
             anchored_dilemmas.append(edge["to"])
 
-    anchored_text = ", ".join(anchored_dilemmas) if anchored_dilemmas else "(none)"
+    # Backtick-wrap IDs per CLAUDE.md §9 rule 1.
+    anchored_text = (
+        ", ".join(f"`{d}`" for d in anchored_dilemmas) if anchored_dilemmas else "(none)"
+    )
 
     return {
         "entity_id": entity_id,
@@ -265,9 +268,9 @@ def format_entity_arc_context(
         "beat_appearances": beat_text,
         "overlay_data": overlay_text,
         "anchored_dilemmas": anchored_text,
-        "path_ids": ", ".join(sorted(paths_seen)),
-        "valid_path_ids": ", ".join(sorted(path_nodes.keys())),
-        "valid_beat_ids": ", ".join(sorted(beat_appearances)),
+        "path_ids": ", ".join(f"`{p}`" for p in sorted(paths_seen)),
+        "valid_path_ids": ", ".join(f"`{p}`" for p in sorted(path_nodes.keys())),
+        "valid_beat_ids": ", ".join(f"`{b}`" for b in sorted(beat_appearances)),
     }
 
 

--- a/src/questfoundry/graph/polish_context.py
+++ b/src/questfoundry/graph/polish_context.py
@@ -265,6 +265,12 @@ def format_entity_arc_context(
         ", ".join(f"`{d}`" for d in anchored_dilemmas) if anchored_dilemmas else "(none)"
     )
 
+    # Render each ID list with a `(none)` fallback when empty so the prompt
+    # never receives a bare empty injection. Matches `anchored_text` above.
+    path_ids_text = ", ".join(f"`{p}`" for p in sorted(paths_seen)) or "(none)"
+    valid_path_ids_text = ", ".join(f"`{p}`" for p in sorted(path_nodes.keys())) or "(none)"
+    valid_beat_ids_text = ", ".join(f"`{b}`" for b in sorted(beat_appearances)) or "(none)"
+
     return {
         "entity_id": entity_id,
         "entity_name": entity_name,
@@ -272,9 +278,9 @@ def format_entity_arc_context(
         "beat_appearances": beat_text,
         "overlay_data": overlay_text,
         "anchored_dilemmas": anchored_text,
-        "path_ids": ", ".join(f"`{p}`" for p in sorted(paths_seen)),
-        "valid_path_ids": ", ".join(f"`{p}`" for p in sorted(path_nodes.keys())),
-        "valid_beat_ids": ", ".join(f"`{b}`" for b in sorted(beat_appearances)),
+        "path_ids": path_ids_text,
+        "valid_path_ids": valid_path_ids_text,
+        "valid_beat_ids": valid_beat_ids_text,
     }
 
 

--- a/src/questfoundry/graph/polish_context.py
+++ b/src/questfoundry/graph/polish_context.py
@@ -231,6 +231,9 @@ def format_entity_arc_context(
         beat_text = compact_items(beat_items, config)
     else:
         beat_text = "\n".join(item.text for item in beat_items)
+    # Empty fallback consistent with the four ID list fields below.
+    if not beat_text:
+        beat_text = "  (none)"
 
     # Overlay data (how entity changes based on state flags)
     # Overlays are embedded on the entity node as {when: [state_flag_ids], details: {k: v}}

--- a/tests/unit/test_polish_context.py
+++ b/tests/unit/test_polish_context.py
@@ -143,11 +143,14 @@ class TestFormatEntityArcContext:
         assert ctx["entity_id"] == "entity::mentor"
         assert ctx["entity_name"] == "The Mentor"
         assert "wise guide" in ctx["entity_description"]
-        assert "beat::intro" in ctx["beat_appearances"]
-        assert "beat::reveal" in ctx["beat_appearances"]
-        # path_ids backtick-wrapped per CLAUDE.md §9 rule 1.
+        # IDs in beat_appearances lines are backtick-wrapped per CLAUDE.md §9
+        # rule 1 — matches the valid_*_ids lists so a model doesn't need to
+        # mentally strip backticks when matching IDs across surfaces.
+        assert "`beat::intro`" in ctx["beat_appearances"]
+        assert "`beat::reveal`" in ctx["beat_appearances"]
+        assert "(path: `path::brave`)" in ctx["beat_appearances"]
+        # Same backtick convention for the standalone ID lists.
         assert "`path::brave`" in ctx["path_ids"]
-        # Same for valid_path_ids and valid_beat_ids.
         assert "`path::brave`" in ctx["valid_path_ids"]
         assert "`beat::intro`" in ctx["valid_beat_ids"]
         assert "`beat::reveal`" in ctx["valid_beat_ids"]

--- a/tests/unit/test_polish_context.py
+++ b/tests/unit/test_polish_context.py
@@ -211,6 +211,24 @@ class TestFormatEntityArcContext:
         # Belt-and-braces: explicitly assert the bracket-format is GONE.
         assert "['umm', 'well']" not in ctx["overlay_data"]
 
+    def test_id_lists_fall_back_to_none_when_empty(self) -> None:
+        """Empty source sets MUST render as `(none)` rather than an empty
+        string so the prompt never receives a bare empty injection. Matches
+        the existing `anchored_dilemmas` fallback pattern; pinned because
+        empty-input behaviour is otherwise easy to regress silently."""
+        graph = Graph.empty()
+        graph.create_node(
+            "entity::loner",
+            {"type": "entity", "raw_id": "loner", "name": "Loner", "description": ""},
+        )
+        # No beats, no paths, no anchored_to edges.
+
+        ctx = format_entity_arc_context(graph, "entity::loner", [])
+        assert ctx["path_ids"] == "(none)"
+        assert ctx["valid_path_ids"] == "(none)"
+        assert ctx["valid_beat_ids"] == "(none)"
+        assert ctx["anchored_dilemmas"] == "(none)"
+
     def test_anchored_dilemmas_backtick_wrapped(self) -> None:
         """Dilemmas the entity is `anchored_to` are backtick-wrapped per
         CLAUDE.md §9 rule 1 — same convention as overlay flag IDs and the

--- a/tests/unit/test_polish_context.py
+++ b/tests/unit/test_polish_context.py
@@ -151,7 +151,9 @@ class TestFormatEntityArcContext:
         assert "(path: `path::brave`)" in ctx["beat_appearances"]
         # Same backtick convention for the standalone ID lists.
         assert "`path::brave`" in ctx["path_ids"]
-        assert "`path::brave`" in ctx["valid_path_ids"]
+        # `valid_path_ids` is entity-scoped (same as `path_ids`) per #1410 —
+        # the Phase 3 prompt forbids arcs on paths the entity isn't in.
+        assert ctx["valid_path_ids"] == ctx["path_ids"]
         assert "`beat::intro`" in ctx["valid_beat_ids"]
         assert "`beat::reveal`" in ctx["valid_beat_ids"]
 
@@ -232,6 +234,30 @@ class TestFormatEntityArcContext:
         # rendered lines normally carry) so the prompt never receives an
         # empty injection.
         assert ctx["beat_appearances"] == "  (none)"
+
+    def test_valid_path_ids_excludes_paths_entity_does_not_appear_on(self) -> None:
+        """`valid_path_ids` MUST be scoped to paths where the entity actually
+        appears (closes #1410). Showing the broader story-wide list confused
+        models into inventing arcs on paths the entity is never in."""
+        graph = Graph.empty()
+        # Two paths exist in the story.
+        graph.create_node("path::story_a", {"type": "path", "raw_id": "story_a"})
+        graph.create_node("path::story_b", {"type": "path", "raw_id": "story_b"})
+        graph.create_node(
+            "entity::loner",
+            {"type": "entity", "raw_id": "loner", "name": "Loner", "description": "x"},
+        )
+        # Entity appears only on path_a (via beat::b1).
+        _make_beat(graph, "beat::b1", "Loner appears", entities=["entity::loner"])
+        graph.add_edge("belongs_to", "beat::b1", "path::story_a")
+
+        ctx = format_entity_arc_context(graph, "entity::loner", ["beat::b1"])
+        # Both path_ids and valid_path_ids show only the entity's path,
+        # NOT path::story_b (which exists in the graph but doesn't include
+        # the entity).
+        assert ctx["path_ids"] == "`path::story_a`"
+        assert ctx["valid_path_ids"] == "`path::story_a`"
+        assert "story_b" not in ctx["valid_path_ids"]
 
     def test_anchored_dilemmas_backtick_wrapped(self) -> None:
         """Dilemmas the entity is `anchored_to` are backtick-wrapped per

--- a/tests/unit/test_polish_context.py
+++ b/tests/unit/test_polish_context.py
@@ -228,6 +228,10 @@ class TestFormatEntityArcContext:
         assert ctx["valid_path_ids"] == "(none)"
         assert ctx["valid_beat_ids"] == "(none)"
         assert ctx["anchored_dilemmas"] == "(none)"
+        # `beat_appearances` uses the same fallback (with the indent the
+        # rendered lines normally carry) so the prompt never receives an
+        # empty injection.
+        assert ctx["beat_appearances"] == "  (none)"
 
     def test_anchored_dilemmas_backtick_wrapped(self) -> None:
         """Dilemmas the entity is `anchored_to` are backtick-wrapped per

--- a/tests/unit/test_polish_context.py
+++ b/tests/unit/test_polish_context.py
@@ -145,7 +145,12 @@ class TestFormatEntityArcContext:
         assert "wise guide" in ctx["entity_description"]
         assert "beat::intro" in ctx["beat_appearances"]
         assert "beat::reveal" in ctx["beat_appearances"]
-        assert "path::brave" in ctx["path_ids"]
+        # path_ids backtick-wrapped per CLAUDE.md §9 rule 1.
+        assert "`path::brave`" in ctx["path_ids"]
+        # Same for valid_path_ids and valid_beat_ids.
+        assert "`path::brave`" in ctx["valid_path_ids"]
+        assert "`beat::intro`" in ctx["valid_beat_ids"]
+        assert "`beat::reveal`" in ctx["valid_beat_ids"]
 
     def test_entity_with_overlays(self) -> None:
         graph = Graph.empty()
@@ -202,6 +207,24 @@ class TestFormatEntityArcContext:
         assert "speech_tics: umm, well" in ctx["overlay_data"]
         # Belt-and-braces: explicitly assert the bracket-format is GONE.
         assert "['umm', 'well']" not in ctx["overlay_data"]
+
+    def test_anchored_dilemmas_backtick_wrapped(self) -> None:
+        """Dilemmas the entity is `anchored_to` are backtick-wrapped per
+        CLAUDE.md §9 rule 1 — same convention as overlay flag IDs and the
+        valid_*_ids lists."""
+        graph = Graph.empty()
+        graph.create_node("path::p1", {"type": "path", "raw_id": "p1"})
+        graph.create_node(
+            "entity::mentor",
+            {"type": "entity", "raw_id": "mentor", "name": "Mentor", "description": "guide"},
+        )
+        graph.create_node("dilemma::trust", {"type": "dilemma", "raw_id": "trust"})
+        graph.add_edge("anchored_to", "entity::mentor", "dilemma::trust")
+        _make_beat(graph, "beat::b1", "Meet mentor", entities=["entity::mentor"])
+        graph.add_edge("belongs_to", "beat::b1", "path::p1")
+
+        ctx = format_entity_arc_context(graph, "entity::mentor", ["beat::b1"])
+        assert ctx["anchored_dilemmas"] == "`dilemma::trust`"
 
     def test_entity_overlay_details_sorted_for_determinism(self) -> None:
         """Detail keys MUST be iterated in sorted order so the rendered string


### PR DESCRIPTION
## Summary

Phase 3 Cluster E-4. Closes #1408. Continues the long-tail context-enrichment work from E-1/E-2/E-3.

Per audit POLISH §`polish_phase3_arcs.yaml`, several context blocks were injected as bare ID lists or labelled with misleading headers. This PR brings them into line with CLAUDE.md §9 rule 1 (backtick-wrap IDs) and §8 (every block needs a header explaining WHAT and WHY).

## Changes

| File | Change |
|---|---|
| `src/questfoundry/graph/polish_context.py` `format_entity_arc_context` | Backtick-wrap each ID in `anchored_dilemmas`, `path_ids`, `valid_path_ids`, `valid_beat_ids`. |
| `prompts/templates/polish_phase3_arcs.yaml` | Schema legend for `{beat_appearances}` lines (`<beat_id> (path: <path_id>) [<scene_type>]: <summary>`); renamed `## Paths in This Story` → `## Paths Where This Entity Appears` with the entity-relative scope explained; constraint stated that `pivots` / `arcs_per_path` IDs must come from this list. |
| `tests/unit/test_polish_context.py` | Existing assertions updated to expect backtick-wrapped IDs; new `test_anchored_dilemmas_backtick_wrapped`. |

Diff: 3 files, +39/-6.

## Test plan

- [x] 13 polish-context tests pass
- [x] mypy + ruff clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)