### PR TITLE
fix(seed): scope shared-beat advisory to multi-path dilemmas only (#1454)

### DIFF
--- a/src/questfoundry/pipeline/stages/seed.py
+++ b/src/questfoundry/pipeline/stages/seed.py
@@ -601,33 +601,44 @@ def _log_beat_summary_stats(artifact_data: dict[str, Any]) -> None:
     """Advisory warnings about Y-shape beat counts.
 
     Under Y-shape, beats come in two kinds:
-    - Shared pre-commit beats (``also_belongs_to`` set) — one per dilemma.
+    - Shared pre-commit beats (``also_belongs_to`` set) — only multi-path
+      dilemmas need them; they form the chain that diverges into per-path
+      commit beats. Single-path soft dilemmas (locked-dilemma shadow) have
+      no Y-divergence and need no shared beat.
     - Post-commit beats (``also_belongs_to`` null) — one per path, including
       the commit and its consequences.
 
-    A healthy SEED output has ~1-2 shared beats per dilemma and ~2-3
-    post-commit beats per path. Warn below these thresholds.
+    A healthy SEED output has ~1-2 shared beats per *multi-path* dilemma
+    and ~2-3 post-commit beats per path. Warn below these thresholds.
     """
+    from collections import Counter
+
     beats = artifact_data.get("initial_beats", [])
-    dilemma_count = len(artifact_data.get("dilemmas", []))
-    path_count = len(artifact_data.get("paths", []))
+    paths = artifact_data.get("paths", [])
+    path_count = len(paths)
+
+    # Multi-path dilemmas are the only ones that need shared pre-commit beats
+    # — single-path soft dilemmas have no Y-divergence to set up.
+    paths_per_dilemma = Counter(p.get("dilemma_id") for p in paths if p.get("dilemma_id"))
+    multi_path_dilemmas = sum(1 for n in paths_per_dilemma.values() if n >= 2)
 
     shared = [b for b in beats if b.get("also_belongs_to")]
     post_commit = [b for b in beats if not b.get("also_belongs_to")]
 
-    shared_avg = (len(shared) / dilemma_count) if dilemma_count else 0.0
+    shared_avg = (len(shared) / multi_path_dilemmas) if multi_path_dilemmas else 0.0
     post_avg = (len(post_commit) / path_count) if path_count else 0.0
 
-    if shared_avg < 1.0 and dilemma_count > 0:
+    if multi_path_dilemmas > 0 and shared_avg < 1.0:
         log.warning(
             "seed_low_shared_beat_count",
             shared_beats=len(shared),
-            dilemmas=dilemma_count,
+            multi_path_dilemmas=multi_path_dilemmas,
             shared_avg=round(shared_avg, 2),
             message=(
-                f"{shared_avg:.1f} shared pre-commit beats/dilemma "
-                f"(expected ≥1). Every dilemma should set up the choice "
-                f"with at least one shared beat before the commit."
+                f"{shared_avg:.1f} shared pre-commit beats per multi-path "
+                f"dilemma (expected ≥1). Every multi-path dilemma should "
+                f"set up the choice with at least one shared beat before "
+                f"the commit. Single-path soft dilemmas are excluded."
             ),
         )
     if post_avg < 2.0 and path_count > 0:

--- a/src/questfoundry/pipeline/stages/seed.py
+++ b/src/questfoundry/pipeline/stages/seed.py
@@ -15,6 +15,7 @@ Requires BRAINSTORM stage to have completed (reads brainstorm from graph).
 from __future__ import annotations
 
 import inspect
+from collections import Counter
 from pathlib import Path  # noqa: TC003 - used at runtime for Graph.load()
 from typing import TYPE_CHECKING, Any
 
@@ -611,8 +612,6 @@ def _log_beat_summary_stats(artifact_data: dict[str, Any]) -> None:
     A healthy SEED output has ~1-2 shared beats per *multi-path* dilemma
     and ~2-3 post-commit beats per path. Warn below these thresholds.
     """
-    from collections import Counter
-
     beats = artifact_data.get("initial_beats", [])
     paths = artifact_data.get("paths", [])
     path_count = len(paths)

--- a/tests/unit/test_seed_stage.py
+++ b/tests/unit/test_seed_stage.py
@@ -1140,15 +1140,16 @@ def test_seed_advisory_warning_splits_shared_vs_post_commit(caplog) -> None:
     from questfoundry.pipeline.stages.seed import _log_beat_summary_stats
 
     # 2 dilemmas x 2 paths = 4 paths, 2 shared beats per dilemma, 2 post
-    # per path. Expected: shared_avg=2.0 per dilemma, post_avg=2.0 per path.
+    # per path. Expected: shared_avg=2.0 per multi-path dilemma, post_avg=
+    # 2.0 per path.
     artifact_data = {
         "entities": [],
         "dilemmas": [{"dilemma_id": "d_a"}, {"dilemma_id": "d_b"}],
         "paths": [
-            {"path_id": "p_a1"},
-            {"path_id": "p_a2"},
-            {"path_id": "p_b1"},
-            {"path_id": "p_b2"},
+            {"path_id": "p_a1", "dilemma_id": "d_a"},
+            {"path_id": "p_a2", "dilemma_id": "d_a"},
+            {"path_id": "p_b1", "dilemma_id": "d_b"},
+            {"path_id": "p_b2", "dilemma_id": "d_b"},
         ],
         "initial_beats": [
             {
@@ -1197,10 +1198,118 @@ def test_seed_advisory_warning_splits_shared_vs_post_commit(caplog) -> None:
         "Expected advisory warning for low post-commit beat count"
     )
 
-    # shared_avg = 4 shared beats / 2 dilemmas = 2.0 → above threshold (< 1.0)
+    # shared_avg = 4 shared beats / 2 multi-path dilemmas = 2.0 → above threshold (< 1.0)
     assert not any("seed_low_shared_beat_count" in r.message for r in caplog.records), (
         "Did not expect advisory warning for shared beat count"
     )
 
     # No errors should be raised
     assert not any(r.levelno >= logging.ERROR for r in caplog.records)
+
+
+def test_seed_advisory_no_shared_warning_when_some_dilemmas_single_path(caplog) -> None:
+    """No false positive when only some dilemmas are multi-path (locked-dilemma shadow).
+
+    Regression coverage for #1454. Reproduces the user-reported case:
+    5 dilemmas total, 2 fully explored (multi-path) and 3 left as single-path
+    soft (locked-dilemma shadow). 4 shared pre-commit beats live on the 2
+    multi-path dilemmas. Old code divided by total dilemma count
+    (4/5=0.8) and warned; new code divides by multi-path-dilemma count
+    (4/2=2.0) and stays silent.
+    """
+    import logging
+
+    from questfoundry.pipeline.stages.seed import _log_beat_summary_stats
+
+    artifact_data = {
+        "entities": [],
+        "dilemmas": [{"dilemma_id": f"d_{i}"} for i in range(5)],
+        "paths": [
+            # d_0 multi-path
+            {"path_id": "p_0a", "dilemma_id": "d_0"},
+            {"path_id": "p_0b", "dilemma_id": "d_0"},
+            # d_1 multi-path
+            {"path_id": "p_1a", "dilemma_id": "d_1"},
+            {"path_id": "p_1b", "dilemma_id": "d_1"},
+            # d_2, d_3, d_4 single-path (locked-dilemma shadow)
+            {"path_id": "p_2a", "dilemma_id": "d_2"},
+            {"path_id": "p_3a", "dilemma_id": "d_3"},
+            {"path_id": "p_4a", "dilemma_id": "d_4"},
+        ],
+        "initial_beats": [
+            # 2 shared beats on each multi-path dilemma — 4 total.
+            {"beat_id": "s_0_1", "path_id": "p_0a", "also_belongs_to": "p_0b"},
+            {"beat_id": "s_0_2", "path_id": "p_0a", "also_belongs_to": "p_0b"},
+            {"beat_id": "s_1_1", "path_id": "p_1a", "also_belongs_to": "p_1b"},
+            {"beat_id": "s_1_2", "path_id": "p_1a", "also_belongs_to": "p_1b"},
+            # ≥2 post-commit beats per path so the post warning doesn't fire.
+            *(
+                {"beat_id": f"pc_{i}", "path_id": p_id}
+                for i, p_id in enumerate(
+                    [
+                        "p_0a",
+                        "p_0a",
+                        "p_0b",
+                        "p_0b",
+                        "p_1a",
+                        "p_1a",
+                        "p_1b",
+                        "p_1b",
+                        "p_2a",
+                        "p_2a",
+                        "p_3a",
+                        "p_3a",
+                        "p_4a",
+                        "p_4a",
+                    ]
+                )
+            ),
+        ],
+    }
+
+    with caplog.at_level(logging.WARNING):
+        _log_beat_summary_stats(artifact_data)
+
+    assert not any("seed_low_shared_beat_count" in r.message for r in caplog.records), (
+        "Did not expect shared-beat warning when 4 shared beats span "
+        "the 2 multi-path dilemmas (4/2=2.0 ≥ 1)."
+    )
+    assert not any("seed_low_post_commit_beat_count" in r.message for r in caplog.records), (
+        "Did not expect post-commit warning (2 post-commit beats per path)."
+    )
+
+
+def test_seed_advisory_warns_when_multi_path_dilemma_lacks_shared_beat(caplog) -> None:
+    """Warning DOES fire when a multi-path dilemma has no shared pre-commit beat."""
+    import logging
+
+    from questfoundry.pipeline.stages.seed import _log_beat_summary_stats
+
+    artifact_data = {
+        "entities": [],
+        "dilemmas": [{"dilemma_id": "d_a"}, {"dilemma_id": "d_b"}],
+        "paths": [
+            {"path_id": "p_a1", "dilemma_id": "d_a"},
+            {"path_id": "p_a2", "dilemma_id": "d_a"},
+            {"path_id": "p_b1", "dilemma_id": "d_b"},
+            {"path_id": "p_b2", "dilemma_id": "d_b"},
+        ],
+        "initial_beats": [
+            # Only one shared beat across both multi-path dilemmas → 1/2 = 0.5 < 1.0.
+            {"beat_id": "s_only", "path_id": "p_a1", "also_belongs_to": "p_a2"},
+            # Plenty of post-commit so we isolate the shared warning.
+            *(
+                {"beat_id": f"pc_{i}", "path_id": p_id}
+                for i, p_id in enumerate(
+                    ["p_a1", "p_a1", "p_a2", "p_a2", "p_b1", "p_b1", "p_b2", "p_b2"]
+                )
+            ),
+        ],
+    }
+
+    with caplog.at_level(logging.WARNING):
+        _log_beat_summary_stats(artifact_data)
+
+    assert any("seed_low_shared_beat_count" in r.message for r in caplog.records), (
+        "Expected shared-beat warning when 1 shared beat covers 2 multi-path dilemmas."
+    )

--- a/tests/unit/test_seed_stage.py
+++ b/tests/unit/test_seed_stage.py
@@ -1310,6 +1310,18 @@ def test_seed_advisory_warns_when_multi_path_dilemma_lacks_shared_beat(caplog) -
     with caplog.at_level(logging.WARNING):
         _log_beat_summary_stats(artifact_data)
 
-    assert any("seed_low_shared_beat_count" in r.message for r in caplog.records), (
-        "Expected shared-beat warning when 1 shared beat covers 2 multi-path dilemmas."
+    # Pull the structured event dict — structlog passes kwargs via record.msg
+    # as a dict — and assert on the actual values, not just the event name.
+    matching = [
+        r.msg
+        for r in caplog.records
+        if isinstance(r.msg, dict) and r.msg.get("event") == "seed_low_shared_beat_count"
+    ]
+    assert len(matching) == 1, (
+        "Expected exactly one shared-beat warning when 1 shared beat covers "
+        f"2 multi-path dilemmas, got {len(matching)}."
     )
+    event = matching[0]
+    assert event["shared_beats"] == 1
+    assert event["multi_path_dilemmas"] == 2
+    assert event["shared_avg"] == 0.5


### PR DESCRIPTION
## Summary

Closes #1454.

\`_log_beat_summary_stats\` divides shared-pre-commit-beat count by **total** dilemma count, which fires a false-positive \`seed_low_shared_beat_count\` advisory whenever some dilemmas are single-path soft (locked-dilemma shadow per the Y-shape model) rather than fully explored.

## Reproducer (from a real run)

5 dilemmas — 2 multi-path (2 paths each, 2 shared beats each), 3 single-path soft (locked-dilemma shadow).

| Logic | Calculation | Result |
|---|---|---|
| Old | \`4 shared / 5 dilemmas = 0.8\` | warning fires (0.8 < 1.0) — false positive |
| New | \`4 shared / 2 multi-path = 2.0\` | silent (2.0 ≥ 1.0) — correct |

## Why the old denominator was wrong

Shared pre-commit beats (\`also_belongs_to\` set) only exist for multi-path dilemmas — they're the chain that diverges into per-path commit beats. Single-path soft dilemmas (legitimate \"locked-dilemma shadow\" pattern per \`how-branching-stories-work.md §Common Language\`) have no Y-divergence and need no shared beat. The denominator should match the rule it's enforcing.

## Fix

\`\`\`python
from collections import Counter

paths_per_dilemma = Counter(p.get(\"dilemma_id\") for p in paths if p.get(\"dilemma_id\"))
multi_path_dilemmas = sum(1 for n in paths_per_dilemma.values() if n >= 2)
shared_avg = len(shared) / multi_path_dilemmas if multi_path_dilemmas else 0.0
if multi_path_dilemmas > 0 and shared_avg < 1.0:
    log.warning(\"seed_low_shared_beat_count\", multi_path_dilemmas=..., shared_avg=...)
\`\`\`

Warning message updated to say \"per multi-path dilemma\" and to call out that single-path soft dilemmas are excluded.

## Tests

- Updated `test_seed_advisory_warning_splits_shared_vs_post_commit` to add \`dilemma_id\` to its paths (the new code reads from there). Same outcome since the fixture's 2 dilemmas are both multi-path.
- New `test_seed_advisory_no_shared_warning_when_some_dilemmas_single_path` reproduces the user case → no warning.
- New `test_seed_advisory_warns_when_multi_path_dilemma_lacks_shared_beat` confirms the warning still fires when 1 shared beat covers 2 multi-path dilemmas (1/2 < 1).

\`\`\`
$ uv run pytest tests/unit/test_seed_stage.py -x -q
35 passed
$ uv run mypy src/        # clean
$ uv run ruff check src/  # clean
\`\`\`

## Test plan

- [x] All seed unit tests pass (35)
- [x] mypy + ruff + pre-commit clean
- [ ] Wait for `claude-code-review` and `gemini-code-assist` before flipping ready