### PR TITLE
fix(polish): group Phase 1a Valid IDs by path + add R-1a.4 GOOD/BAD example

### DIFF
--- a/prompts/templates/polish_phase1a_narrative_gaps.yaml
+++ b/prompts/templates/polish_phase1a_narrative_gaps.yaml
@@ -36,7 +36,12 @@ system: |
   3. Default to sequel type for gap beats — use scene only when the gap
      requires concrete action (travel, visible choice)
   4. Gap beats should be concise transitions, not major story events
-  5. Maximum 2 gap beats per path
+  5. Maximum 2 gap beats per path (R-1a.4)
+
+  GOOD (within cap): Two gap beats on the same path — one bridging
+  setup→escalation, one bridging escalation→climax.
+  BAD (exceeds cap): Three gap beats on the same path. Reduce to the
+  two most impactful and drop the rest.
 
   ## Path → Dilemma mapping (FOR REFERENCE ONLY — do not use in output)
   This is shown so you can recognise which dilemmas a path explores
@@ -55,8 +60,11 @@ system: |
   - Do NOT add prose before or after the JSON output
 
   ## Valid IDs
-  Valid path_ids: {valid_path_ids}
-  Valid beat_ids (for after_beat/before_beat): {valid_beat_ids}
+  Each path's beats are listed under its `path_id`. Use beat IDs only
+  with their owning path — every `after_beat` / `before_beat` you
+  propose MUST belong to the `path_id` of the same gap entry.
+
+  {valid_path_beats}
 
   ## Output Format
   Return a JSON object with a "gaps" array. Each gap has:

--- a/src/questfoundry/pipeline/stages/polish/llm_phases.py
+++ b/src/questfoundry/pipeline/stages/polish/llm_phases.py
@@ -208,9 +208,9 @@ class _PolishLLMPhaseMixin:
         # original context shape so the prompt can be migrated verbatim).
         path_sequences: list[str] = []
         valid_beat_ids: set[str] = set()
-        # Per-path beat lists for the grouped Valid IDs block (#1489 — replaces
-        # the two flat ``valid_path_ids`` + ``valid_beat_ids`` lists that small
-        # models had to cross-correlate by hand).
+        # Per-path beat lists for the grouped Valid IDs block — replaces
+        # the two flat ``valid_path_ids`` + ``valid_beat_ids`` lists that
+        # small models had to cross-correlate by hand.
         path_beats: dict[str, list[str]] = {}
         for pid in sorted(path_nodes.keys()):
             sequence = get_path_beat_sequence(graph, pid)
@@ -249,7 +249,7 @@ class _PolishLLMPhaseMixin:
         path_dilemma_map_text, _ = build_path_dilemma_context(graph, path_nodes)
 
         # Combined Valid IDs block grouped by path so the LLM sees the
-        # path→beats relationship at point of use (#1489).
+        # path→beats relationship at point of use.
         valid_path_beats_lines: list[str] = []
         for pid in sorted(path_beats):
             beats = ", ".join(f"`{b}`" for b in path_beats[pid])

--- a/src/questfoundry/pipeline/stages/polish/llm_phases.py
+++ b/src/questfoundry/pipeline/stages/polish/llm_phases.py
@@ -208,6 +208,10 @@ class _PolishLLMPhaseMixin:
         # original context shape so the prompt can be migrated verbatim).
         path_sequences: list[str] = []
         valid_beat_ids: set[str] = set()
+        # Per-path beat lists for the grouped Valid IDs block (#1489 — replaces
+        # the two flat ``valid_path_ids`` + ``valid_beat_ids`` lists that small
+        # models had to cross-correlate by hand).
+        path_beats: dict[str, list[str]] = {}
         for pid in sorted(path_nodes.keys()):
             sequence = get_path_beat_sequence(graph, pid)
             if len(sequence) < 2:
@@ -221,6 +225,7 @@ class _PolishLLMPhaseMixin:
                 valid_beat_ids.add(bid)
             raw_pid = path_nodes[pid].get("raw_id", pid)
             path_sequences.append(f"  Path: {raw_pid} ({pid})\n" + "\n".join(beat_list))
+            path_beats[pid] = sequence
 
         if not path_sequences:
             log.info("phase1a_no_multibeat_paths", detail="No paths with 2+ beats")
@@ -243,10 +248,17 @@ class _PolishLLMPhaseMixin:
         # reference dilemmas).
         path_dilemma_map_text, _ = build_path_dilemma_context(graph, path_nodes)
 
+        # Combined Valid IDs block grouped by path so the LLM sees the
+        # path→beats relationship at point of use (#1489).
+        valid_path_beats_lines: list[str] = []
+        for pid in sorted(path_beats):
+            beats = ", ".join(f"`{b}`" for b in path_beats[pid])
+            valid_path_beats_lines.append(f"  - `{pid}` → {beats}")
+        valid_path_beats_block = "\n".join(valid_path_beats_lines)
+
         context = {
             "path_sequences": "\n\n".join(path_sequences),
-            "valid_path_ids": ", ".join(sorted(path_nodes.keys())),
-            "valid_beat_ids": ", ".join(sorted(valid_beat_ids)),
+            "valid_path_beats": valid_path_beats_block,
             "path_dilemma_map": path_dilemma_map_text,
         }
 


### PR DESCRIPTION
## Summary

Two soft findings from the 2026-04-25 prompt-vs-spec audit (lines 872-895) for `polish_phase1a_narrative_gaps.yaml`:

1. **Valid IDs grouped by path** — `valid_path_ids` and `valid_beat_ids` were two separate flat lists that small models had to cross-correlate by hand. Replaced with a single grouped `{valid_path_beats}` block:
   ```
   - `path::dilemma_a__answer_x` → `beat::ax1`, `beat::ax2`, `beat::ax3`
   - `path::dilemma_b__answer_y` → `beat::by1`, `beat::by2`
   ```
   The path→beats relationship is now explicit at point of use. `_phase_1a_narrative_gaps` collects `path_beats: dict[pid → list[bid]]` alongside the existing `path_sequences` build (single iteration), then formats the grouped block.

2. **R-1a.4 max-2-gap-beats GOOD/BAD example** — added an inline example pair next to the checklist's max-2 rule, matching the defensive-example pattern in CLAUDE.md / @prompt-engineer Rule 3.

Closes #1489.

## Why

Same Valid-IDs anti-pattern as PR #1487 (POLISH Phase 1 reorder), now applied to Phase 1a. Per CLAUDE.md / @prompt-engineer Rule 1 (Valid ID Injection), Rule 3 (defensive examples).

## Test plan

- [x] `uv run pytest tests/unit/test_polish_llm_phases.py tests/unit/test_polish_phases.py tests/unit/test_polish_context.py` — 77 pass
- [x] `uv run ruff check` + `uv run mypy` — clean
- [x] Prompt YAML loads with `{valid_path_beats}` substring; old `{valid_path_ids}` / `{valid_beat_ids}` substrings absent

## Out of scope

- The pre-existing concern that `valid_dilemma_ids` is no longer in the prompt at all (already noted in code as intentional per R-1a.2).
- The `scene_type: micro_beat` info-severity drift (audit lines 891-895).

🤖 Generated with [Claude Code](https://claude.com/claude-code)