### PR TITLE
fix(polish): group Phase 3 (entity arcs) Valid IDs by path

### DIFF
--- a/prompts/templates/polish_phase3_arcs.yaml
+++ b/prompts/templates/polish_phase3_arcs.yaml
@@ -49,8 +49,12 @@ system: |
      will overwrite it; do not invent a value.
 
   ## Valid IDs
-  Valid path_ids: {valid_path_ids}
-  Valid beat_ids (for pivots and arcs_per_path[*].pivot_beat): {valid_beat_ids}
+  Each path the entity appears on is listed with its beats. Use beat
+  IDs only with their owning path — every `pivots[*].beat_id` and
+  `arcs_per_path[*].pivot_beat` MUST belong to the corresponding
+  `path_id` in the same arc entry.
+
+  {valid_path_beats}
 
   ## Output Format
   Return a JSON object with a "character_arcs" array containing exactly

--- a/src/questfoundry/graph/polish_context.py
+++ b/src/questfoundry/graph/polish_context.py
@@ -189,7 +189,8 @@ def format_entity_arc_context(
 
     Returns:
         Dict with keys: entity_id, entity_name, entity_description,
-        beat_appearances, path_ids, valid_path_ids, valid_beat_ids.
+        beat_appearances, overlay_data, anchored_dilemmas, path_ids,
+        valid_path_beats.
     """
     beat_nodes = graph.get_nodes_by_type("beat")
     entity_nodes = graph.get_nodes_by_type("entity")
@@ -225,7 +226,7 @@ def format_entity_arc_context(
 
         # Backtick-wrap IDs per @prompt-engineer Rule 4 — consistent with the
         # other ID lists this context dict produces, so a model matching beat
-        # IDs against `valid_beat_ids` doesn't have to mentally strip backticks.
+        # IDs against `valid_path_beats` doesn't have to mentally strip backticks.
         if not path_set:
             path_label = "unknown"
         elif len(path_set) == 1:

--- a/src/questfoundry/graph/polish_context.py
+++ b/src/questfoundry/graph/polish_context.py
@@ -279,13 +279,23 @@ def format_entity_arc_context(
 
     # Render each ID list with a `(none)` fallback when empty so the prompt
     # never receives a bare empty injection. Matches `anchored_text` above.
-    # `valid_path_ids` is scoped to the entity's paths (paths_seen) — the
-    # Phase 3 prompt constrains `pivots` / `arcs_per_path` to this set, and
-    # showing the broader story-wide list previously confused models into
-    # inventing arcs for paths the entity never appears in (closes #1410).
+    # `path_ids` is scoped to the entity's paths (paths_seen) — the Phase 3
+    # prompt constrains `pivots` / `arcs_per_path` to this set, and showing
+    # the broader story-wide list previously confused models into inventing
+    # arcs for paths the entity never appears in (closes #1410).
     path_ids_text = ", ".join(f"`{p}`" for p in sorted(paths_seen)) or "(none)"
-    valid_path_ids_text = path_ids_text
-    valid_beat_ids_text = ", ".join(f"`{b}`" for b in sorted(beat_appearances)) or "(none)"
+
+    # Grouped Valid IDs block: one bullet per path listing the entity's
+    # beats on that path. Y-shape pre-commit beats (multi-belongs_to) appear
+    # under each of their paths. Replaces the two flat ``valid_path_ids`` +
+    # ``valid_beat_ids`` lists that small models had to cross-correlate.
+    valid_path_beats_lines: list[str] = []
+    for pid in sorted(paths_seen):
+        path_beats = [bid for bid in beat_appearances if pid in beat_to_paths.get(bid, frozenset())]
+        if path_beats:
+            beats_str = ", ".join(f"`{b}`" for b in path_beats)
+            valid_path_beats_lines.append(f"  - `{pid}` → {beats_str}")
+    valid_path_beats_block = "\n".join(valid_path_beats_lines) or "  (none)"
 
     return {
         "entity_id": entity_id,
@@ -295,8 +305,7 @@ def format_entity_arc_context(
         "overlay_data": overlay_text,
         "anchored_dilemmas": anchored_text,
         "path_ids": path_ids_text,
-        "valid_path_ids": valid_path_ids_text,
-        "valid_beat_ids": valid_beat_ids_text,
+        "valid_path_beats": valid_path_beats_block,
     }
 
 

--- a/tests/unit/test_polish_context.py
+++ b/tests/unit/test_polish_context.py
@@ -202,11 +202,9 @@ class TestFormatEntityArcContext:
         assert "(path: `path::brave`)" in ctx["beat_appearances"]
         # Same backtick convention for the standalone ID lists.
         assert "`path::brave`" in ctx["path_ids"]
-        # `valid_path_ids` is entity-scoped (same as `path_ids`) per #1410 —
-        # the Phase 3 prompt forbids arcs on paths the entity isn't in.
-        assert ctx["valid_path_ids"] == ctx["path_ids"]
-        assert "`beat::intro`" in ctx["valid_beat_ids"]
-        assert "`beat::reveal`" in ctx["valid_beat_ids"]
+        # Grouped Valid IDs block: one bullet per path with its beats.
+        # `path::brave` owns both `beat::intro` and `beat::reveal`.
+        assert "- `path::brave` → `beat::intro`, `beat::reveal`" in ctx["valid_path_beats"]
 
     def test_entity_with_overlays(self) -> None:
         graph = Graph.empty()
@@ -278,18 +276,18 @@ class TestFormatEntityArcContext:
 
         ctx = format_entity_arc_context(graph, "entity::loner", [])
         assert ctx["path_ids"] == "(none)"
-        assert ctx["valid_path_ids"] == "(none)"
-        assert ctx["valid_beat_ids"] == "(none)"
+        assert ctx["valid_path_beats"] == "  (none)"
         assert ctx["anchored_dilemmas"] == "(none)"
         # `beat_appearances` uses the same fallback (with the indent the
         # rendered lines normally carry) so the prompt never receives an
         # empty injection.
         assert ctx["beat_appearances"] == "  (none)"
 
-    def test_valid_path_ids_excludes_paths_entity_does_not_appear_on(self) -> None:
-        """`valid_path_ids` MUST be scoped to paths where the entity actually
-        appears (closes #1410). Showing the broader story-wide list confused
-        models into inventing arcs on paths the entity is never in."""
+    def test_valid_path_beats_excludes_paths_entity_does_not_appear_on(self) -> None:
+        """The grouped `valid_path_beats` block MUST be scoped to paths where
+        the entity actually appears (closes #1410). Showing the broader
+        story-wide list confused models into inventing arcs on paths the
+        entity is never in."""
         graph = Graph.empty()
         # Two paths exist in the story.
         graph.create_node("path::story_a", {"type": "path", "raw_id": "story_a"})
@@ -303,12 +301,40 @@ class TestFormatEntityArcContext:
         graph.add_edge("belongs_to", "beat::b1", "path::story_a")
 
         ctx = format_entity_arc_context(graph, "entity::loner", ["beat::b1"])
-        # Both path_ids and valid_path_ids show only the entity's path,
-        # NOT path::story_b (which exists in the graph but doesn't include
-        # the entity).
+        # `path_ids` shows only the entity's path.
         assert ctx["path_ids"] == "`path::story_a`"
-        assert ctx["valid_path_ids"] == "`path::story_a`"
-        assert "story_b" not in ctx["valid_path_ids"]
+        # The grouped block lists the entity's path + its beat, NOT story_b.
+        assert "- `path::story_a` → `beat::b1`" in ctx["valid_path_beats"]
+        assert "story_b" not in ctx["valid_path_beats"]
+
+    def test_valid_path_beats_lists_y_shape_precommit_under_each_path(self) -> None:
+        """Y-shape pre-commit beats have multi-`belongs_to` (one edge per path
+        of their dilemma). The grouped `valid_path_beats` block MUST list such
+        a beat under EACH of its paths — that's how the LLM knows the beat is
+        legal for both `pivots` entries."""
+        graph = Graph.empty()
+        graph.create_node(
+            "path::canon",
+            {"type": "path", "raw_id": "canon", "dilemma_id": "dilemma::trust"},
+        )
+        graph.create_node(
+            "path::alt",
+            {"type": "path", "raw_id": "alt", "dilemma_id": "dilemma::trust"},
+        )
+        graph.create_node(
+            "entity::mentor",
+            {"type": "entity", "raw_id": "mentor", "name": "Mentor", "description": "guide"},
+        )
+        # `beat::shared` is a Y-shape pre-commit beat (multi-belongs_to)
+        # where the mentor appears.
+        _make_beat(graph, "beat::shared", "Mentor speaks", entities=["entity::mentor"])
+        graph.add_edge("belongs_to", "beat::shared", "path::canon")
+        graph.add_edge("belongs_to", "beat::shared", "path::alt")
+
+        ctx = format_entity_arc_context(graph, "entity::mentor", ["beat::shared"])
+        # The pre-commit beat surfaces under BOTH paths in the grouped block.
+        assert "- `path::alt` → `beat::shared`" in ctx["valid_path_beats"]
+        assert "- `path::canon` → `beat::shared`" in ctx["valid_path_beats"]
 
     def test_anchored_dilemmas_backtick_wrapped(self) -> None:
         """Dilemmas the entity is `anchored_to` are backtick-wrapped per


### PR DESCRIPTION
## Summary

`format_entity_arc_context` (Phase 3) now emits `valid_path_beats` as a single grouped block with one bullet per path listing the entity's beats on that path. Y-shape pre-commit beats (multi-`belongs_to` to paths of the SAME dilemma per Story Graph Ontology Part 8) appear under EACH of their paths.

```
- `path::dilemma_a__answer_x` → `beat::ax1`, `beat::ax3`
- `path::dilemma_b__answer_y` → `beat::by1`, `beat::by2`
```

Old `valid_path_ids` + `valid_beat_ids` flat lists removed from the context dict. `path_ids` retained (still consumed elsewhere in the prompt).

`polish_phase3_arcs.yaml` `## Valid IDs` section rewritten to introduce the grouped block and reinforce the path-scoping invariant on `pivots[*].beat_id` and `arcs_per_path[*].pivot_beat`.

Closes #1488.

## Why

Same Valid-IDs anti-pattern as PR #1487 (Phase 1 reorder) and PR #1490 (Phase 1a). Companion to the open #1488 tracker filed during PR #1487's review.

## Test plan

- [x] `uv run pytest tests/unit/test_polish_context.py tests/unit/test_polish_llm_phases.py tests/unit/test_polish_phases.py` — 78 pass
- [x] `uv run ruff check` — clean
- [x] Y-shape pre-commit invariant pinned by new `test_valid_path_beats_lists_y_shape_precommit_under_each_path`
- [x] #1410 path-scoping coverage preserved (renamed `test_valid_path_beats_excludes_paths_entity_does_not_appear_on`)
- [x] Prompt YAML loads with `{valid_path_beats}`; old flat-list substrings absent

## Out of scope

- Other POLISH phase findings (Phase 2 pacing, Phase 5a-f).

🤖 Generated with [Claude Code](https://claude.com/claude-code)