### PR TITLE
chore: rewrite CLAUDE.md §6-§10 citations as @prompt-engineer Rule 1-5

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -180,18 +180,6 @@ For *adding a new stage* or substantively reshaping an existing one (orchestrato
 
 For *debugging output that came back wrong*, use the **`questfoundry-llm-debugging`** skill.
 
-**Citation map for prior `CLAUDE.md §6–§10` references.** Earlier code, tests, and audit reports cite these section numbers. The rules now live in the `@prompt-engineer` subagent — same content, renamed:
-
-| Old citation | New location |
-|---|---|
-| `CLAUDE.md §6` Valid ID Injection | `@prompt-engineer` Rule 1 |
-| `CLAUDE.md §7` Defensive Prompt Patterns | `@prompt-engineer` Rule 2 |
-| `CLAUDE.md §8` Context Enrichment | `@prompt-engineer` Rule 3 |
-| `CLAUDE.md §9` Prompt Context Formatting | `@prompt-engineer` Rule 4 |
-| `CLAUDE.md §10` Small-Model Bias | `@prompt-engineer` Rule 5 |
-
-Existing inline comments that cite the old numbers can be updated opportunistically; not required for this PR.
-
 ---
 
 ## Configuration (Pointer)

--- a/src/questfoundry/agents/serialize.py
+++ b/src/questfoundry/agents/serialize.py
@@ -235,7 +235,7 @@ async def serialize_to_artifact(
             the validation-failure feedback message on every retry attempt. Used
             to echo expected values for constraint-to-value mappings the model
             loses across long context (e.g. SEED shared-beats `also_belongs_to`
-            sibling path id). Per CLAUDE.md §10, the model does not re-read the
+            sibling path id). Per @prompt-engineer Rule 5, the model does not re-read the
             system prompt on retry — only the new user-message — so the hint
             must be self-contained.
 
@@ -492,7 +492,7 @@ def _build_error_feedback(errors: list[str], extra_hints: list[str] | None = Non
             generic feedback. Used to echo expected values for
             constraint-to-value mappings the model loses across long
             context (e.g. SEED shared-beats `also_belongs_to` value
-            template — see CLAUDE.md §10 small-model repair-loop
+            template — see @prompt-engineer Rule 5 small-model repair-loop
             blindness).
 
     Returns:
@@ -1231,7 +1231,7 @@ async def _serialize_shared_beats_for_dilemma(
     # Per-attempt repair hint — the validator's `also_belongs_to`-missing
     # error names the field but doesn't echo the value, and small models
     # (qwen3:4b production default) lose the constraint-to-value mapping
-    # across retry attempts (CLAUDE.md §10 small-model repair-loop
+    # across retry attempts (@prompt-engineer Rule 5 small-model repair-loop
     # blindness — the model doesn't re-read the system prompt on retry).
     # The hint is dilemma-specific so it always applies to this call.
     also_belongs_to_hint = (

--- a/src/questfoundry/graph/dress_context.py
+++ b/src/questfoundry/graph/dress_context.py
@@ -238,7 +238,7 @@ def format_entity_for_codex(graph: Graph, entity_id: str) -> str:
             continue
         flag_str = ", ".join(f"`{f}`" for f in flags)
         # Format list values explicitly to avoid leaking Python repr
-        # (brackets/quotes) into LLM-facing text per CLAUDE.md §9 rule 1.
+        # (brackets/quotes) into LLM-facing text per @prompt-engineer Rule 4.
         # Sorted for deterministic output across runs.
         detail_str = "; ".join(
             f"{k}: {', '.join(map(str, v)) if isinstance(v, list) else v}"

--- a/src/questfoundry/graph/polish_context.py
+++ b/src/questfoundry/graph/polish_context.py
@@ -80,7 +80,7 @@ def format_linear_section_context(
         impacts = data.get("dilemma_impacts", [])
         entities = data.get("entities", [])
 
-        # Backtick-wrap IDs per CLAUDE.md §9 rule 1.
+        # Backtick-wrap IDs per @prompt-engineer Rule 4.
         impact_str = ""
         if impacts:
             effects = [
@@ -159,7 +159,7 @@ def format_pacing_context(
     pacing_issues = "\n".join(issue_lines) if issue_lines else "No pacing issues detected."
 
     # Valid entity IDs for micro-beat entity references (backtick-wrapped per
-    # CLAUDE.md §9 rule 1, with `(none)` fallback matching the sibling
+    # @prompt-engineer Rule 4, with `(none)` fallback matching the sibling
     # render functions).
     valid_entity_ids = ", ".join(f"`{e}`" for e in sorted(entity_nodes.keys())) or "(none)"
 
@@ -220,7 +220,7 @@ def format_entity_arc_context(
             effects = [imp.get("effect", "?") for imp in impacts]
             impact_str = f" dilemma_effects=[{', '.join(effects)}]"
 
-        # Backtick-wrap IDs per CLAUDE.md §9 rule 1 — consistent with the
+        # Backtick-wrap IDs per @prompt-engineer Rule 4 — consistent with the
         # other ID lists this context dict produces, so a model matching beat
         # IDs against `valid_beat_ids` doesn't have to mentally strip backticks.
         if not path_set:
@@ -249,10 +249,10 @@ def format_entity_arc_context(
         flags = overlay.get("when") or []
         details = overlay.get("details") or {}
         if flags and details:
-            # Backtick-wrap flag IDs per CLAUDE.md §9 rule 1.
+            # Backtick-wrap flag IDs per @prompt-engineer Rule 4.
             flag_str = ", ".join(f"`{f}`" for f in flags)
             # Format list values explicitly to avoid leaking Python repr
-            # (brackets/quotes) into LLM-facing text per CLAUDE.md §9 rule 1.
+            # (brackets/quotes) into LLM-facing text per @prompt-engineer Rule 4.
             # Sorted for deterministic output across runs.
             detail_str = "; ".join(
                 f"{k}: {', '.join(map(str, v)) if isinstance(v, list) else v}"
@@ -269,7 +269,7 @@ def format_entity_arc_context(
         if edge["from"] == entity_id:
             anchored_dilemmas.append(edge["to"])
 
-    # Backtick-wrap IDs per CLAUDE.md §9 rule 1.
+    # Backtick-wrap IDs per @prompt-engineer Rule 4.
     anchored_text = (
         ", ".join(f"`{d}`" for d in anchored_dilemmas) if anchored_dilemmas else "(none)"
     )
@@ -332,7 +332,7 @@ def format_choice_label_context(
         from_summary = truncate_summary(from_spec.get("summary", ""), 80)
         to_summary = truncate_summary(to_spec.get("summary", ""), 80)
 
-        # Backtick-wrap IDs per CLAUDE.md §9 rule 1.
+        # Backtick-wrap IDs per @prompt-engineer Rule 4.
         grants_str = f" grants: {', '.join(f'`{g}`' for g in grants)}" if grants else ""
         choice_lines.append(
             f"  {i + 1}. From: `{from_id}` ({from_summary})\n"
@@ -340,7 +340,7 @@ def format_choice_label_context(
         )
 
     # Valid passage IDs: every passage_id referenced by any ChoiceSpec, sorted
-    # for determinism. Per CLAUDE.md §6 the LLM must receive an explicit Valid
+    # for determinism. Per @prompt-engineer Rule 1 the LLM must receive an explicit Valid
     # IDs list rather than be expected to derive IDs from the choice details
     # block — small models otherwise invent or mangle passage IDs and Phase 6
     # fails to wire choice edges.
@@ -392,7 +392,7 @@ def format_residue_content_context(
         target_spec = passage_lookup.get(target, {})
         target_summary = truncate_summary(target_spec.get("summary", ""), 80)
 
-        # Backtick-wrap IDs per CLAUDE.md §9 rule 1.
+        # Backtick-wrap IDs per @prompt-engineer Rule 4.
         residue_lines.append(
             f"  - residue_id: `{residue_id}` flag: `{flag}` path: `{path_id}`\n"
             f"    Target passage: `{target}` ({target_summary})"
@@ -425,7 +425,7 @@ def format_false_branch_context(
         passage_lookup[spec["passage_id"]] = spec
 
     entity_nodes = graph.get_nodes_by_type("entity")
-    # Backtick-wrap IDs per CLAUDE.md §9 rule 1, with `(none)` fallback.
+    # Backtick-wrap IDs per @prompt-engineer Rule 4, with `(none)` fallback.
     valid_entity_ids = ", ".join(f"`{e}`" for e in sorted(entity_nodes.keys())) or "(none)"
 
     candidate_lines: list[str] = []
@@ -482,7 +482,7 @@ def format_variant_summary_context(
         base_spec = passage_lookup.get(base_id, {})
         base_summary = truncate_summary(base_spec.get("summary", ""), 80)
 
-        # Backtick-wrap IDs per CLAUDE.md §9 rule 1.
+        # Backtick-wrap IDs per @prompt-engineer Rule 4.
         requires_str = ", ".join(f"`{r}`" for r in requires) if requires else "(none)"
         variant_lines.append(
             f"  - variant_id: `{variant_id}` base: `{base_id}` ({base_summary})\n"

--- a/src/questfoundry/pipeline/stages/dress.py
+++ b/src/questfoundry/pipeline/stages/dress.py
@@ -532,7 +532,7 @@ class DressStage:
         if self._unload_after_summarize is not None:
             await self._unload_after_summarize()
 
-        # Phase 3: Serialize. Backtick-wrap IDs per CLAUDE.md §9 rule 1.
+        # Phase 3: Serialize. Backtick-wrap IDs per @prompt-engineer Rule 4.
         entity_ids = "\n".join(
             f"- `{edata.get('raw_id', strip_scope_prefix(eid))}`" for eid, edata in entities.items()
         )

--- a/src/questfoundry/pipeline/stages/fill.py
+++ b/src/questfoundry/pipeline/stages/fill.py
@@ -769,7 +769,7 @@ class FillStage:
         else:
             parts.append("\nPlease fix the errors and try again.")
 
-        # Per CLAUDE.md §6 / §repair-loop quality: echo allowed Literal values
+        # Per @prompt-engineer Rule 1 / §repair-loop quality: echo allowed Literal values
         # for any invalid Literal-typed field so the model can self-correct
         # instead of guessing again. Skipped on structural failures because
         # those carry the "fix ONLY the structural issue" instruction above —
@@ -782,7 +782,7 @@ class FillStage:
                 if values is not None:
                     # Backtick-wrap each value for consistency with the SEED
                     # repair-feedback pattern (serialize.py) and the prompts
-                    # themselves (CLAUDE.md §9 rule 1).
+                    # themselves (@prompt-engineer Rule 4).
                     formatted = ", ".join(f"`{v}`" for v in values)
                     literal_hints.append(f"Allowed values for `{field_path}`: {formatted}")
             if literal_hints:
@@ -1955,7 +1955,7 @@ class FillStage:
             if node:
                 passage_data[passage_id] = node
 
-        # Valid entity IDs (raw, sorted, backtick-wrapped per CLAUDE.md §9 rule 1).
+        # Valid entity IDs (raw, sorted, backtick-wrapped per @prompt-engineer Rule 4).
         # Hoisted out of the per-passage closure since entities don't change
         # during revision — matches the pre-computation pattern above.
         valid_entity_id_list = sorted(

--- a/tests/unit/test_dress_context.py
+++ b/tests/unit/test_dress_context.py
@@ -189,7 +189,7 @@ class TestFormatEntityForCodex:
 
         result = format_entity_for_codex(dress_graph, "character::aldric")
         assert "### Overlays (path-specific arcs)" in result
-        # Both overlays present, with backtick-wrapped state flag IDs (CLAUDE.md §9).
+        # Both overlays present, with backtick-wrapped state flag IDs (@prompt-engineer Rule 4).
         assert "`state_flag::met_aldric`" in result
         assert "`state_flag::trusted_aldric`" in result
         assert "`state_flag::betrayed_aldric`" in result
@@ -248,7 +248,7 @@ class TestFormatEntityForCodex:
 
     def test_overlay_list_values_render_human_readable(self, dress_graph: Graph) -> None:
         """List-valued details render as comma-joined strings (e.g. `umm, well`)
-        — never as Python repr (`['umm', 'well']`) per CLAUDE.md §9 rule 1."""
+        — never as Python repr (`['umm', 'well']`) per @prompt-engineer Rule 4."""
         from questfoundry.graph.dress_context import format_entity_for_codex
 
         dress_graph.update_node(

--- a/tests/unit/test_fill_stage.py
+++ b/tests/unit/test_fill_stage.py
@@ -1108,7 +1108,7 @@ class TestPhase3Revision:
         """The revision call MUST inject `valid_entity_ids` into the prompt
         context AND pass it as `extra_repair_hints` so the constraint survives
         context drift on retry. Closes the FILL §fill_phase3_revision audit
-        finding (CLAUDE.md §6 Valid ID Injection)."""
+        finding (@prompt-engineer Rule 1 Valid ID Injection)."""
         graph = _make_reviewed_graph()
         graph.create_node(
             "entity::kay",
@@ -1155,7 +1155,7 @@ class TestPhase3Revision:
         assert "valid_entity_ids" in captured_context
         valid_ids_text = captured_context["valid_entity_ids"]
         assert "kay" in valid_ids_text  # raw_id of the entity created above
-        assert "`kay`" in valid_ids_text  # backtick-wrapped per CLAUDE.md §9 rule 1
+        assert "`kay`" in valid_ids_text  # backtick-wrapped per @prompt-engineer Rule 4
 
         # Same constraint also flows as a retry hint so it survives context drift.
         assert captured_hints is not None

--- a/tests/unit/test_polish_context.py
+++ b/tests/unit/test_polish_context.py
@@ -193,8 +193,8 @@ class TestFormatEntityArcContext:
         assert ctx["entity_id"] == "entity::mentor"
         assert ctx["entity_name"] == "The Mentor"
         assert "wise guide" in ctx["entity_description"]
-        # IDs in beat_appearances lines are backtick-wrapped per @prompt-engineer Rule 4
-        # rule 1 — matches the valid_*_ids lists so a model doesn't need to
+        # IDs in beat_appearances lines are backtick-wrapped per @prompt-engineer
+        # Rule 4 — matches the valid_*_ids lists so a model doesn't need to
         # mentally strip backticks when matching IDs across surfaces.
         assert "`beat::intro`" in ctx["beat_appearances"]
         assert "`beat::reveal`" in ctx["beat_appearances"]

--- a/tests/unit/test_polish_context.py
+++ b/tests/unit/test_polish_context.py
@@ -39,7 +39,7 @@ class TestFormatLinearSectionContext:
         )
 
         assert ctx["section_id"] == "section_0"
-        # Beat IDs in beat_details lines are backtick-wrapped per CLAUDE.md §9 rule 1.
+        # Beat IDs in beat_details lines are backtick-wrapped per @prompt-engineer Rule 4.
         assert "`beat::a`" in ctx["beat_details"]
         assert "`beat::b`" in ctx["beat_details"]
         assert "`beat::c`" in ctx["beat_details"]
@@ -80,7 +80,7 @@ class TestFormatLinearSectionContext:
 
     def test_section_beat_with_entities_renders_backticks(self) -> None:
         """A section beat whose `entities` field is populated renders the
-        entity list with backticks per CLAUDE.md §9 rule 1 — never as a
+        entity list with backticks per @prompt-engineer Rule 4 — never as a
         Python repr-style bracket list. Covers the linear-section
         equivalent of `test_pacing_beat_with_entities_renders_backticks`."""
         graph = Graph.empty()
@@ -89,7 +89,7 @@ class TestFormatLinearSectionContext:
         ctx = format_linear_section_context(graph, "s0", ["beat::a"], None, None)
 
         assert "entities: `entity::hero`" in ctx["beat_details"]
-        # No bracket-format leak per CLAUDE.md §9 rule 1.
+        # No bracket-format leak per @prompt-engineer Rule 4.
         assert "entities=[" not in ctx["beat_details"]
 
     def test_dilemma_impacts_shown(self) -> None:
@@ -106,7 +106,7 @@ class TestFormatLinearSectionContext:
         assert "commits" in ctx["beat_details"]
         # Dilemma IDs are backtick-wrapped within the impacts: clause.
         assert "`dilemma::d1`" in ctx["beat_details"]
-        # No bracket-format leaks per CLAUDE.md §9 rule 1.
+        # No bracket-format leaks per @prompt-engineer Rule 4.
         assert "impacts=[" not in ctx["beat_details"]
 
 
@@ -131,7 +131,7 @@ class TestFormatPacingContext:
         ctx = format_pacing_context(graph, flags)
 
         assert "consecutive_scene" in ctx["pacing_issues"]
-        # Beat IDs and path IDs backtick-wrapped per CLAUDE.md §9 rule 1.
+        # Beat IDs and path IDs backtick-wrapped per @prompt-engineer Rule 4.
         assert "`beat::a`" in ctx["pacing_issues"]
         assert "Path: `path::p1`" in ctx["pacing_issues"]
         # valid_entity_ids backtick-wrapped, with `(none)` fallback.
@@ -147,7 +147,7 @@ class TestFormatPacingContext:
 
     def test_pacing_beat_with_entities_renders_backticks(self) -> None:
         """A pacing flag whose beats reference entities renders the entity
-        list with backticks per CLAUDE.md §9 rule 1 — never as a Python
+        list with backticks per @prompt-engineer Rule 4 — never as a Python
         repr-style bracket list."""
         graph = Graph.empty()
         _make_beat(graph, "beat::a", "Hero acts", entities=["entity::hero"])
@@ -159,7 +159,7 @@ class TestFormatPacingContext:
         ctx = format_pacing_context(graph, flags)
 
         assert "entities: `entity::hero`" in ctx["pacing_issues"]
-        # No bracket-format leaking through (CLAUDE.md §9 rule 1).
+        # No bracket-format leaking through (@prompt-engineer Rule 4).
         assert "entities=[" not in ctx["pacing_issues"]
 
 
@@ -193,7 +193,7 @@ class TestFormatEntityArcContext:
         assert ctx["entity_id"] == "entity::mentor"
         assert ctx["entity_name"] == "The Mentor"
         assert "wise guide" in ctx["entity_description"]
-        # IDs in beat_appearances lines are backtick-wrapped per CLAUDE.md §9
+        # IDs in beat_appearances lines are backtick-wrapped per @prompt-engineer Rule 4
         # rule 1 — matches the valid_*_ids lists so a model doesn't need to
         # mentally strip backticks when matching IDs across surfaces.
         assert "`beat::intro`" in ctx["beat_appearances"]
@@ -231,13 +231,13 @@ class TestFormatEntityArcContext:
         ctx = format_entity_arc_context(graph, "entity::npc", ["beat::b1"])
 
         assert "hostile" in ctx["overlay_data"]
-        # Flag IDs are backtick-wrapped per CLAUDE.md §9 rule 1 — matches the
+        # Flag IDs are backtick-wrapped per @prompt-engineer Rule 4 — matches the
         # DRESS overlay renderer (closes #1406).
         assert "`dilemma::d1:path::p1`" in ctx["overlay_data"]
 
     def test_entity_overlay_list_values_render_human_readable(self) -> None:
         """List-valued details render as comma-joined strings (e.g. `umm, well`)
-        — never as Python repr (`['umm', 'well']`) per CLAUDE.md §9 rule 1.
+        — never as Python repr (`['umm', 'well']`) per @prompt-engineer Rule 4.
         Pinned because this is exactly the bracket-format the rule forbids."""
         graph = Graph.empty()
         graph.create_node("path::p1", {"type": "path", "raw_id": "p1"})
@@ -311,7 +311,7 @@ class TestFormatEntityArcContext:
 
     def test_anchored_dilemmas_backtick_wrapped(self) -> None:
         """Dilemmas the entity is `anchored_to` are backtick-wrapped per
-        CLAUDE.md §9 rule 1 — same convention as overlay flag IDs and the
+        @prompt-engineer Rule 4 — same convention as overlay flag IDs and the
         valid_*_ids lists."""
         graph = Graph.empty()
         graph.create_node("path::p1", {"type": "path", "raw_id": "p1"})

--- a/tests/unit/test_polish_phase5_context.py
+++ b/tests/unit/test_polish_phase5_context.py
@@ -46,7 +46,7 @@ class TestFormatChoiceLabelContext:
         assert "choice_details" in ctx
         assert "Start" in ctx["choice_details"]
         assert "End" in ctx["choice_details"]
-        # IDs in the choice line are backtick-wrapped per CLAUDE.md §9 rule 1.
+        # IDs in the choice line are backtick-wrapped per @prompt-engineer Rule 4.
         assert "From: `p1`" in ctx["choice_details"]
         assert "To: `p2`" in ctx["choice_details"]
         assert "grants: `flag1`" in ctx["choice_details"]
@@ -103,7 +103,7 @@ class TestFormatResidueContentContext:
 
         ctx = format_residue_content_context(graph, residue_specs, passage_specs)
         assert ctx["residue_count"] == "1"
-        # IDs are backtick-wrapped per CLAUDE.md §9 rule 1.
+        # IDs are backtick-wrapped per @prompt-engineer Rule 4.
         assert "`r1`" in ctx["residue_details"]
         assert "`flag1`" in ctx["residue_details"]
         assert "`path::brave`" in ctx["residue_details"]
@@ -141,7 +141,7 @@ class TestFormatFalseBranchContext:
 
         ctx = format_false_branch_context(graph, candidates, passage_specs)
         assert ctx["candidate_count"] == "1"
-        # IDs backtick-wrapped per CLAUDE.md §9 rule 1.
+        # IDs backtick-wrapped per @prompt-engineer Rule 4.
         assert "`entity::hero`" in ctx["valid_entity_ids"]
         assert "`p1`" in ctx["candidate_details"]
         assert "`p2`" in ctx["candidate_details"]
@@ -177,7 +177,7 @@ class TestFormatVariantSummaryContext:
         ctx = format_variant_summary_context(graph, variant_specs, passage_specs)
         assert ctx["variant_count"] == "1"
         assert "Base passage" in ctx["variant_details"]
-        # IDs backtick-wrapped per CLAUDE.md §9 rule 1.
+        # IDs backtick-wrapped per @prompt-engineer Rule 4.
         assert "`v1`" in ctx["variant_details"]
         assert "`p1`" in ctx["variant_details"]
         assert "`flag1`" in ctx["variant_details"]
@@ -241,7 +241,7 @@ class TestFormatAmbiguousFeasibilityContext:
 class TestFormatTransitionGuidanceContext:
     def test_passage_and_beat_ids_backtick_wrapped(self) -> None:
         """Both `passage_id` (per-passage header) and `bid` (per-beat line)
-        are backtick-wrapped per CLAUDE.md §9 rule 1."""
+        are backtick-wrapped per @prompt-engineer Rule 4."""
         graph = Graph.empty()
         _make_beat(graph, "beat::a", "First beat")
         _make_beat(graph, "beat::b", "Second beat")

--- a/tests/unit/test_serialize.py
+++ b/tests/unit/test_serialize.py
@@ -386,7 +386,7 @@ class TestHelperFunctions:
         Regression for the murder1 SEED halt: the model needs the expected
         sibling path id template echoed alongside the validation error so
         small models (qwen3:4b) can recover from constraint-to-value
-        mapping loss across long context. See CLAUDE.md §10.
+        mapping loss across long context. See @prompt-engineer Rule 5.
         """
         errors = ["beats.0.also_belongs_to: Field required"]
         hint = (


### PR DESCRIPTION
## Summary

- Mechanical sweep replacing `CLAUDE.md §6/§7/§8/§9/§10` citations in active source + tests with `@prompt-engineer Rule 1-5` (the rules' new home after #1448).
- Removes the back-compat citation-map table from CLAUDE.md — now that active code no longer needs it, the map was scaffolding past its purpose.
- 11 files changed: 10 src/test files (40 insertions / 40 deletions, comment-only) plus CLAUDE.md (-12 lines).
- mypy + ruff clean. No behaviour change, no test logic change.

## Mappings

| Old citation | New citation |
|---|---|
| `CLAUDE.md §6` (Valid ID Injection) | `@prompt-engineer Rule 1` |
| `CLAUDE.md §7` (Defensive Patterns) | `@prompt-engineer Rule 2` |
| `CLAUDE.md §8` (Context Enrichment) | `@prompt-engineer Rule 3` |
| `CLAUDE.md §9` (Prompt Context Formatting) | `@prompt-engineer Rule 4` |
| `CLAUDE.md §9 rule 1` | `@prompt-engineer Rule 4` (the "rule 1" suffix is redundant once Rule 4 directly names the no-Python-repr rule) |
| `CLAUDE.md §10` (Small-Model Bias) | `@prompt-engineer Rule 5` |

## Out of scope

Historical audit reports and plans under `docs/superpowers/{specs,reports,plans}/2026-04-*` deliberately keep their original `§6-§10` citations — those are point-in-time records and rewriting them would falsify the historical audit trail. Anyone reading those docs can map the citations via the subagent's Rule 1-5 structure.

## Test plan

- [x] `rg -n 'CLAUDE\.md §(6|7|8|9|10)' src/ tests/` returns zero matches (verified)
- [x] `uv run ruff check` on the 5 modified src files: green
- [x] `uv run mypy` on the 5 modified src files: green
- [ ] Bot reviewers (Gemini, claude-review) approve once posted
- [ ] Inline-comment spot-check: read a sample of changed comments, confirm they still parse cleanly with the new citation phrasing

Closes #1449

🤖 Generated with [Claude Code](https://claude.com/claude-code)