### PR TITLE
fix(dream): split genre/subgenre + themes GOOD/BAD + sandwich + autonomous checklist (Cluster F-4)

### DIFF
--- a/prompts/templates/discuss.yaml
+++ b/prompts/templates/discuss.yaml
@@ -39,7 +39,7 @@ system: |
   DREAM establishes HIGH-LEVEL VISION only. You are NOT writing the story yet.
 
   **What DREAM captures:**
-  - Genre/subgenre (e.g., "dark fantasy mystery")
+  - Genre and subgenre — distinct fields (e.g., `genre: "mystery"`, `subgenre: "dark fantasy"`)
   - Tone descriptors (e.g., "melancholic, intimate, fogbound")
   - Themes to explore (e.g., "memory vs consent", "grief and letting go")
   - Target audience (e.g., "fans of literary IF")

--- a/prompts/templates/discuss.yaml
+++ b/prompts/templates/discuss.yaml
@@ -11,10 +11,17 @@ system: |
 
   ## Your Goal
   Help the user arrive at answers (even rough ones) for these creative questions:
-  1. What genre and subgenre? (e.g., "dark fantasy mystery")
-  2. What's the emotional tone? (e.g., "melancholic, intimate, fogbound")
-  3. What themes will the story explore? (e.g., "memory vs consent")
-  4. Who is the target audience? (e.g., "fans of literary IF")
+  1a. What is the PRIMARY `genre`? (one word or two: "fantasy", "mystery", "horror", "romance")
+  1b. What is the `subgenre`? (a refinement of the primary genre: "dark fantasy", "cozy mystery", "psychological horror")
+
+  IMPORTANT: `genre` and `subgenre` are SEPARATE fields. "cozy mystery" is a SUBGENRE of "mystery"; do NOT merge them. Always elicit BOTH.
+  GOOD: `genre: "mystery"`, `subgenre: "cozy mystery"`
+  BAD: `genre: "cozy mystery"`, `subgenre: ""` (merged into one field)
+  2. What's the emotional `tone`? (e.g., "melancholic, intimate, fogbound")
+  3. What ABSTRACT `themes` will the story explore? (e.g., "memory vs consent", "the price of loyalty")
+     GOOD: "forbidden knowledge", "trust and betrayal", "grief and letting go" (abstract ideas the story examines)
+     BAD: "the mentor dies in chapter three", "protagonist discovers a secret letter" (plot points masquerading as themes — those belong in BRAINSTORM/SEED)
+  4. Who is the target `audience`? (e.g., "fans of literary IF")
   5. How large and complex? (choose a size preset below)
   6. Any style notes? (prose style, POV preferences, pacing)
 
@@ -64,12 +71,24 @@ system: |
   {sandbox_section}
   {mode_section}
 
+  REMINDER: DREAM = high-level vision only. No character names, scene descriptions, or mechanics. `genre` and `subgenre` are SEPARATE. `themes` are ABSTRACT, not plot points.
+
 non_interactive_section: |
   ## Mode: Autonomous
   You are running without user interaction. Do NOT ask clarifying questions.
 
   Complete the required corpus research (see above), then weave what you
   find into confident, specific creative choices.
+
+  Before concluding, confirm you have established ALL of:
+  - `genre` — single primary category (one or two words)
+  - `subgenre` — a refinement of the primary genre (REQUIRED, distinct from `genre`)
+  - `tone` — 2–4 descriptors
+  - `themes` — at least 2 abstract themes (NOT plot points)
+  - `audience` — target reader profile
+  - Story size — exactly one of `micro`/`short`/`medium`/`long`
+
+  Omitting any of the above forces the serialize phase to invent placeholders, which silently degrades the vision.
 
 research_tools_section: |
   ## Craft Corpus Research (REQUIRED)

--- a/tests/unit/test_discuss_agent.py
+++ b/tests/unit/test_discuss_agent.py
@@ -59,6 +59,27 @@ class TestGetDiscussPrompt:
         assert isinstance(prompt, str)
         assert len(prompt) > 100  # Should have substantial content
 
+    def test_prompt_includes_sandwich_reminder(self) -> None:
+        """Prompt MUST end with a sandwich reminder echoing the scope fence
+        and the SEPARATE-fields / abstract-themes constraints. Guards
+        against context drift in long discussions on small models."""
+        prompt = get_discuss_prompt()
+
+        assert "REMINDER: DREAM = high-level vision only" in prompt
+        assert "`genre` and `subgenre` are SEPARATE" in prompt
+        assert "`themes` are ABSTRACT" in prompt
+
+    def test_non_interactive_prompt_includes_completeness_checklist(self) -> None:
+        """Non-interactive (autonomous) mode MUST include the completeness
+        checklist enumerating the six required fields and the consequence
+        of omitting them — guards autonomous runs against silent vision
+        degradation."""
+        prompt = get_discuss_prompt(interactive=False)
+
+        assert "confirm you have established ALL of" in prompt
+        assert "`subgenre`" in prompt
+        assert "forces the serialize phase to invent placeholders" in prompt
+
 
 class TestCreateDiscussAgent:
     """Test agent creation."""

--- a/tests/unit/test_discuss_agent.py
+++ b/tests/unit/test_discuss_agent.py
@@ -18,9 +18,13 @@ class TestGetDiscussPrompt:
         """Prompt should include key creative questions as deliverables."""
         prompt = get_discuss_prompt()
 
-        assert "genre and subgenre" in prompt
-        assert "emotional tone" in prompt
-        assert "target audience" in prompt.lower()
+        # Genre and subgenre are now elicited as separate questions (1a/1b)
+        # per dream.md §R-1.2; assert each field is referenced individually.
+        assert "PRIMARY `genre`" in prompt
+        assert "`subgenre`" in prompt
+        assert "SEPARATE fields" in prompt
+        assert "emotional `tone`" in prompt
+        assert "target `audience`" in prompt.lower()
         assert "themes" in prompt
 
     def test_prompt_includes_tools_section_when_available(self) -> None:
@@ -94,7 +98,9 @@ class TestCreateDiscussAgent:
         call_kwargs = mock_create.call_args.kwargs
         # System prompt should contain discussion guidelines, not user prompt
         assert "creative collaborator" in call_kwargs["system_prompt"]
-        assert "genre and subgenre" in call_kwargs["system_prompt"]
+        # Genre and subgenre are elicited as separate questions per R-1.2.
+        assert "PRIMARY `genre`" in call_kwargs["system_prompt"]
+        assert "`subgenre`" in call_kwargs["system_prompt"]
 
 
 class TestRunDiscussPhase:


### PR DESCRIPTION
## Summary

Phase 3 Cluster F-4 from the [prompt-vs-spec audit](docs/superpowers/reports/2026-04-25-prompt-spec-audit.md). Closes #1425. Four exploration-phase findings on the DREAM discuss prompt that the F-2 (scope rename) and F-3 (serialize schema completeness) PRs didn't reach.

## Findings addressed (audit lines 193-235)

| Severity | Finding | Symptom before |
|---|---|---|
| hard | Q1 example "dark fantasy mystery" merges genre+subgenre into one string | Discuss elicits merged values; serialize emits one filled and one empty (R-1.2 violation) |
| soft | Q3 has no abstract-themes constraint or BAD example | Discuss extracts plot points as themes (R-1.3 violation) |
| soft | Scope-fence (CRITICAL) appears only once | Long discussions push the constraint out of the model's working context |
| soft | non_interactive_section has no completeness checklist | Autonomous runs may emit incomplete visions; serialize fills blanks with placeholders |

## Changes

- **Split Q1 into Q1a (`genre`) + Q1b (`subgenre`)** with GOOD/BAD examples for the merge anti-pattern. Adds explicit "SEPARATE fields" rule.
- **Augment Q3** with GOOD/BAD examples distinguishing abstract themes from plot points (mirrors `dream.md §R-1.3` violations table).
- **Add sandwich reminder** after `{mode_section}` echoing the scope fence + the two new constraints (genre/subgenre separate, themes abstract).
- **Add completeness checklist** inside `non_interactive_section` enumerating the six fields the autonomous run MUST establish, with consequence statement ("forces serialize to invent placeholders").

Per CLAUDE.md §9 rule 1, all field names backtick-wrapped where they appear in LLM-facing text.

## Spec citations

- `docs/design/procedures/dream.md §R-1.2` — "Genre and subgenre are SEPARATE fields"
- `docs/design/procedures/dream.md §R-1.3` — "Themes are ABSTRACT, not plot points"
- `docs/design/procedures/dream.md §R-1.8` — required fields non-empty
- `CLAUDE.md §10` — small-model prompt bias (sandwich repetition)
- `CLAUDE.md §Repair-loop quality` — fallback completeness

## Out of scope (separate efforts)

- `dream.yaml` (dead code) — separate delete-or-reconcile issue
- BRAINSTORM stage findings — separate cluster (F-5+)

## Tests

- `uv run pytest tests/unit/test_dream*.py -x -q` → **35 passed** (no regression; prompts have no dedicated test surface)