### PR TITLE
feat(providers): VRAM-aware num_ctx for Ollama via --max-vram / QF_MAX_VRAM

### DIFF
--- a/src/questfoundry/cli.py
+++ b/src/questfoundry/cli.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import atexit
+import os
 import sys
 from pathlib import Path
 from typing import TYPE_CHECKING, Annotated, Any
@@ -1829,6 +1830,18 @@ def run(
         str | None,
         typer.Option("--language", "-l", help="Output language (ISO 639-1 code, e.g., nl, ja, de)"),
     ] = None,
+    max_vram: Annotated[
+        float | None,
+        typer.Option(
+            "--max-vram",
+            help=(
+                "VRAM budget in GB for Ollama models. Computes the largest num_ctx "
+                "that fits weights + KV cache in this budget, preventing silent "
+                "spillover to CPU. Ignored for cloud providers. Equivalent to "
+                "setting QF_MAX_VRAM=<value> in the environment."
+            ),
+        ),
+    ] = None,
 ) -> None:
     """Run multiple pipeline stages sequentially.
 
@@ -1836,14 +1849,25 @@ def run(
     target stage. By default, skips already-completed stages and uses
     non-interactive mode for batch execution.
 
+    For individual stage commands (qf dream, qf brainstorm, ...), set
+    ``QF_MAX_VRAM=<gb>`` in the environment to apply VRAM-aware
+    num_ctx sizing across the whole session.
+
     Examples:
         qf run --to seed --prompt "A mystery story"
         qf run --to brainstorm --from dream --force
         qf run --to seed --prompt "A mystery" --init --project my-story
+        qf run --to fill --max-vram 12     # sized for a 12 GB consumer GPU
     """
     project_path = _resolve_project_path(project)
     project_path = _ensure_project(project_path, auto_init=init, provider=provider)
     _configure_project_logging(project_path)
+
+    if max_vram is not None:
+        if max_vram <= 0:
+            console.print("[red]Error:[/red] --max-vram must be positive.")
+            raise typer.Exit(1)
+        os.environ["QF_MAX_VRAM"] = str(max_vram)
 
     log = get_logger(__name__)
 

--- a/src/questfoundry/providers/factory.py
+++ b/src/questfoundry/providers/factory.py
@@ -156,6 +156,22 @@ def _preprocess_provider_kwargs(
     """
     kwargs = dict(kwargs)  # Don't mutate input
 
+    # max_vram is a QuestFoundry-only kwarg — never pass it through to the
+    # provider client. Resolve here and translate to num_ctx for ollama.
+    max_vram = kwargs.pop("max_vram", None)
+    if max_vram is None:
+        env_max_vram = os.getenv("QF_MAX_VRAM")
+        if env_max_vram is not None:
+            try:
+                max_vram = float(env_max_vram)
+            except ValueError:
+                log.warning(
+                    "qf_max_vram_invalid",
+                    value=env_max_vram,
+                    msg="QF_MAX_VRAM must be a positive number; ignoring",
+                )
+                max_vram = None
+
     if provider == "ollama":
         # Resolve host from kwargs or env var
         host = kwargs.pop("host", None) or os.getenv("OLLAMA_HOST")
@@ -167,10 +183,45 @@ def _preprocess_provider_kwargs(
             )
         kwargs["base_url"] = host
 
-        # Query Ollama for num_ctx if not explicitly provided
+        # Resolve num_ctx. Precedence:
+        #   1. explicit num_ctx kwarg (caller's choice — never override)
+        #   2. max_vram-driven calculation (one /api/show round-trip)
+        #   3. /api/show num_ctx field (Modelfile or architectural max)
+        #   4. hard fallback 32_768
         if "num_ctx" not in kwargs:
-            num_ctx = _query_ollama_num_ctx(host, model)
+            show_data = _query_ollama_show(host, model)
+            num_ctx: int | None = None
+
+            if max_vram is not None and max_vram > 0 and show_data is not None:
+                from questfoundry.providers.vram import (
+                    VramTooSmallError,
+                    calculate_max_context,
+                )
+
+                try:
+                    architectural_max = _extract_architectural_max_from_show(show_data, model)
+                    num_ctx = calculate_max_context(
+                        max_vram, show_data, architectural_max=architectural_max
+                    )
+                except VramTooSmallError:
+                    raise
+                except ValueError as exc:
+                    log.warning(
+                        "vram_calc_skipped",
+                        model=model,
+                        reason=str(exc),
+                    )
+
+            if num_ctx is None and show_data is not None:
+                num_ctx = _extract_num_ctx_from_show(show_data, model)
+
             kwargs["num_ctx"] = num_ctx if num_ctx else 32_768
+    elif max_vram is not None:
+        log.debug(
+            "max_vram_ignored_non_ollama",
+            provider=provider,
+            msg="--max-vram only affects Ollama; cloud providers manage their own context",
+        )
 
     elif provider == "openai":
         # Resolve API key from kwargs or env var (handles api_key=None case)
@@ -406,19 +457,12 @@ def _normalize_provider(provider_name: str) -> str:
     return name
 
 
-def _query_ollama_num_ctx(host: str, model: str) -> int | None:
-    """Query Ollama /api/show to get the model's configured num_ctx.
+def _query_ollama_show(host: str, model: str) -> dict[str, Any] | None:
+    """Query Ollama /api/show and return the parsed response dict.
 
-    Parses the ``parameters`` field from the response which contains the
-    Modelfile-configured values (e.g., ``num_ctx  32768``).
-
-    Args:
-        host: Ollama server base URL.
-        model: Model name.
-
-    Returns:
-        The num_ctx value from the model's configuration, or None if the
-        query fails or the value is not found.
+    Centralised so callers needing different fields (num_ctx, architecture
+    metadata for VRAM calculation) share one HTTP round-trip per model.
+    Returns None on any error — callers fall back to their own defaults.
     """
     import httpx
 
@@ -426,12 +470,19 @@ def _query_ollama_num_ctx(host: str, model: str) -> int | None:
         with httpx.Client(timeout=10.0) as client:
             resp = client.post(f"{host}/api/show", json={"model": model})
             resp.raise_for_status()
-            data = resp.json()
+            return resp.json()  # type: ignore[no-any-return]
     except Exception as exc:
         log.warning("ollama_show_failed", model=model, error=str(exc))
         return None
 
-    # Parse the 'parameters' field: newline-separated "key  value" pairs
+
+def _extract_num_ctx_from_show(data: dict[str, Any], model: str) -> int | None:
+    """Pull num_ctx from a parsed /api/show response.
+
+    Prefers the Modelfile-configured value (``parameters: "num_ctx 32768"``);
+    falls back to the architectural ``*.context_length`` if no Modelfile
+    override is present.
+    """
     parameters = data.get("parameters", "")
     for line in parameters.splitlines():
         parts = line.split()
@@ -440,7 +491,7 @@ def _query_ollama_num_ctx(host: str, model: str) -> int | None:
                 num_ctx = int(parts[-1])
                 log.info("ollama_num_ctx_from_model", model=model, num_ctx=num_ctx)
                 return num_ctx
-            except ValueError as e:  # pragma: no cover - malformed ollama API response, defensive
+            except ValueError as e:  # pragma: no cover - defensive against malformed Ollama API
                 log.debug(
                     "ollama_num_ctx_parse_failed",
                     error=str(e),
@@ -448,14 +499,33 @@ def _query_ollama_num_ctx(host: str, model: str) -> int | None:
                     value=parts[-1] if parts else None,
                 )
 
-    # Fallback: check model_info for architecture context_length
+    return _extract_architectural_max_from_show(data, model)
+
+
+def _extract_architectural_max_from_show(data: dict[str, Any], model: str) -> int | None:
+    """Return the architectural max context length, ignoring Modelfile overrides.
+
+    Used as the cap for VRAM-aware num_ctx — the Modelfile's `num_ctx`
+    is one default value, but max_vram should be able to compute *up to*
+    the architectural maximum if VRAM allows.
+    """
     model_info = data.get("model_info", {})
     for key, value in model_info.items():
         if key.endswith(".context_length") and isinstance(value, int):
             log.info("ollama_num_ctx_from_arch", model=model, num_ctx=value)
             return value
-
     return None
+
+
+def _query_ollama_num_ctx(host: str, model: str) -> int | None:
+    """Query Ollama /api/show to get the model's configured num_ctx.
+
+    Convenience wrapper preserved for callers that only need num_ctx.
+    """
+    data = _query_ollama_show(host, model)
+    if data is None:
+        return None
+    return _extract_num_ctx_from_show(data, model)
 
 
 async def unload_ollama_model(chat_model: BaseChatModel) -> None:

--- a/src/questfoundry/providers/factory.py
+++ b/src/questfoundry/providers/factory.py
@@ -181,6 +181,9 @@ def _preprocess_provider_kwargs(
                 "ollama",
                 "OLLAMA_HOST not configured. Set OLLAMA_HOST environment variable.",
             )
+        # Strip trailing slash once at the source — httpx silently normalises
+        # the resulting "//api/show" but we'd rather not rely on that.
+        host = host.rstrip("/")
         kwargs["base_url"] = host
 
         # Resolve num_ctx. Precedence:

--- a/src/questfoundry/providers/factory.py
+++ b/src/questfoundry/providers/factory.py
@@ -217,13 +217,17 @@ def _preprocess_provider_kwargs(
 
             kwargs["num_ctx"] = num_ctx if num_ctx else 32_768
     elif max_vram is not None:
+        # max_vram only affects Ollama. Log and fall through to the
+        # cloud-provider config below — claude-review caught a bug where
+        # this branch was the second `elif` in the chain and short-circuited
+        # api_key injection for cloud providers when max_vram was passed.
         log.debug(
             "max_vram_ignored_non_ollama",
             provider=provider,
             msg="--max-vram only affects Ollama; cloud providers manage their own context",
         )
 
-    elif provider == "openai":
+    if provider == "openai":
         # Resolve API key from kwargs or env var (handles api_key=None case)
         api_key = kwargs.get("api_key") or os.getenv("OPENAI_API_KEY")
         if not api_key:

--- a/src/questfoundry/providers/vram.py
+++ b/src/questfoundry/providers/vram.py
@@ -1,0 +1,264 @@
+"""VRAM-aware context-length calculation for local Ollama models.
+
+When a local model is run with too large a context, Ollama silently
+spills the KV cache to CPU memory and inference becomes 10-100x slower —
+the pipeline appears to hang. The user-facing `--max-vram <GB>` flag
+asks: "given this VRAM budget, what is the largest ``num_ctx`` that
+keeps weights + overhead + KV cache in GPU memory?"
+
+The formula (from https://localllm.in/blog/interactive-vram-calculator):
+
+    VRAM = model_weights + overhead + kv_cache
+
+where:
+    model_weights = P * b_w                      # params * bytes/weight
+    overhead      = 0.55 + 0.08 * P              # CUDA buffers + scratchpad
+    kv_cache      = B * N * 2 * L * (d/g) * b_kv / 1e9
+
+Solving for the max context length N:
+    N_max = (vram_gb - model_weights - overhead) * 1e9 / (B * 2 * L * (d/g) * b_kv)
+
+with:
+    P     = parameters in billions
+    b_w   = bytes per weight (quantization-dependent; see QUANT_BYTES_PER_WEIGHT)
+    B     = batch size (1 for QuestFoundry — single request)
+    L     = transformer layers (block_count)
+    d     = hidden dimension (embedding_length)
+    g     = GQA grouping factor (n_head / n_kv_head)
+    b_kv  = bytes per KV scalar (typically 2 for FP16 KV cache)
+
+All architectural values come from Ollama's ``/api/show`` endpoint:
+``details.parameter_size``, ``details.quantization_level``,
+``model_info["*.block_count"]``, ``model_info["*.embedding_length"]``,
+``model_info["*.attention.head_count"]``, ``model_info["*.attention.head_count_kv"]``.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from questfoundry.observability.logging import get_logger
+
+log = get_logger(__name__)
+
+
+# Bytes per weight by GGUF quantization format. Practical values that
+# include a small overhead allowance — see the interactive VRAM calculator
+# referenced in the module docstring. A model packed FP16 takes 2 bytes
+# per weight; lower quantizations pack tighter.
+QUANT_BYTES_PER_WEIGHT: dict[str, float] = {
+    "Q2_K": 0.31,
+    "Q3_K_S": 0.39,
+    "Q3_K_M": 0.43,
+    "Q3_K_L": 0.45,
+    "Q4_0": 0.50,
+    "Q4_1": 0.53,
+    "Q4_K_S": 0.53,
+    "Q4_K_M": 0.57,
+    "Q5_0": 0.63,
+    "Q5_1": 0.65,
+    "Q5_K_S": 0.65,
+    "Q5_K_M": 0.68,
+    "Q6_K": 0.78,
+    "Q8_0": 1.00,
+    "F16": 2.00,
+    "FP16": 2.00,
+    "BF16": 2.00,
+    "F32": 4.00,
+    "FP32": 4.00,
+}
+
+# Conservative fallback when quantization is unknown — assume Q4_K_M
+# (the most common default). A miscalculation here is forgiving:
+# overestimating bytes/weight just gives a smaller num_ctx, never one
+# that overshoots VRAM.
+DEFAULT_BYTES_PER_WEIGHT = 0.57
+
+# Floor: below 2048 tokens, no QuestFoundry stage produces useful output.
+# If max_vram is too small, fail loudly rather than silently choosing 0.
+MIN_NUM_CTX = 2048
+
+# Round down to a 1024-aligned value — Ollama tunes for power-of-2-aligned
+# contexts and arbitrary sizes don't always help.
+NUM_CTX_ALIGNMENT = 1024
+
+
+class VramTooSmallError(ValueError):
+    """Raised when the VRAM budget is below the model's weights + overhead.
+
+    The model can't even load — there's nothing to do but raise. Caller
+    surfaces this to the user with the model and budget so they can pick
+    a smaller model or a larger budget.
+    """
+
+    def __init__(self, model: str, vram_gb: float, weights_gb: float, overhead_gb: float) -> None:
+        self.model = model
+        self.vram_gb = vram_gb
+        self.weights_gb = weights_gb
+        self.overhead_gb = overhead_gb
+        super().__init__(
+            f"Model '{model}' weights ({weights_gb:.2f} GB) plus overhead "
+            f"({overhead_gb:.2f} GB) exceed the {vram_gb:.2f} GB VRAM budget "
+            f"with no room left for KV cache. Pick a smaller model or raise "
+            f"--max-vram."
+        )
+
+
+def parse_quantization(level: str | None) -> float:
+    """Map a GGUF quantization level string to bytes per weight.
+
+    Returns the value from ``QUANT_BYTES_PER_WEIGHT`` if known; otherwise
+    falls back to ``DEFAULT_BYTES_PER_WEIGHT`` and emits a debug log.
+    Match is case-insensitive on the part before any trailing whitespace.
+    """
+    if not level:
+        return DEFAULT_BYTES_PER_WEIGHT
+    key = level.strip().upper()
+    if key in QUANT_BYTES_PER_WEIGHT:
+        return QUANT_BYTES_PER_WEIGHT[key]
+    log.debug("vram_unknown_quantization", level=level, fallback=DEFAULT_BYTES_PER_WEIGHT)
+    return DEFAULT_BYTES_PER_WEIGHT
+
+
+def parse_parameter_size(size_str: str | None) -> float | None:
+    """Parse Ollama's ``parameter_size`` field (e.g., ``"8.0B"``) to billions.
+
+    Returns the float value or None if the string can't be parsed.
+    """
+    if not size_str:
+        return None
+    s = size_str.strip().upper()
+    suffix_multipliers = {"B": 1.0, "M": 0.001, "K": 0.000001}
+    for suffix, multiplier in suffix_multipliers.items():
+        if s.endswith(suffix):
+            try:
+                return float(s[:-1]) * multiplier
+            except ValueError:
+                return None
+    try:
+        return float(s)
+    except ValueError:
+        return None
+
+
+def _extract_arch_field(model_info: dict[str, Any], suffix: str) -> int | None:
+    """Find an architecture field by suffix (e.g., ``.block_count``).
+
+    Ollama prefixes architecture keys with the family name
+    (``"qwen2.block_count"``, ``"llama.embedding_length"``). Walking by
+    suffix avoids hard-coding the family.
+    """
+    for key, value in model_info.items():
+        if key.endswith(suffix) and isinstance(value, int) and value > 0:
+            return value
+    return None
+
+
+def calculate_max_context(
+    vram_gb: float,
+    show_data: dict[str, Any],
+    *,
+    batch_size: int = 1,
+    bytes_per_kv_scalar: int = 2,
+    architectural_max: int | None = None,
+) -> int:
+    """Compute the largest ``num_ctx`` that fits in ``vram_gb`` GB of VRAM.
+
+    Reads architectural metadata from ``show_data`` (the parsed response
+    from Ollama's ``/api/show``), applies the formula in the module
+    docstring, and returns a 1024-aligned context length clamped to
+    ``[MIN_NUM_CTX, architectural_max]``.
+
+    Raises:
+        VramTooSmallError: when weights + overhead alone exceed the budget.
+        ValueError: when required architectural fields are missing from
+            ``show_data`` (the caller should treat this as "unable to
+            compute" and fall back to the standard num_ctx detection).
+    """
+    if vram_gb <= 0:
+        raise ValueError(f"vram_gb must be positive, got {vram_gb}")
+
+    details = show_data.get("details", {}) or {}
+    model_info = show_data.get("model_info", {}) or {}
+
+    parameters_b = parse_parameter_size(details.get("parameter_size"))
+    if parameters_b is None or parameters_b <= 0:
+        raise ValueError("show_data.details.parameter_size missing or unparsable")
+
+    bytes_per_weight = parse_quantization(details.get("quantization_level"))
+
+    block_count = _extract_arch_field(model_info, ".block_count")
+    embedding_length = _extract_arch_field(model_info, ".embedding_length")
+    head_count = _extract_arch_field(model_info, ".attention.head_count")
+    head_count_kv = _extract_arch_field(model_info, ".attention.head_count_kv")
+
+    if not all((block_count, embedding_length, head_count, head_count_kv)):
+        missing = [
+            name
+            for name, val in (
+                ("block_count", block_count),
+                ("embedding_length", embedding_length),
+                ("head_count", head_count),
+                ("head_count_kv", head_count_kv),
+            )
+            if not val
+        ]
+        raise ValueError(f"show_data.model_info missing required fields: {missing}")
+
+    # mypy: all four are non-None after the all() check above
+    assert block_count is not None
+    assert embedding_length is not None
+    assert head_count is not None
+    assert head_count_kv is not None
+
+    weights_gb = parameters_b * bytes_per_weight
+    overhead_gb = 0.55 + 0.08 * parameters_b
+
+    available_for_kv_gb = vram_gb - weights_gb - overhead_gb
+    if available_for_kv_gb <= 0:
+        raise VramTooSmallError(
+            model=details.get("family", "<unknown>"),
+            vram_gb=vram_gb,
+            weights_gb=weights_gb,
+            overhead_gb=overhead_gb,
+        )
+
+    gqa_factor = head_count / head_count_kv
+    kv_per_token_bytes = (
+        batch_size * 2 * block_count * (embedding_length / gqa_factor) * bytes_per_kv_scalar
+    )
+    max_tokens = (available_for_kv_gb * 1e9) / kv_per_token_bytes
+
+    aligned = int(max_tokens // NUM_CTX_ALIGNMENT * NUM_CTX_ALIGNMENT)
+
+    if aligned < MIN_NUM_CTX:
+        # Aligned to a value below the floor — caller may want to raise
+        # rather than run a degenerate small context. We return MIN_NUM_CTX
+        # and let the caller decide; if even that doesn't fit weights+overhead
+        # the VramTooSmallError above already fired.
+        log.warning(
+            "vram_calculated_below_floor",
+            calculated=aligned,
+            floor=MIN_NUM_CTX,
+            vram_gb=vram_gb,
+        )
+        aligned = MIN_NUM_CTX
+
+    if architectural_max is not None and aligned > architectural_max:
+        log.debug(
+            "vram_capped_at_architectural_max",
+            calculated=aligned,
+            architectural_max=architectural_max,
+        )
+        aligned = architectural_max
+
+    log.info(
+        "vram_context_calculated",
+        vram_gb=vram_gb,
+        parameters_b=parameters_b,
+        quantization=details.get("quantization_level"),
+        weights_gb=round(weights_gb, 3),
+        overhead_gb=round(overhead_gb, 3),
+        num_ctx=aligned,
+    )
+    return aligned

--- a/src/questfoundry/providers/vram.py
+++ b/src/questfoundry/providers/vram.py
@@ -35,7 +35,7 @@ All architectural values come from Ollama's ``/api/show`` endpoint:
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, cast
 
 from questfoundry.observability.logging import get_logger
 
@@ -205,11 +205,12 @@ def calculate_max_context(
         ]
         raise ValueError(f"show_data.model_info missing required fields: {missing}")
 
-    # mypy: all four are non-None after the all() check above
-    assert block_count is not None
-    assert embedding_length is not None
-    assert head_count is not None
-    assert head_count_kv is not None
+    # mypy narrowing: all four are non-None after the all() check above.
+    # cast (rather than assert) avoids being stripped under `python -O`.
+    block_count = cast("int", block_count)
+    embedding_length = cast("int", embedding_length)
+    head_count = cast("int", head_count)
+    head_count_kv = cast("int", head_count_kv)
 
     weights_gb = parameters_b * bytes_per_weight
     overhead_gb = 0.55 + 0.08 * parameters_b

--- a/tests/unit/test_provider_factory.py
+++ b/tests/unit/test_provider_factory.py
@@ -692,6 +692,36 @@ def test_max_vram_with_cloud_provider_missing_key_still_raises() -> None:
     assert exc_info.value.provider == "openai"
 
 
+def test_create_chat_model_ollama_max_vram_too_small_raises() -> None:
+    """VramTooSmallError surfaces to the caller when max_vram < weights+overhead.
+
+    The factory's `except VramTooSmallError: raise` is a deliberate re-raise —
+    this test confirms it actually propagates (rather than being swallowed by
+    the broader `ValueError` handler immediately below, which would silently
+    fall back to /api/show num_ctx detection and hide the misconfiguration).
+    """
+    from questfoundry.providers.vram import VramTooSmallError
+
+    mock_chat = MagicMock()
+
+    with (
+        patch.dict("os.environ", {"OLLAMA_HOST": "http://test:11434"}, clear=False),
+        patch(
+            "questfoundry.providers.factory._query_ollama_show",
+            return_value=_llama8b_show_response(),
+        ),
+        patch(
+            "questfoundry.providers.factory._init_chat_model_safe",
+            return_value=mock_chat,
+        ),
+        pytest.raises(VramTooSmallError) as exc_info,
+    ):
+        # 8B Q4_K_M weights ~4.56 GB + overhead ~1.19 GB; 4 GB budget can't fit.
+        create_chat_model("ollama", "model", max_vram=4.0)
+
+    assert exc_info.value.vram_gb == 4.0
+
+
 def test_create_chat_model_ollama_no_temperature_when_not_provided() -> None:
     """Factory does not include temperature when not provided."""
     mock_chat = MagicMock()

--- a/tests/unit/test_provider_factory.py
+++ b/tests/unit/test_provider_factory.py
@@ -497,6 +497,144 @@ def test_create_chat_model_ollama_custom_num_ctx() -> None:
     assert call_kwargs["num_ctx"] == 131072
 
 
+def _llama8b_show_response() -> dict[str, Any]:
+    """Realistic /api/show shape for a Llama-3-8B Q4_K_M model."""
+    return {
+        "details": {
+            "family": "llama",
+            "parameter_size": "8.0B",
+            "quantization_level": "Q4_K_M",
+        },
+        "model_info": {
+            "general.architecture": "llama",
+            "llama.block_count": 32,
+            "llama.embedding_length": 4096,
+            "llama.attention.head_count": 32,
+            "llama.attention.head_count_kv": 8,
+            "llama.context_length": 131072,
+        },
+        "parameters": "num_ctx 32768\ntemperature 0.7",
+    }
+
+
+def test_create_chat_model_ollama_max_vram_kwarg_drives_num_ctx() -> None:
+    """max_vram kwarg triggers VRAM-aware num_ctx calculation for Ollama."""
+    mock_chat = MagicMock()
+
+    with (
+        patch.dict("os.environ", {"OLLAMA_HOST": "http://test:11434"}, clear=False),
+        patch(
+            "questfoundry.providers.factory._query_ollama_show",
+            return_value=_llama8b_show_response(),
+        ),
+        patch(
+            "questfoundry.providers.factory._init_chat_model_safe",
+            return_value=mock_chat,
+        ) as mock_init,
+    ):
+        create_chat_model("ollama", "model", max_vram=12.0)
+
+    call_kwargs = mock_init.call_args[1]
+    # 8B Q4_K_M at 12 GB → tens of thousands of tokens, definitely > the
+    # Modelfile-configured 32768 from `parameters`. Calculation wins.
+    assert call_kwargs["num_ctx"] > 32_768
+    assert call_kwargs["num_ctx"] % 1024 == 0
+    # max_vram itself never reaches the provider client.
+    assert "max_vram" not in call_kwargs
+
+
+def test_create_chat_model_ollama_qf_max_vram_env_var() -> None:
+    """QF_MAX_VRAM env var is the fallback when no kwarg is passed."""
+    mock_chat = MagicMock()
+
+    with (
+        patch.dict(
+            "os.environ",
+            {"OLLAMA_HOST": "http://test:11434", "QF_MAX_VRAM": "12"},
+            clear=False,
+        ),
+        patch(
+            "questfoundry.providers.factory._query_ollama_show",
+            return_value=_llama8b_show_response(),
+        ),
+        patch(
+            "questfoundry.providers.factory._init_chat_model_safe",
+            return_value=mock_chat,
+        ) as mock_init,
+    ):
+        create_chat_model("ollama", "model")
+
+    call_kwargs = mock_init.call_args[1]
+    assert call_kwargs["num_ctx"] > 32_768
+    assert call_kwargs["num_ctx"] % 1024 == 0
+
+
+def test_create_chat_model_ollama_max_vram_does_not_override_explicit_num_ctx() -> None:
+    """An explicit num_ctx kwarg still wins over max_vram (caller's choice)."""
+    mock_chat = MagicMock()
+
+    with (
+        patch.dict("os.environ", {"OLLAMA_HOST": "http://test:11434"}, clear=False),
+        patch(
+            "questfoundry.providers.factory._query_ollama_show",
+            return_value=_llama8b_show_response(),
+        ),
+        patch(
+            "questfoundry.providers.factory._init_chat_model_safe",
+            return_value=mock_chat,
+        ) as mock_init,
+    ):
+        create_chat_model("ollama", "model", num_ctx=8192, max_vram=24.0)
+
+    call_kwargs = mock_init.call_args[1]
+    assert call_kwargs["num_ctx"] == 8192
+    assert "max_vram" not in call_kwargs
+
+
+def test_create_chat_model_max_vram_ignored_for_non_ollama() -> None:
+    """max_vram is silently ignored for cloud providers; never reaches client."""
+    mock_chat = MagicMock()
+
+    with (
+        patch.dict("os.environ", {"OPENAI_API_KEY": "sk-test"}, clear=False),
+        patch(
+            "questfoundry.providers.factory._init_chat_model_safe",
+            return_value=mock_chat,
+        ) as mock_init,
+    ):
+        create_chat_model("openai", "gpt-5-mini", max_vram=12.0)
+
+    call_kwargs = mock_init.call_args[1]
+    assert "max_vram" not in call_kwargs
+    assert "num_ctx" not in call_kwargs
+
+
+def test_create_chat_model_ollama_invalid_qf_max_vram_env_falls_back() -> None:
+    """A non-numeric QF_MAX_VRAM env var is logged and ignored."""
+    mock_chat = MagicMock()
+
+    with (
+        patch.dict(
+            "os.environ",
+            {"OLLAMA_HOST": "http://test:11434", "QF_MAX_VRAM": "not-a-number"},
+            clear=False,
+        ),
+        patch(
+            "questfoundry.providers.factory._query_ollama_show",
+            return_value=_llama8b_show_response(),
+        ),
+        patch(
+            "questfoundry.providers.factory._init_chat_model_safe",
+            return_value=mock_chat,
+        ) as mock_init,
+    ):
+        create_chat_model("ollama", "model")
+
+    call_kwargs = mock_init.call_args[1]
+    # Falls back to Modelfile-configured value from `parameters`.
+    assert call_kwargs["num_ctx"] == 32_768
+
+
 def test_create_chat_model_ollama_no_temperature_when_not_provided() -> None:
     """Factory does not include temperature when not provided."""
     mock_chat = MagicMock()

--- a/tests/unit/test_provider_factory.py
+++ b/tests/unit/test_provider_factory.py
@@ -635,6 +635,63 @@ def test_create_chat_model_ollama_invalid_qf_max_vram_env_falls_back() -> None:
     assert call_kwargs["num_ctx"] == 32_768
 
 
+def test_max_vram_does_not_short_circuit_cloud_provider_setup() -> None:
+    """Regression: max_vram with cloud provider must still inject api_key.
+
+    Caught by claude-review on PR #1518: an earlier draft put
+    ``elif max_vram is not None`` in the provider chain, which silently
+    skipped the OPENAI_API_KEY / ANTHROPIC_API_KEY / GOOGLE_API_KEY branches
+    when max_vram was set alongside a cloud provider.
+    """
+    mock_chat = MagicMock()
+
+    # OpenAI: api_key must reach the provider client even when max_vram is set.
+    with (
+        patch.dict("os.environ", {"OPENAI_API_KEY": "sk-openai"}, clear=False),
+        patch(
+            "questfoundry.providers.factory._init_chat_model_safe",
+            return_value=mock_chat,
+        ) as mock_init,
+    ):
+        create_chat_model("openai", "gpt-5-mini", max_vram=12.0)
+    assert mock_init.call_args[1]["api_key"] == "sk-openai"
+
+    # Anthropic: same.
+    with (
+        patch.dict("os.environ", {"ANTHROPIC_API_KEY": "sk-ant"}, clear=False),
+        patch(
+            "questfoundry.providers.factory._init_chat_model_safe",
+            return_value=mock_chat,
+        ) as mock_init,
+    ):
+        create_chat_model("anthropic", "claude-sonnet-4-20250514", max_vram=12.0)
+    assert mock_init.call_args[1]["api_key"] == "sk-ant"
+
+    # Google: same.
+    with (
+        patch.dict("os.environ", {"GOOGLE_API_KEY": "g-key"}, clear=False),
+        patch(
+            "questfoundry.providers.factory._init_chat_model_safe",
+            return_value=mock_chat,
+        ) as mock_init,
+    ):
+        create_chat_model("google", "gemini-2.5-flash", max_vram=12.0)
+    assert mock_init.call_args[1]["api_key"] == "g-key"
+
+
+def test_max_vram_with_cloud_provider_missing_key_still_raises() -> None:
+    """Regression: missing API key still raises ProviderError when max_vram set.
+
+    The bug fixed for the previous regression test left the api_key check
+    unreachable; verify the error path is still wired correctly.
+    """
+    with patch.dict("os.environ", {}, clear=True), pytest.raises(ProviderError) as exc_info:
+        create_chat_model("openai", "gpt-5-mini", max_vram=12.0)
+
+    assert "API key required" in str(exc_info.value)
+    assert exc_info.value.provider == "openai"
+
+
 def test_create_chat_model_ollama_no_temperature_when_not_provided() -> None:
     """Factory does not include temperature when not provided."""
     mock_chat = MagicMock()

--- a/tests/unit/test_provider_vram.py
+++ b/tests/unit/test_provider_vram.py
@@ -149,7 +149,7 @@ class TestCalculateMaxContext:
             calculate_max_context(12.0, bad)
 
     def test_gqa_factor_affects_kv_cache(self) -> None:
-        """Higher GQA factor (more KV heads per attention head) → larger KV cache."""
+        """Higher GQA grouping (fewer KV heads) → smaller KV cache → larger context fits."""
         no_gqa = _llama8b_show_fixture()
         no_gqa["model_info"]["llama.attention.head_count_kv"] = 32  # GQA factor 1
         with_gqa = _llama8b_show_fixture()  # GQA factor 4 (32/8)

--- a/tests/unit/test_provider_vram.py
+++ b/tests/unit/test_provider_vram.py
@@ -1,0 +1,159 @@
+"""Tests for providers.vram — VRAM-aware num_ctx calculation."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from questfoundry.providers.vram import (
+    DEFAULT_BYTES_PER_WEIGHT,
+    MIN_NUM_CTX,
+    NUM_CTX_ALIGNMENT,
+    QUANT_BYTES_PER_WEIGHT,
+    VramTooSmallError,
+    calculate_max_context,
+    parse_parameter_size,
+    parse_quantization,
+)
+
+
+class TestParseQuantization:
+    def test_known_quants(self) -> None:
+        assert parse_quantization("Q4_K_M") == 0.57
+        assert parse_quantization("Q8_0") == 1.00
+        assert parse_quantization("F16") == 2.00
+        assert parse_quantization("FP16") == 2.00
+
+    def test_case_insensitive(self) -> None:
+        assert parse_quantization("q4_k_m") == 0.57
+        assert parse_quantization("Q4_K_M ") == 0.57
+
+    def test_unknown_quant_falls_back(self) -> None:
+        assert parse_quantization("Q99_K_X") == DEFAULT_BYTES_PER_WEIGHT
+
+    def test_none_falls_back(self) -> None:
+        assert parse_quantization(None) == DEFAULT_BYTES_PER_WEIGHT
+
+    def test_table_completeness(self) -> None:
+        """All entries in QUANT_BYTES_PER_WEIGHT have positive values."""
+        for level, bpw in QUANT_BYTES_PER_WEIGHT.items():
+            assert bpw > 0, f"{level} has non-positive bpw {bpw}"
+
+
+class TestParseParameterSize:
+    @pytest.mark.parametrize(
+        ("value", "expected"),
+        [
+            ("8.0B", 8.0),
+            ("3.8B", 3.8),
+            ("70B", 70.0),
+            ("1.7B", 1.7),
+            ("500M", 0.5),
+            ("250M", 0.25),
+        ],
+    )
+    def test_known_formats(self, value: str, expected: float) -> None:
+        result = parse_parameter_size(value)
+        assert result is not None
+        assert abs(result - expected) < 1e-6
+
+    def test_lowercase(self) -> None:
+        assert parse_parameter_size("8b") == 8.0
+
+    def test_invalid_returns_none(self) -> None:
+        assert parse_parameter_size("not a number") is None
+        assert parse_parameter_size("") is None
+        assert parse_parameter_size(None) is None
+
+
+def _llama8b_show_fixture(quant: str = "Q4_K_M") -> dict[str, Any]:
+    """Realistic /api/show shape for Llama-3-8B-ish model."""
+    return {
+        "details": {
+            "family": "llama",
+            "parameter_size": "8.0B",
+            "quantization_level": quant,
+        },
+        "model_info": {
+            "general.architecture": "llama",
+            "llama.block_count": 32,
+            "llama.embedding_length": 4096,
+            "llama.attention.head_count": 32,
+            "llama.attention.head_count_kv": 8,
+        },
+    }
+
+
+class TestCalculateMaxContext:
+    def test_typical_8b_q4_at_12gb(self) -> None:
+        """8B Q4_K_M at 12 GB VRAM yields a reasonable context (≥16K)."""
+        ctx = calculate_max_context(12.0, _llama8b_show_fixture())
+        assert ctx >= 16_384
+        assert ctx % NUM_CTX_ALIGNMENT == 0
+
+    def test_smaller_vram_smaller_ctx(self) -> None:
+        """Smaller VRAM budget yields smaller (still aligned) context."""
+        ctx_24 = calculate_max_context(24.0, _llama8b_show_fixture())
+        ctx_8 = calculate_max_context(8.0, _llama8b_show_fixture())
+        assert ctx_24 > ctx_8
+        assert ctx_8 % NUM_CTX_ALIGNMENT == 0
+
+    def test_too_small_vram_raises(self) -> None:
+        """Weights + overhead alone exceeding budget raises VramTooSmallError."""
+        # 8B Q4_K_M weights ~ 4.56 GB; overhead ~ 1.19 GB. 4 GB budget can't fit.
+        with pytest.raises(VramTooSmallError) as exc:
+            calculate_max_context(4.0, _llama8b_show_fixture())
+        assert exc.value.vram_gb == 4.0
+
+    def test_higher_quant_smaller_ctx(self) -> None:
+        """Q8_0 leaves less VRAM for KV cache than Q4_K_M at the same budget."""
+        ctx_q4 = calculate_max_context(12.0, _llama8b_show_fixture("Q4_K_M"))
+        ctx_q8 = calculate_max_context(12.0, _llama8b_show_fixture("Q8_0"))
+        assert ctx_q4 > ctx_q8
+
+    def test_architectural_max_caps_calculation(self) -> None:
+        """Calculated num_ctx is capped at the model's architectural max."""
+        ctx = calculate_max_context(64.0, _llama8b_show_fixture(), architectural_max=8_192)
+        assert ctx == 8_192
+
+    def test_aligned_to_1024(self) -> None:
+        """Returned num_ctx is always 1024-aligned."""
+        for vram in (6.0, 8.0, 12.0, 16.0, 24.0):
+            ctx = calculate_max_context(vram, _llama8b_show_fixture())
+            assert ctx % NUM_CTX_ALIGNMENT == 0, f"{vram} → {ctx} not aligned"
+
+    def test_at_least_min_num_ctx(self) -> None:
+        """Returned num_ctx is at least MIN_NUM_CTX (or VramTooSmallError)."""
+        # Find a budget that fits weights+overhead but yields tiny KV room.
+        # 8B Q4_K_M: weights 4.56, overhead 1.19, total 5.75. Use 5.85 for ~0.1 GB KV.
+        ctx = calculate_max_context(5.85, _llama8b_show_fixture())
+        assert ctx >= MIN_NUM_CTX
+
+    def test_invalid_vram_raises(self) -> None:
+        with pytest.raises(ValueError, match="vram_gb must be positive"):
+            calculate_max_context(0, _llama8b_show_fixture())
+        with pytest.raises(ValueError, match="vram_gb must be positive"):
+            calculate_max_context(-5, _llama8b_show_fixture())
+
+    def test_missing_arch_field_raises(self) -> None:
+        bad = _llama8b_show_fixture()
+        del bad["model_info"]["llama.block_count"]
+        with pytest.raises(ValueError, match="missing required fields"):
+            calculate_max_context(12.0, bad)
+
+    def test_missing_parameter_size_raises(self) -> None:
+        bad = _llama8b_show_fixture()
+        del bad["details"]["parameter_size"]
+        with pytest.raises(ValueError, match="parameter_size"):
+            calculate_max_context(12.0, bad)
+
+    def test_gqa_factor_affects_kv_cache(self) -> None:
+        """Higher GQA factor (more KV heads per attention head) → larger KV cache."""
+        no_gqa = _llama8b_show_fixture()
+        no_gqa["model_info"]["llama.attention.head_count_kv"] = 32  # GQA factor 1
+        with_gqa = _llama8b_show_fixture()  # GQA factor 4 (32/8)
+        ctx_no_gqa = calculate_max_context(12.0, no_gqa)
+        ctx_with_gqa = calculate_max_context(12.0, with_gqa)
+        # GQA factor 4 means 4x smaller KV cache → much larger ctx
+        assert ctx_with_gqa > ctx_no_gqa


### PR DESCRIPTION
## Summary

Closes #1245.

Sub-task 2 of #1245 (sub-task 1 — KNOWN_MODELS registry refresh — merged in #1511).

Adds the `--max-vram <gb>` flag and the `QF_MAX_VRAM` env var to compute the largest `num_ctx` that keeps a local Ollama model's weights + KV cache within VRAM. Without it, running a 128K-context model on a 12 GB consumer GPU silently spills the KV cache to CPU and inference becomes 10-100x slower — the pipeline appears to hang.

## Formula

```
VRAM = model_weights + overhead + kv_cache
N_max = (vram_gb - weights - overhead) * 1e9 / (B * 2 * L * (d/g) * b_kv)
```

P (params), b_w (bytes/weight from quantization), L (block_count), d (embedding_length), g (GQA factor = head_count / head_count_kv), b_kv (=2 for FP16 KV) all come from Ollama's `/api/show` endpoint — no hardcoded architecture data. Result is clamped to `[2048, architectural_max]` and rounded down to the nearest 1024.

## What lands

- **New module** `providers/vram.py` — quantization table (Q2_K → F32, plus FP16/BF16/FP32 aliases), parsers, and `calculate_max_context()`.
- **`providers/factory.py`**: refactor `_query_ollama_num_ctx` into `_query_ollama_show` + extractors so num_ctx and VRAM paths share one HTTP round-trip per model. `_preprocess_provider_kwargs` resolves `max_vram` from kwarg or `QF_MAX_VRAM` env var; ollama computes num_ctx via vram when set, falls back to existing detection otherwise. Non-ollama providers ignore with debug log. `max_vram` is popped before reaching the provider client.
- **`cli.py`**: `--max-vram` flag on `qf run` (sets `QF_MAX_VRAM` in env for the call duration). Individual stage commands inherit via the env var — same pattern as `QF_MAX_CONCURRENCY`.

## Precedence

1. Explicit `num_ctx` kwarg (caller's choice — never override).
2. `max_vram` calculation (CLI flag or env var).
3. `/api/show` num_ctx field (Modelfile or architectural max).
4. Hard fallback `32_768`.

## Test plan

- [x] `tests/unit/test_provider_vram.py` — 24 unit tests (parsing, calculation, too-small VRAM, missing arch fields, architectural cap, GQA factor, 1024-alignment).
- [x] `tests/unit/test_provider_factory.py` — 5 new integration tests for the max_vram path (kwarg-driven, env-var-driven, explicit num_ctx wins, ignored for non-ollama, invalid env var graceful).
- [x] `uv run pytest tests/unit/test_provider_vram.py` — 24 passed.
- [x] `uv run pytest tests/unit/test_provider_factory.py` — 94 passed (no regressions on the 89 pre-existing tests).
- [x] `uv run ruff check` + `uv run ruff format` + `uv run mypy` — pass.
- [ ] Bot review.

## Acceptance criteria (from #1245)

- [x] `--max-vram 12` on `qf run` calculates and sets `num_ctx` for Ollama models
- [x] `QF_MAX_VRAM=12` env var works as fallback (covers individual stage commands)
- [x] VRAM calculation uses actual model architecture from `/api/show`, not hardcoded values
- [x] Models whose weights alone exceed `--max-vram` raise `VramTooSmallError` with model + budget context
- [x] Calculated `num_ctx` is clamped between 2048 and the model's architectural maximum
- [x] `--max-vram` is silently ignored (debug log) for non-Ollama providers
- [x] All new code has unit tests; existing tests updated where behaviour changed

## Not included (by design)

- `qf doctor` enhancement to display calculated num_ctx per model — small follow-up; can land separately if useful.
- `--max-vram` flag on every individual stage command — env var covers this ergonomically (export once); adding the flag to 7+ commands is plumbing without a clear win.
- `providers.max_vram` in `project.yaml` — env var is sufficient for the typical "set once per host" pattern; can add later if users want per-project budgets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)