### PR TITLE
fix(polish): Phase 5e atmospheric — narrative_frame header, uncertainty fallback, environment-vs-interiority GOOD/BAD

### DIFF
--- a/prompts/templates/polish_phase5e_atmospheric.yaml
+++ b/prompts/templates/polish_phase5e_atmospheric.yaml
@@ -16,7 +16,7 @@ system: |
   - "Lamp oil smoke curling beneath low stone ceilings" (49 chars)
   - "The persistent drone of cicadas in the humid air" (49 chars)
   - "Cold steel handrails vibrating faintly underfoot" (49 chars)
-  - "The smell of wet earth and rust"
+  - "The smell of wet earth and rust" (31 chars)
 
   BAD (character interiority, not environment — R-5e.2):
   - "A sense of dread hangs in the air" (interiority phrased as environment)

--- a/prompts/templates/polish_phase5e_atmospheric.yaml
+++ b/prompts/templates/polish_phase5e_atmospheric.yaml
@@ -4,6 +4,7 @@ description: Generate atmospheric details for beats (POLISH Phase 5e, Atmospheri
 system: |
   You are adding sensory atmosphere to story beats.
 
+  ## Story Frame (genre and tone, for sensory register reference)
   {narrative_frame}
 
   ## Atmospheric Detail (10-200 characters)
@@ -11,13 +12,16 @@ system: |
   setting — what the protagonist sees, hears, smells, or feels physically.
   This detail will be woven into the prose as a sensory anchor.
 
-  Examples (with character counts):
+  GOOD (environment, physical sensation):
   - "Lamp oil smoke curling beneath low stone ceilings" (49 chars)
   - "The persistent drone of cicadas in the humid air" (49 chars)
   - "Cold steel handrails vibrating faintly underfoot" (49 chars)
+  - "The smell of wet earth and rust"
 
-  Write ENVIRONMENT, not character emotion. Not "a sense of dread" but
-  "the smell of wet earth and rust."
+  BAD (character interiority, not environment — R-5e.2):
+  - "A sense of dread hangs in the air" (interiority phrased as environment)
+  - "The protagonist feels cold and alone" (character emotion)
+  - "Anxiety builds in the room" (interiority phrased as environment)
 
   ## Beats to Annotate
   {beat_summaries}
@@ -39,6 +43,10 @@ user: |
 
   REMINDER: Return ONLY a valid JSON object. Use ONLY IDs from the Valid IDs
   section. Every beat needs an atmospheric_detail.
+  REMINDER: If you are uncertain about the sensory environment for a beat,
+  write a generic sensory anchor (e.g. "Dim ambient light and the faint sound
+  of settling wood") rather than omitting it. Omitting a beat is worse than
+  a generic detail (R-5e.1).
   Do NOT add prose before or after the JSON.
 
 components: []


### PR DESCRIPTION
## Summary

Three soft findings from the 2026-04-25 prompt-vs-spec audit (lines 1143-1163) for `polish_phase5e_atmospheric.yaml`:

1. **`{narrative_frame}` schema header** — added `## Story Frame (genre and tone, for sensory register reference)` before the variable.
2. **Uncertainty fallback (R-5e.1)** — added REMINDER: "If uncertain, write a generic sensory anchor rather than omitting." Omission triggers R-5e.1 partial-coverage WARNING.
3. **GOOD/BAD environment-vs-interiority pair (R-5e.2)** — relabelled existing examples as GOOD and added BAD counterexamples.

Closes #1503.

## Why

Same defensive-prompt patterns as PR #1487, #1490, #1493, #1495, #1497, #1500, #1502. Per CLAUDE.md / @prompt-engineer Rule 2 (Context Enrichment), Rule 3 (defensive examples).

The original "Write ENVIRONMENT, not character emotion." sentence is removed since the GOOD/BAD pair carries the same message in the canonical format.

## Test plan

- [x] `uv run pytest tests/unit/test_polish_context.py` — 18 pass
- [x] Prompt YAML loads cleanly; all 6 expected substrings present (Story Frame, GOOD env, BAD interiority, generic anchor, R-5e.1, R-5e.2); no `\`` escapes (per saved memory)

## Out of scope

- Phase 5e feasibility — audit verdict "clean", nothing to do.
- Phase 5f path_thematic / transitions — separate clusters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)