### PR TITLE
fix(polish): formalize split_passages contract between feasibility and overlay audit

### DIFF
--- a/src/questfoundry/pipeline/stages/polish/deterministic.py
+++ b/src/questfoundry/pipeline/stages/polish/deterministic.py
@@ -302,13 +302,17 @@ def compute_prose_feasibility(
     """Determine feasibility category for each passage.
 
     Returns:
-        Dict with keys: annotations, variant_specs, residue_specs, warnings, ambiguous_specs.
+        Dict with keys: annotations, variant_specs, residue_specs, warnings,
+        ambiguous_specs, split_passages. ``split_passages`` is the set of
+        passage IDs flagged as ``structural_split`` and is the contract
+        ``_audit_overlay_composition`` consumes for deduplication (#1170).
     """
     annotations: dict[str, list[str]] = {}
     variant_specs: list[VariantSpec] = []
     residue_specs: list[ResidueSpec] = []
     ambiguous_specs: list[AmbiguousFeasibilityCase] = []
     warnings: list[str] = []
+    split_passages: set[str] = set()
 
     # Build state_flag → path_id lookup via derived_from → consequence → path_id.
     flag_to_path: dict[str, str] = {}
@@ -407,6 +411,7 @@ def compute_prose_feasibility(
                 f"Passage {spec.passage_id} has {len(conflicting_dilemmas)} "
                 f"conflicting dilemmas — structural split recommended"
             )
+            split_passages.add(spec.passage_id)
             continue
 
         # Categorize flags by residue weight
@@ -486,6 +491,7 @@ def compute_prose_feasibility(
         "residue_specs": residue_specs,
         "ambiguous_specs": ambiguous_specs,
         "warnings": warnings,
+        "split_passages": split_passages,
     }
 
 
@@ -528,16 +534,11 @@ def _audit_overlay_composition(
     # Pre-fetch entity overlay data once
     entity_nodes = graph.get_nodes_by_type("entity")
 
-    # Build passage_id → set of already-flagged passages (structural_split in warnings)
-    # Phase 4b emits structural_split warnings with this format:
-    #   "Passage {passage_id} has N narratively relevant flags — structural split recommended"
-    already_split: set[str] = set()
-    for warning in feasibility.get("warnings", []):
-        # Extract passage_id from the warning string
-        if "structural split recommended" in warning and warning.startswith("Passage "):
-            parts = warning.split(" ", 2)
-            if len(parts) >= 2:
-                already_split.add(parts[1])
+    # Phase 4b populates feasibility["split_passages"] with the IDs of any
+    # passage flagged as structural_split (#1170). The previous version of
+    # this audit re-derived that set by parsing the warning string format,
+    # which silently broke the moment the message changed.
+    already_split: set[str] = feasibility.get("split_passages", set())
 
     for spec in specs:
         if spec.passage_id in already_split:
@@ -583,6 +584,7 @@ def _audit_overlay_composition(
                         f"overlays on entity {entity_id} — structural split recommended "
                         f"(overlay composition limit exceeded)"
                     )
+                    feasibility.setdefault("split_passages", set()).add(spec.passage_id)
                     flagged = True
                     break
 

--- a/src/questfoundry/pipeline/stages/polish/deterministic.py
+++ b/src/questfoundry/pipeline/stages/polish/deterministic.py
@@ -534,10 +534,10 @@ def _audit_overlay_composition(
     # Pre-fetch entity overlay data once
     entity_nodes = graph.get_nodes_by_type("entity")
 
-    # Phase 4b populates feasibility["split_passages"] with the IDs of any
-    # passage flagged as structural_split (#1170). The previous version of
-    # this audit re-derived that set by parsing the warning string format,
-    # which silently broke the moment the message changed.
+    # `feasibility["split_passages"]` is populated by compute_prose_feasibility
+    # with every passage ID flagged as structural_split. Reading it directly
+    # rather than re-deriving from warning strings means a future change to
+    # the warning text cannot silently break dedup.
     already_split: set[str] = feasibility.get("split_passages", set())
 
     for spec in specs:
@@ -584,7 +584,12 @@ def _audit_overlay_composition(
                         f"overlays on entity {entity_id} — structural split recommended "
                         f"(overlay composition limit exceeded)"
                     )
-                    feasibility.setdefault("split_passages", set()).add(spec.passage_id)
+                    # `already_split` aliases feasibility["split_passages"] when
+                    # the key is present (always the case in production); this
+                    # also catches the "key missing" edge so a later spec sees
+                    # this passage in the dedup set in the same audit run.
+                    already_split.add(spec.passage_id)
+                    feasibility["split_passages"] = already_split
                     flagged = True
                     break
 

--- a/tests/unit/test_polish_deterministic.py
+++ b/tests/unit/test_polish_deterministic.py
@@ -2409,7 +2409,7 @@ class TestAuditOverlayComposition:
         assert feasibility["warnings"] == []
 
     def test_already_structural_split_not_double_added(self) -> None:
-        """If a passage is already flagged as structural_split in warnings, it is not added again."""
+        """If a passage is already in feasibility["split_passages"], it is not flagged again (#1170)."""
         from questfoundry.pipeline.stages.polish.deterministic import _audit_overlay_composition
 
         commit_flags = [
@@ -2418,7 +2418,6 @@ class TestAuditOverlayComposition:
             ("path::pc", "dilemma::dc", "beat::cc"),
             ("path::pd", "dilemma::dd", "beat::cd"),
         ]
-        # Overlay when-flags use state_flag node IDs (state_flag::{path_raw}_committed)
         overlay_when_lists = [
             ["state_flag::pa_committed"],
             ["state_flag::pb_committed"],
@@ -2427,16 +2426,54 @@ class TestAuditOverlayComposition:
         ]
         graph, spec = self._build_graph_with_overlays(overlay_when_lists, commit_flags)
 
-        # Pre-seed a structural_split warning for this passage (as Phase 4b would emit)
+        # Pre-seed split_passages with this passage's ID (as Phase 4b would).
         existing_warning = (
             "Passage passage::test has 5 narratively relevant flags — structural split recommended"
         )
-        feasibility: dict = {"warnings": [existing_warning]}
+        feasibility: dict = {
+            "warnings": [existing_warning],
+            "split_passages": {"passage::test"},
+        }
         _audit_overlay_composition(graph, [spec], feasibility)
 
         # Should still have exactly 1 warning (not double-added)
         assert len(feasibility["warnings"]) == 1
         assert feasibility["warnings"][0] == existing_warning
+
+    def test_dedup_uses_split_passages_set_not_warning_string(self) -> None:
+        """Regression: contract is feasibility["split_passages"], not warning-string parsing.
+
+        If the dedup were still string-based, a warning that does NOT mention
+        the passage ID would fail to deduplicate, and the audit would re-flag.
+        With the new contract, an explicit `split_passages` set short-circuits
+        the audit regardless of what the warning string looks like (#1170).
+        """
+        from questfoundry.pipeline.stages.polish.deterministic import _audit_overlay_composition
+
+        commit_flags = [
+            ("path::pa", "dilemma::da", "beat::ca"),
+            ("path::pb", "dilemma::db", "beat::cb"),
+            ("path::pc", "dilemma::dc", "beat::cc"),
+            ("path::pd", "dilemma::dd", "beat::cd"),
+        ]
+        overlay_when_lists = [
+            ["state_flag::pa_committed"],
+            ["state_flag::pb_committed"],
+            ["state_flag::pc_committed"],
+            ["state_flag::pd_committed"],
+        ]
+        graph, spec = self._build_graph_with_overlays(overlay_when_lists, commit_flags)
+
+        # Warning that does NOT contain the passage ID — old string-parsing
+        # dedup would have missed this. Set membership is the source of truth.
+        feasibility: dict = {
+            "warnings": ["some unrelated warning"],
+            "split_passages": {"passage::test"},
+        }
+        _audit_overlay_composition(graph, [spec], feasibility)
+
+        # Should still have exactly 1 warning — no double-add despite mismatched string.
+        assert feasibility["warnings"] == ["some unrelated warning"]
 
     def test_unconditional_overlays_always_active(self) -> None:
         """Overlays with empty ``when`` lists are always active regardless of flag combo.

--- a/tests/unit/test_polish_deterministic.py
+++ b/tests/unit/test_polish_deterministic.py
@@ -2475,6 +2475,55 @@ class TestAuditOverlayComposition:
         # Should still have exactly 1 warning — no double-add despite mismatched string.
         assert feasibility["warnings"] == ["some unrelated warning"]
 
+    def test_overlay_audit_writes_to_split_passages(self) -> None:
+        """When _audit_overlay_composition flags a NEW passage via the overlay
+        threshold, it must add the passage ID to feasibility["split_passages"]
+        (#1170 symmetry invariant: the set always contains every passage ever
+        flagged as structural_split, regardless of which check raised it).
+        """
+        from questfoundry.pipeline.stages.polish.deterministic import _audit_overlay_composition
+
+        graph = Graph.empty()
+        graph.create_node("path::p1", {"type": "path", "raw_id": "p1"})
+        graph.create_node(
+            "entity::hero",
+            {
+                "type": "entity",
+                "raw_id": "hero",
+                "overlays": [
+                    {"when": [], "details": {"key": "a"}},
+                    {"when": [], "details": {"key": "b"}},
+                    {"when": [], "details": {"key": "c"}},
+                    {"when": [], "details": {"key": "d"}},
+                ],
+            },
+        )
+        graph.create_node(
+            "beat::target",
+            {
+                "type": "beat",
+                "raw_id": "target",
+                "summary": "Target beat",
+                "dilemma_impacts": [],
+                "entities": ["entity::hero"],
+                "scene_type": "scene",
+            },
+        )
+        graph.add_edge("belongs_to", "beat::target", "path::p1")
+
+        spec = PassageSpec(
+            passage_id="passage::needs_split",
+            beat_ids=["beat::target"],
+            summary="overlay-flagged passage",
+            entities=["entity::hero"],
+        )
+
+        feasibility: dict = {"warnings": [], "split_passages": set()}
+        _audit_overlay_composition(graph, [spec], feasibility)
+
+        assert "passage::needs_split" in feasibility["split_passages"]
+        assert any("passage::needs_split" in w for w in feasibility["warnings"])
+
     def test_unconditional_overlays_always_active(self) -> None:
         """Overlays with empty ``when`` lists are always active regardless of flag combo.
 


### PR DESCRIPTION
## Summary

Replace brittle warning-string parsing with an explicit \`set[str]\` contract for the structural-split deduplication between \`compute_prose_feasibility\` and \`_audit_overlay_composition\`.

## Before

\`\`\`python
# _audit_overlay_composition
already_split: set[str] = set()
for warning in feasibility.get(\"warnings\", []):
    if \"structural split recommended\" in warning and warning.startswith(\"Passage \"):
        parts = warning.split(\" \", 2)
        if len(parts) >= 2:
            already_split.add(parts[1])
\`\`\`

If the warning format ever changed (different prefix, separator, or a quoted ID), dedup silently broke — re-flagging the same passage twice.

## After

- \`compute_prose_feasibility\` returns \`feasibility[\"split_passages\"]: set[str]\` populated when it emits a structural-split warning.
- \`_audit_overlay_composition\` reads that set directly; warning-string parsing block deleted.
- When \`_audit_overlay_composition\` flags a new passage via the overlay-composition threshold, it adds the ID to \`split_passages\` for symmetry — keeps the invariant that \`split_passages\` contains everything flagged as structural_split (currently no downstream consumer, but cheap insurance).

## Tests

- \`test_already_structural_split_not_double_added\` rewritten to seed \`split_passages\` instead of a warning string.
- New regression \`test_dedup_uses_split_passages_set_not_warning_string\` feeds a warnings list that does NOT mention the passage ID — under the old string-parse this would have re-flagged; under the new contract set membership short-circuits regardless of warning text.

Closes #1170

## Test plan
- [x] \`uv run pytest tests/unit/test_polish_deterministic.py tests/unit/test_polish_phases.py tests/unit/test_polish_apply.py tests/unit/test_polish_validation.py tests/unit/test_polish_passage_validation.py tests/unit/test_polish_contract.py\` (227 passed)
- [x] \`uv run ruff check\` + \`uv run mypy\` clean
- [ ] CI green
- [ ] claude-review approval

🤖 Generated with [Claude Code](https://claude.com/claude-code)