### PR TITLE
fix(fill): inject narrative_function + add shadows/guidance to prose_only (Cluster F-10)

### DIFF
--- a/prompts/templates/fill_phase1_prose.yaml
+++ b/prompts/templates/fill_phase1_prose.yaml
@@ -18,6 +18,7 @@ system: |
   **Passage ID:** {passage_id}
   **Beat Summary:** {beat_summary}
   **Scene Type:** {scene_type}
+  **Narrative Function:** {narrative_function}
 
   ## Open Dramatic Questions
   {dramatic_questions}

--- a/prompts/templates/fill_phase1_prose_only.yaml
+++ b/prompts/templates/fill_phase1_prose_only.yaml
@@ -68,7 +68,6 @@ system: |
   ## Path Arcs
   {path_arcs}
 
-  ## Shadows (Non-Chosen Alternatives)
   {shadow_context}
 
   ## Vocabulary Note

--- a/prompts/templates/fill_phase1_prose_only.yaml
+++ b/prompts/templates/fill_phase1_prose_only.yaml
@@ -18,6 +18,7 @@ system: |
   **Passage ID:** {passage_id}
   **Beat Summary:** {beat_summary}
   **Scene Type:** {scene_type}
+  **Narrative Function:** {narrative_function}
 
   ## Open Dramatic Questions
   {dramatic_questions}
@@ -33,6 +34,18 @@ system: |
     Breathing room after intensity. Ground reactions in physical sensation or gesture.
   - **micro_beat**: Brief transition. 1 paragraph. Functional prose that moves
     the story forward without dwelling. Prefer a single concrete action or image.
+
+  ## Narrative Function Guidance
+  - **introduce**: Ground the reader. Establish new elements through sensory detail
+    and action, not exposition. End with a hook or question.
+  - **develop**: Deepen what is already known. Layer in contradiction, nuance, or
+    intimacy. Show character through choice, not description.
+  - **complicate**: Raise stakes or introduce obstacles. The reader should feel
+    the ground shift. End with the situation worse or more uncertain.
+  - **confront**: Direct engagement with tension. Strip away ambiguity. Force
+    characters (and reader) to face what they have been avoiding.
+  - **resolve**: Settle a thread. Provide earned clarity — not easy answers.
+    The resolution should feel inevitable in hindsight.
 
   ## Scene Blueprint
   {blueprint_context}
@@ -54,6 +67,9 @@ system: |
 
   ## Path Arcs
   {path_arcs}
+
+  ## Shadows (Non-Chosen Alternatives)
+  {shadow_context}
 
   ## Vocabulary Note
   {vocabulary_note}

--- a/src/questfoundry/pipeline/stages/fill.py
+++ b/src/questfoundry/pipeline/stages/fill.py
@@ -1479,6 +1479,7 @@ class FillStage:
                 ),
                 "residue_obligations": format_residue_weight_obligations(graph, passage_id),
                 "shadow_context": format_shadow_context(graph, passage_id, arc_id),
+                "narrative_function": narrative_function,
                 "introduction_guidance": format_introduction_guidance(
                     first_names,
                     arc_hints=compute_arc_hints(graph, first_eids, arc_id),


### PR DESCRIPTION
## Summary

Phase 3 Cluster F-10 from the [prompt-vs-spec audit](docs/superpowers/reports/2026-04-25-prompt-spec-audit.md). Closes #1435. Fixes 1 hard finding + 2 soft findings on FILL phase1 prose templates (audit lines 1418-1442).

## Findings addressed

| Severity | File | Fix |
|---|---|---|
| hard | fill_phase1_prose_only.yaml | Add \`## Shadows (Non-Chosen Alternatives)\` block + \`{shadow_context}\` placeholder. R-2.4 mandates shadows as required context; in two-step mode (\`_two_step=True\`) shadows were silently omitted even though already in the context dict. |
| soft | fill_phase1_prose_only.yaml | Add \`## Narrative Function Guidance\` static section copied from prose.yaml — two-step mode (the more demanding prose-only path) had less structural guidance than single-step. |
| soft | fill_phase1_prose*.yaml | Add \`**Narrative Function:** {narrative_function}\` line right after \`**Scene Type:**\` in BOTH templates so the model sees both values co-located, instead of inferring which guidance entry applies from beat_summary alone. |

## Code change

\`src/questfoundry/pipeline/stages/fill.py\` \`_fill_passage_call\` context dict: add \`narrative_function\` key. The value is already computed at line 1434 (\`beat.get("narrative_function", "develop")\`); just thread it through to the prompt.

## Spec citations

- \`fill.md §R-2.4\` — each LLM call receives full context including shadows
- \`fill.md §R-2.7\` — FILL generates prose per scene-type guidance
- \`fill.md §Implementation Constraints §Context Enrichment\` — shadows mandatory
- \`story-graph-ontology.md §Beat Annotations §Narrative function\`
- \`CLAUDE.md §10\` — small-model bias (constraint-to-value mapping)

## Tests

- \`uv run pytest tests/unit/test_fill*.py -x -q\` → **392 passed** (no regression)
- \`uv run mypy src/questfoundry/pipeline/stages/fill.py\` → clean