### PR TITLE
fix(dress): escalate batch_llm_calls failures per-item instead of silent _errors discard

### DIFF
--- a/src/questfoundry/models/dress.py
+++ b/src/questfoundry/models/dress.py
@@ -297,6 +297,41 @@ class DressPhaseResult(PhaseResult):
     """
 
 
+class DressEscalation(BaseModel):
+    """A DRESS escalation event collected during the run.
+
+    Mirrors ``FillEscalation``: when a ``batch_llm_calls`` invocation
+    exhausts retries on an item, the stage records a per-item
+    escalation rather than silently dropping the item via the
+    ``_errors`` underscore-discard convention. ``DressStage.execute``
+    folds these into the ``DressStageError`` raised at exit so the
+    failure surface points at the batch responses that misbehaved
+    (not just the missing artifacts caught by the output contract).
+    """
+
+    kind: Literal[
+        "briefs_batch_failed",
+        "codex_batch_failed",
+        "distill_batch_failed",
+    ] = Field(description="Which DRESS phase produced this escalation.")
+    item_id: str = Field(
+        description=(
+            "Affected item ID. ``passage::*`` for briefs, prefixed entity ID "
+            "(e.g. ``character::clara_yu``) for codex, ``brief::*`` for distill. "
+            "Empty string only when the failure is not item-scoped."
+        ),
+    )
+    detail: str = Field(
+        description="Human-readable description of the specific failure (exception type + message).",
+    )
+    upstream_stage: Literal["DRESS", "DREAM", "BRAINSTORM", "GROW"] = Field(
+        description=(
+            "Which stage owns the fix. ``DRESS`` for self-owned LLM-call "
+            "failures (rerun DRESS or adjust provider settings)."
+        ),
+    )
+
+
 class DressResult(BaseModel):
     """Overall DRESS stage result."""
 

--- a/src/questfoundry/pipeline/stages/dress.py
+++ b/src/questfoundry/pipeline/stages/dress.py
@@ -302,6 +302,8 @@ class DressStage:
         self._lang_instruction = get_output_language_instruction(kwargs.get("language", "en"))
 
         log.info("stage_start", stage="dress")
+        # Reset escalations for this run; previous runs' escalations don't carry over.
+        self._escalations = []
 
         phases = self._phase_order()
         phase_map = {name: i for i, (_, name) in enumerate(phases)}
@@ -863,23 +865,20 @@ class DressStage:
         )
 
         # Per-item escalation when a brief batch's retries exhausted (#1480).
+        # eligible_ids comes from graph.get_nodes_by_type("passage").keys() —
+        # always fully-prefixed `passage::*`, no normalization needed.
         for idx, exc in errors:
             for affected_pid in chunks[idx]:
-                full_pid = (
-                    affected_pid
-                    if affected_pid.startswith("passage::")
-                    else f"passage::{affected_pid}"
-                )
                 log.warning(
                     "briefs_batch_failed_escalated",
-                    passage_id=full_pid,
+                    passage_id=affected_pid,
                     exc_type=type(exc).__name__,
                     exc_msg=str(exc),
                 )
                 self._escalations.append(
                     DressEscalation(
                         kind="briefs_batch_failed",
-                        item_id=full_pid,
+                        item_id=affected_pid,
                         detail=(
                             f"dress_brief_batch failed after retries "
                             f"({type(exc).__name__}: {exc}). Passage has no "

--- a/src/questfoundry/pipeline/stages/dress.py
+++ b/src/questfoundry/pipeline/stages/dress.py
@@ -401,24 +401,7 @@ class DressStage:
 
             exit_errors = validate_dress_output(graph)
             if exit_errors:
-                # Fold per-item escalations into the contract failure message
-                # so the failure surface points at the batch responses that
-                # misbehaved, not just at the missing artifacts (#1480). The
-                # escalations only enrich an existing contract failure; we
-                # do NOT raise on escalations alone (a phase may legitimately
-                # have no per-item output to validate).
-                lines = [
-                    f"DRESS output contract violated ({len(exit_errors)} error(s)):",
-                    *[f"  - {e}" for e in exit_errors],
-                ]
-                if self._escalations:
-                    lines.append(
-                        f"Plus {len(self._escalations)} batch_llm_calls retry-exhaustion escalation(s):"
-                    )
-                    lines += [
-                        f"  - [{esc.kind}] {esc.item_id}: {esc.detail}" for esc in self._escalations
-                    ]
-                raise DressStageError("\n".join(lines))
+                raise DressStageError(self._format_exit_error(exit_errors))
 
             graph.set_last_stage("dress")
             graph.save(resolved_path / "graph.db")
@@ -448,6 +431,25 @@ class DressStage:
             "codex_entries": dict(codex_entries),
             "illustrations": dict(illustrations),
         }
+
+    def _format_exit_error(self, exit_errors: list[str]) -> str:
+        """Build the message body for the stage-exit ``DressStageError``.
+
+        Folds per-item escalations into the contract-failure message so the
+        failure surface points at the batch responses that misbehaved
+        (#1480). Escalations only ENRICH an existing contract failure; the
+        caller decides whether to raise based on ``exit_errors`` alone.
+        """
+        lines = [
+            f"DRESS output contract violated ({len(exit_errors)} error(s)):",
+            *[f"  - {e}" for e in exit_errors],
+        ]
+        if self._escalations:
+            lines.append(
+                f"Plus {len(self._escalations)} batch_llm_calls retry-exhaustion escalation(s):"
+            )
+            lines += [f"  - [{esc.kind}] {esc.item_id}: {esc.detail}" for esc in self._escalations]
+        return "\n".join(lines)
 
     # -------------------------------------------------------------------------
     # Phase 0: Art Direction (discuss/summarize/serialize)

--- a/src/questfoundry/pipeline/stages/dress.py
+++ b/src/questfoundry/pipeline/stages/dress.py
@@ -61,6 +61,7 @@ from questfoundry.graph.snapshots import save_snapshot
 from questfoundry.models.dress import (
     BatchedBriefOutput,
     BatchedCodexOutput,
+    DressEscalation,
     DressPhase0Output,
     DressPhase2Output,
     DressPhaseResult,
@@ -202,6 +203,10 @@ class DressStage:
         self._lang_instruction: str = ""
         self._on_connectivity_error: ConnectivityRetryFn | None = None
         self._skip_codex: bool = False
+        # Per-item escalations from `batch_llm_calls` retry exhaustion (#1480).
+        # Folded into DressStageError at exit so failures point at the
+        # batch responses, not just at the missing-artifact symptom.
+        self._escalations: list[DressEscalation] = []
 
     PhaseFunc = Callable[["Graph", "BaseChatModel"], Awaitable[DressPhaseResult]]
 
@@ -394,10 +399,24 @@ class DressStage:
 
             exit_errors = validate_dress_output(graph)
             if exit_errors:
-                raise DressStageError(
-                    f"DRESS output contract violated ({len(exit_errors)} "
-                    f"error(s)):\n" + "\n".join(f"  - {e}" for e in exit_errors)
-                )
+                # Fold per-item escalations into the contract failure message
+                # so the failure surface points at the batch responses that
+                # misbehaved, not just at the missing artifacts (#1480). The
+                # escalations only enrich an existing contract failure; we
+                # do NOT raise on escalations alone (a phase may legitimately
+                # have no per-item output to validate).
+                lines = [
+                    f"DRESS output contract violated ({len(exit_errors)} error(s)):",
+                    *[f"  - {e}" for e in exit_errors],
+                ]
+                if self._escalations:
+                    lines.append(
+                        f"Plus {len(self._escalations)} batch_llm_calls retry-exhaustion escalation(s):"
+                    )
+                    lines += [
+                        f"  - [{esc.kind}] {esc.item_id}: {esc.detail}" for esc in self._escalations
+                    ]
+                raise DressStageError("\n".join(lines))
 
             graph.set_last_stage("dress")
             graph.save(resolved_path / "graph.db")
@@ -836,12 +855,40 @@ class DressStage:
 
             return items, llm_calls, tokens
 
-        results, total_llm_calls, total_tokens, _errors = await batch_llm_calls(
+        results, total_llm_calls, total_tokens, errors = await batch_llm_calls(
             chunks,
             _brief_batch,
             self._max_concurrency,
             on_connectivity_error=self._on_connectivity_error,
         )
+
+        # Per-item escalation when a brief batch's retries exhausted (#1480).
+        for idx, exc in errors:
+            for affected_pid in chunks[idx]:
+                full_pid = (
+                    affected_pid
+                    if affected_pid.startswith("passage::")
+                    else f"passage::{affected_pid}"
+                )
+                log.warning(
+                    "briefs_batch_failed_escalated",
+                    passage_id=full_pid,
+                    exc_type=type(exc).__name__,
+                    exc_msg=str(exc),
+                )
+                self._escalations.append(
+                    DressEscalation(
+                        kind="briefs_batch_failed",
+                        item_id=full_pid,
+                        detail=(
+                            f"dress_brief_batch failed after retries "
+                            f"({type(exc).__name__}: {exc}). Passage has no "
+                            "illustration brief; the output contract will "
+                            "fail at stage exit if briefs are required."
+                        ),
+                        upstream_stage="DRESS",
+                    )
+                )
 
         # Post-process results: apply priority mapping, store on graph
         # Composition log is best-effort: concurrent batches read a snapshot
@@ -982,12 +1029,35 @@ class DressStage:
 
             return items, llm_calls, tokens
 
-        results, total_llm_calls, total_tokens, _errors = await batch_llm_calls(
+        results, total_llm_calls, total_tokens, errors = await batch_llm_calls(
             chunks,
             _codex_batch,
             self._max_concurrency,
             on_connectivity_error=self._on_connectivity_error,
         )
+
+        # Per-item escalation when a codex batch's retries exhausted (#1480).
+        for idx, exc in errors:
+            for affected_eid in chunks[idx]:
+                log.warning(
+                    "codex_batch_failed_escalated",
+                    entity_id=affected_eid,
+                    exc_type=type(exc).__name__,
+                    exc_msg=str(exc),
+                )
+                self._escalations.append(
+                    DressEscalation(
+                        kind="codex_batch_failed",
+                        item_id=affected_eid,
+                        detail=(
+                            f"dress_codex_batch failed after retries "
+                            f"({type(exc).__name__}: {exc}). Entity has no "
+                            "codex entries; the Output-5 contract will fail "
+                            "at stage exit."
+                        ),
+                        upstream_stage="DRESS",
+                    )
+                )
 
         spoiler_retries = 0
         spoiler_fallbacks = 0
@@ -1491,7 +1561,7 @@ class DressStage:
                 # formatting. Token count not available from distiller API.
                 return (bid, pos, neg, bdata), 1, 0
 
-            results, _, _, _errs = await batch_llm_calls(
+            results, _, _, distill_errors = await batch_llm_calls(
                 distill_items,
                 _distill_one,
                 self._max_concurrency,
@@ -1500,7 +1570,28 @@ class DressStage:
             for item in results:
                 if item is not None:
                     prepared.append(item)
-            failed += len(_errs)
+            # Per-item escalation when a distill call's retries exhausted (#1480).
+            for idx, exc in distill_errors:
+                affected_brief_id = distill_items[idx][0]
+                log.warning(
+                    "distill_batch_failed_escalated",
+                    brief_id=affected_brief_id,
+                    exc_type=type(exc).__name__,
+                    exc_msg=str(exc),
+                )
+                self._escalations.append(
+                    DressEscalation(
+                        kind="distill_batch_failed",
+                        item_id=affected_brief_id,
+                        detail=(
+                            f"dress_distill failed after retries "
+                            f"({type(exc).__name__}: {exc}). Brief was not "
+                            "rendered; illustration will be missing."
+                        ),
+                        upstream_stage="DRESS",
+                    )
+                )
+            failed += len(distill_errors)
         else:
             # Non-LLM distillation — no concurrency needed
             for brief_id in selected_ids:

--- a/tests/unit/test_dress_stage.py
+++ b/tests/unit/test_dress_stage.py
@@ -1782,6 +1782,81 @@ class TestPhase2Codex:
         assert g.get_node("codex::protagonist_rank1") is not None
 
 
+class TestDressBatchFailureEscalations:
+    """R-1480: ``batch_llm_calls`` retry exhaustion records per-item escalations.
+
+    The previous behaviour (``_errors`` underscore-discard at three sites)
+    silently dropped failed items; symptoms only surfaced at end-of-stage
+    via missing-artifact contract violations. After #1480 each phase
+    populates ``self._escalations`` with per-item ``DressEscalation``
+    entries, and the stage-exit ``DressStageError`` folds them into the
+    contract-failure message.
+    """
+
+    def test_three_new_escalation_kinds_accepted(self) -> None:
+        """Schema sanity: the three new ``DressEscalation.kind`` Literals are accepted."""
+        from questfoundry.models.dress import DressEscalation
+
+        for kind in (
+            "briefs_batch_failed",
+            "codex_batch_failed",
+            "distill_batch_failed",
+        ):
+            esc = DressEscalation(
+                kind=kind,  # type: ignore[arg-type]
+                item_id="passage::p1",
+                detail="some detail",
+                upstream_stage="DRESS",
+            )
+            assert esc.kind == kind
+
+    @pytest.mark.asyncio()
+    async def test_codex_batch_failure_escalates_each_entity_in_chunk(self) -> None:
+        """When _codex_batch retries exhaust, every entity_id in the failed
+        chunk gets a ``codex_batch_failed`` escalation on ``self._escalations``."""
+        from unittest.mock import patch
+
+        g = Graph()
+        for raw in ("clara_yu", "simon_blackwood", "alistair_vance"):
+            g.create_node(
+                f"character::{raw}",
+                {"type": "entity", "raw_id": raw, "entity_type": "character"},
+            )
+
+        captured_chunks: list[list[list[str]]] = []
+
+        async def mock_batch_llm_calls(
+            chunks: list[list[str]],
+            _call_fn,
+            _max_concurrency: int,
+            **_kwargs: object,
+        ):
+            captured_chunks.append(chunks)
+            errors = [(idx, RuntimeError("codex retry exhaustion")) for idx in range(len(chunks))]
+            results = [None] * len(chunks)
+            return results, 0, 0, errors
+
+        stage = DressStage()
+        with patch(
+            "questfoundry.pipeline.stages.dress.batch_llm_calls",
+            new=mock_batch_llm_calls,
+        ):
+            await stage._phase_2_codex(g, MagicMock())
+
+        assert captured_chunks, "expected _phase_2_codex to call batch_llm_calls"
+        expected_eids: set[str] = set()
+        for chunk in captured_chunks[0]:
+            expected_eids.update(chunk)
+
+        codex_escs = [e for e in stage._escalations if e.kind == "codex_batch_failed"]
+        assert len(codex_escs) == len(expected_eids)
+        assert {e.item_id for e in codex_escs} == expected_eids
+        for esc in codex_escs:
+            assert "RuntimeError" in esc.detail
+            assert "codex retry exhaustion" in esc.detail
+            assert esc.upstream_stage == "DRESS"
+
+
 # ---------------------------------------------------------------------------
 # Phase 2: spoiler-direction enforcement (R-3.6)
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_dress_stage.py
+++ b/tests/unit/test_dress_stage.py
@@ -1856,6 +1856,76 @@ class TestDressBatchFailureEscalations:
             assert "codex retry exhaustion" in esc.detail
             assert esc.upstream_stage == "DRESS"
 
+    @pytest.mark.asyncio()
+    async def test_briefs_batch_failure_escalates_each_passage_in_chunk(self) -> None:
+        """Phase 1 briefs: when ``_brief_batch`` retries exhaust, every
+        passage_id in the failed chunk gets a ``briefs_batch_failed``
+        escalation. Uses the same chunk shape as codex but populated
+        from passages-with-prose."""
+        from unittest.mock import patch
+
+        g = Graph()
+        for raw in ("intro", "rising", "climax"):
+            g.create_node(
+                f"passage::{raw}",
+                {
+                    "type": "passage",
+                    "raw_id": raw,
+                    "prose": f"prose for {raw}",
+                },
+            )
+
+        captured_chunks: list[list[list[str]]] = []
+
+        async def mock_batch_llm_calls(
+            chunks: list[list[str]],
+            _call_fn,
+            _max_concurrency: int,
+            **_kwargs: object,
+        ):
+            captured_chunks.append(chunks)
+            errors = [(idx, RuntimeError("briefs retry exhaustion")) for idx in range(len(chunks))]
+            results = [None] * len(chunks)
+            return results, 0, 0, errors
+
+        stage = DressStage()
+        with patch(
+            "questfoundry.pipeline.stages.dress.batch_llm_calls",
+            new=mock_batch_llm_calls,
+        ):
+            await stage._phase_1_briefs(g, MagicMock())
+
+        assert captured_chunks, "expected _phase_1_briefs to call batch_llm_calls"
+        expected_pids: set[str] = set()
+        for chunk in captured_chunks[0]:
+            expected_pids.update(chunk)
+
+        briefs_escs = [e for e in stage._escalations if e.kind == "briefs_batch_failed"]
+        assert len(briefs_escs) == len(expected_pids)
+        assert {e.item_id for e in briefs_escs} == expected_pids
+        for esc in briefs_escs:
+            assert "RuntimeError" in esc.detail
+            assert "briefs retry exhaustion" in esc.detail
+            assert esc.upstream_stage == "DRESS"
+            # Items already prefixed by graph.get_nodes_by_type → key form:
+            assert esc.item_id.startswith("passage::")
+
+    @pytest.mark.asyncio()
+    async def test_briefs_chunk_passage_ids_are_already_prefixed(self) -> None:
+        """``eligible_ids`` is built from ``graph.get_nodes_by_type("passage").keys()``,
+        whose values are always fully-prefixed (e.g. ``passage::intro``). Pin
+        the invariant with a sentinel test so a future refactor that strips
+        the prefix anywhere upstream trips here instead of silently producing
+        bare IDs in escalations."""
+        g = Graph()
+        g.create_node(
+            "passage::intro",
+            {"type": "passage", "raw_id": "intro", "prose": "x"},
+        )
+        passage_keys = list(g.get_nodes_by_type("passage").keys())
+        assert passage_keys == ["passage::intro"]
+        assert all(k.startswith("passage::") for k in passage_keys)
+
 
 # ---------------------------------------------------------------------------
 # Phase 2: spoiler-direction enforcement (R-3.6)

--- a/tests/unit/test_dress_stage.py
+++ b/tests/unit/test_dress_stage.py
@@ -1910,6 +1910,47 @@ class TestDressBatchFailureEscalations:
             # Items already prefixed by graph.get_nodes_by_type → key form:
             assert esc.item_id.startswith("passage::")
 
+    def test_format_exit_error_without_escalations(self) -> None:
+        """Contract failure with no escalations renders just the error list —
+        no ``Plus N escalation(s)`` trailer."""
+        stage = DressStage()
+        msg = stage._format_exit_error(["entity X missing brief", "entity Y missing codex"])
+        assert "DRESS output contract violated (2 error(s)):" in msg
+        assert "  - entity X missing brief" in msg
+        assert "  - entity Y missing codex" in msg
+        assert "Plus" not in msg
+        assert "escalation" not in msg
+
+    def test_format_exit_error_folds_escalations(self) -> None:
+        """When escalations exist alongside contract errors, the folded message
+        names every escalation by ``[kind] item_id: detail``."""
+        from questfoundry.models.dress import DressEscalation
+
+        stage = DressStage()
+        stage._escalations = [
+            DressEscalation(
+                kind="codex_batch_failed",
+                item_id="character::clara_yu",
+                detail="dress_codex_batch failed after retries (RuntimeError: blocked).",
+                upstream_stage="DRESS",
+            ),
+            DressEscalation(
+                kind="briefs_batch_failed",
+                item_id="passage::intro",
+                detail="dress_brief_batch failed after retries (TimeoutError: 30s).",
+                upstream_stage="DRESS",
+            ),
+        ]
+
+        msg = stage._format_exit_error(["entity X missing codex"])
+        # Contract errors come first
+        assert "DRESS output contract violated (1 error(s)):" in msg
+        assert "  - entity X missing codex" in msg
+        # Then the escalation trailer with both items named
+        assert "Plus 2 batch_llm_calls retry-exhaustion escalation(s):" in msg
+        assert "[codex_batch_failed] character::clara_yu: dress_codex_batch failed" in msg
+        assert "[briefs_batch_failed] passage::intro: dress_brief_batch failed" in msg
+
     @pytest.mark.asyncio()
     async def test_briefs_chunk_passage_ids_are_already_prefixed(self) -> None:
         """``eligible_ids`` is built from ``graph.get_nodes_by_type("passage").keys()``,


### PR DESCRIPTION
## Summary

- New `DressEscalation` model in `models/dress.py` (kind, item_id, detail, upstream_stage). Mirrors `FillEscalation` from #1468.
- `DressStage._escalations` list initialised in `__init__`. All three `batch_llm_calls` sites (briefs `dress.py:839`, codex `dress.py:985`, distill `dress.py:1494`) updated to bind `errors` (no underscore), iterate, log structured `*_batch_failed_escalated` warnings, and append per-item escalations.
- At stage exit, escalations are folded into the existing `DressStageError` raised by output-contract failure — the failure message now points at the batch responses that misbehaved, not just at the missing artifacts.
- Escalations only ENRICH an existing contract failure; we do NOT raise on escalations alone (a phase like art_direction may have no per-item output to validate).
- New `TestDressBatchFailureEscalations` class covers schema sanity + end-to-end behaviour.

Closes #1480.

## Why

The murder3 codex outage in #1473 surfaced this pattern: silent-drop at the per-item retry layer means symptoms only appear at end-of-stage. FILL #1468 (PR #1469) fixed the same anti-pattern in FILL Phase 1a/2/3. This PR brings DRESS to parity.

`.gemini/styleguide.md` calls out "silent fallbacks that hide bugs" specifically; this is one.

## Test plan

- [x] `uv run pytest tests/unit/test_dress_stage.py tests/unit/test_dress_models.py tests/unit/test_dress_context.py` — 182 pass
- [x] `uv run ruff check` + `uv run mypy` — clean
- [x] Pre-existing test `TestPhase0ArtDirection::test_phase0_creates_nodes` still passes (escalations don't raise without contract failure)

## Out of scope

- The eventual end-of-stage contract validation logic — that already correctly catches missing codex/brief/distill artifacts. This PR adds structured upstream detail.
- DRESS distill phase increments a `failed` counter at `dress.py:1503`; that was kept and now layered with per-item escalation on top.

🤖 Generated with [Claude Code](https://claude.com/claude-code)