### PR TITLE
spec(fill): add transition-guidance contract item (FILL §Stage Input Contract)

### DIFF
--- a/docs/design/procedures/fill.md
+++ b/docs/design/procedures/fill.md
@@ -26,8 +26,9 @@ FILL does NOT create, reorder, split, or merge beats or passages; does NOT add p
 14. No cycles in the passage graph.
 15. Every beat has `atmospheric_detail` populated (or a WARNING was logged for partial coverage from POLISH Phase 5e).
 16. Every multi-beat path has `path_theme` and `path_mood` populated (or a WARNING was logged for per-path Phase 5f failure).
-17. Gap beats from POLISH Phase 1a carry `is_gap_beat: True`, `role: gap_beat`, single `belongs_to` to their path, and traceability fields (`bridges_from`, `bridges_to`, `transition_style`).
-18. Every beat has `scene_type`, `narrative_function`, and `exit_mood` populated (or a WARNING was logged for partial coverage from GROW Phase 4b; FILL falls back per R-4b.1).
+17. Every collapsed passage (>1 beat) has N-1 transition instructions populated (or a WARNING was logged for per-passage Phase 5f failure) — FILL bridges without explicit guidance if absent (per POLISH R-5f.5).
+18. Gap beats from POLISH Phase 1a carry `is_gap_beat: True`, `role: gap_beat`, single `belongs_to` to their path, and traceability fields (`bridges_from`, `bridges_to`, `transition_style`).
+19. Every beat has `scene_type`, `narrative_function`, and `exit_mood` populated (or a WARNING was logged for partial coverage from GROW Phase 4b; FILL falls back per R-4b.1).
 
 ---
 

--- a/docs/design/procedures/fill.md
+++ b/docs/design/procedures/fill.md
@@ -27,7 +27,7 @@ FILL does NOT create, reorder, split, or merge beats or passages; does NOT add p
 15. Every beat has `atmospheric_detail` populated (or a WARNING was logged for partial coverage from POLISH Phase 5e).
 16. Every multi-beat path has `path_theme` and `path_mood` populated (or a WARNING was logged for per-path Phase 5f failure).
 17. Every collapsed passage (>1 beat) has N-1 transition instructions populated (or a WARNING was logged for per-passage Phase 5f failure) — FILL bridges without explicit guidance if absent (per POLISH R-5f.5).
-18. Gap beats from POLISH Phase 1a carry `is_gap_beat: True`, `role: gap_beat`, single `belongs_to` to their path, and traceability fields (`bridges_from`, `bridges_to`, `transition_style`).
+18. Gap beats inserted by POLISH Phase 1a carry `is_gap_beat: True`, `role: gap_beat`, `created_by: "POLISH"`, zero `dilemma_impacts`, single `belongs_to` to their path, and traceability fields (`bridges_from`, `bridges_to`, `transition_style`).
 19. Every beat has `scene_type`, `narrative_function`, and `exit_mood` populated (or a WARNING was logged for partial coverage from GROW Phase 4b; FILL falls back per R-4b.1).
 
 ---

--- a/docs/design/procedures/polish.md
+++ b/docs/design/procedures/polish.md
@@ -620,6 +620,7 @@ R-7.12. Validation failure halts POLISH with ERROR — partial output is not del
 16. Every multi-beat path has `path_theme` (10–200 characters) and `path_mood` (2–50 characters) populated, or a WARNING was logged for per-path Phase 5f failure.
 17. Every collapsed passage (>1 beat) has N-1 transition instructions populated (or a WARNING was logged for per-passage Phase 5f failure). Mirrors Phase 5f §Output Contract item 7 at the stage level.
 18. Gap beats inserted by Phase 1a carry `is_gap_beat: True`, `role: gap_beat`, `created_by: "POLISH"`, zero `dilemma_impacts`, single `belongs_to` to their path, and traceability fields (`bridges_from`, `bridges_to`, `transition_style`).
+19. Every beat has `scene_type`, `narrative_function`, and `exit_mood` populated (or a WARNING was logged for partial coverage from GROW Phase 4b; downstream phases fall back per R-4b.1). Passes through unchanged from POLISH §Stage Input Contract item 17.
 
 ## Implementation Constraints
 

--- a/docs/design/procedures/polish.md
+++ b/docs/design/procedures/polish.md
@@ -618,7 +618,8 @@ R-7.12. Validation failure halts POLISH with ERROR — partial output is not del
 14. No cycles in the passage graph.
 15. Every beat has `atmospheric_detail` populated (10–200 characters describing sensory environment), or a WARNING was logged for partial Phase 5e coverage.
 16. Every multi-beat path has `path_theme` (10–200 characters) and `path_mood` (2–50 characters) populated, or a WARNING was logged for per-path Phase 5f failure.
-17. Gap beats inserted by Phase 1a carry `is_gap_beat: True`, `role: gap_beat`, `created_by: "POLISH"`, zero `dilemma_impacts`, single `belongs_to` to their path, and traceability fields (`bridges_from`, `bridges_to`, `transition_style`).
+17. Every collapsed passage (>1 beat) has N-1 transition instructions populated (or a WARNING was logged for per-passage Phase 5f failure). Mirrors Phase 5f §Output Contract item 7 at the stage level.
+18. Gap beats inserted by Phase 1a carry `is_gap_beat: True`, `role: gap_beat`, `created_by: "POLISH"`, zero `dilemma_impacts`, single `belongs_to` to their path, and traceability fields (`bridges_from`, `bridges_to`, `transition_style`).
 
 ## Implementation Constraints
 


### PR DESCRIPTION
## Summary

Closes #1389. Per CLAUDE.md §Design Doc Authority — Stage Input Contracts must mirror upstream Stage Output Contracts. POLISH §Phase 5f §Output Contract item 7 declares the transition-instruction guarantee, but FILL §Stage Input Contract had no matching item, so the prose-prep handoff was undocumented.

This is one of the audit's 5 spec gaps that should be closed before downstream prompt fixes per the audit's recommendation.

## Change

Insert new item 17 in `docs/design/procedures/fill.md` §Stage Input Contract, mirroring `polish.md` line 501 + adding the FILL-side fallback clause. Renumber the previous items 17→18 (gap beats) and 18→19 (scene type fields).

## Code impact (none — already implemented)

The contract update simply makes visible what code already does:

| Layer | Status | Verified by |
|---|---|---|
| POLISH Phase 5f produces transitions per R-5f.4 / R-5f.5 | ✅ | `polish_phase5f_transitions.yaml` + `format_transition_guidance_context` |
| POLISH Phase 6 stores them on the passage node | ✅ | `test_polish_deterministic.py::test_transition_guidance_stored_on_passage_node` |
| FILL consumes them in prose context | ✅ | `test_fill_context.py::test_includes_transition_guidance` |
| FILL input-contract validator function | n/a | None of items 15/16/18 are validated at FILL entry either; the contract document is the source of truth |

## Verification

- ✅ `fill.md` Stage Input Contract has new item 17 referencing transition guidance
- ✅ `polish.md` Phase 5f §Output Contract item 7 wording matches (re-checked)
- ✅ No code references the contract by item number — `rg "fill.md.*item"` returns nothing, so renumbering is safe

## Spec citations

- `docs/design/procedures/polish.md` line 501 (Phase 5f Output Contract item 7)
- `docs/design/procedures/polish.md` R-5f.4 (N-1 transition instructions per collapsed passage)
- `docs/design/procedures/polish.md` R-5f.5 (per-passage failure → WARNING + empty list; FILL falls back)
- `CLAUDE.md §Design Doc Authority` — "Stage Input Contracts must mirror upstream Stage Output Contracts"