### PR TITLE
fix(dress): emit prefixed entity_id + state_flag IDs in codex context (murder3 in-the-wild)

### DIFF
--- a/src/questfoundry/graph/dress_context.py
+++ b/src/questfoundry/graph/dress_context.py
@@ -203,7 +203,12 @@ def format_entity_for_codex(graph: Graph, entity_id: str) -> str:
     raw_id = entity.get("raw_id", strip_scope_prefix(entity_id))
     lines: list[str] = []
 
-    lines.append(f"## Entity: {raw_id}")
+    # Emit the prefixed entity_id (e.g. ``character::clara_yu``) here, not the
+    # raw_id. The codex prompt instructs the LLM to mirror this header back as
+    # the JSON ``entity_id`` field; if we strip the prefix, Gemini faithfully
+    # mirrors the unprefixed form and every entry fails the chunk-membership
+    # validator at dress.py — silently dropping all entries.
+    lines.append(f"## Entity: {entity_id}")
     lines.append("")
 
     # Basic info
@@ -267,10 +272,14 @@ def format_entity_for_codex(graph: Graph, entity_id: str) -> str:
         lines.append("")
         lines.append("### Related State Flags (potential codex gates)")
         for sf_raw, trigger in sorted(related):
+            # Emit the prefixed form so the LLM mirrors `state_flag::...` back
+            # in `visible_when` — same prefix-mirroring pattern as the entity
+            # header above. The validator is forgiving here, but consistency
+            # avoids confusing small models.
             if trigger:
-                lines.append(f"- `{sf_raw}`: {trigger}")
+                lines.append(f"- `state_flag::{sf_raw}`: {trigger}")
             else:
-                lines.append(f"- `{sf_raw}`")
+                lines.append(f"- `state_flag::{sf_raw}`")
 
     return "\n".join(lines).strip()
 

--- a/src/questfoundry/graph/dress_context.py
+++ b/src/questfoundry/graph/dress_context.py
@@ -203,11 +203,7 @@ def format_entity_for_codex(graph: Graph, entity_id: str) -> str:
     raw_id = entity.get("raw_id", strip_scope_prefix(entity_id))
     lines: list[str] = []
 
-    # Emit the prefixed entity_id (e.g. ``character::clara_yu``) here, not the
-    # raw_id. The codex prompt instructs the LLM to mirror this header back as
-    # the JSON ``entity_id`` field; if we strip the prefix, Gemini faithfully
-    # mirrors the unprefixed form and every entry fails the chunk-membership
-    # validator at dress.py — silently dropping all entries.
+    # Prompt mirrors this header back as entity_id; must match the prefixed form (#1473).
     lines.append(f"## Entity: {entity_id}")
     lines.append("")
 
@@ -271,11 +267,8 @@ def format_entity_for_codex(graph: Graph, entity_id: str) -> str:
     if related:
         lines.append("")
         lines.append("### Related State Flags (potential codex gates)")
+        # Prefixed `state_flag::` so the LLM mirrors the same form in `visible_when` (#1473).
         for sf_raw, trigger in sorted(related):
-            # Emit the prefixed form so the LLM mirrors `state_flag::...` back
-            # in `visible_when` — same prefix-mirroring pattern as the entity
-            # header above. The validator is forgiving here, but consistency
-            # avoids confusing small models.
             if trigger:
                 lines.append(f"- `state_flag::{sf_raw}`: {trigger}")
             else:

--- a/src/questfoundry/pipeline/stages/dress.py
+++ b/src/questfoundry/pipeline/stages/dress.py
@@ -925,8 +925,14 @@ class DressStage:
 
         vision_ctx = format_dream_vision(graph)
         state_flags = graph.get_nodes_by_type("state_flag")
+        # Emit prefixed `state_flag::` IDs so the LLM mirrors the same form
+        # back in `visible_when`. The validator strip-prefixes for comparison,
+        # so the unprefixed form was tolerated, but emitting the prefixed form
+        # matches the codex prompt's "use IDs from this list" mandate and the
+        # rest of dress_context.py.
         state_flag_list = "\n".join(
-            f"- `{sf_data.get('raw_id', sf_id)}`: {sf_data.get('trigger', '')}"
+            f"- `state_flag::{sf_data.get('raw_id', strip_scope_prefix(sf_id))}`: "
+            f"{sf_data.get('trigger', '')}"
             for sf_id, sf_data in state_flags.items()
         )
 

--- a/src/questfoundry/pipeline/stages/dress.py
+++ b/src/questfoundry/pipeline/stages/dress.py
@@ -925,14 +925,10 @@ class DressStage:
 
         vision_ctx = format_dream_vision(graph)
         state_flags = graph.get_nodes_by_type("state_flag")
-        # Emit prefixed `state_flag::` IDs so the LLM mirrors the same form
-        # back in `visible_when`. The validator strip-prefixes for comparison,
-        # so the unprefixed form was tolerated, but emitting the prefixed form
-        # matches the codex prompt's "use IDs from this list" mandate and the
-        # rest of dress_context.py.
+        # Prefixed `state_flag::` so the LLM mirrors the same form in `visible_when` (#1473).
         state_flag_list = "\n".join(
-            f"- `state_flag::{sf_data.get('raw_id', strip_scope_prefix(sf_id))}`: "
-            f"{sf_data.get('trigger', '')}"
+            f"- `state_flag::{sf_data.get('raw_id', strip_scope_prefix(sf_id))}`:"
+            f" {sf_data.get('trigger', '')}"
             for sf_id, sf_data in state_flags.items()
         )
 

--- a/tests/unit/test_dress_context.py
+++ b/tests/unit/test_dress_context.py
@@ -173,6 +173,23 @@ class TestFormatEntityForCodex:
         # the LLM mirrors the same form back in ``visible_when`` (#1473).
         assert "`state_flag::met_aldric`" in result
 
+    def test_related_state_flag_without_trigger(self, dress_graph: Graph) -> None:
+        """A related state flag with empty ``trigger`` MUST still be emitted —
+        without a trailing ``: <text>``. Covers the no-trigger branch in
+        ``format_entity_for_codex`` (#1473)."""
+        from questfoundry.graph.dress_context import format_entity_for_codex
+
+        # `betrayed_aldric` matches via raw_id substring, has no trigger text.
+        dress_graph.create_node(
+            "state_flag::betrayed_aldric",
+            {"type": "state_flag", "raw_id": "betrayed_aldric", "trigger": ""},
+        )
+
+        result = format_entity_for_codex(dress_graph, "character::aldric")
+        # No-trigger branch: `state_flag::<id>` line with no trailing colon-space-text.
+        assert "- `state_flag::betrayed_aldric`" in result
+        assert "- `state_flag::betrayed_aldric`:" not in result
+
     def test_nonexistent_entity(self, dress_graph: Graph) -> None:
         from questfoundry.graph.dress_context import format_entity_for_codex
 

--- a/tests/unit/test_dress_context.py
+++ b/tests/unit/test_dress_context.py
@@ -151,11 +151,27 @@ class TestFormatEntityForCodex:
         assert "character" in result
         assert "court advisor" in result
 
+    def test_header_uses_prefixed_entity_id(self, dress_graph: Graph) -> None:
+        """The ``## Entity:`` header MUST emit the prefixed ``entity_id`` (e.g.
+        ``character::aldric``), not the raw_id. The codex prompt instructs the
+        LLM to mirror this header back as the JSON ``entity_id``; emitting the
+        unprefixed form makes the LLM return ``"aldric"`` and every entry then
+        fails the chunk-membership validator at dress.py — silently dropping
+        all entries (the murder3 / #1473 in-the-wild bug)."""
+        from questfoundry.graph.dress_context import format_entity_for_codex
+
+        result = format_entity_for_codex(dress_graph, "character::aldric")
+        assert "## Entity: character::aldric" in result
+        # And the raw form is NOT what shows up as the header line:
+        assert "## Entity: aldric\n" not in result
+
     def test_includes_related_state_flags(self, dress_graph: Graph) -> None:
         from questfoundry.graph.dress_context import format_entity_for_codex
 
         result = format_entity_for_codex(dress_graph, "character::aldric")
-        assert "met_aldric" in result
+        # Related state flags are emitted with the ``state_flag::`` prefix so
+        # the LLM mirrors the same form back in ``visible_when`` (#1473).
+        assert "`state_flag::met_aldric`" in result
 
     def test_nonexistent_entity(self, dress_graph: Graph) -> None:
         from questfoundry.graph.dress_context import format_entity_for_codex

--- a/tests/unit/test_dress_stage.py
+++ b/tests/unit/test_dress_stage.py
@@ -1760,6 +1760,66 @@ class TestPhase2Codex:
         assert len(codex_nodes) == 1
 
     @pytest.mark.asyncio()
+    async def test_state_flag_list_uses_prefixed_form(self) -> None:
+        """The ``state_flags`` context key injected into the codex prompt MUST
+        list IDs with the ``state_flag::`` prefix so the LLM mirrors that
+        form back in ``visible_when`` (#1473). The validator strip-prefixes
+        for comparison so the unprefixed form was tolerated, but emitting the
+        prefixed form prevents small-model drift between this list and the
+        per-entity ``Related State Flags`` block."""
+        g = Graph()
+        g.create_node(
+            "entity::e0",
+            {"type": "entity", "raw_id": "e0", "entity_type": "character"},
+        )
+        g.create_node(
+            "state_flag::met_aldric",
+            {
+                "type": "state_flag",
+                "raw_id": "met_aldric",
+                "trigger": "Player has met Aldric",
+            },
+        )
+
+        captured_contexts: list[dict[str, Any]] = []
+
+        async def _mock_llm_call(
+            _model: Any,
+            _template: str,
+            _context: dict[str, Any],
+            _schema: type,
+            **_kwargs: Any,
+        ) -> tuple:
+            captured_contexts.append(_context)
+            if _template == "dress_codex_spoiler_check":
+                return (SpoilerCheckResult(has_leak=False, leaks=[], reason=""), 1, 25)
+            return (
+                BatchedCodexOutput(
+                    entities=[
+                        BatchedCodexItem(
+                            entity_id="entity::e0",
+                            entries=[
+                                CodexEntry(title="E0", rank=1, visible_when=[], content="Info.")
+                            ],
+                        )
+                    ]
+                ),
+                1,
+                100,
+            )
+
+        stage = DressStage()
+        with patch.object(stage, "_dress_llm_call", side_effect=_mock_llm_call):
+            await stage._phase_2_codex(g, MagicMock())
+
+        batch_contexts = [c for c in captured_contexts if "entities_batch" in c]
+        assert batch_contexts, "expected at least one codex_batch call"
+        sf_block = batch_contexts[0]["state_flags"]
+        assert "state_flag::met_aldric" in sf_block
+        # And the unprefixed form is NOT what we emit as the leading ID:
+        assert "- `met_aldric`" not in sf_block
+
+    @pytest.mark.asyncio()
     async def test_logs_validation_warnings(self) -> None:
         """Codex validation warnings are logged but don't fail the phase."""
         g = Graph()

--- a/tests/unit/test_dress_stage.py
+++ b/tests/unit/test_dress_stage.py
@@ -1704,9 +1704,10 @@ class TestPhase2Codex:
                 return (SpoilerCheckResult(has_leak=False, leaks=[], reason=""), 1, 25)
             # dress_codex_batch
             batch_calls.append(_context)
-            # Parse entity IDs from batch context (each starts with "## Entity: <raw_id>")
-            raw_ids = re.findall(r"## Entity: (\S+)", _context["entities_batch"])
-            eids = [f"entity::{raw_id}" for raw_id in raw_ids]
+            # Parse entity IDs from batch context. The header now emits the
+            # full prefixed form (`## Entity: entity::e0`) per #1473 — the LLM
+            # mirrors what it sees, and so does this mock.
+            eids = re.findall(r"## Entity: (\S+)", _context["entities_batch"])
             return (_make_batch_output(eids), 1, 100)
 
         stage = DressStage()


### PR DESCRIPTION
## Summary

- ``graph/dress_context.py`` ``format_entity_for_codex``: emit ``## Entity: {entity_id}`` (e.g. ``character::clara_yu``) instead of ``## Entity: {raw_id}`` (``clara_yu``). The codex prompt instructs the LLM to mirror this header back as the JSON ``entity_id``; the unprefixed form caused 100% silent rejection of every codex entry on ``projects/murder3``.
- ``graph/dress_context.py`` "Related State Flags" subsection: emit ``state_flag::<raw_id>`` for parity (validator was forgiving here, but consistency removes a small-model footgun).
- ``pipeline/stages/dress.py`` global ``state_flag_list``: emit ``state_flag::<raw_id>`` to match.
- Tests: new ``test_header_uses_prefixed_entity_id`` regression pin; ``test_includes_related_state_flags`` now asserts prefixed; ``test_batching_groups_entities`` mock fixed (it was re-prepending ``entity::`` to the regex capture, double-prefixing against the fix).

Closes #1473.

## Why

Running ``qf dress`` on ``projects/murder3`` (Gemini provider) failed at stage exit with ``DRESS output contract violated: 20 Entity(ies) without a CodexEntry`` after all 5 batched LLM calls reported success. Every entry was silently dropped because the LLM's ``entity_id`` field returned ``"clara_yu"`` (mirroring what the context showed) but the validator at ``dress.py:973`` exact-matched against the chunk which contained ``"character::clara_yu"``.

This is a Valid-ID-injection bug per CLAUDE.md §6 / @prompt-engineer Rule 1: the prompt asked for an exact-match ID but the context showed a different form. Gemini follows context literally; qwen3:4b may have been more forgiving, masking the bug.

## Concrete log evidence (from ``projects/murder3/logs/debug.jsonl``)

```
WARNING codex_batch_invalid_entity_id entity_id="clara_yu"
  expected=["character::simon_blackwood", "character::clara_yu", ...]
... (20 such warnings, all batches)
INFO codex_phase_complete entries_created=0 warnings=0
ERROR stage_failed stage=dress error="DRESS output contract violated:
  20 Entity(ies) without a CodexEntry: ..."
```

## Test plan

- [x] ``uv run pytest tests/unit/test_dress_context.py tests/unit/test_dress_stage.py`` — 131 pass
- [x] ``uv run ruff check`` + ``uv run mypy`` on changed source files — clean
- [ ] Empirical: re-run ``qf dress --project projects/murder3 --provider gemini`` and confirm codex phase succeeds. (Snapshot at ``projects/murder3/snapshots/pre-dress.db`` reproduces deterministically.)

## Out of scope

- Per-entity escalation when the chunk-membership validator rejects (same silent-drop pattern as FILL #1468). Pipeline-level concern; the prompt fix unblocks murder3 immediately and is the surgical fix for #1473.

🤖 Generated with [Claude Code](https://claude.com/claude-code)