### PR TITLE
fix(dress): preserve state_flag:: prefix in spoiler-check formatter (R-3.7)

### DIFF
--- a/src/questfoundry/pipeline/stages/dress.py
+++ b/src/questfoundry/pipeline/stages/dress.py
@@ -1767,10 +1767,10 @@ def _format_entries_for_spoiler_check(entries: list[dict[str, Any]]) -> str:
         rank = entry.get("rank", "?")
         title = entry.get("title", "(no title)")
         gates = entry.get("visible_when") or []
+        # Preserve the `state_flag::` prefix (R-3.7) so few-shot examples
+        # in dress_codex_spoiler_check.yaml match runtime input verbatim.
         gate_text = (
-            "always visible"
-            if not gates
-            else "gated by " + ", ".join(f"`{strip_scope_prefix(g)}`" for g in gates)
+            "always visible" if not gates else "gated by " + ", ".join(f"`{g}`" for g in gates)
         )
         content = (entry.get("content") or "").strip() or "(no content)"
         lines.append(f"### Rank {rank} — {title} ({gate_text})\n{content}")

--- a/tests/unit/test_dress_stage.py
+++ b/tests/unit/test_dress_stage.py
@@ -2341,7 +2341,9 @@ def test_format_entries_for_spoiler_check_orders_by_rank() -> None:
     # Rank 1 must appear before Rank 2 in the rendered block
     assert rendered.index("Rank 1") < rendered.index("Rank 2")
     assert "always visible" in rendered
-    assert "gated by `met`" in rendered
+    # state_flag:: prefix preserved per R-3.7 (matches few-shot examples in
+    # dress_codex_spoiler_check.yaml — caught by gemini on PR #1516).
+    assert "gated by `state_flag::met`" in rendered
 
 
 def test_minimal_rank_one_codex_uses_entity_name() -> None:


### PR DESCRIPTION
## Summary

Closes #1519. Follow-up to merged PR #1516.

gemini-code-assist on #1516 caught a real divergence: PR #1516 aligned the few-shot examples in `dress_codex_spoiler_check.yaml` to the canonical `state_flag::met_aldric` form (R-3.7), but the runtime formatter `_format_entries_for_spoiler_check` was passing entries through `strip_scope_prefix(g)` — so the LLM saw two different conventions:

- system prompt example: `gated by \`state_flag::met_aldric\``
- runtime user prompt: `gated by \`met_aldric\``

The fix landed on the #1516 branch right after the merge, so it didn't make the cut. Filing as a small follow-up.

## Test plan

- [x] `uv run pytest tests/unit/test_dress_stage.py -k spoiler` — 6 passed
- [x] Test updated to assert `gated by \`state_flag::met\`` (namespaced form preserved)
- [ ] Bot review

🤖 Generated with [Claude Code](https://claude.com/claude-code)