### PR TITLE
fix(brainstorm): ID prefix propagation + entity_category + bracket-list cleanup (Cluster F-5)

### DIFF
--- a/prompts/templates/discuss_brainstorm.yaml
+++ b/prompts/templates/discuss_brainstorm.yaml
@@ -15,15 +15,25 @@ system: |
   ## Your Goal
   Generate raw creative material that will seed the story structure:
 
-  1. **Entities** - Characters, locations, objects, and factions that could exist in this world
-     - Characters: Individual people/sentient beings
-     - Locations: Places, settings, venues
-     - Objects: Artifacts, devices, significant things
-     - Factions: Groups, organizations, collectives
+  1. **Entities** — each has an `entity_category` (character, location, object, or faction)
+     - Characters (`entity_category: "character"`): Individual people/sentient beings
+     - Locations (`entity_category: "location"`): Places, settings, venues
+     - Objects (`entity_category: "object"`): Artifacts, devices, significant things
+     - Factions (`entity_category: "faction"`): Groups, organizations, collectives
+
+  **Entity IDs include their category as a namespace** — every `entity_id` MUST start with
+  its category prefix (`character::`, `location::`, `object::`, `faction::`). The serializer
+  rejects bare IDs like `mentor` or display-style IDs like `Lady Beatrice`.
+
+  GOOD entity IDs: `character::lady_beatrice`, `location::vane_manor`, `object::silver_dagger`, `faction::old_guard`
+  BAD entity IDs:
+  - `Lady Beatrice` (spaces, capitalization — IDs are snake_case)
+  - `mentor` (missing namespace — would fail `validate_entity_id_format`)
+  - `main_character_mentor` (no namespace, free-form)
 
   **Entity Names**: When a specific name emerges naturally during brainstorming (e.g., "Lady Beatrice
   Ashford", "The Gilded Compass Inn"), include it! Good names add personality and memorability.
-  But don't force names - if you're thinking in terms of "the mentor" or "the hidden archive",
+  But don't force names — if you're thinking in terms of "the mentor" or "the hidden archive",
   that's fine. Names will be generated later for any entities that don't have them yet.
 
   ## BRAINSTORM Stage Scope
@@ -64,7 +74,7 @@ system: |
      - Each dilemma has exactly TWO answers (not more, not less)
      - One answer should be marked as the "default path" (the canonical story outcome)
      - For nuanced concepts, use MULTIPLE binary dilemmas rather than one multi-way choice
-     - Each dilemma must list its **central entities by ID** (e.g., "Central entities: [entity_id_1], [entity_id_2]")
+     - Each dilemma must list its **central entities by ID** using backtick-wrapped IDs (e.g., "Central entities: `character::mentor`, `location::archive`"). Do NOT use bracket-list notation like `[entity_id]` — that's Python repr, not human-readable text.
 
   ## Guidelines
   - Be expansive! Generate MORE material than needed ({size_entities} entities, {size_dilemmas} dilemmas is good)
@@ -81,22 +91,22 @@ system: |
   Bad: "What is the mentor's alignment?" (open-ended, not binary)
 
   ## Dilemma ID Naming
-  Dilemma IDs use the pattern: `subject_optionA_or_optionB`
-  The word `_or_` appears exactly ONCE, between the two options. The ID must END with optionB.
+  Dilemma IDs use the pattern: `dilemma::subject_optionA_or_optionB`. **Every dilemma ID MUST start with the `dilemma::` namespace prefix** — the serializer rejects any ID that does not. The word `_or_` appears exactly ONCE, between the two options. The ID must END with optionB.
 
   GOOD examples:
-  - `detective_corrupt_or_honorable` (ends with `honorable`, not `_or_`)
-  - `witness_truthful_or_lying` (ends with `lying`, not `_or_`)
-  - `mentor_benevolent_or_manipulative` (ends with `manipulative`, not `_or_`)
-  - `artifact_blessed_or_cursed` (ends with `cursed`, not `_or_`)
-  - `ai_helpful_or_hostile` (ends with `hostile`, not `_or_`)
+  - `dilemma::detective_corrupt_or_honorable` (ends with `honorable`, not `_or_`)
+  - `dilemma::witness_truthful_or_lying` (ends with `lying`, not `_or_`)
+  - `dilemma::mentor_benevolent_or_manipulative` (ends with `manipulative`, not `_or_`)
+  - `dilemma::artifact_blessed_or_cursed` (ends with `cursed`, not `_or_`)
+  - `dilemma::ai_helpful_or_hostile` (ends with `hostile`, not `_or_`)
 
   BAD examples (will break the pipeline):
-  - `detective_corrupt_or_honorable_or_` (WRONG: trailing `_or_`)
-  - `witness_truthful_or_lying_or_` (WRONG: trailing `_or_`)
-  - `d1`, `character_motivation`, `trust_issue` (too short or ambiguous)
+  - `mentor_benevolent_or_manipulative` (MISSING `dilemma::` prefix)
+  - `dilemma::detective_corrupt_or_honorable_or_` (WRONG: trailing `_or_`)
+  - `dilemma::witness_truthful_or_lying_or_` (WRONG: trailing `_or_`)
+  - `dilemma::d1`, `dilemma::character_motivation`, `dilemma::trust_issue` (too short or ambiguous — even with the prefix)
 
-  NEVER end a dilemma ID with `_or_` -- the last word must be the second option.
+  NEVER end a dilemma ID with `_or_` — the last word must be the second option. NEVER omit the `dilemma::` prefix.
 
   **DO NOT copy example IDs** - generate IDs specific to YOUR story's characters and dilemmas.
 
@@ -106,6 +116,8 @@ system: |
   - Do NOT ask clarifying questions in non-interactive mode
   - Do NOT use short codes like `d1`, `d2` for dilemma IDs - use descriptive names
   - Do NOT end dilemma IDs with `_or_` — the ID must end with the second option word
+  - Do NOT omit the `dilemma::` prefix on dilemma IDs or the namespace prefix (`character::` etc.) on entity IDs
+  - Do NOT use bracket-list notation (`[entity_id_1], [entity_id_2]`) — backtick-wrap each ID instead
 
   ## Output Format Examples
 
@@ -166,6 +178,10 @@ research_tools_section: |
 
   Do NOT skip research because you think you already know the answer.
   The corpus may contain guidance that contradicts or refines your assumptions.
+
+  **Tool-error fallback**: If a tool call returns an error or `no_results`,
+  note it briefly and continue with your existing knowledge. Do not retry
+  the same query more than once.
 
   ## Structured Options (Interactive Mode)
   INVOKE the `present_options` tool through function calling for structured choices:

--- a/prompts/templates/discuss_brainstorm.yaml
+++ b/prompts/templates/discuss_brainstorm.yaml
@@ -28,7 +28,7 @@ system: |
   GOOD entity IDs: `character::lady_beatrice`, `location::vane_manor`, `object::silver_dagger`, `faction::old_guard`
   BAD entity IDs:
   - `Lady Beatrice` (spaces, capitalization — IDs are snake_case)
-  - `mentor` (missing namespace — would fail `validate_entity_id_format`)
+  - `mentor` (missing namespace — would fail R-2.3 semantic validation)
   - `main_character_mentor` (no namespace, free-form)
 
   **Entity Names**: When a specific name emerges naturally during brainstorming (e.g., "Lady Beatrice

--- a/prompts/templates/serialize_brainstorm.yaml
+++ b/prompts/templates/serialize_brainstorm.yaml
@@ -6,23 +6,21 @@ system: |
 
   ## Entity Mapping (CRITICAL)
 
-  The brief describes story elements in categories. Map them to entities with the correct `type`:
+  The brief describes story elements in categories. Map them to entities with the correct `entity_category` field value:
 
-  | Brief Category | Entity Type      |
-  |----------------|------------------|
-  | Characters     | "character"      |
-  | Locations      | "location"       |
-  | Objects        | "object"         |
-  | Factions       | "faction"        |
+  | Brief Category | `entity_category` value |
+  |----------------|-------------------------|
+  | Characters     | `"character"`           |
+  | Locations      | `"location"`            |
+  | Objects        | `"object"`              |
+  | Factions       | `"faction"`             |
 
   Each entity needs:
-  - `entity_id`: Short snake_case identifier (e.g., "lady_beatrice", "vane_manor")
-  - `entity_category`: One of "character", "location", "object", "faction"
-  - `name`: Optional canonical display name if it emerged naturally during brainstorming
-    (e.g., "Lady Beatrice Ashford", "The Gilded Compass"). Leave absent if no specific
-    name was established - SEED will generate one. Do NOT just title-case the entity_id.
-  - `concept`: One-line essence from the brief
-  - `notes`: Optional additional context from the brief
+  - `entity_id`: Snake_case identifier with the category as a namespace prefix (e.g., `character::lady_beatrice`, `location::vane_manor`, `object::silver_dagger`, `faction::old_guard`). The serializer rejects bare IDs.
+  - `entity_category`: One of `"character"`, `"location"`, `"object"`, `"faction"` (singular, lowercase — must match the table above).
+  - `name`: REQUIRED non-empty canonical display name. If a specific name was established during brainstorming (e.g., "Lady Beatrice Ashford", "The Gilded Compass"), use it. Otherwise generate a simple descriptive name (e.g., "The Mentor", "The Archive") — do NOT leave name absent. Do NOT just title-case the entity_id.
+  - `concept`: One-line essence from the brief.
+  - `notes`: Optional additional context from the brief.
 
   ## Dilemma Structure
 
@@ -38,25 +36,25 @@ system: |
 
   ## Dilemma ID Naming (CRITICAL)
 
-  Dilemma IDs use the pattern: `subject_optionA_or_optionB`
-  The word `_or_` appears exactly ONCE, between the two options. The ID MUST END with optionB.
+  Dilemma IDs use the pattern: `dilemma::subject_optionA_or_optionB`. **Every dilemma ID MUST start with the `dilemma::` namespace prefix** — the serializer rejects any ID that does not. The word `_or_` appears exactly ONCE, between the two options. The ID MUST END with optionB.
 
   GOOD examples (generate YOUR OWN based on your story):
-  - `mentor_benevolent_or_manipulative` (ends with `manipulative`)
-  - `artifact_blessed_or_cursed` (ends with `cursed`)
-  - `faction_allied_or_hostile` (ends with `hostile`)
+  - `dilemma::mentor_benevolent_or_manipulative` (ends with `manipulative`)
+  - `dilemma::artifact_blessed_or_cursed` (ends with `cursed`)
+  - `dilemma::faction_allied_or_hostile` (ends with `hostile`)
 
   BAD examples (will cause downstream failures):
-  - `mentor_benevolent_or_manipulative_or_` (WRONG: trailing `_or_`)
-  - `artifact_blessed_or_cursed_or_` (WRONG: trailing `_or_`)
-  - `d1`, `d2`, `dilemma_a` (too short, not descriptive)
-  - `character_motivation` (ambiguous, could be confused with path name)
-  - `trust_issue` (too vague)
-  - `single_word` (could be mistaken for a path ID)
+  - `mentor_benevolent_or_manipulative` (MISSING `dilemma::` prefix — most common failure)
+  - `dilemma::mentor_benevolent_or_manipulative_or_` (WRONG: trailing `_or_`)
+  - `dilemma::artifact_blessed_or_cursed_or_` (WRONG: trailing `_or_`)
+  - `dilemma::d1`, `dilemma::d2`, `dilemma::dilemma_a` (too short, not descriptive — even with the prefix)
+  - `dilemma::character_motivation` (ambiguous, could be confused with path name)
+  - `dilemma::trust_issue` (too vague)
+  - `dilemma::single_word` (could be mistaken for a path ID)
 
-  NEVER end a dilemma ID with `_or_` -- the last word must always be the second option.
+  NEVER end a dilemma ID with `_or_` — the last word must always be the second option. NEVER omit the `dilemma::` prefix.
 
-  **DO NOT copy IDs from other stories** - generate IDs specific to YOUR story.
+  **DO NOT copy IDs from other stories** — generate IDs specific to YOUR story.
 
   ## Guidelines
 

--- a/prompts/templates/serialize_brainstorm.yaml
+++ b/prompts/templates/serialize_brainstorm.yaml
@@ -31,7 +31,7 @@ system: |
     - `answer_id`: Unique short identifier for THIS answer (e.g., "guilty", "framed", "dagger", "poison")
     - `description`: Full description
     - `is_canonical`: true for ONE answer (the default path), false for the other
-  - `central_entity_ids`: List of entity_id values related to this dilemma
+  - `central_entity_ids`: List of **namespaced** `entity_id` values related to this dilemma (e.g., `character::mentor`, `location::archive`). Bare IDs without the category prefix will fail R-2.3 semantic validation.
   - `why_it_matters`: Thematic stakes
 
   ## Dilemma ID Naming (CRITICAL)

--- a/prompts/templates/summarize_brainstorm.yaml
+++ b/prompts/templates/summarize_brainstorm.yaml
@@ -8,34 +8,38 @@ system: |
   Condense the conversation into a **prose brief** that captures all discussed story elements.
   Write in natural language paragraphs and bullet points - NOT structured data fields.
 
-  ### Characters (list all discussed)
+  ### Characters (`entity_category: "character"`, list all discussed)
   Describe each character discussed:
   - Who they are and their role in the story
   - Key traits, motivations, or secrets
   - Any relationships or conflicts mentioned
+  - If a specific name was established in discussion, include it. If only a role was discussed, omit the name — the serializer will leave it absent for SEED to generate.
 
-  ### Locations (list all discussed)
+  ### Locations (`entity_category: "location"`, list all discussed)
   Describe each location discussed:
   - What the place is and its atmosphere
   - Why it matters to the story
   - Any secrets or special features
+  - Include the established name only if one was discussed.
 
-  ### Objects (list all discussed)
+  ### Objects (`entity_category: "object"`, list all discussed)
   Describe significant objects discussed:
   - What the object is
   - Why it's important (clue, macguffin, symbol, etc.)
+  - Include the established name only if one was discussed.
 
-  ### Factions (if any)
+  ### Factions (`entity_category: "faction"`, if any)
   Describe any groups or organizations:
   - What they are and their goals
   - Key members or relationships
+  - Include the established name only if one was discussed.
 
   ### Dramatic Dilemmas (list all discussed)
   For each dilemma, describe in prose:
   - The central question or conflict
   - The two possible answers/outcomes (one being the "default path")
-  - **Central entity IDs**: List the exact entity IDs involved (e.g., "[character_id], [location_id]")
-  - Why this dilemma matters thematically
+  - **Central entity IDs**: list the namespaced IDs as backtick-wrapped tokens (e.g., `` `character::mentor`, `location::archive` ``). Do NOT use bracket-list notation like `[character_id]` — that's Python repr, not human-readable text.
+  - Why this dilemma matters thematically. **If `why_it_matters` was not discussed, do NOT invent one.** Write: `why_it_matters: [NOT DISCUSSED — serializer will flag this]` so the serializer surfaces the gap rather than silently degrading.
 
   ## NO DELEGATION (CRITICAL)
   You are writing the summary, not suggesting how to write it.

--- a/prompts/templates/summarize_brainstorm.yaml
+++ b/prompts/templates/summarize_brainstorm.yaml
@@ -13,33 +13,33 @@ system: |
   - Who they are and their role in the story
   - Key traits, motivations, or secrets
   - Any relationships or conflicts mentioned
-  - If a specific name was established in discussion, include it. If only a role was discussed, omit the name — the serializer will leave it absent for SEED to generate.
+  - If a specific name was established in discussion, include it. If only a role was discussed, omit the name from the summary — the serializer will create a descriptive name from the entity's role (e.g., "The Mentor", "The Archive").
 
   ### Locations (`entity_category: "location"`, list all discussed)
   Describe each location discussed:
   - What the place is and its atmosphere
   - Why it matters to the story
   - Any secrets or special features
-  - Include the established name only if one was discussed.
+  - If a specific name was established, include it. Otherwise omit the name — the serializer will create a descriptive name from the entity's role.
 
   ### Objects (`entity_category: "object"`, list all discussed)
   Describe significant objects discussed:
   - What the object is
   - Why it's important (clue, macguffin, symbol, etc.)
-  - Include the established name only if one was discussed.
+  - If a specific name was established, include it. Otherwise omit the name — the serializer will create a descriptive name from the entity's role.
 
   ### Factions (`entity_category: "faction"`, if any)
   Describe any groups or organizations:
   - What they are and their goals
   - Key members or relationships
-  - Include the established name only if one was discussed.
+  - If a specific name was established, include it. Otherwise omit the name — the serializer will create a descriptive name from the entity's role.
 
   ### Dramatic Dilemmas (list all discussed)
   For each dilemma, describe in prose:
   - The central question or conflict
   - The two possible answers/outcomes (one being the "default path")
   - **Central entity IDs**: list the namespaced IDs as backtick-wrapped tokens (e.g., `` `character::mentor`, `location::archive` ``). Do NOT use bracket-list notation like `[character_id]` — that's Python repr, not human-readable text.
-  - Why this dilemma matters thematically. **If `why_it_matters` was not discussed, do NOT invent one.** Write: `why_it_matters: [NOT DISCUSSED — serializer will flag this]` so the serializer surfaces the gap rather than silently degrading.
+  - Why this dilemma matters thematically. R-3.1 makes `why_it_matters` REQUIRED — non-empty for every dilemma. If it wasn't discussed explicitly, synthesize a plausible 1–2 sentence rationale from the dilemma's question, central entities, and the story's themes. Do NOT leave it blank, write a placeholder string, or use a sentinel like `[NOT DISCUSSED]` — the validator does not detect those, and they propagate verbatim into SEED/GROW/FILL.
 
   ## NO DELEGATION (CRITICAL)
   You are writing the summary, not suggesting how to write it.


### PR DESCRIPTION
## Summary

Phase 3 Cluster F-5 from the [prompt-vs-spec audit](docs/superpowers/reports/2026-04-25-prompt-spec-audit.md). Closes #1428. Audit-recommended **PR A**: prompt-only fixes that break the BRAINSTORM "informal notation → strict schema" failure chain (audit lines 485-488). Repair-loop / two-pass serialize refactor deferred to F-6 (#1429).

## Failure chain being broken (audit)

> Discuss teaches informal notation → summarizer echoes it → serializer receives ambiguous notation → emits invalid \`central_entity_ids\` and un-prefixed \`dilemma_id\`s → Pydantic + semantic validation fires → repair-loop gets generic message without the actual entity list → second attempt also fails.

This PR closes the **first three links** (discuss + summarize + serialize prompts). F-6 (#1429) handles the repair-loop link.

## Findings addressed

| Severity | File | Finding |
|---|---|---|
| hard | discuss_brainstorm | Bracket-list \`central_entity_ids\` notation (§9 violation) |
| hard | discuss_brainstorm | \`dilemma::\` prefix never taught; GOOD examples lacked it |
| hard | discuss_brainstorm | Prose used "entity type" / "type"; field is \`entity_category\` |
| hard | discuss_brainstorm | Entity namespace (\`character::mentor\`) never taught |
| hard | summarize_brainstorm | Bracket-list notation (mirrors discuss) |
| hard | summarize_brainstorm | No instruction for missing \`why_it_matters\` (silent invent) |
| hard | serialize_brainstorm | Table column "Entity Type"; field is \`entity_category\` |
| hard | serialize_brainstorm | All \`Dilemma ID Naming\` GOOD examples lacked \`dilemma::\` |
| hard | serialize_brainstorm | \`name: Optional\` in prompt vs Pydantic \`min_length=1\` REQUIRED |
| soft | discuss_brainstorm | No GOOD/BAD examples for entity ID format |
| soft | discuss_brainstorm | No tool-error fallback in research_tools_section |
| soft | summarize_brainstorm | Section headers plural \`### Characters\` vs singular Pydantic value |
| soft | summarize_brainstorm | name field handling not mentioned per section |
| soft | serialize_brainstorm | name field said "leave absent" — would fail validation |

## Out of scope (separate clusters)

- **F-6 (#1429)** — Valid Entity IDs section (requires two-pass serialize refactor; code change)
- Repair-loop improvement (\`BrainstormMutationError._format_message()\`) — F-6 candidate
- Sandwich repetition for binary-only / single-canonical constraints — F-6 candidate
- Spec gap: brainstorm.md §R-1.1 abundance targets vs size preset — separate spec issue

## Spec citations

- \`brainstorm.md §R-2.1\` — Entity name non-empty
- \`brainstorm.md §R-2.2\` — entity_category field
- \`brainstorm.md §R-2.3\` — Entity ID namespace
- \`brainstorm.md §R-3.7\` — \`dilemma::\` prefix required
- \`brainstorm.md §R-3.1\` — why_it_matters required
- \`CLAUDE.md §6\` — Valid ID Injection Principle
- \`CLAUDE.md §7\` — Defensive Prompt Patterns
- \`CLAUDE.md §9\` — Prompt Context Formatting

## Verification

\`\`\`sh
$ rg -nE '^  - \`dilemma::' prompts/templates/discuss_brainstorm.yaml prompts/templates/serialize_brainstorm.yaml | wc -l
17  # All GOOD/BAD example bullets carry the dilemma:: prefix

$ rg -nE 'Entity Type' prompts/templates/serialize_brainstorm.yaml
(no matches)  # Renamed to entity_category value

$ rg -nE 'Optional canonical|leave absent' prompts/templates/serialize_brainstorm.yaml
(no matches)  # name is now REQUIRED with descriptive-fallback rule
\`\`\`

## Tests

- \`uv run pytest tests/unit/test_brainstorm*.py -x -q\` → **49 passed** (no regression)