### PR TITLE
fix(ship): _extract_choices reads choice edges (per ontology), not non-existent choice nodes

### DIFF
--- a/src/questfoundry/export/context.py
+++ b/src/questfoundry/export/context.py
@@ -138,11 +138,17 @@ def _extract_choices(graph: Graph) -> list[ExportChoice]:
             from_passage=edge["from"],
             to_passage=edge["to"],
             label=edge.get("label", "continue"),
-            requires_codewords=edge.get("requires_state_flags", edge.get("requires_codewords", [])),
+            # POLISH writes the gate-condition key as `"requires"` (see
+            # `_create_choice_edge` in pipeline/stages/polish/deterministic.py).
+            # Older fixtures used `requires_state_flags` / `requires_codewords`
+            # — those fallbacks are kept for migration safety.
+            requires_codewords=edge.get(
+                "requires", edge.get("requires_state_flags", edge.get("requires_codewords", []))
+            ),
             grants=edge.get("grants", []),
             is_return=edge.get("is_return", False),
         )
-        for edge in sorted(edges, key=lambda e: (e["from"], e["to"]))
+        for edge in sorted(edges, key=lambda e: (e["from"], e["to"], e.get("label", "")))
     ]
 
 

--- a/src/questfoundry/export/context.py
+++ b/src/questfoundry/export/context.py
@@ -124,18 +124,25 @@ def _extract_passages(graph: Graph) -> list[ExportPassage]:
 
 
 def _extract_choices(graph: Graph) -> list[ExportChoice]:
-    """Extract choice nodes (navigation links between passages)."""
-    nodes = graph.get_nodes_by_type("choice")
+    """Extract choice edges (navigation links between passages).
+
+    POLISH stores choices as graph edges (`add_edge("choice", ...)` in
+    `pipeline/stages/polish/deterministic.py`) — never as nodes. The
+    earlier node-based read silently produced an empty list, leaving
+    every export with zero navigable links and tripping SHIP's
+    reachability check on every project (#1532).
+    """
+    edges = graph.get_edges(edge_type="choice")
     return [
         ExportChoice(
-            from_passage=data["from_passage"],
-            to_passage=data["to_passage"],
-            label=data.get("label", "continue"),
-            requires_codewords=data.get("requires_state_flags", data.get("requires_codewords", [])),
-            grants=data.get("grants", []),
-            is_return=data.get("is_return", False),
+            from_passage=edge["from"],
+            to_passage=edge["to"],
+            label=edge.get("label", "continue"),
+            requires_codewords=edge.get("requires_state_flags", edge.get("requires_codewords", [])),
+            grants=edge.get("grants", []),
+            is_return=edge.get("is_return", False),
         )
-        for _node_id, data in sorted(nodes.items())
+        for edge in sorted(edges, key=lambda e: (e["from"], e["to"]))
     ]
 
 

--- a/tests/unit/test_export_context.py
+++ b/tests/unit/test_export_context.py
@@ -49,33 +49,25 @@ def _minimal_graph() -> Graph:
             "prose": "You flee into the forest.",
         },
     )
-    g.create_node(
-        "choice::intro_to_a",
-        {
-            "type": "choice",
-            "from_passage": "passage::intro",
-            "to_passage": "passage::choice_a",
-            "label": "Enter the castle",
-            "requires_codewords": [],
-            "grants": ["codeword::entered_castle"],
-        },
+    # Choices are stored as graph edges (POLISH writes them via
+    # `graph.add_edge("choice", ...)`) — see #1532 for the regression
+    # where the export context read non-existent choice nodes instead.
+    g.add_edge(
+        "choice",
+        "passage::intro",
+        "passage::choice_a",
+        label="Enter the castle",
+        requires_codewords=[],
+        grants=["codeword::entered_castle"],
     )
-    g.create_node(
-        "choice::intro_to_b",
-        {
-            "type": "choice",
-            "from_passage": "passage::intro",
-            "to_passage": "passage::choice_b",
-            "label": "Flee to the forest",
-            "requires_codewords": [],
-            "grants": [],
-        },
+    g.add_edge(
+        "choice",
+        "passage::intro",
+        "passage::choice_b",
+        label="Flee to the forest",
+        requires_codewords=[],
+        grants=[],
     )
-    # Edges for choice connectivity
-    g.add_edge("choice_from", "choice::intro_to_a", "passage::intro")
-    g.add_edge("choice_to", "choice::intro_to_a", "passage::choice_a")
-    g.add_edge("choice_from", "choice::intro_to_b", "passage::intro")
-    g.add_edge("choice_to", "choice::intro_to_b", "passage::choice_b")
     return g
 
 
@@ -155,6 +147,20 @@ class TestBuildExportContext:
         assert len(ctx.passages) == 3
         assert len(ctx.choices) == 2
 
+    def test_choices_read_from_edges_not_nodes(self) -> None:
+        # Regression for #1532: POLISH stores choices as edges, not nodes.
+        # The earlier _extract_choices read non-existent choice nodes and
+        # silently produced 0 choices, leaving every export with no
+        # navigable links.
+        g = _minimal_graph()
+        # Sanity: graph really has zero choice nodes and non-zero choice edges.
+        assert g.get_nodes_by_type("choice") == {}
+        assert len(g.get_edges(edge_type="choice")) == 2
+        ctx = build_export_context(g, "regression-1532")
+        assert len(ctx.choices) == 2
+        labels = {c.label for c in ctx.choices}
+        assert labels == {"Enter the castle", "Flee to the forest"}
+
     def test_start_passage_detected(self) -> None:
         g = _minimal_graph()
         ctx = build_export_context(g, "test")
@@ -174,33 +180,23 @@ class TestBuildExportContext:
                 "prose": "You look around.",
             },
         )
-        g.create_node(
-            "choice::intro_to_spoke_0",
-            {
-                "type": "choice",
-                "from_passage": "passage::intro",
-                "to_passage": "passage::spoke_0",
-                "label": "Look around",
-                "requires_codewords": [],
-                "grants": [],
-            },
+        g.add_edge(
+            "choice",
+            "passage::intro",
+            "passage::spoke_0",
+            label="Look around",
+            requires_codewords=[],
+            grants=[],
         )
-        g.add_edge("choice_from", "choice::intro_to_spoke_0", "passage::intro")
-        g.add_edge("choice_to", "choice::intro_to_spoke_0", "passage::spoke_0")
-        g.create_node(
-            "choice::spoke_0_return",
-            {
-                "type": "choice",
-                "from_passage": "passage::spoke_0",
-                "to_passage": "passage::intro",
-                "label": "Return",
-                "is_return": True,
-                "requires_codewords": [],
-                "grants": [],
-            },
+        g.add_edge(
+            "choice",
+            "passage::spoke_0",
+            "passage::intro",
+            label="Return",
+            is_return=True,
+            requires_codewords=[],
+            grants=[],
         )
-        g.add_edge("choice_from", "choice::spoke_0_return", "passage::spoke_0")
-        g.add_edge("choice_to", "choice::spoke_0_return", "passage::intro")
 
         ctx = build_export_context(g, "test")
         start_passages = [p for p in ctx.passages if p.is_start]

--- a/tests/unit/test_export_context.py
+++ b/tests/unit/test_export_context.py
@@ -161,6 +161,27 @@ class TestBuildExportContext:
         labels = {c.label for c in ctx.choices}
         assert labels == {"Enter the castle", "Flee to the forest"}
 
+    def test_choice_requires_round_trips_polish_edge_key(self) -> None:
+        # Regression for #1532 follow-up: POLISH writes the gate-condition
+        # key as `"requires"` (see _create_choice_edge in
+        # pipeline/stages/polish/deterministic.py:1430). The export must read
+        # the same key — the prior fallback chain (requires_state_flags →
+        # requires_codewords → []) silently dropped POLISH's gate values.
+        g = Graph()
+        g.create_node("passage::a", {"type": "passage", "raw_id": "a", "prose": "."})
+        g.create_node("passage::b", {"type": "passage", "raw_id": "b", "prose": "."})
+        g.add_edge(
+            "choice",
+            "passage::a",
+            "passage::b",
+            label="Open the gate",
+            requires=["state_flag::has_key"],  # POLISH's actual key name
+            grants=[],
+        )
+        ctx = build_export_context(g, "test")
+        assert len(ctx.choices) == 1
+        assert ctx.choices[0].requires_codewords == ["state_flag::has_key"]
+
     def test_start_passage_detected(self) -> None:
         g = _minimal_graph()
         ctx = build_export_context(g, "test")

--- a/tests/unit/test_ship_stage.py
+++ b/tests/unit/test_ship_stage.py
@@ -60,17 +60,14 @@ def _create_project_with_graph(project_path: Path, *, with_prose: bool = True) -
             "is_ending": True,
         },
     )
-    g.create_node(
-        "choice::enter",
-        {
-            "type": "choice",
-            "from_passage": "passage::intro",
-            "to_passage": "passage::castle",
-            "label": "Enter the castle",
-        },
+    # Per ontology Part 4, choices are edges (not nodes) — POLISH writes them
+    # via graph.add_edge("choice", from, to, ...). See #1532.
+    g.add_edge(
+        "choice",
+        "passage::intro",
+        "passage::castle",
+        label="Enter the castle",
     )
-    g.add_edge("choice_from", "choice::enter", "passage::intro")
-    g.add_edge("choice_to", "choice::enter", "passage::castle")
 
     g.save(project_path / "graph.db")
 


### PR DESCRIPTION
## Summary

Closes #1532. Surfaced from murder3 SHIP failure 2026-04-28.

## Root cause + ontology citation

\`docs/design/story-graph-ontology.md\` is unambiguous:

- L428: "**A choice is a directed edge between two passages**: 'from this passage, the player can go to that passage.'"
- L147: "the fork is encoded in predecessor/successor edges between beats and in **choice edges** between passages."
- L583-584 (POLISH stage table): "Creates: Passage nodes, **choice edges** ... Edges created: ... passage → passage (choices with labels/gates/grants)"
- L618 (SHIP stage table): "Reads ... **choice edges**, entities (with overlays)..."

POLISH writes choice edges via \`graph.add_edge("choice", from_passage, to_passage, ...)\` (\`pipeline/stages/polish/deterministic.py:1434/1496/1500/1555\`). SHIP's \`_extract_choices\` was reading \`graph.get_nodes_by_type("choice")\` — direct ontology violation that returned empty for every project. SHIP exported every story.twee with zero navigable links; reachability validation correctly fired on murder3 (\`73/74 passages unreachable from \\\`:: Start\\\`\`).

## Fix

Read \`graph.get_edges(edge_type="choice")\` and convert each edge dict (with \`from\`/\`to\` keys) to \`ExportChoice\`. Sort by (from, to) for stable output.

## Test plan

- [x] \`uv run pytest tests/unit/test_export_context.py tests/unit/test_export_validation.py tests/unit/test_twee_exporter.py\` — 83 passed
- [x] New regression test \`test_choices_read_from_edges_not_nodes\` asserts the fixture graph has zero choice nodes and non-zero choice edges, then verifies the export reads them
- [x] Migrated \`_minimal_graph\` and \`test_start_passage_ignores_return_links\` fixtures from \`create_node("choice::...", ...)\` + \`choice_from\`/\`choice_to\` edge pairs to direct \`add_edge("choice", from, to, label=...)\` — matches POLISH's actual storage and the ontology
- [ ] Bot review

## Note on murder3

Even after this fix, murder3's POLISH only produced 4 of an expected ~10 choice edges (binary forks for 2 of 5 dilemmas). That's a separate POLISH choice-edge derivation issue — \`compute_choice_edges\` may be missing some Y-shape forks. Track separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)