### PR TITLE
fix(polish): backtick-wrap IDs in 4 sibling render functions (Cluster E-6)

### DIFF
--- a/src/questfoundry/graph/polish_context.py
+++ b/src/questfoundry/graph/polish_context.py
@@ -80,19 +80,22 @@ def format_linear_section_context(
         impacts = data.get("dilemma_impacts", [])
         entities = data.get("entities", [])
 
+        # Backtick-wrap IDs per CLAUDE.md §9 rule 1.
         impact_str = ""
         if impacts:
-            effects = [f"{imp.get('effect', '?')}({imp.get('dilemma_id', '?')})" for imp in impacts]
-            impact_str = f" impacts=[{', '.join(effects)}]"
+            effects = [
+                f"{imp.get('effect', '?')}(`{imp.get('dilemma_id', '?')}`)" for imp in impacts
+            ]
+            impact_str = f" impacts: {', '.join(effects)}"
 
         entity_str = ""
         if entities:
             # Truncate to 5 entities per beat to keep context compact
             display = entities[:5]
             suffix = f" +{len(entities) - 5}" if len(entities) > 5 else ""
-            entity_str = f" entities=[{', '.join(display)}{suffix}]"
+            entity_str = f" entities: {', '.join(f'`{e}`' for e in display)}{suffix}"
 
-        line = f"  {i + 1}. {bid}: [{scene_type}] {summary}{impact_str}{entity_str}"
+        line = f"  {i + 1}. `{bid}`: [{scene_type}] {summary}{impact_str}{entity_str}"
         beat_items.append(ContextItem(id=bid, text=line))
 
     if config:
@@ -106,10 +109,10 @@ def format_linear_section_context(
 
     return {
         "section_id": section_id,
-        "beat_details": beat_details,
+        "beat_details": beat_details or "(none)",
         "before_context": before_context,
         "after_context": after_context,
-        "valid_beat_ids": ", ".join(beat_ids),
+        "valid_beat_ids": ", ".join(f"`{b}`" for b in beat_ids) or "(none)",
         "beat_count": str(len(beat_ids)),
     }
 
@@ -415,7 +418,7 @@ def format_false_branch_context(
         passage_specs: List of passage spec dicts.
 
     Returns:
-        Dict with keys: candidate_details, story_context, candidate_count.
+        Dict with keys: candidate_details, valid_entity_ids, candidate_count.
     """
     passage_lookup: dict[str, dict[str, Any]] = {}
     for spec in passage_specs:
@@ -544,7 +547,7 @@ def format_ambiguous_feasibility_context(
 
         flags_str = "\n".join(flag_lines)
         case_lines.append(
-            f"  passage_id: {case.passage_id}\n"
+            f"  passage_id: `{case.passage_id}`\n"
             f"  summary: {summary}\n"
             f"  entities: {entities_str}\n"
             f"  flags:\n{flags_str}"
@@ -591,12 +594,12 @@ def format_transition_guidance_context(
             summary = truncate_summary(data.get("summary", ""), 90)
             scene_type = data.get("scene_type", "")
             scene_tag = f"[{scene_type}] " if scene_type else ""
-            beat_lines.append(f"    Beat {i + 1}: {bid} {scene_tag}— {summary}")
+            beat_lines.append(f"    Beat {i + 1}: `{bid}` {scene_tag}— {summary}")
 
         boundary_count = len(beat_ids) - 1
         beats_str = "\n".join(beat_lines)
         passage_lines.append(
-            f"  passage_id: {passage_id}\n"
+            f"  passage_id: `{passage_id}`\n"
             f"  entities: {entities_str}\n"
             f"  beats ({len(beat_ids)} total, {boundary_count} boundary/ies):\n{beats_str}"
         )

--- a/src/questfoundry/graph/polish_context.py
+++ b/src/questfoundry/graph/polish_context.py
@@ -141,20 +141,24 @@ def format_pacing_context(
 
         issue_lines.append(f"\n### Pacing Issue: {issue_type}")
         if path_id:
-            issue_lines.append(f"Path: {path_id}")
+            issue_lines.append(f"Path: `{path_id}`")
 
         for bid in beat_ids:
             data = beat_nodes.get(bid, {})
             summary = truncate_summary(data.get("summary", ""), 100)
             scene_type = data.get("scene_type", "unknown")
             entities = data.get("entities", [])
-            entity_str = f" entities=[{', '.join(entities[:3])}]" if entities else ""
-            issue_lines.append(f"  - {bid}: [{scene_type}] {summary}{entity_str}")
+            entity_str = (
+                f" entities: {', '.join(f'`{e}`' for e in entities[:3])}" if entities else ""
+            )
+            issue_lines.append(f"  - `{bid}`: [{scene_type}] {summary}{entity_str}")
 
     pacing_issues = "\n".join(issue_lines) if issue_lines else "No pacing issues detected."
 
-    # Valid entity IDs for micro-beat entity references
-    valid_entity_ids = ", ".join(sorted(entity_nodes.keys()))
+    # Valid entity IDs for micro-beat entity references (backtick-wrapped per
+    # CLAUDE.md §9 rule 1, with `(none)` fallback matching the sibling
+    # render functions).
+    valid_entity_ids = ", ".join(f"`{e}`" for e in sorted(entity_nodes.keys())) or "(none)"
 
     return {
         "pacing_issues": pacing_issues,
@@ -325,10 +329,11 @@ def format_choice_label_context(
         from_summary = truncate_summary(from_spec.get("summary", ""), 80)
         to_summary = truncate_summary(to_spec.get("summary", ""), 80)
 
-        grants_str = f" grants=[{', '.join(grants)}]" if grants else ""
+        # Backtick-wrap IDs per CLAUDE.md §9 rule 1.
+        grants_str = f" grants: {', '.join(f'`{g}`' for g in grants)}" if grants else ""
         choice_lines.append(
-            f"  {i + 1}. From: {from_id} ({from_summary})\n"
-            f"     To: {to_id} ({to_summary}){grants_str}"
+            f"  {i + 1}. From: `{from_id}` ({from_summary})\n"
+            f"     To: `{to_id}` ({to_summary}){grants_str}"
         )
 
     # Valid passage IDs: every passage_id referenced by any ChoiceSpec, sorted
@@ -346,10 +351,10 @@ def format_choice_label_context(
     )
 
     return {
-        "choice_details": "\n".join(choice_lines),
+        "choice_details": "\n".join(choice_lines) or "(none)",
         "story_context": story_context,
         "choice_count": str(len(choice_specs)),
-        "valid_passage_ids": ", ".join(valid_passage_ids),
+        "valid_passage_ids": ", ".join(f"`{p}`" for p in valid_passage_ids) or "(none)",
     }
 
 
@@ -417,7 +422,8 @@ def format_false_branch_context(
         passage_lookup[spec["passage_id"]] = spec
 
     entity_nodes = graph.get_nodes_by_type("entity")
-    valid_entity_ids = ", ".join(sorted(entity_nodes.keys()))
+    # Backtick-wrap IDs per CLAUDE.md §9 rule 1, with `(none)` fallback.
+    valid_entity_ids = ", ".join(f"`{e}`" for e in sorted(entity_nodes.keys())) or "(none)"
 
     candidate_lines: list[str] = []
     for i, cand in enumerate(candidates):
@@ -428,7 +434,7 @@ def format_false_branch_context(
         for pid in passage_ids:
             spec = passage_lookup.get(pid, {})
             summary = truncate_summary(spec.get("summary", ""), 60)
-            passage_details.append(f"    - {pid}: {summary}")
+            passage_details.append(f"    - `{pid}`: {summary}")
 
         candidate_lines.append(
             f"  Candidate {i}:\n"
@@ -437,7 +443,7 @@ def format_false_branch_context(
         )
 
     return {
-        "candidate_details": "\n".join(candidate_lines),
+        "candidate_details": "\n".join(candidate_lines) or "(none)",
         "valid_entity_ids": valid_entity_ids,
         "candidate_count": str(len(candidates)),
     }
@@ -473,13 +479,15 @@ def format_variant_summary_context(
         base_spec = passage_lookup.get(base_id, {})
         base_summary = truncate_summary(base_spec.get("summary", ""), 80)
 
+        # Backtick-wrap IDs per CLAUDE.md §9 rule 1.
+        requires_str = ", ".join(f"`{r}`" for r in requires) if requires else "(none)"
         variant_lines.append(
-            f"  - {variant_id}: base={base_id} ({base_summary})\n"
-            f"    requires=[{', '.join(requires)}]"
+            f"  - variant_id: `{variant_id}` base: `{base_id}` ({base_summary})\n"
+            f"    requires: {requires_str}"
         )
 
     return {
-        "variant_details": "\n".join(variant_lines),
+        "variant_details": "\n".join(variant_lines) or "(none)",
         "story_context": story_context,
         "variant_count": str(len(variant_specs)),
     }

--- a/tests/unit/test_polish_context.py
+++ b/tests/unit/test_polish_context.py
@@ -78,6 +78,20 @@ class TestFormatLinearSectionContext:
         assert ctx["valid_beat_ids"] == "(none)"
         assert ctx["beat_count"] == "0"
 
+    def test_section_beat_with_entities_renders_backticks(self) -> None:
+        """A section beat whose `entities` field is populated renders the
+        entity list with backticks per CLAUDE.md §9 rule 1 — never as a
+        Python repr-style bracket list. Covers the linear-section
+        equivalent of `test_pacing_beat_with_entities_renders_backticks`."""
+        graph = Graph.empty()
+        _make_beat(graph, "beat::a", "Hero acts", entities=["entity::hero"])
+
+        ctx = format_linear_section_context(graph, "s0", ["beat::a"], None, None)
+
+        assert "entities: `entity::hero`" in ctx["beat_details"]
+        # No bracket-format leak per CLAUDE.md §9 rule 1.
+        assert "entities=[" not in ctx["beat_details"]
+
     def test_dilemma_impacts_shown(self) -> None:
         graph = Graph.empty()
         _make_beat(

--- a/tests/unit/test_polish_context.py
+++ b/tests/unit/test_polish_context.py
@@ -68,6 +68,16 @@ class TestFormatLinearSectionContext:
         assert "start/end" in ctx["before_context"]
         assert "start/end" in ctx["after_context"]
 
+    def test_empty_section_falls_back_to_none(self) -> None:
+        """Empty `beat_ids` MUST render `(none)` for both `beat_details` and
+        `valid_beat_ids` per the consistent empty-fallback pattern across
+        polish_context render functions."""
+        graph = Graph.empty()
+        ctx = format_linear_section_context(graph, "section_0", [], None, None)
+        assert ctx["beat_details"] == "(none)"
+        assert ctx["valid_beat_ids"] == "(none)"
+        assert ctx["beat_count"] == "0"
+
     def test_dilemma_impacts_shown(self) -> None:
         graph = Graph.empty()
         _make_beat(

--- a/tests/unit/test_polish_context.py
+++ b/tests/unit/test_polish_context.py
@@ -103,14 +103,36 @@ class TestFormatPacingContext:
         ctx = format_pacing_context(graph, flags)
 
         assert "consecutive_scene" in ctx["pacing_issues"]
-        assert "beat::a" in ctx["pacing_issues"]
-        assert "entity::hero" in ctx["valid_entity_ids"]
+        # Beat IDs and path IDs backtick-wrapped per CLAUDE.md §9 rule 1.
+        assert "`beat::a`" in ctx["pacing_issues"]
+        assert "Path: `path::p1`" in ctx["pacing_issues"]
+        # valid_entity_ids backtick-wrapped, with `(none)` fallback.
+        assert "`entity::hero`" in ctx["valid_entity_ids"]
         assert ctx["entity_count"] == "1"
 
     def test_no_flags(self) -> None:
         graph = Graph.empty()
         ctx = format_pacing_context(graph, [])
         assert "No pacing issues" in ctx["pacing_issues"]
+        # No entities → valid_entity_ids falls back to `(none)`.
+        assert ctx["valid_entity_ids"] == "(none)"
+
+    def test_pacing_beat_with_entities_renders_backticks(self) -> None:
+        """A pacing flag whose beats reference entities renders the entity
+        list with backticks per CLAUDE.md §9 rule 1 — never as a Python
+        repr-style bracket list."""
+        graph = Graph.empty()
+        _make_beat(graph, "beat::a", "Hero acts", entities=["entity::hero"])
+        graph.create_node("entity::hero", {"type": "entity", "raw_id": "hero", "name": "Hero"})
+
+        flags = [
+            {"issue_type": "consecutive_scene", "beat_ids": ["beat::a"], "path_id": "path::p1"}
+        ]
+        ctx = format_pacing_context(graph, flags)
+
+        assert "entities: `entity::hero`" in ctx["pacing_issues"]
+        # No bracket-format leaking through (CLAUDE.md §9 rule 1).
+        assert "entities=[" not in ctx["pacing_issues"]
 
 
 class TestFormatEntityArcContext:

--- a/tests/unit/test_polish_context.py
+++ b/tests/unit/test_polish_context.py
@@ -39,11 +39,12 @@ class TestFormatLinearSectionContext:
         )
 
         assert ctx["section_id"] == "section_0"
-        assert "beat::a" in ctx["beat_details"]
-        assert "beat::b" in ctx["beat_details"]
-        assert "beat::c" in ctx["beat_details"]
+        # Beat IDs in beat_details lines are backtick-wrapped per CLAUDE.md §9 rule 1.
+        assert "`beat::a`" in ctx["beat_details"]
+        assert "`beat::b`" in ctx["beat_details"]
+        assert "`beat::c`" in ctx["beat_details"]
         assert ctx["beat_count"] == "3"
-        assert ctx["valid_beat_ids"] == "beat::a, beat::b, beat::c"
+        assert ctx["valid_beat_ids"] == "`beat::a`, `beat::b`, `beat::c`"
 
     def test_with_context_beats(self) -> None:
         graph = Graph.empty()
@@ -79,7 +80,10 @@ class TestFormatLinearSectionContext:
         ctx = format_linear_section_context(graph, "s0", ["beat::commit"], None, None)
 
         assert "commits" in ctx["beat_details"]
-        assert "dilemma::d1" in ctx["beat_details"]
+        # Dilemma IDs are backtick-wrapped within the impacts: clause.
+        assert "`dilemma::d1`" in ctx["beat_details"]
+        # No bracket-format leaks per CLAUDE.md §9 rule 1.
+        assert "impacts=[" not in ctx["beat_details"]
 
 
 class TestFormatPacingContext:

--- a/tests/unit/test_polish_phase5_context.py
+++ b/tests/unit/test_polish_phase5_context.py
@@ -43,18 +43,22 @@ class TestFormatChoiceLabelContext:
         assert "choice_details" in ctx
         assert "Start" in ctx["choice_details"]
         assert "End" in ctx["choice_details"]
-        # valid_passage_ids must be populated for the prompt's Valid IDs section
-        # (CLAUDE.md §6) — sorted, comma-joined union of from/to passage IDs.
-        assert ctx["valid_passage_ids"] == "p1, p2"
+        # IDs in the choice line are backtick-wrapped per CLAUDE.md §9 rule 1.
+        assert "From: `p1`" in ctx["choice_details"]
+        assert "To: `p2`" in ctx["choice_details"]
+        assert "grants: `flag1`" in ctx["choice_details"]
+        # valid_passage_ids: backtick-wrapped, sorted, deduplicated.
+        assert ctx["valid_passage_ids"] == "`p1`, `p2`"
 
-    def test_empty_choices(self) -> None:
+    def test_empty_choices_falls_back_to_none(self) -> None:
+        """Empty choice_specs MUST render as `(none)` for both
+        `choice_details` and `valid_passage_ids` per the consistent
+        empty-fallback pattern across polish_context render functions."""
         graph = Graph.empty()
         ctx = format_choice_label_context(graph, [], [])
         assert ctx["choice_count"] == "0"
-        assert ctx["choice_details"] == ""
-        # Empty input → empty Valid IDs string (still present so the template
-        # placeholder always renders).
-        assert ctx["valid_passage_ids"] == ""
+        assert ctx["choice_details"] == "(none)"
+        assert ctx["valid_passage_ids"] == "(none)"
 
     def test_valid_passage_ids_dedups_and_sorts(self) -> None:
         # Same passage appearing as both `from` and `to` across multiple choices
@@ -66,7 +70,7 @@ class TestFormatChoiceLabelContext:
             {"from_passage": "p2", "to_passage": "p3"},
         ]
         ctx = format_choice_label_context(graph, choice_specs, [])
-        assert ctx["valid_passage_ids"] == "p1, p2, p3"
+        assert ctx["valid_passage_ids"] == "`p1`, `p2`, `p3`"
 
     def test_story_context_from_dream(self) -> None:
         graph = Graph.empty()
@@ -134,13 +138,22 @@ class TestFormatFalseBranchContext:
 
         ctx = format_false_branch_context(graph, candidates, passage_specs)
         assert ctx["candidate_count"] == "1"
-        assert "entity::hero" in ctx["valid_entity_ids"]
+        # IDs backtick-wrapped per CLAUDE.md §9 rule 1.
+        assert "`entity::hero`" in ctx["valid_entity_ids"]
+        assert "`p1`" in ctx["candidate_details"]
+        assert "`p2`" in ctx["candidate_details"]
+        assert "`p3`" in ctx["candidate_details"]
         assert "First" in ctx["candidate_details"]
 
-    def test_empty_candidates(self) -> None:
+    def test_empty_candidates_falls_back_to_none(self) -> None:
+        """Empty candidates / empty entity nodes MUST render `(none)` for both
+        `candidate_details` and `valid_entity_ids` per the consistent
+        empty-fallback pattern."""
         graph = Graph.empty()
         ctx = format_false_branch_context(graph, [], [])
         assert ctx["candidate_count"] == "0"
+        assert ctx["candidate_details"] == "(none)"
+        assert ctx["valid_entity_ids"] == "(none)"
 
 
 class TestFormatVariantSummaryContext:
@@ -161,9 +174,32 @@ class TestFormatVariantSummaryContext:
         ctx = format_variant_summary_context(graph, variant_specs, passage_specs)
         assert ctx["variant_count"] == "1"
         assert "Base passage" in ctx["variant_details"]
-        assert "flag1" in ctx["variant_details"]
+        # IDs backtick-wrapped per CLAUDE.md §9 rule 1.
+        assert "`v1`" in ctx["variant_details"]
+        assert "`p1`" in ctx["variant_details"]
+        assert "`flag1`" in ctx["variant_details"]
 
-    def test_empty_variants(self) -> None:
+    def test_empty_variants_falls_back_to_none(self) -> None:
+        """Empty variant_specs MUST render `(none)` for `variant_details`."""
         graph = Graph.empty()
         ctx = format_variant_summary_context(graph, [], [])
         assert ctx["variant_count"] == "0"
+        assert ctx["variant_details"] == "(none)"
+
+    def test_variant_with_no_requires_renders_none(self) -> None:
+        """A variant with no `requires` flags MUST render `requires: (none)`
+        in the per-variant line (consistent with the standalone fallback)."""
+        graph = Graph.empty()
+        ctx = format_variant_summary_context(
+            graph,
+            [
+                {
+                    "variant_id": "v1",
+                    "base_passage_id": "p1",
+                    "requires": [],
+                    "summary": "",
+                },
+            ],
+            [{"passage_id": "p1", "summary": "Base", "beat_ids": ["b1"]}],
+        )
+        assert "requires: (none)" in ctx["variant_details"]

--- a/tests/unit/test_polish_phase5_context.py
+++ b/tests/unit/test_polish_phase5_context.py
@@ -4,11 +4,14 @@ from __future__ import annotations
 
 from questfoundry.graph.graph import Graph
 from questfoundry.graph.polish_context import (
+    format_ambiguous_feasibility_context,
     format_choice_label_context,
     format_false_branch_context,
     format_residue_content_context,
+    format_transition_guidance_context,
     format_variant_summary_context,
 )
+from questfoundry.models.polish import AmbiguousFeasibilityCase
 
 
 def _make_beat(graph: Graph, beat_id: str, summary: str = "A beat") -> None:
@@ -203,3 +206,74 @@ class TestFormatVariantSummaryContext:
             [{"passage_id": "p1", "summary": "Base", "beat_ids": ["b1"]}],
         )
         assert "requires: (none)" in ctx["variant_details"]
+
+
+class TestFormatAmbiguousFeasibilityContext:
+    def test_passage_id_backtick_wrapped(self) -> None:
+        r"""`case_details` lines wrap `passage_id` in backticks per CLAUDE.md
+        §9 rule 1, consistent with the surrounding `flag=\`...\`` /
+        `dilemma=\`...\`` pattern already in this function."""
+        graph = Graph.empty()
+        graph.create_node(
+            "dilemma::trust",
+            {"type": "dilemma", "raw_id": "trust", "question": "Trust?", "weight": "heavy"},
+        )
+        case = AmbiguousFeasibilityCase(
+            passage_id="passage::p1",
+            passage_summary="A tense scene",
+            entities=["entity::hero"],
+            flags=["dilemma::trust:path::brave"],
+        )
+        ctx = format_ambiguous_feasibility_context(
+            graph, [case], [{"passage_id": "passage::p1", "summary": "scene"}]
+        )
+        assert "passage_id: `passage::p1`" in ctx["case_details"]
+
+    def test_no_cases_renders_placeholder(self) -> None:
+        """Empty input renders the existing `(no cases)` placeholder rather
+        than an empty string."""
+        graph = Graph.empty()
+        ctx = format_ambiguous_feasibility_context(graph, [], [])
+        assert ctx["case_details"] == "(no cases)"
+        assert ctx["case_count"] == "0"
+
+
+class TestFormatTransitionGuidanceContext:
+    def test_passage_and_beat_ids_backtick_wrapped(self) -> None:
+        """Both `passage_id` (per-passage header) and `bid` (per-beat line)
+        are backtick-wrapped per CLAUDE.md §9 rule 1."""
+        graph = Graph.empty()
+        _make_beat(graph, "beat::a", "First beat")
+        _make_beat(graph, "beat::b", "Second beat")
+        passage_specs = [
+            {
+                "passage_id": "passage::collapse_0",
+                "beat_ids": ["beat::a", "beat::b"],
+                "grouping_type": "collapse",
+                "entities": ["entity::hero"],
+            }
+        ]
+        ctx = format_transition_guidance_context(graph, passage_specs)
+        assert "passage_id: `passage::collapse_0`" in ctx["collapsed_passage_details"]
+        assert "`beat::a`" in ctx["collapsed_passage_details"]
+        assert "`beat::b`" in ctx["collapsed_passage_details"]
+        assert ctx["collapsed_count"] == "1"
+
+    def test_no_collapsed_passages_renders_placeholder(self) -> None:
+        """Empty / non-collapse-only input renders the existing `(none)`
+        placeholder."""
+        graph = Graph.empty()
+        # All passages are single-beat or non-collapse — none qualify.
+        ctx = format_transition_guidance_context(
+            graph,
+            [
+                {
+                    "passage_id": "passage::single",
+                    "beat_ids": ["beat::a"],
+                    "grouping_type": "collapse",
+                    "entities": [],
+                },
+            ],
+        )
+        assert ctx["collapsed_passage_details"] == "(none)"
+        assert ctx["collapsed_count"] == "0"


### PR DESCRIPTION
## Summary

Phase 3 Cluster E-6. Closes #1414. Sweep cleanup that brings the four remaining `format_*_context()` render functions into line with the backtick-wrapping convention adopted across E-3 / E-4 / E-5.

Per CLAUDE.md §9 rule 1: IDs in LLM-facing text must be unambiguously delimited. Two functions producing the same data shape with different formatting is a small-model trap; this PR closes the last gaps.

## Changes

| Function | Change |
|---|---|
| `format_pacing_context` | Beat IDs / path IDs / entity IDs in pacing-issue lines now backtick-wrapped. Replaced `entities=[…]` bracket-format with `entities: \`a\`, \`b\`` (the bracket form was a §9 rule 1 violation). `valid_entity_ids` backtick-wrapped + `(none)` fallback. |
| `format_choice_label_context` | From/To/grants IDs backtick-wrapped per line; `valid_passage_ids` and `choice_details` fall back to `(none)` on empty. |
| `format_false_branch_context` | Passage IDs in candidate lines + `valid_entity_ids` backtick-wrapped; `(none)` fallback on both. |
| `format_variant_summary_context` | `variant_id` / `base_passage_id` / `requires` IDs backtick-wrapped; `requires: (none)` per variant if empty; `variant_details` `(none)` fallback. |

Diff: 3 files, +98/-32.

## Test plan

- [x] 27 tests across `test_polish_context.py` + `test_polish_phase5_context.py` pass
- [x] mypy + ruff clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)