### PR TITLE
fix(polish): improve Phase 1 reorder Valid IDs format + context labels + rationale examples

### DIFF
--- a/prompts/templates/polish_phase1_reorder.yaml
+++ b/prompts/templates/polish_phase1_reorder.yaml
@@ -20,15 +20,20 @@ system: |
   ## Section to Reorder
   Section ID: {section_id}
 
-  ### Context (preceding/following beats — NOT part of this section)
+  ### Preceding context (NOT part of this section — do not include in output):
   {before_context}
+
+  ### Following context (NOT part of this section — do not include in output):
   {after_context}
 
   ### Beats in Current Order
   {beat_details}
 
   ## Valid IDs
-  Valid beat_ids (use ONLY these, in any order): {valid_beat_ids}
+  Valid beat_ids (use ONLY these, in any order — one bullet per ID):
+
+  {valid_beat_ids}
+
   Total beats in section: {beat_count}
 
   ## Output Format
@@ -45,6 +50,13 @@ system: |
       }}
     ]
   }}
+
+  ### Rationale Quality
+  The `rationale` is what reviewers inspect when R-1.4 logs an invalid
+  proposal as a WARNING. Make it concrete enough to diagnose later.
+
+  GOOD rationale: "Moved reflection beat before discovery to follow scene-sequel rhythm — action scene then processing beat"
+  BAD rationale: "Better order" (too vague to diagnose if WARNING fires)
 
   ## What NOT to Do
   - Do NOT use IDs not listed in the Valid IDs section

--- a/prompts/templates/polish_phase1_reorder.yaml
+++ b/prompts/templates/polish_phase1_reorder.yaml
@@ -52,11 +52,11 @@ system: |
   }}
 
   ### Rationale Quality
-  The `rationale` is what reviewers inspect when R-1.4 logs an invalid
-  proposal as a WARNING. Make it concrete enough to diagnose later.
+  The `rationale` is the only artifact a reviewer sees later. Make it
+  concrete enough to explain the reorder when revisited.
 
   GOOD rationale: "Moved reflection beat before discovery to follow scene-sequel rhythm — action scene then processing beat"
-  BAD rationale: "Better order" (too vague to diagnose if WARNING fires)
+  BAD rationale: "Better order" (too vague — you will not be able to explain the choice later)
 
   ## What NOT to Do
   - Do NOT use IDs not listed in the Valid IDs section

--- a/prompts/templates/polish_phase1_reorder.yaml
+++ b/prompts/templates/polish_phase1_reorder.yaml
@@ -46,7 +46,7 @@ system: |
       {{
         "section_id": "section_0",
         "beat_ids": ["beat::reflect", "beat::discover", "beat::confront"],
-        "rationale": "Moved reflection before discovery to build anticipation"
+        "rationale": "Moved reflection beat before discovery to follow scene-sequel rhythm — action scene then processing beat"
       }}
     ]
   }}

--- a/src/questfoundry/graph/polish_context.py
+++ b/src/questfoundry/graph/polish_context.py
@@ -107,12 +107,15 @@ def format_linear_section_context(
     before_context = _format_context_beat(beat_nodes, before_beat, "preceding")
     after_context = _format_context_beat(beat_nodes, after_beat, "following")
 
+    # Bullet list per ID; small models lose track of flat comma-separated lists for 8-15 beats.
+    valid_beat_ids_block = "\n".join(f"- `{b}`" for b in beat_ids) if beat_ids else "(none)"
+
     return {
         "section_id": section_id,
         "beat_details": beat_details or "(none)",
         "before_context": before_context,
         "after_context": after_context,
-        "valid_beat_ids": ", ".join(f"`{b}`" for b in beat_ids) or "(none)",
+        "valid_beat_ids": valid_beat_ids_block,
         "beat_count": str(len(beat_ids)),
     }
 

--- a/tests/unit/test_polish_context.py
+++ b/tests/unit/test_polish_context.py
@@ -44,7 +44,8 @@ class TestFormatLinearSectionContext:
         assert "`beat::b`" in ctx["beat_details"]
         assert "`beat::c`" in ctx["beat_details"]
         assert ctx["beat_count"] == "3"
-        assert ctx["valid_beat_ids"] == "`beat::a`, `beat::b`, `beat::c`"
+        # Bullet-per-line, not flat comma-separated (#1486).
+        assert ctx["valid_beat_ids"] == "- `beat::a`\n- `beat::b`\n- `beat::c`"
 
     def test_with_context_beats(self) -> None:
         graph = Graph.empty()


### PR DESCRIPTION
## Summary

Three soft findings from the 2026-04-25 prompt-vs-spec audit (lines 803-836) for `polish_phase1_reorder.yaml`:

1. **Valid IDs bullet-per-line** — `format_linear_section_context` now emits `valid_beat_ids` as one bullet per line instead of a flat comma-separated string. For 8-15 beat sections, the bullet form prevents small models from losing track and inventing beat IDs from adjacent sections in the prompt assembly.

2. **Context-block headers** — split the single `### Context (preceding/following beats — NOT part of this section)` block into two separate headers, each making "do not include in output" explicit.

3. **Rationale GOOD/BAD examples** — added a Rationale Quality subsection directly under the output schema with concrete examples for `ReorderedSection.rationale`.

Closes #1486.

## Why

Same Valid-IDs anti-pattern as PR #1477 (GROW grouped beat_ids), now applied to POLISH Phase 1. Per CLAUDE.md / @prompt-engineer Rule 1 (Valid ID Injection), Rule 2 (Context Enrichment), Rule 3 (defensive examples).

## Test plan

- [x] `uv run pytest tests/unit/test_polish_context.py tests/unit/test_polish_llm_phases.py tests/unit/test_polish_phases.py` — 77 pass
- [x] `uv run ruff check` — clean
- [x] `test_basic_section` updated for the new bullet-per-line format

## Out of scope

- Other POLISH phase findings (Phase 1a Valid IDs, Phase 2 pacing, Phase 3 arcs, Phase 5a-f). Each is a separate cluster.

🤖 Generated with [Claude Code](https://claude.com/claude-code)