### PR TITLE
fix(polish): add residue_feedback repair-loop slot for Phase 5b mapping_strategy validation

### DIFF
--- a/prompts/templates/polish_phase5b_residue.yaml
+++ b/prompts/templates/polish_phase5b_residue.yaml
@@ -75,6 +75,5 @@ user: |
   REMINDER: Return ONLY valid JSON. Provide exactly one entry per residue, with both
   "content_hint" and "mapping_strategy" fields filled in.
   REMINDER: `mapping_strategy` MUST be exactly one of: `residue_passage_with_variants`, `parallel_passages`.
-  {residue_feedback}
 
 components: []

--- a/prompts/templates/polish_phase5b_residue.yaml
+++ b/prompts/templates/polish_phase5b_residue.yaml
@@ -74,5 +74,7 @@ user: |
 
   REMINDER: Return ONLY valid JSON. Provide exactly one entry per residue, with both
   "content_hint" and "mapping_strategy" fields filled in.
+  REMINDER: `mapping_strategy` MUST be exactly one of: `residue_passage_with_variants`, `parallel_passages`.
+  {residue_feedback}
 
 components: []

--- a/src/questfoundry/graph/polish_context.py
+++ b/src/questfoundry/graph/polish_context.py
@@ -405,6 +405,8 @@ def format_residue_content_context(
         "residue_details": "\n".join(residue_lines) or "(none)",
         "story_context": story_context,
         "residue_count": str(len(residue_specs)),
+        # Repair-loop slot (mirrors Phase 3 structural_feedback, Phase 4g transition_feedback).
+        "residue_feedback": "",
     }
 
 

--- a/src/questfoundry/graph/polish_context.py
+++ b/src/questfoundry/graph/polish_context.py
@@ -405,8 +405,6 @@ def format_residue_content_context(
         "residue_details": "\n".join(residue_lines) or "(none)",
         "story_context": story_context,
         "residue_count": str(len(residue_specs)),
-        # Repair-loop slot (mirrors Phase 3 structural_feedback, Phase 4g transition_feedback).
-        "residue_feedback": "",
     }
 
 


### PR DESCRIPTION
## Summary

- Add `residue_feedback` slot to `format_residue_content_context` (defaults to empty string).
- Add `{residue_feedback}` placeholder to the user turn in `polish_phase5b_residue.yaml`.
- Add a positive REMINDER about the two valid `mapping_strategy` values right above the feedback slot.

Closes #1496.

## Why

The 2026-04-25 prompt-vs-spec audit (lines 1062-1066) flagged the absence of a repair-loop slot in `polish_phase5b_residue.yaml`. The `mapping_strategy` field is a Literal of two values (`residue_passage_with_variants` / `parallel_passages`); when an LLM produces a value outside that set, validation fails but no mechanism exists to inject a targeted hint on retry.

Pattern matches Phase 3 `structural_feedback` and Phase 4g `transition_feedback`. Per CLAUDE.md / @prompt-engineer Rule 5 (Repair Loop).

## Note on the other two audit findings

The audit also flagged:
- **#1 schema description for `{residue_details}`** — already present in the prompt (lines around 18-22, "Format per residue:" with backtick-wrapped IDs).
- **#2 GOOD/BAD content_hint length pair** — already present (lines 13-15, R-5.6 critical block).

Both were addressed in prior cleanup work. Verified by reading the current prompt before scoping this PR.

## Test plan

- [x] `uv run pytest tests/unit/test_polish_context.py` — 18 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)