### PR TITLE
fix(seed): Y-shape schema + branching + flavor removal across SEED prompts (Cluster F-7)

### DIFF
--- a/prompts/templates/discuss_seed.yaml
+++ b/prompts/templates/discuss_seed.yaml
@@ -87,7 +87,7 @@ system: |
 
   BAD (only canonical answers explored):
   - All dilemmas: explored = `[canonical_answer_only]` → linear story, 0 choices
-  - Only 1 dilemma fully explored → fails R-5.1; story has only one fork
+  - Only 1 dilemma fully explored → story has only one fork; POLISH Phase 4c produces ≤2 choices
 
   Pick at least 2 dilemmas where exploring both answers serves the story (per the
   Identity-defining / Genuine dilemma / Distinct content tests above). Beyond

--- a/prompts/templates/discuss_seed.yaml
+++ b/prompts/templates/discuss_seed.yaml
@@ -22,8 +22,8 @@ system: |
   Every entity needs exactly ONE decision (retain or cut). No entity can be skipped.
 
   **Dilemmas** are binary dramatic questions with two mutually exclusive answers:
-  - One is **canonical** (marked `is_canonical: true`) - the spine/default story
-  - One is **non-canonical** - exploring it creates a branch
+  - One is **canonical** (the spine/default story — marked `(default)` in the brief and serialized with `is_canonical: true`)
+  - One is **non-canonical** — exploring it creates a branch
 
   **Paths** are storylines you commit to developing from explored answers.
   The canonical answer ALWAYS becomes a path. You decide which non-canonical
@@ -73,8 +73,24 @@ system: |
   the player COULD have discovered he was manipulative - but didn't. The shadow
   enriches the text without adding complexity.
 
-  Explore all answers you find compelling. The system will balance scope
-  automatically - you don't need to count arcs or worry about limits.
+  ## MINIMUM BRANCHING REQUIREMENT (R-5.1, CRITICAL)
+
+  **At least 2 dilemmas MUST have BOTH answers explored.** A single-branch story
+  collapses to a linear track and POLISH Phase 4c will produce 0 choice edges.
+  The downstream pipeline assumes a real branching structure.
+
+  GOOD (3 dilemmas, 2 fully explored):
+  - `dilemma::keeper_honest_or_hiding`: explored = `[honest, hiding]` — both answers
+  - `dilemma::artifact_blessed_or_cursed`: explored = `[blessed, cursed]` — both answers
+  - `dilemma::weather_storm_or_clear`: explored = `[clear]` — canonical only (atmospheric)
+
+  BAD (only canonical answers explored):
+  - All dilemmas: explored = `[canonical_answer_only]` → linear story, 0 choices
+  - Only 1 dilemma fully explored → fails R-5.1; story has only one fork
+
+  Pick at least 2 dilemmas where exploring both answers serves the story (per the
+  Identity-defining / Genuine dilemma / Distinct content tests above). Beyond
+  that minimum, explore more if compelling — the size preset bounds the upper end.
 
   ### 3. Create Paths from Explored Answers
 
@@ -96,11 +112,39 @@ system: |
   - Vary locations (not all beats in one place)
   - Impact dilemmas (advance, reveal, commit, complicate)
 
+  **Y-shape beat shape (R-3.6, CRITICAL).** Each beat carries a `path_id`
+  (its primary path). Pre-commit beats — beats SHARED between the two
+  paths of one dilemma — also set `also_belongs_to: [<other_path_id>]`
+  to declare the dual membership. Commit beats and post-commit beats are
+  exclusive to one path; they set `also_belongs_to: null`.
+
+  GOOD (Y-shape with `path_id` + `also_belongs_to`):
+  ```
+  shared pre-commit:  path_id = path::keeper_honest, also_belongs_to = [path::keeper_hiding]
+  commit (honest):    path_id = path::keeper_honest, also_belongs_to = null
+  post-commit (honest): path_id = path::keeper_honest, also_belongs_to = null
+  commit (hiding):    path_id = path::keeper_hiding, also_belongs_to = null
+  post-commit (hiding): path_id = path::keeper_hiding, also_belongs_to = null
+  ```
+
+  BAD (legacy `paths: [...]` list — DEPRECATED, do not use):
+  ```
+  paths: [path::keeper_honest, path::keeper_hiding]   # DROP — use path_id + also_belongs_to
+  ```
+
+  Beats may also carry optional `temporal_hint` (rough scene ordering),
+  `location_alternatives` (acceptable substitutes if the primary location
+  is constrained), and `role` (`setup` for opening framing beats,
+  `epilogue` for closing beats — most beats omit `role`).
+
   ### 5. Design Convergence Points
 
   Paths MUST converge at specific physical locations, not abstract narrative moments.
   Design {size_convergence_points} convergence points where characters from different dilemmas are forced
-  into the same scene:
+  into the same scene. **Note:** convergence applies only to **soft** dilemmas
+  whose paths rejoin. Hard dilemmas have NO convergence — their paths run to
+  separate endings and never meet. The target above counts soft-dilemma
+  convergences only.
 
   - **Location-based convergence**: Name the specific location where paths meet
     (e.g., "all paths converge at the archive_vault for the final confrontation")
@@ -161,6 +205,16 @@ system: |
   - **reveals**: Surfaces information bearing on the question
   - **commits**: Point of no return - answer is locked in
   - **complicates**: Introduces doubt or new dimension
+
+  ## Consequences (per path)
+
+  Each path carries `consequences` describing what happens in the world
+  after the player commits to that answer. Each `Consequence` has a
+  `description` (REQUIRED, non-empty — describes a world-state change,
+  NOT a player action) and `narrative_effects` (REQUIRED — downstream
+  ripples, e.g., NPCs change disposition, locations become accessible
+  or barred). Consequences are not raw IDs; they are described in prose
+  that the serializer uses to produce `Consequence` objects.
 
   ## Format Pitfalls
   - Do NOT skip beat creation - every path needs beats

--- a/prompts/templates/discuss_seed.yaml
+++ b/prompts/templates/discuss_seed.yaml
@@ -73,11 +73,12 @@ system: |
   the player COULD have discovered he was manipulative - but didn't. The shadow
   enriches the text without adding complexity.
 
-  ## MINIMUM BRANCHING REQUIREMENT (R-5.1, CRITICAL)
+  ## MINIMUM BRANCHING REQUIREMENT (CRITICAL)
 
-  **At least 2 dilemmas MUST have BOTH answers explored.** A single-branch story
-  collapses to a linear track and POLISH Phase 4c will produce 0 choice edges.
-  The downstream pipeline assumes a real branching structure.
+  **At least 2 dilemmas MUST have BOTH answers explored.** Without at least
+  one Y-fork, POLISH Phase 4c produces 0 choice edges (see seed.md §Overview)
+  and the story collapses to a linear track. The downstream pipeline assumes
+  a real branching structure.
 
   GOOD (3 dilemmas, 2 fully explored):
   - `dilemma::keeper_honest_or_hiding`: explored = `[honest, hiding]` — both answers

--- a/prompts/templates/serialize_seed.yaml
+++ b/prompts/templates/serialize_seed.yaml
@@ -72,25 +72,49 @@ system: |
 
   ### 5. initial_beats (Y-shape — shared pre-commit + per-path post-commit)
   Each dilemma is Y-shaped: SHARED pre-commit beats (belong to both paths
-  of the dilemma via path_id + also_belongs_to) + a COMMIT beat per path
-  (single belongs_to) + post-commit consequence beats per path (single
-  belongs_to). Target counts: {size_shared_beats_per_dilemma} shared
-  beats per dilemma, {size_post_commit_beats_per_path} post-commit beats
-  per path. A dilemma with 2 explored paths and 1 shared + 1 commit + 2
-  consequence beats per path produces 1 + 2 * 3 = 7 beats.
+  of the dilemma via `path_id` + `also_belongs_to`) + a COMMIT beat per
+  path (`also_belongs_to: null`) + post-commit consequence beats per path
+  (`also_belongs_to: null`). Target counts: {size_shared_beats_per_dilemma}
+  shared beats per dilemma, {size_post_commit_beats_per_path} post-commit
+  beats per path. A dilemma with 2 explored paths and 1 shared + 1 commit
+  + 2 consequence beats per path produces 1 + 2 * 3 = 7 beats.
+
+  **Use `path_id` + `also_belongs_to`. Do NOT emit the legacy `paths: [...]` list field — it was deprecated in the Y-shape refactor (#1206) and the serializer rejects it.**
+
+  Example A — SHARED pre-commit beat (dual membership):
   ```json
   {{
-    "beat_id": "host_motive_beat_01",
-    "summary": "What happens in this beat",
-    "paths": ["path::host_benevolent_or_selfish__protector"],
+    "beat_id": "host_motive_setup_01",
+    "summary": "The host greets the guest with calculated warmth",
+    "path_id": "path::host_benevolent_or_selfish__protector",
+    "also_belongs_to": ["path::host_benevolent_or_selfish__manipulator"],
     "dilemma_impacts": [
       {{
         "dilemma_id": "dilemma::host_benevolent_or_selfish",
         "effect": "advances",
-        "note": "Explanation of the impact"
+        "note": "Establishes the host's surface charm before the fork"
       }}
     ],
-    "entities": ["character::butler", "character::guest"],
+    "entities": ["character::host", "character::guest"],
+    "location": "location::manor"
+  }}
+  ```
+
+  Example B — COMMIT or POST-COMMIT beat (exclusive to one path):
+  ```json
+  {{
+    "beat_id": "host_protector_proof_01",
+    "summary": "The host shields the guest from a poisoned drink",
+    "path_id": "path::host_benevolent_or_selfish__protector",
+    "also_belongs_to": null,
+    "dilemma_impacts": [
+      {{
+        "dilemma_id": "dilemma::host_benevolent_or_selfish",
+        "effect": "commits",
+        "note": "The host's intervention locks in the protector answer"
+      }}
+    ],
+    "entities": ["character::host", "character::guest"],
     "location": "location::manor",
     "location_alternatives": ["location::garden"]
   }}

--- a/prompts/templates/serialize_seed.yaml
+++ b/prompts/templates/serialize_seed.yaml
@@ -100,7 +100,7 @@ system: |
   }}
   ```
 
-  Example B — COMMIT or POST-COMMIT beat (exclusive to one path):
+  Example B — COMMIT beat (exclusive to one path, fork point):
   ```json
   {{
     "beat_id": "host_protector_proof_01",
@@ -119,6 +119,12 @@ system: |
     "location_alternatives": ["location::garden"]
   }}
   ```
+
+  POST-COMMIT (aftermath) beats use the same `also_belongs_to: null` shape
+  as Example B, but their `effect` MUST NOT be `commits` — use `advances`,
+  `reveals`, or `complicates` instead. Only the single COMMIT beat per path
+  carries `effect: commits`; subsequent post-commit beats prove the
+  already-committed answer through consequences.
 
   ## Mapping Rules
 

--- a/prompts/templates/serialize_seed_sections.yaml
+++ b/prompts/templates/serialize_seed_sections.yaml
@@ -449,13 +449,14 @@ beats_prompt: |
             "note": "Explanation of the impact"
           }
         ],
-        "entities": ["character::[character_id]", "location::[location_id]"],
-        "location": "location::[location_id]",
-        "location_alternatives": ["location::[other_location]"],
+        "entities": ["character::actual_character_id", "location::actual_location_id"],
+        "location": "location::actual_location_id",
+        "location_alternatives": ["location::another_actual_location_id"],
         "temporal_hint": {
-          "relative_to": "dilemma::[other_dilemma_id]",
+          "relative_to": "dilemma::another_actual_dilemma_id",
           "position": "before_commit"
         }
+        // ↑ Replace `actual_*` / `another_actual_*` with REAL IDs from your story's manifest. Square-bracket placeholders like `[other_dilemma_id]` are NOT template syntax — emitting them literally will fail validation.
       }
     ]
   }
@@ -654,10 +655,10 @@ shared_beats_prompt: |
   pre-commit beats (1–2 is the sweet spot for most stories).
 
   Each shared beat:
+    - **MUST have `also_belongs_to` = `{also_belongs_to}` (the sibling path above) — REQUIRED.** This is the single most-frequently-missed field; setting it correctly is what makes the beat a "shared" beat. Omitting it converts the beat to a single-path beat and breaks the Y-shape.
+    - MUST have `path_id` = `{path_id}` (the primary path above).
     - MUST have `effect` in {{advances, reveals, complicates}}. NEVER `commits`.
     - MUST reference the current dilemma in `dilemma_impacts[0].dilemma_id`.
-    - MUST have `path_id` = `{path_id}` (the primary path above).
-    - MUST have `also_belongs_to` = `{also_belongs_to}` (the sibling path above).
     - SHOULD explore the dilemma's central tension without privileging either answer.
 
   ## Schema
@@ -781,13 +782,14 @@ per_path_beats_prompt: |
             "note": "Explanation"
           }}
         ],
-        "entities": ["character::character_id"],
-        "location": "location::location_id",
-        "location_alternatives": ["location::other_location_if_scene_could_move_there"],
+        "entities": ["character::actual_character_id"],
+        "location": "location::actual_location_id",
+        "location_alternatives": ["location::another_actual_location_id"],
         "temporal_hint": {{
-          "relative_to": "dilemma::[other_dilemma_id]",
+          "relative_to": "dilemma::another_actual_dilemma_id",
           "position": "before_commit"
         }}
+        // ↑ Replace `actual_*` / `another_actual_*` with REAL IDs from your story's manifest. Square-bracket placeholders like `[other_dilemma_id]` are NOT template syntax — emitting them literally will fail validation.
       }}
     ]
   }}
@@ -873,8 +875,11 @@ per_path_beats_prompt: |
   For EACH beat you generate, verify:
   1. `path_id` is `{path_id}`
   2. `dilemma_impacts[0].dilemma_id` is `{dilemma_id}`
+  3. `also_belongs_to` is `null` (these are POST-COMMIT beats, exclusive
+     to one path — never shared)
 
   If you see a dilemma ID in your `path_id` value, YOU MADE A MISTAKE. Fix it.
+  If `also_belongs_to` is anything other than `null`, YOU MADE A MISTAKE. Fix it.
 
   ## Output
   Return ONLY valid JSON with the "initial_beats" array ({size_post_commit_beats_per_path} beats).
@@ -1110,7 +1115,9 @@ dilemma_analyses_prompt: |
      classify the strongest dilemma as hard. If more than 3 are hard:
      demote the weakest to soft.
   2. SOFT count is the majority.
-  3. FLAVOR count is 0-2.
+  3. Every entry has `dilemma_role` set to exactly `hard` or `soft` —
+     no other values are accepted (R-7.1). The legacy `flavor` role was
+     removed; never emit it.
   4. At most 2 have `ending_salience: "high"`.
   5. Every dilemma with `ending_tone` set also has `ending_salience: "high"`.
   6. At most 2 have `residue_weight: "heavy"`.

--- a/prompts/templates/summarize_seed.yaml
+++ b/prompts/templates/summarize_seed.yaml
@@ -82,14 +82,34 @@ system: |
   - ripples: story effects this implies
 
   ### Initial Beats (Y-shape: {size_shared_beats_per_dilemma} shared per dilemma + {size_post_commit_beats_per_path} post-commit per path)
-  For each opening beat, provide a beat sketch:
-  - beat_id: unique beat identifier
-  - summary: one sentence describing what happens
-  - location: primary location entity ID (must be a retained location)
-  - entities: key entity IDs present in this beat
-  - paths: list of path IDs this beat serves
+  For each opening beat, provide a beat sketch using the canonical Y-shape fields:
+  - `beat_id`: unique beat identifier
+  - `summary`: one sentence describing what happens
+  - `location`: primary location entity ID (must be a retained location)
+  - `entities`: key entity IDs present in this beat
+  - `path_id`: the beat's primary path (REQUIRED, single path ID)
+  - `also_belongs_to`: for SHARED pre-commit beats, list the other path(s) this
+    beat is shared with (e.g., `[path::keeper_hiding]` on a shared beat whose
+    `path_id` is `path::keeper_honest`). For COMMIT and POST-COMMIT beats, use
+    `null` (they are exclusive to one path).
+
+  **Do NOT use the legacy `paths: [a, b]` list field — it was deprecated in
+  the Y-shape refactor (#1206) and will be rejected by the serializer.**
 
   **Location Diversity**: Use at least 2 different locations across your beats.
+
+  ### VERIFY (run BEFORE moving to Convergence Sketch)
+  For EACH dilemma with 2 fully-explored paths, confirm in the summary:
+  1. At least 1 SHARED pre-commit beat exists with `path_id` set to one path
+     AND `also_belongs_to` listing the other path.
+  2. Each path has exactly 1 COMMIT beat (`also_belongs_to: null`, exclusive
+     to its path).
+  3. Each path has at least the configured number of POST-COMMIT beats
+     (`also_belongs_to: null`).
+  4. Pre-commit beats are listed before commit beats in `temporal_hint` order.
+
+  If any of the above is missing, the serializer will fail and the repair
+  loop will rebuild the section from scratch — fix the gap here.
 
   ### Convergence Sketch
   - convergence_points: where paths should merge
@@ -107,6 +127,8 @@ system: |
 
   If your story needs a scene in a character's personal space, use a retained
   location and put details in the beat summary.
+
+  REMINDER: All location IDs MUST be retained entity IDs from brainstorm. No invented locations.
   {output_language_instruction}
 
   ## Output Format

--- a/prompts/templates/summarize_seed.yaml
+++ b/prompts/templates/summarize_seed.yaml
@@ -106,7 +106,7 @@ system: |
      to its path).
   3. Each path has at least the configured number of POST-COMMIT beats
      (`also_belongs_to: null`).
-  4. Pre-commit beats are listed before commit beats in `temporal_hint` order.
+  4. Pre-commit beats appear before commit beats in the listing (or, if `temporal_hint` is set, its `position` is `before_commit`). `temporal_hint` is OPTIONAL — listing order alone is sufficient.
 
   If any of the above is missing, the serializer will fail and the repair
   loop will rebuild the section from scratch — fix the gap here.

--- a/prompts/templates/summarize_seed_sections.yaml
+++ b/prompts/templates/summarize_seed_sections.yaml
@@ -141,9 +141,13 @@ dilemmas_system: |
 
   ## FINAL CHECK before returning
   Count how many of your dilemmas have ALL answers in `explored` (`unexplored=[]`).
-  If that count is less than 2, GO BACK and fully explore at least 2 dilemmas
-  by moving ALL their answers from `unexplored` into `explored`.
-  A story with fewer than 2 fully-explored dilemmas is REJECTED downstream.
+  If that count is less than 2, **OVERRIDE the discussion's exploration choices**:
+  for any dilemma whose discussion did NOT explicitly say "explore both", you
+  MAY move its non-default answer from `unexplored` into `explored` (and clear
+  it from `unexplored`) until the fully-explored count reaches 2. Pick whichever
+  remaining dilemmas best serve the story.
+  A story with fewer than 2 fully-explored dilemmas is REJECTED downstream;
+  the override is required, not optional.
 
   VERIFY: Your list MUST have exactly {dilemma_count} items.
   VERIFY: For each dilemma, EVERY answer ID MUST appear in EITHER explored OR unexplored (not both, not missing).
@@ -171,8 +175,23 @@ paths_system: |
   - ripples: downstream story effects
 
   ## Path ID Convention
-  Path IDs follow the pattern: `dilemma_id__answer_id` (double underscore).
-  Example: dilemma `mentor_trust_or_betrayal` with answer `trust` becomes path `mentor_trust_or_betrayal__trust`.
+  Path IDs follow the pattern: `path::dilemma_id__answer_id` (note the
+  `path::` prefix and the **double underscore** between dilemma_id and
+  answer_id).
+
+  GOOD examples:
+  - `path::mentor_trust_or_betrayal__trust`
+  - `path::artifact_blessed_or_cursed__cursed`
+  - `path::keeper_honest_or_hiding__hiding`
+
+  BAD examples:
+  - `mentor_trust_or_betrayal__trust` (MISSING `path::` prefix)
+  - `path::mentor_trust_or_betrayal_trust` (single underscore — must be double)
+  - `path::mentor_trust` (drops the answer_id)
+  - `mentor_loyalty` (free-form name; pattern is mechanical)
+
+  The path's `pov_character` is OPTIONAL — set it only if a specific
+  character anchors the player's perspective on this path; otherwise omit.
 
   ## Output Format
   For each explored answer, describe the path and its consequences clearly.
@@ -199,13 +218,18 @@ beats_system: |
   ## Your Task
   For each dilemma, sketch the shared setup first; then for each explored
   path of that dilemma, sketch the commit and the consequence beats.
-  - beat_id: unique identifier
-  - summary: one sentence describing what happens
-  - location: a RETAINED location entity ID
-  - entities: key entity IDs present in this beat
-  - paths: which path IDs this beat serves
+  - `beat_id`: unique identifier
+  - `summary`: one sentence describing what happens
+  - `location`: a RETAINED location entity ID
+  - `entities`: key entity IDs present in this beat
+  - `path_id`: the beat's primary path (REQUIRED, single path ID)
+  - `also_belongs_to`: for SHARED pre-commit beats, list the OTHER path(s)
+    this beat is shared with (e.g., `[path::keeper_hiding]` on a shared
+    beat whose `path_id` is `path::keeper_honest`). For COMMIT and
+    POST-COMMIT beats, use `null`.
 
-  Shared pre-commit beats can serve multiple paths (list both path IDs).
+  **Do NOT use the legacy `paths: [a, b]` list field — it was deprecated
+  in the Y-shape refactor (#1206) and the serializer will reject it.**
 
   ## Output Format
   List beats grouped by the dilemma they belong to, then by path.


### PR DESCRIPTION
## Summary

Phase 3 Cluster F-7 from the [prompt-vs-spec audit](docs/superpowers/reports/2026-04-25-prompt-spec-audit.md). Closes #1431. Audit-recommended **SEED PR-A** (audit lines 511-641): Y-shape consistency across all 5 SEED prompt files + MINIMUM BRANCHING in discuss_seed + Y-shape VERIFY in summarize_seed + GO BACK rephrase + flavor removal + bonus soft fixes.

This is the **murder1 fix root cause** cluster — the Y-shape gaps in SEED were the original audit trigger. PR #1206 introduced the Y-shape but propagation across the 5-prompt SEED set was incomplete; this closes the gap.

## Hard findings addressed

| File | Fix |
|---|---|
| discuss_seed.yaml | Worked Example replaced with Y-shape (\`path_id\` + \`also_belongs_to\`); legacy \`paths: [...]\` called out as DEPRECATED |
| discuss_seed.yaml | New MINIMUM BRANCHING REQUIREMENT block (R-5.1) with GOOD/BAD; "don't worry" sentence removed |
| summarize_seed.yaml | Initial Beats schema rewritten to \`path_id\` + \`also_belongs_to\`; legacy \`paths\` rejected |
| summarize_seed.yaml | New VERIFY block: shared/commit/post-commit Y-shape completeness check before Convergence Sketch |
| summarize_seed_sections.yaml | "GO BACK" rephrased as self-sufficient OVERRIDE instruction (small models can't go back) |
| summarize_seed_sections.yaml | \`beats_system\` rewritten with \`path_id\` + \`also_belongs_to\`; legacy \`paths\` rejected |
| serialize_seed.yaml | Section 5 schema example replaced with TWO canonical examples — shared (with \`also_belongs_to\`) and per-path (with \`null\`) |
| serialize_seed_sections.yaml | \`dilemma_analyses_prompt\` Self-Check no longer mentions \`flavor\` (R-7.1 rejects it) |

## Soft findings folded in

| File | Fix |
|---|---|
| discuss_seed.yaml | \`is_canonical: true\` aligned with \`(default)\` marker terminology |
| discuss_seed.yaml | Convergence target hard-dilemma caveat (hard dilemmas don't converge) |
| discuss_seed.yaml | Consequence schema details (\`description\` + \`narrative_effects\` REQUIRED) |
| summarize_seed.yaml | Sandwich repetition of Location Constraint at end |
| summarize_seed_sections.yaml | \`paths_system\` GOOD/BAD path ID examples with \`path::\` prefix + double underscore |
| serialize_seed_sections.yaml | \`shared_beats\` \`also_belongs_to\` REQUIRED constraint hoisted to bullet #1 |
| serialize_seed_sections.yaml | \`per_path_beats\` FINAL VERIFICATION adds \`also_belongs_to: null\` re-check |
| serialize_seed_sections.yaml | Square-bracket placeholders in temporal_hint examples replaced with \`actual_*\` naming + explicit "NOT template syntax" note |

## Out of scope (separate clusters)

- \`serialize_seed.yaml\` dead-code investigation (audit line 602) — needs runtime trace
- \`dilemma_relationships_prompt\` exhaustive O(n²) vs spec R-8.2 — separate spec-update issue
- \`per_dilemma_paths_prompt\` template-variable confusion — separate cluster
- Repair-loop / two-pass refactors — separate code-touching cluster
- BRAINSTORM Valid Entity IDs (#1429) — separate code-touching cluster

## Spec citations

- \`docs/design/procedures/seed.md §R-3.6\` — Y-shape \`also_belongs_to\` requirement
- \`docs/design/procedures/seed.md §R-3.10\` — pre-commit/commit/post-commit distinction
- \`docs/design/procedures/seed.md §R-5.1\` — minimum 2 dilemmas fully explored
- \`docs/design/procedures/seed.md §R-7.1\` — \`dilemma_role\` only \`hard\` or \`soft\`
- \`docs/design/story-graph-ontology.md §Part 8\` — Y-shape guard rails
- \`CLAUDE.md §9\` — no Python repr in LLM-facing text
- \`CLAUDE.md §10\` — small-model bias

## Verification

\`\`\`sh
$ rg -nE '^\s*paths:' prompts/templates/*seed*.yaml | grep -v '#\|\(legacy\|do not\|Do NOT'
(no matches)  # All remaining occurrences are in BAD examples / anti-pattern callouts

$ rg -n 'flavor' prompts/templates/serialize_seed_sections.yaml
131:  "Soft" dilemmas (only the default explored) add flavor without adding branching arcs.
138:  - 4 default-only (only default in \`explored\`): adds 4 flavor arcs
# Both are in dilemma classification narrative — not the Self-Check rule
\`\`\`

## Tests

- \`uv run pytest tests/unit/test_seed*.py tests/unit/test_serialize.py tests/unit/test_brainstorm*.py tests/unit/test_dream*.py -x -q\` → **413 passed** (no regression)