### PR TITLE
feat(grow): group Phase 8c valid_entity_ids + valid_state_flag_ids in overlay context

### DIFF
--- a/prompts/templates/grow_phase8c_overlays.yaml
+++ b/prompts/templates/grow_phase8c_overlays.yaml
@@ -79,8 +79,17 @@ system: |
   - Do NOT add prose before or after the JSON output
 
   ## Valid IDs
-  Valid entity_ids: {valid_entity_ids}
-  Valid state_flag_ids (for "when" field): {valid_state_flag_ids}
+
+  Valid entity_ids (use ONLY these), grouped by entity category:
+
+  {valid_entity_ids}
+
+  Valid state_flag_ids (for "when" field), grouped by the dilemma each
+  flag derives from. Flags inside the same dilemma group are mutually
+  exclusive — a player commits to exactly one of them, so an overlay's
+  "when" list MUST NOT combine flags from the same group.
+
+  {valid_state_flag_ids}
 
   ## Output Format
   Return a JSON object with an "overlays" array. Each overlay has:

--- a/src/questfoundry/graph/grow_context.py
+++ b/src/questfoundry/graph/grow_context.py
@@ -6,10 +6,59 @@ context strings for GROW's LLM-powered phases.
 
 from __future__ import annotations
 
+from collections import defaultdict
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from questfoundry.graph.graph import Graph
+
+
+def format_valid_entity_ids_by_category(
+    graph: Graph,
+    entity_ids: list[str],
+) -> str:
+    """Format ``entity_ids`` grouped by entity_category; the ``(unknown)`` bucket holds entities with no category."""
+    if not entity_ids:
+        return ""
+
+    by_category: dict[str, list[str]] = defaultdict(list)
+    for eid in sorted(entity_ids):
+        node = graph.get_node(eid) or {}
+        category = node.get("entity_category") or node.get("entity_type") or "unknown"
+        by_category[category].append(eid)
+
+    lines: list[str] = []
+    for category in sorted(by_category):
+        items = ", ".join(f"`{e}`" for e in by_category[category])
+        lines.append(f"- {category}: {items}")
+    return "\n".join(lines)
+
+
+def format_valid_state_flag_ids_by_dilemma(
+    state_flag_ids: list[str],
+    flag_to_dilemma: dict[str, str],
+) -> str:
+    """Format ``state_flag_ids`` grouped by dilemma; flags with no dilemma land in ``(unmapped)``."""
+    if not state_flag_ids:
+        return ""
+
+    by_dilemma: dict[str, list[str]] = defaultdict(list)
+    unmapped: list[str] = []
+    for sf_id in sorted(state_flag_ids):
+        dilemma_id = flag_to_dilemma.get(sf_id, "")
+        if dilemma_id:
+            by_dilemma[dilemma_id].append(sf_id)
+        else:
+            unmapped.append(sf_id)
+
+    lines: list[str] = []
+    for dilemma_id in sorted(by_dilemma):
+        items = ", ".join(f"`{f}`" for f in by_dilemma[dilemma_id])
+        lines.append(f"- `{dilemma_id}`: {items}")
+    if unmapped:
+        items = ", ".join(f"`{f}`" for f in unmapped)
+        lines.append(f"- (unmapped): {items}")
+    return "\n".join(lines)
 
 
 def format_grow_valid_ids(graph: Graph) -> dict[str, str]:

--- a/src/questfoundry/graph/grow_context.py
+++ b/src/questfoundry/graph/grow_context.py
@@ -62,7 +62,7 @@ def format_valid_entity_ids_by_category(
     graph: Graph,
     entity_ids: list[str],
 ) -> str:
-    """Format ``entity_ids`` grouped by entity_category; the ``(unknown)`` bucket holds entities with no category."""
+    """Format ``entity_ids`` grouped by entity_category; the ``unknown`` bucket holds entities with no category."""
     if not entity_ids:
         return ""
 

--- a/src/questfoundry/graph/grow_context.py
+++ b/src/questfoundry/graph/grow_context.py
@@ -72,8 +72,9 @@ def format_grow_valid_ids(graph: Graph) -> dict[str, str]:
 
     Returns:
         Dict with keys 'valid_beat_ids', 'valid_path_ids',
-        'valid_dilemma_ids', 'valid_entity_ids'. Each value is a
-        comma-separated string of scoped IDs, or empty string if none.
+        'valid_dilemma_ids', 'valid_entity_ids', 'valid_passage_ids',
+        'valid_choice_ids'. Each value is a comma-separated string of
+        scoped IDs, or empty string if none.
     """
 
     def _get_sorted_ids(node_type: str) -> str:

--- a/src/questfoundry/pipeline/stages/grow/llm_phases.py
+++ b/src/questfoundry/pipeline/stages/grow/llm_phases.py
@@ -965,11 +965,18 @@ class _LLMPhaseMixin:
 
         entity_context = "\n".join(entity_lines)
 
+        from questfoundry.graph.grow_context import (
+            format_valid_entity_ids_by_category,
+            format_valid_state_flag_ids_by_dilemma,
+        )
+
         context = {
             "consequence_context": consequence_context,
             "entity_context": entity_context,
-            "valid_entity_ids": ", ".join(valid_entity_ids),
-            "valid_state_flag_ids": ", ".join(valid_state_flag_ids),
+            "valid_entity_ids": format_valid_entity_ids_by_category(graph, valid_entity_ids),
+            "valid_state_flag_ids": format_valid_state_flag_ids_by_dilemma(
+                valid_state_flag_ids, flag_to_dilemma
+            ),
         }
 
         from questfoundry.graph.grow_validators import validate_phase8c_output

--- a/src/questfoundry/pipeline/stages/grow/llm_phases.py
+++ b/src/questfoundry/pipeline/stages/grow/llm_phases.py
@@ -22,6 +22,10 @@ from questfoundry.graph.context_compact import (
     truncate_summary,
 )
 from questfoundry.graph.graph import Graph
+from questfoundry.graph.grow_context import (
+    format_valid_entity_ids_by_category,
+    format_valid_state_flag_ids_by_dilemma,
+)
 from questfoundry.models.grow import GrowPhaseResult
 from questfoundry.pipeline.stages.grow._helpers import (
     GrowStageError,
@@ -964,11 +968,6 @@ class _LLMPhaseMixin:
             entity_lines.append(f"- {ent_id} ({category}): {concept}")
 
         entity_context = "\n".join(entity_lines)
-
-        from questfoundry.graph.grow_context import (
-            format_valid_entity_ids_by_category,
-            format_valid_state_flag_ids_by_dilemma,
-        )
 
         context = {
             "consequence_context": consequence_context,

--- a/tests/unit/test_grow_context.py
+++ b/tests/unit/test_grow_context.py
@@ -1,0 +1,146 @@
+"""Tests for GROW context-formatting helpers."""
+
+from __future__ import annotations
+
+from questfoundry.graph.graph import Graph
+from questfoundry.graph.grow_context import (
+    format_valid_entity_ids_by_category,
+    format_valid_state_flag_ids_by_dilemma,
+)
+
+
+class TestFormatValidEntityIdsByCategory:
+    """Pin the grouped entity-Valid-IDs layout for Phase 8c (#1482)."""
+
+    def _seed_graph(self) -> Graph:
+        g = Graph()
+        g.create_node(
+            "character::clara_yu",
+            {"type": "entity", "raw_id": "clara_yu", "entity_category": "character"},
+        )
+        g.create_node(
+            "character::simon_blackwood",
+            {"type": "entity", "raw_id": "simon_blackwood", "entity_category": "character"},
+        )
+        g.create_node(
+            "location::manor",
+            {"type": "entity", "raw_id": "manor", "entity_category": "location"},
+        )
+        g.create_node(
+            "object::brooch",
+            {"type": "entity", "raw_id": "brooch", "entity_category": "object"},
+        )
+        # Entity with no entity_category — falls through to entity_type.
+        g.create_node(
+            "entity::stray",
+            {"type": "entity", "raw_id": "stray", "entity_type": "faction"},
+        )
+        # Entity with neither category nor type — surfaces as "unknown".
+        g.create_node(
+            "entity::orphan",
+            {"type": "entity", "raw_id": "orphan"},
+        )
+        return g
+
+    def test_groups_by_entity_category(self) -> None:
+        g = self._seed_graph()
+        result = format_valid_entity_ids_by_category(
+            g,
+            [
+                "character::clara_yu",
+                "character::simon_blackwood",
+                "location::manor",
+                "object::brooch",
+            ],
+        )
+        # One bullet per category, sorted alphabetically by category, with
+        # backtick-wrapped IDs.
+        assert "- character: `character::clara_yu`, `character::simon_blackwood`" in result
+        assert "- location: `location::manor`" in result
+        assert "- object: `object::brooch`" in result
+
+    def test_falls_back_to_entity_type_when_category_missing(self) -> None:
+        g = self._seed_graph()
+        result = format_valid_entity_ids_by_category(g, ["entity::stray"])
+        assert "- faction: `entity::stray`" in result
+
+    def test_unknown_bucket_for_entities_with_no_classification(self) -> None:
+        g = self._seed_graph()
+        result = format_valid_entity_ids_by_category(g, ["entity::orphan"])
+        assert "- unknown: `entity::orphan`" in result
+
+    def test_categories_render_alphabetically(self) -> None:
+        g = self._seed_graph()
+        result = format_valid_entity_ids_by_category(
+            g,
+            ["object::brooch", "character::clara_yu", "location::manor"],
+        )
+        char_idx = result.index("- character:")
+        loc_idx = result.index("- location:")
+        obj_idx = result.index("- object:")
+        assert char_idx < loc_idx < obj_idx
+
+    def test_empty_input_returns_empty_string(self) -> None:
+        g = self._seed_graph()
+        assert format_valid_entity_ids_by_category(g, []) == ""
+
+
+class TestFormatValidStateFlagIdsByDilemma:
+    """Pin the grouped state_flag-Valid-IDs layout for Phase 8c (#1482).
+
+    The helper is graph-free — it consumes a ``flag_to_dilemma`` map the
+    caller already builds from consequence → path → dilemma traversal in
+    ``_phase_8c_overlays`` (line 890)."""
+
+    def test_groups_by_dilemma(self) -> None:
+        result = format_valid_state_flag_ids_by_dilemma(
+            [
+                "state_flag::mentor_friendly_committed",
+                "state_flag::mentor_hostile_committed",
+                "state_flag::artifact_safe_committed",
+            ],
+            flag_to_dilemma={
+                "state_flag::mentor_friendly_committed": "dilemma::mentor_trust",
+                "state_flag::mentor_hostile_committed": "dilemma::mentor_trust",
+                "state_flag::artifact_safe_committed": "dilemma::artifact_nature",
+            },
+        )
+        assert "- `dilemma::artifact_nature`: `state_flag::artifact_safe_committed`" in result
+        assert (
+            "- `dilemma::mentor_trust`: `state_flag::mentor_friendly_committed`,"
+            " `state_flag::mentor_hostile_committed`" in result
+        )
+        # No unmapped bucket when every flag has a dilemma.
+        assert "(unmapped)" not in result
+
+    def test_unmapped_bucket_for_flags_without_dilemma(self) -> None:
+        result = format_valid_state_flag_ids_by_dilemma(
+            ["state_flag::raw_flag"],
+            flag_to_dilemma={},
+        )
+        assert "- (unmapped): `state_flag::raw_flag`" in result
+        assert "dilemma::" not in result
+
+    def test_dilemma_then_unmapped_render_order(self) -> None:
+        result = format_valid_state_flag_ids_by_dilemma(
+            ["state_flag::mapped", "state_flag::orphan"],
+            flag_to_dilemma={"state_flag::mapped": "dilemma::trust"},
+        )
+        mapped_idx = result.index("- `dilemma::trust`")
+        unmapped_idx = result.index("- (unmapped)")
+        assert mapped_idx < unmapped_idx
+
+    def test_dilemmas_sorted_alphabetically(self) -> None:
+        result = format_valid_state_flag_ids_by_dilemma(
+            ["state_flag::a", "state_flag::b"],
+            flag_to_dilemma={
+                "state_flag::a": "dilemma::zeta",
+                "state_flag::b": "dilemma::alpha",
+            },
+        )
+        alpha_idx = result.index("dilemma::alpha")
+        zeta_idx = result.index("dilemma::zeta")
+        assert alpha_idx < zeta_idx
+
+    def test_empty_input_returns_empty_string(self) -> None:
+        assert format_valid_state_flag_ids_by_dilemma([], {}) == ""


### PR DESCRIPTION
## Summary

- Two new helpers in `graph/grow_context.py`:
  - `format_valid_entity_ids_by_category(graph, entity_ids)` — groups entity IDs by `entity_category` (with `entity_type` fallback, then `unknown`).
  - `format_valid_state_flag_ids_by_dilemma(state_flag_ids, flag_to_dilemma)` — groups state flag IDs by the dilemma they derive from, with an `(unmapped)` bucket for orphans.
- Wired into `_phase_8c_overlays`: replaces flat `", ".join(...)` injections. Template variable names (`valid_entity_ids` / `valid_state_flag_ids`) unchanged; only rendered content changes.
- `grow_phase8c_overlays.yaml`: rewrote the `## Valid IDs` section to introduce both groupings. State-flag grouping by dilemma reinforces the existing mutual-exclusivity rule.
- New `tests/unit/test_grow_context.py` (10 tests across two classes).

Closes #1482.

## Why

The 2026-04-25 prompt-vs-spec audit (lines 763-770) flagged the asymmetry: "Consequence context block IS grouped by dilemma — Valid IDs should mirror that grouping." Same pattern as PR #1477 (`format_valid_beat_ids_by_dilemma`), now extended to entities (by category) and state flags (by dilemma).

## Test plan

- [x] `uv run pytest tests/unit/test_grow_context.py tests/unit/test_grow_stage.py tests/unit/test_grow_validators.py` — 116 pass
- [x] `uv run ruff check` + `uv run mypy` — clean

## Out of scope

- Phase 8c `details: list[{key,value}]` schema-skew (audit 760-762, separate finding).
- `_phase_8c_overlays` docstring fix (audit 762).

🤖 Generated with [Claude Code](https://claude.com/claude-code)