### PR TITLE
spec: align scope-preset vocabulary in authoritative docs (Cluster F-9)

### DIFF
--- a/docs/design/how-branching-stories-work.md
+++ b/docs/design/how-branching-stories-work.md
@@ -101,7 +101,7 @@ Every story begins with a creative contract: what kind of experience are we maki
 
 DREAM establishes the boundaries that every later decision must respect. It defines the genre and subgenre (cyberpunk noir, cozy mystery, epic fantasy), the emotional tone (gritty and cynical, whimsical and warm), the themes the story wants to explore ("what is the price of loyalty?"), the intended audience, and preferences for narrative style.
 
-DREAM also sets the scope — how large this story will be. A vignette with two dilemmas and a handful of passages is a fundamentally different undertaking from a full-length adventure with five dilemmas and a hundred passages. Scope constrains everything downstream: how many dilemmas are feasible, how many beats each path can sustain, how much prose needs to be written.
+DREAM also sets the scope — how large this story will be. A `micro`-sized story with two dilemmas and a handful of passages is a fundamentally different undertaking from a `long`-sized adventure with five dilemmas and a hundred passages. Scope constrains everything downstream: how many dilemmas are feasible, how many beats each path can sustain, how much prose needs to be written.
 
 If an idea later in the pipeline contradicts the vision — a slapstick scene in a gritty noir, a light-hearted tone in a story about grief — it gets cut. DREAM is the North Star.
 

--- a/docs/design/story-graph-ontology.md
+++ b/docs/design/story-graph-ontology.md
@@ -24,7 +24,7 @@ The vision's fields include:
 - **Genre and subgenre** — the primary genre (e.g., "mystery") and a more specific subgenre (e.g., "cozy mystery," "noir detective"). "How Branching Stories Work" discusses subgenre narratively; this document formalizes it as a distinct field.
 - **Point-of-view style** — a hint, not a binding constraint. Expressed as one of four narrative perspectives (first person, second person, third person limited, third person omniscient). FILL's voice document makes the final decision — the vision's `pov_style` is advisory context.
 - **Content notes** — explicit guidance on what the story should include or exclude (themes to embrace, topics to avoid, content boundaries). This is a substantive creative constraint, not a filter — it shapes what BRAINSTORM generates and what SEED retains.
-- **Scope** — expressed as a named preset (e.g., "vignette," "short story," "novella") that implies approximate sizes for the cast, dilemma count, beat count, and passage count. The preset system provides BRAINSTORM and SEED with concrete targets.
+- **Scope** — expressed as a named preset (`micro`, `short`, `medium`, or `long` — the canonical names defined in `pipeline/size.py` PRESETS) that implies approximate sizes for the cast, dilemma count, beat count, and passage count. The preset system provides BRAINSTORM and SEED with concrete targets.
 
 The vision has no edges to other nodes. Downstream stages receive it as context — it informs decisions but does not participate in the graph structure. It is working data, not exported to the player.
 


### PR DESCRIPTION
## Summary

Closes #1421. Surfaced by review of #1419 (Cluster F-2 — DREAM scope preset rename). The prompt templates (F-2/F-3/F-4) and Pydantic model use the canonical preset names (\`micro\`, \`short\`, \`medium\`, \`long\` per \`pipeline/size.py\` PRESETS), but two authoritative spec docs still used illustrative \`vignette\` / \`short story\` / \`novella\` wording in prose. Per CLAUDE.md §Design Doc Authority the spec and code must use the same vocabulary even in illustrative passages — otherwise readers learning from these docs will reach for the wrong preset names.

## Changes (2 lines, 2 files)

- **\`docs/design/story-graph-ontology.md:27\`** — replace \`(e.g., "vignette," "short story," "novella")\` with the canonical enumeration plus a \`pipeline/size.py\` PRESETS pointer.
- **\`docs/design/how-branching-stories-work.md:104\`** — rephrase the vignette/full-length contrast to use canonical preset names (\`micro\`-sized story / \`long\`-sized adventure).

## Verification

\`\`\`sh
$ rg -nE 'vignette|"short story"|novella' docs/design/story-graph-ontology.md docs/design/how-branching-stories-work.md
(no matches)
\`\`\`

## Spec citations

- \`CLAUDE.md §Design Doc Authority\` — spec and code use the same vocabulary
- \`src/questfoundry/pipeline/size.py:91-208\` — canonical PRESETS (\`micro\`, \`short\`, \`medium\`, \`long\`)
- \`src/questfoundry/models/dream.py:34\` — \`Literal["micro", "short", "medium", "long"]\`

## Related

- Audit report: \`docs/superpowers/reports/2026-04-25-prompt-spec-audit.md\` DREAM section
- F-2 PR #1419 (prompt-side scope rename)
- F-3 PR #1423 (serialize schema completeness)
- F-4 PR #1426 (discuss R-1.2/R-1.3 + sandwich + checklist)