### PR TITLE
fix(dress): align spoiler_check.yaml examples with dress.md R-3.6 + R-3.7

### DIFF
--- a/docs/design/procedures/dress.md
+++ b/docs/design/procedures/dress.md
@@ -149,7 +149,7 @@ R-3.8. LLM call per entity receives: full Entity description (base + overlays), 
 |---------|-----------|-------------|
 | Entity has no CodexEntry | Phase 3 skipped | R-3.1 |
 | Rank-1 entry has `visible_when: [state_flag::mentor_hostile]` | Rank 1 must be unconditional | R-3.2 |
-| Rank-1 entry: "A mysterious scholar who secretly knows your true identity." Rank 2 (gated behind `met_aldric`): "Aldric is the traitor who betrayed your mentor." | Rank 1 prematurely disclosed the deception angle — that reveal was supposed to be gated behind rank 2. Direction of spoiler is low tier → high tier content | R-3.6 |
+| Rank-1 entry: "A mysterious scholar who secretly knows your true identity." Rank 2 (gated behind `state_flag::met_aldric`): "Aldric is the traitor who betrayed your mentor." | Rank 1 prematurely disclosed the deception angle — that reveal was supposed to be gated behind rank 2. Direction of spoiler is low tier → high tier content | R-3.6 |
 | `visible_when` references `codeword::met_aldric` | Should be a state flag ID; codewords are SHIP's projection | R-3.7 |
 | Entry: "Aldric is a character who serves as the protagonist's mentor" | Non-diegetic voice | R-3.4 |
 

--- a/prompts/templates/dress_codex_spoiler_check.yaml
+++ b/prompts/templates/dress_codex_spoiler_check.yaml
@@ -18,14 +18,14 @@ system: |
   ## Examples
 
   **Leak (rank 1 → rank 2):**
-  - rank 1: "A traveling scholar who secretly knows your true identity."
-  - rank 2 (gated by `met_aldric`): "Aldric is the traitor who betrayed your mentor."
+  - rank 1: "A mysterious scholar who secretly knows your true identity."
+  - rank 2 (gated by `state_flag::met_aldric`): "Aldric is the traitor who betrayed your mentor."
   - Verdict: rank 1 leaks the deception angle. The reveal "this trusted figure
     is hiding a major secret about you" is what rank 2 was supposed to deliver.
 
   **No leak:**
-  - rank 1: "A traveling scholar who offers guidance to weary travelers."
-  - rank 2 (gated by `met_aldric`): "Aldric is the traitor who betrayed your mentor."
+  - rank 1: "A mysterious scholar who offers guidance to weary travelers."
+  - rank 2 (gated by `state_flag::met_aldric`): "Aldric is the traitor who betrayed your mentor."
   - Verdict: rank 1 stays in deliberately vague public-knowledge territory.
 
   ## Output Schema


### PR DESCRIPTION
## Summary

Closes #1440.

Two pre-existing inconsistencies in `prompts/templates/dress_codex_spoiler_check.yaml` vs the just-updated generation templates (`dress_codex.yaml` / `dress_codex_batch.yaml` — both updated in #1438):

1. **BAD example wording**: leak example used `"A traveling scholar..."` but the canonical wording in `dress.md:152` (R-3.6 violations table) is `"A mysterious scholar..."`. Updated both leak + no-leak examples so the contrast is just the rank-1 framing of the same character.
2. **State flag prefix**: bare `met_aldric` → namespaced `state_flag::met_aldric` per R-3.7 (mandatory). Generation templates already use the namespaced form; spoiler_check predates the convention tightening.

Prompt-only change. No code changes.

## Test plan

- [x] `dress_codex_spoiler_check.yaml` BAD example uses `"mysterious scholar"` (verbatim from spec violations table)
- [x] All state flag IDs in the template carry the `state_flag::` prefix
- [x] `uv run pytest tests/unit/test_dress_stage.py` — 106 passed (no regressions)
- [ ] Bot review

🤖 Generated with [Claude Code](https://claude.com/claude-code)