### PR TITLE
fix(seed): align dilemma_relationships prompt + context with R-8.2 (relevant pairs only)

### DIFF
--- a/prompts/templates/serialize_seed_sections.yaml
+++ b/prompts/templates/serialize_seed_sections.yaml
@@ -914,14 +914,14 @@ dilemma_analyses_prompt: |
 
 # Section 8: Dilemma Ordering Relationships (post-prune, Story Graph Ontology)
 dilemma_relationships_prompt: |
-  You are classifying the temporal ordering between ALL dilemma pairs for a SEED stage.
+  You are classifying the temporal ordering of relevant dilemma pairs for a SEED stage.
 
-  Each dilemma pair has a structural relationship that affects how GROW
-  interleaves their beats. You MUST classify EVERY pair listed in the Context.
-  `concurrent` is the default when no structural nesting or sequencing exists,
-  but you must still include the pair with `ordering: "concurrent"` — do NOT
-  skip it. An empty list means NOTHING was classified and is only correct when
-  the Context says "fewer than 2 surviving dilemmas."
+  Each ordering edge tells GROW how to interleave the beats of two dilemmas.
+  Declare an edge **only when the relationship matters** — pairs that share
+  entities, have a causal dependency, or have explicit authorial ordering
+  intent. Pairs you don't classify default to implicit `concurrent` (free
+  interleaving with no temporal hints), so omitting an unambiguous pair is
+  the right move; do not pad the output to make it exhaustive.
 
   ## Ordering Types
 
@@ -930,9 +930,11 @@ dilemma_relationships_prompt: |
     wraps the mentor's betrayal subplot (B) — the mystery is present from the
     start and resolves at the climax, while the betrayal plays out in the middle."
   - **concurrent**: Neither wraps the other. Both are active simultaneously,
-    interleaving but without nesting. Use this when no clear nesting or
-    sequencing exists. Example: "both the romance and the political intrigue
-    develop in parallel."
+    interleaving but without nesting. Declare this *explicitly* only when the
+    pair shares entities or has causal interaction worth recording — otherwise
+    leave it out. Example: "the romance and the political intrigue both
+    revolve around the council, so their beats must alternate to keep both
+    threads visible."
   - **serial**: A resolves (commits and converges) before B introduces. The
     dilemmas never structurally interact. Example: "the escape subplot resolves
     in Act 1 before the revenge plot begins in Act 2."
@@ -940,23 +942,42 @@ dilemma_relationships_prompt: |
   NOTE: shared_entity is NOT an ordering type — it is derived automatically
   from entity anchoring in the graph. Do NOT classify pairs as shared_entity.
 
+  ## What to Classify
+
+  - **Relevant pairs (default candidates):** every pair listed under "Relevant
+    Pairs" in the Context. Pick `wraps`, `concurrent`, or `serial` based on
+    the dilemmas' details. Skipping a relevant pair is acceptable only if you
+    have no signal — but normally these pairs are listed precisely *because*
+    they share entities, so an explicit ordering helps GROW.
+  - **Other pairs (optional):** every pair under "Other Pairs" is opt-in.
+    Include one only when the dilemma details reveal a causal dependency or
+    authorial ordering intent that GROW would otherwise miss. Padding this
+    section with `concurrent` defaults adds no information and is wasteful.
+
   ## What NOT to Do
-  - Do NOT skip any pair — every pair in "All Dilemma Pairs" must appear in output
-  - Do NOT use ordering values other than wraps, concurrent, serial
-  - Do NOT classify shared characters/locations as ordering — that is derived
-  - Do NOT return an empty array unless the Context says fewer than 2 dilemmas
+
+  - Do NOT mechanically classify every pair from both sections — empty arrays
+    and partial classifications are valid outputs.
+  - Do NOT use ordering values other than `wraps`, `concurrent`, `serial`.
+  - Do NOT classify shared characters/locations as `shared_entity` — that is
+    derived from `anchored_to` edges, not an ordering relationship.
 
   GOOD: "The central mystery wraps the betrayal subplot — it introduces first
-  and resolves last."
-  BAD: "Both dilemmas involve the mentor" (that is shared_entity, derived from
-  anchored_to edges, not an ordering relationship).
+  and resolves last." (relevant pair, justified)
+  GOOD: Returning `[]` when only one entity-sharing pair has a clear ordering
+  and the rest are independent.
+  GOOD: Including an "Other Pairs" entry as `serial` because Dilemma B's
+  resolution unlocks a fact that Dilemma A depends on.
+  BAD: Adding a `concurrent` entry for every "Other Pairs" entry just to be
+  thorough — that is the over-application R-8.2 explicitly discourages.
 
   ## Context
 
   {candidate_pairs_context}
 
   ## Schema
-  Return a JSON object with a "dilemma_relationships" array — one entry per pair:
+  Return a JSON object with a "dilemma_relationships" array. Include zero or
+  more entries — only the pairs you actually classified:
   ```json
   {{
     "dilemma_relationships": [
@@ -971,7 +992,8 @@ dilemma_relationships_prompt: |
   }}
   ```
 
-  If the Context says "No candidate pairs — fewer than 2 surviving dilemmas", return:
+  If the Context says "No candidate pairs — fewer than 2 surviving dilemmas",
+  or if you have no ordering signal worth recording, return:
   ```json
   {{
     "dilemma_relationships": []
@@ -979,15 +1001,10 @@ dilemma_relationships_prompt: |
   ```
 
   ## Rules
-  - Classify EVERY pair from the "All Dilemma Pairs" list in the Context
-  - Use canonical ordering: dilemma_a < dilemma_b (alphabetically)
-  - `ordering` must be exactly one of: `wraps`, `concurrent`, `serial`
-  - `reasoning` must explain the temporal (not thematic) relationship
-  - Output must contain one entry per pair — no pairs may be omitted
-
-  ## FINAL CHECK
-  Count the pairs listed under "All Dilemma Pairs" in the Context.
-  Your output MUST contain that exact number of entries.
+  - Use canonical ordering: dilemma_a < dilemma_b (alphabetically).
+  - `ordering` must be exactly one of: `wraps`, `concurrent`, `serial`.
+  - `reasoning` must explain the temporal (not thematic) relationship.
+  - Each pair appears at most once.
 
   ## Output
   Return ONLY valid JSON with the "dilemma_relationships" array.

--- a/prompts/templates/serialize_seed_sections.yaml
+++ b/prompts/templates/serialize_seed_sections.yaml
@@ -1004,7 +1004,6 @@ dilemma_relationships_prompt: |
   - Use canonical ordering: dilemma_a < dilemma_b (alphabetically).
   - `ordering` must be exactly one of: `wraps`, `concurrent`, `serial`.
   - `reasoning` must explain the temporal (not thematic) relationship.
-  - Each pair appears at most once.
 
   ## Output
   Return ONLY valid JSON with the "dilemma_relationships" array.

--- a/src/questfoundry/graph/context.py
+++ b/src/questfoundry/graph/context.py
@@ -1093,20 +1093,26 @@ def format_interaction_candidates_context(
     seed_output: SeedOutput,
     graph: Graph,
 ) -> str:
-    """Format all dilemma pairs for ordering classification (Section 8).
+    """Format dilemma pairs for ordering classification (Section 8).
 
     Builds rich per-dilemma context (question, stakes, answers via has_answer
-    edges, convergence point) and enumerates ALL pairs of surviving dilemmas.
-    Pairs that share central entities are flagged so the LLM has extra signal,
-    but every pair is included because small stories (2-4 dilemmas = 3-6 pairs
-    max) rarely have enough shared-entity pairs to trigger any classification.
+    edges, convergence point) and groups surviving-dilemma pairs into two
+    buckets per spec R-8.2:
+
+    - **Relevant pairs** (share at least one anchored entity): these are the
+      default candidates for an ordering relationship; the LLM should
+      classify them.
+    - **Other pairs** (no shared entities): listed for reference only.
+      Declaring an ordering for these is optional and only valuable when it
+      removes ambiguity for GROW (causal dependency or explicit authorial
+      ordering intent that the LLM detects from the dilemma details).
 
     Args:
         seed_output: Pruned SEED output with surviving dilemmas.
         graph: Graph containing brainstorm dilemma nodes.
 
     Returns:
-        Formatted markdown context with all pairs and per-dilemma details,
+        Formatted markdown context with grouped pairs and per-dilemma details,
         or a short message if fewer than 2 dilemmas survive.
     """
     surviving_ids = {strip_scope_prefix(d.dilemma_id) for d in seed_output.dilemmas}
@@ -1162,17 +1168,19 @@ def format_interaction_candidates_context(
             block.append("**Central entities:** " + ", ".join(f"`{e}`" for e in sorted(entities)))
         dilemma_blocks.append("\n".join(block))
 
-    # Enumerate ALL pairs; flag shared-entity pairs for extra signal
-    pair_lines: list[str] = []
+    # Group pairs by relevance: shared-entity pairs are the default candidates
+    # for classification (R-8.2); pairs with no shared entities are listed for
+    # reference only, declaring an ordering is optional.
+    relevant_lines: list[str] = []
+    other_lines: list[str] = []
     for i, id_a in enumerate(sorted_ids):
         for id_b in sorted_ids[i + 1 :]:
             shared = dilemma_entities[id_a] & dilemma_entities[id_b]
-            shared_note = (
-                f" — shared entities: {', '.join(f'`{e}`' for e in sorted(shared))}"
-                if shared
-                else ""
-            )
-            pair_lines.append(f"- `dilemma::{id_a}` + `dilemma::{id_b}`{shared_note}")
+            if shared:
+                shared_note = " — shared entities: " + ", ".join(f"`{e}`" for e in sorted(shared))
+                relevant_lines.append(f"- `dilemma::{id_a}` + `dilemma::{id_b}`{shared_note}")
+            else:
+                other_lines.append(f"- `dilemma::{id_a}` + `dilemma::{id_b}`")
 
     valid_ids = [f"`dilemma::{rid}`" for rid in sorted_ids]
 
@@ -1181,14 +1189,40 @@ def format_interaction_candidates_context(
         "",
         *[line for block in dilemma_blocks for line in block.split("\n")],
         "",
-        "## All Dilemma Pairs (classify EVERY pair)",
+        "## Relevant Pairs (classify these)",
         "",
-        "You MUST classify ALL pairs below. `concurrent` is the default when no",
-        "structural ordering exists, but do NOT skip any pair — an empty list means",
-        "NOTHING was classified, which is only correct when fewer than 2 surviving",
-        "dilemmas exist.",
+    ]
+    if relevant_lines:
+        lines += [
+            "These pairs share at least one anchored entity, so the way they",
+            "interact temporally affects how GROW interleaves their beats.",
+            "Classify each as `wraps`, `concurrent`, or `serial`.",
+            "",
+            *relevant_lines,
+        ]
+    else:
+        lines += [
+            "_No pairs share anchored entities. You may still classify pairs",
+            "from the next section if causal dependencies or authorial",
+            "ordering intent are clear from the dilemma details above; otherwise",
+            "return an empty list._",
+        ]
+    lines += [
         "",
-        *pair_lines,
+        "## Other Pairs (optional)",
+        "",
+        "These pairs have no shared entities. Declaring an ordering is",
+        "**optional** — include a pair here only if you can identify a causal",
+        "dependency or authorial ordering intent from the dilemma details that",
+        "would otherwise be ambiguous for GROW. The default for unlisted pairs",
+        "is implicit `concurrent` (free interleaving with no temporal hints).",
+        "",
+    ]
+    if other_lines:
+        lines += other_lines
+    else:
+        lines.append("_No other pairs — every pair shares at least one entity._")
+    lines += [
         "",
         "### Valid Dilemma IDs",
         "",

--- a/tests/unit/test_graph_context.py
+++ b/tests/unit/test_graph_context.py
@@ -1617,7 +1617,8 @@ class TestFormatInteractionCandidatesContext:
         assert "every pair shares at least one entity" in other_section
 
     def test_disjoint_pair_listed_as_other(self) -> None:
-        """Pairs with no shared entities appear under 'Other Pairs (optional)'."""
+        """Pairs with no shared entities appear under 'Other Pairs (optional)'
+        and the Relevant section explicitly says the LLM may return ``[]``."""
         graph = self._graph_with_dilemmas(
             {
                 "alpha": ["entity::hero"],
@@ -1632,6 +1633,27 @@ class TestFormatInteractionCandidatesContext:
         # Disjoint pair must appear under Other, not Relevant
         assert "dilemma::alpha" in other_section
         assert "dilemma::beta" in other_section
+        assert "alpha` + `dilemma::beta" not in relevant_section
+        # Relevant section must guide the LLM to an empty result when no pair shares entities
+        assert "No pairs share anchored entities" in relevant_section
+        assert "return an empty list" in relevant_section
+
+    def test_dilemma_without_anchored_entities_pairs_as_other(self) -> None:
+        """A dilemma with zero ``anchored_to`` edges paired with one that has
+        entities lands under 'Other Pairs' — set intersection is empty, so the
+        pair cannot be relevant."""
+        graph = Graph.empty()
+        # Build the entity for the entity-having dilemma
+        graph.create_node("entity::hero", {"type": "entity", "raw_id": "hero"})
+        # alpha has the entity; beta has none
+        graph.create_node("dilemma::alpha", {"type": "dilemma", "raw_id": "alpha"})
+        graph.add_edge("anchored_to", "dilemma::alpha", "entity::hero")
+        graph.create_node("dilemma::beta", {"type": "dilemma", "raw_id": "beta"})
+
+        seed = _seed_output(dilemmas=[_dilemma("alpha"), _dilemma("beta")])
+        result = format_interaction_candidates_context(seed, graph)
+        relevant_section, _, other_section = result.partition("## Other Pairs")
+        assert "alpha` + `dilemma::beta" in other_section
         assert "alpha` + `dilemma::beta" not in relevant_section
 
     def test_mixed_pairs_split_by_relevance(self) -> None:

--- a/tests/unit/test_graph_context.py
+++ b/tests/unit/test_graph_context.py
@@ -1598,8 +1598,8 @@ class TestFormatInteractionCandidatesContext:
                 graph.add_edge("anchored_to", f"dilemma::{did}", eid)
         return graph
 
-    def test_shared_entity_pair_found(self) -> None:
-        """Two dilemmas sharing an entity produce a pair with shared-entity note."""
+    def test_shared_entity_pair_listed_as_relevant(self) -> None:
+        """Pairs sharing an entity appear under 'Relevant Pairs' with the shared entity."""
         graph = self._graph_with_dilemmas(
             {
                 "alpha": ["entity::hero", "entity::castle"],
@@ -1608,13 +1608,16 @@ class TestFormatInteractionCandidatesContext:
         )
         seed = _seed_output(dilemmas=[_dilemma("alpha"), _dilemma("beta")])
         result = format_interaction_candidates_context(seed, graph)
-        assert "## All Dilemma Pairs" in result
-        assert "dilemma::alpha" in result
-        assert "dilemma::beta" in result
-        assert "hero" in result  # shared entity flagged in pair line
+        assert "## Relevant Pairs (classify these)" in result
+        relevant_section, _, other_section = result.partition("## Other Pairs")
+        assert "dilemma::alpha" in relevant_section
+        assert "dilemma::beta" in relevant_section
+        assert "hero" in relevant_section  # shared entity flagged
+        # Disjoint pair section should be empty for this fixture
+        assert "every pair shares at least one entity" in other_section
 
-    def test_no_shared_entities_still_shows_all_pairs(self) -> None:
-        """Disjoint entities still produce a pair listing — all pairs are always shown."""
+    def test_disjoint_pair_listed_as_other(self) -> None:
+        """Pairs with no shared entities appear under 'Other Pairs (optional)'."""
         graph = self._graph_with_dilemmas(
             {
                 "alpha": ["entity::hero"],
@@ -1623,9 +1626,49 @@ class TestFormatInteractionCandidatesContext:
         )
         seed = _seed_output(dilemmas=[_dilemma("alpha"), _dilemma("beta")])
         result = format_interaction_candidates_context(seed, graph)
-        assert "## All Dilemma Pairs" in result
-        assert "dilemma::alpha" in result
-        assert "dilemma::beta" in result
+        assert "## Relevant Pairs (classify these)" in result
+        assert "## Other Pairs (optional)" in result
+        relevant_section, _, other_section = result.partition("## Other Pairs")
+        # Disjoint pair must appear under Other, not Relevant
+        assert "dilemma::alpha" in other_section
+        assert "dilemma::beta" in other_section
+        assert "alpha` + `dilemma::beta" not in relevant_section
+
+    def test_mixed_pairs_split_by_relevance(self) -> None:
+        """Three dilemmas with one shared-entity pair: the pair is Relevant; the
+        other two are Other."""
+        graph = self._graph_with_dilemmas(
+            {
+                "alpha": ["entity::hero"],
+                "beta": ["entity::hero"],
+                "gamma": ["entity::villain"],
+            }
+        )
+        seed = _seed_output(dilemmas=[_dilemma("alpha"), _dilemma("beta"), _dilemma("gamma")])
+        result = format_interaction_candidates_context(seed, graph)
+        relevant_section, _, other_section = result.partition("## Other Pairs")
+        # alpha+beta share hero
+        assert "alpha` + `dilemma::beta" in relevant_section
+        # alpha+gamma and beta+gamma have no shared entity
+        assert "alpha` + `dilemma::gamma" in other_section
+        assert "beta` + `dilemma::gamma" in other_section
+        # No "classify EVERY pair" mandate
+        assert "classify EVERY pair" not in result
+
+    def test_relevant_pairs_empty_when_all_disjoint(self) -> None:
+        """When no pairs share entities, Relevant section explains the LLM may
+        return an empty list."""
+        graph = self._graph_with_dilemmas(
+            {
+                "alpha": ["entity::hero"],
+                "beta": ["entity::villain"],
+            }
+        )
+        seed = _seed_output(dilemmas=[_dilemma("alpha"), _dilemma("beta")])
+        result = format_interaction_candidates_context(seed, graph)
+        relevant_section, _, _ = result.partition("## Other Pairs")
+        assert "No pairs share anchored entities" in relevant_section
+        assert "return an empty list" in relevant_section
 
     def test_single_dilemma_returns_no_candidates(self) -> None:
         """Fewer than 2 dilemmas cannot have pairs."""


### PR DESCRIPTION
## Summary

- `format_interaction_candidates_context` now splits dilemma pairs into `## Relevant Pairs (classify these)` (pairs sharing an anchored entity) and `## Other Pairs (optional)` (disjoint pairs, classify only if causal/authorial ordering intent is clear) — replacing the old "All Dilemma Pairs (classify EVERY pair)" enumeration.
- `dilemma_relationships_prompt` is reframed to encourage relevant-pairs-only as the default; the FINAL CHECK pair-count gate is removed; empty / partial classifications are now explicitly valid outcomes.
- Tests cover shared-entity, disjoint, mixed, and empty-relevant cases and assert no "classify EVERY pair" language remains.

Closes #1462.

## Why

`docs/design/procedures/seed.md` §R-8.2 (line 458) says ordering relationships are declared "only for relevant pairs — those sharing entities, with causal dependencies, or with explicit authorial ordering intent. Exhaustive O(n²) declaration is wasteful but not forbidden." The implementation did the opposite. The 2026-04-25 prompt-vs-spec audit (line 643 of `docs/superpowers/reports/2026-04-25-prompt-spec-audit.md`) flagged this as a direct spec/prompt contradiction.

This is the SEED PR-B2 cluster from the prompt-vs-spec audit, sequenced after PR-B1 (#1463 dead-code removal).

## Why no GROW change

GROW already iterates only the relationship edges that exist in the graph (`src/questfoundry/graph/grow_algorithms.py` L2896-2901). Pairs with no edge get no temporal constraint applied — effectively implicit `concurrent` (free interleaving with no temporal hints). Sparse relationship sets are already supported.

## Test plan

- [x] `uv run pytest tests/unit/test_graph_context.py` — 5 new/updated InteractionCandidates tests pass
- [x] `uv run pytest tests/unit/test_seed_models.py tests/unit/test_graph_context.py tests/unit/test_serialize.py` — 352 pass
- [x] `uv run pytest -k "relationship or dilemma"` — 366 pass
- [x] `uv run ruff check` + `uv run mypy src/questfoundry/graph/context.py` — clean
- [x] `_load_seed_section_prompts()` loads cleanly; "classify EVERY pair" string is absent

🤖 Generated with [Claude Code](https://claude.com/claude-code)