### PR TITLE
fix(polish): phase5b residue context enrichment + phase3 legend (E-5)

### DIFF
--- a/prompts/templates/polish_phase3_arcs.yaml
+++ b/prompts/templates/polish_phase3_arcs.yaml
@@ -20,7 +20,9 @@ system: |
   Beat and path IDs are backtick-wrapped (matches the Valid IDs section
   below). Pre-commit beats list both paths of their dilemma and end
   with `(shared pre-commit)`. Beats with `dilemma_effects=[…]` carry
-  those effects on their listed dilemmas.
+  those effects on their listed dilemmas. A beat with no `belongs_to`
+  edges renders as `(path: unknown)` (sentinel literal, not an ID —
+  anomalous data; treat the beat as path-agnostic).
   {beat_appearances}
 
   ## Paths Where This Entity Appears

--- a/prompts/templates/polish_phase5b_residue.yaml
+++ b/prompts/templates/polish_phase5b_residue.yaml
@@ -14,7 +14,7 @@ system: |
 
   ### `content_hint` length (CRITICAL — R-5.6)
   GOOD: "You enter the vault with quiet confidence, the mentor's words still ringing in your ears" (1 sentence, mood-setter)
-  BAD: "You spent years preparing for this moment. The vault door is cold to the touch. Behind you, the city sleeps, unaware of what you're about to uncover, and the weight of every choice you've made up to this point presses against your chest." (multi-sentence, reads as a full passage — too long, mood-setter only)
+  BAD: "You spent years preparing for this moment. The vault door is cold to the touch. Behind you, the city sleeps, unaware of what you're about to uncover, and the weight of every choice you've made up to this point presses against your chest." (too long — keep it to a single mood-setter sentence)
 
   ## Story Context
   {story_context}

--- a/prompts/templates/polish_phase5b_residue.yaml
+++ b/prompts/templates/polish_phase5b_residue.yaml
@@ -12,10 +12,23 @@ system: |
   - **Path-specific** — reflect the emotional state from the player's choices
   - **Non-duplicating** — do NOT repeat the shared passage's content
 
+  ### `content_hint` length (CRITICAL — R-5.6)
+  GOOD: "You enter the vault with quiet confidence, the mentor's words still ringing in your ears" (1 sentence, mood-setter)
+  BAD: "You spent years preparing for this moment. The vault door is cold to the touch. Behind you, the city sleeps, unaware of what you're about to uncover, and the weight of every choice you've made up to this point presses against your chest." (multi-sentence, reads as a full passage — too long, mood-setter only)
+
   ## Story Context
   {story_context}
 
   ## Residue Beats to Write
+  Format per residue (IDs backtick-wrapped to match the Valid IDs
+  convention elsewhere in POLISH prompts):
+  ```
+  - residue_id: `<id>` flag: `<state_flag_id>` path: `<path_id>`
+    Target passage: `<passage_id>` (<short summary of the shared scene>)
+  ```
+  Each residue's `content_hint` must reflect the emotional state of THIS
+  residue's `path` (the player chose that branch). The sibling path's
+  flag is intentionally absent, so the hint should not allude to it.
   {residue_details}
 
   ## Mapping Strategy (choose per residue)

--- a/prompts/templates/polish_phase5b_residue.yaml
+++ b/prompts/templates/polish_phase5b_residue.yaml
@@ -62,7 +62,7 @@ system: |
   }}
 
   ## What NOT to Do
-  - Do NOT write full passages — just a mood-setting hint (1-2 sentences max)
+  - Do NOT write full passages — just one mood-setter sentence (see the CRITICAL block above)
   - Do NOT duplicate content from the target passage
   - Do NOT skip any residue — provide content for every residue listed
   - Do NOT add prose before or after the JSON output

--- a/src/questfoundry/graph/polish_context.py
+++ b/src/questfoundry/graph/polish_context.py
@@ -384,13 +384,15 @@ def format_residue_content_context(
         target_spec = passage_lookup.get(target, {})
         target_summary = truncate_summary(target_spec.get("summary", ""), 80)
 
+        # Backtick-wrap IDs per CLAUDE.md §9 rule 1, consistent with the
+        # other polish_context render functions (E-3, E-4).
         residue_lines.append(
-            f"  - {residue_id}: flag={flag} path={path_id}\n"
-            f"    Target passage: {target} ({target_summary})"
+            f"  - residue_id: `{residue_id}` flag: `{flag}` path: `{path_id}`\n"
+            f"    Target passage: `{target}` ({target_summary})"
         )
 
     return {
-        "residue_details": "\n".join(residue_lines),
+        "residue_details": "\n".join(residue_lines) or "(none)",
         "story_context": story_context,
         "residue_count": str(len(residue_specs)),
     }

--- a/src/questfoundry/graph/polish_context.py
+++ b/src/questfoundry/graph/polish_context.py
@@ -384,8 +384,7 @@ def format_residue_content_context(
         target_spec = passage_lookup.get(target, {})
         target_summary = truncate_summary(target_spec.get("summary", ""), 80)
 
-        # Backtick-wrap IDs per CLAUDE.md §9 rule 1, consistent with the
-        # other polish_context render functions (E-3, E-4).
+        # Backtick-wrap IDs per CLAUDE.md §9 rule 1.
         residue_lines.append(
             f"  - residue_id: `{residue_id}` flag: `{flag}` path: `{path_id}`\n"
             f"    Target passage: `{target}` ({target_summary})"

--- a/tests/unit/test_polish_phase5_context.py
+++ b/tests/unit/test_polish_phase5_context.py
@@ -96,13 +96,21 @@ class TestFormatResidueContentContext:
 
         ctx = format_residue_content_context(graph, residue_specs, passage_specs)
         assert ctx["residue_count"] == "1"
-        assert "r1" in ctx["residue_details"]
+        # IDs are backtick-wrapped per CLAUDE.md §9 rule 1, consistent with
+        # the other polish_context render functions (E-3 / E-4 / E-5).
+        assert "`r1`" in ctx["residue_details"]
+        assert "`flag1`" in ctx["residue_details"]
+        assert "`path::brave`" in ctx["residue_details"]
+        assert "`p1`" in ctx["residue_details"]
         assert "Target passage" in ctx["residue_details"]
 
-    def test_empty_residues(self) -> None:
+    def test_empty_residues_falls_back_to_none(self) -> None:
+        """Empty residue_specs MUST render as `(none)` per the consistent
+        empty-fallback pattern across polish_context render functions."""
         graph = Graph.empty()
         ctx = format_residue_content_context(graph, [], [])
         assert ctx["residue_count"] == "0"
+        assert ctx["residue_details"] == "(none)"
 
 
 class TestFormatFalseBranchContext:

--- a/tests/unit/test_polish_phase5_context.py
+++ b/tests/unit/test_polish_phase5_context.py
@@ -96,8 +96,7 @@ class TestFormatResidueContentContext:
 
         ctx = format_residue_content_context(graph, residue_specs, passage_specs)
         assert ctx["residue_count"] == "1"
-        # IDs are backtick-wrapped per CLAUDE.md §9 rule 1, consistent with
-        # the other polish_context render functions (E-3 / E-4 / E-5).
+        # IDs are backtick-wrapped per CLAUDE.md §9 rule 1.
         assert "`r1`" in ctx["residue_details"]
         assert "`flag1`" in ctx["residue_details"]
         assert "`path::brave`" in ctx["residue_details"]


### PR DESCRIPTION
## Summary

Phase 3 Cluster E-5. Continues the long-tail context enrichment with two related POLISH prompt cleanups. Closes **#1411** (post-merge follow-up from E-4) and **#1412** (E-5 umbrella).

## Changes

| File | Change |
|---|---|
| `src/questfoundry/graph/polish_context.py` `format_residue_content_context` | Backtick-wrap `residue_id`, `flag`, `path`, `target` per CLAUDE.md §9 rule 1; `(none)` fallback for empty `residue_specs` matching the consistent pattern across other render functions. |
| `prompts/templates/polish_phase5b_residue.yaml` | New `### content_hint length (CRITICAL — R-5.6)` block with explicit GOOD/BAD example pair (CLAUDE.md §7); schema legend before `{residue_details}` documenting the per-line format and path/flag semantics (CLAUDE.md §8). |
| `prompts/templates/polish_phase3_arcs.yaml` | Format legend documents the `(path: unknown)` sentinel so models reading anomalous data don't misread it as an error (closes #1411). |
| `tests/unit/test_polish_phase5_context.py` | Updated existing assertions to expect backtick-wrapped IDs; new `test_empty_residues_falls_back_to_none` pins the fallback. |

Diff: 4 files, +31/-6.

## Out of scope

The third phase5b audit finding (repair-loop slot for `mapping_strategy`) — larger surface change requiring `{residue_feedback}` variable + retry plumbing. Deferrable per scope rules; the prompt is materially improved without it.

## Test plan

- [x] 25 tests across polish phase 3 + 5 context suites pass
- [x] mypy + ruff clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)