### PR TITLE
fix(fill): subset-token fallback resolves short LLM entity names

### DIFF
--- a/src/questfoundry/pipeline/stages/fill.py
+++ b/src/questfoundry/pipeline/stages/fill.py
@@ -253,8 +253,8 @@ def _resolve_entity_id(graph: Graph, raw_id: str) -> str | None:
 
     Tries all entity category prefixes (character::, location::, etc.)
     and legacy entity:: prefix to find a matching node in the graph.
-    Falls back to a subset-token match when exact lookup misses (#1259):
-    a short LLM-supplied name like ``the_compass`` resolves to graph ID
+    Falls back to a subset-token match when exact lookup misses: a short
+    LLM-supplied name like ``the_compass`` resolves to graph ID
     ``object::the_weathered_compass`` when the LLM tokens are a subset
     of the graph entity's tokens AND exactly one graph entity matches.
 
@@ -283,9 +283,9 @@ def _resolve_entity_id(graph: Graph, raw_id: str) -> str | None:
     if graph.has_node(legacy):
         return legacy
 
-    # Subset-token fallback (#1259). Build a token set from raw_id with
-    # stopwords removed; require at least one non-stopword token so a name
-    # of `the` alone never matches anything.
+    # Subset-token fallback. Build a token set from raw_id with stopwords
+    # removed; require at least one non-stopword token so a name of `the`
+    # alone never matches anything.
     raw_tokens = {tok for tok in raw_id.split("_") if tok and tok not in _ENTITY_NAME_STOPWORDS}
     if not raw_tokens:
         return None

--- a/src/questfoundry/pipeline/stages/fill.py
+++ b/src/questfoundry/pipeline/stages/fill.py
@@ -241,18 +241,29 @@ def _get_prompts_path() -> Path:
 log = get_logger(__name__)
 
 
+# Tokens stripped from short-name candidates before subset matching against
+# graph entity IDs. These articles carry no entity identity and would
+# otherwise produce trivially-true subset matches (e.g. "the" matches every
+# `the_*` entity in the graph).
+_ENTITY_NAME_STOPWORDS: frozenset[str] = frozenset({"the", "a", "an", "of"})
+
+
 def _resolve_entity_id(graph: Graph, raw_id: str) -> str | None:
     """Resolve a raw entity ID to its prefixed graph ID.
 
     Tries all entity category prefixes (character::, location::, etc.)
     and legacy entity:: prefix to find a matching node in the graph.
+    Falls back to a subset-token match when exact lookup misses (#1259):
+    a short LLM-supplied name like ``the_compass`` resolves to graph ID
+    ``object::the_weathered_compass`` when the LLM tokens are a subset
+    of the graph entity's tokens AND exactly one graph entity matches.
 
     Args:
         graph: Graph to search.
         raw_id: Raw entity ID (may or may not have prefix).
 
     Returns:
-        Entity ID as found in graph, None if not found.
+        Entity ID as found in graph, None if not found or ambiguous.
     """
     # If already prefixed, check if it exists
     if "::" in raw_id:
@@ -272,6 +283,40 @@ def _resolve_entity_id(graph: Graph, raw_id: str) -> str | None:
     if graph.has_node(legacy):
         return legacy
 
+    # Subset-token fallback (#1259). Build a token set from raw_id with
+    # stopwords removed; require at least one non-stopword token so a name
+    # of `the` alone never matches anything.
+    raw_tokens = {tok for tok in raw_id.split("_") if tok and tok not in _ENTITY_NAME_STOPWORDS}
+    if not raw_tokens:
+        return None
+
+    candidates: list[str] = []
+    for category in ENTITY_CATEGORIES:
+        for node_id in graph.get_nodes_by_type(category):
+            graph_raw = strip_scope_prefix(node_id)
+            graph_tokens = {
+                tok for tok in graph_raw.split("_") if tok and tok not in _ENTITY_NAME_STOPWORDS
+            }
+            if raw_tokens.issubset(graph_tokens):
+                candidates.append(node_id)
+
+    if len(candidates) == 1:
+        log.info(
+            "entity_id_resolved_via_subset_match",
+            raw_id=raw_id,
+            resolved=candidates[0],
+        )
+        return candidates[0]
+    if len(candidates) > 1:
+        log.warning(
+            "entity_id_ambiguous_subset_match",
+            raw_id=raw_id,
+            candidates=sorted(candidates),
+            detail=(
+                "Subset-token fallback found multiple graph entities "
+                "containing the LLM-supplied short name; refusing to guess."
+            ),
+        )
     return None
 
 

--- a/tests/unit/test_fill_stage.py
+++ b/tests/unit/test_fill_stage.py
@@ -72,7 +72,7 @@ def _bypass_seam_validators(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 class TestResolveEntityId:
-    """Tests for _resolve_entity_id (#1259 subset-token fallback)."""
+    """Tests for _resolve_entity_id subset-token fallback."""
 
     def _build_graph_with(self, entities: list[tuple[str, str]]) -> Graph:
         """entities is a list of (category, raw_id) tuples."""
@@ -141,14 +141,20 @@ class TestResolveEntityId:
             assert _resolve_entity_id(graph, "compass") is None
         assert any("entity_id_ambiguous_subset_match" in str(r.message) for r in caplog.records)
 
-    def test_ambiguous_subset_across_categories_returns_none(self) -> None:
+    def test_ambiguous_subset_across_categories_returns_none(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
         """Two entities in DIFFERENT categories sharing a token → still ambiguous → None.
 
         Tightens the contract: the resolver collapses the cross-category
         candidate set before applying the unique-match rule, so an LLM
         token that matches one entity per category is correctly rejected
-        rather than silently picking the first walked.
+        rather than silently picking the first walked. Also asserts the
+        ambiguous-match warning fires (same `len(candidates) > 1` branch
+        as the same-category case).
         """
+        import logging
+
         from questfoundry.pipeline.stages.fill import _resolve_entity_id
 
         graph = self._build_graph_with(
@@ -157,7 +163,9 @@ class TestResolveEntityId:
                 ("object", "the_brass_compass"),
             ]
         )
-        assert _resolve_entity_id(graph, "compass") is None
+        with caplog.at_level(logging.WARNING, logger="questfoundry.pipeline.stages.fill"):
+            assert _resolve_entity_id(graph, "compass") is None
+        assert any("entity_id_ambiguous_subset_match" in str(r.message) for r in caplog.records)
 
     def test_unknown_id_returns_none(self) -> None:
         from questfoundry.pipeline.stages.fill import _resolve_entity_id

--- a/tests/unit/test_fill_stage.py
+++ b/tests/unit/test_fill_stage.py
@@ -123,13 +123,37 @@ class TestResolveEntityId:
         )
         assert _resolve_entity_id(graph, "the") is None
 
-    def test_ambiguous_subset_returns_none(self) -> None:
-        """Multiple subset matches → return None and log a warning."""
+    def test_ambiguous_subset_returns_none_and_warns(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Multiple subset matches → return None and emit the ambiguous-match warning."""
+        import logging
+
         from questfoundry.pipeline.stages.fill import _resolve_entity_id
 
         graph = self._build_graph_with(
             [
                 ("object", "the_weathered_compass"),
+                ("object", "the_brass_compass"),
+            ]
+        )
+        with caplog.at_level(logging.WARNING, logger="questfoundry.pipeline.stages.fill"):
+            assert _resolve_entity_id(graph, "compass") is None
+        assert any("entity_id_ambiguous_subset_match" in str(r.message) for r in caplog.records)
+
+    def test_ambiguous_subset_across_categories_returns_none(self) -> None:
+        """Two entities in DIFFERENT categories sharing a token → still ambiguous → None.
+
+        Tightens the contract: the resolver collapses the cross-category
+        candidate set before applying the unique-match rule, so an LLM
+        token that matches one entity per category is correctly rejected
+        rather than silently picking the first walked.
+        """
+        from questfoundry.pipeline.stages.fill import _resolve_entity_id
+
+        graph = self._build_graph_with(
+            [
+                ("character", "the_compass_keeper"),
                 ("object", "the_brass_compass"),
             ]
         )
@@ -141,8 +165,11 @@ class TestResolveEntityId:
         graph = self._build_graph_with([("character", "mentor")])
         assert _resolve_entity_id(graph, "phantom_entity") is None
 
-    def test_subset_does_not_cross_categories(self) -> None:
-        """The subset fallback returns the actual node ID with its category prefix."""
+    def test_subset_match_returns_category_prefixed_id(self) -> None:
+        """Two independent unambiguous subset lookups each resolve to the
+        correct category-prefixed graph ID — i.e., a subset hit returns the
+        graph node ID exactly as stored, not a re-derived form.
+        """
         from questfoundry.pipeline.stages.fill import _resolve_entity_id
 
         graph = self._build_graph_with(

--- a/tests/unit/test_fill_stage.py
+++ b/tests/unit/test_fill_stage.py
@@ -71,6 +71,90 @@ def _bypass_seam_validators(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(_fov, "validate_fill_output", lambda _g: [])
 
 
+class TestResolveEntityId:
+    """Tests for _resolve_entity_id (#1259 subset-token fallback)."""
+
+    def _build_graph_with(self, entities: list[tuple[str, str]]) -> Graph:
+        """entities is a list of (category, raw_id) tuples."""
+        from questfoundry.graph.graph import Graph
+
+        graph = Graph.empty()
+        for category, raw_id in entities:
+            graph.create_node(
+                f"{category}::{raw_id}",
+                {"type": category, "raw_id": raw_id, "name": raw_id.replace("_", " ").title()},
+            )
+        return graph
+
+    def test_exact_match_with_prefix(self) -> None:
+        from questfoundry.pipeline.stages.fill import _resolve_entity_id
+
+        graph = self._build_graph_with([("object", "the_weathered_compass")])
+        assert _resolve_entity_id(graph, "object::the_weathered_compass") == (
+            "object::the_weathered_compass"
+        )
+
+    def test_exact_match_via_category_prefix(self) -> None:
+        from questfoundry.pipeline.stages.fill import _resolve_entity_id
+
+        graph = self._build_graph_with([("character", "mentor")])
+        assert _resolve_entity_id(graph, "mentor") == "character::mentor"
+
+    def test_subset_token_resolves_short_name(self) -> None:
+        """`the_compass` resolves to `object::the_weathered_compass` when unique."""
+        from questfoundry.pipeline.stages.fill import _resolve_entity_id
+
+        graph = self._build_graph_with([("object", "the_weathered_compass")])
+        assert _resolve_entity_id(graph, "the_compass") == "object::the_weathered_compass"
+
+    def test_subset_token_drops_stopwords(self) -> None:
+        """A bare `compass` resolves to the unique graph entity."""
+        from questfoundry.pipeline.stages.fill import _resolve_entity_id
+
+        graph = self._build_graph_with([("object", "the_weathered_compass")])
+        assert _resolve_entity_id(graph, "compass") == "object::the_weathered_compass"
+
+    def test_only_stopwords_returns_none(self) -> None:
+        """A name made entirely of stopwords must NOT match anything."""
+        from questfoundry.pipeline.stages.fill import _resolve_entity_id
+
+        graph = self._build_graph_with(
+            [("object", "the_weathered_compass"), ("location", "the_archive")]
+        )
+        assert _resolve_entity_id(graph, "the") is None
+
+    def test_ambiguous_subset_returns_none(self) -> None:
+        """Multiple subset matches → return None and log a warning."""
+        from questfoundry.pipeline.stages.fill import _resolve_entity_id
+
+        graph = self._build_graph_with(
+            [
+                ("object", "the_weathered_compass"),
+                ("object", "the_brass_compass"),
+            ]
+        )
+        assert _resolve_entity_id(graph, "compass") is None
+
+    def test_unknown_id_returns_none(self) -> None:
+        from questfoundry.pipeline.stages.fill import _resolve_entity_id
+
+        graph = self._build_graph_with([("character", "mentor")])
+        assert _resolve_entity_id(graph, "phantom_entity") is None
+
+    def test_subset_does_not_cross_categories(self) -> None:
+        """The subset fallback returns the actual node ID with its category prefix."""
+        from questfoundry.pipeline.stages.fill import _resolve_entity_id
+
+        graph = self._build_graph_with(
+            [
+                ("character", "old_mentor"),
+                ("object", "the_weathered_compass"),
+            ]
+        )
+        assert _resolve_entity_id(graph, "mentor") == "character::old_mentor"
+        assert _resolve_entity_id(graph, "compass") == "object::the_weathered_compass"
+
+
 class TestFillStageInit:
     def test_default_gate(self) -> None:
         stage = FillStage()


### PR DESCRIPTION
## Summary

When FILL prose generation emits a shorter form of an entity name (e.g. \`the_compass\` for graph entity \`object::the_weathered_compass\`), \`_resolve_entity_id\` returned \`None\` and the entity update was silently skipped with an \`entity_update_skipped\` warning. On stories with descriptive object names this meant prose updates never landed in the graph (test-new4 hit this twice).

## Fix

Add a subset-token fallback to \`_resolve_entity_id\` (\`pipeline/stages/fill.py\`):

- Tokenize the LLM short name on \`_\`, drop stopwords (\`the\`, \`a\`, \`an\`, \`of\`).
- For each graph entity-category, walk nodes; tokenize each ID's raw form (after \`strip_scope_prefix\`); check if LLM tokens are a SUBSET of graph tokens.
- **Exactly one match** → resolved (INFO log \`entity_id_resolved_via_subset_match\`).
- **Zero matches** → \`None\`, no change.
- **Two or more matches** → \`None\` + WARNING (\`entity_id_ambiguous_subset_match\`) with candidate list — refuses to guess.

Stopword stripping is the safety net: a bare \`the\` won't match every \`the_*\` graph entity. The stopword set is intentionally minimal (English articles); meaningful tokens like adjectives stay.

Out-of-scope per the issue: fuzzy matching (Levenshtein), prompt-side forcing of scoped IDs.

Closes #1259

## Test plan
- [x] \`uv run pytest tests/unit/test_fill_stage.py tests/unit/test_fill_models.py tests/unit/test_fill_validation.py tests/unit/test_fill_continuity_warning.py\` (195 passed)
- [x] New \`TestResolveEntityId\` covers eight behavioral cases (exact match, category-prefix exact, subset-resolves-short, drops-stopwords, only-stopwords→None, ambiguous→None, unknown→None, subset doesn't cross categories)
- [x] \`uv run ruff check\` + \`uv run mypy\` clean
- [ ] CI green
- [ ] claude-review approval

🤖 Generated with [Claude Code](https://claude.com/claude-code)