### PR TITLE
fix(polish): add schema description for Phase 5d variant_details

### DIFF
--- a/prompts/templates/polish_phase5d_variants.yaml
+++ b/prompts/templates/polish_phase5d_variants.yaml
@@ -17,6 +17,12 @@ system: |
   {story_context}
 
   ## Variants to Summarize
+  Each entry follows this shape:
+    `  - variant_id: \`<id>\` base: \`<base_passage_id>\` (<base summary>)`
+    `    requires: \`<flag_id>\`, \`<flag_id>\`` (the active state flags
+    that gate this variant — write a summary that reflects what those
+    flags imply happened on this player's path)
+
   {variant_details}
 
   ## Output Format

--- a/prompts/templates/polish_phase5d_variants.yaml
+++ b/prompts/templates/polish_phase5d_variants.yaml
@@ -17,11 +17,15 @@ system: |
   {story_context}
 
   ## Variants to Summarize
-  Each entry follows this shape:
-    `  - variant_id: \`<id>\` base: \`<base_passage_id>\` (<base summary>)`
-    `    requires: \`<flag_id>\`, \`<flag_id>\`` (the active state flags
-    that gate this variant — write a summary that reflects what those
-    flags imply happened on this player's path)
+  Each entry follows this shape (two-space indent on the dash,
+  four-space indent on the `requires:` line):
+
+    - variant_id: `<id>` base: `<base_passage_id>` (<base summary>)
+      requires: `<flag_id>`, `<flag_id>`
+
+  The `requires` list gives you the active state flags that gate this
+  variant — write a summary that reflects what those flags imply
+  happened on this player's path.
 
   {variant_details}
 

--- a/prompts/templates/polish_phase5d_variants.yaml
+++ b/prompts/templates/polish_phase5d_variants.yaml
@@ -25,7 +25,8 @@ system: |
 
   The `requires` list gives you the active state flags that gate this
   variant — write a summary that reflects what those flags imply
-  happened on this player's path.
+  happened on this player's path. If the line reads `requires: (none)`,
+  no flags gate this variant; treat it as the base/canonical case.
 
   {variant_details}
 


### PR DESCRIPTION
## Summary

Add a schema stub above `{variant_details}` in `polish_phase5d_variants.yaml` describing the actual rendered format from `format_variant_summary_context` and explicitly noting that `requires` lists the active state flags the model should reflect.

Schema stub mirrors the actual byte-for-byte output:
```
  - variant_id: `<id>` base: `<base_passage_id>` (<base summary>)
    requires: `<flag_id>`, `<flag_id>`
```

Closes #1494.

## Why

The 2026-04-25 prompt-vs-spec audit (lines 1120-1131) flagged `{variant_details}` as injected without schema description. R-5.13 requires distinct summaries reflecting each variant's flag combination; without explicit flag context, all variants risk being generic.

Same defensive-prompt pattern as PR #1493 (Phase 2 pacing schema description). Per CLAUDE.md / @prompt-engineer Rule 2 (Context Enrichment).

## Test plan

- [x] `uv run pytest tests/unit/test_polish_context.py` — 18 pass
- [x] Prompt YAML loads cleanly; schema stub + requires explanation both present
- [x] Schema description matches the actual `format_variant_summary_context` output byte-for-byte

## Out of scope

- Other Phase 5* findings (5a, 5b, 5c, 5e, 5f) — each a separate cluster.

🤖 Generated with [Claude Code](https://claude.com/claude-code)