### PR TITLE
fix(polish): emit Continue choice edges for linear cross-passage transitions

### DIFF
--- a/docs/design/procedures/polish.md
+++ b/docs/design/procedures/polish.md
@@ -321,6 +321,8 @@ R-4c.5. Choices with a single outgoing successor across all arcs have empty `req
 
 R-4c.6. False branch choices (cosmetic) have empty `requires` unless they grant a cosmetic state flag that gates a later residue beat.
 
+R-4c.7. Every cross-passage beat predecessor edge that is NOT already covered by a Y-fork (R-4c.1) produces a `Continue` ChoiceSpec with empty `requires` and empty `grants`. Without these edges the passage layer is unreachable past Y-fork commit beats — every linear post-commit chain becomes a dead end and SHIP's reachability validator (R-4.2) fires. The label is the literal string `"Continue"` (Phase 5a does not relabel R-4c.7 choices). Two beats in the same passage do NOT generate a choice — within-passage transitions belong to FILL prose. A divergence-source beat (≥2 successors) is skipped here; its choices are handled by R-4c.1.
+
 **Violations:**
 
 | Symptom | Root cause | Broken rule |
@@ -328,6 +330,7 @@ R-4c.6. False branch choices (cosmetic) have empty `requires` unless they grant 
 | Phase 4c produces zero choice edges | No Y-fork in beat DAG — SEED did not produce Y-shape, or GROW failed. POLISH MUST halt with ERROR identifying the broken upstream stage; silently passing an empty plan forward violates the Silent Degradation policy (see Implementation Constraints) | R-4c.2 |
 | Post-convergence soft-dilemma choice has empty `requires` | Flag gate missing — player on wrong path can take unavailable choice | R-4c.3 |
 | Hard-dilemma choice has `requires` set | Unnecessary gate (passage graph is already separate) | R-4c.4 |
+| Linear post-commit passages produce zero outgoing choices | R-4c.7 not implemented — every cross-passage predecessor edge should yield a `Continue` | R-4c.7 |
 
 #### 4d: False Branch Candidate Identification
 
@@ -705,6 +708,7 @@ R-4c.3: Post-convergence soft-dilemma choices have `requires` set.
 R-4c.4: Hard-dilemma choices have empty `requires`.
 R-4c.5: Single-outgoing-successor choices have empty `requires`.
 R-4c.6: False-branch choices empty `requires` unless granting cosmetic flag.
+R-4c.7: Cross-passage non-fork transitions emit a `Continue` choice (label literal, empty `requires`/`grants`).
 R-4d.1: False branch candidates are 3+ consecutive choice-less passages.
 R-4d.2: Phase 4d identifies only; no node creation.
 R-4d.3: Candidates include surrounding context.

--- a/src/questfoundry/pipeline/stages/polish/deterministic.py
+++ b/src/questfoundry/pipeline/stages/polish/deterministic.py
@@ -144,20 +144,33 @@ async def phase_plan_computation(
 
     # 4c: Choice edge derivation
     plan.choice_specs = compute_choice_edges(graph, plan.passage_specs)
-    if not plan.choice_specs:
+    # R-4c.2 only fires when there are no Y-fork choices. Continue choices
+    # (R-4c.7) cover linear cross-passage transitions and do NOT satisfy the
+    # "story has Y-forks" invariant — a story with only Continue edges is
+    # still a SEED/GROW failure, just one that R-4c.7 partly masks. Filter
+    # Continue edges out before counting.
+    fork_choices = [c for c in plan.choice_specs if c.label != "Continue"]
+    if not fork_choices:
         from questfoundry.graph.polish_validation import PolishContractError
 
         log.error(
             "polish_zero_choice_halt",
             upstream="SEED/GROW",
             passage_count=len(plan.passage_specs),
-            detail="Phase 4c produced zero choice edges — upstream DAG has no Y-forks",
+            total_choices=len(plan.choice_specs),
+            continue_choices=len(plan.choice_specs),
+            detail="Phase 4c produced no Y-fork choice edges — upstream DAG has no Y-forks",
         )
         raise PolishContractError(
-            "R-4c.2: Phase 4c produced zero choice edges — SEED/GROW DAG has "
-            "no Y-forks.  Upstream bug — halting POLISH."
+            "R-4c.2: Phase 4c produced no Y-fork choice edges (only "
+            f"{len(plan.choice_specs)} Continue edge(s)) — SEED/GROW DAG has "
+            "no Y-forks. Upstream bug — halting POLISH."
         )
-    log.debug("phase4c_complete", choices=len(plan.choice_specs))
+    log.debug(
+        "phase4c_complete",
+        choices=len(plan.choice_specs),
+        fork_choices=len(fork_choices),
+    )
 
     # 4d: False branch candidate identification
     plan.false_branch_candidates = find_false_branch_candidates(graph, plan.passage_specs)

--- a/src/questfoundry/pipeline/stages/polish/deterministic.py
+++ b/src/questfoundry/pipeline/stages/polish/deterministic.py
@@ -864,6 +864,35 @@ def compute_choice_edges(
                         label="",  # Populated by Phase 5
                     )
 
+    # R-4c.7: emit Continue choice edges for linear cross-passage transitions.
+    # Every cross-passage beat predecessor edge that does not originate at a
+    # divergence point produces a single "Continue" choice. Without this the
+    # passage layer is unreachable past Y-fork commit beats — SHIP's
+    # reachability validator (R-4.2) fires on any post-commit linear chain.
+    for edge in predecessor_edges:
+        from_beat = edge["to"]  # predecessor relation: B requires A → A precedes B
+        to_beat = edge["from"]
+        if from_beat not in beat_nodes or to_beat not in beat_nodes:
+            continue
+        from_p = beat_to_passage.get(from_beat)
+        to_p = beat_to_passage.get(to_beat)
+        if not from_p or not to_p or from_p == to_p:
+            continue
+        if (from_p, to_p) in choices_map:
+            continue  # already covered by Y-fork handler
+        # Skip when source beat is a divergence point: the Y-fork handler
+        # already emitted same-dilemma choices, and other-dilemma children
+        # are temporal interleaving (not player choices).
+        if len(children.get(from_beat, [])) > 1:
+            continue
+        choices_map[(from_p, to_p)] = ChoiceSpec(
+            from_passage=from_p,
+            to_passage=to_p,
+            grants=[],
+            requires=[],
+            label="Continue",
+        )
+
     return list(choices_map.values())
 
 

--- a/src/questfoundry/pipeline/stages/polish/llm_phases.py
+++ b/src/questfoundry/pipeline/stages/polish/llm_phases.py
@@ -863,7 +863,10 @@ class _PolishLLMPhaseMixin:
 
             # R-5.2: labels are distinct within a source passage.  Case-insensitive
             # uniqueness — detect collisions, log a WARNING so humans can review.
-            for collision in _detect_duplicate_labels_in_passage(choice_specs):
+            # Use labelable_specs (excludes Continue): two Continue edges from the
+            # same passage are navigational, not diegetic, so a "Continue/Continue"
+            # collision is meaningless and should not surface as an R-5.2 warning.
+            for collision in _detect_duplicate_labels_in_passage(labelable_specs):
                 log.warning(
                     "phase5a_duplicate_labels_in_passage",
                     from_passage=collision["from_passage"],

--- a/src/questfoundry/pipeline/stages/polish/llm_phases.py
+++ b/src/questfoundry/pipeline/stages/polish/llm_phases.py
@@ -827,8 +827,12 @@ class _PolishLLMPhaseMixin:
         enrichment_parts: list[str] = []
 
         # 5a: Choice labels
-        if choice_specs:
-            context = format_choice_label_context(graph, choice_specs, passage_specs)
+        # R-4c.7: Continue choices ship with the literal label "Continue" already
+        # set by compute_choice_edges. They are navigational (linear cross-passage
+        # transitions) and should not be sent to the LLM for diegetic relabeling.
+        labelable_specs = [s for s in choice_specs if s.get("label", "") != "Continue"]
+        if labelable_specs:
+            context = format_choice_label_context(graph, labelable_specs, passage_specs)
             result, llm_calls, tokens = await self._polish_llm_call(  # type: ignore[attr-defined]
                 model=model,
                 template_name="polish_phase5a_choice_labels",
@@ -852,7 +856,7 @@ class _PolishLLMPhaseMixin:
                     )
                 else:
                     label_lookup[key] = item.label
-            for spec in choice_specs:
+            for spec in labelable_specs:
                 key = (spec["from_passage"], spec["to_passage"])
                 if key in label_lookup:
                     spec["label"] = label_lookup[key]

--- a/tests/unit/test_polish_contract.py
+++ b/tests/unit/test_polish_contract.py
@@ -437,7 +437,37 @@ def test_phase_4c_zero_choices_raises_contract_error() -> None:
     # passages → no choices. Phase 4a will produce empty passage_specs.
     graph = Graph.empty()
 
-    with pytest.raises(PolishContractError, match=r"R-4c\.2|zero choice"):
+    with pytest.raises(PolishContractError, match=r"R-4c\.2|zero choice|no Y-fork"):
+        asyncio.run(deterministic.phase_plan_computation(graph, MagicMock()))
+
+
+def test_phase_4c_linear_only_still_raises_contract_error() -> None:
+    """A non-empty linear story (Continue choices but no Y-forks) still trips R-4c.2.
+
+    R-4c.7 emits Continue edges for cross-passage transitions, so a linear-only
+    graph passes `if not plan.choice_specs`. The R-4c.2 halt must filter out
+    Continue edges to keep its "story has no Y-forks" semantics.
+    """
+    from unittest.mock import MagicMock
+
+    from questfoundry.pipeline.stages.polish import deterministic
+
+    graph = Graph.empty()
+    # Two beats in different paths' worth of passages but no Y-fork.
+    graph.create_node("path::p1", {"type": "path", "raw_id": "p1"})
+    graph.create_node(
+        "beat::a",
+        {"type": "beat", "raw_id": "a", "summary": "A.", "dilemma_impacts": []},
+    )
+    graph.create_node(
+        "beat::b",
+        {"type": "beat", "raw_id": "b", "summary": "B.", "dilemma_impacts": []},
+    )
+    graph.add_edge("belongs_to", "beat::a", "path::p1")
+    graph.add_edge("belongs_to", "beat::b", "path::p1")
+    graph.add_edge("predecessor", "beat::b", "beat::a")
+
+    with pytest.raises(PolishContractError, match=r"R-4c\.2|no Y-fork"):
         asyncio.run(deterministic.phase_plan_computation(graph, MagicMock()))
 
 

--- a/tests/unit/test_polish_deterministic.py
+++ b/tests/unit/test_polish_deterministic.py
@@ -338,8 +338,8 @@ class TestComputeChoiceEdges:
         assert from_passages == {"p_start"}
         assert to_passages == {"p_a", "p_b"}
 
-    def test_no_divergence(self) -> None:
-        """Linear chain produces no choices."""
+    def test_no_divergence_emits_continue_choice(self) -> None:
+        """Linear cross-passage transition emits a `Continue` choice (R-4c.7)."""
         graph = Graph.empty()
         graph.create_node("path::p1", {"type": "path", "raw_id": "p1"})
         _make_beat(graph, "beat::a", "A")
@@ -354,7 +354,35 @@ class TestComputeChoiceEdges:
         ]
 
         choices = compute_choice_edges(graph, specs)
-        assert len(choices) == 0
+        assert len(choices) == 1
+        assert choices[0].from_passage == "p_a"
+        assert choices[0].to_passage == "p_b"
+        assert choices[0].label == "Continue"
+        assert choices[0].requires == []
+        assert choices[0].grants == []
+
+    def test_within_passage_transitions_emit_no_choice(self) -> None:
+        """Two beats grouped into a single passage do NOT generate a choice
+        (R-4c.7: within-passage transitions belong to FILL prose).
+        """
+        graph = Graph.empty()
+        graph.create_node("path::p1", {"type": "path", "raw_id": "p1"})
+        _make_beat(graph, "beat::a", "A")
+        _make_beat(graph, "beat::b", "B")
+        _add_belongs_to(graph, "beat::a", "path::p1")
+        _add_belongs_to(graph, "beat::b", "path::p1")
+        _add_predecessor(graph, "beat::b", "beat::a")
+
+        specs = [
+            PassageSpec(
+                passage_id="p_collapsed",
+                beat_ids=["beat::a", "beat::b"],
+                summary="collapsed",
+            ),
+        ]
+
+        choices = compute_choice_edges(graph, specs)
+        assert choices == []
 
     def test_grants_from_commit(self) -> None:
         """Choice leading to a commit beat populates grants."""
@@ -401,6 +429,105 @@ class TestComputeChoiceEdges:
         choice_to_a = [c for c in choices if c.to_passage == "p_a"]
         assert len(choice_to_a) == 1
         assert len(choice_to_a[0].grants) > 0
+
+
+class TestContinueChoiceEdges:
+    """Tests for R-4c.7: cross-passage non-fork transitions emit Continue edges."""
+
+    def test_three_beat_linear_path_emits_two_continue_choices(self) -> None:
+        """A 3-beat linear path with one beat per passage produces 2 Continue choices."""
+        graph = Graph.empty()
+        graph.create_node("path::p1", {"type": "path", "raw_id": "p1"})
+        for raw in ("a", "b", "c"):
+            _make_beat(graph, f"beat::{raw}", raw.upper())
+            _add_belongs_to(graph, f"beat::{raw}", "path::p1")
+        _add_predecessor(graph, "beat::b", "beat::a")
+        _add_predecessor(graph, "beat::c", "beat::b")
+
+        specs = [
+            PassageSpec(passage_id="p_a", beat_ids=["beat::a"], summary="a"),
+            PassageSpec(passage_id="p_b", beat_ids=["beat::b"], summary="b"),
+            PassageSpec(passage_id="p_c", beat_ids=["beat::c"], summary="c"),
+        ]
+
+        choices = compute_choice_edges(graph, specs)
+        assert len(choices) == 2
+        for choice in choices:
+            assert choice.label == "Continue"
+            assert choice.requires == []
+            assert choice.grants == []
+        pairs = {(c.from_passage, c.to_passage) for c in choices}
+        assert pairs == {("p_a", "p_b"), ("p_b", "p_c")}
+
+    def test_fork_plus_linear_emits_fork_choices_and_continue(self) -> None:
+        """A Y-fork followed by linear post-commit paths produces fork choices
+        plus Continue choices on each post-commit segment.
+        """
+        graph = Graph.empty()
+        graph.create_node("path::pa", {"type": "path", "raw_id": "pa"})
+        graph.create_node("path::pb", {"type": "path", "raw_id": "pb"})
+        _setup_dilemma(graph, "dilemma::d1", ["path::pa", "path::pb"])
+
+        _make_beat(graph, "beat::start", "Start")
+        _make_beat(
+            graph,
+            "beat::commit_a",
+            "Commit A",
+            dilemma_impacts=[{"dilemma_id": "dilemma::d1", "effect": "commits"}],
+        )
+        _make_beat(
+            graph,
+            "beat::commit_b",
+            "Commit B",
+            dilemma_impacts=[{"dilemma_id": "dilemma::d1", "effect": "commits"}],
+        )
+        _make_beat(graph, "beat::after_a", "After A")
+        _make_beat(graph, "beat::after_b", "After B")
+
+        _add_belongs_to(graph, "beat::start", "path::pa")
+        _add_belongs_to(graph, "beat::start", "path::pb")
+        _add_belongs_to(graph, "beat::commit_a", "path::pa")
+        _add_belongs_to(graph, "beat::commit_b", "path::pb")
+        _add_belongs_to(graph, "beat::after_a", "path::pa")
+        _add_belongs_to(graph, "beat::after_b", "path::pb")
+
+        _add_predecessor(graph, "beat::commit_a", "beat::start")
+        _add_predecessor(graph, "beat::commit_b", "beat::start")
+        _add_predecessor(graph, "beat::after_a", "beat::commit_a")
+        _add_predecessor(graph, "beat::after_b", "beat::commit_b")
+
+        graph.create_node(
+            "state_flag::pa_committed", {"type": "state_flag", "raw_id": "pa_committed"}
+        )
+        graph.create_node(
+            "state_flag::pb_committed", {"type": "state_flag", "raw_id": "pb_committed"}
+        )
+        graph.add_edge("grants", "beat::commit_a", "state_flag::pa_committed")
+        graph.add_edge("grants", "beat::commit_b", "state_flag::pb_committed")
+
+        specs = [
+            PassageSpec(passage_id="p_start", beat_ids=["beat::start"], summary="start"),
+            PassageSpec(passage_id="p_commit_a", beat_ids=["beat::commit_a"], summary="ca"),
+            PassageSpec(passage_id="p_commit_b", beat_ids=["beat::commit_b"], summary="cb"),
+            PassageSpec(passage_id="p_after_a", beat_ids=["beat::after_a"], summary="aa"),
+            PassageSpec(passage_id="p_after_b", beat_ids=["beat::after_b"], summary="ab"),
+        ]
+
+        choices = compute_choice_edges(graph, specs)
+        fork = [c for c in choices if c.label != "Continue"]
+        cont = [c for c in choices if c.label == "Continue"]
+
+        # Two fork choices from start
+        assert len(fork) == 2
+        assert {c.to_passage for c in fork} == {"p_commit_a", "p_commit_b"}
+        assert all(c.from_passage == "p_start" for c in fork)
+
+        # Two Continue choices on the post-commit linear segments
+        assert len(cont) == 2
+        assert {(c.from_passage, c.to_passage) for c in cont} == {
+            ("p_commit_a", "p_after_a"),
+            ("p_commit_b", "p_after_b"),
+        }
 
 
 class TestChoiceEdgesIntersectionMultiBeat:
@@ -1109,16 +1236,17 @@ class TestChoiceEdgesYShapeAdvancesChild:
 
         choices = compute_choice_edges(graph, specs)
 
-        # Should produce 2 choices: shared → a_setup, shared → b_setup
-        assert len(choices) == 2, (
-            f"Expected 2 choices, got {len(choices)}: "
-            f"{[(c.from_passage, c.to_passage) for c in choices]}"
+        # Filter out R-4c.7 Continue edges; this test asserts the fork shape.
+        fork_choices = [c for c in choices if c.label != "Continue"]
+        assert len(fork_choices) == 2, (
+            f"Expected 2 fork choices, got {len(fork_choices)}: "
+            f"{[(c.from_passage, c.to_passage) for c in fork_choices]}"
         )
-        to_passages = {c.to_passage for c in choices}
+        to_passages = {c.to_passage for c in fork_choices}
         assert "passage::a_setup" in to_passages
         assert "passage::b_setup" in to_passages
-        # All choices should originate from the shared passage
-        assert all(c.from_passage == "passage::shared" for c in choices)
+        # All fork choices should originate from the shared passage
+        assert all(c.from_passage == "passage::shared" for c in fork_choices)
 
     def test_grants_found_via_deep_walk(self) -> None:
         """Grants should be populated even when commits beat is a grandchild."""
@@ -1232,9 +1360,11 @@ class TestChoiceEdgesYShapeAdvancesChild:
 
         choices = compute_choice_edges(graph, specs)
 
-        assert len(choices) == 2
-        # Each choice should have grants from the commits beat downstream
-        for choice in choices:
+        # Filter to fork choices; R-4c.7 Continue edges are linear and have no grants.
+        fork_choices = [c for c in choices if c.label != "Continue"]
+        assert len(fork_choices) == 2
+        # Each fork choice should have grants from the commits beat downstream
+        for choice in fork_choices:
             assert len(choice.grants) > 0, (
                 f"Choice {choice.from_passage}→{choice.to_passage} has no grants; "
                 f"commits beat should have been found via deep walk"

--- a/tests/unit/test_polish_phases.py
+++ b/tests/unit/test_polish_phases.py
@@ -638,6 +638,188 @@ class TestPhase5eAmbiguousFeasibility:
         assert "0 ambiguous cases resolved" in result.detail
 
 
+class _RecordingPolishLLMHost(_PolishLLMPhaseMixin):
+    """Like _FakePolishLLMHost, but records (template_name, context, schema) per call.
+
+    Used by Phase 5a tests to assert which specs were forwarded to the LLM.
+    """
+
+    def __init__(self, results_by_template: dict[str, object]) -> None:
+        self._results = results_by_template
+        self.calls: list[tuple[str, object, object]] = []
+
+    async def _polish_llm_call(
+        self,
+        model: object,  # noqa: ARG002
+        template_name: str,
+        context: object,
+        output_schema: object,
+    ) -> tuple[object, int, int]:
+        self.calls.append((template_name, context, output_schema))
+        result = self._results.get(template_name)
+        if result is None:
+            raise AssertionError(f"Unexpected template call: {template_name}")
+        return (result, 1, 100)
+
+
+class TestPhase5aContinueFiltering:
+    """Phase 5a must NOT forward Continue (R-4c.7) choices to the labeling LLM.
+
+    Continue edges already carry the literal label `"Continue"`, set by
+    `compute_choice_edges`. Sending them to the LLM wastes tokens and risks
+    relabeling them to diegetic phrases.
+    """
+
+    def _build_plan_with_mixed_choices(self, graph: Graph) -> None:
+        from questfoundry.models.polish import ChoiceSpec, PassageSpec
+
+        passages = [
+            PassageSpec(
+                passage_id=f"passage::p{i}",
+                beat_ids=[f"beat::b{i}"],
+                summary=f"summary {i}",
+                entities=[],
+                grouping_type="singleton",
+            )
+            for i in range(3)
+        ]
+
+        # Two choices: one fork (no label yet — to be filled by 5a) and one
+        # Continue (already labeled by R-4c.7).
+        choices = [
+            ChoiceSpec(
+                from_passage="passage::p0",
+                to_passage="passage::p1",
+                grants=[],
+                requires=[],
+                label="",
+            ).model_dump(),
+            ChoiceSpec(
+                from_passage="passage::p1",
+                to_passage="passage::p2",
+                grants=[],
+                requires=[],
+                label="Continue",
+            ).model_dump(),
+        ]
+
+        graph.create_node(
+            "polish_plan::current",
+            {
+                "type": "polish_plan",
+                "raw_id": "current",
+                "passage_count": 3,
+                "variant_count": 0,
+                "residue_count": 0,
+                "choice_count": 2,
+                "candidate_count": 0,
+                "warnings": [],
+                "passage_specs": [p.model_dump() for p in passages],
+                "variant_specs": [],
+                "residue_specs": [],
+                "choice_specs": choices,
+                "false_branch_candidates": [],
+                "false_branch_specs": [],
+                "feasibility_annotations": {},
+                "ambiguous_specs": [],
+                "arc_traversals": {},
+            },
+        )
+
+    def test_continue_specs_not_forwarded_to_llm(self) -> None:
+        from questfoundry.models.polish import (
+            ChoiceLabelItem,
+            Phase5aOutput,
+        )
+
+        graph = Graph.empty()
+        self._build_plan_with_mixed_choices(graph)
+
+        labeled = Phase5aOutput(
+            choice_labels=[
+                ChoiceLabelItem(
+                    from_passage="passage::p0",
+                    to_passage="passage::p1",
+                    label="Trust the mentor",
+                )
+            ]
+        )
+
+        host = _RecordingPolishLLMHost({"polish_phase5a_choice_labels": labeled})
+        result = asyncio.run(host._phase_5_llm_enrichment(graph, MagicMock()))  # type: ignore[arg-type]
+        assert result.status == "completed"
+
+        # Locate the Phase 5a call. The context dict carries "choice_count".
+        phase5a_calls = [c for c in host.calls if c[0] == "polish_phase5a_choice_labels"]
+        assert len(phase5a_calls) == 1
+        _, context, _ = phase5a_calls[0]
+        assert isinstance(context, dict)
+        assert context["choice_count"] == "1"  # Continue spec excluded
+
+        # The fork choice should now carry the LLM-supplied label.
+        plan_data = graph.get_nodes_by_type("polish_plan")["polish_plan::current"]
+        labels = {
+            (c["from_passage"], c["to_passage"]): c["label"] for c in plan_data["choice_specs"]
+        }
+        assert labels[("passage::p0", "passage::p1")] == "Trust the mentor"
+        # Continue label preserved exactly.
+        assert labels[("passage::p1", "passage::p2")] == "Continue"
+
+    def test_only_continue_choices_skips_phase5a_llm_call(self) -> None:
+        """When every choice is a Continue, Phase 5a must not invoke the LLM."""
+        from questfoundry.models.polish import ChoiceSpec, PassageSpec
+
+        graph = Graph.empty()
+        passages = [
+            PassageSpec(
+                passage_id=f"passage::p{i}",
+                beat_ids=[f"beat::b{i}"],
+                summary=f"summary {i}",
+                entities=[],
+                grouping_type="singleton",
+            )
+            for i in range(2)
+        ]
+        choices = [
+            ChoiceSpec(
+                from_passage="passage::p0",
+                to_passage="passage::p1",
+                grants=[],
+                requires=[],
+                label="Continue",
+            ).model_dump(),
+        ]
+        graph.create_node(
+            "polish_plan::current",
+            {
+                "type": "polish_plan",
+                "raw_id": "current",
+                "passage_count": 2,
+                "variant_count": 0,
+                "residue_count": 0,
+                "choice_count": 1,
+                "candidate_count": 0,
+                "warnings": [],
+                "passage_specs": [p.model_dump() for p in passages],
+                "variant_specs": [],
+                "residue_specs": [],
+                "choice_specs": choices,
+                "false_branch_candidates": [],
+                "false_branch_specs": [],
+                "feasibility_annotations": {},
+                "ambiguous_specs": [],
+                "arc_traversals": {},
+            },
+        )
+
+        host = _RecordingPolishLLMHost({})  # no Phase 5a result registered
+        result = asyncio.run(host._phase_5_llm_enrichment(graph, MagicMock()))  # type: ignore[arg-type]
+        assert result.status == "completed"
+
+        phase5a_calls = [c for c in host.calls if c[0] == "polish_phase5a_choice_labels"]
+        assert phase5a_calls == []
+
+
 # ---------------------------------------------------------------------------
 # Tests for Issue #1158: Phase 5f — transition guidance for collapsed passages
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

POLISH previously emitted choice edges only at Y-fork divergence points. Linear post-commit chains and any non-fork cross-passage transition produced no choices, so the player-facing graph had unreachable passages and SHIP's reachability validation (R-4.2) fired on every realistic project (e.g. murder3 — 73 of 74 passages "defined but unreachable").

## Spec change

`docs/design/procedures/polish.md`:

- **New R-4c.7**: every cross-passage beat predecessor edge that is NOT already covered by a Y-fork (R-4c.1) produces a `Continue` ChoiceSpec with empty `requires` and empty `grants`. Within-passage transitions belong to FILL prose. Divergence-source beats (≥2 successors) are covered by R-4c.1 and skipped here.
- Violation table updated.
- Rule digest at the bottom updated.

## Code

- `compute_choice_edges` (`pipeline/stages/polish/deterministic.py`): after the Y-fork loop, a second pass scans `predecessor_edges` and emits Continue choices for every cross-passage transition not already in `choices_map`. Source beats with ≥2 successors are handled by the Y-fork pass and skipped.
- `_phase_5_llm_enrichment` Phase 5a (`pipeline/stages/polish/llm_phases.py`): filters out pre-labeled Continue specs before the LLM call. Continue edges are navigational, not diegetic forks; the LLM should not receive them or relabel them.

## Tests

- New `TestContinueChoiceEdges` with a 3-beat linear path (→ 2 Continue choices) and a Y-fork + linear-tail mix (→ fork + Continue edges in correct positions).
- `test_no_divergence` repurposed to assert the new behavior.
- New `test_within_passage_transitions_emit_no_choice` confirms two beats in one passage → zero choices.
- Existing Y-shape tests now filter on `c.label != "Continue"` when asserting fork-only shape.

Closes #1534

## Test plan
- [x] `uv run pytest tests/unit/test_polish_deterministic.py tests/unit/test_polish_phases.py tests/unit/test_polish_apply.py tests/unit/test_export_context.py tests/unit/test_ship_stage.py tests/unit/test_polish_passage_validation.py tests/unit/test_polish_phase5_models.py` (260 passed)
- [x] `uv run ruff check` + `uv run ruff format --check` clean
- [x] `uv run mypy` clean (pre-commit)
- [ ] CI green
- [ ] Re-run a project (e.g. murder3 fixture) to confirm SHIP reachability passes — deferred to follow-up since this PR's focus is the structural fix; the SHIP regression tests cover the mechanical side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)