### PR TITLE
fix(polish): Phase 5f transitions — collapsed_passage_details schema + transition-count GOOD/BAD

### DIFF
--- a/prompts/templates/polish_phase5f_transitions.yaml
+++ b/prompts/templates/polish_phase5f_transitions.yaml
@@ -28,11 +28,29 @@ system: |
   ## What NOT to Do
   - Do NOT write full prose — only brief transition directives
   - Do NOT provide more or fewer transitions than beat boundaries
+
+  GOOD (2-beat passage = 1 boundary = 1 transition):
+    {{"transitions": ["The silence stretches until the protagonist turns away."]}}
+  BAD (2-beat passage with 2 transitions — too many):
+    {{"transitions": ["The silence stretches until they turn away.", "Then they leave."]}}
+  BAD (3-beat passage with 3 transitions — should be 2):
+    {{"transitions": ["...", "...", "..."]}}
+
   - Do NOT restate what happened in the beat — bridge to the next beat
   - Do NOT skip any collapsed passage
   - Do NOT add prose before or after the JSON output
 
   ## Collapsed Passages to Process
+  Each entry follows this shape (the `boundary/ies` count is exactly
+  the number of `transitions` you must return for that `passage_id`):
+
+    passage_id: `<id>`
+    entities: `<entity_id>`, `<entity_id>`
+    beats (<N> total, <N-1> boundary/ies):
+      Beat 1: `<beat_id>` [<scene_type>] — <summary>
+      Beat 2: `<beat_id>` [<scene_type>] — <summary>
+      ...
+
   {collapsed_passage_details}
 
   ## Output Format


### PR DESCRIPTION
## Summary

Two soft findings from the 2026-04-25 prompt-vs-spec audit (lines 1230-1254) for `polish_phase5f_transitions.yaml`:

1. **`{collapsed_passage_details}` schema description** — added a shape stub matching `format_transition_guidance_context` exactly. Explicitly tells the model the `boundary/ies` count IS the required transitions count.
2. **Transition-count GOOD/BAD examples** — added inline pairs to "What NOT to Do": GOOD (2-beat = 1 transition), BAD (2-beat = 2 transitions, too many), BAD (3-beat = 3 transitions, should be 2). Pins the off-by-N failure mode the audit specifically called out.

Closes #1508.

**This completes the POLISH live-prompt soft findings cluster from the audit.** PRs in the series: #1487, #1490, #1493, #1495, #1497, #1500, #1502, #1504, #1507, this PR.

## Out of scope

- **Spec gap** (audit lines 1256-1260): `polish.md §Phase 5f` should list transition guidance as a named sub-task. Filed separately as #1509 — spec change, not prompt change. Per CLAUDE.md "Design Doc Authority", spec edits precede code conformance.

Remaining open trackers from this work: #1505 (Phase 5e `valid_beat_ids` bulletization), #1509 (Phase 5f spec gap). Architectural blocker #1498 still applies for any future `*_feedback` slot wiring.

## Test plan

- [x] `uv run pytest tests/unit/test_polish_context.py` — 18 pass
- [x] Prompt YAML loads cleanly; schema stub + count-violation BAD examples both present; no `\`` escapes per saved memory

🤖 Generated with [Claude Code](https://claude.com/claude-code)