### PR TITLE
fix(dream): rename scope presets vignette/standard → micro/medium (Cluster F-2)

### DIFF
--- a/prompts/templates/discuss.yaml
+++ b/prompts/templates/discuss.yaml
@@ -115,13 +115,13 @@ research_tools_section: |
 size_presets_section: |
   ## Story Size Presets
   When discussing scope, guide the user toward one of these size presets:
-  - **vignette**: 5-15 passages, 2000-5000 words. Tight single-scene exploration with minimal branching.
+  - **micro**: 5-15 passages, 2000-5000 words. Tight single-scene exploration with minimal branching.
   - **short**: 15-30 passages, 5000-15000 words. Focused story with limited branching paths.
-  - **standard** (default): 30-60 passages, 15000-30000 words. Full branching narrative with multiple paths.
+  - **medium** (default): 30-60 passages, 15000-30000 words. Full branching narrative with multiple paths.
   - **long**: 60-120 passages, 30000-60000 words. Expansive world with deep branching and many characters.
 
   The chosen preset determines entity counts, word targets, and branching complexity
-  for all downstream stages. If the user doesn't express a preference, default to "standard".
+  for all downstream stages. If the user doesn't express a preference, default to "medium".
 
 interactive_section: |
   ## Interactive Session

--- a/prompts/templates/serialize.yaml
+++ b/prompts/templates/serialize.yaml
@@ -22,14 +22,15 @@ system: |
 
   ## scope field (REQUIRED — validation will reject output without it)
   The "scope" object is REQUIRED. You MUST include it with a "story_size" value.
-  Pick one of: "vignette", "short", "standard", "long".
+  Pick one of: "micro", "short", "medium", "long".
 
-  Example: "scope": {"story_size": "vignette"}
+  Example: "scope": {"story_size": "micro"}
 
-  If the brief says "vignette-length" or "vignette" → use "vignette".
+  If the brief says "micro" or "vignette-length" → use "micro".
   If the brief says "short" → use "short".
+  If the brief says "medium" or "standard" → use "medium".
   If the brief says "long" → use "long".
-  If no size is mentioned → use "standard".
+  If no size is mentioned → use "medium".
 
   ## Scope Boundary (for DREAM artifacts)
   DREAM artifacts capture HIGH-LEVEL VISION only. Even if the brief contains

--- a/prompts/templates/serialize.yaml
+++ b/prompts/templates/serialize.yaml
@@ -26,7 +26,7 @@ system: |
 
   Example: "scope": {"story_size": "micro"}
 
-  If the brief says "micro" or "vignette-length" → use "micro".
+  If the brief says "micro", "vignette", or "vignette-length" → use "micro".
   If the brief says "short" → use "short".
   If the brief says "medium" or "standard" → use "medium".
   If the brief says "long" → use "long".

--- a/prompts/templates/summarize.yaml
+++ b/prompts/templates/summarize.yaml
@@ -11,7 +11,7 @@ system: |
   - Target audience
   - Core themes to explore
   - Style guidance for writing
-  - Story size: one of "vignette", "short", "standard", or "long" (preserve the exact keyword from the discussion)
+  - Story size: one of "micro", "short", "medium", or "long" (preserve the exact keyword from the discussion)
   - Content notes (what to include/exclude)
 
   ## NO DELEGATION (CRITICAL)
@@ -44,7 +44,7 @@ system: |
 
   **Keep only:**
   - Genre, tone, themes (high-level)
-  - Audience and story size (exact keyword: vignette/short/standard/long)
+  - Audience and story size (exact keyword: micro/short/medium/long)
   - Style guidance
   - Content warnings/notes (general, not specific scenes)
 

--- a/prompts/templates/summarize.yaml
+++ b/prompts/templates/summarize.yaml
@@ -11,7 +11,7 @@ system: |
   - Target audience
   - Core themes to explore
   - Style guidance for writing
-  - Story size: one of "micro", "short", "medium", or "long" (preserve the exact keyword from the discussion)
+  - Story size: one of "micro", "short", "medium", or "long" — use exactly one of these four words
   - Content notes (what to include/exclude)
 
   ## NO DELEGATION (CRITICAL)


### PR DESCRIPTION
## Summary

Phase 3 Cluster F-2 from the [prompt-vs-spec audit](docs/superpowers/reports/2026-04-25-prompt-spec-audit.md). Closes #1418.

3 hard findings (one per active DREAM template — audit lines 181-192, 250-253, 280-296). The DREAM prompts instruct the LLM to use scope preset names that the Pydantic model rejects. **Every DREAM run currently produces a `ValidationError` on `story_size`** unless the LLM disregards the prompt.

## Why

| File | Wrong names |
|---|---|
| `discuss.yaml` line 118, 120, 124 | `vignette`, `standard` (default), `default to "standard"` |
| `summarize.yaml` line 14, 47 | `"vignette" / "standard"`, `vignette/short/standard/long` |
| `serialize.yaml` line 25, 27, 29, 32 | `Pick one of: "vignette"...`, example `"vignette"`, `vignette-length` mapping, `→ use "standard"` |

vs `src/questfoundry/models/dream.py:34` — `Literal["micro", "short", "medium", "long"]` and `src/questfoundry/pipeline/size.py:91-208` — `PRESETS` dict keys.

## Changes (pure mechanical rename)

| Old | New | Word/passage range (already matched, just renamed) |
|---|---|---|
| `vignette` | `micro` | 5-15 passages, 2000-5000 words |
| `standard` | `medium` | 30-60 passages, 15000-30000 words |

`short` and `long` were already correct; default is now `medium` (matches `size.py:213` `get_size_profile(preset: str = "medium")`).

`serialize.yaml` retains the old keywords as **legacy aliases** mapping TO the new correct values (`vignette-length → micro`, `standard → medium`). This preserves robustness for user-prepared briefs that may still use the old terminology.

## Out of scope (separate PRs per audit recommendation)

- `dream.yaml` (dead code) — separate issue to delete
- `serialize.yaml` `content_notes` nested structure missing — Cluster F-3 candidate
- `serialize.yaml` `pov_style` valid values not listed — Cluster F-3 candidate
- `discuss.yaml` R-1.2/R-1.3 instruction additions — Cluster F-4 candidate

## Verification

```sh
$ rg -nE '"vignette"|"standard"' prompts/templates/discuss.yaml prompts/templates/summarize.yaml
(no matches)

$ rg -nE 'vignette|standard' prompts/templates/serialize.yaml
prompts/templates/serialize.yaml:29:  If the brief says "micro" or "vignette-length" → use "micro".
prompts/templates/serialize.yaml:31:  If the brief says "medium" or "standard" → use "medium".
# ↑ both lines map legacy keyword TO new preset — intentional
```

## Tests

- `uv run pytest tests/unit/test_dream*.py tests/unit/test_size.py -x -q` → **64 passed**
- `uv run mypy src/questfoundry/models/dream.py src/questfoundry/pipeline/size.py` → **clean**