### PR TITLE
feat(cli): per-stage summary block after stage completion

### DIFF
--- a/src/questfoundry/cli.py
+++ b/src/questfoundry/cli.py
@@ -669,6 +669,11 @@ def _run_stage_command(
     if _log_enabled:
         console.print(f"  Logs: [dim]{project_path / 'logs'}[/dim]")
 
+    if result.summary_lines:
+        console.print("  Summary:")
+        for line in result.summary_lines:
+            console.print(f"    - {line}")
+
     console.print()
     if next_step_hint:
         console.print(f"Run: [cyan]{next_step_hint}[/cyan]")

--- a/src/questfoundry/pipeline/orchestrator.py
+++ b/src/questfoundry/pipeline/orchestrator.py
@@ -28,6 +28,7 @@ from questfoundry.pipeline.config import (
 )
 from questfoundry.pipeline.gates import AutoApproveGate, GateHook
 from questfoundry.pipeline.size import resolve_size_from_graph
+from questfoundry.pipeline.summary import build_stage_summary
 from questfoundry.providers.base import ProviderError
 from questfoundry.providers.factory import (
     create_chat_model,
@@ -107,6 +108,7 @@ class StageResult:
     errors: list[str] = field(default_factory=list)
     duration_seconds: float = 0.0
     run_id: str | None = None  # LangSmith trace correlation ID
+    summary_lines: list[str] = field(default_factory=list)
 
 
 @dataclass
@@ -697,6 +699,10 @@ class PipelineOrchestrator:
                 )
                 errors.extend(validation_errors)
 
+            summary_lines: list[str] = []
+            if not validation_errors:
+                summary_lines = build_stage_summary(stage_name, artifact_data)
+
             # Apply mutations to unified graph (only for stages with mutation handlers)
             if not validation_errors and has_mutation_handler(stage_name):
                 try:
@@ -743,6 +749,7 @@ class PipelineOrchestrator:
                 errors=errors,
                 duration_seconds=duration,
                 run_id=run_id,
+                summary_lines=summary_lines,
             )
 
             # Call gate hook

--- a/src/questfoundry/pipeline/summary.py
+++ b/src/questfoundry/pipeline/summary.py
@@ -5,6 +5,21 @@ After a stage completes successfully, the orchestrator passes its artifact
 :func:`build_stage_summary` to produce a short bulleted list shown in the
 CLI completion block. The intent is a 2-5 line ballpark check — "BRAINSTORM
 produced 3 dilemmas + 8 entities" — without opening the artifact files.
+
+Per-stage artifact shapes (as of 2026-04, post-#1057):
+
+- DREAM, BRAINSTORM, SEED, GROW: ``<Pydantic>.model_dump()`` — keys match
+  the model fields (genre/tone/themes; entities/dilemmas; arc_count etc.).
+- FILL: ``FillResult.model_dump()`` — passages_filled, passages_flagged,
+  entity_updates_applied, review_cycles, phases_completed.
+- DRESS: graph-derived dict with art_direction (dict), entity_visuals,
+  briefs, codex_entries, illustrations (each a dict-of-dicts keyed by id).
+- POLISH: ``{"phases_completed": [PolishPhaseResult, ...]}`` — only the
+  phase log; per-passage/choice counts live in the graph, not the artifact.
+
+Builders that look up a key not present in the artifact silently skip
+that line — adding a new stage or restructuring an artifact without
+updating the builder yields a missing summary, not an error.
 """
 
 from __future__ import annotations
@@ -12,10 +27,14 @@ from __future__ import annotations
 from collections import Counter
 from typing import TYPE_CHECKING, Any
 
+from questfoundry.observability.logging import get_logger
+
 if TYPE_CHECKING:
     from collections.abc import Callable, Iterable
 
     StageSummaryBuilder = Callable[[dict[str, Any]], list[str]]
+
+log = get_logger(__name__)
 
 
 def build_stage_summary(stage_name: str, artifact_data: Any) -> list[str]:
@@ -26,6 +45,11 @@ def build_stage_summary(stage_name: str, artifact_data: Any) -> list[str]:
     Summary block when the list is empty.
     """
     if not isinstance(artifact_data, dict):
+        log.debug(
+            "stage_summary_skipped_non_dict_artifact",
+            stage=stage_name,
+            type=type(artifact_data).__name__,
+        )
         return []
 
     builder = _BUILDERS.get(stage_name)
@@ -116,36 +140,39 @@ def _summarize_fill(data: dict[str, Any]) -> list[str]:
 
 
 def _summarize_dress(data: dict[str, Any]) -> list[str]:
+    """Summary for DRESS — artifact is graph-derived (dict-of-dicts per type).
+
+    Reports counts of entity_visuals / illustration_briefs / codex_entries /
+    illustrations. The illustrations count includes successes only; failures
+    surface as warnings during the run, not in this summary.
+    """
     lines: list[str] = []
-    if data.get("art_direction_created"):
+    if isinstance(data.get("art_direction"), dict) and data["art_direction"]:
         lines.append("Art direction: created")
-    lines.extend(
-        _count_int_fields(
-            data,
-            (
-                ("entity_visuals_created", "Entity visuals"),
-                ("codex_entries_created", "Codex entries"),
-                ("briefs_created", "Illustration briefs"),
-                ("illustrations_generated", "Illustrations generated"),
-                ("illustrations_failed", "Illustrations failed"),
-            ),
-        )
-    )
+    for key, label in (
+        ("entity_visuals", "Entity visuals"),
+        ("briefs", "Illustration briefs"),
+        ("codex_entries", "Codex entries"),
+        ("illustrations", "Illustrations"),
+    ):
+        value = data.get(key)
+        if isinstance(value, dict) and value:
+            lines.append(f"{label}: {len(value)}")
     return lines
 
 
 def _summarize_polish(data: dict[str, Any]) -> list[str]:
-    return _count_int_fields(
-        data,
-        (
-            ("passage_count", "Passages"),
-            ("choice_count", "Choices"),
-            ("variant_count", "Variants"),
-            ("residue_count", "Residue beats"),
-            ("sidetrack_count", "Sidetrack beats"),
-            ("false_branch_count", "False branches"),
-        ),
-    )
+    """Summary for POLISH — artifact is `{"phases_completed": [...]}`.
+
+    POLISH writes its outputs to the graph (passages, choices, state flags)
+    rather than into the artifact dict, so the per-count fields on
+    `PolishResult` aren't available here. We surface the phase tally only;
+    for headline counts, run `qf status` after POLISH.
+    """
+    phases = data.get("phases_completed")
+    if isinstance(phases, list) and phases:
+        return [f"Phases completed: {len(phases)}"]
+    return []
 
 
 _BUILDERS: dict[str, StageSummaryBuilder] = {
@@ -174,15 +201,14 @@ def _format_str_list(value: Any, limit: int = 4) -> str | None:
     return _truncate_items(items, limit=limit)
 
 
-def _truncate_items(items: Iterable[str], limit: int) -> str:
-    seq = list(items)
-    if len(seq) <= limit:
-        return ", ".join(seq)
-    return ", ".join(seq[:limit]) + ", ..."
+def _truncate_items(items: list[str], limit: int) -> str:
+    if len(items) <= limit:
+        return ", ".join(items)
+    return ", ".join(items[:limit]) + ", ..."
 
 
 def _format_counts(counter: Counter[str]) -> str:
-    return ", ".join(f"{count} {label}" for label, count in counter.most_common())
+    return ", ".join(f"{count} {category}" for category, count in counter.most_common())
 
 
 def _list_of_dicts(value: Any) -> list[dict[str, Any]]:

--- a/src/questfoundry/pipeline/summary.py
+++ b/src/questfoundry/pipeline/summary.py
@@ -1,0 +1,215 @@
+"""Build per-stage summary lines from stage artifact data.
+
+After a stage completes successfully, the orchestrator passes its artifact
+(the dict serialized from the stage's Pydantic output) through
+:func:`build_stage_summary` to produce a short bulleted list shown in the
+CLI completion block. The intent is a 2-5 line ballpark check — "BRAINSTORM
+produced 3 dilemmas + 8 entities" — without opening the artifact files.
+"""
+
+from __future__ import annotations
+
+from collections import Counter
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Iterable
+
+    StageSummaryBuilder = Callable[[dict[str, Any]], list[str]]
+
+
+def build_stage_summary(stage_name: str, artifact_data: Any) -> list[str]:
+    """Build a short list of summary lines for a stage's artifact.
+
+    Returns an empty list for stages without a builder, or for artifact
+    payloads that don't match the expected shape — the CLI suppresses the
+    Summary block when the list is empty.
+    """
+    if not isinstance(artifact_data, dict):
+        return []
+
+    builder = _BUILDERS.get(stage_name)
+    if builder is None:
+        return []
+    return builder(artifact_data)
+
+
+def _summarize_dream(data: dict[str, Any]) -> list[str]:
+    lines: list[str] = []
+    genre = _as_str(data.get("genre"))
+    subgenre = _as_str(data.get("subgenre"))
+    if genre:
+        lines.append(f"Genre: {genre} ({subgenre})" if subgenre else f"Genre: {genre}")
+    audience = _as_str(data.get("audience"))
+    if audience:
+        lines.append(f"Audience: {audience}")
+    tone = _format_str_list(data.get("tone"))
+    if tone:
+        lines.append(f"Tone: {tone}")
+    themes = _format_str_list(data.get("themes"))
+    if themes:
+        lines.append(f"Themes: {themes}")
+    scope = data.get("scope")
+    if isinstance(scope, dict):
+        story_size = _as_str(scope.get("story_size"))
+        if story_size:
+            lines.append(f"Scope: {story_size}")
+    return lines
+
+
+def _summarize_brainstorm(data: dict[str, Any]) -> list[str]:
+    lines: list[str] = []
+    entities = _list_of_dicts(data.get("entities"))
+    dilemmas = _list_of_dicts(data.get("dilemmas"))
+
+    if entities:
+        category_counts = Counter(
+            cat for cat in (_as_str(e.get("entity_category")) for e in entities) if cat is not None
+        )
+        if category_counts:
+            lines.append(f"Entities: {len(entities)} ({_format_counts(category_counts)})")
+        else:
+            lines.append(f"Entities: {len(entities)}")
+
+    if dilemmas:
+        lines.append(f"Dilemmas: {len(dilemmas)}")
+
+    return lines
+
+
+def _summarize_seed(data: dict[str, Any]) -> list[str]:
+    return _count_list_fields(
+        data,
+        (
+            ("entities", "Entities"),
+            ("dilemmas", "Dilemmas"),
+            ("paths", "Paths"),
+            ("consequences", "Consequences"),
+            ("initial_beats", "Initial beats"),
+        ),
+    )
+
+
+def _summarize_grow(data: dict[str, Any]) -> list[str]:
+    # GROW emits GrowResult after epic #1057 — beats live in graph; this
+    # artifact records derived counts only.
+    return _count_int_fields(
+        data,
+        (
+            ("arc_count", "Arcs"),
+            ("state_flag_count", "State flags"),
+            ("overlay_count", "Overlays"),
+        ),
+    )
+
+
+def _summarize_fill(data: dict[str, Any]) -> list[str]:
+    return _count_int_fields(
+        data,
+        (
+            ("passages_filled", "Passages filled"),
+            ("passages_flagged", "Passages flagged"),
+            ("entity_updates_applied", "Entity updates"),
+            ("review_cycles", "Review cycles"),
+        ),
+    )
+
+
+def _summarize_dress(data: dict[str, Any]) -> list[str]:
+    lines: list[str] = []
+    if data.get("art_direction_created"):
+        lines.append("Art direction: created")
+    lines.extend(
+        _count_int_fields(
+            data,
+            (
+                ("entity_visuals_created", "Entity visuals"),
+                ("codex_entries_created", "Codex entries"),
+                ("briefs_created", "Illustration briefs"),
+                ("illustrations_generated", "Illustrations generated"),
+                ("illustrations_failed", "Illustrations failed"),
+            ),
+        )
+    )
+    return lines
+
+
+def _summarize_polish(data: dict[str, Any]) -> list[str]:
+    return _count_int_fields(
+        data,
+        (
+            ("passage_count", "Passages"),
+            ("choice_count", "Choices"),
+            ("variant_count", "Variants"),
+            ("residue_count", "Residue beats"),
+            ("sidetrack_count", "Sidetrack beats"),
+            ("false_branch_count", "False branches"),
+        ),
+    )
+
+
+_BUILDERS: dict[str, StageSummaryBuilder] = {
+    "dream": _summarize_dream,
+    "brainstorm": _summarize_brainstorm,
+    "seed": _summarize_seed,
+    "grow": _summarize_grow,
+    "fill": _summarize_fill,
+    "dress": _summarize_dress,
+    "polish": _summarize_polish,
+}
+
+
+def _as_str(value: Any) -> str | None:
+    if isinstance(value, str) and value.strip():
+        return value.strip()
+    return None
+
+
+def _format_str_list(value: Any, limit: int = 4) -> str | None:
+    if not isinstance(value, list):
+        return None
+    items = [s for s in (_as_str(v) for v in value) if s is not None]
+    if not items:
+        return None
+    return _truncate_items(items, limit=limit)
+
+
+def _truncate_items(items: Iterable[str], limit: int) -> str:
+    seq = list(items)
+    if len(seq) <= limit:
+        return ", ".join(seq)
+    return ", ".join(seq[:limit]) + ", ..."
+
+
+def _format_counts(counter: Counter[str]) -> str:
+    return ", ".join(f"{count} {label}" for label, count in counter.most_common())
+
+
+def _list_of_dicts(value: Any) -> list[dict[str, Any]]:
+    if not isinstance(value, list):
+        return []
+    return [item for item in value if isinstance(item, dict)]
+
+
+def _count_list_fields(
+    data: dict[str, Any],
+    mapping: Iterable[tuple[str, str]],
+) -> list[str]:
+    lines: list[str] = []
+    for key, label in mapping:
+        value = data.get(key)
+        if isinstance(value, list) and value:
+            lines.append(f"{label}: {len(value)}")
+    return lines
+
+
+def _count_int_fields(
+    data: dict[str, Any],
+    mapping: Iterable[tuple[str, str]],
+) -> list[str]:
+    lines: list[str] = []
+    for key, label in mapping:
+        value = data.get(key)
+        if isinstance(value, int) and value > 0:
+            lines.append(f"{label}: {value}")
+    return lines

--- a/tests/unit/test_pipeline_summary.py
+++ b/tests/unit/test_pipeline_summary.py
@@ -130,47 +130,55 @@ class TestFill:
 
 class TestDress:
     def test_dress_full(self) -> None:
+        # Mirrors the actual graph-derived shape from DressStage._extract_artifact:
+        # dict-of-dicts keyed by node id, plus an art_direction dict.
         data = {
-            "art_direction_created": True,
-            "entity_visuals_created": 5,
-            "codex_entries_created": 8,
-            "briefs_created": 3,
-            "illustrations_generated": 3,
-            "illustrations_failed": 0,
+            "art_direction": {"art_direction_id": "main", "style": "noir"},
+            "entity_visuals": {"ev1": {}, "ev2": {}, "ev3": {}, "ev4": {}, "ev5": {}},
+            "briefs": {"b1": {}, "b2": {}, "b3": {}},
+            "codex_entries": {f"c{i}": {} for i in range(8)},
+            "illustrations": {"i1": {}, "i2": {}, "i3": {}},
         }
         lines = build_stage_summary("dress", data)
         assert lines[0] == "Art direction: created"
         assert "Entity visuals: 5" in lines
         assert "Codex entries: 8" in lines
-        assert "Illustrations failed: 0" not in lines  # zero skipped
+        assert "Illustration briefs: 3" in lines
+        assert "Illustrations: 3" in lines
 
     def test_dress_no_art_direction(self) -> None:
-        data = {"art_direction_created": False, "codex_entries_created": 3}
+        # Graph extraction returns {} when the art_direction node is absent.
+        data = {"art_direction": {}, "codex_entries": {"c1": {}, "c2": {}, "c3": {}}}
         lines = build_stage_summary("dress", data)
         assert lines == ["Codex entries: 3"]
 
+    def test_dress_empty_collections_skipped(self) -> None:
+        data = {
+            "art_direction": {},
+            "entity_visuals": {},
+            "briefs": {"b1": {}},
+            "codex_entries": {},
+            "illustrations": {},
+        }
+        lines = build_stage_summary("dress", data)
+        assert lines == ["Illustration briefs: 1"]
+
 
 class TestPolish:
-    def test_polish_counts(self) -> None:
-        data = {
-            "passage_count": 24,
-            "choice_count": 18,
-            "variant_count": 4,
-            "residue_count": 2,
-            "sidetrack_count": 1,
-            "false_branch_count": 3,
-        }
+    # POLISH writes its outputs to the graph (passages, choices, state flags),
+    # not into the artifact dict. The artifact is just `{"phases_completed": [...]}`,
+    # so the summary surfaces phase tally only — for headline counts use `qf status`.
+    def test_polish_phases_completed(self) -> None:
+        data = {"phases_completed": [{"phase": "5a"}, {"phase": "5b"}, {"phase": "5c"}]}
         lines = build_stage_summary("polish", data)
-        assert lines == [
-            "Passages: 24",
-            "Choices: 18",
-            "Variants: 4",
-            "Residue beats: 2",
-            "Sidetrack beats: 1",
-            "False branches: 3",
-        ]
+        assert lines == ["Phases completed: 3"]
 
-    def test_polish_zero_skipped(self) -> None:
-        data = {"passage_count": 24, "choice_count": 0}
+    def test_polish_empty_phases(self) -> None:
+        data: dict[str, Any] = {"phases_completed": []}
         lines = build_stage_summary("polish", data)
-        assert lines == ["Passages: 24"]
+        assert lines == []
+
+    def test_polish_missing_phases_key(self) -> None:
+        data: dict[str, Any] = {"some_other_field": 42}
+        lines = build_stage_summary("polish", data)
+        assert lines == []

--- a/tests/unit/test_pipeline_summary.py
+++ b/tests/unit/test_pipeline_summary.py
@@ -1,0 +1,176 @@
+"""Tests for pipeline.summary — per-stage CLI summary builders."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from questfoundry.pipeline.summary import build_stage_summary
+
+
+class TestUnknownAndEmpty:
+    def test_unknown_stage_returns_empty(self) -> None:
+        assert build_stage_summary("nope", {"foo": "bar"}) == []
+
+    def test_non_dict_artifact_returns_empty(self) -> None:
+        assert build_stage_summary("dream", "not a dict") == []  # type: ignore[arg-type]
+
+    def test_empty_dict_returns_empty(self) -> None:
+        assert build_stage_summary("dream", {}) == []
+
+
+class TestDream:
+    def test_full_dream(self) -> None:
+        data: dict[str, Any] = {
+            "genre": "dark fantasy",
+            "subgenre": "gothic horror",
+            "audience": "adult",
+            "tone": ["bleak", "claustrophobic"],
+            "themes": ["guilt", "redemption", "sacrifice"],
+            "scope": {"story_size": "short"},
+        }
+        lines = build_stage_summary("dream", data)
+        assert lines == [
+            "Genre: dark fantasy (gothic horror)",
+            "Audience: adult",
+            "Tone: bleak, claustrophobic",
+            "Themes: guilt, redemption, sacrifice",
+            "Scope: short",
+        ]
+
+    def test_dream_no_subgenre(self) -> None:
+        data = {"genre": "noir", "audience": "adult", "themes": ["loss"], "tone": ["cold"]}
+        lines = build_stage_summary("dream", data)
+        assert lines[0] == "Genre: noir"
+
+    def test_dream_long_themes_truncated(self) -> None:
+        data = {
+            "genre": "g",
+            "themes": ["a", "b", "c", "d", "e", "f"],
+            "tone": ["t"],
+        }
+        lines = build_stage_summary("dream", data)
+        # _format_str_list default limit=4
+        assert "Themes: a, b, c, d, ..." in lines
+
+
+class TestBrainstorm:
+    def test_entities_with_categories(self) -> None:
+        data = {
+            "entities": [
+                {"entity_category": "character"},
+                {"entity_category": "character"},
+                {"entity_category": "location"},
+            ],
+            "dilemmas": [{"id": "d1"}, {"id": "d2"}],
+        }
+        lines = build_stage_summary("brainstorm", data)
+        assert lines[0].startswith("Entities: 3 (")
+        assert "2 character" in lines[0]
+        assert "1 location" in lines[0]
+        assert lines[-1] == "Dilemmas: 2"
+
+    def test_entities_without_categories(self) -> None:
+        data = {"entities": [{"foo": "bar"}]}
+        lines = build_stage_summary("brainstorm", data)
+        assert lines == ["Entities: 1"]
+
+
+class TestSeed:
+    def test_seed_counts(self) -> None:
+        data = {
+            "entities": [{}, {}, {}],
+            "dilemmas": [{}, {}],
+            "paths": [{}, {}, {}, {}],
+            "consequences": [{}],
+            "initial_beats": [{}, {}, {}, {}, {}],
+        }
+        lines = build_stage_summary("seed", data)
+        assert lines == [
+            "Entities: 3",
+            "Dilemmas: 2",
+            "Paths: 4",
+            "Consequences: 1",
+            "Initial beats: 5",
+        ]
+
+    def test_seed_empty_lists_skipped(self) -> None:
+        data = {"entities": [], "dilemmas": [{}]}
+        lines = build_stage_summary("seed", data)
+        assert lines == ["Dilemmas: 1"]
+
+
+class TestGrow:
+    def test_grow_int_counts(self) -> None:
+        data = {"arc_count": 3, "state_flag_count": 5, "overlay_count": 2}
+        lines = build_stage_summary("grow", data)
+        assert lines == ["Arcs: 3", "State flags: 5", "Overlays: 2"]
+
+    def test_grow_zero_counts_skipped(self) -> None:
+        data = {"arc_count": 0, "state_flag_count": 4}
+        lines = build_stage_summary("grow", data)
+        assert lines == ["State flags: 4"]
+
+
+class TestFill:
+    def test_fill_counts(self) -> None:
+        data = {
+            "passages_filled": 12,
+            "passages_flagged": 1,
+            "entity_updates_applied": 4,
+            "review_cycles": 2,
+        }
+        lines = build_stage_summary("fill", data)
+        assert lines == [
+            "Passages filled: 12",
+            "Passages flagged: 1",
+            "Entity updates: 4",
+            "Review cycles: 2",
+        ]
+
+
+class TestDress:
+    def test_dress_full(self) -> None:
+        data = {
+            "art_direction_created": True,
+            "entity_visuals_created": 5,
+            "codex_entries_created": 8,
+            "briefs_created": 3,
+            "illustrations_generated": 3,
+            "illustrations_failed": 0,
+        }
+        lines = build_stage_summary("dress", data)
+        assert lines[0] == "Art direction: created"
+        assert "Entity visuals: 5" in lines
+        assert "Codex entries: 8" in lines
+        assert "Illustrations failed: 0" not in lines  # zero skipped
+
+    def test_dress_no_art_direction(self) -> None:
+        data = {"art_direction_created": False, "codex_entries_created": 3}
+        lines = build_stage_summary("dress", data)
+        assert lines == ["Codex entries: 3"]
+
+
+class TestPolish:
+    def test_polish_counts(self) -> None:
+        data = {
+            "passage_count": 24,
+            "choice_count": 18,
+            "variant_count": 4,
+            "residue_count": 2,
+            "sidetrack_count": 1,
+            "false_branch_count": 3,
+        }
+        lines = build_stage_summary("polish", data)
+        assert lines == [
+            "Passages: 24",
+            "Choices: 18",
+            "Variants: 4",
+            "Residue beats: 2",
+            "Sidetrack beats: 1",
+            "False branches: 3",
+        ]
+
+    def test_polish_zero_skipped(self) -> None:
+        data = {"passage_count": 24, "choice_count": 0}
+        lines = build_stage_summary("polish", data)
+        assert lines == ["Passages: 24"]


### PR DESCRIPTION
## Summary

Closes #1512. Supersedes the stale PR #947 (closed) which was 2 months out of date and referenced the pre-#1057 GROW artifact shape (arc_count / passage_count / codeword_count, since migrated to POLISH and renamed StateFlag).

After a stage completes successfully, print a 2-5 line bulleted summary of the artifact's salient counts and headline fields — a quick ballpark check ("BRAINSTORM produced 3 dilemmas + 8 entities") without opening the artifact files.

```
  ✓ DREAM stage completed
    Tokens: 1,234
    Duration: 5.2s
    Summary:
      - Genre: dark fantasy (gothic horror)
      - Audience: adult
      - Tone: bleak, claustrophobic
      - Themes: guilt, redemption, sacrifice
      - Scope: short
```

## Stages covered

| Stage | Fields shown |
|-------|--------------|
| DREAM | genre + subgenre, audience, tone, themes, scope.story_size |
| BRAINSTORM | entity count by category, dilemma count |
| SEED | entities, dilemmas, paths, consequences, initial_beats |
| GROW | arc_count, state_flag_count, overlay_count |
| FILL | passages_filled, passages_flagged, entity_updates_applied, review_cycles |
| DRESS | art_direction (presence), entity_visuals, briefs, codex_entries, illustrations (graph-derived dict-of-dicts counts) |
| POLISH | phases_completed (graph-derived counts available via `qf status`) |

POLISH writes its outputs to the graph rather than into the artifact dict (the actual artifact is just `{"phases_completed": [...]}`), so the summary surfaces phase tally only.

SHIP is intentionally excluded — it runs through a different CLI code path (`_run_ship`), no LLM, output is a file path rather than an artifact dict. Worth a follow-up if useful.

## Plumbing

- `StageResult.summary_lines: list[str] = field(default_factory=list)` (orchestrator)
- Populated only when validation passes (skipped on stage failure)
- Rendered by the CLI completion block in `cli.py`
- Builders dispatch table in `pipeline/summary.py:_BUILDERS`; unknown stages return `[]` so no Summary block prints
- Non-dict artifacts emit a `log.debug("stage_summary_skipped_non_dict_artifact")` so silent misses are visible during dev

## Test plan

- [x] `uv run ruff check` + `uv run ruff format` — pass
- [x] `uv run mypy src/questfoundry/pipeline/summary.py src/questfoundry/pipeline/orchestrator.py src/questfoundry/cli.py` — pass
- [x] `uv run pytest tests/unit/test_pipeline_summary.py` — 19 passed
- [x] `uv run pytest tests/unit/test_orchestrator.py` — 52 passed (no regressions)
- [x] Bot review (claude-review) — approved on 2nd pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)