### PR TITLE
fix(fill): escalate batch_llm_calls failures per-passage instead of silent-drop (#1468)

### DIFF
--- a/src/questfoundry/models/fill.py
+++ b/src/questfoundry/models/fill.py
@@ -284,6 +284,9 @@ class FillEscalation(BaseModel):
         "voice_research_failed",
         "blueprint_validation_failed",
         "entity_extract_failed",
+        "expand_batch_failed",
+        "review_batch_failed",
+        "revision_failed",
     ] = Field(description="What kind of escalation this is.")
     passage_id: str = Field(
         description="Passage where the escalation was raised. Empty string if not passage-scoped."

--- a/src/questfoundry/pipeline/stages/fill.py
+++ b/src/questfoundry/pipeline/stages/fill.py
@@ -1312,11 +1312,9 @@ class FillStage:
             on_connectivity_error=self._on_connectivity_error,
         )
 
-        # Escalate per-passage when an entire chunk's retries exhausted
-        # (e.g. provider safety block, transient errors past the connectivity
-        # retry loop). Per `.gemini/styleguide.md` §4 "silent fallbacks that
-        # hide bugs": surface which passages have NO blueprint so the user
-        # sees the gap at stage exit instead of guessing from prose quality.
+        # Escalate per-passage when a chunk's retries exhausted: each
+        # passage in the failed chunk gets no blueprint, downstream Phase 1
+        # prose is generated without it.
         for idx, exc in errors:
             chunk_ids, _arc_id = chunks[idx]
             for affected_pid in chunk_ids:
@@ -1324,6 +1322,11 @@ class FillStage:
                     affected_pid
                     if affected_pid.startswith("passage::")
                     else f"passage::{affected_pid}"
+                )
+                log.warning(
+                    "expand_batch_failed_escalated",
+                    passage_id=full_pid,
+                    error=f"{type(exc).__name__}: {exc}",
                 )
                 self._escalations.append(
                     FillEscalation(
@@ -1901,6 +1904,11 @@ class FillStage:
                     if affected_pid.startswith("passage::")
                     else f"passage::{affected_pid}"
                 )
+                log.warning(
+                    "review_batch_failed_escalated",
+                    passage_id=full_pid,
+                    error=f"{type(exc).__name__}: {exc}",
+                )
                 self._escalations.append(
                     FillEscalation(
                         kind="review_batch_failed",
@@ -2097,11 +2105,17 @@ class FillStage:
         # Per-passage escalation when a revision call's retries exhausted —
         # the passage keeps its old (flagged-as-broken) prose with no fix.
         for idx, exc in errors:
-            affected_pid, _flags = passage_items[idx]
+            raw_pid, _flags = passage_items[idx]
+            full_pid = raw_pid if raw_pid.startswith("passage::") else f"passage::{raw_pid}"
+            log.warning(
+                "revision_failed_escalated",
+                passage_id=full_pid,
+                error=f"{type(exc).__name__}: {exc}",
+            )
             self._escalations.append(
                 FillEscalation(
                     kind="revision_failed",
-                    passage_id=affected_pid,
+                    passage_id=full_pid,
                     detail=(
                         f"fill_phase3_revision call failed after retries "
                         f"({type(exc).__name__}: {exc}). Passage retains its "

--- a/src/questfoundry/pipeline/stages/fill.py
+++ b/src/questfoundry/pipeline/stages/fill.py
@@ -1305,12 +1305,40 @@ class FillStage:
 
             return [bp.model_dump() for bp in output.blueprints], llm_calls, tokens
 
-        results, total_llm_calls, total_tokens, _errors = await batch_llm_calls(
+        results, total_llm_calls, total_tokens, errors = await batch_llm_calls(
             chunks,
             _expand_chunk,
             self._max_concurrency,
             on_connectivity_error=self._on_connectivity_error,
         )
+
+        # Escalate per-passage when an entire chunk's retries exhausted
+        # (e.g. provider safety block, transient errors past the connectivity
+        # retry loop). Per `.gemini/styleguide.md` §4 "silent fallbacks that
+        # hide bugs": surface which passages have NO blueprint so the user
+        # sees the gap at stage exit instead of guessing from prose quality.
+        for idx, exc in errors:
+            chunk_ids, _arc_id = chunks[idx]
+            for affected_pid in chunk_ids:
+                full_pid = (
+                    affected_pid
+                    if affected_pid.startswith("passage::")
+                    else f"passage::{affected_pid}"
+                )
+                self._escalations.append(
+                    FillEscalation(
+                        kind="expand_batch_failed",
+                        passage_id=full_pid,
+                        detail=(
+                            f"fill_phase1_expand chunk failed after retries "
+                            f"({type(exc).__name__}: {exc}). Passage has no "
+                            "expand-phase blueprint; downstream Phase 1 prose "
+                            "will be generated without the blueprint context "
+                            "and may be lower quality."
+                        ),
+                        upstream_stage="FILL",
+                    )
+                )
 
         # Store blueprints on passage nodes
         blueprints_created = 0
@@ -1856,12 +1884,37 @@ class FillStage:
                 FillPhase2Output,
             )
 
-        results, total_llm_calls, total_tokens, _errors = await batch_llm_calls(
+        results, total_llm_calls, total_tokens, errors = await batch_llm_calls(
             batches,
             _review_batch,
             self._max_concurrency,
             on_connectivity_error=self._on_connectivity_error,
         )
+
+        # Per-passage escalation when a review batch's retries exhausted —
+        # those passages skip review entirely (no flags = looks identical to
+        # "passed review", which it isn't).
+        for idx, exc in errors:
+            for affected_pid in batches[idx]:
+                full_pid = (
+                    affected_pid
+                    if affected_pid.startswith("passage::")
+                    else f"passage::{affected_pid}"
+                )
+                self._escalations.append(
+                    FillEscalation(
+                        kind="review_batch_failed",
+                        passage_id=full_pid,
+                        detail=(
+                            f"fill_phase2_review batch failed after retries "
+                            f"({type(exc).__name__}: {exc}). Passage was not "
+                            "reviewed for prose-quality issues — any "
+                            "flat_prose / blueprint_bleed / continuity issues "
+                            "will not be flagged for revision."
+                        ),
+                        upstream_stage="FILL",
+                    )
+                )
 
         for output in results:
             if output is None:
@@ -2034,12 +2087,30 @@ class FillStage:
                 tokens,
             )
 
-        results, total_llm_calls, total_tokens, _errors = await batch_llm_calls(
+        results, total_llm_calls, total_tokens, errors = await batch_llm_calls(
             passage_items,
             _revise_passage,
             self._max_concurrency,
             on_connectivity_error=self._on_connectivity_error,
         )
+
+        # Per-passage escalation when a revision call's retries exhausted —
+        # the passage keeps its old (flagged-as-broken) prose with no fix.
+        for idx, exc in errors:
+            affected_pid, _flags = passage_items[idx]
+            self._escalations.append(
+                FillEscalation(
+                    kind="revision_failed",
+                    passage_id=affected_pid,
+                    detail=(
+                        f"fill_phase3_revision call failed after retries "
+                        f"({type(exc).__name__}: {exc}). Passage retains its "
+                        "original prose with the prior phase-2 review flags "
+                        "unaddressed."
+                    ),
+                    upstream_stage="FILL",
+                )
+            )
 
         # Apply results to graph (sequential — graph mutations not thread-safe)
         for item in results:

--- a/src/questfoundry/pipeline/stages/fill.py
+++ b/src/questfoundry/pipeline/stages/fill.py
@@ -1312,9 +1312,7 @@ class FillStage:
             on_connectivity_error=self._on_connectivity_error,
         )
 
-        # Escalate per-passage when a chunk's retries exhausted: each
-        # passage in the failed chunk gets no blueprint, downstream Phase 1
-        # prose is generated without it.
+        # Per-passage escalation: failed chunks have no blueprint; downstream Phase 1 prose lacks it.
         for idx, exc in errors:
             chunk_ids, _arc_id = chunks[idx]
             for affected_pid in chunk_ids:
@@ -1326,7 +1324,8 @@ class FillStage:
                 log.warning(
                     "expand_batch_failed_escalated",
                     passage_id=full_pid,
-                    error=f"{type(exc).__name__}: {exc}",
+                    exc_type=type(exc).__name__,
+                    exc_msg=str(exc),
                 )
                 self._escalations.append(
                     FillEscalation(
@@ -1894,9 +1893,7 @@ class FillStage:
             on_connectivity_error=self._on_connectivity_error,
         )
 
-        # Per-passage escalation when a review batch's retries exhausted —
-        # those passages skip review entirely (no flags = looks identical to
-        # "passed review", which it isn't).
+        # Per-passage escalation: failed review batches silently skip review (no flags ≠ "passed review").
         for idx, exc in errors:
             for affected_pid in batches[idx]:
                 full_pid = (
@@ -1907,7 +1904,8 @@ class FillStage:
                 log.warning(
                     "review_batch_failed_escalated",
                     passage_id=full_pid,
-                    error=f"{type(exc).__name__}: {exc}",
+                    exc_type=type(exc).__name__,
+                    exc_msg=str(exc),
                 )
                 self._escalations.append(
                     FillEscalation(
@@ -2102,15 +2100,15 @@ class FillStage:
             on_connectivity_error=self._on_connectivity_error,
         )
 
-        # Per-passage escalation when a revision call's retries exhausted —
-        # the passage keeps its old (flagged-as-broken) prose with no fix.
+        # Per-passage escalation: failed revision keeps old flagged-as-broken prose with no fix.
         for idx, exc in errors:
             raw_pid, _flags = passage_items[idx]
             full_pid = raw_pid if raw_pid.startswith("passage::") else f"passage::{raw_pid}"
             log.warning(
                 "revision_failed_escalated",
                 passage_id=full_pid,
-                error=f"{type(exc).__name__}: {exc}",
+                exc_type=type(exc).__name__,
+                exc_msg=str(exc),
             )
             self._escalations.append(
                 FillEscalation(

--- a/tests/unit/test_fill_stage.py
+++ b/tests/unit/test_fill_stage.py
@@ -2342,6 +2342,103 @@ class TestFillSilentDegradationEscalations:
             )
 
 
+class TestFillBatchFailureEscalations:
+    """#1468: batch_llm_calls failures must escalate per-passage, not silent-drop.
+
+    The three batched FILL phases (expand / review / revision) used to bind
+    the errors list to ``_errors`` and discard it. When a batch chunk
+    exhausted retries (e.g. provider safety block — see #1466 for murder3
+    PROHIBITED_CONTENT — or a network error past the connectivity loop), the
+    affected passages got no blueprint / no review / no revision and FILL
+    continued silently. This test class pins the per-passage escalation
+    contract for each phase.
+    """
+
+    def test_three_new_escalation_kinds_accepted(self) -> None:
+        from questfoundry.models.fill import FillEscalation
+
+        for kind in ("expand_batch_failed", "review_batch_failed", "revision_failed"):
+            e = FillEscalation(
+                kind=kind,  # type: ignore[arg-type]
+                passage_id="passage::pid",
+                detail="batch retry exhausted",
+                upstream_stage="FILL",
+            )
+            assert e.kind == kind
+
+    @pytest.mark.asyncio
+    async def test_expand_batch_failure_escalates_each_passage_in_chunk(self) -> None:
+        """When _expand_chunk's call fails for an entire chunk, every passage
+        in that chunk must get an ``expand_batch_failed`` escalation so the
+        gap is visible at stage exit.
+
+        Drives _phase_1_expand directly with patched batch_llm_calls so we
+        exercise the real escalation-building loop without mocking the rest
+        of FILL.
+        """
+        from questfoundry.pipeline.stages.fill import FillStage
+
+        chunk_passage_ids = ["pid_a", "pid_b", "pid_c"]
+        captured_chunks: list[list[tuple[list[str], str]]] = []
+
+        async def mock_batch_llm_calls(
+            chunks: list[tuple[list[str], str]],
+            _call_fn,
+            _max_concurrency: int,
+            **_kwargs: object,
+        ):
+            captured_chunks.append(chunks)
+            # Simulate every chunk failing all retries — the inner repair
+            # loop in serialize_to_artifact would surface this as a
+            # SerializationError, which batch_llm_calls collects into errors.
+            errors = [
+                (idx, RuntimeError("simulated retry exhaustion")) for idx in range(len(chunks))
+            ]
+            results = [None] * len(chunks)
+            return results, 0, 0, errors
+
+        graph = _make_prose_graph()
+        stage = FillStage()
+        # Stub out the chunk-building dependencies that don't matter for the
+        # escalation path: pre-seed generation_order via a graph that has
+        # passages with valid IDs.
+        from unittest.mock import patch
+
+        # The _phase_1_expand body builds chunks from generation_order and
+        # passage_constraints. Patch batch_llm_calls and verify the resulting
+        # escalations carry the expected passage IDs.
+        with patch(
+            "questfoundry.pipeline.stages.fill.batch_llm_calls",
+            new=mock_batch_llm_calls,
+        ):
+            await stage._phase_1a_expand(graph, MagicMock())
+
+        # _make_prose_graph creates passage::p1 (and possibly more); the
+        # exact chunk shape depends on EXPAND_BATCH_SIZE. What matters: every
+        # passage that was in a failed chunk gets an escalation entry.
+        assert captured_chunks, "expected _phase_1_expand to call batch_llm_calls"
+        chunks_passed = captured_chunks[0]
+        expected_passage_ids: set[str] = set()
+        for chunk_ids, _arc_id in chunks_passed:
+            for pid in chunk_ids:
+                full_pid = pid if pid.startswith("passage::") else f"passage::{pid}"
+                expected_passage_ids.add(full_pid)
+
+        expand_escalations = [e for e in stage._escalations if e.kind == "expand_batch_failed"]
+        assert len(expand_escalations) == len(expected_passage_ids), (
+            f"expected one escalation per affected passage, got "
+            f"{len(expand_escalations)} for {len(expected_passage_ids)} passages"
+        )
+        escalated_pids = {e.passage_id for e in expand_escalations}
+        assert escalated_pids == expected_passage_ids
+        for e in expand_escalations:
+            assert "RuntimeError" in e.detail
+            assert "simulated retry exhaustion" in e.detail
+            assert e.upstream_stage == "FILL"
+        # `chunk_passage_ids` was reserved for a future expansion of this test.
+        del chunk_passage_ids
+
+
 class TestReviewCycleEscalation:
     """R-5.2: unresolved review flags after the final cycle become escalations."""
 

--- a/tests/unit/test_fill_stage.py
+++ b/tests/unit/test_fill_stage.py
@@ -2461,6 +2461,7 @@ class TestFillBatchFailureEscalations:
         assert len(review_escalations) == len(expected_passage_ids)
         assert {e.passage_id for e in review_escalations} == expected_passage_ids
         for e in review_escalations:
+            assert "RuntimeError" in e.detail
             assert "phase2 retry exhaustion" in e.detail
             assert e.upstream_stage == "FILL"
 
@@ -2516,6 +2517,7 @@ class TestFillBatchFailureEscalations:
         assert len(revision_escalations) == len(expected_passage_ids)
         assert {e.passage_id for e in revision_escalations} == expected_passage_ids
         for e in revision_escalations:
+            assert "RuntimeError" in e.detail
             assert "phase3 retry exhaustion" in e.detail
             assert e.upstream_stage == "FILL"
 

--- a/tests/unit/test_fill_stage.py
+++ b/tests/unit/test_fill_stage.py
@@ -2368,17 +2368,12 @@ class TestFillBatchFailureEscalations:
 
     @pytest.mark.asyncio
     async def test_expand_batch_failure_escalates_each_passage_in_chunk(self) -> None:
-        """When _expand_chunk's call fails for an entire chunk, every passage
-        in that chunk must get an ``expand_batch_failed`` escalation so the
-        gap is visible at stage exit.
+        """Phase 1a: when batch_llm_calls returns errors for a chunk, every
+        passage in that chunk must get an ``expand_batch_failed`` escalation."""
+        from unittest.mock import patch
 
-        Drives _phase_1_expand directly with patched batch_llm_calls so we
-        exercise the real escalation-building loop without mocking the rest
-        of FILL.
-        """
         from questfoundry.pipeline.stages.fill import FillStage
 
-        chunk_passage_ids = ["pid_a", "pid_b", "pid_c"]
         captured_chunks: list[list[tuple[list[str], str]]] = []
 
         async def mock_batch_llm_calls(
@@ -2388,9 +2383,6 @@ class TestFillBatchFailureEscalations:
             **_kwargs: object,
         ):
             captured_chunks.append(chunks)
-            # Simulate every chunk failing all retries — the inner repair
-            # loop in serialize_to_artifact would surface this as a
-            # SerializationError, which batch_llm_calls collects into errors.
             errors = [
                 (idx, RuntimeError("simulated retry exhaustion")) for idx in range(len(chunks))
             ]
@@ -2399,44 +2391,133 @@ class TestFillBatchFailureEscalations:
 
         graph = _make_prose_graph()
         stage = FillStage()
-        # Stub out the chunk-building dependencies that don't matter for the
-        # escalation path: pre-seed generation_order via a graph that has
-        # passages with valid IDs.
-        from unittest.mock import patch
-
-        # The _phase_1_expand body builds chunks from generation_order and
-        # passage_constraints. Patch batch_llm_calls and verify the resulting
-        # escalations carry the expected passage IDs.
         with patch(
             "questfoundry.pipeline.stages.fill.batch_llm_calls",
             new=mock_batch_llm_calls,
         ):
             await stage._phase_1a_expand(graph, MagicMock())
 
-        # _make_prose_graph creates passage::p1 (and possibly more); the
-        # exact chunk shape depends on EXPAND_BATCH_SIZE. What matters: every
-        # passage that was in a failed chunk gets an escalation entry.
-        assert captured_chunks, "expected _phase_1_expand to call batch_llm_calls"
-        chunks_passed = captured_chunks[0]
+        assert captured_chunks, "expected _phase_1a_expand to call batch_llm_calls"
         expected_passage_ids: set[str] = set()
-        for chunk_ids, _arc_id in chunks_passed:
+        for chunk_ids, _arc_id in captured_chunks[0]:
             for pid in chunk_ids:
                 full_pid = pid if pid.startswith("passage::") else f"passage::{pid}"
                 expected_passage_ids.add(full_pid)
 
         expand_escalations = [e for e in stage._escalations if e.kind == "expand_batch_failed"]
-        assert len(expand_escalations) == len(expected_passage_ids), (
-            f"expected one escalation per affected passage, got "
-            f"{len(expand_escalations)} for {len(expected_passage_ids)} passages"
-        )
-        escalated_pids = {e.passage_id for e in expand_escalations}
-        assert escalated_pids == expected_passage_ids
+        assert len(expand_escalations) == len(expected_passage_ids)
+        assert {e.passage_id for e in expand_escalations} == expected_passage_ids
         for e in expand_escalations:
             assert "RuntimeError" in e.detail
             assert "simulated retry exhaustion" in e.detail
             assert e.upstream_stage == "FILL"
-        # `chunk_passage_ids` was reserved for a future expansion of this test.
-        del chunk_passage_ids
+
+    @pytest.mark.asyncio
+    async def test_review_batch_failure_escalates_each_passage_in_batch(self) -> None:
+        """Phase 2: when a review batch fails, every passage in that batch
+        must get a ``review_batch_failed`` escalation.
+
+        Phase 2 batches are ``list[list[str]]`` (just passage IDs, no arc
+        tuple), so the unpacking shape differs from Phase 1a — that's the
+        per-phase shape difference this test pins.
+        """
+        from unittest.mock import patch
+
+        from questfoundry.pipeline.stages.fill import FillStage
+
+        captured_batches: list[list[list[str]]] = []
+
+        async def mock_batch_llm_calls(
+            batches: list[list[str]],
+            _call_fn,
+            _max_concurrency: int,
+            **_kwargs: object,
+        ):
+            captured_batches.append(batches)
+            errors = [(idx, RuntimeError("phase2 retry exhaustion")) for idx in range(len(batches))]
+            results = [None] * len(batches)
+            return results, 0, 0, errors
+
+        graph = _make_prose_graph()
+        # _phase_2_review only batches passages that have a non-empty prose
+        # field. Seed both passages so the batching loop produces work.
+        graph.update_node("passage::p1", prose="draft prose for p1")
+        graph.update_node("passage::p2", prose="draft prose for p2")
+        stage = FillStage()
+        with patch(
+            "questfoundry.pipeline.stages.fill.batch_llm_calls",
+            new=mock_batch_llm_calls,
+        ):
+            await stage._phase_2_review(graph, MagicMock())
+
+        assert captured_batches, "expected _phase_2_review to call batch_llm_calls"
+        expected_passage_ids: set[str] = set()
+        for batch_ids in captured_batches[0]:
+            for pid in batch_ids:
+                full_pid = pid if pid.startswith("passage::") else f"passage::{pid}"
+                expected_passage_ids.add(full_pid)
+
+        review_escalations = [e for e in stage._escalations if e.kind == "review_batch_failed"]
+        assert len(review_escalations) == len(expected_passage_ids)
+        assert {e.passage_id for e in review_escalations} == expected_passage_ids
+        for e in review_escalations:
+            assert "phase2 retry exhaustion" in e.detail
+            assert e.upstream_stage == "FILL"
+
+    @pytest.mark.asyncio
+    async def test_revision_failure_escalates_each_failed_passage(self) -> None:
+        """Phase 3: when a per-passage revision call fails, that passage must
+        get a ``revision_failed`` escalation.
+
+        Phase 3 ``passage_items`` is ``list[tuple[str, list[dict]]]`` —
+        unpacking ``(pid, flags)`` rather than the Phase 1a ``(chunk_ids,
+        arc_id)`` or Phase 2 plain list — exercising the third shape variant.
+        """
+        from unittest.mock import patch
+
+        from questfoundry.pipeline.stages.fill import FillStage
+
+        captured_items: list[list[tuple[str, list[dict[str, str]]]]] = []
+
+        async def mock_batch_llm_calls(
+            passage_items: list[tuple[str, list[dict[str, str]]]],
+            _call_fn,
+            _max_concurrency: int,
+            **_kwargs: object,
+        ):
+            captured_items.append(passage_items)
+            errors = [
+                (idx, RuntimeError("phase3 retry exhaustion")) for idx in range(len(passage_items))
+            ]
+            results = [None] * len(passage_items)
+            return results, 0, 0, errors
+
+        graph = _make_prose_graph()
+        # Seed a review flag on p1 so _phase_3_revision finds something to revise.
+        graph.update_node(
+            "passage::p1",
+            review_flags=[{"issue_type": "voice_drift", "issue": "x"}],
+            prose="draft",
+        )
+        stage = FillStage()
+        with patch(
+            "questfoundry.pipeline.stages.fill.batch_llm_calls",
+            new=mock_batch_llm_calls,
+        ):
+            await stage._phase_3_revision(graph, MagicMock(), final_cycle=False)
+
+        assert captured_items, "expected _phase_3_revision to call batch_llm_calls"
+        expected_passage_ids = {
+            (pid if pid.startswith("passage::") else f"passage::{pid}")
+            for pid, _flags in captured_items[0]
+        }
+
+        revision_escalations = [e for e in stage._escalations if e.kind == "revision_failed"]
+        assert len(revision_escalations) == len(expected_passage_ids)
+        assert {e.passage_id for e in revision_escalations} == expected_passage_ids
+        for e in revision_escalations:
+            assert "phase3 retry exhaustion" in e.detail
+            assert e.upstream_stage == "FILL"
 
 
 class TestReviewCycleEscalation:


### PR DESCRIPTION
## Summary

Closes #1468.

All three batched FILL phases (\`_phase_1a_expand\`, \`_phase_2_review\`, \`_phase_3_revision\`) bound the \`batch_llm_calls\` errors list to \`_errors\` (intentionally-unused convention) and discarded it. When a chunk's retries exhausted (provider safety block, transient errors past the connectivity-retry loop), \`results[idx]\` became \`None\`, the \`if x is None: continue\` loop skipped it silently, and FILL continued reporting success while passages were missing their blueprint / review / revision.

This is the diagnostic backstop for #1466 / PR #1467: even when a future project / provider / content combination trips a filter we can't bypass via \`safety_settings\`, the user gets a clear signal about which passages need attention rather than a silently-degraded run.

Per \`.gemini/styleguide.md\` §4 \"silent fallbacks that hide bugs\": the failures are now surfaced as \`FillEscalation\` entries that flow through the existing exit-time \`FillContractError\` machinery, so the user sees the full set of affected passages at stage exit.

## Three new escalation kinds

\`FillEscalation.kind\` extended (in \`src/questfoundry/models/fill.py\`):

| Kind | Phase | What's missing downstream |
|---|---|---|
| \`expand_batch_failed\` | 1a | No expand-phase blueprint; Phase 1 prose generated without the blueprint context |
| \`review_batch_failed\` | 2 | No review flags; flat_prose / blueprint_bleed / continuity issues silently un-flagged for revision |
| \`revision_failed\` | 3 | Original prose retained with the prior phase-2 flags unaddressed |

Each escalation includes the passage_id, the original exception type/message, and a detail string explaining the downstream impact.

## Implementation

Per call site in \`fill.py\`:

\`\`\`python
results, total_llm_calls, total_tokens, errors = await batch_llm_calls(...)

for idx, exc in errors:
    chunk_ids, _arc_id = chunks[idx]   # or batches[idx], or passage_items[idx][0]
    for affected_pid in chunk_ids:
        full_pid = (
            affected_pid
            if affected_pid.startswith(\"passage::\")
            else f\"passage::{affected_pid}\"
        )
        self._escalations.append(
            FillEscalation(kind=..., passage_id=full_pid, detail=..., upstream_stage=\"FILL\")
        )
\`\`\`

The shape is consistent across the three call sites; only the chunk-shape and escalation kind differ. Phase 1a and Phase 2 chunks are lists of passage IDs (one escalation per affected passage); Phase 3 \`passage_items\` is one passage per item (one escalation per failed item).

## Tests

\`TestFillBatchFailureEscalations\` (in \`tests/unit/test_fill_stage.py\`) adds:

- \`test_three_new_escalation_kinds_accepted\` — Pydantic Literal accepts all three new kinds (\`expand_batch_failed\`, \`review_batch_failed\`, \`revision_failed\`)
- \`test_expand_batch_failure_escalates_each_passage_in_chunk\` — patches \`batch_llm_calls\` to return errors for every chunk, calls \`_phase_1a_expand\` on a real graph, asserts one escalation per affected passage with the right kind / passage_id / detail / upstream_stage

\`\`\`
$ uv run pytest tests/unit/test_fill_stage.py -x -q
100 passed
$ uv run pytest tests/unit/ -k fill -x -q
422 passed
$ uv run mypy src/        # clean
$ uv run ruff check src/  # clean
\`\`\`

## Out of scope

- The deeper concern of \"why do prose-call retries fail and what should be done about it\" (provider fallback, prompt rewording, batch-size tuning) is a separate design question. This PR is purely about visibility — making failures observable so the user can decide what to do.
- Connectivity retries are already handled by \`batch_llm_calls\`'s built-in retry loop; this fix kicks in only for non-retryable failures that exhaust the inner repair loop.

## Test plan

- [x] Targeted fill tests pass (100 in test_fill_stage; 422 across all fill files)
- [x] mypy + ruff + pre-commit clean
- [x] FillEscalation Pydantic schema extended without breaking existing escalation kinds
- [ ] Wait for \`claude-code-review\` and \`gemini-code-assist\` before flipping ready