### PR TITLE
fix(seed): enforce single-path → hard classification in dilemma_analyses (Cluster F-12)

### DIFF
--- a/prompts/templates/serialize_seed_sections.yaml
+++ b/prompts/templates/serialize_seed_sections.yaml
@@ -936,8 +936,8 @@ dilemma_analyses_prompt: |
   For each remaining dilemma (still both-answers-explored), ask:
   "Could the SAME scene plausibly follow BOTH answers?"
   - YES, with meaningful or cosmetic differences -> `soft` (most common)
-  - NO, world states are incompatible -> `hard` (max 3 total including Pass 1
-    and the Pass 0 single-path overrides)
+  - NO, world states are incompatible -> `hard` (max 3 total from Pass 1+2
+    combined; Pass 0 single-path overrides are excluded from this cap)
 
   ## Convergence Policies
 

--- a/prompts/templates/serialize_seed_sections.yaml
+++ b/prompts/templates/serialize_seed_sections.yaml
@@ -890,17 +890,19 @@ dilemma_analyses_prompt: |
 
   Classify EVERY dilemma listed below based on its QUESTION and STAKES.
   A dilemma's question/stakes drive whether `hard` or `soft` is the
-  right *conceptual* answer.
+  right answer — `dilemma_role` is a property of the answer pair, not
+  of how many paths happened to be developed.
 
-  **Structural override (GROW R-6.4):** if a dilemma's `explored` list
-  contains only ONE answer (the other is a shadow), you MUST classify
-  it as `hard`. `soft` reserves a convergence beat where the two paths
-  rejoin — and with only one path, there is nothing for that beat to
-  merge with. GROW R-6.4 will halt loudly at convergence validation if
-  a single-path dilemma reaches it as `soft`. The structural override
-  takes precedence over the conceptual classification: a "naturally
-  soft" dilemma whose alternate answer was deliberately left as a
-  shadow is structurally `hard`.
+  **Single-path constraint (SEED R-7.6):** if a dilemma's `explored`
+  list contains only ONE answer (the other is a shadow), keep the
+  conceptual classification (`hard` or `soft` based on stakes) but set
+  `convergence_point: null`. With only one path, there is no second
+  path to converge with — so no convergence pointer applies. A
+  "naturally soft" dilemma whose alternate answer was deliberately
+  left as a shadow stays `soft`; only `convergence_point` is gated by
+  path count. GROW R-6.4 fires only when `convergence_point` is
+  non-null and the corresponding beat cannot be located; null
+  `convergence_point` skips that check.
 
   ## Why This Matters
 
@@ -918,26 +920,26 @@ dilemma_analyses_prompt: |
 
   ## Decision Process
 
-  Classify dilemmas in THREE passes:
-
-  ### Pass 0: Apply the structural override (GROW R-6.4)
-  For each dilemma, check the `explored` list from the SEED Dilemmas
-  Decisions section above. If `explored` contains only ONE answer (the
-  other is a shadow), the dilemma is structurally `hard` — no
-  conceptual analysis needed. Mark these now and skip them in Pass 1/2.
+  Classify dilemmas in TWO passes (path count does NOT change the role,
+  it only gates `convergence_point` — see R-7.6 above):
 
   ### Pass 1: Find the hardest dilemma
-  Among dilemmas with both answers explored, pick the ONE whose answers
-  create the MOST incompatible world states (someone lives vs dies,
-  identity irrevocably changed, key entity permanently destroyed).
-  Classify it as `hard`.
+  Read ALL dilemmas. Pick the ONE whose answers create the MOST
+  incompatible world states (someone lives vs dies, identity irrevocably
+  changed, key entity permanently destroyed). Classify it as `hard`.
 
   ### Pass 2: Classify the rest
-  For each remaining dilemma (still both-answers-explored), ask:
-  "Could the SAME scene plausibly follow BOTH answers?"
+  For each remaining dilemma, ask: "Could the SAME scene plausibly
+  follow BOTH answers?"
   - YES, with meaningful or cosmetic differences -> `soft` (most common)
-  - NO, world states are incompatible -> `hard` (max 3 total from Pass 1+2
-    combined; Pass 0 single-path overrides are excluded from this cap)
+  - NO, world states are incompatible -> `hard` (max 3 total per story).
+
+  ### Convergence Point pass (R-7.6)
+  After classifying each dilemma's role, set its `convergence_point`:
+  - If the dilemma's `explored` list has only ONE answer → `null`,
+    regardless of role.
+  - If `dilemma_role` is `hard` → `null` (paths never merge).
+  - Otherwise → a location-based, concrete description.
 
   ## Convergence Policies
 
@@ -972,21 +974,23 @@ dilemma_analyses_prompt: |
   - Different emotional tones (that is `soft`)
   - Choosing different allies or methods (usually `soft` — the destination is the same)
 
-  ## Single-Path Examples (GROW R-6.4 structural override)
+  ## Single-Path Examples (SEED R-7.6)
 
-  GOOD (single-path → forced `hard`):
+  GOOD (single-path soft, convergence_point null):
   - `dilemma::locket_planted_or_dropped`, `explored: ["planted"]`,
-    `unexplored: ["dropped"]` → classify as `hard`. Conceptually this
-    might read as soft (both answers describe the same investigation
-    outcome), but the `dropped` path was deliberately left as a shadow,
-    so there is no sibling path to converge with. `convergence_point: null`.
+    `unexplored: ["dropped"]` → classify as `dilemma_role: "soft"`
+    (both answers describe the same investigation outcome — the
+    conceptual classification stands), with `convergence_point: null`
+    (no second path to converge with — the structural pointer has
+    nothing to point at).
 
-  BAD (single-path classified `soft`):
+  BAD (single-path soft with non-null convergence_point):
   - Same input, classified as `dilemma_role: "soft"`,
     `convergence_point: "paths converge during final accusation scene"`
-    → GROW R-6.4 will halt: the "convergence" beat has no sibling path
-    to merge with. The reactive failure is loud and explicit; the
-    proactive fix is to follow the Pass 0 override here.
+    → GROW R-6.4 will halt: it tries to locate the convergence beat
+    and finds no sibling path to merge from. The conceptual role is
+    fine; only the structural pointer is wrong. Set
+    `convergence_point: null` for any single-path dilemma.
 
   ## payoff_budget
 
@@ -997,12 +1001,14 @@ dilemma_analyses_prompt: |
 
   ## Convergence Point
 
-  For `soft`: a **location-based, concrete** description of
-  where paths physically merge.
-  GOOD: "paths converge at archive_vault where evidence is revealed"
-  BAD: "paths merge emotionally in the final act" (abstract)
-
-  For `hard`: set convergence_point to null (paths never merge).
+  - For `soft` dilemmas with BOTH answers explored: a **location-based,
+    concrete** description of where paths physically merge.
+    GOOD: "paths converge at archive_vault where evidence is revealed"
+    BAD: "paths merge emotionally in the final act" (abstract)
+  - For `hard` dilemmas: `null` (paths never merge — separate endings).
+  - For ANY dilemma with only one answer in `explored` (the other is a
+    shadow): `null`, regardless of role (R-7.6). With one path there is
+    nothing to converge with.
 
   The residue_note describes differences persisting AFTER convergence.
   Set to null for `hard` dilemmas or when no differences persist.
@@ -1128,15 +1134,16 @@ dilemma_analyses_prompt: |
 
   ## Rules
   - Classify EVERY dilemma from the ### Valid Dilemma IDs list
-  - Classify based on the dilemma's QUESTION and STAKES — UNLESS Pass 0 applies (single explored answer → forced `hard` per GROW R-6.4)
-  - Follow the three-pass procedure above (Pass 0: structural override; Pass 1: find hardest; Pass 2: classify the rest)
+  - Classify based on the dilemma's QUESTION and STAKES; path count does NOT change the role (it only gates `convergence_point` per R-7.6)
+  - Follow the two-pass procedure above (Pass 1: find hardest; Pass 2: classify the rest), then run the Convergence Point pass
   - Do NOT classify as `hard` just because paths have different activities or approaches
   - Do NOT classify as `hard` unless convergence is IMPOSSIBLE (not just difficult)
+  - Do NOT downgrade a conceptually-soft dilemma to `hard` just because only one answer was explored — keep the role and set `convergence_point: null` (R-7.6)
   - If in doubt between `soft` and `hard`, check: does one answer involve death, destruction, or irrevocable identity change? If YES -> `hard`. If NO -> `soft`
   - `reasoning` must be 1-2 sentences explaining WHY (reference the question/stakes)
   - GOOD reasoning: "Homicide vs accident creates incompatible suspect lists and requires different endings."
   - BAD reasoning: "It is soft." / "Only one path."
-  - `convergence_point`: null for `hard`; location-based description for `soft`
+  - `convergence_point`: null for `hard`; null for any single-path dilemma (R-7.6); location-based description for `soft` with both answers explored
   - `residue_note`: null for `hard` or if no differences persist; short description otherwise
   - `ending_salience`: "low" for most dilemmas (default); "high" for 1-2 dilemmas whose choice should shape endings; "none" for cosmetic-only choices
   - `ending_salience` is INDEPENDENT of `dilemma_role` — a `soft` dilemma can be `high`, a `hard` dilemma can be `low`
@@ -1146,20 +1153,19 @@ dilemma_analyses_prompt: |
 
   ## Self-Check
   Count your classifications and verify ALL of these:
-  1. HARD count is 1-3 among **both-answers-explored** dilemmas. If 0
-     are hard among that subset: you skipped Pass 1 — go back and
-     classify the strongest both-answers dilemma as hard. If more than
-     3 are hard in that subset: demote the weakest to soft. (The Pass 0
-     single-path overrides do NOT count toward this 1-3 cap — they are
-     forced hard for structural reasons, not by stakes ranking.)
-  2. SOFT count is the majority among both-answers-explored dilemmas.
+  1. HARD count is 1-3. If 0 are hard: you skipped Pass 1 — go back
+     and classify the strongest dilemma as hard. If more than 3 are
+     hard: demote the weakest to soft.
+  2. SOFT count is the majority.
   3. Every entry has `dilemma_role` set to exactly `hard` or `soft` —
      no other values are accepted (R-7.1). The legacy `flavor` role was
      removed; never emit it.
-  4. **Path-count cross-check (GROW R-6.4):** for every entry classified
-     `soft`, the corresponding dilemma has BOTH answers in `explored`.
-     If a dilemma's `explored` list contains only ONE answer, it MUST
-     be `hard` with `convergence_point: null` — single-path soft will
+  4. **Convergence pointer cross-check (SEED R-7.6):** for every entry,
+     `convergence_point` is `null` if EITHER (a) `dilemma_role` is
+     `hard`, OR (b) the dilemma's `explored` list contains only ONE
+     answer (the other is a shadow). Non-null `convergence_point` is
+     only allowed for `soft` dilemmas with BOTH answers explored.
+     A non-null `convergence_point` on a single-path dilemma will
      halt GROW R-6.4.
   5. At most 2 have `ending_salience: "high"`.
   6. Every dilemma with `ending_tone` set also has `ending_salience: "high"`.
@@ -1167,19 +1173,17 @@ dilemma_analyses_prompt: |
 
   ## REMINDER
   Classify ALL dilemmas. Follow this procedure:
-  STEP 0 (GROW R-6.4 structural override): Check each dilemma's `explored` list.
-  If it contains only ONE answer (other is a shadow), mark it `hard` with
-  `convergence_point: null`. Skip these in STEP 1/2 — they are settled.
-  STEP 1: Among the REMAINING dilemmas (both answers explored), find your
-  STRONGEST one — the one where answers create the MOST incompatible
-  world states. Classify it as `hard`.
-  STEP 2: For each remaining both-answers-explored dilemma, ask: "Could the
-  SAME scene follow both answers?"
+  STEP 1: Find your STRONGEST dilemma — the one where answers create the MOST
+  incompatible world states. Classify it as `hard`.
+  STEP 2: For each remaining dilemma, ask: "Could the SAME scene follow both answers?"
     YES with differences -> soft. YES nearly identical -> soft with residue_weight: cosmetic.
-    NO (incompatible world states) -> hard (max 3 total in STEP 1+2 combined).
+    NO (incompatible world states) -> hard (max 3 total).
+  STEP 2b (R-7.6 convergence-pointer pass): For EACH dilemma you classified,
+  check its `explored` list. If it has only ONE answer (other is a shadow),
+  set `convergence_point: null` regardless of role. The role stays as
+  classified in STEP 1/2 — only the structural pointer is gated by path count.
   STEP 3: Count. Among both-answers dilemmas you should have 1-3 hard, majority soft.
-  If you have 0 hard among both-answers, go back to STEP 1.
-  (Pass 0 single-path overrides do NOT count toward this 1-3 cap.)
+  If you have 0 hard, go back to STEP 1.
   Set `ending_salience` and `residue_weight` for EVERY dilemma (required fields).
   Set `ending_tone` ONLY when `ending_salience` is "high", null otherwise.
 

--- a/prompts/templates/serialize_seed_sections.yaml
+++ b/prompts/templates/serialize_seed_sections.yaml
@@ -892,12 +892,12 @@ dilemma_analyses_prompt: |
   A dilemma's question/stakes drive whether `hard` or `soft` is the
   right *conceptual* answer.
 
-  **Structural override (R-7.4):** if a dilemma's `explored` list
+  **Structural override (GROW R-6.4):** if a dilemma's `explored` list
   contains only ONE answer (the other is a shadow), you MUST classify
   it as `hard`. `soft` reserves a convergence beat where the two paths
   rejoin — and with only one path, there is nothing for that beat to
-  merge with. GROW will halt loudly at convergence validation if a
-  single-path dilemma reaches it as `soft`. The structural override
+  merge with. GROW R-6.4 will halt loudly at convergence validation if
+  a single-path dilemma reaches it as `soft`. The structural override
   takes precedence over the conceptual classification: a "naturally
   soft" dilemma whose alternate answer was deliberately left as a
   shadow is structurally `hard`.
@@ -920,7 +920,7 @@ dilemma_analyses_prompt: |
 
   Classify dilemmas in THREE passes:
 
-  ### Pass 0: Apply the structural override (R-7.4)
+  ### Pass 0: Apply the structural override (GROW R-6.4)
   For each dilemma, check the `explored` list from the SEED Dilemmas
   Decisions section above. If `explored` contains only ONE answer (the
   other is a shadow), the dilemma is structurally `hard` — no
@@ -972,7 +972,7 @@ dilemma_analyses_prompt: |
   - Different emotional tones (that is `soft`)
   - Choosing different allies or methods (usually `soft` — the destination is the same)
 
-  ## Single-Path Examples (R-7.4 structural override)
+  ## Single-Path Examples (GROW R-6.4 structural override)
 
   GOOD (single-path → forced `hard`):
   - `dilemma::locket_planted_or_dropped`, `explored: ["planted"]`,
@@ -984,7 +984,7 @@ dilemma_analyses_prompt: |
   BAD (single-path classified `soft`):
   - Same input, classified as `dilemma_role: "soft"`,
     `convergence_point: "paths converge during final accusation scene"`
-    → GROW R-7.4 will halt: the "convergence" beat has no sibling path
+    → GROW R-6.4 will halt: the "convergence" beat has no sibling path
     to merge with. The reactive failure is loud and explicit; the
     proactive fix is to follow the Pass 0 override here.
 
@@ -1128,8 +1128,8 @@ dilemma_analyses_prompt: |
 
   ## Rules
   - Classify EVERY dilemma from the ### Valid Dilemma IDs list
-  - Classify based on the dilemma's QUESTION and STAKES, not path count
-  - Follow the two-pass procedure above (find hardest first, then classify the rest)
+  - Classify based on the dilemma's QUESTION and STAKES — UNLESS Pass 0 applies (single explored answer → forced `hard` per GROW R-6.4)
+  - Follow the three-pass procedure above (Pass 0: structural override; Pass 1: find hardest; Pass 2: classify the rest)
   - Do NOT classify as `hard` just because paths have different activities or approaches
   - Do NOT classify as `hard` unless convergence is IMPOSSIBLE (not just difficult)
   - If in doubt between `soft` and `hard`, check: does one answer involve death, destruction, or irrevocable identity change? If YES -> `hard`. If NO -> `soft`
@@ -1156,24 +1156,30 @@ dilemma_analyses_prompt: |
   3. Every entry has `dilemma_role` set to exactly `hard` or `soft` —
      no other values are accepted (R-7.1). The legacy `flavor` role was
      removed; never emit it.
-  4. **Path-count cross-check (R-7.4):** for every entry classified
+  4. **Path-count cross-check (GROW R-6.4):** for every entry classified
      `soft`, the corresponding dilemma has BOTH answers in `explored`.
      If a dilemma's `explored` list contains only ONE answer, it MUST
      be `hard` with `convergence_point: null` — single-path soft will
-     halt GROW.
+     halt GROW R-6.4.
   5. At most 2 have `ending_salience: "high"`.
   6. Every dilemma with `ending_tone` set also has `ending_salience: "high"`.
   7. At most 2 have `residue_weight: "heavy"`.
 
   ## REMINDER
   Classify ALL dilemmas. Follow this procedure:
-  STEP 1: Find your STRONGEST dilemma — the one where answers create the MOST
-  incompatible world states. Classify it as `hard`.
-  STEP 2: For each remaining dilemma, ask: "Could the SAME scene follow both answers?"
+  STEP 0 (GROW R-6.4 structural override): Check each dilemma's `explored` list.
+  If it contains only ONE answer (other is a shadow), mark it `hard` with
+  `convergence_point: null`. Skip these in STEP 1/2 — they are settled.
+  STEP 1: Among the REMAINING dilemmas (both answers explored), find your
+  STRONGEST one — the one where answers create the MOST incompatible
+  world states. Classify it as `hard`.
+  STEP 2: For each remaining both-answers-explored dilemma, ask: "Could the
+  SAME scene follow both answers?"
     YES with differences -> soft. YES nearly identical -> soft with residue_weight: cosmetic.
-    NO (incompatible world states) -> hard (max 3 total).
-  STEP 3: Count. You should have 1-3 hard, majority soft.
-  If you have 0 hard, go back to STEP 1.
+    NO (incompatible world states) -> hard (max 3 total in STEP 1+2 combined).
+  STEP 3: Count. Among both-answers dilemmas you should have 1-3 hard, majority soft.
+  If you have 0 hard among both-answers, go back to STEP 1.
+  (Pass 0 single-path overrides do NOT count toward this 1-3 cap.)
   Set `ending_salience` and `residue_weight` for EVERY dilemma (required fields).
   Set `ending_tone` ONLY when `ending_salience` is "high", null otherwise.
 

--- a/prompts/templates/serialize_seed_sections.yaml
+++ b/prompts/templates/serialize_seed_sections.yaml
@@ -888,9 +888,19 @@ per_path_beats_prompt: |
 dilemma_analyses_prompt: |
   You are classifying dilemma convergence policies for a SEED stage.
 
-  Classify EVERY dilemma listed below based on its QUESTION and STAKES, not
-  on how many paths it currently has. A dilemma with 1 surviving path can
-  still be `hard` if the question involves incompatible world states.
+  Classify EVERY dilemma listed below based on its QUESTION and STAKES.
+  A dilemma's question/stakes drive whether `hard` or `soft` is the
+  right *conceptual* answer.
+
+  **Structural override (R-7.4):** if a dilemma's `explored` list
+  contains only ONE answer (the other is a shadow), you MUST classify
+  it as `hard`. `soft` reserves a convergence beat where the two paths
+  rejoin — and with only one path, there is nothing for that beat to
+  merge with. GROW will halt loudly at convergence validation if a
+  single-path dilemma reaches it as `soft`. The structural override
+  takes precedence over the conceptual classification: a "naturally
+  soft" dilemma whose alternate answer was deliberately left as a
+  shadow is structurally `hard`.
 
   ## Why This Matters
 
@@ -908,17 +918,26 @@ dilemma_analyses_prompt: |
 
   ## Decision Process
 
-  Classify dilemmas in TWO passes:
+  Classify dilemmas in THREE passes:
+
+  ### Pass 0: Apply the structural override (R-7.4)
+  For each dilemma, check the `explored` list from the SEED Dilemmas
+  Decisions section above. If `explored` contains only ONE answer (the
+  other is a shadow), the dilemma is structurally `hard` — no
+  conceptual analysis needed. Mark these now and skip them in Pass 1/2.
 
   ### Pass 1: Find the hardest dilemma
-  Read ALL dilemmas. Pick the ONE whose answers create the MOST incompatible
-  world states (someone lives vs dies, identity irrevocably changed, key
-  entity permanently destroyed). Classify it as `hard`.
+  Among dilemmas with both answers explored, pick the ONE whose answers
+  create the MOST incompatible world states (someone lives vs dies,
+  identity irrevocably changed, key entity permanently destroyed).
+  Classify it as `hard`.
 
   ### Pass 2: Classify the rest
-  For each remaining dilemma, ask: "Could the SAME scene plausibly follow BOTH answers?"
+  For each remaining dilemma (still both-answers-explored), ask:
+  "Could the SAME scene plausibly follow BOTH answers?"
   - YES, with meaningful or cosmetic differences -> `soft` (most common)
-  - NO, world states are incompatible -> `hard` (max 3 total including Pass 1)
+  - NO, world states are incompatible -> `hard` (max 3 total including Pass 1
+    and the Pass 0 single-path overrides)
 
   ## Convergence Policies
 
@@ -952,6 +971,22 @@ dilemma_analyses_prompt: |
     or allegiance, in which case the triggers above apply)
   - Different emotional tones (that is `soft`)
   - Choosing different allies or methods (usually `soft` — the destination is the same)
+
+  ## Single-Path Examples (R-7.4 structural override)
+
+  GOOD (single-path → forced `hard`):
+  - `dilemma::locket_planted_or_dropped`, `explored: ["planted"]`,
+    `unexplored: ["dropped"]` → classify as `hard`. Conceptually this
+    might read as soft (both answers describe the same investigation
+    outcome), but the `dropped` path was deliberately left as a shadow,
+    so there is no sibling path to converge with. `convergence_point: null`.
+
+  BAD (single-path classified `soft`):
+  - Same input, classified as `dilemma_role: "soft"`,
+    `convergence_point: "paths converge during final accusation scene"`
+    → GROW R-7.4 will halt: the "convergence" beat has no sibling path
+    to merge with. The reactive failure is loud and explicit; the
+    proactive fix is to follow the Pass 0 override here.
 
   ## payoff_budget
 
@@ -1111,16 +1146,24 @@ dilemma_analyses_prompt: |
 
   ## Self-Check
   Count your classifications and verify ALL of these:
-  1. HARD count is 1-3. If 0 are hard: you skipped Pass 1 — go back and
-     classify the strongest dilemma as hard. If more than 3 are hard:
-     demote the weakest to soft.
-  2. SOFT count is the majority.
+  1. HARD count is 1-3 among **both-answers-explored** dilemmas. If 0
+     are hard among that subset: you skipped Pass 1 — go back and
+     classify the strongest both-answers dilemma as hard. If more than
+     3 are hard in that subset: demote the weakest to soft. (The Pass 0
+     single-path overrides do NOT count toward this 1-3 cap — they are
+     forced hard for structural reasons, not by stakes ranking.)
+  2. SOFT count is the majority among both-answers-explored dilemmas.
   3. Every entry has `dilemma_role` set to exactly `hard` or `soft` —
      no other values are accepted (R-7.1). The legacy `flavor` role was
      removed; never emit it.
-  4. At most 2 have `ending_salience: "high"`.
-  5. Every dilemma with `ending_tone` set also has `ending_salience: "high"`.
-  6. At most 2 have `residue_weight: "heavy"`.
+  4. **Path-count cross-check (R-7.4):** for every entry classified
+     `soft`, the corresponding dilemma has BOTH answers in `explored`.
+     If a dilemma's `explored` list contains only ONE answer, it MUST
+     be `hard` with `convergence_point: null` — single-path soft will
+     halt GROW.
+  5. At most 2 have `ending_salience: "high"`.
+  6. Every dilemma with `ending_tone` set also has `ending_salience: "high"`.
+  7. At most 2 have `residue_weight: "heavy"`.
 
   ## REMINDER
   Classify ALL dilemmas. Follow this procedure:


### PR DESCRIPTION
## Summary

**Blocked on PR #1443** (spec rule must land first per CLAUDE.md §Design Doc Authority). This PR was rewritten around the narrower R-7.6 framing once the spec direction was course-corrected.

Closes #1439. Surfaced by investigation of the \`projects/murder2/\` run failure: SEED produced \`dilemma::locket_planted_or_dropped\` with \`dilemma_role: "soft"\`, \`explored: ["planted"]\`, **\`convergence_point: "paths converge during final accusation scene"\`**. GROW R-6.4 caught the structural error correctly (no sibling path to merge from), but the SEED-side prompt should not have produced a non-null convergence_point for a single-path dilemma.

## Why the narrower rule (corrected from first draft)

The first draft of F-12 forced single-path dilemmas to \`dilemma_role: "hard"\`. **That was a category error.** \`dilemma_role\` is a property of the answer pair (does it create incompatible world states?), not of how many paths happened to be developed. The F-7 cluster's \`dilemmas_prompt\` already documents single-path soft as a legitimate "flavor" pattern.

The narrower rule preserves the conceptual classification and only constrains the structural pointer GROW reads:

- \`dilemma_role\` stays as classified by stakes — \`soft\` for naturally-soft dilemmas even when only one answer was explored.
- \`convergence_point\` MUST be null when \`explored\` has only one answer (R-7.6) — there's nothing to converge with.

## Changes

In \`prompts/templates/serialize_seed_sections.yaml dilemma_analyses_prompt\`:

1. **Replace "Structural override forces hard"** with "Single-path constraint (SEED R-7.6)": preserves role, gates \`convergence_point\` only.
2. **Restore Decision Process to 2 passes** (no Pass 0 forcing hard) plus a new "Convergence Point pass" applied per-dilemma after classification.
3. **Replace Single-Path Examples**: GOOD shows single-path soft with \`convergence_point: null\`; BAD shows single-path soft with non-null convergence_point.
4. **Update Convergence Point section**: explicit triple rule (hard → null; single-path → null per R-7.6; soft+both-explored → location-based).
5. **Update Rules**:
   - "Path count does NOT change the role (it only gates \`convergence_point\` per R-7.6)"
   - New guard: "Do NOT downgrade a conceptually-soft dilemma to hard just because only one answer was explored — keep the role and set \`convergence_point: null\`."
6. **Update Self-Check item 4**: "Convergence pointer cross-check" — \`convergence_point\` null iff (hard) OR (single-path), regardless of role.
7. **Update REMINDER**: drop STEP 0 (no role override); add STEP 2b (convergence-pointer pass).

## Spec citations

- \`docs/design/procedures/seed.md §R-7.6\` — single-path → \`convergence_point: null\` (added by PR #1443)
- \`docs/design/procedures/grow.md §R-6.4\` (line 448) — downstream convergence validator
- \`CLAUDE.md §Design Doc Authority\` — spec first, always

## Tests

- \`uv run pytest tests/unit/test_seed*.py tests/unit/test_serialize.py -x -q\` → **329 passed** (no regression)

## Related

- #1439 — original prompt-fix tracker (closes here)
- #1442 — spec gap (closed by PR #1443)
- PR #1443 — the spec PR this PR is blocked on