### PR TITLE
fix(polish): Phase 5c — candidate_details schema, R-5.12 anti-pattern, decision GOOD examples

### DIFF
--- a/prompts/templates/polish_phase5c_false_branches.yaml
+++ b/prompts/templates/polish_phase5c_false_branches.yaml
@@ -56,9 +56,9 @@ system: |
   - Do NOT add more than one false branch per candidate
   - Do NOT skip any candidate — provide a decision for every candidate listed
   - Do NOT overuse diamond/sidetrack — "skip" is a valid and often best choice
-  - Do NOT propose `diamond` or `sidetrack` at a passage that ends with a real
-    dilemma choice (R-5.12 — false branches are cosmetic and never affect
-    dilemma-driven branching)
+  - Do NOT propose `diamond` or `sidetrack` for a candidate stretch whose last
+    passage ends with a real dilemma choice (R-5.12 — false branches are
+    cosmetic and never affect dilemma-driven branching)
   - Do NOT add prose before or after the JSON output
 
 user: |

--- a/prompts/templates/polish_phase5c_false_branches.yaml
+++ b/prompts/templates/polish_phase5c_false_branches.yaml
@@ -14,6 +14,14 @@ system: |
     Provide a detour summary, entity assignments, and choice labels.
 
   ## Candidate Stretches
+  Each candidate follows this shape (passage IDs are backtick-wrapped,
+  summaries truncated to ~60 chars; the `Context:` line is optional):
+
+    Candidate <N>:        # 0-based, matches `candidate_index` in output
+      - `<passage_id>`: <summary>
+      - `<passage_id>`: <summary>
+      Context: <context_summary>
+
   {candidate_details}
 
   ## Valid Entity IDs (for sidetrack entity assignments)
@@ -48,6 +56,9 @@ system: |
   - Do NOT add more than one false branch per candidate
   - Do NOT skip any candidate — provide a decision for every candidate listed
   - Do NOT overuse diamond/sidetrack — "skip" is a valid and often best choice
+  - Do NOT propose `diamond` or `sidetrack` at a passage that ends with a real
+    dilemma choice (R-5.12 — false branches are cosmetic and never affect
+    dilemma-driven branching)
   - Do NOT add prose before or after the JSON output
 
 user: |
@@ -55,6 +66,10 @@ user: |
   branch for variety. Prefer "skip" unless the stretch genuinely needs more
   player engagement. Use "diamond" for scenes that work from two angles.
   Use "sidetrack" for stretches that benefit from a brief detour.
+
+  GOOD reason to skip: "Passage run is naturally tense — forcing a choice here would interrupt the momentum"
+  GOOD reason for diamond: "Introductory scene works equally well from two sensory angles"
+  GOOD reason for sidetrack: "Stretch is 5 passages with no narrative texture — a brief encounter adds atmosphere"
 
   REMINDER: Return ONLY valid JSON. Provide exactly one decision per candidate.
 


### PR DESCRIPTION
## Summary

Three soft findings from the 2026-04-25 prompt-vs-spec audit (lines 1077-1108) for `polish_phase5c_false_branches.yaml`:

1. **`{candidate_details}` schema description** — added a stub showing the rendered shape from `format_false_branch_context`: 0-based `Candidate <N>:` label, backtick-wrapped passage IDs, optional `Context:` line.
2. **R-5.12 commit-beat anti-pattern** — added explicit "Do NOT propose diamond/sidetrack at passages that end with a real dilemma choice" rule to "What NOT to Do".
3. **GOOD reasoning examples** — added three example reasons (skip / diamond / sidetrack) to the user turn.

Closes #1501.

## Why

Same defensive-prompt patterns as PR #1487, #1490, #1493, #1495, #1497, #1500. R-5.12 is a hard rule that the prompt previously didn't surface — adding it as a "Do NOT" anti-pattern makes the rule visible to small models at decision time.

The audit's [info] off-by-one note about `candidate_index` was verified — the prompt label (0-based) and Pydantic field (0-based) already align. No action needed beyond confirming the schema stub uses 0-based labels.

No repair-loop slot was recommended for Phase 5c, so #1498 doesn't block here.

## Test plan

- [x] `uv run pytest tests/unit/test_polish_context.py` — 18 pass
- [x] Prompt YAML loads cleanly; no `\`` escapes (per saved memory note)
- [x] Schema description matches `format_false_branch_context` byte-for-byte

🤖 Generated with [Claude Code](https://claude.com/claude-code)