### PR TITLE
fix(grow): align IntersectionProposal.resolved_location type with prompt (str → required)

### DIFF
--- a/prompts/templates/grow_phase3_intersections.yaml
+++ b/prompts/templates/grow_phase3_intersections.yaml
@@ -51,11 +51,11 @@ system: |
   ## Output Format
   Return a JSON object with an "intersections" array. Each element has:
   - beat_ids: list of 2-3 beat IDs that form the intersection (from DIFFERENT dilemmas)
-  - resolved_location: the specific location where this scene occurs — MUST be a
-    non-empty string. If the candidate group lists multiple possible locations, pick
-    the one that fits most beats. If location is genuinely unknown, use the most
-    specific location mentioned in any of the beat descriptions (e.g., "the village
-    square" rather than "unknown"). NEVER output null. NEVER output the word "null".
+  - resolved_location: the specific location where this scene occurs. If the
+    candidate group lists multiple possible locations, pick the one that fits
+    most beats. If location is genuinely unknown, use the most specific
+    location mentioned in any of the beat descriptions (e.g., "the village
+    square" rather than "unknown").
   - shared_entities: list of entity IDs shared between the intersecting beats — use the
     full "entity::<name>" format (e.g., "entity::merchant", "entity::artifact"). If no
     entities are shared, use an empty list []. Do NOT invent entity IDs — use only IDs
@@ -92,8 +92,8 @@ user: |
   - Return ONLY a valid JSON object — no prose before or after.
   - Use ONLY beat IDs from the Valid IDs section. Do NOT invent IDs.
   - Each beat may appear in at most ONE intersection.
-  - resolved_location MUST be a non-empty string. If uncertain, pick the best-fit
-    location from the beat descriptions. NEVER output null or the word "null".
+  - resolved_location: pick the best-fit location from the beat descriptions
+    when uncertain (the schema requires a non-empty string).
   - shared_entities MUST use "entity::<name>" format or be an empty list [].
   - rationale MUST explain WHY the beats belong in one scene, not just that they share a location.
   {structural_feedback}

--- a/src/questfoundry/models/grow.py
+++ b/src/questfoundry/models/grow.py
@@ -111,7 +111,16 @@ class IntersectionProposal(BaseModel):
     """Phase 3: Proposes beats that form structural intersections."""
 
     beat_ids: list[str] = Field(min_length=2)
-    resolved_location: str | None = None
+    resolved_location: str = Field(
+        min_length=1,
+        description=(
+            "Specific location where the intersection scene occurs. Must be a "
+            "non-empty string — pick the best-fit location from the candidate "
+            "beats when uncertain rather than punting. The deterministic "
+            "resolver only runs as a fallback when the model returns the "
+            "literal word 'null' as a string."
+        ),
+    )
     shared_entities: list[str] = Field(default_factory=list)
     rationale: str = Field(min_length=1)
 

--- a/src/questfoundry/models/grow.py
+++ b/src/questfoundry/models/grow.py
@@ -114,11 +114,11 @@ class IntersectionProposal(BaseModel):
     resolved_location: str = Field(
         min_length=1,
         description=(
-            "Specific location where the intersection scene occurs. Must be a "
-            "non-empty string — pick the best-fit location from the candidate "
-            "beats when uncertain rather than punting. The deterministic "
-            "resolver only runs as a fallback when the model returns the "
-            "literal word 'null' as a string."
+            "Specific location where this intersection scene occurs. "
+            "Must be a non-empty string. When multiple locations are mentioned "
+            "in the candidate group, pick the one that fits most beats. "
+            "When genuinely uncertain, use the most specific location from "
+            "any of the beat descriptions rather than a placeholder."
         ),
     )
     shared_entities: list[str] = Field(default_factory=list)

--- a/src/questfoundry/pipeline/stages/grow/llm_phases.py
+++ b/src/questfoundry/pipeline/stages/grow/llm_phases.py
@@ -221,22 +221,21 @@ class _LLMPhaseMixin:
                     skipped_count += 1
                     continue
 
-                # Resolve location (prefer LLM proposal, fallback to algorithm)
-                # Guard against qwen3:4b returning the literal string "null".
+                # Resolve location (prefer LLM proposal, fallback to algorithm).
+                # Pydantic enforces non-empty via min_length=1; the only path
+                # the algorithm-fallback now exercises is the qwen3:4b footgun
+                # of returning the literal word "null" as a string.
                 raw_loc = proposal.resolved_location
-                llm_location: str | None = (
-                    None if raw_loc in (None, "null", "NULL", "") else raw_loc
-                )
                 location: str | None
-                if llm_location:
-                    location = llm_location
-                else:
+                if raw_loc.lower() == "null":
                     location = resolve_intersection_location(pre_intersection_graph, valid_ids)
                     log.debug(
                         "phase3_location_resolved",
                         beat_ids=valid_ids,
                         resolved=location,
                     )
+                else:
+                    location = raw_loc
 
                 accepted.append((valid_ids, location, proposal.shared_entities, proposal.rationale))
                 log.debug(

--- a/tests/unit/test_grow_models.py
+++ b/tests/unit/test_grow_models.py
@@ -207,15 +207,23 @@ class TestIntersectionProposal:
 
     def test_single_beat_rejected(self) -> None:
         with pytest.raises(ValidationError, match="beat_ids"):
-            IntersectionProposal(beat_ids=["beat_1"], rationale="test")
+            IntersectionProposal(beat_ids=["beat_1"], resolved_location="x", rationale="test")
 
     def test_empty_beat_ids_rejected(self) -> None:
         with pytest.raises(ValidationError, match="beat_ids"):
-            IntersectionProposal(beat_ids=[], rationale="test")
+            IntersectionProposal(beat_ids=[], resolved_location="x", rationale="test")
 
-    def test_no_resolved_location_allowed(self) -> None:
-        intersection = IntersectionProposal(beat_ids=["b1", "b2"], rationale="Entity overlap")
-        assert intersection.resolved_location is None
+    def test_missing_resolved_location_rejected(self) -> None:
+        with pytest.raises(ValidationError, match="resolved_location"):
+            IntersectionProposal(beat_ids=["b1", "b2"], rationale="Entity overlap")  # type: ignore[call-arg]
+
+    def test_empty_resolved_location_rejected(self) -> None:
+        with pytest.raises(ValidationError, match="resolved_location"):
+            IntersectionProposal(
+                beat_ids=["b1", "b2"],
+                resolved_location="",
+                rationale="Entity overlap",
+            )
 
 
 class TestSceneTypeTag:

--- a/tests/unit/test_grow_stage.py
+++ b/tests/unit/test_grow_stage.py
@@ -644,8 +644,11 @@ class TestPhase3Knots:
         assert graph.get_node("beat::artifact_discover")["location"] == "market"
 
     @pytest.mark.asyncio
-    async def test_phase_3_resolves_location_when_missing(self) -> None:
-        """Phase 3 resolves location when LLM leaves it null."""
+    async def test_phase_3_resolves_location_when_llm_returns_null_string(self) -> None:
+        """Phase 3 falls back to the deterministic resolver when the LLM
+        returns the literal word ``"null"`` as a string. Pydantic catches
+        missing/empty values via ``min_length=1``; the algorithmic fallback
+        only covers the qwen3:4b footgun of stringified null."""
         from questfoundry.models.grow import IntersectionProposal, Phase3Output
         from tests.fixtures.grow_fixtures import make_intersection_candidate_graph
 
@@ -656,7 +659,7 @@ class TestPhase3Knots:
             intersections=[
                 IntersectionProposal(
                     beat_ids=["beat::mentor_meet", "beat::artifact_discover"],
-                    resolved_location=None,
+                    resolved_location="null",
                     rationale="Let the algorithm resolve the shared location",
                 ),
             ]

--- a/tests/unit/test_grow_validators.py
+++ b/tests/unit/test_grow_validators.py
@@ -27,7 +27,11 @@ class TestValidatePhase3Output:
     def test_valid_output_no_errors(self) -> None:
         result = Phase3Output(
             intersections=[
-                IntersectionProposal(beat_ids=["beat::b1", "beat::b2"], rationale="test"),
+                IntersectionProposal(
+                    beat_ids=["beat::b1", "beat::b2"],
+                    resolved_location="market square",
+                    rationale="test",
+                ),
             ]
         )
         errors = validate_phase3_output(
@@ -41,6 +45,7 @@ class TestValidatePhase3Output:
             intersections=[
                 IntersectionProposal(
                     beat_ids=["beat::b1", "beat::b2", "beat::b3", "beat::b4"],
+                    resolved_location="market square",
                     rationale="too big",
                 )
             ]
@@ -56,7 +61,11 @@ class TestValidatePhase3Output:
     def test_invalid_beat_id(self) -> None:
         result = Phase3Output(
             intersections=[
-                IntersectionProposal(beat_ids=["beat::b1", "beat::phantom"], rationale="test"),
+                IntersectionProposal(
+                    beat_ids=["beat::b1", "beat::phantom"],
+                    resolved_location="market square",
+                    rationale="test",
+                ),
             ]
         )
         errors = validate_phase3_output(
@@ -69,8 +78,16 @@ class TestValidatePhase3Output:
     def test_beat_reused_across_intersections(self) -> None:
         result = Phase3Output(
             intersections=[
-                IntersectionProposal(beat_ids=["beat::b1", "beat::b2"], rationale="intersection1"),
-                IntersectionProposal(beat_ids=["beat::b2", "beat::b3"], rationale="intersection2"),
+                IntersectionProposal(
+                    beat_ids=["beat::b1", "beat::b2"],
+                    resolved_location="market square",
+                    rationale="intersection1",
+                ),
+                IntersectionProposal(
+                    beat_ids=["beat::b2", "beat::b3"],
+                    resolved_location="council chamber",
+                    rationale="intersection2",
+                ),
             ]
         )
         errors = validate_phase3_output(
@@ -85,8 +102,16 @@ class TestValidatePhase3Output:
     def test_both_invalid_and_reused(self) -> None:
         result = Phase3Output(
             intersections=[
-                IntersectionProposal(beat_ids=["beat::b1", "beat::bad"], rationale="intersection1"),
-                IntersectionProposal(beat_ids=["beat::b1", "beat::b2"], rationale="intersection2"),
+                IntersectionProposal(
+                    beat_ids=["beat::b1", "beat::bad"],
+                    resolved_location="market square",
+                    rationale="intersection1",
+                ),
+                IntersectionProposal(
+                    beat_ids=["beat::b1", "beat::b2"],
+                    resolved_location="council chamber",
+                    rationale="intersection2",
+                ),
             ]
         )
         errors = validate_phase3_output(
@@ -535,7 +560,13 @@ class TestCountEntries:
 
     def test_counts_intersections(self) -> None:
         result = Phase3Output(
-            intersections=[IntersectionProposal(beat_ids=["b1", "b2"], rationale="test")]
+            intersections=[
+                IntersectionProposal(
+                    beat_ids=["b1", "b2"],
+                    resolved_location="market square",
+                    rationale="test",
+                )
+            ]
         )
         assert count_entries(result) == 1
 


### PR DESCRIPTION
## Summary

- `IntersectionProposal.resolved_location: str | None = None` → `str = Field(min_length=1, description=...)`. Pydantic now rejects null / missing / empty at validation time, triggering the existing structured-output retry path.
- Drop the two "NEVER output null" / "NEVER output the word 'null'" repetitions from `grow_phase3_intersections.yaml`. Keep the positive guidance.
- Collapse the runtime guard in `llm_phases.py` to a single `raw_loc.lower() == "null"` check — the `None`/`""` cases are now schema-rejected; only the `qwen3:4b` literal-string-"null" footgun remains.
- Update the two affected tests: `test_missing_resolved_location_rejected` + `test_empty_resolved_location_rejected` replace `test_no_resolved_location_allowed`; `test_phase_3_resolves_location_when_missing` → `test_phase_3_resolves_location_when_llm_returns_null_string`.

Closes #1471.

## Why

The schema permitted `None` while the prompt forbade it — a direct schema-prompt contradiction. Runtime code papered over the conflict by treating four equivalent "not provided" sentinels (`None`, `""`, `"null"`, `"NULL"`) as the same case. With the schema tightened, Pydantic catches three of the four; only the qwen3:4b footgun of returning the *word* "null" as a string remains, since Pydantic can't catch a non-empty string that happens to be that word.

The 2026-04-25 prompt-vs-spec audit (`docs/superpowers/reports/2026-04-25-prompt-spec-audit.md` line 677) flagged this. First of the GROW live-prompt soft findings cluster (audit lines 675-781).

## Test plan

- [x] `uv run pytest tests/unit/test_grow_models.py tests/unit/test_grow_stage.py` — 159 pass
- [x] `uv run ruff check` + `uv run mypy` on changed source files — clean
- [x] Prompt template loads cleanly; "NEVER output null" / "NEVER output the word" strings absent

🤖 Generated with [Claude Code](https://claude.com/claude-code)