### PR TITLE
docs(dream): worked example uses YAML list for tone

### DIFF
--- a/docs/design/procedures/brainstorm.md
+++ b/docs/design/procedures/brainstorm.md
@@ -274,7 +274,9 @@ R-3.8: No Path / Beat / Consequence / State Flag / Passage / Intersection Group 
 vision:
   genre: "dark fantasy"
   subgenre: "mystery"
-  tone: "atmospheric, morally ambiguous"
+  tone:
+    - "atmospheric"
+    - "morally ambiguous"
   themes: ["forbidden knowledge", "trust", "corruption"]
   audience: "adult readers of literary speculative fiction"
   scope: short

--- a/docs/design/procedures/dream.md
+++ b/docs/design/procedures/dream.md
@@ -237,7 +237,9 @@ R-1.13: Rejection loops back to the operation that contains the misalignment.
 vision:
   genre: "dark fantasy"
   subgenre: "mystery"
-  tone: "atmospheric, morally ambiguous"
+  tone:
+    - "atmospheric"
+    - "morally ambiguous"
   themes:
     - "forbidden knowledge"
     - "trust"


### PR DESCRIPTION
## Summary

Closes #1424.

The DREAM worked example at `docs/design/procedures/dream.md:240` showed `tone` as a comma-separated string (`"atmospheric, morally ambiguous"`), but `DreamArtifact.tone` (`src/questfoundry/models/dream.py:57-59`) is `list[str]`. Anyone using the example as a copy-paste reference would emit output that fails Pydantic validation.

Updated to YAML list style, matching `themes` directly below in the same example.

## Test plan

- [x] `dream.md:240` shows `tone` as a YAML list
- [x] Worked example still parses as valid YAML and would deserialize cleanly to `DreamArtifact`
- [ ] Bot review

🤖 Generated with [Claude Code](https://claude.com/claude-code)