### PR TITLE
fix(polish): Phase 5f path_thematic — POLISH attribution, entity_arcs label, beat_sequence schema

### DIFF
--- a/prompts/templates/polish_phase5f_path_thematic.yaml
+++ b/prompts/templates/polish_phase5f_path_thematic.yaml
@@ -2,9 +2,9 @@ name: polish_phase5f_path_thematic
 description: Generate thematic arc context for a single path (POLISH Phase 5f, Path Thematic Annotation)
 
 system: |
-  You are a narrative architect analyzing a single path through a branching
-  interactive fiction story. Your task is to identify the thematic through-line
-  and emotional tone of this path.
+  You are the POLISH stage (Phase 5f: Path Thematic Annotation),
+  synthesizing the emotional through-line of a single story path. Your task
+  is to identify the thematic through-line and emotional tone of this path.
 
   ## Path Information
   **Path ID:** {path_id}
@@ -15,10 +15,18 @@ system: |
   ## Key Entities
   {entity_context}
 
-  ## Entity Arcs (character transformations on this path)
+  ## Character Arcs on This Path (synthesized by POLISH Phase 3)
+  Use these to understand how character trajectories influence the path's
+  emotional through-line.
+
   {entity_arcs}
 
   ## Beat Sequence (in order)
+  Format per beat:
+    `<beat_id>` — <summary> — scene_type: <scene|sequel|micro_beat> —
+    narrative_function: <introduce|develop|complicate|confront|resolve> —
+    exit_mood: <mood>
+
   {beat_sequence}
 
   ## Rules


### PR DESCRIPTION
## Summary

Three soft findings from the 2026-04-25 prompt-vs-spec audit (lines 1205-1218) for `polish_phase5f_path_thematic.yaml`:

1. **POLISH attribution** — system prompt now opens with "You are the POLISH stage (Phase 5f: Path Thematic Annotation)..." per the absorbed-from-GROW-4e traceability intent.
2. **`{entity_arcs}` schema label** — relabelled to `## Character Arcs on This Path (synthesized by POLISH Phase 3)` so a small model sees explicitly that this data is POLISH-synthesized arc metadata.
3. **`{beat_sequence}` schema description** — added per-beat shape stub matching R-5f.2's required rich-context format.

Closes #1506.

## Why

Same defensive-prompt patterns as PR #1487, #1490, #1493, #1495, #1497, #1500, #1502, #1504. Per CLAUDE.md / @prompt-engineer Rule 2 (Context Enrichment).

The audit's [info] note (line 1220) calls Phase 5f "the best small-model-resilience implementation in all 12 POLISH prompts" — length-requirement examples kept untouched.

## Test plan

- [x] `uv run pytest tests/unit/test_polish_context.py` — 18 pass
- [x] Prompt YAML loads cleanly; all 4 expected substrings present (POLISH attribution, Character Arcs label, Phase 3 attribution, beat schema); no `\`` escapes per saved memory

## Out of scope

- Phase 5f transitions — separate cluster.
- #1505 valid_beat_ids bulletization for Phase 5e atmospheric.

🤖 Generated with [Claude Code](https://claude.com/claude-code)