### PR TITLE
fix(brainstorm): R-3.6 retry-bypass — central_entity_ids min_length=1 + semantic + prompt

### DIFF
--- a/.claude/agents/prompt-engineer.md
+++ b/.claude/agents/prompt-engineer.md
@@ -57,6 +57,7 @@ that triggered it:
 |---|---|---|
 | Spec accuracy | `drift` | Field renamed in spec but old name in prompt; deprecated phase name; wrong rule citation |
 | Repair-loop quality | `repair-gap` | Validation feedback that names a missing field but does NOT echo the expected value. Example: "Beats missing `also_belongs_to`" without saying what value to use. Small models lose the constraint-to-value mapping across long context. |
+| Late enforcement | `retry-bypass` | A required-by-contract constraint is enforced ONLY at graph-mutation time (or stage-output-contract time), AFTER the serialize retry loop is exhausted. Pydantic accepts the violating payload (`default_factory=list` with no `min_length`, `Optional` fields that are actually required, etc.) and the in-retry semantic validator doesn't catch it either, so the model never sees the error and the pipeline aborts with no repair opportunity. The fix lives in TWO places: (a) Pydantic schema tightening (`min_length=1`, `@model_validator(mode="after")`) so the retry loop fires; (b) the in-retry semantic validator gets the same check so coerced edge cases are caught. The graph/contract validator stays as defense-in-depth. |
 | Small-model resilience | `sm-fragile` | Implicit instructions, no concrete examples, ambiguous constraint phrasing, no sandwich repetition (critical instructions only at the start) |
 | Schema alignment | `schema-skew` | Prompt describes fields the Pydantic model doesn't have, or omits required ones, or names them differently |
 | Drift markers | `terminology` | "codeword" where spec says "state_flag", "passage_from" where spec says "grouped_in", "Codeword" class name, deprecated POLISH/GROW field references |
@@ -71,6 +72,12 @@ A `repair-gap` that names but doesn't echo the expected value is
 **always at least soft**, and **hard** if the validator that emits
 the message is on the contract path (FillContractError,
 DressStageError, GrowStageError, etc.).
+
+A `retry-bypass` is **always hard** — it means a contract rule is
+enforced at a point where the retry loop cannot recover, so any
+non-compliant model output aborts the pipeline. Hard regardless of
+whether the failure has been observed in the wild yet (the gap
+exists; the next probabilistic miss will hit it).
 
 ## Required reading: small-model failure modes
 
@@ -93,6 +100,22 @@ modes you care about most:
 5. **Repair-loop blindness** — the model doesn't re-read the
    system prompt on retry; only the new user-message is fresh
    context. Repair feedback must be self-contained.
+6. **Retry-bypass enforcement** — a contract rule (R-X.Y) is
+   enforced only at graph-commit / stage-output-contract time,
+   AFTER all serialize retries have completed. Pydantic accepts
+   the violating output (typically `list` field with no
+   `min_length`, or `Optional` field that's actually mandatory),
+   the in-retry semantic validator doesn't catch it, and the
+   model never gets a repair chance. The pipeline aborts with no
+   opportunity to recover. Found via murder4 SEED `also_belongs_to`
+   (#1521) and murder5 BRAINSTORM `central_entity_ids` (#TBD) —
+   both same shape: small model fills schema-permissive default
+   instead of the required value, contract validator rejects
+   post-retry. Fix is structural: tighten the Pydantic schema
+   (`min_length=1`, `@model_validator`) AND mirror the check into
+   the in-retry semantic validator. Audit every stage's
+   discuss→summarize→serialize loop for required fields whose
+   Pydantic type is permissive.
 
 ## Project prompt rules
 

--- a/prompts/templates/discuss_brainstorm.yaml
+++ b/prompts/templates/discuss_brainstorm.yaml
@@ -74,7 +74,10 @@ system: |
      - Each dilemma has exactly TWO answers (not more, not less)
      - One answer should be marked as the "default path" (the canonical story outcome)
      - For nuanced concepts, use MULTIPLE binary dilemmas rather than one multi-way choice
-     - Each dilemma must list its **central entities by ID** using backtick-wrapped IDs (e.g., "Central entities: `character::mentor`, `location::archive`"). Do NOT use bracket-list notation like `[entity_id]` — that's Python repr, not human-readable text.
+     - Each dilemma MUST list ≥1 **central entity by ID** using backtick-wrapped IDs (e.g., "Central entities: `character::mentor`, `location::archive`"). Do NOT use bracket-list notation like `[entity_id]` — that's Python repr, not human-readable text.
+
+       GOOD: "Central entities: `character::elara_thorne`, `object::silver_locket`" (≥1 entity)
+       BAD:  "Central entities: (none)" or omitted — every dilemma anchors to ≥1 entity per R-3.6; the pipeline rejects an unanchored dilemma.
 
   ## Guidelines
   - Be expansive! Generate MORE material than needed ({size_entities} entities, {size_dilemmas} dilemmas is good)

--- a/prompts/templates/serialize_brainstorm_dilemmas.yaml
+++ b/prompts/templates/serialize_brainstorm_dilemmas.yaml
@@ -21,7 +21,12 @@ system: |
     - `answer_id`: Unique short identifier for THIS answer (e.g., "guilty", "framed", "dagger", "poison")
     - `description`: Full description
     - `is_canonical`: true for ONE answer (the default path), false for the other
-  - `central_entity_ids`: List of **namespaced** `entity_id` values FROM the `### Valid Entity IDs` section above (e.g., `character::mentor`, `location::archive`). Bare IDs without the category prefix, or IDs not in the section above, will fail R-2.3 / R-3.6 semantic validation.
+  - `central_entity_ids`: **REQUIRED — MUST be non-empty.** List ≥1 **namespaced** `entity_id` values FROM the `### Valid Entity IDs` section above (e.g., `character::mentor`, `location::archive`). An empty list `[]` or omitted field is rejected at validation per R-3.6 ("every dilemma has at least one anchored_to edge"). Bare IDs without the category prefix, or IDs not in the section above, also fail R-2.3 / R-3.6.
+
+    GOOD: `"central_entity_ids": ["character::elara_thorne", "object::silver_locket"]` (≥1 namespaced entity ID)
+    BAD:  `"central_entity_ids": []` — empty list, R-3.6 violation, pipeline rejects
+    BAD:  field omitted entirely — same as empty, same failure
+    BAD:  `"central_entity_ids": ["elara_thorne"]` — bare ID without category prefix, R-2.3 violation
   - `why_it_matters`: Thematic stakes
 
   ## Dilemma ID Naming (CRITICAL)
@@ -55,7 +60,12 @@ system: |
   - Each dilemma MUST have exactly ONE answer with `is_canonical=true`.
   - `answer_id` values MUST be unique per dilemma and MUST be short outcome labels (e.g., `guilty`, `framed`), NOT entity references.
   - ONLY use `entity_id` values listed in `### Valid Entity IDs` above. Do NOT invent new entity IDs.
+  - Every dilemma MUST have ≥1 entry in `central_entity_ids`. The dilemma's question or `why_it_matters` mentioning an entity by name is NOT enough — the entity ID must appear in the `central_entity_ids` list itself.
   {output_language_instruction}
+
+  ## REMINDER — central_entity_ids is REQUIRED (R-3.6)
+
+  Before generating JSON: for EACH dilemma, identify which entities from `### Valid Entity IDs` above are directly involved. Write those IDs into `central_entity_ids`. Do NOT output `"central_entity_ids": []` — empty lists are the most common failure for this field.
 
   ## Output
 
@@ -69,7 +79,7 @@ system: |
           {{"answer_id": "...", "description": "...", "is_canonical": true}},
           {{"answer_id": "...", "description": "...", "is_canonical": false}}
         ],
-        "central_entity_ids": ["character::..."],
+        "central_entity_ids": ["character::elara_thorne", "object::silver_locket"],
         "why_it_matters": "..."
       }}
     ]

--- a/prompts/templates/summarize_brainstorm.yaml
+++ b/prompts/templates/summarize_brainstorm.yaml
@@ -38,7 +38,11 @@ system: |
   For each dilemma, describe in prose:
   - The central question or conflict
   - The two possible answers/outcomes (one being the "default path")
-  - **Central entity IDs**: list the namespaced IDs as backtick-wrapped tokens (e.g., `` `character::mentor`, `location::archive` ``). Do NOT use bracket-list notation like `[character_id]` — that's Python repr, not human-readable text.
+  - **Central entity IDs (REQUIRED for EVERY dilemma — MUST be non-empty)**: list ≥1 namespaced ID as backtick-wrapped tokens (e.g., `` `character::mentor`, `location::archive` ``). Do NOT use bracket-list notation like `[character_id]` — that's Python repr, not human-readable text.
+
+    GOOD: `` `character::elara_thorne`, `object::silver_locket` `` (≥1 namespaced entity ID)
+    BAD: *(omitted)* — the serializer cannot fill `central_entity_ids` and the dilemma will be rejected per R-3.6.
+    BAD: `(none)` or `[]` — empty anchor is invalid; every dilemma must reference at least one entity.
   - Why this dilemma matters thematically. R-3.1 makes `why_it_matters` REQUIRED — non-empty for every dilemma. If it wasn't discussed explicitly, synthesize a plausible 1–2 sentence rationale from the dilemma's question, central entities, and the story's themes. Do NOT leave it blank, write a placeholder string, or use a sentinel like `[NOT DISCUSSED]` — the validator does not detect those, and they propagate verbatim into SEED/GROW/FILL.
 
   ## NO DELEGATION (CRITICAL)
@@ -59,6 +63,7 @@ system: |
   - Be specific about which answer is the "default path"
   - IMPORTANT: For each dilemma, list the central entity IDs exactly as defined in the entities section
   - If something wasn't discussed, don't invent it
+  - SELF-CHECK before finishing: for EVERY dilemma you wrote, confirm there is at least one backtick-wrapped entity ID listed. If a dilemma's central entities were only described in prose ("this dilemma involves the silver locket"), convert those references to namespaced IDs now using the entity IDs from the Characters/Locations/Objects/Factions sections above.
   {output_language_instruction}
 
   ## Output Format

--- a/src/questfoundry/graph/mutations.py
+++ b/src/questfoundry/graph/mutations.py
@@ -714,8 +714,30 @@ def validate_brainstorm_mutations(output: dict[str, Any]) -> list[BrainstormVali
         else:
             seen_dilemma_ids[dilemma_id] = i
 
+        # 0. R-3.6: central_entity_ids MUST be non-empty.
+        # The Pydantic schema (Dilemma.central_entity_ids min_length=1) catches
+        # this on attempt 1; this in-retry semantic check is defense-in-depth
+        # for None / coercion edge cases that bypass Pydantic, and ensures the
+        # error is delivered with the concrete entity ID list (via
+        # BrainstormMutationError.to_feedback) rather than a generic Pydantic
+        # message. Per #1524 and the prompt-engineer retry-bypass canon.
+        raw_central_entities = dilemma.get("central_entity_ids") or []
+        if not raw_central_entities:
+            errors.append(
+                BrainstormValidationError(
+                    field_path=f"dilemmas.{i}.central_entity_ids",
+                    issue=(
+                        f"Dilemma '{dilemma_id}' has no central_entity_ids (R-3.6). "
+                        "Every dilemma MUST anchor to ≥1 entity. Add entity IDs "
+                        "from the entities list."
+                    ),
+                    available=sorted_entity_ids,
+                    provided="[]",
+                )
+            )
+
         # 1. Check central_entity_ids reference valid entities
-        for eid in dilemma.get("central_entity_ids", []):
+        for eid in raw_central_entities:
             normalized_eid = strip_scope_prefix(eid)
             if normalized_eid not in entity_ids:
                 errors.append(

--- a/src/questfoundry/graph/mutations.py
+++ b/src/questfoundry/graph/mutations.py
@@ -714,13 +714,13 @@ def validate_brainstorm_mutations(output: dict[str, Any]) -> list[BrainstormVali
         else:
             seen_dilemma_ids[dilemma_id] = i
 
-        # 0. R-3.6: central_entity_ids MUST be non-empty.
+        # 0a. R-3.6: central_entity_ids MUST be non-empty.
         # The Pydantic schema (Dilemma.central_entity_ids min_length=1) catches
         # this on attempt 1; this in-retry semantic check is defense-in-depth
         # for None / coercion edge cases that bypass Pydantic, and ensures the
         # error is delivered with the concrete entity ID list (via
         # BrainstormMutationError.to_feedback) rather than a generic Pydantic
-        # message. Per #1524 and the prompt-engineer retry-bypass canon.
+        # message. Mirrors the prompt-engineer retry-bypass canon.
         raw_central_entities = dilemma.get("central_entity_ids") or []
         if not raw_central_entities:
             errors.append(

--- a/src/questfoundry/models/brainstorm.py
+++ b/src/questfoundry/models/brainstorm.py
@@ -144,8 +144,14 @@ class Dilemma(BaseModel):
         description="Exactly two possible answers",
     )
     central_entity_ids: list[str] = Field(
-        default_factory=list,
-        description="Entity IDs central to this dilemma — stored as anchored_to edges, not node properties",
+        min_length=1,
+        description=(
+            "Entity IDs central to this dilemma — stored as anchored_to edges, "
+            "not node properties. MUST contain ≥1 entry per R-3.6 ('every dilemma "
+            "has at least one anchored_to edge to an entity'). An empty list is "
+            "rejected at Pydantic validation so the retry loop sees a concrete "
+            "error message and can repair (#1524)."
+        ),
     )
     why_it_matters: str = Field(
         min_length=1,

--- a/src/questfoundry/models/brainstorm.py
+++ b/src/questfoundry/models/brainstorm.py
@@ -148,9 +148,7 @@ class Dilemma(BaseModel):
         description=(
             "Entity IDs central to this dilemma — stored as anchored_to edges, "
             "not node properties. MUST contain ≥1 entry per R-3.6 ('every dilemma "
-            "has at least one anchored_to edge to an entity'). An empty list is "
-            "rejected at Pydantic validation so the retry loop sees a concrete "
-            "error message and can repair (#1524)."
+            "has at least one anchored_to edge to an entity')."
         ),
     )
     why_it_matters: str = Field(

--- a/src/questfoundry/pipeline/stages/brainstorm.py
+++ b/src/questfoundry/pipeline/stages/brainstorm.py
@@ -416,6 +416,26 @@ class BrainstormStage:
             output_language_instruction=lang_instruction,
         )
         dilemmas_validator = _make_brainstorm_dilemmas_validator(entities_dump)
+        # Per-attempt repair hint — R-3.6 requires every dilemma to anchor to
+        # ≥1 entity via `central_entity_ids`. Pydantic now enforces this with
+        # min_length=1 (#1524), but a hint is still cheap to ship: it leads
+        # the repair message with the value to populate, mirroring the SEED
+        # also_belongs_to fix from #1522. See @prompt-engineer Rule 5
+        # (small-model repair-loop blindness).
+        central_entity_hint = (
+            "ACTION REQUIRED — your previous output was rejected.\n\n"
+            "EVERY dilemma MUST have `central_entity_ids` populated with ≥1 "
+            "entity ID from the `### Valid Entity IDs` section in the system "
+            "prompt. An empty list `[]` or a missing field is rejected per "
+            "R-3.6 ('every dilemma has at least one anchored_to edge to an "
+            "entity').\n\n"
+            "Self-check before submitting:\n"
+            "  [ ] Every dilemma has `central_entity_ids` with ≥1 entry.\n"
+            "  [ ] Every entry uses the namespaced form (e.g., "
+            "`character::mentor`, NOT bare `mentor`).\n"
+            "  [ ] Every ID is from the `### Valid Entity IDs` section "
+            "(no invented IDs)."
+        )
         dilemmas_artifact, dilemmas_tokens = await serialize_to_artifact(
             model=chosen_serialize_model,
             brief=brief,
@@ -426,6 +446,7 @@ class BrainstormStage:
             semantic_validator=dilemmas_validator,
             semantic_error_class=BrainstormMutationError,
             stage="brainstorm",
+            extra_repair_hints=[central_entity_hint],
         )
         total_llm_calls += 1
         total_tokens += dilemmas_tokens

--- a/tests/unit/test_brainstorm_stage.py
+++ b/tests/unit/test_brainstorm_stage.py
@@ -814,7 +814,7 @@ def test_dilemma_requires_two_answers() -> None:
             dilemma_id="dilemma::test",
             question="Test?",
             answers=[{"answer_id": "one", "description": "Only one", "is_canonical": True}],
-            central_entity_ids=[],
+            central_entity_ids=["character::test"],
             why_it_matters="Test",
         )
 
@@ -832,6 +832,31 @@ def test_dilemma_requires_one_default_path_answer() -> None:
             answers=[
                 {"answer_id": "one", "description": "First", "is_canonical": True},
                 {"answer_id": "two", "description": "Second", "is_canonical": True},
+            ],
+            central_entity_ids=["character::test"],
+            why_it_matters="Test",
+        )
+
+
+def test_dilemma_rejects_empty_central_entity_ids() -> None:
+    """R-3.6: Dilemma model rejects empty central_entity_ids list (#1524 retry-bypass).
+
+    Was a retry-bypass: Pydantic accepted empty `[]`, in-retry semantic validator
+    didn't catch it, graph-mutation post-check rejected with no repair opportunity.
+    Now Pydantic refuses at attempt 1 so the existing repair loop fires with the
+    valid entity IDs echoed via BrainstormMutationError.to_feedback.
+    """
+    from pydantic import ValidationError
+
+    from questfoundry.models.brainstorm import Dilemma
+
+    with pytest.raises(ValidationError, match="at least 1 item"):
+        Dilemma(
+            dilemma_id="dilemma::test",
+            question="Test?",
+            answers=[
+                {"answer_id": "one", "description": "First", "is_canonical": True},
+                {"answer_id": "two", "description": "Second", "is_canonical": False},
             ],
             central_entity_ids=[],
             why_it_matters="Test",
@@ -855,6 +880,7 @@ def test_dilemma_rejects_trailing_or_in_id() -> None:
             dilemma_id="dilemma::host_benevolent_or_selfish_or_",
             question="Is the host benevolent?",
             answers=_TWO_ANSWERS,
+            central_entity_ids=["character::host"],
             why_it_matters="Trust",
         )
 
@@ -864,6 +890,7 @@ def test_dilemma_rejects_trailing_or_in_id() -> None:
             dilemma_id="dilemma::host_benevolent_or_selfish_or",
             question="Is the host benevolent?",
             answers=_TWO_ANSWERS,
+            central_entity_ids=["character::host"],
             why_it_matters="Trust",
         )
 
@@ -872,6 +899,7 @@ def test_dilemma_rejects_trailing_or_in_id() -> None:
         dilemma_id="dilemma::host_benevolent_or_selfish",
         question="Is the host benevolent?",
         answers=_TWO_ANSWERS,
+        central_entity_ids=["character::host"],
         why_it_matters="Trust",
     )
     assert d.dilemma_id == "dilemma::host_benevolent_or_selfish"
@@ -903,6 +931,7 @@ def test_dilemma_question_must_end_with_qmark() -> None:
             dilemma_id="dilemma::x",
             question="not a question",
             why_it_matters="stakes",
+            central_entity_ids=["character::x"],
             answers=[
                 {"answer_id": "a", "description": "d", "is_canonical": True},
                 {"answer_id": "b", "description": "d", "is_canonical": False},
@@ -940,6 +969,7 @@ def test_dilemma_id_must_have_prefix() -> None:
             dilemma_id="mentor_trust",  # missing prefix
             question="Q?",
             why_it_matters="stakes",
+            central_entity_ids=["character::mentor"],
             answers=[
                 {"answer_id": "a", "description": "d", "is_canonical": True},
                 {"answer_id": "b", "description": "d", "is_canonical": False},

--- a/tests/unit/test_mutations.py
+++ b/tests/unit/test_mutations.py
@@ -1066,7 +1066,7 @@ class TestValidateBrainstormMutations:
                 {
                     "dilemma_id": "trust",
                     "question": "Can the mentor be trusted?",
-                    "central_entity_ids": [],
+                    "central_entity_ids": ["location::archive"],
                     "answers": [
                         {"answer_id": "option_a", "description": "A", "is_canonical": True},
                         {
@@ -1085,6 +1085,68 @@ class TestValidateBrainstormMutations:
         duplicate_errors = [e for e in errors if "Duplicate" in e.issue]
         assert len(duplicate_errors) == 1
 
+    def test_empty_central_entity_ids_detected(self) -> None:
+        """R-3.6: empty central_entity_ids fires the in-retry validator (#1524).
+
+        Defense-in-depth alongside the Pydantic min_length=1 — the semantic
+        validator catches None/coercion edge cases that bypass Pydantic and
+        delivers the error with the concrete entity ID list (via
+        BrainstormMutationError.to_feedback) rather than a generic message.
+        """
+        output = {
+            "entities": [
+                {"entity_id": "archive", "entity_category": "location", "concept": "Archive"},
+                {"entity_id": "tower", "entity_category": "location", "concept": "Tower"},
+            ],
+            "dilemmas": [
+                {
+                    "dilemma_id": "trust",
+                    "question": "Can the mentor be trusted?",
+                    "central_entity_ids": [],  # R-3.6 violation — empty
+                    "answers": [
+                        {"answer_id": "yes", "description": "Yes", "is_canonical": True},
+                        {"answer_id": "no", "description": "No", "is_canonical": False},
+                    ],
+                }
+            ],
+        }
+
+        errors = validate_brainstorm_mutations(output)
+
+        # The empty central_entity_ids check fires BEFORE the per-ID existence loop,
+        # so it produces exactly one error (not one per missing ID).
+        assert len(errors) == 1
+        assert "no central_entity_ids" in errors[0].issue
+        assert "R-3.6" in errors[0].issue
+        # Available entity IDs are echoed for the repair feedback path
+        assert "archive" in errors[0].available
+        assert "tower" in errors[0].available
+
+    def test_missing_central_entity_ids_key_detected(self) -> None:
+        """R-3.6: missing central_entity_ids key (None) is treated as empty (#1524)."""
+        output = {
+            "entities": [
+                {"entity_id": "archive", "entity_category": "location", "concept": "Archive"},
+                {"entity_id": "tower", "entity_category": "location", "concept": "Tower"},
+            ],
+            "dilemmas": [
+                {
+                    "dilemma_id": "trust",
+                    "question": "Can the mentor be trusted?",
+                    # central_entity_ids key intentionally absent
+                    "answers": [
+                        {"answer_id": "yes", "description": "Yes", "is_canonical": True},
+                        {"answer_id": "no", "description": "No", "is_canonical": False},
+                    ],
+                }
+            ],
+        }
+
+        errors = validate_brainstorm_mutations(output)
+
+        assert len(errors) == 1
+        assert "no central_entity_ids" in errors[0].issue
+
     def test_no_default_path_detected(self) -> None:
         """Detects when no answer has is_canonical=True."""
         output = {
@@ -1096,7 +1158,7 @@ class TestValidateBrainstormMutations:
                 {
                     "dilemma_id": "trust",
                     "question": "Can the mentor be trusted?",
-                    "central_entity_ids": [],
+                    "central_entity_ids": ["location::archive"],
                     "answers": [
                         {"answer_id": "yes", "description": "Yes", "is_canonical": False},
                         {"answer_id": "no", "description": "No", "is_canonical": False},
@@ -1121,7 +1183,7 @@ class TestValidateBrainstormMutations:
                 {
                     "dilemma_id": "trust",
                     "question": "Can the mentor be trusted?",
-                    "central_entity_ids": [],
+                    "central_entity_ids": ["location::archive"],
                     "answers": [
                         {"answer_id": "yes", "description": "Yes", "is_canonical": True},
                         {"answer_id": "no", "description": "No", "is_canonical": True},
@@ -1185,7 +1247,7 @@ class TestValidateBrainstormMutations:
                 {
                     "dilemma_id": "trust",
                     "question": "Can the mentor be trusted?",
-                    "central_entity_ids": [],
+                    "central_entity_ids": ["location::archive"],
                     "answers": [],  # No answers at all
                 }
             ],
@@ -1275,7 +1337,7 @@ class TestValidateBrainstormMutations:
                 {
                     "dilemma_id": "trust_or_betray",
                     "question": "Can the mentor be trusted?",
-                    "central_entity_ids": [],
+                    "central_entity_ids": ["location::archive"],
                     "answers": [
                         {"answer_id": "trust", "description": "Trust", "is_canonical": True},
                         {"answer_id": "betray", "description": "Betray", "is_canonical": False},
@@ -1284,7 +1346,7 @@ class TestValidateBrainstormMutations:
                 {
                     "dilemma_id": "trust_or_betray",
                     "question": "Duplicate dilemma",
-                    "central_entity_ids": [],
+                    "central_entity_ids": ["location::archive"],
                     "answers": [
                         {"answer_id": "a", "description": "A", "is_canonical": True},
                         {"answer_id": "b", "description": "B", "is_canonical": False},


### PR DESCRIPTION
## Summary

Closes #1524. Same shape as merged #1522 (SEED \`also_belongs_to\` retry-bypass), different field.

\`projects/murder5\` BRAINSTORM crashed with \`gemma4:e2b\`: all 5 dilemmas had empty \`central_entity_ids\`. Pydantic accepted (\`default_factory=list\`, no \`min_length\`), in-retry semantic validator missed the empty case, R-3.6 enforced post-retry via \`BrainstormContractError\` with no repair opportunity.

## Three-layer fix

1. **Schema** (highest leverage): \`Dilemma.central_entity_ids\` gets \`min_length=1\`. Empty list fails Pydantic on attempt 1, fires existing repair loop with valid entity IDs echoed via \`BrainstormMutationError.to_feedback()\`.
2. **Semantic validator** (defense in depth): \`validate_brainstorm_mutations\` checks non-empty BEFORE the per-ID existence loop. Catches None / coercion edge cases.
3. **Prompts**: REQUIRED marker + GOOD/BAD/BAD/BAD contrast + sandwich reminder + filled JSON example in \`serialize_brainstorm_dilemmas.yaml\`; REQUIRED + self-check in \`summarize_brainstorm.yaml\`; MUST + BAD-empty in \`discuss_brainstorm.yaml\`.
4. **Repair-loop wiring**: \`extra_repair_hints\` now passed to dilemmas serialize call. Per #1522's ordering, hints lead retry messages.

## Subagent canon updated

\`.claude/agents/prompt-engineer.md\`:
- New audit dimension \`retry-bypass\` (always **hard** severity)
- New small-model failure mode #6 (retry-bypass enforcement)

This will guide future audits to look for the pattern proactively.

## Cross-stage implication (background audit completed)

The @prompt-engineer cross-stage audit (this session) found **5 more hard retry-bypass instances** in GROW + POLISH:

| # | Field | Severity | Why it'll fire |
|---|-------|----------|----------------|
| P-2 | \`PassageSpec.summary = ""\` default | hard | summary often emitted as narrative not key; FILL gets empty context |
| P-6 | \`Phase5aOutput.choice_labels = []\` default | hard | empty list silently leaves all labels \`""\`; Phase 7 R-7.7 fails post-Phase-6 |
| G-3 | \`Phase4aOutput.tags = []\` default | hard | empty scene-type tags silently degrades all POLISH pacing |
| P-5a | \`ResidueSpec.path_id = ""\` default | hard | residue beats can't be path-attributed |
| G-6 | \`GapProposal.after_beat AND before_beat = None\` | hard | unplaceable gap beats |

Plus 6 soft and 1 info findings. Trackers will land separately as PR-A (GROW + SEED schema) and PR-B (POLISH schema + exit validator).

## Test plan

- [x] \`uv run pytest tests/unit/test_brainstorm_stage.py\` — 34 passed
- [x] \`uv run pytest tests/unit/test_mutations.py -k Brainstorm\` — 36 passed
- [x] \`uv run pytest tests/unit/test_serialize.py\` — 111 passed (no regressions)
- [x] \`uv run ruff check\` + \`uv run ruff format\` + \`uv run mypy\` — pass
- [ ] Bot review

🤖 Generated with [Claude Code](https://claude.com/claude-code)