### PR TITLE
fix(polish): wire 3 missing mixin LLM phases into _METHOD_PHASES (#1453)

### DIFF
--- a/src/questfoundry/pipeline/stages/polish/stage.py
+++ b/src/questfoundry/pipeline/stages/polish/stage.py
@@ -90,11 +90,18 @@ class PolishStage(_PolishLLMHelperMixin, _PolishLLMPhaseMixin):
         self._serialize_provider_name: str | None = None
 
     # Map from registry phase name → self method name.
-    # LLM phases that need binding to ``self`` at call time.
+    # LLM phases on _PolishLLMPhaseMixin that need binding to ``self`` at call
+    # time. Every method on the mixin decorated with @polish_phase MUST appear
+    # here — _phase_order() rejects an unmapped phase rather than silently
+    # falling back to the unbound mixin function (which would crash when called
+    # as ``fn(graph, model)`` because ``self`` is missing).
     _METHOD_PHASES: ClassVar[dict[str, str]] = {
         "beat_reordering": "_phase_1_beat_reordering",
+        "narrative_gaps": "_phase_1a_narrative_gaps",
         "pacing": "_phase_2_pacing",
         "character_arcs": "_phase_3_character_arcs",
+        "atmospheric_annotation": "_phase_5e_atmospheric",
+        "path_thematic_annotation": "_phase_5f_path_thematic",
         "llm_enrichment": "_phase_5_llm_enrichment",
     }
 
@@ -109,9 +116,13 @@ class PolishStage(_PolishLLMHelperMixin, _PolishLLMPhaseMixin):
     def _phase_order(self) -> list[tuple[PhaseFunc, str]]:
         """Return ordered list of (phase_function, phase_name) tuples.
 
-        Uses the phase registry for topological ordering, then resolves
-        each phase to its callable: bound method for LLM phases, module-
-        level import for deterministic free functions.
+        Uses the phase registry for topological ordering, then resolves each
+        phase to its callable: bound method for LLM phases, module-level
+        import for deterministic free functions. Phases registered via
+        ``@polish_phase`` that do not appear in either ``_METHOD_PHASES`` or
+        ``_FREE_PHASES`` are a programming error — they're rejected here
+        rather than silently dispatched through the registry, which would
+        return an unbound mixin function and crash mid-stage.
         """
         import questfoundry.pipeline.stages.polish.stage as _this_module
 
@@ -127,18 +138,13 @@ class PolishStage(_PolishLLMHelperMixin, _PolishLLMPhaseMixin):
             elif free_name is not None:
                 fn = getattr(_this_module, free_name)
             else:
-                log.warning(
-                    "phase_fallback_to_registry",
-                    phase=phase_name,
-                    hint="Phase not in _METHOD_PHASES or _FREE_PHASES; "
-                    "using registry.get_function() fallback",
+                raise PolishStageError(
+                    f"Phase {phase_name!r} is registered via @polish_phase "
+                    "but is missing from PolishStage._METHOD_PHASES "
+                    "(LLM mixin methods) or PolishStage._FREE_PHASES "
+                    "(deterministic free functions). Add the mapping where "
+                    "the phase belongs."
                 )
-                fn = registry.get_function(phase_name)
-                if fn is None:
-                    raise PolishStageError(
-                        f"Phase {phase_name!r} has no resolvable function "
-                        "(not in _METHOD_PHASES, _FREE_PHASES, or registry)."
-                    )
 
             result.append((fn, phase_name))
 

--- a/tests/unit/test_polish_registry.py
+++ b/tests/unit/test_polish_registry.py
@@ -289,3 +289,21 @@ class TestPolishStagePhaseMappingDrift:
                 f"_METHOD_PHASES[{phase_name!r}] = {method_name!r}, but that "
                 "method does not exist on _PolishLLMPhaseMixin."
             )
+
+    def test_free_phases_target_existing_module_functions(self) -> None:
+        """Every mapped free-function name must exist in polish/stage.py.
+
+        Mirror of ``test_method_phases_target_existing_methods_on_mixin``
+        for the deterministic side. Catches typos in ``_FREE_PHASES`` values
+        before they become runtime AttributeErrors at ``_phase_order()``.
+        """
+        import questfoundry.pipeline.stages.polish.stage as polish_stage_module
+        from questfoundry.pipeline.stages.polish.stage import PolishStage
+
+        for phase_name, fn_name in PolishStage._FREE_PHASES.items():
+            assert hasattr(polish_stage_module, fn_name), (
+                f"_FREE_PHASES[{phase_name!r}] = {fn_name!r}, but that "
+                "function is not importable from polish.stage. The free "
+                "function must be re-exported via stage.py for "
+                "_phase_order()'s getattr lookup to find it."
+            )

--- a/tests/unit/test_polish_registry.py
+++ b/tests/unit/test_polish_registry.py
@@ -219,3 +219,73 @@ class TestGrowRegistryBackwardCompat:
         registry = get_registry()
         errors = registry.validate()
         assert errors == [], f"GROW registry validation errors: {errors}"
+
+
+class TestPolishStagePhaseMappingDrift:
+    """Verify PolishStage's hand-maintained phase maps cover every registered phase.
+
+    Regression coverage for #1453 — three @polish_phase-decorated mixin methods
+    were missing from PolishStage._METHOD_PHASES, so phase resolution silently
+    fell back to the unbound mixin function and crashed mid-stage when the
+    execute loop called fn(graph, model) with self unbound.
+    """
+
+    def test_every_mixin_phase_method_is_in_method_phases(self) -> None:
+        """Every @polish_phase-decorated method on _PolishLLMPhaseMixin must be mapped.
+
+        Walks the mixin directly rather than the global registry — the
+        registry singleton is shared across tests in this file, some of
+        which deliberately seed bad-shape phases (cycles, duplicates) into
+        it.
+        """
+        from questfoundry.pipeline.registry import PHASE_META_ATTR
+        from questfoundry.pipeline.stages.polish.llm_phases import _PolishLLMPhaseMixin
+        from questfoundry.pipeline.stages.polish.stage import PolishStage
+
+        registered_via_mixin: set[str] = set()
+        for attr_name in dir(_PolishLLMPhaseMixin):
+            attr = getattr(_PolishLLMPhaseMixin, attr_name)
+            meta = getattr(attr, PHASE_META_ATTR, None)
+            if meta is not None:
+                registered_via_mixin.add(meta.name)
+
+        unmapped = sorted(registered_via_mixin - set(PolishStage._METHOD_PHASES))
+        assert not unmapped, (
+            "@polish_phase mixin methods missing from PolishStage._METHOD_PHASES: "
+            f"{unmapped}. Add an entry for each — phase resolution falls "
+            "back to the unbound mixin function otherwise, which crashes "
+            "when called as fn(graph, model)."
+        )
+
+    def test_every_free_phase_module_function_is_in_free_phases(self) -> None:
+        """Every @polish_phase-decorated free function in stage.py must be mapped.
+
+        Mirror of the mixin check for the deterministic side.
+        """
+        import questfoundry.pipeline.stages.polish.stage as polish_stage_module
+        from questfoundry.pipeline.registry import PHASE_META_ATTR
+        from questfoundry.pipeline.stages.polish.stage import PolishStage
+
+        registered_in_module: set[str] = set()
+        for attr_name in dir(polish_stage_module):
+            attr = getattr(polish_stage_module, attr_name)
+            meta = getattr(attr, PHASE_META_ATTR, None)
+            if meta is not None:
+                registered_in_module.add(meta.name)
+
+        unmapped = sorted(registered_in_module - set(PolishStage._FREE_PHASES))
+        assert not unmapped, (
+            "@polish_phase free functions in polish/stage.py missing from "
+            f"PolishStage._FREE_PHASES: {unmapped}. Add an entry for each."
+        )
+
+    def test_method_phases_target_existing_methods_on_mixin(self) -> None:
+        """Every mapped method name must exist on _PolishLLMPhaseMixin."""
+        from questfoundry.pipeline.stages.polish.llm_phases import _PolishLLMPhaseMixin
+        from questfoundry.pipeline.stages.polish.stage import PolishStage
+
+        for phase_name, method_name in PolishStage._METHOD_PHASES.items():
+            assert hasattr(_PolishLLMPhaseMixin, method_name), (
+                f"_METHOD_PHASES[{phase_name!r}] = {method_name!r}, but that "
+                "method does not exist on _PolishLLMPhaseMixin."
+            )


### PR DESCRIPTION
## Summary

Closes #1453.

POLISH crashed on the `narrative_gaps` phase in real runs (`projects/murder3`):

\`\`\`
TypeError: _PolishLLMPhaseMixin._phase_1a_narrative_gaps()
  missing 1 required positional argument: 'model'
\`\`\`

Two more phases (`atmospheric_annotation`, `path_thematic_annotation`) would have crashed identically. All three appear as `phase_fallback_to_registry` WARNINGs in the debug log just before the failure.

## Root cause

`PolishStage._METHOD_PHASES` is a hand-maintained mapping from registered phase name → bound method on `_PolishLLMPhaseMixin`. Three mixin LLM phases registered via `@polish_phase` were never added to it. `_phase_order()`'s fallback path then returned the **unbound** mixin function from the registry, which the execute loop called as `fn(graph, model)` — interpreted as `self=graph, graph=model, model=missing` → `TypeError`.

## Fix

| Change | Why |
|---|---|
| Add `narrative_gaps`, `atmospheric_annotation`, `path_thematic_annotation` to `_METHOD_PHASES` | Resolves the immediate crash. |
| Replace silent `phase_fallback_to_registry` WARNING with hard `PolishStageError` | Per CLAUDE.md anti-patterns, \"tried but gave up\" silent degradation is exactly the failure mode that hid this bug — fail loudly at startup. |
| Add 3 drift-prevention tests | Future `@polish_phase` decorations on the mixin or in `polish/stage.py` without a corresponding `_METHOD_PHASES`/`_FREE_PHASES` entry now fail unit tests, not production. |

## Verification

Phase resolution now succeeds for all 10 phases (7 bound mixin + 3 free):

\`\`\`
$ uv run python -c \"from questfoundry.pipeline.stages.polish.stage import PolishStage; PolishStage()._phase_order()\"
beat_reordering          -> _PolishLLMPhaseMixin._phase_1_beat_reordering   [bound]
narrative_gaps           -> _PolishLLMPhaseMixin._phase_1a_narrative_gaps   [bound]
pacing                   -> _PolishLLMPhaseMixin._phase_2_pacing            [bound]
character_arcs           -> _PolishLLMPhaseMixin._phase_3_character_arcs    [bound]
atmospheric_annotation   -> _PolishLLMPhaseMixin._phase_5e_atmospheric      [bound]
path_thematic_annotation -> _PolishLLMPhaseMixin._phase_5f_path_thematic    [bound]
plan_computation         -> phase_plan_computation                          [free]
llm_enrichment           -> _PolishLLMPhaseMixin._phase_5_llm_enrichment    [bound]
plan_application         -> phase_plan_application                          [free]
validation               -> phase_validation                                [free]
\`\`\`

\`\`\`
$ uv run pytest tests/unit/ -k polish -x -q
363 passed
$ uv run mypy src/        # clean
$ uv run ruff check src/  # clean
\`\`\`

## Test plan

- [x] All polish unit tests pass (363)
- [x] Drift tests fail when a phase is removed from `_METHOD_PHASES` (verified by reverting the additions)
- [ ] Wait for `claude-code-review` and `gemini-code-assist` before flipping ready