### PR TITLE
fix(seed): repair-loop convergence for shared-beats also_belongs_to

### DIFF
--- a/prompts/templates/discuss_seed.yaml
+++ b/prompts/templates/discuss_seed.yaml
@@ -115,13 +115,14 @@ system: |
 
   **Y-shape beat shape (R-3.6, CRITICAL).** Each beat carries a `path_id`
   (its primary path). Pre-commit beats — beats SHARED between the two
-  paths of one dilemma — also set `also_belongs_to: [<other_path_id>]`
-  to declare the dual membership. Commit beats and post-commit beats are
-  exclusive to one path; they set `also_belongs_to: null`.
+  paths of one dilemma — also set `also_belongs_to: <other_path_id>` (a
+  PLAIN STRING, not a list) to declare the dual membership. Commit beats
+  and post-commit beats are exclusive to one path; they set
+  `also_belongs_to: null`.
 
-  GOOD (Y-shape with `path_id` + `also_belongs_to`):
+  GOOD (Y-shape with `path_id` + `also_belongs_to` as plain string):
   ```
-  shared pre-commit:  path_id = path::keeper_honest, also_belongs_to = [path::keeper_hiding]
+  shared pre-commit:  path_id = path::keeper_honest, also_belongs_to = path::keeper_hiding
   commit (honest):    path_id = path::keeper_honest, also_belongs_to = null
   post-commit (honest): path_id = path::keeper_honest, also_belongs_to = null
   commit (hiding):    path_id = path::keeper_hiding, also_belongs_to = null
@@ -131,6 +132,12 @@ system: |
   BAD (legacy `paths: [...]` list — DEPRECATED, do not use):
   ```
   paths: [path::keeper_honest, path::keeper_hiding]   # DROP — use path_id + also_belongs_to
+  ```
+
+  BAD (`also_belongs_to` as a list — REJECTED by validator):
+  ```
+  also_belongs_to: [path::keeper_hiding]   # WRONG — must be a plain string
+  also_belongs_to: path::keeper_hiding     # CORRECT
   ```
 
   Beats may also carry optional `temporal_hint` (rough scene ordering),

--- a/prompts/templates/serialize_seed_sections.yaml
+++ b/prompts/templates/serialize_seed_sections.yaml
@@ -468,6 +468,15 @@ shared_beats_prompt: |
   - Do NOT omit a shared beat for this dilemma — every Y-shape needs at least one.
   - Do NOT use path IDs from other dilemmas.
 
+  ### `also_belongs_to` type contrast
+  This field is the most-frequently-missed value. Type rules:
+  ```
+  GOOD: "also_belongs_to": "{also_belongs_to}"        ← plain string, copy exactly
+  BAD:  "also_belongs_to": null                       ← rejected — this is a SHARED beat
+  BAD:  "also_belongs_to": ["{also_belongs_to}"]      ← rejected — must be a string, not a list
+  BAD:  (field omitted entirely)                      ← rejected — field is REQUIRED
+  ```
+
   ## FINAL CHECK (verify before output)
   For EACH beat you generate:
   1. `path_id` is `{path_id}`

--- a/prompts/templates/summarize_seed_sections.yaml
+++ b/prompts/templates/summarize_seed_sections.yaml
@@ -223,10 +223,13 @@ beats_system: |
   - `location`: a RETAINED location entity ID
   - `entities`: key entity IDs present in this beat
   - `path_id`: the beat's primary path (REQUIRED, single path ID)
-  - `also_belongs_to`: for SHARED pre-commit beats, list the OTHER path(s)
-    this beat is shared with (e.g., `[path::keeper_hiding]` on a shared
-    beat whose `path_id` is `path::keeper_honest`). For COMMIT and
+  - `also_belongs_to`: for SHARED pre-commit beats, the sibling path ID as
+    a PLAIN STRING (not a list). E.g., `path::keeper_hiding` on a shared
+    beat whose `path_id` is `path::keeper_honest`. For COMMIT and
     POST-COMMIT beats, use `null`.
+
+    GOOD: `also_belongs_to: path::keeper_hiding`  (plain string)
+    BAD:  `also_belongs_to: [path::keeper_hiding]`  (list — REJECTED)
 
   **Do NOT use the legacy `paths: [a, b]` list field — it was deprecated
   in the Y-shape refactor (#1206) and the serializer will reject it.**

--- a/src/questfoundry/agents/serialize.py
+++ b/src/questfoundry/agents/serialize.py
@@ -486,26 +486,38 @@ def _build_error_feedback(errors: list[str], extra_hints: list[str] | None = Non
 
     Args:
         errors: List of validation error messages.
-        extra_hints: Optional caller-supplied hints appended after the
-            generic feedback. Used to echo expected values for
+        extra_hints: Optional caller-supplied hints with the actionable
+            directive (expected values, copy-paste JSON snippets) for
             constraint-to-value mappings the model loses across long
-            context (e.g. SEED shared-beats `also_belongs_to` value
-            template — see @prompt-engineer Rule 5 small-model repair-loop
-            blindness).
+            context. When present, hints are placed BEFORE the validator
+            output — small models (qwen3:4b) attend disproportionately to
+            the opening tokens of the most-recent message, and the
+            actionable directive must lead. See @prompt-engineer Rule 5
+            (small-model repair-loop blindness) and the murder4 SEED
+            crash post-mortem (#1521).
 
     Returns:
         Formatted feedback message for the model.
     """
     error_list = "\n".join(f"  - {e}" for e in errors)
-    base = (
+    if extra_hints:
+        # Hint-first ordering: the actionable directive leads, validator
+        # errors follow as supporting context. Reverses the prior layout
+        # where the directive was buried after a multi-line validator dump.
+        hints_block = "\n\n".join(extra_hints)
+        return (
+            f"{hints_block}\n\n"
+            "---\n\n"
+            "Validation errors that triggered this retry:\n"
+            f"{error_list}\n\n"
+            "Resubmit the corrected JSON now."
+        )
+    return (
         "The output had validation errors:\n"
         f"{error_list}\n\n"
         "Please fix these issues and try again. "
         "Ensure all required fields are present and have valid values."
     )
-    if extra_hints:
-        return base + "\n\n" + "\n\n".join(extra_hints)
-    return base
 
 
 # Required prompt keys for SEED section serialization
@@ -1230,13 +1242,31 @@ async def _serialize_shared_beats_for_dilemma(
     # across retry attempts (@prompt-engineer Rule 5 small-model repair-loop
     # blindness — the model doesn't re-read the system prompt on retry).
     # The hint is dilemma-specific so it always applies to this call.
+    #
+    # Format chosen for #1521: leads with a copy-paste JSON snippet, names
+    # the type explicitly (STRING not list/null), and includes a
+    # self-contained mini-checklist mirroring the system prompt FINAL CHECK
+    # so the model doesn't need to re-read upstream context on retry.
     also_belongs_to_hint = (
-        f"REMINDER for shared pre-commit beats of dilemma `{prefixed_dilemma_id}`:\n"
-        f"  - `path_id` MUST be `{primary_path_id}`\n"
-        f"  - `also_belongs_to` MUST be `{sibling_path_id}`\n"
-        f'Add `also_belongs_to: "{sibling_path_id}"` to EVERY beat in this output. '
-        f"Without it the beat is rejected by the Y-shape guard rail "
-        f"(Story Graph Ontology Part 8)."
+        "ACTION REQUIRED — your previous output was rejected.\n\n"
+        "Add this to EVERY beat in `initial_beats` (copy exactly):\n\n"
+        "```json\n"
+        f'  "path_id": "{primary_path_id}",\n'
+        f'  "also_belongs_to": "{sibling_path_id}"\n'
+        "```\n\n"
+        "Type rules for `also_belongs_to`:\n"
+        "  - It is a STRING (not a list, not null).\n"
+        f"  - For this dilemma, the value MUST be `{sibling_path_id}` exactly.\n"
+        "  - Without it, every beat is rejected by the Y-shape guard rail "
+        "(Story Graph Ontology Part 8).\n\n"
+        f"Self-check before submitting (for dilemma `{prefixed_dilemma_id}`):\n"
+        f'  [ ] Every beat has `"path_id": "{primary_path_id}"`\n'
+        f'  [ ] Every beat has `"also_belongs_to": "{sibling_path_id}"` '
+        "(STRING, not list)\n"
+        f'  [ ] No beat has `"effect": "commits"` '
+        "(these are pre-commit beats, not commits)\n"
+        f'  [ ] Every beat has `"dilemma_impacts[0].dilemma_id": '
+        f'"{prefixed_dilemma_id}"`'
     )
 
     result, tokens = await serialize_to_artifact(

--- a/src/questfoundry/agents/serialize.py
+++ b/src/questfoundry/agents/serialize.py
@@ -229,13 +229,16 @@ async def serialize_to_artifact(
             for formatting semantic validation errors. Required if semantic_validator
             is provided.
         stage: Pipeline stage name for tracing metadata (e.g., "dream", "seed").
-        extra_repair_hints: Optional caller-supplied reminder strings appended to
-            the validation-failure feedback message on every retry attempt. Used
-            to echo expected values for constraint-to-value mappings the model
-            loses across long context (e.g. SEED shared-beats `also_belongs_to`
-            sibling path id). Per @prompt-engineer Rule 5, the model does not re-read the
-            system prompt on retry — only the new user-message — so the hint
-            must be self-contained.
+        extra_repair_hints: Optional caller-supplied reminder strings placed at
+            the START of the validation-failure feedback message on every retry
+            attempt — the validator-error dump follows as supporting context.
+            Used to echo expected values for constraint-to-value mappings the
+            model loses across long context (e.g. SEED shared-beats
+            `also_belongs_to` sibling path id). Per @prompt-engineer Rule 5,
+            the model does not re-read the system prompt on retry — only the
+            new user-message — and small models attend disproportionately to
+            the opening tokens, so the actionable hint must lead and be
+            self-contained.
 
     Returns:
         Tuple of (validated_artifact, tokens_used).
@@ -1265,8 +1268,8 @@ async def _serialize_shared_beats_for_dilemma(
         "(STRING, not list)\n"
         f'  [ ] No beat has `"effect": "commits"` '
         "(these are pre-commit beats, not commits)\n"
-        f'  [ ] Every beat has `"dilemma_impacts[0].dilemma_id": '
-        f'"{prefixed_dilemma_id}"`'
+        f"  [ ] Every beat's first dilemma_impact has "
+        f'`"dilemma_id": "{prefixed_dilemma_id}"`'
     )
 
     result, tokens = await serialize_to_artifact(

--- a/tests/unit/test_serialize.py
+++ b/tests/unit/test_serialize.py
@@ -380,37 +380,61 @@ class TestHelperFunctions:
         assert "count" in feedback
         assert "fix" in feedback.lower()
 
-    def test_build_error_feedback_appends_extra_hints(self) -> None:
-        """Caller-supplied repair hints land after the generic feedback.
+    def test_build_error_feedback_includes_extra_hints(self) -> None:
+        """Caller-supplied repair hints reach the model with all values echoed.
 
-        Regression for the murder1 SEED halt: the model needs the expected
-        sibling path id template echoed alongside the validation error so
-        small models (qwen3:4b) can recover from constraint-to-value
+        Regression for the murder1/murder4 SEED halt: the model needs the
+        expected sibling path id template echoed alongside the validation
+        error so small models (qwen3:4b) can recover from constraint-to-value
         mapping loss across long context. See @prompt-engineer Rule 5.
         """
         errors = ["beats.0.also_belongs_to: Field required"]
         hint = (
-            "REMINDER for shared pre-commit beats of dilemma `dilemma::x`:\n"
+            "ACTION REQUIRED — your previous output was rejected.\n"
             "  - `path_id` MUST be `path::x__a`\n"
             "  - `also_belongs_to` MUST be `path::x__b`"
         )
 
         feedback = _build_error_feedback(errors, extra_hints=[hint])
 
-        # Generic feedback still present
+        # Validator output still present
         assert "validation errors" in feedback.lower()
         assert "beats.0.also_belongs_to" in feedback
-        # Hint appended verbatim — sibling path id ECHOED (not just named)
+        # Hint preserved verbatim — sibling path id ECHOED (not just named)
         assert "path::x__b" in feedback
-        assert "REMINDER" in feedback
+        assert "ACTION REQUIRED" in feedback
 
-    def test_build_error_feedback_no_hints_unchanged(self) -> None:
-        """Without extra_hints, the output is identical to the legacy form."""
+    def test_build_error_feedback_hints_lead_validator_follows(self) -> None:
+        """Hints precede validator errors so small models attend to the directive first.
+
+        @prompt-engineer audit on the murder4 crash: when the actionable
+        directive is buried after a multi-line validator dump, qwen3:4b
+        attends to the validator output (the opening tokens of the
+        message) and out-attends the directive at the end. The fix
+        reverses ordering — hint-block first, validator errors after.
+        """
+        errors = ["beats.0.also_belongs_to: Field required"]
+        hint_marker = "ACTION REQUIRED — your previous output was rejected."
+
+        feedback = _build_error_feedback(errors, extra_hints=[hint_marker])
+
+        # Hint marker appears strictly before the validator error block
+        assert hint_marker in feedback
+        assert "Validation errors that triggered this retry" in feedback
+        assert feedback.index(hint_marker) < feedback.index(
+            "Validation errors that triggered this retry"
+        )
+
+    def test_build_error_feedback_no_hints_uses_legacy_layout(self) -> None:
+        """Without extra_hints, the output uses the original validator-first form."""
         errors = ["x: required"]
         without = _build_error_feedback(errors)
         with_empty = _build_error_feedback(errors, extra_hints=None)
         with_empty_list = _build_error_feedback(errors, extra_hints=[])
         assert without == with_empty == with_empty_list
+        # Legacy phrasing preserved when no hints
+        assert "The output had validation errors:" in without
+        assert "Please fix these issues and try again" in without
 
 
 class TestSerializationError:


### PR DESCRIPTION
## Summary

Closes #1521. Surfaces from `projects/murder4` SEED crash (2026-04-28T05:23:45Z) and the @prompt-engineer audit on the failing repair loop.

qwen3:4b-instruct-32k failed all 3 retries on shared pre-commit beats missing \`also_belongs_to\`. The sibling dilemma in the same call hit the same validator on attempt 1 but recovered by attempt 3 — same prompt, same hint, different sampling outcome. The crash was the expected tail outcome of a probabilistically-thin repair loop, not a one-off.

## Four hard findings, tightly coupled

1. **Schema-skew (highest leverage)**: \`SharedBeatNode.also_belongs_to\` is \`str | None\` (\`models/seed.py:277\`) but \`discuss_seed.yaml:118,124\` and \`summarize_seed_sections.yaml:226-227\` showed it as a list. Model's in-context prior fought the serialize schema. Fixed both upstream prompts to show plain string + explicit "NOT a list" notes + GOOD/BAD contrast.
2. **\`_build_error_feedback\` ordering**: when \`extra_hints\` is present, lead with the hint block, validator errors follow as supporting context. Legacy validator-first layout preserved when no hints.
3. **\`also_belongs_to_hint\` content**: rewrote with literal copy-paste JSON snippet, explicit "STRING not list/null" type contradiction, and self-contained 4-item mini-checklist mirroring the system prompt FINAL CHECK.
4. **\`shared_beats_prompt\` "WHAT NOT TO DO"**: added GOOD/BAD/BAD/BAD type contrast for \`also_belongs_to\`.

## Architectural choice

Did NOT touch the \`HumanMessage\`-append retry path — that's #1498's territory (re-render the system prompt) and replicating it here would couple two unrelated architectural changes. The current "append HumanMessage" shape is correct for small models when the feedback is self-contained; the failure was content, not architecture.

## Predicted impact

Per the auditor: per-attempt compliance probability raises from ~50% to >95%. With 3 retries that's near-certain convergence.

## Test plan

- [x] \`uv run ruff check\` + \`uv run ruff format\` + \`uv run mypy\` — pass
- [x] \`uv run pytest tests/unit/test_serialize.py\` — 111 passed
  - \`test_build_error_feedback_hints_lead_validator_follows\` — NEW: asserts hint marker precedes validator-error block
  - \`test_build_error_feedback_includes_extra_hints\` — renamed (was \`_appends\` — semantics broader now)
  - \`test_build_error_feedback_no_hints_uses_legacy_layout\` — NEW: asserts no-hints branch preserves original wording
- [x] \`uv run pytest tests/unit/test_seed_stage.py tests/unit/test_dress_stage.py\` — 141 passed (no regressions)
- [ ] Bot review

🤖 Generated with [Claude Code](https://claude.com/claude-code)