### PR TITLE
fix(polish): retry-bypass cluster — PassageSpec.summary + Phase5aOutput.choice_labels + FalseBranchDecisionItem

### DIFF
--- a/docs/design/procedures/polish.md
+++ b/docs/design/procedures/polish.md
@@ -263,6 +263,8 @@ R-4a.4. POLISH does NOT consume Intersection Group nodes as a constraint on grou
 
 R-4a.5. (Subsumed by R-4a.3.) The prior allowance for optional multi-path grouping is now automatic: multi-path chains that are linear in the DAG are collapsed by the topology rule; those separated by divergences or convergences are in different passages by topology.
 
+R-4a.6. Every `PassageSpec` produced by Phase 4a has a non-empty `summary` field, derived from the constituent beats' summaries. Empty summaries are rejected at Pydantic validation — FILL has no prose context without them, and Phase 7's exit validator catches the gap only after Phase 6 commits. Pydantic enforcement (`min_length=1`) keeps the rule in the in-retry repair path.
+
 **Notes on structural beats.** Residue and false-branch beats are created by POLISH in Phase 6 *after* Phase 4a completes; their passage placement is governed by Phase 6 creation rules (R-6.x), not Phase 4a. Micro-beats (Phase 2, from POLISH), gap beats (Phase 1a, from POLISH), and transition beats (from GROW) are already in the DAG at Phase 4a and are grouped uniformly by R-4a.3. No sub-type-specific grouping rules are needed in Phase 4a.
 
 **Violations:**
@@ -377,6 +379,8 @@ R-5.3. Labels are concise (suitable for a button or gamebook instruction).
 
 R-5.4. The LLM receives full context for each choice: source passage summary, target passage summary, surrounding beat summaries, active state flags, relevant dilemma question.
 
+R-5.4a. The Phase 5a output (`Phase5aOutput.choice_labels`) MUST contain at least one entry — an empty list is treated as full LLM failure and triggers retry. POLISH has no semantic-validator hook (#1498), so Pydantic enforcement (`min_length=1`) is the only in-retry guard; without it, `ChoiceSpec.label` fields stay at their default empty string and Phase 7 R-7.7 fails post-Phase-6 with no repair opportunity.
+
 **Violations:**
 
 | Symptom | Root cause | Broken rule |
@@ -384,6 +388,7 @@ R-5.4. The LLM receives full context for each choice: source passage summary, ta
 | Choice label: "Choose option 1" | Non-diegetic | R-5.1 |
 | Two choices from same passage labeled "Go" and "Continue" | Not distinct | R-5.2 |
 | Label generation LLM call has bare ChoiceSpec IDs | Context missing | R-5.4 |
+| `Phase5aOutput.choice_labels = []` accepted by Pydantic | Empty list = LLM failure; Pydantic must reject so retry fires | R-5.4a |
 
 #### Residue Beat Content Generation
 
@@ -416,7 +421,7 @@ R-5.8. The chosen mapping is recorded in the plan so Phase 6 can apply it atomic
 
 **Rules:**
 
-R-5.9. False branch decisions are one of: `skip` (no branch), `diamond` (two alternatives reconverging), `sidetrack` (1–2 beat detour).
+R-5.9. False branch decisions are one of: `skip` (no branch), `diamond` (two alternatives reconverging), `sidetrack` (1–2 beat detour). For `decision = sidetrack`, the LLM MUST populate `sidetrack_summary` (Pydantic-enforced, non-empty). For `decision = diamond`, the LLM MUST populate BOTH `diamond_summary_a` AND `diamond_summary_b` (Pydantic-enforced, non-empty). Empty content is rejected at validation time so the retry loop fires; FILL has no prose context to write false-branch beats from.
 
 R-5.10. False-branch beats created here have `role: "false_branch_beat"`, zero `dilemma_impacts`, zero `belongs_to`.
 

--- a/src/questfoundry/models/polish.py
+++ b/src/questfoundry/models/polish.py
@@ -23,7 +23,7 @@ from __future__ import annotations
 
 from typing import Literal
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
 
 # ---------------------------------------------------------------------------
 # Phase 1: Beat Reordering — LLM output schema
@@ -198,7 +198,14 @@ class PassageSpec(BaseModel):
 
     passage_id: str = Field(min_length=1)
     beat_ids: list[str] = Field(min_length=1)
-    summary: str = Field(default="")
+    summary: str = Field(
+        min_length=1,
+        description=(
+            "Human-readable scene summary derived from the passage's beats. "
+            "Stage Output Contract item 2 requires every passage to have a "
+            "non-empty summary; FILL has no prose context without it."
+        ),
+    )
     entities: list[str] = Field(default_factory=list)
     grouping_type: str = Field(
         default="singleton",
@@ -317,9 +324,22 @@ class ChoiceLabelItem(BaseModel):
 
 
 class Phase5aOutput(BaseModel):
-    """Output of Phase 5a: Choice Label Generation."""
+    """Output of Phase 5a: Choice Label Generation.
 
-    choice_labels: list[ChoiceLabelItem] = Field(default_factory=list)
+    POLISH has no semantic_validator hook (#1498), so Pydantic is the only
+    in-retry enforcement point. An empty list silently leaves all
+    `ChoiceSpec.label` fields at their default `""`, which Phase 7 R-7.7
+    catches at exit AFTER Phase 6 has committed all passages — too late
+    for repair. `min_length=1` fires the retry loop instead.
+    """
+
+    choice_labels: list[ChoiceLabelItem] = Field(
+        min_length=1,
+        description=(
+            "Diegetic, concise labels for choices. MUST contain ≥1 entry; "
+            "empty list is treated as LLM failure and triggers retry."
+        ),
+    )
 
 
 class ResidueContentItem(BaseModel):
@@ -357,6 +377,35 @@ class FalseBranchDecisionItem(BaseModel):
     sidetrack_entities: list[str] = Field(default_factory=list)
     choice_label_enter: str = Field(default="")
     choice_label_return: str = Field(default="")
+
+    @model_validator(mode="after")
+    def _require_decision_specific_fields(self) -> FalseBranchDecisionItem:
+        """R-5.9 / R-5.10: decision-specific fields MUST be populated.
+
+        - sidetrack: sidetrack_summary MUST be non-empty (R-5.9)
+        - diamond: diamond_summary_a AND diamond_summary_b MUST be non-empty (R-5.10)
+        - skip: no additional content required
+
+        POLISH has no semantic_validator hook (#1498); this Pydantic check is
+        the only in-retry enforcement point. Phase 6 would otherwise create
+        false branch beats with empty summaries that FILL has nothing to
+        write from.
+        """
+        if self.decision == "sidetrack" and not self.sidetrack_summary:
+            raise ValueError(
+                "FalseBranchDecisionItem with decision='sidetrack' MUST have "
+                "non-empty `sidetrack_summary` (R-5.9). FILL has no prose "
+                "context to write the sidetrack beat without it."
+            )
+        if self.decision == "diamond" and (
+            not self.diamond_summary_a or not self.diamond_summary_b
+        ):
+            raise ValueError(
+                "FalseBranchDecisionItem with decision='diamond' MUST have "
+                "non-empty `diamond_summary_a` AND `diamond_summary_b` "
+                "(R-5.10). Both alternative passages need prose hints."
+            )
+        return self
 
 
 class Phase5cOutput(BaseModel):

--- a/src/questfoundry/models/polish.py
+++ b/src/questfoundry/models/polish.py
@@ -380,10 +380,10 @@ class FalseBranchDecisionItem(BaseModel):
 
     @model_validator(mode="after")
     def _require_decision_specific_fields(self) -> FalseBranchDecisionItem:
-        """R-5.9 / R-5.10: decision-specific fields MUST be populated.
+        """R-5.9: decision-specific fields MUST be populated.
 
         - sidetrack: sidetrack_summary MUST be non-empty (R-5.9)
-        - diamond: diamond_summary_a AND diamond_summary_b MUST be non-empty (R-5.10)
+        - diamond: diamond_summary_a AND diamond_summary_b MUST be non-empty (R-5.9)
         - skip: no additional content required
 
         POLISH has no semantic_validator hook (#1498); this Pydantic check is
@@ -403,7 +403,7 @@ class FalseBranchDecisionItem(BaseModel):
             raise ValueError(
                 "FalseBranchDecisionItem with decision='diamond' MUST have "
                 "non-empty `diamond_summary_a` AND `diamond_summary_b` "
-                "(R-5.10). Both alternative passages need prose hints."
+                "(R-5.9). Both alternative passages need prose hints."
             )
         return self
 

--- a/tests/unit/test_polish_deterministic.py
+++ b/tests/unit/test_polish_deterministic.py
@@ -1076,19 +1076,34 @@ class TestChoiceEdgesYShapeAdvancesChild:
         # Passages: shared_02 in its own, each path beat in its own
         specs = [
             PassageSpec(
-                passage_id="passage::shared", beat_ids=["beat::shared_02"], grouping_type="single"
+                passage_id="passage::shared",
+                beat_ids=["beat::shared_02"],
+                grouping_type="single",
+                summary="auto-summary",
             ),
             PassageSpec(
-                passage_id="passage::a_setup", beat_ids=["beat::d1_a_01"], grouping_type="single"
+                passage_id="passage::a_setup",
+                beat_ids=["beat::d1_a_01"],
+                grouping_type="single",
+                summary="auto-summary",
             ),
             PassageSpec(
-                passage_id="passage::b_setup", beat_ids=["beat::d1_b_01"], grouping_type="single"
+                passage_id="passage::b_setup",
+                beat_ids=["beat::d1_b_01"],
+                grouping_type="single",
+                summary="auto-summary",
             ),
             PassageSpec(
-                passage_id="passage::a_commit", beat_ids=["beat::d1_a_02"], grouping_type="single"
+                passage_id="passage::a_commit",
+                beat_ids=["beat::d1_a_02"],
+                grouping_type="single",
+                summary="auto-summary",
             ),
             PassageSpec(
-                passage_id="passage::b_commit", beat_ids=["beat::d1_b_02"], grouping_type="single"
+                passage_id="passage::b_commit",
+                beat_ids=["beat::d1_b_02"],
+                grouping_type="single",
+                summary="auto-summary",
             ),
         ]
 
@@ -1184,15 +1199,34 @@ class TestChoiceEdgesYShapeAdvancesChild:
 
         specs = [
             PassageSpec(
-                passage_id="passage::shared", beat_ids=["beat::shared"], grouping_type="single"
-            ),
-            PassageSpec(passage_id="passage::a", beat_ids=["beat::a_01"], grouping_type="single"),
-            PassageSpec(passage_id="passage::b", beat_ids=["beat::b_01"], grouping_type="single"),
-            PassageSpec(
-                passage_id="passage::a_commit", beat_ids=["beat::a_02"], grouping_type="single"
+                passage_id="passage::shared",
+                beat_ids=["beat::shared"],
+                grouping_type="single",
+                summary="auto-summary",
             ),
             PassageSpec(
-                passage_id="passage::b_commit", beat_ids=["beat::b_02"], grouping_type="single"
+                passage_id="passage::a",
+                beat_ids=["beat::a_01"],
+                grouping_type="single",
+                summary="auto-summary",
+            ),
+            PassageSpec(
+                passage_id="passage::b",
+                beat_ids=["beat::b_01"],
+                grouping_type="single",
+                summary="auto-summary",
+            ),
+            PassageSpec(
+                passage_id="passage::a_commit",
+                beat_ids=["beat::a_02"],
+                grouping_type="single",
+                summary="auto-summary",
+            ),
+            PassageSpec(
+                passage_id="passage::b_commit",
+                beat_ids=["beat::b_02"],
+                grouping_type="single",
+                summary="auto-summary",
             ),
         ]
 

--- a/tests/unit/test_polish_phase5_models.py
+++ b/tests/unit/test_polish_phase5_models.py
@@ -143,14 +143,14 @@ class TestFalseBranchDecisionItem:
         ],
     )
     def test_diamond_requires_both_summaries(self, summary_a: str, summary_b: str) -> None:
-        """R-5.10: diamond decision requires both diamond_summary_a AND _b (#1527).
+        """R-5.9: diamond decision requires both diamond_summary_a AND _b (#1527).
 
         Each parametrize case runs independently — if `missing_b` were to
         regress, `missing_a` and `missing_both` still get their own
         assertion (vs nested `pytest.raises` blocks where the first
         unexpectedly-not-raising case short-circuits the rest).
         """
-        with pytest.raises(ValidationError, match=r"R-5\.10"):
+        with pytest.raises(ValidationError, match=r"R-5\.9"):
             FalseBranchDecisionItem(
                 candidate_index=0,
                 decision="diamond",

--- a/tests/unit/test_polish_phase5_models.py
+++ b/tests/unit/test_polish_phase5_models.py
@@ -134,21 +134,28 @@ class TestFalseBranchDecisionItem:
                 sidetrack_summary="",  # empty — must be rejected
             )
 
-    def test_diamond_requires_both_summaries(self) -> None:
-        """R-5.10: diamond decision requires both diamond_summary_a AND _b (#1527)."""
+    @pytest.mark.parametrize(
+        ("summary_a", "summary_b"),
+        [
+            pytest.param("Path A", "", id="missing_b"),
+            pytest.param("", "Path B", id="missing_a"),
+            pytest.param("", "", id="missing_both"),
+        ],
+    )
+    def test_diamond_requires_both_summaries(self, summary_a: str, summary_b: str) -> None:
+        """R-5.10: diamond decision requires both diamond_summary_a AND _b (#1527).
+
+        Each parametrize case runs independently — if `missing_b` were to
+        regress, `missing_a` and `missing_both` still get their own
+        assertion (vs nested `pytest.raises` blocks where the first
+        unexpectedly-not-raising case short-circuits the rest).
+        """
         with pytest.raises(ValidationError, match=r"R-5\.10"):
             FalseBranchDecisionItem(
                 candidate_index=0,
                 decision="diamond",
-                diamond_summary_a="Path A",
-                diamond_summary_b="",  # missing — must be rejected
-            )
-        with pytest.raises(ValidationError, match=r"R-5\.10"):
-            FalseBranchDecisionItem(
-                candidate_index=0,
-                decision="diamond",
-                diamond_summary_a="",  # missing
-                diamond_summary_b="Path B",
+                diamond_summary_a=summary_a,
+                diamond_summary_b=summary_b,
             )
 
 

--- a/tests/unit/test_polish_phase5_models.py
+++ b/tests/unit/test_polish_phase5_models.py
@@ -9,6 +9,7 @@ from questfoundry.models.polish import (
     ChoiceLabelItem,
     FalseBranchDecisionItem,
     FalseBranchSpec,
+    PassageSpec,
     Phase5aOutput,
     Phase5bOutput,
     Phase5cOutput,
@@ -17,6 +18,29 @@ from questfoundry.models.polish import (
     ResidueSpec,
     VariantSummaryItem,
 )
+
+
+class TestPassageSpecSummaryRequired:
+    """Stage Output Contract item 2 + #1527: every passage MUST have a non-empty summary.
+
+    Phase 4a constructs PassageSpec from beat summaries (which are guaranteed
+    non-empty by SEED's InitialBeat.summary `min_length=1` and POLISH's
+    GapProposal.summary `min_length=1`). FILL has no prose context without it.
+    """
+
+    def test_empty_summary_rejected(self) -> None:
+        with pytest.raises(ValidationError, match=r"summary"):
+            PassageSpec(passage_id="passage::test", beat_ids=["beat::a"], summary="")
+
+    def test_missing_summary_rejected(self) -> None:
+        with pytest.raises(ValidationError, match=r"summary"):
+            PassageSpec(passage_id="passage::test", beat_ids=["beat::a"])  # type: ignore[call-arg]
+
+    def test_non_empty_summary_accepted(self) -> None:
+        spec = PassageSpec(
+            passage_id="passage::test", beat_ids=["beat::a"], summary="Hero enters the cave."
+        )
+        assert spec.summary == "Hero enters the cave."
 
 
 class TestChoiceLabelItem:
@@ -30,9 +54,16 @@ class TestChoiceLabelItem:
 
 
 class TestPhase5aOutput:
-    def test_empty_labels(self) -> None:
-        out = Phase5aOutput()
-        assert out.choice_labels == []
+    def test_empty_labels_rejected(self) -> None:
+        """Phase 5a empty choice_labels = LLM failure (#1527 retry-bypass).
+
+        POLISH has no semantic_validator hook (#1498); Pydantic is the only
+        in-retry enforcement point. Empty list silently leaves all
+        ChoiceSpec.label at their default `""`; Phase 7 R-7.7 catches it
+        at exit AFTER Phase 6 commits — too late for repair.
+        """
+        with pytest.raises(ValidationError, match=r"at least 1 item"):
+            Phase5aOutput(choice_labels=[])
 
     def test_with_labels(self) -> None:
         out = Phase5aOutput(
@@ -89,6 +120,36 @@ class TestFalseBranchDecisionItem:
     def test_negative_index_rejected(self) -> None:
         with pytest.raises(ValidationError):
             FalseBranchDecisionItem(candidate_index=-1, decision="skip")
+
+    def test_sidetrack_requires_summary(self) -> None:
+        """R-5.9: sidetrack decision requires non-empty sidetrack_summary (#1527).
+
+        Closes a retry-bypass: empty summary previously passed Pydantic
+        and Phase 6 created sidetrack beats with no prose context.
+        """
+        with pytest.raises(ValidationError, match=r"R-5\.9"):
+            FalseBranchDecisionItem(
+                candidate_index=0,
+                decision="sidetrack",
+                sidetrack_summary="",  # empty — must be rejected
+            )
+
+    def test_diamond_requires_both_summaries(self) -> None:
+        """R-5.10: diamond decision requires both diamond_summary_a AND _b (#1527)."""
+        with pytest.raises(ValidationError, match=r"R-5\.10"):
+            FalseBranchDecisionItem(
+                candidate_index=0,
+                decision="diamond",
+                diamond_summary_a="Path A",
+                diamond_summary_b="",  # missing — must be rejected
+            )
+        with pytest.raises(ValidationError, match=r"R-5\.10"):
+            FalseBranchDecisionItem(
+                candidate_index=0,
+                decision="diamond",
+                diamond_summary_a="",  # missing
+                diamond_summary_b="Path B",
+            )
 
 
 class TestPhase5cOutput:


### PR DESCRIPTION
## Summary

Closes #1527. Same pattern as #1522 (SEED \`also_belongs_to\`), #1525 (BRAINSTORM \`central_entity_ids\`), #1528 (GROW cluster).

POLISH has the highest density of retry-bypass findings because it has **no \`semantic_validator\` hook** (#1498) — only Pydantic \`ValidationError\` can fire the in-retry repair loop. Every spec contract not enforced by Pydantic constraints is automatically a retry-bypass once Phase 6 applies.

## Three hard findings

| Finding | Field | Spec | Severity |
|---|---|---|---|
| P-2 | \`PassageSpec.summary = ""\` default | Stage Output Contract item 2 | hard |
| P-6 | \`Phase5aOutput.choice_labels = []\` default | R-7.7 / new R-5.4a | hard |
| P-7 | \`FalseBranchDecisionItem.sidetrack_summary / diamond_summary_a/b\` | R-5.9 / R-5.10 | hard (promoted from soft) |

## Fixes

- **Schema**: \`min_length=1\` on \`PassageSpec.summary\`, \`min_length=1\` on \`Phase5aOutput.choice_labels\`, new \`@model_validator\` on \`FalseBranchDecisionItem\` requiring decision-specific content.
- **Spec edits** (\`polish.md\`):
  - **R-4a.6** (new): every PassageSpec has non-empty summary (closes spec-gap 3)
  - **R-5.4a** (new): Phase5aOutput.choice_labels MUST contain ≥1 entry (closes spec-gap 2)
  - **R-5.9** (expanded): sidetrack/diamond content requirements explicit + Pydantic-enforced

## Skipped from audit scope

- **P-5a / P-5b** (\`ResidueSpec.path_id\` / \`content_hint\` defaults): code construction sites in \`deterministic.py:453\` and \`llm_phases.py:1009\` CAN produce empty values when the flag-to-path lookup fails. This is a **code-construction issue, not a retry-bypass** — separate tracker recommended.
- **P-1** (\`CharacterArcMetadata\` pivots/end_per_path/arcs_per_path defaults): soft severity per audit; tightening would require updating ~20 test fixtures and no production failure has been observed yet. Defer to a follow-up.

## Test plan

- [x] \`uv run pytest tests/unit/ -k polish\` — 378 passed
- [x] \`uv run ruff check\` + \`uv run ruff format\` + \`uv run mypy\` — pass
- [ ] Bot review

## Tests added

- \`TestPassageSpecSummaryRequired\` (3 tests) — empty/missing summary rejected, non-empty accepted
- \`Phase5aOutput.test_empty_labels_rejected\` — replaces the inverted prior test
- \`FalseBranchDecisionItem.test_sidetrack_requires_summary\` — R-5.9
- \`FalseBranchDecisionItem.test_diamond_requires_both_summaries\` — R-5.10 (both directions: missing _a or missing _b)

Updated 8 existing \`PassageSpec\` test fixtures in \`test_polish_deterministic.py\` via a mechanical migration script — added \`summary="auto-summary"\` where missing.

## Related

- @prompt-engineer cross-stage audit (this session)
- #1521 / #1522 — SEED \`also_belongs_to\` (parallel pattern, merged)
- #1524 / #1525 — BRAINSTORM \`central_entity_ids\` (merged)
- #1526 / #1528 — GROW retry-bypass cluster (in flight)
- #1498 — POLISH retry-loop architecture (separate concern; not coupled)

🤖 Generated with [Claude Code](https://claude.com/claude-code)