### PR TITLE
fix(providers): default Gemini safety_settings to BLOCK_NONE (#1464)

### DIFF
--- a/src/questfoundry/providers/factory.py
+++ b/src/questfoundry/providers/factory.py
@@ -224,15 +224,12 @@ def _preprocess_provider_kwargs(
         if not kwargs.get("safety_settings"):
             try:
                 kwargs["safety_settings"] = _default_google_safety_settings()
-            except (ImportError, AttributeError):
+            except ImportError:
                 # Defer to the centralised handler in ``create_chat_model``:
                 # a missing ``langchain-google-genai`` package surfaces as
                 # ``ProviderError`` with the ``uv add ...`` hint when
-                # ``_init_chat_model_safe`` runs. ``AttributeError`` covers
-                # version skew (e.g. ``HARM_CATEGORY_CIVIC_INTEGRITY`` is
-                # absent in langchain-google-genai < 1.0.4 — pyproject pins
-                # >=2.0 today, so this is a defensive guard for future
-                # downgrades, not the happy path).
+                # ``_init_chat_model_safe`` runs. We only swallow this one
+                # exception class so unknown failures still propagate.
                 pass
             else:
                 log.debug(
@@ -246,25 +243,35 @@ def _preprocess_provider_kwargs(
 def _default_google_safety_settings() -> dict[Any, Any]:
     """Return the default ``safety_settings`` dict for the Google provider.
 
-    Maps the five user-facing harm categories to ``BLOCK_NONE``. Imported
-    lazily so the factory doesn't require ``langchain-google-genai`` at
-    module load time — only when a Google model is actually requested.
+    Maps the four core user-facing harm categories to ``BLOCK_NONE``, plus
+    ``HARM_CATEGORY_CIVIC_INTEGRITY`` when the installed
+    ``langchain-google-genai`` exposes it (added in v1.0.4; pyproject pins
+    >=2.0 today, so the absence path is forward-defensive). When that
+    category is absent we log a warning to make the gap observable rather
+    than silently shipping a smaller default set.
 
-    Note: ``HARM_CATEGORY_CIVIC_INTEGRITY`` was added in Gemini 1.5 (early
-    2024) and is absent from older models. The default model in
-    :data:`PROVIDER_DEFAULTS` is ``gemini-2.5-flash``, which supports it;
-    callers using pre-1.5 models should pass an explicit
-    ``safety_settings`` dict that omits this category.
+    Imported lazily so the factory doesn't require ``langchain-google-genai``
+    at module load time — only when a Google model is actually requested.
     """
     from langchain_google_genai import HarmBlockThreshold, HarmCategory
 
-    return {
+    settings: dict[Any, Any] = {
         HarmCategory.HARM_CATEGORY_HARASSMENT: HarmBlockThreshold.BLOCK_NONE,
         HarmCategory.HARM_CATEGORY_HATE_SPEECH: HarmBlockThreshold.BLOCK_NONE,
         HarmCategory.HARM_CATEGORY_SEXUALLY_EXPLICIT: HarmBlockThreshold.BLOCK_NONE,
         HarmCategory.HARM_CATEGORY_DANGEROUS_CONTENT: HarmBlockThreshold.BLOCK_NONE,
-        HarmCategory.HARM_CATEGORY_CIVIC_INTEGRITY: HarmBlockThreshold.BLOCK_NONE,
     }
+    civic = getattr(HarmCategory, "HARM_CATEGORY_CIVIC_INTEGRITY", None)
+    if civic is not None:
+        settings[civic] = HarmBlockThreshold.BLOCK_NONE
+    else:
+        log.warning(
+            "google_safety_category_missing",
+            category="HARM_CATEGORY_CIVIC_INTEGRITY",
+            hint="langchain-google-genai < 1.0.4; civic-integrity content "
+            "uses Gemini's built-in defaults for this category only.",
+        )
+    return settings
 
 
 def _map_provider_for_init(provider: str) -> str:

--- a/src/questfoundry/providers/factory.py
+++ b/src/questfoundry/providers/factory.py
@@ -216,8 +216,14 @@ def _preprocess_provider_kwargs(
         # blackmail-ledger / undercover-journalist passage batch. QuestFoundry
         # users explicitly opt into a creative-writing pipeline; the safety
         # filter is a chatbot-deployment concern, not an authoring concern.
-        if "safety_settings" not in kwargs:
+        # ``not kwargs.get(...)`` (rather than ``not in``) intentionally treats
+        # ``safety_settings=None`` and ``safety_settings={}`` as "use our
+        # defaults" too — silently letting None through would re-enable
+        # Gemini's consumer-level defaults, the exact failure this guards
+        # against.
+        if not kwargs.get("safety_settings"):
             kwargs["safety_settings"] = _default_google_safety_settings()
+            log.debug("google_safety_settings_injected", categories=5)
 
     return kwargs
 
@@ -228,6 +234,12 @@ def _default_google_safety_settings() -> dict[Any, Any]:
     Maps the five user-facing harm categories to ``BLOCK_NONE``. Imported
     lazily so the factory doesn't require ``langchain-google-genai`` at
     module load time — only when a Google model is actually requested.
+
+    Note: ``HARM_CATEGORY_CIVIC_INTEGRITY`` was added in Gemini 1.5 (early
+    2024) and is absent from older models. The default model in
+    :data:`PROVIDER_DEFAULTS` is ``gemini-2.5-flash``, which supports it;
+    callers using pre-1.5 models should pass an explicit
+    ``safety_settings`` dict that omits this category.
     """
     from langchain_google_genai import HarmBlockThreshold, HarmCategory
 

--- a/src/questfoundry/providers/factory.py
+++ b/src/questfoundry/providers/factory.py
@@ -222,8 +222,23 @@ def _preprocess_provider_kwargs(
         # Gemini's consumer-level defaults, the exact failure this guards
         # against.
         if not kwargs.get("safety_settings"):
-            kwargs["safety_settings"] = _default_google_safety_settings()
-            log.debug("google_safety_settings_injected", categories=5)
+            try:
+                kwargs["safety_settings"] = _default_google_safety_settings()
+            except (ImportError, AttributeError):
+                # Defer to the centralised handler in ``create_chat_model``:
+                # a missing ``langchain-google-genai`` package surfaces as
+                # ``ProviderError`` with the ``uv add ...`` hint when
+                # ``_init_chat_model_safe`` runs. ``AttributeError`` covers
+                # version skew (e.g. ``HARM_CATEGORY_CIVIC_INTEGRITY`` is
+                # absent in langchain-google-genai < 1.0.4 — pyproject pins
+                # >=2.0 today, so this is a defensive guard for future
+                # downgrades, not the happy path).
+                pass
+            else:
+                log.debug(
+                    "google_safety_settings_injected",
+                    categories=len(kwargs["safety_settings"]),
+                )
 
     return kwargs
 

--- a/src/questfoundry/providers/factory.py
+++ b/src/questfoundry/providers/factory.py
@@ -209,7 +209,35 @@ def _preprocess_provider_kwargs(
             )
         kwargs["api_key"] = api_key
 
+        # Apply default safety_settings unless caller already supplied one (#1464).
+        # Gemini's defaults (BLOCK_MEDIUM_AND_ABOVE) reject genre-typical content
+        # for QuestFoundry's mystery / noir / horror / thriller use cases — see
+        # projects/murder3 PROHIBITED_CONTENT block on fill_phase1_expand for a
+        # blackmail-ledger / undercover-journalist passage batch. QuestFoundry
+        # users explicitly opt into a creative-writing pipeline; the safety
+        # filter is a chatbot-deployment concern, not an authoring concern.
+        if "safety_settings" not in kwargs:
+            kwargs["safety_settings"] = _default_google_safety_settings()
+
     return kwargs
+
+
+def _default_google_safety_settings() -> dict[Any, Any]:
+    """Return the default ``safety_settings`` dict for the Google provider.
+
+    Maps the five user-facing harm categories to ``BLOCK_NONE``. Imported
+    lazily so the factory doesn't require ``langchain-google-genai`` at
+    module load time — only when a Google model is actually requested.
+    """
+    from langchain_google_genai import HarmBlockThreshold, HarmCategory
+
+    return {
+        HarmCategory.HARM_CATEGORY_HARASSMENT: HarmBlockThreshold.BLOCK_NONE,
+        HarmCategory.HARM_CATEGORY_HATE_SPEECH: HarmBlockThreshold.BLOCK_NONE,
+        HarmCategory.HARM_CATEGORY_SEXUALLY_EXPLICIT: HarmBlockThreshold.BLOCK_NONE,
+        HarmCategory.HARM_CATEGORY_DANGEROUS_CONTENT: HarmBlockThreshold.BLOCK_NONE,
+        HarmCategory.HARM_CATEGORY_CIVIC_INTEGRITY: HarmBlockThreshold.BLOCK_NONE,
+    }
 
 
 def _map_provider_for_init(provider: str) -> str:

--- a/tests/unit/test_provider_factory.py
+++ b/tests/unit/test_provider_factory.py
@@ -373,6 +373,31 @@ def test_create_chat_model_google_safety_settings_override_preserved() -> None:
     assert mock_init.call_args[1]["safety_settings"] is custom
 
 
+def test_create_chat_model_google_safety_settings_none_falls_back_to_default() -> None:
+    """``safety_settings=None`` is treated as "use our defaults", not as opt-out.
+
+    Letting ``None`` pass through to ``ChatGoogleGenerativeAI`` would silently
+    re-enable Gemini's consumer-level thresholds — exactly the failure mode
+    this guard exists to prevent. Same treatment for the empty-dict case.
+    """
+    from langchain_google_genai import HarmBlockThreshold, HarmCategory
+
+    mock_chat = MagicMock()
+    with (
+        patch.dict("os.environ", {"GOOGLE_API_KEY": "test-key"}),
+        patch(
+            "questfoundry.providers.factory._init_chat_model_safe",
+            return_value=mock_chat,
+        ) as mock_init,
+    ):
+        create_chat_model("google", "gemini-2.5-flash", safety_settings=None)
+
+    safety_settings = mock_init.call_args[1]["safety_settings"]
+    assert safety_settings is not None
+    assert HarmCategory.HARM_CATEGORY_DANGEROUS_CONTENT in safety_settings
+    assert all(threshold == HarmBlockThreshold.BLOCK_NONE for threshold in safety_settings.values())
+
+
 def test_create_chat_model_google_safety_settings_skipped_for_other_providers() -> None:
     """safety_settings default applies only to Google; other providers untouched."""
     mock_chat = MagicMock()

--- a/tests/unit/test_provider_factory.py
+++ b/tests/unit/test_provider_factory.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import FrozenInstanceError
+from typing import Any
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -373,12 +374,16 @@ def test_create_chat_model_google_safety_settings_override_preserved() -> None:
     assert mock_init.call_args[1]["safety_settings"] is custom
 
 
-def test_create_chat_model_google_safety_settings_none_falls_back_to_default() -> None:
-    """``safety_settings=None`` is treated as "use our defaults", not as opt-out.
+@pytest.mark.parametrize("falsy_override", [None, {}])
+def test_create_chat_model_google_safety_settings_falsy_falls_back_to_default(
+    falsy_override: Any,
+) -> None:
+    """``safety_settings=None`` and ``safety_settings={}`` both use our defaults.
 
-    Letting ``None`` pass through to ``ChatGoogleGenerativeAI`` would silently
+    Letting either pass through to ``ChatGoogleGenerativeAI`` would silently
     re-enable Gemini's consumer-level thresholds — exactly the failure mode
-    this guard exists to prevent. Same treatment for the empty-dict case.
+    this guard exists to prevent. ``not kwargs.get(...)`` treats both falsy
+    sentinels the same as absence.
     """
     from langchain_google_genai import HarmBlockThreshold, HarmCategory
 
@@ -390,7 +395,7 @@ def test_create_chat_model_google_safety_settings_none_falls_back_to_default() -
             return_value=mock_chat,
         ) as mock_init,
     ):
-        create_chat_model("google", "gemini-2.5-flash", safety_settings=None)
+        create_chat_model("google", "gemini-2.5-flash", safety_settings=falsy_override)
 
     safety_settings = mock_init.call_args[1]["safety_settings"]
     assert safety_settings is not None

--- a/tests/unit/test_provider_factory.py
+++ b/tests/unit/test_provider_factory.py
@@ -398,6 +398,34 @@ def test_create_chat_model_google_safety_settings_none_falls_back_to_default() -
     assert all(threshold == HarmBlockThreshold.BLOCK_NONE for threshold in safety_settings.values())
 
 
+def test_create_chat_model_google_missing_package_still_raises_provider_error() -> None:
+    """If langchain-google-genai isn't installed, the centralised handler still wins.
+
+    The lazy import inside ``_default_google_safety_settings`` happens during
+    ``_preprocess_provider_kwargs`` — outside the ``try/except ImportError``
+    in ``create_chat_model``. A bare ``ImportError`` from the helper would
+    bypass the ``ProviderError`` handler and hide the user-friendly
+    "Run: uv add langchain-google-genai" message. The call site swallows the
+    ``ImportError`` so the existing handler around ``_init_chat_model_safe``
+    can report the missing package cleanly.
+    """
+    with (
+        patch.dict("os.environ", {"GOOGLE_API_KEY": "test-key"}),
+        patch(
+            "questfoundry.providers.factory._default_google_safety_settings",
+            side_effect=ImportError("No module named 'langchain_google_genai'"),
+        ),
+        patch(
+            "questfoundry.providers.factory._init_chat_model_safe",
+            side_effect=ImportError("No module named 'langchain_google_genai'"),
+        ),
+        pytest.raises(ProviderError) as exc_info,
+    ):
+        create_chat_model("google", "gemini-2.5-flash")
+
+    assert "langchain-google-genai not installed" in str(exc_info.value)
+
+
 def test_create_chat_model_google_safety_settings_skipped_for_other_providers() -> None:
     """safety_settings default applies only to Google; other providers untouched."""
     mock_chat = MagicMock()

--- a/tests/unit/test_provider_factory.py
+++ b/tests/unit/test_provider_factory.py
@@ -323,6 +323,71 @@ def test_create_chat_model_google_top_p() -> None:
     assert call_kwargs["top_p"] == 0.9
 
 
+def test_create_chat_model_google_default_safety_settings_blocks_none() -> None:
+    """Google default safety_settings unblocks all 5 harm categories (#1464).
+
+    Gemini's defaults (BLOCK_MEDIUM_AND_ABOVE) reject genre-typical content
+    for QuestFoundry's mystery / noir / horror / thriller use cases. The
+    factory injects BLOCK_NONE across the board so creative-fiction prose
+    isn't blocked by chatbot-tuned safety thresholds.
+    """
+    from langchain_google_genai import HarmBlockThreshold, HarmCategory
+
+    mock_chat = MagicMock()
+    with (
+        patch.dict("os.environ", {"GOOGLE_API_KEY": "test-key"}),
+        patch(
+            "questfoundry.providers.factory._init_chat_model_safe",
+            return_value=mock_chat,
+        ) as mock_init,
+    ):
+        create_chat_model("google", "gemini-2.5-flash")
+
+    safety_settings = mock_init.call_args[1]["safety_settings"]
+    expected_categories = {
+        HarmCategory.HARM_CATEGORY_HARASSMENT,
+        HarmCategory.HARM_CATEGORY_HATE_SPEECH,
+        HarmCategory.HARM_CATEGORY_SEXUALLY_EXPLICIT,
+        HarmCategory.HARM_CATEGORY_DANGEROUS_CONTENT,
+        HarmCategory.HARM_CATEGORY_CIVIC_INTEGRITY,
+    }
+    assert set(safety_settings.keys()) == expected_categories
+    assert all(threshold == HarmBlockThreshold.BLOCK_NONE for threshold in safety_settings.values())
+
+
+def test_create_chat_model_google_safety_settings_override_preserved() -> None:
+    """Caller-supplied safety_settings is not overwritten by the default."""
+    from langchain_google_genai import HarmBlockThreshold, HarmCategory
+
+    custom = {HarmCategory.HARM_CATEGORY_HARASSMENT: HarmBlockThreshold.BLOCK_LOW_AND_ABOVE}
+    mock_chat = MagicMock()
+    with (
+        patch.dict("os.environ", {"GOOGLE_API_KEY": "test-key"}),
+        patch(
+            "questfoundry.providers.factory._init_chat_model_safe",
+            return_value=mock_chat,
+        ) as mock_init,
+    ):
+        create_chat_model("google", "gemini-2.5-flash", safety_settings=custom)
+
+    assert mock_init.call_args[1]["safety_settings"] is custom
+
+
+def test_create_chat_model_google_safety_settings_skipped_for_other_providers() -> None:
+    """safety_settings default applies only to Google; other providers untouched."""
+    mock_chat = MagicMock()
+    with (
+        patch.dict("os.environ", {"OPENAI_API_KEY": "test-key"}),
+        patch(
+            "questfoundry.providers.factory._init_chat_model_safe",
+            return_value=mock_chat,
+        ) as mock_init,
+    ):
+        create_chat_model("openai", "gpt-5-mini")
+
+    assert "safety_settings" not in mock_init.call_args[1]
+
+
 def test_create_chat_model_case_insensitive() -> None:
     """Factory handles uppercase provider names."""
     mock_chat = MagicMock()


### PR DESCRIPTION
## Summary

Closes #1464.

\`ChatGoogleGenerativeAI\` applies built-in safety thresholds (\`BLOCK_MEDIUM_AND_ABOVE\` per Gemini docs) when no \`safety_settings\` are passed. Those defaults are tuned for general consumer chatbots and reject genre-typical content for QuestFoundry's mystery / noir / horror / thriller use cases.

## Reproducer (`projects/murder3`)

Latest FILL run halted on \`fill_phase1_expand\` for an 8-passage batch (residue + gap_6 passages mentioning a blackmail ledger and an undercover journalist):

\`\`\`
WARNING Gemini produced an empty response.
        block_reason=<BlockedReason.PROHIBITED_CONTENT: 'PROHIBITED_CONTENT'>
WARNING fill_llm_validation_fail (3 attempts, all empty)
WARNING batch_item_failed
\`\`\`

Three retries, all blocked, then the batch item silently dropped — those 8 passages got no expand-phase blueprint.

## Root cause + fix

Pre-fix: zero matches for \`safety_settings|HarmCategory|BLOCK_NONE\` in \`src/\`. The Google branch of \`_preprocess_provider_kwargs\` set the API key but never the safety thresholds.

Post-fix: factory injects a default \`safety_settings\` dict mapping the 5 user-facing harm categories to \`BLOCK_NONE\`:

| Category | Threshold |
|---|---|
| \`HARM_CATEGORY_HARASSMENT\` | \`BLOCK_NONE\` |
| \`HARM_CATEGORY_HATE_SPEECH\` | \`BLOCK_NONE\` |
| \`HARM_CATEGORY_SEXUALLY_EXPLICIT\` | \`BLOCK_NONE\` |
| \`HARM_CATEGORY_DANGEROUS_CONTENT\` | \`BLOCK_NONE\` |
| \`HARM_CATEGORY_CIVIC_INTEGRITY\` | \`BLOCK_NONE\` |

Caller-supplied \`safety_settings\` is preserved (the default only fires when the kwarg is absent), so project-level configuration can tune thresholds per genre / audience.

The helper \`_default_google_safety_settings\` imports \`langchain_google_genai\` lazily — the factory doesn't require the package at module load, only when a Google model is actually requested.

## Verification

\`\`\`bash
$ GOOGLE_API_KEY=test-key uv run python -c "
from questfoundry.providers.factory import create_chat_model
m = create_chat_model('google', 'gemini-2.5-flash')
for k, v in (m.safety_settings or {}).items():
    print(f'{k.name} -> {v.name}')
"
HARM_CATEGORY_HARASSMENT -> BLOCK_NONE
HARM_CATEGORY_HATE_SPEECH -> BLOCK_NONE
HARM_CATEGORY_SEXUALLY_EXPLICIT -> BLOCK_NONE
HARM_CATEGORY_DANGEROUS_CONTENT -> BLOCK_NONE
HARM_CATEGORY_CIVIC_INTEGRITY -> BLOCK_NONE
\`\`\`

## Tests

Three new cases in \`tests/unit/test_provider_factory.py\`:

- \`test_create_chat_model_google_default_safety_settings_blocks_none\` — default fills all 5 categories with \`BLOCK_NONE\`
- \`test_create_chat_model_google_safety_settings_override_preserved\` — caller-supplied \`safety_settings\` survives intact
- \`test_create_chat_model_google_safety_settings_skipped_for_other_providers\` — openai/anthropic/ollama get no \`safety_settings\` default

\`\`\`
$ uv run pytest tests/unit/test_provider_factory.py -k google -x -q
11 passed
$ uv run pytest tests/unit/test_provider_factory.py tests/unit/test_settings.py -x -q
178 passed
$ uv run mypy src/        # clean
$ uv run ruff check src/  # clean
\`\`\`

## Out of scope

- **FILL silent batch-item drop on PROHIBITED_CONTENT** — after 3 retries on blocked content, the batch item drops silently and FILL continues. Per \`.gemini/styleguide.md\` "Silent fallbacks that hide bugs" this should escalate explicitly so downstream phases know which passages have incomplete prose context. Pipeline-level concern, separate issue.

## Test plan

- [x] Targeted google tests pass (11)
- [x] Full provider_factory + settings tests pass (178)
- [x] mypy + ruff + pre-commit clean
- [x] Smoke test on the constructed model confirms 5 categories at BLOCK_NONE
- [ ] Wait for \`claude-code-review\` and \`gemini-code-assist\` before flipping ready