### PR TITLE
fix(polish): variant passages inherit entities from base (#1459)

### DIFF
--- a/docs/design/procedures/polish.md
+++ b/docs/design/procedures/polish.md
@@ -526,7 +526,12 @@ R-6.3. Any step failure rolls back the transaction. No graph mutations are commi
 
 R-6.4. Phase 6 creates new beat nodes only for residue beats and false-branch beats — never new narrative beats.
 
-R-6.5. Residue passages and their companion residue beats inherit the `entities` field from their target passage (the passage referenced by `residue_for`). The residue plays out at the same dramatic moment as its target — same cast on stage. FILL builds its `### Valid Entity IDs` prompt context from `passage["entities"]`; an empty or missing list there forces phantom-ID emissions in the prose call. Both `residue_passage_with_variants` and `parallel_passages` mapping strategies must apply this inheritance.
+R-6.5. Synthesized passages inherit the `entities` field from their source passage on the beat layer. This applies to:
+
+- **Residue passages** and their companion **residue beats** — inherit from the passage referenced by `residue_for`. Both `residue_passage_with_variants` and `parallel_passages` mapping strategies must apply the inheritance.
+- **Variant passages** — inherit from the passage referenced by `variant_of` (the base passage).
+
+The synthesized node plays out at the same dramatic moment as its source — same cast on stage. FILL builds its `### Valid Entity IDs` prompt context from `passage["entities"]`; an empty or missing list there forces phantom-ID emissions in the prose call (the model invents short IDs from the passage_id text). A missing source passage is a structural failure (R-6.2 application order guarantees the source exists first) and must raise rather than silently fall back to an empty list.
 
 **Violations:**
 
@@ -536,6 +541,8 @@ R-6.5. Residue passages and their companion residue beats inherit the `entities`
 | Phase 6 creates a commit beat | Narrative-beat creation forbidden post-SEED | R-6.4 |
 | Phase 6 mutates an existing `belongs_to` edge | Should only add passage-layer and structural-beat nodes | R-6.4 |
 | Residue passage emits phantom entity IDs (e.g. `clara` instead of `character::clara_yu`) at FILL | Residue created with empty `entities` instead of inheriting from target | R-6.5 |
+| Variant passage emits phantom entity IDs at FILL | Variant created with empty `entities` instead of inheriting from base | R-6.5 |
+| Synthesized passage created against a missing source — empty `entities` propagated silently | R-6.2 application order violated; helper used silent fallback `[]` instead of raising | R-6.5 |
 
 ### Output Contract
 

--- a/src/questfoundry/pipeline/stages/polish/deterministic.py
+++ b/src/questfoundry/pipeline/stages/polish/deterministic.py
@@ -1189,14 +1189,7 @@ def _create_passage_node(graph: Graph, spec: PassageSpec) -> None:
 
 
 def _create_variant_passage(graph: Graph, vspec: VariantSpec) -> None:
-    """Create a variant passage node with variant_of edge to base.
-
-    The variant inherits its ``entities`` from the base passage per R-6.5 —
-    a variant plays out at the same dramatic moment as its base, with the
-    same cast on stage. Without the inheritance, FILL's `### Valid Entity
-    IDs` prompt slot would be empty for variant prose generation, which is
-    the same phantom-ID failure mode that produced #1457 for residues.
-    """
+    """Create a variant passage node with variant_of edge to base, inheriting entities (R-6.5)."""
     inherited_entities = _inherited_passage_entities(graph, vspec.base_passage_id)
     graph.create_node(
         vspec.variant_id,
@@ -1240,8 +1233,9 @@ def _inherited_passage_entities(graph: Graph, source_passage_id: str) -> list[st
     if source is None:
         raise ValueError(
             f"R-6.5: source passage {source_passage_id!r} not found in graph. "
-            "Phase 6 application order (R-6.2) requires base passages to be created "
-            "before variants and residues."
+            "Phase 6 application order (R-6.2) requires source passages "
+            "(residue targets and variant bases) to be created before "
+            "their dependent residue / variant nodes."
         )
     return list(source.get("entities") or [])
 

--- a/src/questfoundry/pipeline/stages/polish/deterministic.py
+++ b/src/questfoundry/pipeline/stages/polish/deterministic.py
@@ -1189,7 +1189,15 @@ def _create_passage_node(graph: Graph, spec: PassageSpec) -> None:
 
 
 def _create_variant_passage(graph: Graph, vspec: VariantSpec) -> None:
-    """Create a variant passage node with variant_of edge to base."""
+    """Create a variant passage node with variant_of edge to base.
+
+    The variant inherits its ``entities`` from the base passage per R-6.5 —
+    a variant plays out at the same dramatic moment as its base, with the
+    same cast on stage. Without the inheritance, FILL's `### Valid Entity
+    IDs` prompt slot would be empty for variant prose generation, which is
+    the same phantom-ID failure mode that produced #1457 for residues.
+    """
+    inherited_entities = _inherited_passage_entities(graph, vspec.base_passage_id)
     graph.create_node(
         vspec.variant_id,
         {
@@ -1198,42 +1206,44 @@ def _create_variant_passage(graph: Graph, vspec: VariantSpec) -> None:
             "summary": vspec.summary,
             "requires": vspec.requires,
             "is_variant": True,
+            "entities": inherited_entities,
         },
     )
 
     graph.add_edge("variant_of", vspec.variant_id, vspec.base_passage_id)
 
 
-def _residue_inherited_entities(graph: Graph, target_passage_id: str) -> list[str]:
-    """Return the entity IDs a residue should inherit from its target passage.
+def _inherited_passage_entities(graph: Graph, source_passage_id: str) -> list[str]:
+    """Return the entity IDs a synthesized passage should inherit from its source.
 
-    A residue passage / beat plays out narratively at the same dramatic moment
-    as its target — same cast on stage. FILL builds its `### Valid Entity IDs`
-    context from the passage's ``entities`` field, so a missing or empty list
-    on the residue forces the prose-call to invent IDs from the passage_id
-    text and produces phantom-ID escalations downstream (#1457).
+    Residue passages / beats and variant passages all play out narratively at
+    the same dramatic moment as a base passage — same cast on stage. FILL
+    builds its `### Valid Entity IDs` context from the passage's ``entities``
+    field, so a missing or empty list on the synthesized node forces the
+    prose-call to invent IDs from the passage_id text and produces phantom-ID
+    escalations downstream (#1457 for residues, #1459 for variants).
 
-    A target passage that doesn't exist is a structural failure: phase 6's
-    application order (R-6.2) creates target passages before residues, so
-    this can only happen if Phase 4-5 produced a plan that violates that
-    order or someone called this helper out-of-band. Raise rather than
-    fall back to ``[]`` — silently inheriting an empty entity list is the
-    exact failure mode that produced #1457 in the first place. (Per
-    ``.gemini/styleguide.md`` anti-pattern: silent fallbacks that hide
+    A source passage that doesn't exist is a structural failure: Phase 6's
+    application order (R-6.2) creates base passages before variants and
+    residues, so this can only happen if Phase 4-5 produced a plan that
+    violates that order or someone called this helper out-of-band. Raise
+    rather than fall back to ``[]`` — silently inheriting an empty entity
+    list is the exact failure mode that produced #1457 in the first place.
+    (Per ``.gemini/styleguide.md`` anti-pattern: silent fallbacks that hide
     bugs prefer explicit errors.)
 
-    The inner ``or []`` on ``target.get("entities")`` handles a *present*
-    target whose entities field is missing or explicitly ``None`` — that's
+    The inner ``or []`` on ``source.get("entities")`` handles a *present*
+    source whose entities field is missing or explicitly ``None`` — that's
     a legitimate empty case (e.g. setup beats before any cast is on stage).
     """
-    target = graph.get_node(target_passage_id)
-    if target is None:
+    source = graph.get_node(source_passage_id)
+    if source is None:
         raise ValueError(
-            f"R-6.5: residue target passage {target_passage_id!r} not found in graph. "
-            "Phase 6 application order (R-6.2) requires target passages to be created "
-            "before residues."
+            f"R-6.5: source passage {source_passage_id!r} not found in graph. "
+            "Phase 6 application order (R-6.2) requires base passages to be created "
+            "before variants and residues."
         )
-    return list(target.get("entities") or [])
+    return list(source.get("entities") or [])
 
 
 def _create_residue_beat_and_passage(graph: Graph, rspec: ResidueSpec) -> None:
@@ -1269,7 +1279,7 @@ def _apply_residue_with_variants(graph: Graph, rspec: ResidueSpec) -> None:
     beat_id = f"beat::residue_{residue_suffix}"
     residue_passage_id = f"passage::residue_{residue_suffix}"
 
-    inherited_entities = _residue_inherited_entities(graph, rspec.target_passage_id)
+    inherited_entities = _inherited_passage_entities(graph, rspec.target_passage_id)
 
     # Create residue beat node
     graph.create_node(
@@ -1355,7 +1365,7 @@ def _apply_residue_parallel_passages(graph: Graph, rspec: ResidueSpec) -> None:
     beat_id = f"beat::residue_{residue_suffix}"
     residue_passage_id = f"passage::residue_{residue_suffix}"
 
-    inherited_entities = _residue_inherited_entities(graph, rspec.target_passage_id)
+    inherited_entities = _inherited_passage_entities(graph, rspec.target_passage_id)
 
     # Create residue beat — same shape as the variants strategy.
     graph.create_node(

--- a/tests/unit/test_polish_apply.py
+++ b/tests/unit/test_polish_apply.py
@@ -28,7 +28,7 @@ from questfoundry.pipeline.stages.polish.deterministic import (
     _create_passage_node,
     _create_residue_beat_and_passage,
     _create_variant_passage,
-    _residue_inherited_entities,
+    _inherited_passage_entities,
     _store_plan,
     phase_plan_application,
 )
@@ -130,6 +130,41 @@ class TestCreateVariantPassage:
         assert len(edges) == 1
         assert edges[0]["from"] == "passage::variant_0"
         assert edges[0]["to"] == "passage::base"
+
+    def test_variant_inherits_entities_from_base_passage(self) -> None:
+        """Regression: #1459 — variant passages must copy entities from base.
+
+        Same shape and rationale as #1457 for residues: a variant plays out
+        at the same dramatic moment as its base, so FILL's `### Valid Entity
+        IDs` prompt slot needs the entity list populated. R-6.5 covers both
+        residue and variant inheritance.
+        """
+        graph = Graph.empty()
+        _make_beat(graph, "beat::a")
+
+        base_spec = PassageSpec(
+            passage_id="passage::base",
+            beat_ids=["beat::a"],
+            summary="Base passage",
+            entities=["character::clara_yu", "character::alistair_vance"],
+        )
+        _create_passage_node(graph, base_spec)
+
+        vspec = VariantSpec(
+            base_passage_id="passage::base",
+            variant_id="passage::variant_0",
+            requires=["flag1"],
+            summary="Variant version",
+        )
+        _create_variant_passage(graph, vspec)
+
+        passages = graph.get_nodes_by_type("passage")
+        variant = passages.get("passage::variant_0")
+        assert variant is not None
+        assert variant["entities"] == [
+            "character::clara_yu",
+            "character::alistair_vance",
+        ]
 
 
 class TestCreateResidueBeatAndPassage:
@@ -381,19 +416,20 @@ class TestCreateResidueBeatAndPassage:
         assert residue_beat is not None
         assert residue_beat["entities"] == ["character::clara_yu"]
 
-    def test_residue_inherited_entities_raises_for_absent_target(self) -> None:
-        """Helper raises ``ValueError`` when the target passage is missing.
+    def test_inherited_passage_entities_raises_for_absent_source(self) -> None:
+        """Helper raises ``ValueError`` when the source passage is missing.
 
         Per `.gemini/styleguide.md` anti-pattern (silent fallbacks that hide
-        bugs prefer explicit errors): a residue created against a missing
-        target passage is a structural failure — Phase 6's application order
-        (R-6.2) creates target passages before residues. Returning ``[]``
-        instead would silently propagate the exact symptom #1457 fixed
-        (residue with empty entities → FILL phantom-ID escalations).
+        bugs prefer explicit errors): a residue or variant synthesized against
+        a missing source is a structural failure — Phase 6's application order
+        (R-6.2) creates base passages before residues and variants. Returning
+        ``[]`` instead would silently propagate the exact symptom #1457 fixed
+        (synthesized passage with empty entities → FILL phantom-ID
+        escalations); same failure mode for variants per #1459.
         """
         graph = Graph.empty()
-        with pytest.raises(ValueError, match=r"R-6\.5: residue target passage"):
-            _residue_inherited_entities(graph, "passage::does_not_exist")
+        with pytest.raises(ValueError, match=r"R-6\.5: source passage"):
+            _inherited_passage_entities(graph, "passage::does_not_exist")
 
     def test_residue_inheritance_defensive_when_target_has_no_entities(self) -> None:
         """If the target has no entities (early-stage passage), residue gets []


### PR DESCRIPTION
## Summary

Closes #1459. Companion to #1457 / PR #1458.

\`_create_variant_passage\` created variant nodes without an \`entities\` field — same shape as the residue bug fixed in #1458. FILL reaches variant passages via the catch-all sweep at the end of \`_get_generation_order\` (\`fill.py:1120-1124\`), so the same phantom-ID failure mode applies once a project's POLISH plan produces variants.

## Reproducer

No in-the-wild repro: \`projects/murder3\` happens to have **0** variants (its POLISH plan didn't propose any). But the bug is structural — confirmed by reading the code paths:

1. \`_create_variant_passage\` (\`deterministic.py:1191\` pre-fix): no \`entities\` key set on the variant node.
2. \`_get_generation_order\` (\`fill.py:1118-1124\`): sweeps every passage with no prose, including variants.
3. FILL Phase 1 prose call reads \`passage.get(\"entities\", [])\` → \`[]\` → Valid Entity IDs slot becomes \`(none)\` → LLM hallucinates short-form IDs from passage_id text → \`_resolve_entity_id\` rejects → \`missing_entity\` escalation. Identical chain to #1457.

## Fix

Mirror of #1458 / R-6.5:

- Rename helper `_residue_inherited_entities` → `_inherited_passage_entities` since the invariant is now shared by residues and variants.
- `_create_variant_passage` reads \`vspec.base_passage_id\`'s entities and copies them into the new variant node.
- Same \`is None: raise ValueError\` shape per \`.gemini/styleguide.md\` anti-pattern (silent fallbacks that hide bugs).

## Spec update — R-6.5 extension

\`docs/design/procedures/polish.md\` R-6.5 now covers both residue and variant inheritance under a single rule (same underlying invariant: synthesized passage at the same dramatic moment as a source passage MUST inherit that source's entities). Two new violation-table rows: variant phantom-ID symptom, and the missing-source raise.

## Tests

| Test | What it pins |
|---|---|
| \`test_variant_inherits_entities_from_base_passage\` (new) | Primary regression: variant copies entities list from base |
| \`test_inherited_passage_entities_raises_for_absent_source\` (renamed from residue-specific) | Helper raises \`ValueError\` naming R-6.5 + R-6.2 — covers both residue and variant code paths |

Existing residue tests + the \`test_apply_full_plan_to_graph\` integration test continue to pass — the rename is a pure refactor at the call sites.

\`\`\`
$ uv run pytest tests/unit/ -k polish -x -q
369 passed
$ uv run mypy src/        # clean
$ uv run ruff check src/  # clean
\`\`\`

## Test plan

- [x] All polish unit tests pass (369)
- [x] mypy + ruff + pre-commit clean
- [ ] Wait for \`claude-code-review\` and \`gemini-code-assist\` before flipping ready