### PR TITLE
fix(providers): switch Gemini safety_settings from BLOCK_NONE to OFF (#1466)

### DIFF
--- a/src/questfoundry/providers/factory.py
+++ b/src/questfoundry/providers/factory.py
@@ -243,12 +243,21 @@ def _preprocess_provider_kwargs(
 def _default_google_safety_settings() -> dict[Any, Any]:
     """Return the default ``safety_settings`` dict for the Google provider.
 
-    Maps the four core user-facing harm categories to ``BLOCK_NONE``, plus
+    Maps the four core user-facing harm categories to ``OFF``, plus
     ``HARM_CATEGORY_CIVIC_INTEGRITY`` when the installed
     ``langchain-google-genai`` exposes it (added in v1.0.4; pyproject pins
     >=2.0 today, so the absence path is forward-defensive). When that
     category is absent we log a warning to make the gap observable rather
     than silently shipping a smaller default set.
+
+    ``OFF`` (not ``BLOCK_NONE``) is intentional: ``BLOCK_NONE`` only governs
+    the response-side filter — the input-side prefilter still rejects
+    prompts that mention things like \"blackmail ledger\" or \"undercover
+    journalist\" with ``block_reason=PROHIBITED_CONTENT`` (#1466 reproduced
+    against the murder3 cozy-mystery project after #1465 / #1464). ``OFF``
+    is the documented threshold that disables filtering at both layers,
+    appropriate for a creative-fiction authoring tool where genre-typical
+    content is expected.
 
     Imported lazily so the factory doesn't require ``langchain-google-genai``
     at module load time — only when a Google model is actually requested.
@@ -256,14 +265,14 @@ def _default_google_safety_settings() -> dict[Any, Any]:
     from langchain_google_genai import HarmBlockThreshold, HarmCategory
 
     settings: dict[Any, Any] = {
-        HarmCategory.HARM_CATEGORY_HARASSMENT: HarmBlockThreshold.BLOCK_NONE,
-        HarmCategory.HARM_CATEGORY_HATE_SPEECH: HarmBlockThreshold.BLOCK_NONE,
-        HarmCategory.HARM_CATEGORY_SEXUALLY_EXPLICIT: HarmBlockThreshold.BLOCK_NONE,
-        HarmCategory.HARM_CATEGORY_DANGEROUS_CONTENT: HarmBlockThreshold.BLOCK_NONE,
+        HarmCategory.HARM_CATEGORY_HARASSMENT: HarmBlockThreshold.OFF,
+        HarmCategory.HARM_CATEGORY_HATE_SPEECH: HarmBlockThreshold.OFF,
+        HarmCategory.HARM_CATEGORY_SEXUALLY_EXPLICIT: HarmBlockThreshold.OFF,
+        HarmCategory.HARM_CATEGORY_DANGEROUS_CONTENT: HarmBlockThreshold.OFF,
     }
     civic = getattr(HarmCategory, "HARM_CATEGORY_CIVIC_INTEGRITY", None)
     if civic is not None:
-        settings[civic] = HarmBlockThreshold.BLOCK_NONE
+        settings[civic] = HarmBlockThreshold.OFF
     else:
         log.warning(
             "google_safety_category_missing",

--- a/tests/unit/test_provider_factory.py
+++ b/tests/unit/test_provider_factory.py
@@ -324,13 +324,17 @@ def test_create_chat_model_google_top_p() -> None:
     assert call_kwargs["top_p"] == 0.9
 
 
-def test_create_chat_model_google_default_safety_settings_blocks_none() -> None:
-    """Google default safety_settings unblocks all 5 harm categories (#1464).
+def test_create_chat_model_google_default_safety_settings_off() -> None:
+    """Google default safety_settings sets all 5 harm categories to OFF (#1464 / #1466).
 
     Gemini's defaults (BLOCK_MEDIUM_AND_ABOVE) reject genre-typical content
-    for QuestFoundry's mystery / noir / horror / thriller use cases. The
-    factory injects BLOCK_NONE across the board so creative-fiction prose
-    isn't blocked by chatbot-tuned safety thresholds.
+    for QuestFoundry's mystery / noir / horror / thriller use cases. We use
+    ``OFF`` rather than ``BLOCK_NONE`` because BLOCK_NONE only disables the
+    response-side filter — the input-side prefilter still rejects prompts
+    with ``block_reason=PROHIBITED_CONTENT`` for plain mystery content.
+    ``OFF`` is the documented threshold that disables filtering at both
+    layers (#1466 reproduced against the murder3 cozy-mystery project after
+    BLOCK_NONE landed in #1465 and didn't unblock the prompt prefilter).
     """
     from langchain_google_genai import HarmBlockThreshold, HarmCategory
 
@@ -353,7 +357,7 @@ def test_create_chat_model_google_default_safety_settings_blocks_none() -> None:
         HarmCategory.HARM_CATEGORY_CIVIC_INTEGRITY,
     }
     assert set(safety_settings.keys()) == expected_categories
-    assert all(threshold == HarmBlockThreshold.BLOCK_NONE for threshold in safety_settings.values())
+    assert all(threshold == HarmBlockThreshold.OFF for threshold in safety_settings.values())
 
 
 def test_create_chat_model_google_safety_settings_override_preserved() -> None:
@@ -400,7 +404,7 @@ def test_create_chat_model_google_safety_settings_falsy_falls_back_to_default(
     safety_settings = mock_init.call_args[1]["safety_settings"]
     assert safety_settings is not None
     assert HarmCategory.HARM_CATEGORY_DANGEROUS_CONTENT in safety_settings
-    assert all(threshold == HarmBlockThreshold.BLOCK_NONE for threshold in safety_settings.values())
+    assert all(threshold == HarmBlockThreshold.OFF for threshold in safety_settings.values())
 
 
 def test_create_chat_model_google_missing_package_still_raises_provider_error() -> None:


### PR DESCRIPTION
## Summary

Closes #1466.

PR #1465 set Gemini \`safety_settings\` to \`BLOCK_NONE\` for all five harm categories. Murder3 re-run at 16:51 (after #1465 merged at 16:49) still hit the same \`PROHIBITED_CONTENT\` block on \`fill_phase1_expand\`:

\`\`\`
google_safety_settings_injected categories=5      ← #1465 fix is applied
chat_model_created provider=google model=gemini-2.5-pro
...
WARNING Gemini produced an empty response.
        Feedback: block_reason=<BlockedReason.PROHIBITED_CONTENT>
                  safety_ratings=None
WARNING fill_llm_validation_fail (×3)
WARNING batch_item_failed
\`\`\`

The blocked content was a beat-blueprint prompt for 8 cozy-mystery passages mentioning a blackmail ledger, an undercover journalist, and "who is protecting the killer" — standard genre tropes, nothing that should hard-block.

## Diagnosis

\`block_reason=PROHIBITED_CONTENT\` lives on \`prompt_feedback\` (with \`safety_ratings=None\`), meaning the block fires at the **input prefilter**, before generation. The output-side filter governed by \`safety_settings\` thresholds never runs.

| Threshold | Effect |
|---|---|
| `BLOCK_NONE` | "never blocks" but only governs the response filter |
| `OFF` | "turns off the safety filter" — disables filtering at **both** input and output layers |

We picked `BLOCK_NONE` in #1465 thinking it was the most permissive. `OFF` is strictly more permissive and is the documented threshold to bypass the prompt prefilter for creative-fiction tooling.

## Fix

Swap `HarmBlockThreshold.BLOCK_NONE` → `HarmBlockThreshold.OFF` for all five categories in `_default_google_safety_settings`. The `OFF` enum is exposed by `langchain-google-genai>=2.0` (pyproject pin satisfied), forwarded unchanged via `_format_safety_settings` to the underlying `google.genai` SDK.

## Verification

\`\`\`bash
$ GOOGLE_API_KEY=test-key uv run python -c \"
from questfoundry.providers.factory import create_chat_model
m = create_chat_model('google', 'gemini-2.5-pro')
for k, v in (m.safety_settings or {}).items():
    print(f'{k.name} -> {v.name}')
\"
HARM_CATEGORY_HARASSMENT -> OFF
HARM_CATEGORY_HATE_SPEECH -> OFF
HARM_CATEGORY_SEXUALLY_EXPLICIT -> OFF
HARM_CATEGORY_DANGEROUS_CONTENT -> OFF
HARM_CATEGORY_CIVIC_INTEGRITY -> OFF
\`\`\`

Then re-run murder3 FILL — expect zero \`PROHIBITED_CONTENT\` blocks on the expand phase.

## Caveat — known fallback paths if OFF still blocks

If \`OFF\` doesn't fully bypass the prefilter on the user's specific Gemini installation (some model versions or API endpoints may treat \`OFF\` and \`BLOCK_NONE\` equivalently in practice), the fallback options are:

- Smaller batch sizes for \`fill_phase1_expand\` on Google provider — cumulative content of 8 mystery beats may be the actual trigger; one beat per call may pass
- Prepend a "fictional content for an interactive fiction game" preamble to the system prompt
- Pipeline-level: visible escalation when input prefilter blocks, with passage IDs surfaced (separate concern; complementary fix to the FILL silent-batch-drop pattern)

These would be separate PRs if needed.

## Tests

\`test_create_chat_model_google_default_safety_settings_off\` (renamed from \`_blocks_none\`) and the falsy-override test now assert \`HarmBlockThreshold.OFF\` instead of \`BLOCK_NONE\`.

\`\`\`
$ uv run pytest tests/unit/test_provider_factory.py -k google -x -q
14 passed
$ uv run mypy src/        # clean
$ uv run ruff check src/  # clean
\`\`\`

## Test plan

- [x] Targeted google tests pass (14)
- [x] mypy + ruff + pre-commit clean
- [x] Smoke test on constructed model confirms 5 categories at OFF
- [ ] **User confirmation that murder3 FILL no longer blocks** — empirical fix, requires real run against Gemini API
- [ ] Wait for \`claude-code-review\` and \`gemini-code-assist\` before flipping ready