### PR TITLE
spec(seed): add R-7.6 — single-path Dilemma's convergence_point MUST be null

### DIFF
--- a/docs/design/procedures/seed.md
+++ b/docs/design/procedures/seed.md
@@ -422,6 +422,8 @@ R-7.4. `residue_weight` and `dilemma_role` are independent axes — a soft dilem
 
 R-7.5. If the LLM call fails, defaults are applied (role: soft, weight: light, salience: low) but the failure is logged at WARNING level with the Dilemma IDs affected. Silent default application is forbidden.
 
+R-7.6. When a Dilemma's `explored` list (from Phase 2) contains only one Answer, `convergence_point` MUST be `null` regardless of `dilemma_role`. With only one path, there is no structural convergence to point to. The conceptual classification (`hard` vs `soft`) is preserved — `soft` remains correct for a dilemma whose alternate answer was deliberately left as a shadow per the F-7 flavor pattern (only the default explored, single arc) — but the structural pointer is not applicable. GROW Phase 6 R-6.4 ("soft Dilemma without structural convergence → halt") fires only when `convergence_point` is non-null and the corresponding beat cannot be located; a null `convergence_point` skips that check, so single-path soft dilemmas pass GROW without a structural error.
+
 **Violations:**
 
 | Symptom | Root cause | Broken rule |
@@ -429,6 +431,7 @@ R-7.5. If the LLM call fails, defaults are applied (role: soft, weight: light, s
 | Dilemma has no `dilemma_role` field after Phase 7 | Phase 7 soft-failed and left the field unset | R-7.1 / R-7.5 |
 | Dilemma has `dilemma_role: flavor` | `flavor` is not a valid role (flavor-level choices are handled by POLISH false branches, not by dilemma role) | R-7.1 |
 | Phase 7 LLM failure produces no log entry | Silent default application | R-7.5 |
+| Dilemma has `explored: [a]`, `unexplored: [b]`, non-null `convergence_point` | Convergence pointer set despite no second path to converge with; will halt GROW R-6.4 unable to locate the beat | R-7.6 (downstream-validated by GROW R-6.4) |
 
 ### Output Contract
 
@@ -572,6 +575,7 @@ R-7.2: Every Dilemma has `residue_weight` ∈ {heavy, light, cosmetic}.
 R-7.3: Every Dilemma has `ending_salience` ∈ {high, low, none}.
 R-7.4: `residue_weight` and `dilemma_role` are independent axes.
 R-7.5: LLM failure in Phase 7 logged at WARNING; no silent defaults.
+R-7.6: Single-explored-Answer Dilemma MUST have `convergence_point: null` regardless of `dilemma_role`; downstream-validated by GROW R-6.4.
 R-8.1: Valid relationships: wraps, concurrent, serial.
 R-8.2: Relationships declared only for relevant pairs; exhaustive O(n²) is wasteful but acceptable when ambiguity-removing.
 R-8.3: `concurrent` is symmetric; stored once with lex-smaller ID as `dilemma_a`.


### PR DESCRIPTION
## Summary

Closes #1442. Codifies the structural invariant surfaced by the \`projects/murder2/\` run failure: when a Dilemma's \`explored\` list contains only one Answer, \`convergence_point\` MUST be null regardless of \`dilemma_role\`.

**Per CLAUDE.md §Design Doc Authority — "spec first, always":** PR #1441 (Cluster F-12 prompt fix) is **blocked on this PR**. Once R-7.6 lands, F-12 rewrites around the narrower rule.

## Why this rule (not the wrong-direction first draft)

The first draft of R-7.6 forced single-path dilemmas to \`dilemma_role: "hard"\`. **That was a category error**: \`dilemma_role\` is a property of the QUESTION/STAKES (does this answer pair create incompatible world states?), not of how many paths happened to be developed. The F-7 cluster's own \`dilemmas_prompt\` spells this out:

> \"'Soft' dilemmas (only the default explored) add flavor without adding branching arcs.\"

Forcing such a dilemma to \`hard\` would break the conceptual classification to suit the structural validator.

The narrower rule preserves the conceptual classification and only constrains the structural pointer GROW reads:

- \`dilemma_role\` stays \`soft\` for a "naturally soft" dilemma whose alternate answer was deliberately left as a shadow.
- \`convergence_point\` MUST be null because there is no second path to converge with.
- GROW R-6.4 only fires when \`convergence_point\` is non-null and the corresponding beat cannot be located; a null \`convergence_point\` skips the check, so single-path soft dilemmas pass GROW without a structural error.

## Trigger

\`projects/murder2/\` graph.db had:

\`\`\`
"locket_planted_or_dropped": {
  "dilemma_role": "soft",                                     # correct (semantic)
  "explored": ["planted"],
  "unexplored": ["dropped"],
  "convergence_point": "paths converge during final accusation scene"   # WRONG
}
\`\`\`

The bug is in the last field — SEED set a non-null \`convergence_point\` for a single-path dilemma. GROW R-6.4 caught it correctly, but the SEED-side prompt should not have produced it.

## Changes (4 lines, 1 file)

1. **New \`R-7.6\` rule** in \`docs/design/procedures/seed.md §Phase 7 §Rules\`.
2. **New entry in §Phase 7 Violations table** for the murder2-style symptom.
3. **New entry in §Rule Index footer**.

## Spec citations

- \`docs/design/procedures/seed.md §Phase 7\` — Dilemma Analysis (this PR adds R-7.6)
- \`docs/design/procedures/grow.md §R-6.4\` (line 448) — downstream convergence validator
- \`CLAUDE.md §Design Doc Authority\` — spec first, always

## Related

- #1439 — original prompt-fix tracker (will be retargeted to the narrower rule once spec lands)
- #1442 — this spec gap (closed by this PR)
- PR #1441 (Cluster F-12) — blocked on this PR; will rewrite around the narrower rule after merge