### PR TITLE
docs(grow): clarify Phase 8c overlay docstring — LLM list vs graph dict shape

### DIFF
--- a/src/questfoundry/pipeline/stages/grow/llm_phases.py
+++ b/src/questfoundry/pipeline/stages/grow/llm_phases.py
@@ -860,7 +860,13 @@ class _LLMPhaseMixin:
         - Consequence nodes linked to paths and dilemmas.
 
         Postconditions:
-        - Entity nodes gain overlays list with {when: [state_flag_ids], details: {...}}.
+        - Entity nodes gain overlays list. Each overlay is stored with
+          ``when: [state_flag_ids]`` and ``details: dict[str, str]`` —
+          this is the *graph-stored* shape (``EntityOverlay.details``).
+          The LLM produces ``OverlayProposal.details: list[OverlayDetailItem]``
+          (key/value list, OpenAI strict-mode-compatible) which is
+          converted via ``OverlayProposal.details_as_dict()`` at
+          graph-write time.
         - Overlays modify entity presentation when state flags are granted.
         - Invalid entity/state flag IDs from LLM output silently skipped.
 


### PR DESCRIPTION
## Summary

Updates the `_phase_8c_overlays` docstring's Postconditions to clarify that the LLM produces `OverlayProposal.details: list[OverlayDetailItem]` (key/value list, OpenAI strict-mode compatible) which is converted via `OverlayProposal.details_as_dict()` at graph-write time. The graph-stored shape on `EntityOverlay.details` IS `dict[str, str]`, but the docstring previously implied that was the LLM-facing shape too.

Closes #1484.

## Why

The 2026-04-25 prompt-vs-spec audit (lines 760-762) flagged the docstring's `details: {...}` notation as misleading. It conflated the LLM-facing schema (list of key/value objects) with the graph storage (dict). Future readers tracing the LLM contract end-to-end could think the LLM also returns a dict, but `OverlayProposal` is explicit: `list[OverlayDetailItem]`.

The audit also recommended adding a test for `details_as_dict()` — already satisfied by `tests/unit/test_grow_models.py:332` (`test_details_as_dict`).

## Test plan

- [x] `uv run pytest tests/unit/test_grow_stage.py tests/unit/test_grow_models.py` — 158 pass
- [x] `uv run ruff check` — clean

## Out of scope

- Phase 8c → Phase numbering rename (audit info-severity, separate finding).

🤖 Generated with [Claude Code](https://claude.com/claude-code)