### PR TITLE
fix(dream): add content_notes/pov_style/protagonist_defined/skeleton sections to serialize prompt (Cluster F-3)

### DIFF
--- a/docs/design/procedures/dream.md
+++ b/docs/design/procedures/dream.md
@@ -245,10 +245,11 @@ vision:
   audience: "adult readers of literary speculative fiction"
   scope: short                     # enum value — unquoted
   content_notes:
-    - "single protagonist POV"
-    - "no explicit magic system"
-    - "no graphic violence"
-    - "intimate scope (few key relationships)"
+    includes:
+      - "intimate scope (few key relationships)"
+    excludes:
+      - "explicit magic system"
+      - "graphic violence"
   pov_style: third_person_limited  # enum value — unquoted
 ```
 

--- a/prompts/templates/serialize.yaml
+++ b/prompts/templates/serialize.yaml
@@ -32,16 +32,71 @@ system: |
   If the brief says "long" → use "long".
   If no size is mentioned → use "medium".
 
+  ## `content_notes` field (optional nested object)
+  If the brief mentions content advisories or themes to include/exclude,
+  output `content_notes` using THIS nested structure (NOT a flat list,
+  NOT a string):
+
+  ```
+  "content_notes": {
+    "includes": ["single-protagonist POV", "atmospheric horror elements"],
+    "excludes": ["graphic violence", "explicit magic systems"]
+  }
+  ```
+
+  Both `includes` and `excludes` are lists of short strings. Either may
+  be empty `[]`. If no content notes were discussed, OMIT the field
+  entirely (do NOT emit `null` or `{}`).
+
+  ## `pov_style` field (optional)
+  If a POV preference was discussed, set `pov_style` to EXACTLY one of
+  these four values:
+  - `"first_person"`
+  - `"second_person"`
+  - `"third_person_limited"`
+  - `"third_person_omniscient"`
+
+  Any other value (e.g. `"first"`, `"limited"`, `"omniscient"`,
+  `"third"`) will fail validation. If no POV preference was stated in
+  the brief, OMIT the field entirely.
+
+  ## `protagonist_defined` field (boolean)
+  Set `protagonist_defined: true` if the brief established a specific
+  main character (named or clearly identified by role). Set to `false`
+  if the protagonist is left open for BRAINSTORM/SEED to define. Default
+  is `false` if unstated.
+
   ## Scope Boundary (for DREAM artifacts)
   DREAM artifacts capture HIGH-LEVEL VISION only. Even if the brief contains
   detailed content, include ONLY:
-  - genre, subgenre, tone, audience, themes (high-level descriptors)
-  - style_notes (prose guidance, 50-200 chars, NOT plot summaries)
-  - scope (REQUIRED — see above)
-  - content_notes (warnings/guidance, NOT specific scenes or character arcs)
+  - `genre`, `subgenre`, `tone`, `audience`, `themes` (high-level descriptors)
+  - `style_notes` (prose guidance, 50-200 chars, NOT plot summaries)
+  - `scope` (REQUIRED — see above)
+  - `content_notes` (warnings/guidance, NOT specific scenes or character arcs)
+  - `pov_style` (POV preference hint for FILL — see above)
+  - `protagonist_defined` (boolean — see above)
 
   Do NOT serialize specific characters, scenes, endings, or mechanics into
   DREAM fields. Those belong in BRAINSTORM/SEED stages.
+
+  ## Output skeleton (fill in the values; omit `← optional` fields if absent)
+  ```
+  {
+    "genre": "...",
+    "subgenre": "...",                      ← optional
+    "tone": ["...", "..."],
+    "themes": ["...", "..."],
+    "audience": "...",
+    "scope": {"story_size": "micro|short|medium|long"},
+    "style_notes": "...",                   ← optional
+    "content_notes": {"includes": [...], "excludes": [...]},  ← optional, nested
+    "pov_style": "first_person",            ← optional, Literal
+    "protagonist_defined": false
+  }
+  ```
+
+  Output ONE flat JSON object at the top level. Do NOT wrap it in a
+  `{"dream": {...}}` envelope or any other key.
 
   REMINDER: "scope" is required. Do not omit it.
 

--- a/prompts/templates/serialize.yaml
+++ b/prompts/templates/serialize.yaml
@@ -39,7 +39,7 @@ system: |
 
   ```
   "content_notes": {
-    "includes": ["single-protagonist POV", "atmospheric horror elements"],
+    "includes": ["slow-burn pacing", "unreliable narrator voice"],
     "excludes": ["graphic violence", "explicit magic systems"]
   }
   ```
@@ -87,7 +87,7 @@ system: |
     "tone": ["...", "..."],
     "themes": ["...", "..."],
     "audience": "...",
-    "scope": {"story_size": "micro|short|medium|long"},
+    "scope": {"story_size": "short"},       ← required; choose: micro|short|medium|long
     "style_notes": "...",                   ← optional
     "content_notes": {"includes": [...], "excludes": [...]},  ← optional, nested
     "pov_style": "first_person",            ← optional, Literal


### PR DESCRIPTION
## Summary

Phase 3 Cluster F-3 from the [prompt-vs-spec audit](docs/superpowers/reports/2026-04-25-prompt-spec-audit.md). Closes #1422. The DREAM serialize prompt taught the model nothing about three Pydantic fields it must produce correctly, so the LLM either omitted them or guessed the wrong shape — causing runtime ValidationError or silent data loss.

## Findings addressed (audit lines 297-345)

| Severity | Field | Symptom before |
|---|---|---|
| hard | `content_notes` | Model emits flat list / string instead of `{"includes": [...], "excludes": [...]}` → ValidationError |
| hard | `pov_style` | Model emits `"first"` / `"limited"` instead of full Literal values → ValidationError |
| soft | `protagonist_defined` | Field never mentioned → always emits default `false` regardless of discussion |
| soft | output envelope | No top-level skeleton; small models may wrap output in `{"dream": {...}}` or omit fields unpredictably |

## Changes

Insert four new sections in `prompts/templates/serialize.yaml` (before `Scope Boundary`):

1. **`## content_notes field (optional nested object)`** — explicit nested schema with includes/excludes example + omit-on-absent rule
2. **`## pov_style field (optional)`** — full Literal value list backtick-wrapped + warning that any other value fails validation
3. **`## protagonist_defined field (boolean)`** — short instruction tying the boolean to actual discussion content
4. **`## Output skeleton`** — full top-level shape with `← optional` markers + explicit "do not wrap in `{"dream": {...}}` envelope"

Also expanded the **Scope Boundary** field list to include `pov_style` and `protagonist_defined` (previously the boundary section enumerated allowed fields but missed these two).

Per CLAUDE.md §9 rule 1 — all field names and Literal values are backtick-wrapped.

## Spec citations

- `src/questfoundry/models/dream.py:15-23` — `ContentNotes(excludes: list[str], includes: list[str])`
- `src/questfoundry/models/dream.py:63-70` — `pov_style: Literal[...] | None`
- `src/questfoundry/models/dream.py:75-78` — `protagonist_defined: bool` (default False)
- `docs/design/procedures/dream.md §R-1.9` — POV style values
- `CLAUDE.md §9 rule 1` — backtick-wrap IDs and Literal values in LLM-facing text

## Out of scope (separate PRs)

- `discuss.yaml` R-1.2 / R-1.3 instruction additions — Cluster F-4 candidate
- `dream.yaml` (dead code) — separate delete-or-reconcile issue

## Tests

- `uv run pytest tests/unit/test_dream*.py -x -q` → **35 passed** (no regression; prompts have no dedicated test surface)