### PR TITLE
feat(providers): refresh KNOWN_MODELS registry — Ollama additions + Anthropic 1M context

### DIFF
--- a/src/questfoundry/providers/model_info.py
+++ b/src/questfoundry/providers/model_info.py
@@ -51,7 +51,9 @@ KNOWN_MODELS: dict[str, dict[str, ModelProperties]] = {
         "qwen3:4b-instruct-32k": ModelProperties(context_window=32_768),
         "qwen3:8b": ModelProperties(context_window=32_768),
         "qwen3:14b": ModelProperties(context_window=32_768),
+        # qwen3:30b is the 30B-A3B MoE; qwen3:32b is the dense 32B variant.
         "qwen3:30b": ModelProperties(context_window=32_768),
+        "qwen3:32b": ModelProperties(context_window=32_768),
         "qwen2.5:7b": ModelProperties(context_window=32_768),
         # gemma3 / gemma4
         "gemma3:1b": ModelProperties(context_window=32_768),
@@ -75,7 +77,10 @@ KNOWN_MODELS: dict[str, dict[str, ModelProperties]] = {
         "mistral-nemo:12b": ModelProperties(context_window=32_768),
         # deepseek
         "deepseek-coder:6.7b": ModelProperties(context_window=16_384),
+        "deepseek-r1:1.5b": ModelProperties(context_window=32_768),
         "deepseek-r1:7b": ModelProperties(context_window=32_768),
+        # deepseek-r1:8b is the Llama-3.1-8B distill (separate from the 7b qwen distill).
+        "deepseek-r1:8b": ModelProperties(context_window=32_768),
         "deepseek-r1:14b": ModelProperties(context_window=32_768),
         "deepseek-r1:32b": ModelProperties(context_window=32_768),
     },

--- a/src/questfoundry/providers/model_info.py
+++ b/src/questfoundry/providers/model_info.py
@@ -78,8 +78,9 @@ KNOWN_MODELS: dict[str, dict[str, ModelProperties]] = {
         # deepseek
         "deepseek-coder:6.7b": ModelProperties(context_window=16_384),
         "deepseek-r1:1.5b": ModelProperties(context_window=32_768),
+        # deepseek-r1:7b is the Qwen2.5-7B distill.
         "deepseek-r1:7b": ModelProperties(context_window=32_768),
-        # deepseek-r1:8b is the Llama-3.1-8B distill (separate from the 7b qwen distill).
+        # deepseek-r1:8b is the Llama-3.1-8B distill (separate from the 7b Qwen distill).
         "deepseek-r1:8b": ModelProperties(context_window=32_768),
         "deepseek-r1:14b": ModelProperties(context_window=32_768),
         "deepseek-r1:32b": ModelProperties(context_window=32_768),

--- a/src/questfoundry/providers/model_info.py
+++ b/src/questfoundry/providers/model_info.py
@@ -43,13 +43,41 @@ class ModelProperties:
 # Consolidates context window and capability information.
 KNOWN_MODELS: dict[str, dict[str, ModelProperties]] = {
     "ollama": {
+        # Practical defaults — set below the model's theoretical max so a stage
+        # doesn't silently spill the KV cache to CPU on a typical consumer GPU.
+        # Use --max-vram to compute a higher num_ctx that still fits in VRAM.
+        # qwen2.5 / qwen3
+        "qwen3:1.7b": ModelProperties(context_window=32_768),
         "qwen3:4b-instruct-32k": ModelProperties(context_window=32_768),
         "qwen3:8b": ModelProperties(context_window=32_768),
-        "qwen2.5:7b": ModelProperties(context_window=128_000),
+        "qwen3:14b": ModelProperties(context_window=32_768),
+        "qwen3:30b": ModelProperties(context_window=32_768),
+        "qwen2.5:7b": ModelProperties(context_window=32_768),
+        # gemma3 / gemma4
+        "gemma3:1b": ModelProperties(context_window=32_768),
+        "gemma3:4b": ModelProperties(context_window=32_768, supports_vision=True),
+        "gemma3:12b": ModelProperties(context_window=32_768, supports_vision=True),
+        "gemma3:27b": ModelProperties(context_window=32_768, supports_vision=True),
+        # gemma4:e2b — model claims more but is unusable above 16K on consumer GPUs.
+        "gemma4:e2b": ModelProperties(context_window=16_384),
+        # phi4
+        "phi4:14b": ModelProperties(context_window=16_384),
+        "phi4-mini:3.8b": ModelProperties(context_window=16_384),
+        # llama3.x
         "llama3:8b": ModelProperties(context_window=8_192),
-        "llama3.1:8b": ModelProperties(context_window=128_000),
+        "llama3.1:8b": ModelProperties(context_window=32_768),
+        "llama3.2:1b": ModelProperties(context_window=32_768),
+        "llama3.2:3b": ModelProperties(context_window=32_768),
+        "llama3.3:70b": ModelProperties(context_window=32_768),
+        # mistral
         "mistral:7b": ModelProperties(context_window=32_768),
+        "mistral-small:22b": ModelProperties(context_window=32_768),
+        "mistral-nemo:12b": ModelProperties(context_window=32_768),
+        # deepseek
         "deepseek-coder:6.7b": ModelProperties(context_window=16_384),
+        "deepseek-r1:7b": ModelProperties(context_window=32_768),
+        "deepseek-r1:14b": ModelProperties(context_window=32_768),
+        "deepseek-r1:32b": ModelProperties(context_window=32_768),
     },
     "openai": {
         # GPT-5 family: verbosity + reasoning_effort, rejects stop sequences
@@ -118,12 +146,19 @@ KNOWN_MODELS: dict[str, dict[str, ModelProperties]] = {
         ),
     },
     "anthropic": {
-        "claude-opus-4-6": ModelProperties(context_window=200_000, supports_vision=True),
-        "claude-opus-4-5-20251101": ModelProperties(context_window=200_000, supports_vision=True),
-        "claude-sonnet-4-5-20250929": ModelProperties(context_window=200_000, supports_vision=True),
-        "claude-sonnet-4-20250514": ModelProperties(context_window=200_000, supports_vision=True),
-        "claude-opus-4-20250514": ModelProperties(context_window=200_000, supports_vision=True),
-        "claude-haiku-4-5-20251001": ModelProperties(context_window=200_000, supports_vision=True),
+        # Claude 4.x family — 1M context available via the 1M-token API.
+        "claude-opus-4-7": ModelProperties(context_window=1_000_000, supports_vision=True),
+        "claude-opus-4-6": ModelProperties(context_window=1_000_000, supports_vision=True),
+        "claude-opus-4-5-20251101": ModelProperties(context_window=1_000_000, supports_vision=True),
+        "claude-sonnet-4-6": ModelProperties(context_window=1_000_000, supports_vision=True),
+        "claude-sonnet-4-5-20250929": ModelProperties(
+            context_window=1_000_000, supports_vision=True
+        ),
+        "claude-sonnet-4-20250514": ModelProperties(context_window=1_000_000, supports_vision=True),
+        "claude-opus-4-20250514": ModelProperties(context_window=1_000_000, supports_vision=True),
+        "claude-haiku-4-5-20251001": ModelProperties(
+            context_window=1_000_000, supports_vision=True
+        ),
     },
     "google": {
         "gemini-2.5-flash": ModelProperties(context_window=1_000_000, supports_vision=True),

--- a/src/questfoundry/providers/model_info.py
+++ b/src/questfoundry/providers/model_info.py
@@ -62,7 +62,7 @@ KNOWN_MODELS: dict[str, dict[str, ModelProperties]] = {
         "gemma3:27b": ModelProperties(context_window=32_768, supports_vision=True),
         # gemma4:e2b — model claims more but is unusable above 16K on consumer GPUs.
         "gemma4:e2b": ModelProperties(context_window=16_384),
-        # phi4
+        # phi4 — 16K is the model's native context (not a hardware-safety cap).
         "phi4:14b": ModelProperties(context_window=16_384),
         "phi4-mini:3.8b": ModelProperties(context_window=16_384),
         # llama3.x

--- a/tests/unit/test_model_info.py
+++ b/tests/unit/test_model_info.py
@@ -153,9 +153,16 @@ class TestModelRegistryContextWindows:
         for model in ("gpt-4.1", "gpt-4.1-mini", "gpt-4.1-nano"):
             assert KNOWN_MODELS["openai"][model].context_window == 1_000_000, f"{model}"
 
-    def test_qwen25_7b_context_window(self) -> None:
-        """qwen2.5:7b has 32K practical context window (uses --max-vram for higher)."""
-        assert KNOWN_MODELS["ollama"]["qwen2.5:7b"].context_window == 32_768
+    def test_ollama_practical_defaults(self) -> None:
+        """Models with 128K+ theoretical context are capped at 32K practical default.
+
+        Both qwen2.5:7b and llama3.1:8b ship with 128K theoretical max but
+        spill KV cache to CPU at that size on a typical consumer GPU. The
+        registry caps both at 32K; --max-vram (sub-task 2 of #1245) computes
+        a higher fitting num_ctx per call when VRAM allows.
+        """
+        for model in ("qwen2.5:7b", "llama3.1:8b"):
+            assert KNOWN_MODELS["ollama"][model].context_window == 32_768, f"{model}"
 
     def test_gemma4_e2b_context_window(self) -> None:
         """gemma4:e2b is capped at 16K — model claims more but is unusable above 16K on consumer GPUs."""

--- a/tests/unit/test_model_info.py
+++ b/tests/unit/test_model_info.py
@@ -162,12 +162,15 @@ class TestModelRegistryContextWindows:
         assert KNOWN_MODELS["ollama"]["gemma4:e2b"].context_window == 16_384
 
     def test_anthropic_1m_context_window(self) -> None:
-        """Anthropic Claude 4.x models have 1M context window (1M-token API)."""
+        """All registered Anthropic Claude 4.x models have 1M context (1M-token API)."""
         for model in (
             "claude-opus-4-7",
             "claude-opus-4-6",
+            "claude-opus-4-5-20251101",
+            "claude-opus-4-20250514",
             "claude-sonnet-4-6",
             "claude-sonnet-4-5-20250929",
+            "claude-sonnet-4-20250514",
             "claude-haiku-4-5-20251001",
         ):
             assert KNOWN_MODELS["anthropic"][model].context_window == 1_000_000, f"{model}"
@@ -229,6 +232,7 @@ class TestModelRegistryContextWindows:
             assert model in KNOWN_MODELS["ollama"], f"{model} missing"
 
     def test_gemma3_vision_support(self) -> None:
-        """gemma3 4b/12b/27b support vision."""
+        """gemma3 4b/12b/27b support vision; 1b is the odd one out and does not."""
         for model in ("gemma3:4b", "gemma3:12b", "gemma3:27b"):
             assert KNOWN_MODELS["ollama"][model].supports_vision is True, f"{model}"
+        assert KNOWN_MODELS["ollama"]["gemma3:1b"].supports_vision is False

--- a/tests/unit/test_model_info.py
+++ b/tests/unit/test_model_info.py
@@ -154,8 +154,23 @@ class TestModelRegistryContextWindows:
             assert KNOWN_MODELS["openai"][model].context_window == 1_000_000, f"{model}"
 
     def test_qwen25_7b_context_window(self) -> None:
-        """qwen2.5:7b has 128K context window (not 32K)."""
-        assert KNOWN_MODELS["ollama"]["qwen2.5:7b"].context_window == 128_000
+        """qwen2.5:7b has 32K practical context window (uses --max-vram for higher)."""
+        assert KNOWN_MODELS["ollama"]["qwen2.5:7b"].context_window == 32_768
+
+    def test_gemma4_e2b_context_window(self) -> None:
+        """gemma4:e2b is capped at 16K — model claims more but is unusable above on consumer GPUs."""
+        assert KNOWN_MODELS["ollama"]["gemma4:e2b"].context_window == 16_384
+
+    def test_anthropic_1m_context_window(self) -> None:
+        """Anthropic Claude 4.x models have 1M context window (1M-token API)."""
+        for model in (
+            "claude-opus-4-7",
+            "claude-opus-4-6",
+            "claude-sonnet-4-6",
+            "claude-sonnet-4-5-20250929",
+            "claude-haiku-4-5-20251001",
+        ):
+            assert KNOWN_MODELS["anthropic"][model].context_window == 1_000_000, f"{model}"
 
     def test_retired_models_removed(self) -> None:
         """Retired models are no longer in the registry."""
@@ -176,8 +191,10 @@ class TestModelRegistryContextWindows:
             assert model in KNOWN_MODELS["openai"], f"{model} missing"
         # Anthropic
         for model in (
+            "claude-opus-4-7",
             "claude-opus-4-6",
             "claude-opus-4-5-20251101",
+            "claude-sonnet-4-6",
             "claude-sonnet-4-5-20250929",
             "claude-haiku-4-5-20251001",
         ):
@@ -185,3 +202,30 @@ class TestModelRegistryContextWindows:
         # Google
         for model in ("gemini-2.5-flash-lite", "gemini-3-pro-preview", "gemini-3-flash-preview"):
             assert model in KNOWN_MODELS["google"], f"{model} missing"
+        # Ollama — refreshed in #1245
+        for model in (
+            "gemma3:1b",
+            "gemma3:4b",
+            "gemma3:12b",
+            "gemma3:27b",
+            "gemma4:e2b",
+            "phi4:14b",
+            "phi4-mini:3.8b",
+            "qwen3:1.7b",
+            "qwen3:14b",
+            "qwen3:30b",
+            "llama3.2:1b",
+            "llama3.2:3b",
+            "llama3.3:70b",
+            "mistral-small:22b",
+            "mistral-nemo:12b",
+            "deepseek-r1:7b",
+            "deepseek-r1:14b",
+            "deepseek-r1:32b",
+        ):
+            assert model in KNOWN_MODELS["ollama"], f"{model} missing"
+
+    def test_gemma3_vision_support(self) -> None:
+        """gemma3 4b/12b/27b support vision."""
+        for model in ("gemma3:4b", "gemma3:12b", "gemma3:27b"):
+            assert KNOWN_MODELS["ollama"][model].supports_vision is True, f"{model}"

--- a/tests/unit/test_model_info.py
+++ b/tests/unit/test_model_info.py
@@ -158,7 +158,7 @@ class TestModelRegistryContextWindows:
         assert KNOWN_MODELS["ollama"]["qwen2.5:7b"].context_window == 32_768
 
     def test_gemma4_e2b_context_window(self) -> None:
-        """gemma4:e2b is capped at 16K — model claims more but is unusable above on consumer GPUs."""
+        """gemma4:e2b is capped at 16K — model claims more but is unusable above 16K on consumer GPUs."""
         assert KNOWN_MODELS["ollama"]["gemma4:e2b"].context_window == 16_384
 
     def test_anthropic_1m_context_window(self) -> None:
@@ -214,12 +214,15 @@ class TestModelRegistryContextWindows:
             "qwen3:1.7b",
             "qwen3:14b",
             "qwen3:30b",
+            "qwen3:32b",
             "llama3.2:1b",
             "llama3.2:3b",
             "llama3.3:70b",
             "mistral-small:22b",
             "mistral-nemo:12b",
+            "deepseek-r1:1.5b",
             "deepseek-r1:7b",
+            "deepseek-r1:8b",
             "deepseek-r1:14b",
             "deepseek-r1:32b",
         ):

--- a/tests/unit/test_provider_factory.py
+++ b/tests/unit/test_provider_factory.py
@@ -858,7 +858,7 @@ def test_get_model_info_anthropic() -> None:
     """get_model_info works for Anthropic models."""
     info = get_model_info("anthropic", "claude-sonnet-4-20250514")
 
-    assert info.context_window == 200_000
+    assert info.context_window == 1_000_000
     assert info.supports_vision is True
 
 


### PR DESCRIPTION
## Summary

Part of #1245 (sub-task 1 of 2). Sub-task 2 (`--max-vram` for VRAM-aware `num_ctx` calculation) lands in a follow-up PR — splitting because both touch `model_info.py`/`factory.py` serially and bundling makes review harder.

- **Ollama**: add gemma3 (1b/4b/12b/27b — vision on 4b+), gemma4:e2b (capped at 16K per acceptance criteria), phi4:14b + phi4-mini, qwen3 1.7b/14b/30b, llama3.2 1b/3b, llama3.3:70b, mistral-small/nemo, deepseek-r1 distills.
- **Ollama context defaults**: practical 32K (or 16K for known-tight models), set below the model's theoretical maximum so a stage doesn't silently spill the KV cache to CPU on a typical consumer GPU. The upcoming `--max-vram` flag (sub-task 2) will compute a higher fitting `num_ctx` per call. `qwen2.5:7b` updated 128K → 32K for consistency with this policy.
- **Anthropic**: bump Claude 4.x family to `1_000_000` context window (1M-token API now generally available); add `claude-opus-4-7` and `claude-sonnet-4-6` entries.

## Test plan

- [x] `uv run ruff check src/questfoundry/providers/model_info.py tests/unit/test_model_info.py`
- [x] `uv run ruff format` (1 file reformatted)
- [x] `uv run mypy src/questfoundry/providers/model_info.py`
- [x] `uv run pytest tests/unit/test_model_info.py` — 28 passed
- [x] `uv run pytest tests/unit/test_provider_factory.py` — 89 passed (after updating one Anthropic context assertion)
- [ ] Bot review (claude-review, gemini-code-assist) — pending push

🤖 Generated with [Claude Code](https://claude.com/claude-code)