### PR TITLE
fix(polish): ResidueSpec.path_id required + skip-on-unmapped-flag at construction

### DIFF
--- a/src/questfoundry/models/polish.py
+++ b/src/questfoundry/models/polish.py
@@ -243,7 +243,14 @@ class ResidueSpec(BaseModel):
     target_passage_id: str = Field(min_length=1)
     residue_id: str = Field(min_length=1)
     flag: str = Field(min_length=1, description="State flag this residue addresses")
-    path_id: str = Field(default="")
+    path_id: str = Field(
+        min_length=1,
+        description=(
+            "Path the residue beat is attributed to. Derived from the flag's "
+            "consequence at construction time; if the lookup misses, the "
+            "residue beat is skipped rather than mis-attributed (#1530)."
+        ),
+    )
     content_hint: str = Field(
         default="", description="Mood-setting prose hint (populated by Phase 5)"
     )

--- a/src/questfoundry/pipeline/stages/polish/deterministic.py
+++ b/src/questfoundry/pipeline/stages/polish/deterministic.py
@@ -458,7 +458,7 @@ def compute_prose_feasibility(
                         "residue_spec_skipped_unmapped_flag",
                         flag=flag,
                         passage=spec.passage_id,
-                        available_paths=sorted(flag_to_path.values()),
+                        available_paths=sorted(set(flag_to_path.values())),
                         detail=(
                             "state_flag has no derived_from consequence with a "
                             "path_id; cannot attribute residue to a path. The "
@@ -1312,9 +1312,7 @@ def _apply_residue_with_variants(graph: Graph, rspec: ResidueSpec) -> None:
         },
     )
 
-    # Add belongs_to edge to path if specified
-    if rspec.path_id:
-        graph.add_edge("belongs_to", beat_id, rspec.path_id)
+    graph.add_edge("belongs_to", beat_id, rspec.path_id)
 
     # Create residue passage containing this beat
     graph.create_node(
@@ -1398,8 +1396,7 @@ def _apply_residue_parallel_passages(graph: Graph, rspec: ResidueSpec) -> None:
         },
     )
 
-    if rspec.path_id:
-        graph.add_edge("belongs_to", beat_id, rspec.path_id)
+    graph.add_edge("belongs_to", beat_id, rspec.path_id)
 
     # Create parallel residue passage — residue_for + mapping_strategy set
     # so Phase 7's _check_residue_mapping_strategy validates successfully.

--- a/src/questfoundry/pipeline/stages/polish/deterministic.py
+++ b/src/questfoundry/pipeline/stages/polish/deterministic.py
@@ -448,7 +448,29 @@ def compute_prose_feasibility(
         else:
             # All relevant flags are light → deterministically residue
             for flag in relevant_flags:
-                path_id = flag_to_path.get(flag, "")
+                path_id = flag_to_path.get(flag)
+                if not path_id:
+                    # Flag has no derived_from→consequence→path_id mapping.
+                    # Skip rather than emit a malformed ResidueSpec with empty
+                    # path_id (which would silently mis-attribute the residue
+                    # beat downstream — see #1530).
+                    log.warning(
+                        "residue_spec_skipped_unmapped_flag",
+                        flag=flag,
+                        passage=spec.passage_id,
+                        available_paths=sorted(flag_to_path.values()),
+                        detail=(
+                            "state_flag has no derived_from consequence with a "
+                            "path_id; cannot attribute residue to a path. The "
+                            "residue beat for this flag will be missing — fix "
+                            "the upstream consequence wiring."
+                        ),
+                    )
+                    warnings.append(
+                        f"Residue beat skipped for unmapped flag {flag} on "
+                        f"passage {spec.passage_id} (R-5.5 path attribution)."
+                    )
+                    continue
                 residue_specs.append(
                     ResidueSpec(
                         target_passage_id=spec.passage_id,

--- a/src/questfoundry/pipeline/stages/polish/llm_phases.py
+++ b/src/questfoundry/pipeline/stages/polish/llm_phases.py
@@ -1003,7 +1003,30 @@ class _PolishLLMPhaseMixin:
                         ).model_dump()
                     )
                 elif d == "residue":
-                    path_id = flag.split(":")[-1] if ":" in flag else ""
+                    # Resolve flag → path_id via derived_from→consequence (same
+                    # lookup as Phase 4b in deterministic.py — see #1530).
+                    # The previous `flag.split(":")[-1]` was a string-mangling
+                    # heuristic that did NOT yield a real path_id and silently
+                    # mis-attributed the residue beat downstream.
+                    path_id = ""
+                    consequence_nodes = graph.get_nodes_by_type("consequence")
+                    for edge in graph.get_edges(edge_type="derived_from", from_id=flag):
+                        cdata = consequence_nodes.get(edge["to"], {})
+                        candidate = cdata.get("path_id", "")
+                        if candidate:
+                            path_id = candidate
+                            break
+                    if not path_id:
+                        log.warning(
+                            "phase5e_residue_skipped_unmapped_flag",
+                            flag=flag,
+                            passage=passage_id,
+                            detail=(
+                                "state_flag has no derived_from consequence "
+                                "with a path_id; residue beat skipped (#1530)."
+                            ),
+                        )
+                        continue
                     passage_raw = passage_id.split("::")[-1]
                     residue_specs.append(
                         ResidueSpec(

--- a/src/questfoundry/pipeline/stages/polish/llm_phases.py
+++ b/src/questfoundry/pipeline/stages/polish/llm_phases.py
@@ -972,6 +972,16 @@ class _PolishLLMPhaseMixin:
                 c.passage_id: c for c in ambiguous_cases
             }
 
+            # Hoist flag → path_id resolution (mirrors deterministic.py:313-322
+            # so Phase 5e residue construction uses the same lookup as Phase 4b).
+            consequence_nodes = graph.get_nodes_by_type("consequence")
+            flag_to_path: dict[str, str] = {}
+            for edge in graph.get_edges(edge_type="derived_from"):
+                cdata = consequence_nodes.get(edge["to"], {})
+                candidate = cdata.get("path_id", "")
+                if candidate:
+                    flag_to_path[edge["from"]] = candidate
+
             resolved_count = 0
             for decision in result_e.feasibility_decisions:
                 passage_id = decision.passage_id
@@ -1003,27 +1013,16 @@ class _PolishLLMPhaseMixin:
                         ).model_dump()
                     )
                 elif d == "residue":
-                    # Resolve flag → path_id via derived_from→consequence (same
-                    # lookup as Phase 4b in deterministic.py — see #1530).
-                    # The previous `flag.split(":")[-1]` was a string-mangling
-                    # heuristic that did NOT yield a real path_id and silently
-                    # mis-attributed the residue beat downstream.
-                    path_id = ""
-                    consequence_nodes = graph.get_nodes_by_type("consequence")
-                    for edge in graph.get_edges(edge_type="derived_from", from_id=flag):
-                        cdata = consequence_nodes.get(edge["to"], {})
-                        candidate = cdata.get("path_id", "")
-                        if candidate:
-                            path_id = candidate
-                            break
+                    path_id = flag_to_path.get(flag, "")
                     if not path_id:
                         log.warning(
                             "phase5e_residue_skipped_unmapped_flag",
                             flag=flag,
                             passage=passage_id,
+                            available_paths=sorted(set(flag_to_path.values())),
                             detail=(
                                 "state_flag has no derived_from consequence "
-                                "with a path_id; residue beat skipped (#1530)."
+                                "with a path_id; residue beat skipped."
                             ),
                         )
                         continue

--- a/tests/unit/test_polish_apply.py
+++ b/tests/unit/test_polish_apply.py
@@ -221,6 +221,7 @@ class TestCreateResidueBeatAndPassage:
     def test_residue_without_content_hint_uses_default(self) -> None:
         graph = Graph.empty()
         _make_beat(graph, "beat::target")
+        graph.create_node("path::brave", {"type": "path", "raw_id": "brave"})
 
         target_spec = PassageSpec(
             passage_id="passage::target",
@@ -233,6 +234,7 @@ class TestCreateResidueBeatAndPassage:
             target_passage_id="passage::target",
             residue_id="residue::r2",
             flag="flag1",
+            path_id="path::brave",
         )
         _create_residue_beat_and_passage(graph, rspec)
 
@@ -439,6 +441,7 @@ class TestCreateResidueBeatAndPassage:
         """
         graph = Graph.empty()
         _make_beat(graph, "beat::target")
+        graph.create_node("path::brave", {"type": "path", "raw_id": "brave"})
 
         target_spec = PassageSpec(
             passage_id="passage::target",
@@ -452,6 +455,7 @@ class TestCreateResidueBeatAndPassage:
             target_passage_id="passage::target",
             residue_id="residue::r_empty",
             flag="flag1",
+            path_id="path::brave",
         )
         _create_residue_beat_and_passage(graph, rspec)
 

--- a/tests/unit/test_polish_deterministic.py
+++ b/tests/unit/test_polish_deterministic.py
@@ -1900,6 +1900,50 @@ class TestAmbiguousFeasibilityDetection:
         assert len(result["ambiguous_specs"]) == 0
         assert len(result["variant_specs"]) == 1  # heavy → variant
 
+    def test_residue_skipped_when_flag_has_no_consequence_mapping(self) -> None:
+        """Single light flag with no derived_from→consequence→path_id wiring →
+        residue spec is skipped (warn + continue), not constructed with empty
+        path_id (#1530).
+        """
+        graph = Graph.empty()
+
+        graph.create_node(
+            "dilemma::d1",
+            {"type": "dilemma", "raw_id": "d1", "residue_weight": "light"},
+        )
+        graph.create_node("path::p1", {"type": "path", "raw_id": "p1"})
+
+        # Commit beat creates the state_flag node, but no derived_from edge
+        # to a consequence with a path_id — flag_to_path lookup will miss.
+        sf_p1 = self._make_commit_beat(graph, "beat::c1", "path::p1", "dilemma::d1")
+
+        graph.create_node(
+            "entity::hero",
+            {
+                "type": "entity",
+                "raw_id": "hero",
+                "overlays": [
+                    {"when": [sf_p1], "details": {"mood": "wistful"}},
+                ],
+            },
+        )
+
+        _make_beat(graph, "beat::target", "Target", entities=["entity::hero"])
+        graph.add_edge("belongs_to", "beat::target", "path::p1")
+        _add_predecessor(graph, "beat::target", "beat::c1")
+
+        spec = PassageSpec(
+            passage_id="passage::orphan",
+            beat_ids=["beat::target"],
+            summary="orphan flag passage",
+            entities=["entity::hero"],
+        )
+
+        result = compute_prose_feasibility(graph, [spec])
+        assert result["residue_specs"] == []
+        warnings = result["warnings"]
+        assert any("Residue beat skipped" in w and sf_p1 in w for w in warnings)
+
 
 # ---------------------------------------------------------------------------
 # Tests for Issue #1158: transition_guidance stored on passage node in Phase 6

--- a/tests/unit/test_polish_phase5_models.py
+++ b/tests/unit/test_polish_phase5_models.py
@@ -181,7 +181,9 @@ class TestResidueSpecContentHint:
     """Test the content_hint field added to ResidueSpec."""
 
     def test_default_empty(self) -> None:
-        spec = ResidueSpec(target_passage_id="p1", residue_id="r1", flag="flag1")
+        spec = ResidueSpec(
+            target_passage_id="p1", residue_id="r1", flag="flag1", path_id="path::test"
+        )
         assert spec.content_hint == ""
 
     def test_with_content_hint(self) -> None:
@@ -190,6 +192,7 @@ class TestResidueSpecContentHint:
             residue_id="r1",
             flag="flag1",
             content_hint="You enter confidently",
+            path_id="path::test",
         )
         assert spec.content_hint == "You enter confidently"
 

--- a/tests/unit/test_polish_phases.py
+++ b/tests/unit/test_polish_phases.py
@@ -616,6 +616,77 @@ class TestPhase5eAmbiguousFeasibility:
         # Nothing added to variant or residue specs
         assert len(plan_data.get("variant_specs", [])) == 0
 
+    def test_residue_decision_with_unmapped_flag_skips_spec(self) -> None:
+        """LLM 'residue' decision on a flag without a derived_from→consequence
+        path_id mapping skips the spec instead of constructing a malformed one.
+        """
+        from questfoundry.models.polish import (
+            AmbiguousFeasibilityCase,
+            FeasibilityDecisionItem,
+            PassageSpec,
+            Phase5eOutput,
+        )
+
+        graph = Graph.empty()
+
+        passage = PassageSpec(
+            passage_id="passage::ambig_x",
+            beat_ids=["beat::x"],
+            summary="Ambiguous passage with unmapped flag",
+            entities=["entity::hero"],
+            grouping_type="singleton",
+        )
+        ambiguous = AmbiguousFeasibilityCase(
+            passage_id="passage::ambig_x",
+            passage_summary="Ambiguous passage with unmapped flag",
+            entities=["entity::hero"],
+            flags=["dilemma::heavy:path::orphan"],
+        )
+
+        # Intentionally no derived_from edge / consequence wiring for this flag.
+        graph.create_node(
+            "polish_plan::current",
+            {
+                "type": "polish_plan",
+                "raw_id": "current",
+                "passage_count": 1,
+                "variant_count": 0,
+                "residue_count": 0,
+                "choice_count": 0,
+                "candidate_count": 0,
+                "warnings": [],
+                "passage_specs": [passage.model_dump()],
+                "variant_specs": [],
+                "residue_specs": [],
+                "choice_specs": [],
+                "false_branch_candidates": [],
+                "false_branch_specs": [],
+                "feasibility_annotations": {},
+                "ambiguous_specs": [ambiguous.model_dump()],
+                "arc_traversals": {},
+            },
+        )
+
+        llm_output = Phase5eOutput(
+            feasibility_decisions=[
+                FeasibilityDecisionItem(
+                    passage_id="passage::ambig_x",
+                    flag_index=0,
+                    decision="residue",
+                )
+            ]
+        )
+
+        host = _FakePolishLLMHost(llm_output)
+        result = asyncio.run(host._phase_5_llm_enrichment(graph, MagicMock()))  # type: ignore[arg-type]
+
+        assert result.status == "completed"
+
+        plan_nodes = graph.get_nodes_by_type("polish_plan")
+        plan_data = plan_nodes.get("polish_plan::current", {})
+        residue_specs = plan_data.get("residue_specs", [])
+        assert residue_specs == []
+
     def test_skipped_when_no_ambiguous_cases(self) -> None:
         """Phase 5e is skipped when ambiguous_specs is empty."""
         from questfoundry.models.polish import Phase5eOutput

--- a/tests/unit/test_polish_phases.py
+++ b/tests/unit/test_polish_phases.py
@@ -488,6 +488,19 @@ class TestPhase5eAmbiguousFeasibility:
             flags=["dilemma::heavy:path::ph"],
         )
 
+        # Wire flag → consequence → path_id so the residue-decision lookup
+        # in Phase 5e (#1530) can resolve the flag to a real path.
+        graph.create_node("path::ph", {"type": "path", "raw_id": "ph"})
+        graph.create_node(
+            "consequence::heavy",
+            {"type": "consequence", "raw_id": "heavy", "path_id": "path::ph"},
+        )
+        graph.create_node(
+            "dilemma::heavy:path::ph",
+            {"type": "state_flag", "raw_id": "heavy", "derived_from": "consequence::heavy"},
+        )
+        graph.add_edge("derived_from", "dilemma::heavy:path::ph", "consequence::heavy")
+
         graph.create_node(
             "polish_plan::current",
             {


### PR DESCRIPTION
## Summary

Closes #1530.

Two ResidueSpec construction sites silently fell back to empty \`path_id\` when the flag→path lookup missed:

| Site | Old fallback | New behavior |
|---|---|---|
| \`deterministic.py:451\` (Phase 4b) | \`flag_to_path.get(flag, "")\` | Log structured WARNING + skip the residue spec |
| \`llm_phases.py:1006\` (Phase 5e) | \`flag.split(":")[-1] if ":" in flag else ""\` (string-split heuristic, NOT a real path_id) | Replace with same derived_from→consequence→path_id lookup as Phase 4b; same WARNING-and-skip on miss |

After tightening, \`ResidueSpec.path_id\` Pydantic constraint becomes \`min_length=1\` (no default). Production paths produce non-empty values.

## Skipped from audit scope

- \`ResidueSpec.content_hint\` and \`VariantSpec.summary\` — populated by Phase 5b/5d (\`Phase5bOutput.residue_content[*].content_hint\` and \`VariantSummaryItem.summary\` already have \`min_length=1\`). Phase 4b/4c create with empty default that Phase 5 fills. Tightening these would require reordering Phase 4 / Phase 5 coupling — separate concern.

## Test plan

- [x] \`uv run pytest tests/unit/ -k polish\` — 380 passed
- [x] \`uv run ruff check\` + \`uv run ruff format\` + \`uv run mypy\` — pass
- [ ] Bot review

## Tests

- 4 existing test fixtures migrated via mechanical patch script to provide \`path_id="path::brave"\` or \`path_id="path::test"\`
- 2 \`test_polish_apply\` fixtures gained \`graph.create_node("path::brave", ...)\` setup so the resulting \`belongs_to\` edge target exists
- \`_build_plan_with_ambiguous\` in \`test_polish_phases\` now wires \`flag → consequence → path_id\` so Phase 5e residue lookup succeeds

## Related

- @prompt-engineer cross-stage audit (this session) — P-5a/P-5b
- #1521 / #1522, #1524 / #1525, #1526 / #1528, #1527 / #1529 — parallel retry-bypass cluster fixes
- #1531 — Phase4eOutput/Phase4fOutput defaults + GapProposal.transition_style (next in queue)

🤖 Generated with [Claude Code](https://claude.com/claude-code)