### PR TITLE
spec(grow): scope R-6.4 to two-path soft Dilemmas; exempt single-path

### DIFF
--- a/docs/design/procedures/grow.md
+++ b/docs/design/procedures/grow.md
@@ -445,21 +445,23 @@ R-6.2. `convergence_payoff` is the minimum count of path-exclusive beats (includ
 
 R-6.3. Hard Dilemmas have `converges_at: null` and `convergence_payoff: null`. Paths never rejoin.
 
-R-6.4. If a soft Dilemma has no structural convergence beat (e.g., paths lead to different endings), this is a classification error — the Dilemma should be hard. Halt with error identifying the Dilemma.
+R-6.4. If a soft Dilemma **with two explored paths** has no structural convergence beat (e.g., paths lead to different endings), this is a classification error — the Dilemma should be hard. Halt with error identifying the Dilemma. The two-path scope matches the Operations header above: single-path soft Dilemmas are not processed by Phase 6 and are not subject to R-6.4. Single-path soft is a legitimate "flavor" pattern (per SEED Phase 2 R-2.2 — non-canonical Answers may be `shadow`); such a Dilemma keeps `dilemma_role: soft` but `converges_at` and `convergence_payoff` stay null because there is no second path to converge with.
 
 **Violations:**
 
 | Symptom | Root cause | Broken rule |
 |---------|-----------|-------------|
 | Hard Dilemma has `converges_at` set | Mis-applied to hard role | R-6.3 |
-| Soft Dilemma has `converges_at: null` but paths do rejoin in DAG | Computation skipped | R-6.1 |
-| Soft Dilemma's paths never rejoin and GROW proceeds | Should have halted with classification error | R-6.4 |
+| Soft Dilemma with two explored paths has `converges_at: null` but paths do rejoin in DAG | Computation skipped | R-6.1 |
+| Soft Dilemma with two explored paths never rejoins and GROW proceeds | Should have halted with classification error | R-6.4 |
+| Single-path soft Dilemma triggers a Phase 6 halt | R-6.4 applied beyond its two-path scope | R-6.4 (mis-application) |
 
 ### Output Contract
 
-1. Every soft Dilemma has `converges_at` (beat ID) and `convergence_payoff` (integer) populated from DAG topology.
+1. Every soft Dilemma **with two explored paths** has `converges_at` (beat ID) and `convergence_payoff` (integer) populated from DAG topology.
 2. Every hard Dilemma has both fields null.
-3. No soft Dilemma survives without a convergence beat.
+3. Every single-path soft Dilemma has both fields null (no second path to converge with — per R-6.4 single-path scope).
+4. No soft Dilemma with two explored paths survives without a convergence beat.
 
 ---
 
@@ -558,7 +560,7 @@ R-8.4. Pruning never deletes a beat that has `belongs_to` to an explored Path �
 7. Every Consequence has ≥1 associated State Flag node with a `derived_from` edge.
 8. State flag names express world state, not player actions.
 9. Entity nodes have overlay lists activated by state flags; overlays are embedded, not separate nodes.
-10. Every soft Dilemma has `converges_at` and `convergence_payoff` populated from DAG topology.
+10. Every soft Dilemma with two explored paths has `converges_at` and `convergence_payoff` populated from DAG topology; single-path soft Dilemmas have both fields null (per R-6.4 single-path scope).
 11. Every hard Dilemma has `converges_at: null` and `convergence_payoff: null`.
 12. No Passage, Choice, variant passage, residue beat, or character arc metadata exists.
 13. No cycles in `predecessor` edges.
@@ -639,7 +641,7 @@ R-5.8: Hard and soft Dilemmas both produce overlays.
 R-6.1: `converges_at` computed from DAG reachability.
 R-6.2: `convergence_payoff` is min exclusive-beat count per path.
 R-6.3: Hard Dilemmas have both fields null.
-R-6.4: Soft Dilemma without structural convergence → halt (classification error).
+R-6.4: Soft Dilemma with TWO explored paths and no structural convergence → halt (classification error). Single-path soft Dilemmas are out of scope.
 R-7.1: Arc traversal walks `predecessor` successors; follows path at forks.
 R-7.2: Arcs computed, not stored (materialized uses `materialized_` prefix).
 R-7.3: Every arc reaches a terminal beat.
@@ -699,7 +701,8 @@ R-8.4: Path-member beats that are unreachable are structural bugs, not pruning t
 | 2 | All intersection candidates rejected | Silent degradation check | Halt ERROR (not warning) |
 | 3 | Hint cycles slip through (`interleave_cycle_skipped`) | Phase 4a detection | Halt — Phase 3 invariant violated |
 | 4c | Transition drafting LLM fails | LLM timeout/error | Retry once; if still failing, insert placeholder transition beat and log WARNING |
-| 6 | Soft dilemma has no convergence beat | R-6.4 check | Halt — classification error in SEED |
+| 6 | Soft dilemma with TWO explored paths has no convergence beat | R-6.4 check | Halt — classification error in SEED |
+| 6 | Single-path soft Dilemma reaches Phase 6 | R-6.4 single-path scope | Skip — legitimate "flavor" pattern; `converges_at`/`convergence_payoff` stay null |
 | 7 | Arc has dead end | Reachability check | Re-run Phase 2 (intersection) or abort to SEED |
 
 ## Context Management

--- a/docs/design/procedures/grow.md
+++ b/docs/design/procedures/grow.md
@@ -445,7 +445,7 @@ R-6.2. `convergence_payoff` is the minimum count of path-exclusive beats (includ
 
 R-6.3. Hard Dilemmas have `converges_at: null` and `convergence_payoff: null`. Paths never rejoin.
 
-R-6.4. If a soft Dilemma **with two explored paths** has no structural convergence beat (e.g., paths lead to different endings), this is a classification error — the Dilemma should be hard. Halt with error identifying the Dilemma. The two-path scope matches the Operations header above: single-path soft Dilemmas are not processed by Phase 6 and are not subject to R-6.4. Single-path soft is a legitimate "flavor" pattern (per SEED Phase 2 R-2.2 — non-canonical Answers may be `shadow`); such a Dilemma keeps `dilemma_role: soft` but `converges_at` and `convergence_payoff` stay null because there is no second path to converge with.
+R-6.4. If a soft Dilemma **with two explored paths** has no structural convergence beat (e.g., paths lead to different endings), this is a classification error — the Dilemma should be hard. Halt with error identifying the Dilemma. The two-path scope matches the Operations header above: single-path soft Dilemmas are not processed by Phase 6 and are not subject to R-6.4. Single-path soft is a legitimate **locked-dilemma shadow** pattern (per SEED Phase 2 R-2.2 — non-canonical Answers may be `shadow`; see `how-branching-stories-work.md` §Common Language for the term); such a Dilemma keeps `dilemma_role: soft` but `converges_at` and `convergence_payoff` stay null because there is no second path to converge with. (Note: a Dilemma where SEED Phase 4 R-4.4 convergence-failure loop-back triggered drops the non-canonical path and is "effectively hard"; SEED Phase 7 should reclassify it to `dilemma_role: hard` before GROW runs, so it never reaches Phase 6 as single-path soft.)
 
 **Violations:**
 
@@ -702,7 +702,7 @@ R-8.4: Path-member beats that are unreachable are structural bugs, not pruning t
 | 3 | Hint cycles slip through (`interleave_cycle_skipped`) | Phase 4a detection | Halt — Phase 3 invariant violated |
 | 4c | Transition drafting LLM fails | LLM timeout/error | Retry once; if still failing, insert placeholder transition beat and log WARNING |
 | 6 | Soft dilemma with TWO explored paths has no convergence beat | R-6.4 check | Halt — classification error in SEED |
-| 6 | Single-path soft Dilemma reaches Phase 6 | R-6.4 single-path scope | Skip — legitimate "flavor" pattern; `converges_at`/`convergence_payoff` stay null |
+| 6 | Single-path soft Dilemma reaches Phase 6 | R-6.4 single-path scope | Skip — legitimate locked-dilemma shadow pattern; `converges_at`/`convergence_payoff` stay null |
 | 7 | Arc has dead end | Reachability check | Re-run Phase 2 (intersection) or abort to SEED |
 
 ## Context Management


### PR DESCRIPTION
## Summary

Closes #1442 and #1439. Fixes the actual layer where the \`projects/murder2/\` failure originated — not the layer where the symptom surfaced.

## Why this rule (after two wrong-direction attempts)

PR #1443 (closed) tried SEED Phase 7 R-7.6. PR #1441 (closed) tried the matching prompt change in \`serialize_seed_sections.yaml\`. Both were in the wrong layer:

- \`convergence_point\` (SEED, prose hint) and \`converges_at\` (GROW, computed beat ID from DAG reachability) are **different fields at different layers**. R-6.4 reads the GROW-computed \`converges_at\`, not the SEED-declared hint.
- GROW Phase 6's Operations header (\`grow.md:438\`) explicitly scopes the operation to *"each Dilemma with \`dilemma_role: soft\` and **two explored paths**"*. A single-path soft Dilemma is not processed.
- But R-6.4's halt wording (\`grow.md:448\`, original) said only *"if a soft Dilemma has no structural convergence beat"* — without the two-path qualifier. So \`converges_at\` stays null for a single-path soft (Phase 6 didn't process it), and R-6.4 fires reading that null.

**The bug is the wording mismatch between the Operations header (scoped) and R-6.4 (unscoped).** Aligning the wordings is the actual fix.

## Changes (1 file, 4 deltas)

1. **R-6.4 wording** — add "with two explored paths" qualifier; new sentence explaining single-path soft is the legitimate F-7 "flavor" pattern (per SEED Phase 2 R-2.2 — non-canonical Answers may be \`shadow\`); explicitly state single-path soft Dilemmas keep \`dilemma_role: soft\` with both convergence fields null.
2. **Phase 6 §Violations table** — row text scoped to "with two explored paths"; new row for the mis-application case.
3. **Phase 6 §Output Contract** — split item 1 into "two-path soft has computed fields" + new item 3 "single-path soft has both null"; item 4 (was 3) scoped to two-path.
4. **§Stage Output Contract item 10** + **§Rule Index R-6.4 entry** + **§Troubleshooting table** — all updated to carry the two-path scope and exempt single-path soft.

## Layering correctness (per CLAUDE.md §Design Doc Authority)

- Spec change goes in the layer where the rule lives. R-6.4 is GROW Phase 6's halt rule; the fix lives here.
- No SEED-side spec change is required. SEED's \`dilemma_role\` semantics stay intact (a "naturally soft" dilemma is still \`soft\`).
- No prompt change is strictly required either. The murder2 SEED prompt output was conceptually correct; the SEED prompt's \`convergence_point\` hint is unused for single-path soft after this rule lands.

## Trigger

\`projects/murder2/\` graph.db: \`dilemma::locket_planted_or_dropped\` with \`dilemma_role: "soft"\`, \`explored: ["planted"]\`, GROW Phase 6 halted at R-6.4 because \`converges_at\` was null. After this rule, that exact same input passes Phase 6 cleanly — the operation skips it (already-correct Operations-header behavior) and R-6.4 no longer mis-applies.

## Tests

- \`uv run pytest tests/unit/test_grow*.py -x -q\` → **589 passed** (no regression)

The spec change does not yet require a code change; GROW's existing Phase 6 implementation already skips single-path soft per the Operations header — the spec rule was just lagging the implementation.

## Related (closed)

- PR #1441 — wrong-layer SEED prompt change
- PR #1443 — wrong-layer SEED spec change
- #1439 — original prompt-fix tracker (closes here)
- #1442 — spec gap tracker (closes here)