### PR TITLE
feat(grow): add Valid IDs section + transition_feedback slot to Phase 4g prompt

### DIFF
--- a/prompts/templates/grow_phase4g_transition_gaps.yaml
+++ b/prompts/templates/grow_phase4g_transition_gaps.yaml
@@ -14,6 +14,12 @@ system: |
   ## Transitions
   {transitions_context}
 
+  ## Valid IDs
+  Use ONLY these `transition_id` strings — invented or paraphrased IDs are
+  rejected. Each ID corresponds to one transition above.
+
+  {transition_ids}
+
   ## Story Context
   Genre: {genre}
   Tone: {tone}
@@ -45,7 +51,8 @@ user: |
 
   REMINDER: Return ONLY a valid JSON object with a "bridges" array.
   REMINDER: Each bridge must reference entities or locations from BOTH sides of the transition.
-  REMINDER: Use the exact transition_id strings provided in the Transitions section.
+  REMINDER: Use the exact transition_id strings from the Valid IDs section.
   REMINDER: Bridges are atmospheric only — do NOT commit a character to any dilemma choice.
+  {transition_feedback}
 
 components: []

--- a/src/questfoundry/pipeline/stages/grow/llm_phases.py
+++ b/src/questfoundry/pipeline/stages/grow/llm_phases.py
@@ -758,8 +758,7 @@ class _LLMPhaseMixin:
             elif isinstance(tone_val, str):
                 tone = tone_val
 
-        # Build a structured Valid IDs list for the prompt (CLAUDE.md §6 /
-        # @prompt-engineer Rule 1). Sorted for deterministic context.
+        # Sorted for deterministic prompt output (phantom-ID guard).
         transition_ids_block = "\n".join(f"- `{tid}`" for tid in sorted(transition_map))
 
         context = {
@@ -768,9 +767,7 @@ class _LLMPhaseMixin:
             "transition_ids": transition_ids_block,
             "genre": genre or "(not specified)",
             "tone": tone or "(not specified)",
-            # Repair-loop slot reserved for future ``semantic_validator``
-            # wiring (mirrors Phase 3's ``structural_feedback``). Empty by
-            # default so the first call sees no corrective hints.
+            # Empty on first call; reserved for future repair-loop wiring (mirrors Phase 3).
             "transition_feedback": "",
         }
 

--- a/src/questfoundry/pipeline/stages/grow/llm_phases.py
+++ b/src/questfoundry/pipeline/stages/grow/llm_phases.py
@@ -758,11 +758,20 @@ class _LLMPhaseMixin:
             elif isinstance(tone_val, str):
                 tone = tone_val
 
+        # Build a structured Valid IDs list for the prompt (CLAUDE.md §6 /
+        # @prompt-engineer Rule 1). Sorted for deterministic context.
+        transition_ids_block = "\n".join(f"- `{tid}`" for tid in sorted(transition_map))
+
         context = {
             "transition_count": str(len(transitions)),
             "transitions_context": "\n\n".join(transition_lines),
+            "transition_ids": transition_ids_block,
             "genre": genre or "(not specified)",
             "tone": tone or "(not specified)",
+            # Repair-loop slot reserved for future ``semantic_validator``
+            # wiring (mirrors Phase 3's ``structural_feedback``). Empty by
+            # default so the first call sees no corrective hints.
+            "transition_feedback": "",
         }
 
         try:

--- a/tests/unit/test_llm_phases.py
+++ b/tests/unit/test_llm_phases.py
@@ -721,3 +721,32 @@ class TestPhaseTransitionGaps:
         )
         # Only the original two beat nodes should exist
         assert set(beat_nodes.keys()) == {"beat::aq_beat", "beat::mt_beat"}
+
+    @pytest.mark.asyncio
+    async def test_transition_gaps_context_has_valid_ids_and_feedback_slot(self) -> None:
+        """Phase 4g context MUST inject ``transition_ids`` (Valid IDs section
+        per CLAUDE.md §6) and ``transition_feedback`` (repair-loop slot,
+        defaults to empty string) — #1478. Pin both keys in the context dict
+        passed to ``_grow_llm_call`` so future template work can trust the
+        slots exist."""
+        graph = _make_cross_dilemma_hard_transition_graph()
+        stage = _make_grow_stage_instance()
+        mock_model = MagicMock()
+
+        captured: dict[str, object] = {}
+
+        async def _capture_call(*, context: dict[str, object], **_kwargs: object) -> tuple:
+            captured.update(context)
+            return TransitionGapsOutput(bridges=[]), 1, 10
+
+        with patch.object(stage, "_grow_llm_call", new=AsyncMock(side_effect=_capture_call)):
+            await stage._phase_transition_gaps(graph, mock_model)
+
+        # Valid IDs section: backtick-wrapped transition_id from the seam.
+        assert "transition_ids" in captured
+        transition_ids_block = captured["transition_ids"]
+        assert isinstance(transition_ids_block, str)
+        assert "`beat::aq_beat|beat::mt_beat`" in transition_ids_block
+
+        # Repair-loop slot exists and defaults to empty string for first call.
+        assert captured.get("transition_feedback") == ""

--- a/tests/unit/test_llm_phases.py
+++ b/tests/unit/test_llm_phases.py
@@ -724,11 +724,7 @@ class TestPhaseTransitionGaps:
 
     @pytest.mark.asyncio
     async def test_transition_gaps_context_has_valid_ids_and_feedback_slot(self) -> None:
-        """Phase 4g context MUST inject ``transition_ids`` (Valid IDs section
-        per CLAUDE.md §6) and ``transition_feedback`` (repair-loop slot,
-        defaults to empty string) — #1478. Pin both keys in the context dict
-        passed to ``_grow_llm_call`` so future template work can trust the
-        slots exist."""
+        """Pin Phase 4g context: ``transition_ids`` Valid IDs block + empty ``transition_feedback`` slot (#1478)."""
         graph = _make_cross_dilemma_hard_transition_graph()
         stage = _make_grow_stage_instance()
         mock_model = MagicMock()


### PR DESCRIPTION
## Summary

- `grow_phase4g_transition_gaps.yaml`: add `## Valid IDs` section listing the new `{transition_ids}` template variable. Add `{transition_feedback}` slot near user-section reminders for future repair-loop wiring.
- `pipeline/stages/grow/llm_phases.py` `_phase_transition_gaps`: build sorted, backtick-wrapped Valid IDs block from `transition_map.keys()`; inject as `transition_ids` and `transition_feedback=""` (empty for first call).
- Test: `test_transition_gaps_context_has_valid_ids_and_feedback_slot` captures the context passed to `_grow_llm_call` and asserts both keys are present.

Closes #1478.

## Why

The 2026-04-25 prompt-vs-spec audit (lines 745-755) flagged Phase 4g as missing the standard Valid IDs anti-phantom-ID protection. Composite `transition_id` strings like `beat::a|beat::b` were only embedded inline in the `{transitions_context}` block — small models that miss the inline format produce phantom IDs that fall through the `transition_map.get()` exact-match check at runtime, dropping bridges silently.

Other GROW phases support structured retry feedback (Phase 3's `{structural_feedback}`); Phase 4g had no slot. This PR adds the slot now so any future `semantic_validator` wiring has somewhere to inject corrective hints — adding a behaviour-changing validator is out of scope here.

## Test plan

- [x] `uv run pytest tests/unit/test_llm_phases.py` — 18 pass
- [x] `uv run ruff check` + `uv run mypy` — clean
- [x] Prompt YAML loads cleanly; both `{transition_ids}` and `{transition_feedback}` substrings present.

## Out of scope

- Wiring an actual `semantic_validator` for Phase 4g — behaviour change.
- Phase 4g → Phase 4c rename (cosmetic, info-severity, audit line 758).

🤖 Generated with [Claude Code](https://claude.com/claude-code)