### PR TITLE
feat(grow): group valid_beat_ids by dilemma in Phase 3 + Phase 4a context

### DIFF
--- a/prompts/templates/grow_phase3_intersections.yaml
+++ b/prompts/templates/grow_phase3_intersections.yaml
@@ -46,7 +46,12 @@ system: |
   {candidate_groups}
 
   ## Valid IDs
-  Valid beat_ids (use ONLY these): {valid_beat_ids}
+  Valid beat_ids (use ONLY these), grouped by the dilemma each beat
+  belongs to. Beats whose ``belongs_to`` resolves to multiple dilemmas
+  (rare, structural error) and beats with no ``belongs_to`` mapping
+  appear in dedicated buckets.
+
+  {valid_beat_ids}
 
   ## Output Format
   Return a JSON object with an "intersections" array. Each element has:

--- a/prompts/templates/grow_phase4a_scene_types.yaml
+++ b/prompts/templates/grow_phase4a_scene_types.yaml
@@ -43,7 +43,13 @@ system: |
   - Do NOT add prose before or after the JSON output
 
   ## Valid IDs
-  Valid beat_ids (use ONLY these): {valid_beat_ids}
+  Valid beat_ids (use ONLY these), grouped by the dilemma each beat
+  belongs to. Beats whose ``belongs_to`` resolves to multiple dilemmas
+  (rare, structural error) and beats with no ``belongs_to`` mapping
+  appear in dedicated buckets.
+
+  {valid_beat_ids}
+
   Total beats: {beat_count}
 
   ## Output Format

--- a/src/questfoundry/graph/grow_context.py
+++ b/src/questfoundry/graph/grow_context.py
@@ -6,10 +6,90 @@ context strings for GROW's LLM-powered phases.
 
 from __future__ import annotations
 
+from collections import defaultdict
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from questfoundry.graph.graph import Graph
+
+
+def format_valid_beat_ids_by_dilemma(graph: Graph, beat_ids: set[str]) -> str:
+    """Format a beat-ID list grouped by the dilemma each beat belongs to.
+
+    Replaces the flat ``", ".join(sorted(...))`` injection that small models
+    lose track of for large stories. Per CLAUDE.md §6 Valid ID Injection,
+    structured Valid IDs lists prevent phantom-ID hallucinations and reduce
+    position-bias errors when the surface area is large.
+
+    Layout:
+    - One bullet per dilemma listing its beats (sorted). Y-shape pre-commit
+      beats (multiple ``belongs_to`` edges to paths of the SAME dilemma per
+      Story Graph Ontology Part 8) land under that dilemma's bullet — they
+      are single-dilemma in narrative terms.
+    - One ``(spans multiple dilemmas)`` bullet for beats whose
+      ``belongs_to`` paths resolve to multiple distinct dilemmas. Per SGO
+      Part 8 this is a spec violation; surfacing it defensively helps
+      catch upstream regressions rather than silently picking one
+      dilemma's bullet.
+    - One ``(unmapped)`` bullet for beats with no ``belongs_to`` edge —
+      e.g. structural beats that haven't been wired to a path yet. Surfaced
+      explicitly so the LLM doesn't silently invent a parent.
+
+    Empty buckets are omitted. The whole list returns as a single string
+    suitable for direct injection as the ``valid_beat_ids`` template
+    variable. The caller must own the input set; this helper does not
+    consult the graph for which beats are "valid" — it groups whatever
+    set is passed.
+
+    Args:
+        graph: Graph used to look up ``belongs_to`` edges and ``path``
+            nodes for dilemma resolution.
+        beat_ids: Beat IDs (prefixed, e.g. ``beat::foo``) to group.
+
+    Returns:
+        Multi-line markdown string. Empty string if ``beat_ids`` is empty.
+    """
+    if not beat_ids:
+        return ""
+
+    from questfoundry.graph.context import normalize_scoped_id
+
+    path_nodes = graph.get_nodes_by_type("path")
+    beat_dilemmas: dict[str, set[str]] = defaultdict(set)
+    for edge in graph.get_edges(from_id=None, to_id=None, edge_type="belongs_to"):
+        beat_id = edge["from"]
+        if beat_id not in beat_ids:
+            continue
+        path_data = path_nodes.get(edge["to"])
+        if not path_data:
+            continue
+        dilemma_id = path_data.get("dilemma_id")
+        if dilemma_id:
+            beat_dilemmas[beat_id].add(normalize_scoped_id(dilemma_id, "dilemma"))
+
+    by_dilemma: dict[str, list[str]] = defaultdict(list)
+    multi: list[str] = []
+    unmapped: list[str] = []
+    for bid in sorted(beat_ids):
+        dilemmas = beat_dilemmas.get(bid, set())
+        if len(dilemmas) == 0:
+            unmapped.append(bid)
+        elif len(dilemmas) == 1:
+            by_dilemma[next(iter(dilemmas))].append(bid)
+        else:
+            multi.append(bid)
+
+    lines: list[str] = []
+    for did in sorted(by_dilemma):
+        beat_list = ", ".join(f"`{b}`" for b in by_dilemma[did])
+        lines.append(f"- `{did}`: {beat_list}")
+    if multi:
+        beat_list = ", ".join(f"`{b}`" for b in multi)
+        lines.append(f"- (spans multiple dilemmas): {beat_list}")
+    if unmapped:
+        beat_list = ", ".join(f"`{b}`" for b in unmapped)
+        lines.append(f"- (unmapped): {beat_list}")
+    return "\n".join(lines)
 
 
 def format_grow_valid_ids(graph: Graph) -> dict[str, str]:

--- a/src/questfoundry/graph/grow_context.py
+++ b/src/questfoundry/graph/grow_context.py
@@ -14,41 +14,7 @@ if TYPE_CHECKING:
 
 
 def format_valid_beat_ids_by_dilemma(graph: Graph, beat_ids: set[str]) -> str:
-    """Format a beat-ID list grouped by the dilemma each beat belongs to.
-
-    Replaces the flat ``", ".join(sorted(...))`` injection that small models
-    lose track of for large stories. Per CLAUDE.md §6 Valid ID Injection,
-    structured Valid IDs lists prevent phantom-ID hallucinations and reduce
-    position-bias errors when the surface area is large.
-
-    Layout:
-    - One bullet per dilemma listing its beats (sorted). Y-shape pre-commit
-      beats (multiple ``belongs_to`` edges to paths of the SAME dilemma per
-      Story Graph Ontology Part 8) land under that dilemma's bullet — they
-      are single-dilemma in narrative terms.
-    - One ``(spans multiple dilemmas)`` bullet for beats whose
-      ``belongs_to`` paths resolve to multiple distinct dilemmas. Per SGO
-      Part 8 this is a spec violation; surfacing it defensively helps
-      catch upstream regressions rather than silently picking one
-      dilemma's bullet.
-    - One ``(unmapped)`` bullet for beats with no ``belongs_to`` edge —
-      e.g. structural beats that haven't been wired to a path yet. Surfaced
-      explicitly so the LLM doesn't silently invent a parent.
-
-    Empty buckets are omitted. The whole list returns as a single string
-    suitable for direct injection as the ``valid_beat_ids`` template
-    variable. The caller must own the input set; this helper does not
-    consult the graph for which beats are "valid" — it groups whatever
-    set is passed.
-
-    Args:
-        graph: Graph used to look up ``belongs_to`` edges and ``path``
-            nodes for dilemma resolution.
-        beat_ids: Beat IDs (prefixed, e.g. ``beat::foo``) to group.
-
-    Returns:
-        Multi-line markdown string. Empty string if ``beat_ids`` is empty.
-    """
+    """Format ``beat_ids`` grouped by dilemma; cross-dilemma anomalies and unmapped beats surface in dedicated buckets."""
     if not beat_ids:
         return ""
 

--- a/src/questfoundry/pipeline/stages/grow/llm_phases.py
+++ b/src/questfoundry/pipeline/stages/grow/llm_phases.py
@@ -148,9 +148,11 @@ class _LLMPhaseMixin:
             candidates, beat_nodes, beat_dilemmas, graph=graph
         )
 
+        from questfoundry.graph.grow_context import format_valid_beat_ids_by_dilemma
+
         context: dict[str, str] = {
             "candidate_groups": candidate_groups_text,
-            "valid_beat_ids": ", ".join(sorted(valid_beat_ids)),
+            "valid_beat_ids": format_valid_beat_ids_by_dilemma(graph, valid_beat_ids),
             "structural_feedback": "",
         }
 
@@ -602,9 +604,11 @@ class _LLMPhaseMixin:
             line = f'- {bid}: "{summary}" [impacts={n_impacts}]'
             beat_items.append(ContextItem(id=bid, text=line))
 
+        from questfoundry.graph.grow_context import format_valid_beat_ids_by_dilemma
+
         context = {
             "beat_summaries": compact_items(beat_items, self._compact_config()),  # type: ignore[attr-defined]
-            "valid_beat_ids": ", ".join(sorted(beat_nodes.keys())),
+            "valid_beat_ids": format_valid_beat_ids_by_dilemma(graph, set(beat_nodes.keys())),
             "beat_count": str(len(beat_nodes)),
         }
 

--- a/tests/unit/test_grow_context.py
+++ b/tests/unit/test_grow_context.py
@@ -1,0 +1,141 @@
+"""Tests for GROW context-formatting helpers."""
+
+from __future__ import annotations
+
+from questfoundry.graph.graph import Graph
+from questfoundry.graph.grow_context import format_valid_beat_ids_by_dilemma
+
+
+class TestFormatValidBeatIdsByDilemma:
+    """Pin the grouped Valid IDs layout for Phase 3 + Phase 4a (#1476)."""
+
+    def _seed_graph(self) -> Graph:
+        """Build a graph with two dilemmas, two paths each, plus a Y-shape
+        pre-commit beat that belongs to both paths of one dilemma, and a
+        structural beat with no ``belongs_to`` edge."""
+        g = Graph()
+        for did in ("mentor_trust", "archive_nature"):
+            g.create_node(f"dilemma::{did}", {"type": "dilemma", "raw_id": did})
+        # Two paths per dilemma
+        g.create_node(
+            "path::mt_canonical",
+            {"type": "path", "raw_id": "mt_canonical", "dilemma_id": "dilemma::mentor_trust"},
+        )
+        g.create_node(
+            "path::mt_alt",
+            {"type": "path", "raw_id": "mt_alt", "dilemma_id": "dilemma::mentor_trust"},
+        )
+        g.create_node(
+            "path::an_canonical",
+            {"type": "path", "raw_id": "an_canonical", "dilemma_id": "dilemma::archive_nature"},
+        )
+        # Beats
+        for bid in (
+            "beat::mt_a",
+            "beat::mt_b",
+            "beat::mt_pre",
+            "beat::an_a",
+            "beat::orphan",
+        ):
+            g.create_node(bid, {"type": "beat", "raw_id": bid.split("::", 1)[1]})
+
+        # Single-dilemma mappings
+        g.add_edge("belongs_to", "beat::mt_a", "path::mt_canonical")
+        g.add_edge("belongs_to", "beat::mt_b", "path::mt_alt")
+        g.add_edge("belongs_to", "beat::an_a", "path::an_canonical")
+        # Y-shape pre-commit: belongs to BOTH paths of mentor_trust
+        g.add_edge("belongs_to", "beat::mt_pre", "path::mt_canonical")
+        g.add_edge("belongs_to", "beat::mt_pre", "path::mt_alt")
+        # beat::orphan has no belongs_to edge
+
+        return g
+
+    def test_groups_by_dilemma(self) -> None:
+        g = self._seed_graph()
+        beat_ids = {"beat::mt_a", "beat::mt_b", "beat::an_a"}
+        result = format_valid_beat_ids_by_dilemma(g, beat_ids)
+        assert "- `dilemma::archive_nature`: `beat::an_a`" in result
+        assert "- `dilemma::mentor_trust`: `beat::mt_a`, `beat::mt_b`" in result
+        # No multi or unmapped buckets when all beats are single-dilemma
+        assert "(multi-dilemma" not in result
+        assert "(unmapped)" not in result
+
+    def test_pre_commit_beat_groups_under_its_dilemma(self) -> None:
+        """Y-shape pre-commit beats have multiple ``belongs_to`` edges, but all
+        to paths of the SAME dilemma (Story Graph Ontology Part 8: "Multi-
+        belongs_to only within one dilemma"). They land under that dilemma's
+        bucket, NOT in the cross-dilemma bucket."""
+        g = self._seed_graph()
+        beat_ids = {"beat::mt_a", "beat::mt_pre"}
+        result = format_valid_beat_ids_by_dilemma(g, beat_ids)
+        # Both beats land under mentor_trust (mt_pre has 2 belongs_to but to
+        # the SAME dilemma's paths — single-dilemma in Y-shape semantics).
+        assert "- `dilemma::mentor_trust`: `beat::mt_a`, `beat::mt_pre`" in result
+        # Cross-dilemma bucket MUST be absent for this fixture:
+        assert "(spans multiple dilemmas)" not in result
+
+    def test_cross_dilemma_beat_lands_in_multi_bucket(self) -> None:
+        """A beat with ``belongs_to`` edges to paths of DIFFERENT dilemmas
+        is a Story Graph Ontology Part 8 violation. The helper surfaces such
+        anomalies in a dedicated bucket rather than silently grouping them
+        under one of the dilemmas."""
+        g = self._seed_graph()
+        # Synthetic spec-violation: a beat that belongs to paths of two
+        # different dilemmas. Production graph code should never produce
+        # this, but defensive surfacing helps catch upstream regressions.
+        g.create_node("beat::cross", {"type": "beat", "raw_id": "cross"})
+        g.add_edge("belongs_to", "beat::cross", "path::mt_canonical")
+        g.add_edge("belongs_to", "beat::cross", "path::an_canonical")
+
+        result = format_valid_beat_ids_by_dilemma(g, {"beat::mt_a", "beat::cross", "beat::an_a"})
+        # Single-dilemma beats land under their dilemma:
+        assert "- `dilemma::mentor_trust`: `beat::mt_a`" in result
+        assert "- `dilemma::archive_nature`: `beat::an_a`" in result
+        # Cross-dilemma beat lands in the spec-violation bucket:
+        assert "- (spans multiple dilemmas): `beat::cross`" in result
+
+    def test_unmapped_beat_lands_in_unmapped_bucket(self) -> None:
+        g = self._seed_graph()
+        result = format_valid_beat_ids_by_dilemma(g, {"beat::orphan"})
+        assert "- (unmapped): `beat::orphan`" in result
+        assert "dilemma::" not in result
+
+    def test_empty_input_returns_empty_string(self) -> None:
+        g = self._seed_graph()
+        assert format_valid_beat_ids_by_dilemma(g, set()) == ""
+
+    def test_only_listed_beats_grouped(self) -> None:
+        """Beats not in the input set MUST NOT appear, even if the graph has
+        ``belongs_to`` edges for them. The helper groups whatever the caller
+        passes — it doesn't consult the graph for the canonical beat list."""
+        g = self._seed_graph()
+        result = format_valid_beat_ids_by_dilemma(g, {"beat::mt_a"})
+        assert "beat::mt_a" in result
+        assert "beat::mt_b" not in result
+        assert "beat::an_a" not in result
+        assert "beat::mt_pre" not in result
+
+    def test_dilemmas_sorted_alphabetically(self) -> None:
+        """Dilemma buckets sort lexicographically so identical inputs render
+        identically across runs (deterministic prompt context)."""
+        g = self._seed_graph()
+        result = format_valid_beat_ids_by_dilemma(g, {"beat::an_a", "beat::mt_a"})
+        an_idx = result.index("dilemma::archive_nature")
+        mt_idx = result.index("dilemma::mentor_trust")
+        assert an_idx < mt_idx
+
+    def test_buckets_render_in_dilemma_then_multi_then_unmapped_order(self) -> None:
+        """When all three bucket kinds are present, render order is:
+        single-dilemma buckets → cross-dilemma → unmapped."""
+        g = self._seed_graph()
+        # Synthetic cross-dilemma beat (same construction as
+        # test_cross_dilemma_beat_lands_in_multi_bucket).
+        g.create_node("beat::cross", {"type": "beat", "raw_id": "cross"})
+        g.add_edge("belongs_to", "beat::cross", "path::mt_canonical")
+        g.add_edge("belongs_to", "beat::cross", "path::an_canonical")
+
+        result = format_valid_beat_ids_by_dilemma(g, {"beat::mt_a", "beat::cross", "beat::orphan"})
+        single_idx = result.index("- `dilemma::mentor_trust`")
+        multi_idx = result.index("- (spans multiple dilemmas)")
+        unmapped_idx = result.index("- (unmapped)")
+        assert single_idx < multi_idx < unmapped_idx

--- a/tests/unit/test_grow_context.py
+++ b/tests/unit/test_grow_context.py
@@ -56,8 +56,9 @@ class TestFormatValidBeatIdsByDilemma:
         result = format_valid_beat_ids_by_dilemma(g, beat_ids)
         assert "- `dilemma::archive_nature`: `beat::an_a`" in result
         assert "- `dilemma::mentor_trust`: `beat::mt_a`, `beat::mt_b`" in result
-        # No multi or unmapped buckets when all beats are single-dilemma
-        assert "(multi-dilemma" not in result
+        # No cross-dilemma or unmapped buckets when all beats are single-dilemma.
+        # Use the real bucket label so a future rename trips this test.
+        assert "(spans multiple dilemmas)" not in result
         assert "(unmapped)" not in result
 
     def test_pre_commit_beat_groups_under_its_dilemma(self) -> None:


### PR DESCRIPTION
## Summary

- New `format_valid_beat_ids_by_dilemma(graph, beat_ids)` helper in `graph/grow_context.py` groups beats by the dilemma each belongs to. Y-shape pre-commit beats land under their single dilemma (per SGO Part 8: "Multi-belongs_to only within one dilemma"). Genuinely cross-dilemma beats (spec violations) and unmapped beats land in dedicated buckets so the LLM doesn't see them silently disappear.
- Wired into Phase 3 (intersections) and Phase 4a (scene_types). Template variable `{valid_beat_ids}` unchanged; rendered content changes from flat comma-separated string to grouped markdown.
- Both prompt templates' `## Valid IDs` sections updated to describe the new layout.
- New `tests/unit/test_grow_context.py` (7 tests).

Closes #1476.

## Why

The 2026-04-25 prompt-vs-spec audit (lines 681 + 705) flagged `valid_beat_ids` as small-model-fragile — for large stories the flat list is hundreds of unstructured tokens that trigger position-bias errors and phantom-ID hallucinations. CLAUDE.md §6 Valid ID Injection prescribes structured grouping over flat lists.

## Output format

```
- `dilemma::archive_nature`: `beat::a`, `beat::b`
- `dilemma::mentor_trust`: `beat::c`, `beat::d`, `beat::pre_commit_xy`
- (spans multiple dilemmas): `beat::cross_dilemma_anomaly`
- (unmapped): `beat::orphan`
```

Empty buckets are omitted.

## Test plan

- [x] `uv run pytest tests/unit/test_grow_context.py tests/unit/test_grow_stage.py tests/unit/test_grow_validators.py` — 114 pass
- [x] `uv run ruff check` + `uv run mypy` — clean
- [x] Y-shape pre-commit beats verified to land under their dilemma (test_pre_commit_beat_groups_under_its_dilemma)
- [x] Cross-dilemma anomaly bucket verified (test_cross_dilemma_beat_lands_in_multi_bucket)

## Out of scope

- Phase 8c overlay `valid_entity_ids` + `valid_state_flag_ids` flat-listed (separate audit finding).
- Phase 4g transition_gaps Valid IDs section (separate audit finding).
- phase3 → phase2 template rename (cosmetic, info-severity).

🤖 Generated with [Claude Code](https://claude.com/claude-code)