### PR TITLE
fix(grow): retry-bypass cluster — Phase4aOutput.tags + Phase4dOutput.details + GapProposal placement

### DIFF
--- a/docs/design/procedures/grow.md
+++ b/docs/design/procedures/grow.md
@@ -298,13 +298,13 @@ R-4a.5. No cycles are introduced. If a cycle would be introduced, the input from
 
 **Rules:**
 
-R-4b.1. Every beat receives `scene_type ∈ {scene, sequel, micro_beat}`. Partial coverage (LLM tags only some beats) MUST emit a WARNING; downstream consumers fall back to `"scene"` if the field is absent.
+R-4b.1. Every beat receives `scene_type ∈ {scene, sequel, micro_beat}`. **Partial coverage** (1 ≤ tagged beats < total — LLM tags only some beats) MUST emit a WARNING; downstream consumers fall back to `"scene"` if the field is absent. **Zero coverage** (zero beats tagged) is treated as full LLM failure under R-4b.4 — Pydantic enforces `min_length=1` on the tags list to fire the retry loop, not the partial-coverage WARNING path.
 
 R-4b.2. Every beat receives `narrative_function ∈ {introduce, develop, complicate, confront, resolve}`.
 
 R-4b.3. Every beat receives `exit_mood`: a 2–40 character free-form descriptor of the emotional handoff to the next beat.
 
-R-4b.4. Phase 4b is a single LLM call covering all beats; per-beat retries are not used. On overall LLM failure, the phase MUST return failed status (no silent default).
+R-4b.4. Phase 4b is a single LLM call covering all beats; per-beat retries are not used. On overall LLM failure (zero coverage), the phase MUST return failed status (no silent default). Partial coverage is the only "soft" outcome — anything from one beat tagged upward proceeds with WARNING.
 
 **Violations:**
 

--- a/docs/design/procedures/polish.md
+++ b/docs/design/procedures/polish.md
@@ -94,7 +94,7 @@ R-1a.1. Inserted gap beats carry `is_gap_beat: True` and `role: gap_beat` and `c
 
 R-1a.2. Inserted gap beats carry zero `dilemma_impacts`. They are structural transition beats; they MUST NOT advance any dilemma. This matches the structural-beat invariant for all POLISH-created beats (R-2.1, R-5.10, etc.).
 
-R-1a.3. Inserted gap beats record traceability fields: `bridges_from` (the earlier beat ID), `bridges_to` (the later beat ID), `transition_style` (free-form descriptor).
+R-1a.3. Inserted gap beats record traceability fields: `bridges_from` (the earlier beat ID), `bridges_to` (the later beat ID), `transition_style` (free-form descriptor). At least one of `bridges_from` / `bridges_to` MUST be set so the gap beat is placeable in the sequence — a gap with neither anchor is rejected at validation time. Both anchors are preferred when both adjacent beats exist; a single anchor is permitted only at sequence boundaries (open-start at the path's first position, open-end at its last) where the corresponding adjacent beat is genuinely absent. `transition_style` is currently informational free-form text and not yet schema-enforced.
 
 R-1a.4. Per-path cap: maximum 2 gap beats inserted per path per Phase 1a invocation.
 

--- a/src/questfoundry/models/grow.py
+++ b/src/questfoundry/models/grow.py
@@ -184,13 +184,7 @@ class SceneTypeTag(BaseModel):
 
 
 class Phase4aOutput(BaseModel):
-    """Wrapper for Phase 4a structured output (scene-type tags).
-
-    Spec R-4b.1 distinguishes partial coverage (1 ≤ tagged < total → WARNING +
-    fallback) from zero coverage (= LLM failure under R-4b.4 → halt + retry).
-    `min_length=1` enforces the zero-coverage halt at Pydantic time so the
-    retry loop fires; partial coverage is handled downstream as a WARNING.
-    """
+    """Wrapper for Phase 4a structured output (scene-type tags)."""
 
     tags: list[SceneTypeTag] = Field(
         min_length=1,
@@ -214,12 +208,7 @@ class AtmosphericDetail(BaseModel):
 
 
 class Phase4dOutput(BaseModel):
-    """Wrapper for Phase 4d structured output (atmospheric details).
-
-    Like Phase 4a, zero details = full coverage gap = LLM failure that should
-    trigger a retry. Partial coverage emits a WARNING per POLISH R-5e.1 and
-    FILL falls back without explicit guidance.
-    """
+    """Wrapper for Phase 4d structured output (atmospheric details)."""
 
     details: list[AtmosphericDetail] = Field(
         min_length=1,

--- a/src/questfoundry/models/grow.py
+++ b/src/questfoundry/models/grow.py
@@ -231,10 +231,9 @@ class Phase4dOutput(BaseModel):
 
     @model_validator(mode="after")
     def _validate_unique_beat_ids(self) -> Phase4dOutput:
-        if self.details:
-            detail_ids = [d.beat_id for d in self.details]
-            if len(detail_ids) != len(set(detail_ids)):
-                raise ValueError("beat_id in details list must be unique")
+        detail_ids = [d.beat_id for d in self.details]
+        if len(detail_ids) != len(set(detail_ids)):
+            raise ValueError("beat_id in details list must be unique")
         return self
 
 
@@ -343,13 +342,7 @@ class GapProposal(BaseModel):
 
     @model_validator(mode="after")
     def _require_placement(self) -> GapProposal:
-        """POLISH R-1a.3: gap beats record `bridges_from` / `bridges_to`.
-
-        Both `after_beat` and `before_beat` being null makes the gap
-        unplaceable in the beat sequence. POLISH has no semantic_validator
-        hook (#1498), so any retry-bypass in a POLISH-shaped output relies
-        on Pydantic enforcement to fire the retry loop.
-        """
+        """POLISH R-1a.3: at least one of after_beat/before_beat must be set."""
         if self.after_beat is None and self.before_beat is None:
             raise ValueError(
                 "GapProposal must have at least one of `after_beat` or "

--- a/src/questfoundry/models/grow.py
+++ b/src/questfoundry/models/grow.py
@@ -184,9 +184,22 @@ class SceneTypeTag(BaseModel):
 
 
 class Phase4aOutput(BaseModel):
-    """Wrapper for Phase 4a structured output (scene-type tags)."""
+    """Wrapper for Phase 4a structured output (scene-type tags).
 
-    tags: list[SceneTypeTag] = Field(default_factory=list)
+    Spec R-4b.1 distinguishes partial coverage (1 ≤ tagged < total → WARNING +
+    fallback) from zero coverage (= LLM failure under R-4b.4 → halt + retry).
+    `min_length=1` enforces the zero-coverage halt at Pydantic time so the
+    retry loop fires; partial coverage is handled downstream as a WARNING.
+    """
+
+    tags: list[SceneTypeTag] = Field(
+        min_length=1,
+        description=(
+            "Scene-type annotations for beats. Zero tags is treated as LLM "
+            "failure (R-4b.4) and triggers retry; partial coverage is allowed "
+            "with a downstream WARNING (R-4b.1)."
+        ),
+    )
 
 
 class AtmosphericDetail(BaseModel):
@@ -201,9 +214,20 @@ class AtmosphericDetail(BaseModel):
 
 
 class Phase4dOutput(BaseModel):
-    """Wrapper for Phase 4d structured output (atmospheric details)."""
+    """Wrapper for Phase 4d structured output (atmospheric details).
 
-    details: list[AtmosphericDetail] = Field(default_factory=list)
+    Like Phase 4a, zero details = full coverage gap = LLM failure that should
+    trigger a retry. Partial coverage emits a WARNING per POLISH R-5e.1 and
+    FILL falls back without explicit guidance.
+    """
+
+    details: list[AtmosphericDetail] = Field(
+        min_length=1,
+        description=(
+            "Atmospheric details per beat. Zero details is treated as LLM "
+            "failure and triggers retry; partial coverage emits WARNING."
+        ),
+    )
 
     @model_validator(mode="after")
     def _validate_unique_beat_ids(self) -> Phase4dOutput:
@@ -314,6 +338,25 @@ class GapProposal(BaseModel):
                 "Gap beats are structural transition beats only — they cannot "
                 "advance, reveal, commit, or complicate any dilemma. Remove the "
                 "dilemma_impacts entries from this gap proposal."
+            )
+        return self
+
+    @model_validator(mode="after")
+    def _require_placement(self) -> GapProposal:
+        """POLISH R-1a.3: gap beats record `bridges_from` / `bridges_to`.
+
+        Both `after_beat` and `before_beat` being null makes the gap
+        unplaceable in the beat sequence. POLISH has no semantic_validator
+        hook (#1498), so any retry-bypass in a POLISH-shaped output relies
+        on Pydantic enforcement to fire the retry loop.
+        """
+        if self.after_beat is None and self.before_beat is None:
+            raise ValueError(
+                "GapProposal must have at least one of `after_beat` or "
+                "`before_beat` set to be placeable in the beat sequence "
+                "(POLISH R-1a.3). A gap beat with neither anchor cannot be "
+                "inserted — provide the earlier beat (`after_beat`) or the "
+                "later beat (`before_beat`) or both."
             )
         return self
 

--- a/tests/unit/test_grow_models.py
+++ b/tests/unit/test_grow_models.py
@@ -297,17 +297,34 @@ class TestGapProposal:
         assert gap.scene_type == "sequel"
 
     def test_default_scene_type_is_sequel(self) -> None:
-        gap = GapProposal(path_id="t1", summary="A transition.")
+        gap = GapProposal(path_id="t1", after_beat="beat_a", summary="A transition.")
         assert gap.scene_type == "sequel"
 
-    def test_no_before_after_allowed(self) -> None:
-        gap = GapProposal(path_id="t1", summary="Opening scene.")
-        assert gap.after_beat is None
+    def test_after_beat_only_allowed(self) -> None:
+        # Anchoring the gap to only the earlier beat (open-ended forward) is valid.
+        gap = GapProposal(path_id="t1", after_beat="beat_a", summary="Open transition.")
+        assert gap.after_beat == "beat_a"
         assert gap.before_beat is None
+
+    def test_before_beat_only_allowed(self) -> None:
+        # Anchoring the gap to only the later beat (open-ended backward) is valid.
+        gap = GapProposal(path_id="t1", before_beat="beat_b", summary="Closing transition.")
+        assert gap.after_beat is None
+        assert gap.before_beat == "beat_b"
+
+    def test_both_placement_nulls_rejected(self) -> None:
+        """R-1a.3: gap beats must record bridges_from/bridges_to.
+
+        A gap with neither anchor is unplaceable. Closes a retry-bypass
+        (#1526): POLISH has no semantic_validator hook (#1498), so this
+        must fire at Pydantic time to trigger the retry loop.
+        """
+        with pytest.raises(ValidationError, match=r"R-1a\.3"):
+            GapProposal(path_id="t1", summary="Unplaceable gap.")
 
     def test_empty_summary_rejected(self) -> None:
         with pytest.raises(ValidationError, match="summary"):
-            GapProposal(path_id="t1", summary="")
+            GapProposal(path_id="t1", after_beat="beat_a", summary="")
 
     def test_dilemma_impacts_rejected_per_r_1a_2(self) -> None:
         # Per polish.md R-1a.2, gap beats are structural and must carry zero
@@ -316,6 +333,7 @@ class TestGapProposal:
         with pytest.raises(ValidationError, match=r"R-1a\.2"):
             GapProposal(
                 path_id="t1",
+                after_beat="beat_a",
                 summary="A transition beat.",
                 dilemma_impacts=[
                     {  # type: ignore[list-item]
@@ -469,9 +487,14 @@ class TestAtmosphericDetail:
 
 
 class TestPhase4dOutput:
-    def test_default_empty(self) -> None:
-        out = Phase4dOutput()
-        assert out.details == []
+    def test_empty_details_rejected(self) -> None:
+        """Zero atmospheric details is treated as LLM failure (#1526 retry-bypass).
+
+        Phase 4d is a single LLM call; zero coverage is full failure that
+        should fire the retry loop, not silent partial-coverage WARNING.
+        """
+        with pytest.raises(ValidationError, match=r"at least 1 item"):
+            Phase4dOutput(details=[])
 
     def test_with_details(self) -> None:
         out = Phase4dOutput(
@@ -496,6 +519,20 @@ class TestPhase4dOutput:
                     ),
                 ],
             )
+
+
+class TestPhase4aOutputZeroCoverageRejected:
+    """R-4b.1 vs R-4b.4: zero coverage = LLM failure (#1526 retry-bypass).
+
+    Partial coverage (1 ≤ tagged < total) is allowed with WARNING; zero
+    coverage is full failure that fires the retry loop.
+    """
+
+    def test_empty_tags_rejected(self) -> None:
+        from questfoundry.models.grow import Phase4aOutput
+
+        with pytest.raises(ValidationError, match=r"at least 1 item"):
+            Phase4aOutput(tags=[])
 
 
 class TestPathMiniArc:

--- a/tests/unit/test_grow_models.py
+++ b/tests/unit/test_grow_models.py
@@ -313,12 +313,8 @@ class TestGapProposal:
         assert gap.before_beat == "beat_b"
 
     def test_both_placement_nulls_rejected(self) -> None:
-        """R-1a.3: gap beats must record bridges_from/bridges_to.
-
-        A gap with neither anchor is unplaceable. Closes a retry-bypass
-        (#1526): POLISH has no semantic_validator hook (#1498), so this
-        must fire at Pydantic time to trigger the retry loop.
-        """
+        # R-1a.3: gap with neither anchor is unplaceable; POLISH has no
+        # semantic_validator (#1498), so this must fire at Pydantic time.
         with pytest.raises(ValidationError, match=r"R-1a\.3"):
             GapProposal(path_id="t1", summary="Unplaceable gap.")
 
@@ -488,11 +484,7 @@ class TestAtmosphericDetail:
 
 class TestPhase4dOutput:
     def test_empty_details_rejected(self) -> None:
-        """Zero atmospheric details is treated as LLM failure (#1526 retry-bypass).
-
-        Phase 4d is a single LLM call; zero coverage is full failure that
-        should fire the retry loop, not silent partial-coverage WARNING.
-        """
+        # Zero atmospheric details = LLM failure (R-4b.4 zero-coverage halt).
         with pytest.raises(ValidationError, match=r"at least 1 item"):
             Phase4dOutput(details=[])
 
@@ -522,11 +514,7 @@ class TestPhase4dOutput:
 
 
 class TestPhase4aOutputZeroCoverageRejected:
-    """R-4b.1 vs R-4b.4: zero coverage = LLM failure (#1526 retry-bypass).
-
-    Partial coverage (1 ≤ tagged < total) is allowed with WARNING; zero
-    coverage is full failure that fires the retry loop.
-    """
+    """R-4b.4: zero scene-type coverage is LLM failure, not partial."""
 
     def test_empty_tags_rejected(self) -> None:
         from questfoundry.models.grow import Phase4aOutput


### PR DESCRIPTION
## Summary

Closes #1526. Same pattern as merged #1522 (SEED \`also_belongs_to\`) and #1525 (BRAINSTORM \`central_entity_ids\`).

Three retry-bypass instances in GROW from the @prompt-engineer cross-stage audit:

| Finding | Field | File | Spec | Severity |
|---|---|---|---|---|
| G-3 | \`Phase4aOutput.tags\` empty list | \`models/grow.py:189\` | R-4b.4 (zero = LLM failure) | hard |
| G-4 | \`Phase4dOutput.details\` empty list | \`models/grow.py:206\` | POLISH R-5e.1 zero-coverage | hard (promoted from soft) |
| G-6 | \`GapProposal\` both placement fields nullable | \`models/grow.py:290-295\` | POLISH R-1a.3 | hard |

All three: Pydantic accepted permissive defaults, no in-retry semantic guard, post-retry validators didn't catch — pipeline continued silently with degraded output (G-3, G-4) or aborted with no repair opportunity (G-6).

## Fixes

- **Schema (3)**: \`min_length=1\` on \`Phase4aOutput.tags\` and \`Phase4dOutput.details\`; \`@model_validator\` on \`GapProposal\` requiring at least one of \`after_beat\` / \`before_beat\` non-null.
- **Spec clarification**: \`grow.md\` R-4b.1 / R-4b.4 now explicitly distinguish partial coverage (WARNING + fallback) from zero coverage (LLM failure → halt + retry).

## Skipped from audit scope

**S-1 (\`SeedOutput\` top-level lists)** — per-section wrappers already provide \`min_length\` on the typical serialization path; the auditor ranked it lowest-likelihood. Not worth the migration risk in this PR.

## Test plan

- [x] \`uv run pytest tests/unit/test_grow_models.py\` — 88 passed
- [x] \`uv run pytest tests/unit/test_grow_validators.py tests/unit/test_grow_stage.py\` — 106 passed (no regressions)
- [x] \`uv run ruff check\` + \`uv run ruff format\` + \`uv run mypy\` — pass
- [ ] Bot review

## Tests added

- \`test_both_placement_nulls_rejected\` — \`GapProposal\` R-1a.3
- \`test_after_beat_only_allowed\` / \`test_before_beat_only_allowed\` — one-anchor placement still valid
- \`test_empty_tags_rejected\` (Phase4aOutput) — zero-coverage rejection
- \`test_empty_details_rejected\` (Phase4dOutput) — zero-coverage rejection

Updates 4 existing \`GapProposal\` test fixtures that omitted placement fields.

## Related

- @prompt-engineer cross-stage audit (this session)
- #1521 / #1522 — SEED \`also_belongs_to\` (parallel pattern, fixed)
- #1524 / #1525 — BRAINSTORM \`central_entity_ids\` (parallel pattern, merged)
- #1527 — POLISH retry-bypass cluster (next PR)
- #1498 — POLISH retry-loop architecture (out of scope here)

🤖 Generated with [Claude Code](https://claude.com/claude-code)