### PR TITLE
fix(dress): add R-3.6 spoiler-direction instruction at codex generation time (Cluster F-11)

### DIFF
--- a/prompts/templates/dress_codex.yaml
+++ b/prompts/templates/dress_codex.yaml
@@ -28,11 +28,29 @@ system: |
 
   {output_language_instruction}
 
+  ## Spoiler Direction (R-3.6, CRITICAL)
+
+  The DIRECTION of a spoiler is what matters. **Rank 1 may be deliberately
+  vague; rank 2+ may fully reveal — but rank 1 MUST NOT leak information
+  that rank 2+ is supposed to gate.** The lower-ranked (earlier-visible)
+  entry must not prematurely disclose content whose reveal is gated behind
+  a higher-ranked tier.
+
+  GOOD (rank 1 vague, rank 2 reveals):
+  - Rank 1 (always visible): "A traveling scholar who offers guidance — though some who travel with him say his counsel cuts deeper than expected."
+  - Rank 2 (gated behind `state_flag::met_aldric`): "Aldric is the traitor who betrayed your mentor."
+
+  BAD (rank 1 leaks the rank-2 reveal):
+  - Rank 1 (always visible): "A mysterious scholar who secretly knows your true identity."
+  - Rank 2 (gated behind `state_flag::met_aldric`): "Aldric is the traitor who betrayed your mentor." → Rank 1 already disclosed the deception angle that rank 2 was supposed to surface.
+
+  Before writing rank 1, ask: "Could this entry be read by a player who has not yet earned the rank-2 state flag, and would it spoil the rank-2 reveal?" If yes, rewrite rank 1 to be vaguer.
+
   ## Rules
   - Rank 1 entry MUST have empty visible_when (always visible to player)
   - Higher rank entries should require relevant state flags
   - Content must be diegetic — written as if it exists in the story world
-  - Do NOT spoil future plot events — each tier reveals only what the player has earned
+  - Apply Spoiler Direction (R-3.6) above — rank 1 must NOT leak rank 2+ reveals
   - State flag IDs in visible_when MUST be from the Available State Flags list above
   - Each rank must be unique — no duplicate rank numbers
   - Return ONLY valid JSON. No prose before or after.

--- a/prompts/templates/dress_codex.yaml
+++ b/prompts/templates/dress_codex.yaml
@@ -44,7 +44,7 @@ system: |
   - Rank 1 (always visible): "A mysterious scholar who secretly knows your true identity."
   - Rank 2 (gated behind `state_flag::met_aldric`): "Aldric is the traitor who betrayed your mentor." → Rank 1 already disclosed the deception angle that rank 2 was supposed to surface.
 
-  Before writing rank 1, ask: "Could this entry be read by a player who has not yet earned the rank-2 state flag, and would it spoil the rank-2 reveal?" If yes, rewrite rank 1 to be vaguer.
+  Before writing each rank, ask: "Could this entry be read by a player who has not yet earned the state flags for any higher-ranked tier, and would it spoil what a higher-ranked entry was meant to reveal?" If yes, rewrite the lower-ranked entry to be vaguer. Apply this between every adjacent rank pair (1↔2, 2↔3, 3↔4, etc.) — not just rank 1 vs rank 2.
 
   ## Rules
   - Rank 1 entry MUST have empty visible_when (always visible to player)

--- a/prompts/templates/dress_codex_batch.yaml
+++ b/prompts/templates/dress_codex_batch.yaml
@@ -43,7 +43,7 @@ system: |
   - Rank 1 (always visible): "A mysterious scholar who secretly knows your true identity."
   - Rank 2 (gated behind `state_flag::met_aldric`): "Aldric is the traitor who betrayed your mentor." → Rank 1 already disclosed the deception angle that rank 2 was supposed to surface.
 
-  Apply this per-entity: for EACH entity in the batch, before writing its rank 1, ask: "Could this entry be read by a player who has not yet earned the rank-2 state flag, and would it spoil the rank-2 reveal?" If yes, rewrite rank 1 to be vaguer.
+  Apply this per-entity: for EACH entity in the batch, before writing each rank, ask: "Could this entry be read by a player who has not yet earned the state flags for any higher-ranked tier, and would it spoil what a higher-ranked entry was meant to reveal?" If yes, rewrite the lower-ranked entry to be vaguer. Apply between every adjacent rank pair (1↔2, 2↔3, 3↔4, etc.) — not just rank 1 vs rank 2.
 
   ## Rules
   - Rank 1 entry MUST have empty visible_when (always visible to player)

--- a/prompts/templates/dress_codex_batch.yaml
+++ b/prompts/templates/dress_codex_batch.yaml
@@ -27,11 +27,29 @@ system: |
 
   {output_language_instruction}
 
+  ## Spoiler Direction (R-3.6, CRITICAL)
+
+  The DIRECTION of a spoiler is what matters. **Rank 1 may be deliberately
+  vague; rank 2+ may fully reveal — but rank 1 MUST NOT leak information
+  that rank 2+ is supposed to gate.** The lower-ranked (earlier-visible)
+  entry must not prematurely disclose content whose reveal is gated behind
+  a higher-ranked tier.
+
+  GOOD (rank 1 vague, rank 2 reveals):
+  - Rank 1 (always visible): "A traveling scholar who offers guidance — though some who travel with him say his counsel cuts deeper than expected."
+  - Rank 2 (gated behind `state_flag::met_aldric`): "Aldric is the traitor who betrayed your mentor."
+
+  BAD (rank 1 leaks the rank-2 reveal):
+  - Rank 1 (always visible): "A mysterious scholar who secretly knows your true identity."
+  - Rank 2 (gated behind `state_flag::met_aldric`): "Aldric is the traitor who betrayed your mentor." → Rank 1 already disclosed the deception angle that rank 2 was supposed to surface.
+
+  Apply this per-entity: for EACH entity in the batch, before writing its rank 1, ask: "Could this entry be read by a player who has not yet earned the rank-2 state flag, and would it spoil the rank-2 reveal?" If yes, rewrite rank 1 to be vaguer.
+
   ## Rules
   - Rank 1 entry MUST have empty visible_when (always visible to player)
   - Higher rank entries should require relevant state flags
   - Content must be diegetic — written as if it exists in the story world
-  - Do NOT spoil future plot events — each tier reveals only what the player has earned
+  - Apply Spoiler Direction (R-3.6) above — rank 1 must NOT leak rank 2+ reveals
   - State flag IDs in visible_when MUST be from the Available State Flags list above
   - Each rank must be unique per entity — no duplicate rank numbers
   - Return ONLY valid JSON. No prose before or after.


### PR DESCRIPTION
## Summary

Phase 3 Cluster F-11 from the [prompt-vs-spec audit](docs/superpowers/reports/2026-04-25-prompt-spec-audit.md). Closes #1437. Cross-cutting issue #4 from the DRESS Stage Summary (audit lines 1782-1788):

> 4. **Spoiler-direction rule absent from generation prompts** — \`dress_codex.yaml\` and \`dress_codex_batch.yaml\` have no R-3.6 instruction; spoiler avoidance is entirely reactive (post-hoc check) rather than proactive (instruction at generation time).

## Problem

Both templates only carried a generic \`"Do NOT spoil future plot events"\` rule. R-3.6 is more specific: the **direction** of the spoiler is what matters. Rank 1 may be deliberately vague; rank 2+ may fully reveal — but rank 1 MUST NOT leak information that rank 2+ is supposed to gate.

Currently this is only enforced **reactively** by \`dress_codex_spoiler_check.yaml\` running after generation. Catching the violation post-hoc costs a retry; teaching the rule at generation time prevents the violation in the first place.

## Fix

Add a dedicated \`## Spoiler Direction (R-3.6, CRITICAL)\` section to both \`dress_codex.yaml\` and \`dress_codex_batch.yaml\` with:

- Plain-English explanation of the directional rule
- GOOD/BAD example pair (mirrors the dress.md violations table line 152)
- Self-check question for the model to apply per entity

Also replace the generic "Do NOT spoil future plot events" rule line with a pointer to the new section.

The reactive \`dress_codex_spoiler_check.yaml\` stays as a safety net but should now run on already-clean output.

## Spec citations

- \`docs/design/procedures/dress.md §R-3.6\` — spoiler direction matters; rank 1 must not leak rank 2+
- \`docs/design/procedures/dress.md §R-3.7\` — \`visible_when\` uses state flag IDs (already correct in current prompts)
- \`CLAUDE.md §7\` — Defensive Prompt Patterns; GOOD/BAD examples mandatory

## Tests

- \`uv run pytest tests/unit/test_dress*.py -x -q\` → **210 passed** (no regression)