### PR TITLE
fix(polish): Phase 5a — story_context header + choice_details schema description

### DIFF
--- a/prompts/templates/polish_phase5a_choice_labels.yaml
+++ b/prompts/templates/polish_phase5a_choice_labels.yaml
@@ -11,10 +11,19 @@ system: |
   - **Distinct** — each choice from the same passage must be clearly different
   - **Concise** — short enough for a button or gamebook instruction (5-12 words)
 
-  ## Story Context
+  ## Story Background (for tone and diegetic voice reference)
   {story_context}
 
   ## Choices to Label
+  Each entry follows this shape (from / to passage IDs are
+  backtick-wrapped, summaries are truncated to ~80 chars):
+
+    1. From: `<passage_id>` (<summary>)
+       To: `<passage_id>` (<summary>) grants: `<flag_id>`, `<flag_id>`
+
+  The `grants:` suffix is optional — present when the choice grants
+  state flags, absent otherwise.
+
   {choice_details}
 
   ## Valid IDs


### PR DESCRIPTION
## Summary

Two soft findings from the 2026-04-25 prompt-vs-spec audit (lines 1002-1022) for `polish_phase5a_choice_labels.yaml`:

1. **`{story_context}` schema header** — added `## Story Background (for tone and diegetic voice reference)` so small models don't conflate the context with the choices that follow.
2. **`{choice_details}` schema description** — added a short stub showing the rendered shape (`From:` / `To:` with backtick-wrapped passage IDs, optional `grants:` suffix). Matches `format_choice_label_context` byte-for-byte.

Closes #1499.

## Why no other changes

- The audit's **HARD** finding (#991, "no Valid Passage IDs section") was already addressed in prior work — `valid_passage_ids` is wired in `format_choice_label_context` (line 350) and the prompt has a `## Valid IDs` section. Verified by reading the current state.
- The audit's repair-loop slot recommendation (#1024, `{choice_label_feedback}`) is deferred per #1498 — POLISH's retry architecture doesn't re-render templates, so the slot would be inert dead code (same finding that led to dropping inert slots from PRs #1493 and #1497).

## Test plan

- [x] `uv run pytest tests/unit/test_polish_context.py` — 18 pass
- [x] Prompt YAML loads with new headers; rendered text contains both new sections; no YAML `\`` escapes (per the saved memory note)

🤖 Generated with [Claude Code](https://claude.com/claude-code)