### PR TITLE
fix(polish): _check_divergences_have_choices reads predecessor edges

### DIFF
--- a/src/questfoundry/graph/polish_validation.py
+++ b/src/questfoundry/graph/polish_validation.py
@@ -387,7 +387,6 @@ def _check_divergences_have_choices(
     errors: list[str],
 ) -> None:
     """Beats with 2+ children on different paths must live in a passage with 2+ outgoing choices."""
-    # Find beats that have 2+ outgoing next/branch edges leading to beats on different paths
     beat_nodes = graph.get_nodes_by_type("beat")
     belongs_to_edges = graph.get_edges(edge_type="belongs_to")
     _accum: dict[str, set[str]] = {}

--- a/src/questfoundry/graph/polish_validation.py
+++ b/src/questfoundry/graph/polish_validation.py
@@ -396,11 +396,17 @@ def _check_divergences_have_choices(
             _accum.setdefault(edge["from"], set()).add(edge["to"])
     beat_to_paths: dict[str, frozenset[str]] = {bid: frozenset(ps) for bid, ps in _accum.items()}
 
-    next_edges = graph.get_edges(edge_type="next")
-    branch_edges = graph.get_edges(edge_type="branch")
+    # Build children index from predecessor edges. ``predecessor(B, A)`` means
+    # B requires A — A is the parent, B is the child. Earlier versions of this
+    # function read ``next``/``branch`` edges that no code in the codebase ever
+    # produced, leaving this validator inert (#1199).
+    predecessor_edges = graph.get_edges(edge_type="predecessor")
     children_by_beat: dict[str, list[str]] = {}
-    for edge in next_edges + branch_edges:
-        children_by_beat.setdefault(edge["from"], []).append(edge["to"])
+    for edge in predecessor_edges:
+        parent = edge["to"]
+        child = edge["from"]
+        if parent in beat_nodes and child in beat_nodes:
+            children_by_beat.setdefault(parent, []).append(child)
 
     # Build passage -> outgoing choice count
     choice_edges = graph.get_edges(edge_type="choice")

--- a/tests/unit/test_polish_passage_validation.py
+++ b/tests/unit/test_polish_passage_validation.py
@@ -1809,14 +1809,14 @@ def _build_y_shape_with_choices() -> Graph:
         {"type": "beat", "raw_id": "commit_a", "summary": "Commit A."},
     )
     graph.add_edge("belongs_to", "beat::commit_a", "path::trust__a")
-    graph.add_edge("next", "beat::shared_setup", "beat::commit_a")
+    graph.add_edge("predecessor", "beat::commit_a", "beat::shared_setup")
 
     graph.create_node(
         "beat::commit_b",
         {"type": "beat", "raw_id": "commit_b", "summary": "Commit B."},
     )
     graph.add_edge("belongs_to", "beat::commit_b", "path::trust__b")
-    graph.add_edge("next", "beat::shared_setup", "beat::commit_b")
+    graph.add_edge("predecessor", "beat::commit_b", "beat::shared_setup")
 
     # Passages
     graph.create_node("passage::p0", {"type": "passage", "raw_id": "p0", "summary": "S"})
@@ -1848,14 +1848,14 @@ def _build_y_shape_without_choices() -> Graph:
         {"type": "beat", "raw_id": "commit_a", "summary": "Commit A."},
     )
     graph.add_edge("belongs_to", "beat::commit_a", "path::trust__a")
-    graph.add_edge("next", "beat::shared_setup", "beat::commit_a")
+    graph.add_edge("predecessor", "beat::commit_a", "beat::shared_setup")
 
     graph.create_node(
         "beat::commit_b",
         {"type": "beat", "raw_id": "commit_b", "summary": "Commit B."},
     )
     graph.add_edge("belongs_to", "beat::commit_b", "path::trust__b")
-    graph.add_edge("next", "beat::shared_setup", "beat::commit_b")
+    graph.add_edge("predecessor", "beat::commit_b", "beat::shared_setup")
 
     # Passages — NO choice edges from p0
     graph.create_node("passage::p0", {"type": "passage", "raw_id": "p0", "summary": "S"})
@@ -1893,3 +1893,25 @@ def test_check_divergences_have_choices_flags_y_shape_without_choices() -> None:
     }
     _check_divergences_have_choices(graph, beat_to_passages, errors)
     assert any("divergence point" in e for e in errors)
+
+
+def test_check_divergences_have_choices_ignores_linear_chain() -> None:
+    """A linear non-divergence chain is not flagged even with no choice edges."""
+    from questfoundry.graph.polish_validation import _check_divergences_have_choices
+
+    graph = Graph.empty()
+    graph.create_node("path::p1", {"type": "path", "raw_id": "p1"})
+
+    graph.create_node("beat::a", {"type": "beat", "raw_id": "a", "summary": "A."})
+    graph.create_node("beat::b", {"type": "beat", "raw_id": "b", "summary": "B."})
+    graph.add_edge("belongs_to", "beat::a", "path::p1")
+    graph.add_edge("belongs_to", "beat::b", "path::p1")
+    graph.add_edge("predecessor", "beat::b", "beat::a")
+
+    graph.create_node("passage::pa", {"type": "passage", "raw_id": "pa", "summary": "A"})
+    graph.create_node("passage::pb", {"type": "passage", "raw_id": "pb", "summary": "B"})
+
+    errors: list[str] = []
+    beat_to_passages = {"beat::a": ["passage::pa"], "beat::b": ["passage::pb"]}
+    _check_divergences_have_choices(graph, beat_to_passages, errors)
+    assert errors == []

--- a/tests/unit/test_polish_validation.py
+++ b/tests/unit/test_polish_validation.py
@@ -524,7 +524,6 @@ class TestDivergencesHaveChoices:
         graph.add_edge("belongs_to", "beat::a", "path::pa")
         graph.add_edge("belongs_to", "beat::b", "path::pb")
 
-        # next/branch edges making beat::div a divergence point
         graph.add_edge("predecessor", "beat::a", "beat::div")
         graph.add_edge("predecessor", "beat::b", "beat::div")
 

--- a/tests/unit/test_polish_validation.py
+++ b/tests/unit/test_polish_validation.py
@@ -525,8 +525,8 @@ class TestDivergencesHaveChoices:
         graph.add_edge("belongs_to", "beat::b", "path::pb")
 
         # next/branch edges making beat::div a divergence point
-        graph.add_edge("branch", "beat::div", "beat::a")
-        graph.add_edge("branch", "beat::div", "beat::b")
+        graph.add_edge("predecessor", "beat::a", "beat::div")
+        graph.add_edge("predecessor", "beat::b", "beat::div")
 
         # Group all beats into passages
         _create_passage_node(
@@ -568,8 +568,8 @@ class TestDivergencesHaveChoices:
         graph.add_edge("belongs_to", "beat::a", "path::pa")
         graph.add_edge("belongs_to", "beat::b", "path::pb")
 
-        graph.add_edge("branch", "beat::div", "beat::a")
-        graph.add_edge("branch", "beat::div", "beat::b")
+        graph.add_edge("predecessor", "beat::a", "beat::div")
+        graph.add_edge("predecessor", "beat::b", "beat::div")
 
         _create_passage_node(
             graph,


### PR DESCRIPTION
## Summary

The Phase 7 check "Every divergence has choice edges" (polish.md L405) was inert. `_check_divergences_have_choices` read `next` and `branch` edge types that no code in the codebase ever produces — so every project silently passed regardless of whether the divergence-source passage actually had outgoing choices.

## Fix

- Replace the `next + branch` lookup with a `predecessor` edge traversal — same source `compute_choice_edges` uses for Y-fork detection.
- Update the two existing fixture builders (`_build_y_shape_with_choices` / `_without_choices`) to emit `predecessor` edges; the old `add_edge("next", ...)` calls were also dead — feeding the inert validator.
- Add a third test asserting the validator does NOT fire on a linear non-divergence chain.

## Test plan
- [x] `uv run pytest tests/unit/test_polish_passage_validation.py` (74 passed)
- [x] `uv run ruff check src/questfoundry/graph/polish_validation.py` clean
- [x] `uv run mypy src/questfoundry/graph/polish_validation.py` clean
- [ ] CI green
- [ ] claude-review approval

Closes #1199

🤖 Generated with [Claude Code](https://claude.com/claude-code)