### PR TITLE
fix(polish): residue passages inherit entities from target passage (#1457)

### DIFF
--- a/docs/design/procedures/polish.md
+++ b/docs/design/procedures/polish.md
@@ -526,6 +526,8 @@ R-6.3. Any step failure rolls back the transaction. No graph mutations are commi
 
 R-6.4. Phase 6 creates new beat nodes only for residue beats and false-branch beats — never new narrative beats.
 
+R-6.5. Residue passages and their companion residue beats inherit the `entities` field from their target passage (the passage referenced by `residue_for`). The residue plays out at the same dramatic moment as its target — same cast on stage. FILL builds its `### Valid Entity IDs` prompt context from `passage["entities"]`; an empty or missing list there forces phantom-ID emissions in the prose call. Both `residue_passage_with_variants` and `parallel_passages` mapping strategies must apply this inheritance.
+
 **Violations:**
 
 | Symptom | Root cause | Broken rule |
@@ -533,6 +535,7 @@ R-6.4. Phase 6 creates new beat nodes only for residue beats and false-branch be
 | Half-built passage layer visible to Phase 7 | Atomicity violated | R-6.1 / R-6.3 |
 | Phase 6 creates a commit beat | Narrative-beat creation forbidden post-SEED | R-6.4 |
 | Phase 6 mutates an existing `belongs_to` edge | Should only add passage-layer and structural-beat nodes | R-6.4 |
+| Residue passage emits phantom entity IDs (e.g. `clara` instead of `character::clara_yu`) at FILL | Residue created with empty `entities` instead of inheriting from target | R-6.5 |
 
 ### Output Contract
 

--- a/src/questfoundry/pipeline/stages/polish/deterministic.py
+++ b/src/questfoundry/pipeline/stages/polish/deterministic.py
@@ -1213,15 +1213,26 @@ def _residue_inherited_entities(graph: Graph, target_passage_id: str) -> list[st
     on the residue forces the prose-call to invent IDs from the passage_id
     text and produces phantom-ID escalations downstream (#1457).
 
-    Defensive against the target passage being absent (resilient to call-order
-    issues) or its ``entities`` field being None / missing — both degrade to
-    an empty list rather than raising. The explicit ``is None`` check guards
-    the missing-target case; ``or []`` on the inner lookup handles a present
-    target with no entities or a None value.
+    A target passage that doesn't exist is a structural failure: phase 6's
+    application order (R-6.2) creates target passages before residues, so
+    this can only happen if Phase 4-5 produced a plan that violates that
+    order or someone called this helper out-of-band. Raise rather than
+    fall back to ``[]`` — silently inheriting an empty entity list is the
+    exact failure mode that produced #1457 in the first place. (Per
+    ``.gemini/styleguide.md`` anti-pattern: silent fallbacks that hide
+    bugs prefer explicit errors.)
+
+    The inner ``or []`` on ``target.get("entities")`` handles a *present*
+    target whose entities field is missing or explicitly ``None`` — that's
+    a legitimate empty case (e.g. setup beats before any cast is on stage).
     """
     target = graph.get_node(target_passage_id)
     if target is None:
-        return []
+        raise ValueError(
+            f"R-6.5: residue target passage {target_passage_id!r} not found in graph. "
+            "Phase 6 application order (R-6.2) requires target passages to be created "
+            "before residues."
+        )
     return list(target.get("entities") or [])
 
 

--- a/src/questfoundry/pipeline/stages/polish/deterministic.py
+++ b/src/questfoundry/pipeline/stages/polish/deterministic.py
@@ -1215,9 +1215,13 @@ def _residue_inherited_entities(graph: Graph, target_passage_id: str) -> list[st
 
     Defensive against the target passage being absent (resilient to call-order
     issues) or its ``entities`` field being None / missing — both degrade to
-    an empty list rather than raising.
+    an empty list rather than raising. The explicit ``is None`` check guards
+    the missing-target case; ``or []`` on the inner lookup handles a present
+    target with no entities or a None value.
     """
-    target = graph.get_node(target_passage_id) or {}
+    target = graph.get_node(target_passage_id)
+    if target is None:
+        return []
     return list(target.get("entities") or [])
 
 

--- a/src/questfoundry/pipeline/stages/polish/deterministic.py
+++ b/src/questfoundry/pipeline/stages/polish/deterministic.py
@@ -1204,6 +1204,23 @@ def _create_variant_passage(graph: Graph, vspec: VariantSpec) -> None:
     graph.add_edge("variant_of", vspec.variant_id, vspec.base_passage_id)
 
 
+def _residue_inherited_entities(graph: Graph, target_passage_id: str) -> list[str]:
+    """Return the entity IDs a residue should inherit from its target passage.
+
+    A residue passage / beat plays out narratively at the same dramatic moment
+    as its target — same cast on stage. FILL builds its `### Valid Entity IDs`
+    context from the passage's ``entities`` field, so a missing or empty list
+    on the residue forces the prose-call to invent IDs from the passage_id
+    text and produces phantom-ID escalations downstream (#1457).
+
+    Defensive against the target passage being absent (resilient to call-order
+    issues) or its ``entities`` field being None / missing — both degrade to
+    an empty list rather than raising.
+    """
+    target = graph.get_node(target_passage_id) or {}
+    return list(target.get("entities") or [])
+
+
 def _create_residue_beat_and_passage(graph: Graph, rspec: ResidueSpec) -> None:
     """Phase 6: materialize a residue spec into the passage layer.
 
@@ -1237,6 +1254,8 @@ def _apply_residue_with_variants(graph: Graph, rspec: ResidueSpec) -> None:
     beat_id = f"beat::residue_{residue_suffix}"
     residue_passage_id = f"passage::residue_{residue_suffix}"
 
+    inherited_entities = _residue_inherited_entities(graph, rspec.target_passage_id)
+
     # Create residue beat node
     graph.create_node(
         beat_id,
@@ -1247,7 +1266,7 @@ def _apply_residue_with_variants(graph: Graph, rspec: ResidueSpec) -> None:
             "role": "residue_beat",
             "scene_type": "sequel",
             "dilemma_impacts": [],
-            "entities": [],
+            "entities": list(inherited_entities),
             "created_by": "POLISH",
         },
     )
@@ -1267,6 +1286,7 @@ def _apply_residue_with_variants(graph: Graph, rspec: ResidueSpec) -> None:
             "is_residue": True,
             "residue_for": rspec.target_passage_id,
             "mapping_strategy": rspec.mapping_strategy,
+            "entities": list(inherited_entities),
         },
     )
 
@@ -1320,6 +1340,8 @@ def _apply_residue_parallel_passages(graph: Graph, rspec: ResidueSpec) -> None:
     beat_id = f"beat::residue_{residue_suffix}"
     residue_passage_id = f"passage::residue_{residue_suffix}"
 
+    inherited_entities = _residue_inherited_entities(graph, rspec.target_passage_id)
+
     # Create residue beat — same shape as the variants strategy.
     graph.create_node(
         beat_id,
@@ -1330,7 +1352,7 @@ def _apply_residue_parallel_passages(graph: Graph, rspec: ResidueSpec) -> None:
             "role": "residue_beat",
             "scene_type": "sequel",
             "dilemma_impacts": [],
-            "entities": [],
+            "entities": list(inherited_entities),
             "created_by": "POLISH",
         },
     )
@@ -1350,6 +1372,7 @@ def _apply_residue_parallel_passages(graph: Graph, rspec: ResidueSpec) -> None:
             "is_residue": True,
             "residue_for": rspec.target_passage_id,
             "mapping_strategy": rspec.mapping_strategy,
+            "entities": list(inherited_entities),
         },
     )
 

--- a/src/questfoundry/pipeline/stages/polish/deterministic.py
+++ b/src/questfoundry/pipeline/stages/polish/deterministic.py
@@ -1266,7 +1266,7 @@ def _apply_residue_with_variants(graph: Graph, rspec: ResidueSpec) -> None:
             "role": "residue_beat",
             "scene_type": "sequel",
             "dilemma_impacts": [],
-            "entities": list(inherited_entities),
+            "entities": inherited_entities,
             "created_by": "POLISH",
         },
     )
@@ -1286,7 +1286,7 @@ def _apply_residue_with_variants(graph: Graph, rspec: ResidueSpec) -> None:
             "is_residue": True,
             "residue_for": rspec.target_passage_id,
             "mapping_strategy": rspec.mapping_strategy,
-            "entities": list(inherited_entities),
+            "entities": inherited_entities,
         },
     )
 
@@ -1352,7 +1352,7 @@ def _apply_residue_parallel_passages(graph: Graph, rspec: ResidueSpec) -> None:
             "role": "residue_beat",
             "scene_type": "sequel",
             "dilemma_impacts": [],
-            "entities": list(inherited_entities),
+            "entities": inherited_entities,
             "created_by": "POLISH",
         },
     )
@@ -1372,7 +1372,7 @@ def _apply_residue_parallel_passages(graph: Graph, rspec: ResidueSpec) -> None:
             "is_residue": True,
             "residue_for": rspec.target_passage_id,
             "mapping_strategy": rspec.mapping_strategy,
-            "entities": list(inherited_entities),
+            "entities": inherited_entities,
         },
     )
 

--- a/tests/unit/test_polish_apply.py
+++ b/tests/unit/test_polish_apply.py
@@ -381,18 +381,19 @@ class TestCreateResidueBeatAndPassage:
         assert residue_beat is not None
         assert residue_beat["entities"] == ["character::clara_yu"]
 
-    def test_residue_inherited_entities_returns_empty_for_absent_target(self) -> None:
-        """Helper degrades to ``[]`` when the target passage doesn't exist.
+    def test_residue_inherited_entities_raises_for_absent_target(self) -> None:
+        """Helper raises ``ValueError`` when the target passage is missing.
 
-        The full residue creation path can't reach this branch in practice —
-        ``graph.add_edge('precedes', residue, target)`` raises
-        ``EdgeEndpointError`` first when the target is absent. But the
-        helper's ``is None`` guard exists so unit tests, alternate call
-        sites, and future refactors don't have to special-case the
-        missing-target case themselves.
+        Per `.gemini/styleguide.md` anti-pattern (silent fallbacks that hide
+        bugs prefer explicit errors): a residue created against a missing
+        target passage is a structural failure — Phase 6's application order
+        (R-6.2) creates target passages before residues. Returning ``[]``
+        instead would silently propagate the exact symptom #1457 fixed
+        (residue with empty entities → FILL phantom-ID escalations).
         """
         graph = Graph.empty()
-        assert _residue_inherited_entities(graph, "passage::does_not_exist") == []
+        with pytest.raises(ValueError, match=r"R-6\.5: residue target passage"):
+            _residue_inherited_entities(graph, "passage::does_not_exist")
 
     def test_residue_inheritance_defensive_when_target_has_no_entities(self) -> None:
         """If the target has no entities (early-stage passage), residue gets []

--- a/tests/unit/test_polish_apply.py
+++ b/tests/unit/test_polish_apply.py
@@ -293,6 +293,124 @@ class TestCreateResidueBeatAndPassage:
         # path; flag-present players take the parallel-passage detour above.
         assert ("beat::target", "beat::pred") in beat_edges
 
+    def test_residue_with_variants_inherits_target_entities(self) -> None:
+        """Regression: #1457 — residue_passage_with_variants must copy entities
+        from the target passage onto both the residue beat and residue
+        passage. FILL builds its Valid Entity IDs prompt context from
+        ``passage["entities"]`` — an empty list there forces phantom-ID
+        emissions like ``clara`` instead of ``character::clara_yu``.
+        """
+        graph = Graph.empty()
+        _make_beat(graph, "beat::target")
+        graph.create_node("path::brave", {"type": "path", "raw_id": "brave"})
+
+        target_spec = PassageSpec(
+            passage_id="passage::target",
+            beat_ids=["beat::target"],
+            summary="Target",
+            entities=["character::clara_yu", "character::alistair_vance"],
+        )
+        _create_passage_node(graph, target_spec)
+
+        rspec = ResidueSpec(
+            target_passage_id="passage::target",
+            residue_id="residue::r1",
+            flag="dilemma::d1:path::brave",
+            path_id="path::brave",
+            content_hint="You feel confident",
+        )
+        _create_residue_beat_and_passage(graph, rspec)
+
+        passages = graph.get_nodes_by_type("passage")
+        residue_passage = passages.get("passage::residue_r1")
+        assert residue_passage is not None
+        assert residue_passage["entities"] == [
+            "character::clara_yu",
+            "character::alistair_vance",
+        ]
+
+        beats = graph.get_nodes_by_type("beat")
+        residue_beat = beats.get("beat::residue_r1")
+        assert residue_beat is not None
+        assert residue_beat["entities"] == [
+            "character::clara_yu",
+            "character::alistair_vance",
+        ]
+
+    def test_residue_parallel_passages_inherits_target_entities(self) -> None:
+        """Same inheritance contract for the ``parallel_passages`` strategy."""
+        graph = Graph.empty()
+        _make_beat(graph, "beat::pred")
+        _make_beat(graph, "beat::target")
+        graph.add_edge("predecessor", "beat::target", "beat::pred")
+        graph.create_node("path::brave", {"type": "path", "raw_id": "brave"})
+
+        pred_spec = PassageSpec(
+            passage_id="passage::pred",
+            beat_ids=["beat::pred"],
+            summary="Pred",
+        )
+        target_spec = PassageSpec(
+            passage_id="passage::target",
+            beat_ids=["beat::target"],
+            summary="Target",
+            entities=["character::clara_yu"],
+        )
+        _create_passage_node(graph, pred_spec)
+        _create_passage_node(graph, target_spec)
+        graph.add_edge("precedes", "passage::pred", "passage::target")
+
+        rspec = ResidueSpec(
+            target_passage_id="passage::target",
+            residue_id="residue::r_par",
+            flag="dilemma::d1:path::brave",
+            path_id="path::brave",
+            content_hint="You feel confident",
+            mapping_strategy="parallel_passages",
+        )
+        _create_residue_beat_and_passage(graph, rspec)
+
+        passages = graph.get_nodes_by_type("passage")
+        residue_passage = passages.get("passage::residue_r_par")
+        assert residue_passage is not None
+        assert residue_passage["entities"] == ["character::clara_yu"]
+
+        beats = graph.get_nodes_by_type("beat")
+        residue_beat = beats.get("beat::residue_r_par")
+        assert residue_beat is not None
+        assert residue_beat["entities"] == ["character::clara_yu"]
+
+    def test_residue_inheritance_defensive_when_target_has_no_entities(self) -> None:
+        """If the target has no entities (early-stage passage), residue gets []
+        rather than raising. The structural invariant — target passage exists —
+        is enforced by spec validators elsewhere; the helper just degrades
+        gracefully on missing/empty entity data.
+        """
+        graph = Graph.empty()
+        _make_beat(graph, "beat::target")
+
+        target_spec = PassageSpec(
+            passage_id="passage::target",
+            beat_ids=["beat::target"],
+            summary="Target",
+            # No entities passed — PassageSpec defaults to empty list.
+        )
+        _create_passage_node(graph, target_spec)
+
+        rspec = ResidueSpec(
+            target_passage_id="passage::target",
+            residue_id="residue::r_empty",
+            flag="flag1",
+        )
+        _create_residue_beat_and_passage(graph, rspec)
+
+        residue_passage = graph.get_nodes_by_type("passage").get("passage::residue_r_empty")
+        assert residue_passage is not None
+        assert residue_passage["entities"] == []
+        residue_beat = graph.get_nodes_by_type("beat").get("beat::residue_r_empty")
+        assert residue_beat is not None
+        assert residue_beat["entities"] == []
+
 
 class TestCreateChoiceEdge:
     """Tests for _create_choice_edge."""

--- a/tests/unit/test_polish_apply.py
+++ b/tests/unit/test_polish_apply.py
@@ -28,6 +28,7 @@ from questfoundry.pipeline.stages.polish.deterministic import (
     _create_passage_node,
     _create_residue_beat_and_passage,
     _create_variant_passage,
+    _residue_inherited_entities,
     _store_plan,
     phase_plan_application,
 )
@@ -379,6 +380,19 @@ class TestCreateResidueBeatAndPassage:
         residue_beat = beats.get("beat::residue_r_par")
         assert residue_beat is not None
         assert residue_beat["entities"] == ["character::clara_yu"]
+
+    def test_residue_inherited_entities_returns_empty_for_absent_target(self) -> None:
+        """Helper degrades to ``[]`` when the target passage doesn't exist.
+
+        The full residue creation path can't reach this branch in practice —
+        ``graph.add_edge('precedes', residue, target)`` raises
+        ``EdgeEndpointError`` first when the target is absent. But the
+        helper's ``is None`` guard exists so unit tests, alternate call
+        sites, and future refactors don't have to special-case the
+        missing-target case themselves.
+        """
+        graph = Graph.empty()
+        assert _residue_inherited_entities(graph, "passage::does_not_exist") == []
 
     def test_residue_inheritance_defensive_when_target_has_no_entities(self) -> None:
         """If the target has no entities (early-stage passage), residue gets []


### PR DESCRIPTION
## Summary

Closes #1457.

Residue passages (and their companion beats) were created without an \`entities\` field. FILL Phase 1 builds its \`### Valid Entity IDs\` prompt context from \`passage[\"entities\"]\`, so the slot became \`(none)\` and the prose-call LLM hallucinated short-form entity IDs from passage_id text — \`clara\` instead of \`character::clara_yu\`. \`_resolve_entity_id\` then escalated \`missing_entity\` and FILL halted at the contract gate.

## Reproducer

\`projects/murder3\` POLISH→FILL run halted on:

\`\`\`
passage::residue_clara_victim_or_accomplice__victim_beat_02_state_flag__clara_stolen_genius_committed
  field=appearance,  provided=clara
  field=appearance,  provided=clara
  field=mannerism,   provided=clara
  field=sensory,     provided=clara
\`\`\`

The source passage \`passage::clara_victim_or_accomplice__victim_beat_02\` has \`entities=['character::clara_yu', 'character::alistair_vance']\`. The residue inherited nothing.

## Scope

**All 28** residue passages in murder3 lack the field. Only 1 surfaced as a hard failure this run; the rest produced silently-wrong prose (no entity_updates emitted, or phantom IDs that happened to resolve). The bug is structural — every residue created since the residue layer landed has missed inheriting entities.

## Fix

| Change | What |
|---|---|
| New helper \`_residue_inherited_entities(graph, target_passage_id)\` | Reads target's \`entities\`, defensive against missing target / None / missing field. |
| \`_apply_residue_with_variants\` | Passes inherited list into BOTH the residue beat and residue passage \`create_node\` calls. |
| \`_apply_residue_parallel_passages\` | Same fix for the alternate strategy. |

## Out of scope

- **Defense in depth in FILL**: \`_fill_extract_call\` could fall back to all-graph-entities when \`valid_entity_ids\` is empty. Useful but separate — empty entities is a structural problem the prompt shouldn't paper over.
- **Re-running murder3 with corrected residues**: existing graph data won't backfill — POLISH would need to be rewound past the residue phase to regenerate. Out of scope for this PR.

## Tests

\`tests/unit/test_polish_apply.py::TestCreateResidueBeatAndPassage\` adds 3 tests:

- \`test_residue_with_variants_inherits_target_entities\` — primary regression
- \`test_residue_parallel_passages_inherits_target_entities\` — same contract for the alt strategy
- \`test_residue_inheritance_defensive_when_target_has_no_entities\` — graceful degrade to \`[]\`

\`\`\`
$ uv run pytest tests/unit/ -k polish -x -q
367 passed
$ uv run mypy src/        # clean
$ uv run ruff check src/  # clean
\`\`\`

## Test plan

- [x] All polish unit tests pass (367)
- [x] mypy + ruff + pre-commit clean
- [ ] Wait for \`claude-code-review\` and \`gemini-code-assist\` before flipping ready