### PR TITLE
fix(fill): accept POLISH (not GROW) as FILL's predecessor + test rename

### DIFF
--- a/src/questfoundry/pipeline/stages/fill.py
+++ b/src/questfoundry/pipeline/stages/fill.py
@@ -1,7 +1,7 @@
 """FILL stage implementation.
 
 The FILL stage generates prose for all passages in the story graph.
-It takes a validated graph from GROW (with passages, arcs, choices)
+It takes a validated graph from POLISH (with passages, arcs, choices)
 and populates each passage with prose text following a voice document.
 
 FILL manages its own graph: it loads, mutates, and saves the graph
@@ -413,7 +413,7 @@ class FillStage:
             Tuple of (artifact_data dict, total_llm_calls, total_tokens).
 
         Raises:
-            FillStageError: If project_path is not provided or GROW not completed.
+            FillStageError: If project_path is not provided or POLISH not completed.
         """
         resolved_path = project_path or self.project_path
         if resolved_path is None:

--- a/tests/unit/test_fill_stage.py
+++ b/tests/unit/test_fill_stage.py
@@ -31,8 +31,8 @@ from questfoundry.pipeline.stages.fill import (
 
 
 @pytest.fixture
-def grow_graph(tmp_path: Path) -> Graph:
-    """Create a minimal GROW-completed graph."""
+def polish_graph(tmp_path: Path) -> Graph:
+    """Create a minimal POLISH-completed graph (FILL's actual predecessor)."""
     g = Graph.empty()
     g.set_last_stage("polish")
 
@@ -184,10 +184,11 @@ class TestFillStageExecute:
             await stage.execute(mock_model, "")
 
     @pytest.mark.asyncio
-    @pytest.mark.parametrize("last_stage", ["dream", "brainstorm", "seed"])
-    async def test_rejects_pre_grow_stages(
+    @pytest.mark.parametrize("last_stage", ["dream", "brainstorm", "seed", "grow"])
+    async def test_rejects_pre_polish_stages(
         self, mock_model: MagicMock, tmp_path: Path, last_stage: str
     ) -> None:
+        """FILL must reject GROW too: POLISH creates the passages and choices FILL needs."""
         g = Graph.empty()
         g.set_last_stage(last_stage)
         g.save(tmp_path / "graph.db")
@@ -198,7 +199,7 @@ class TestFillStageExecute:
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize("last_stage", ["polish", "fill", "dress", "ship"])
-    async def test_accepts_grow_and_later_stages(
+    async def test_accepts_polish_and_later_stages(
         self, mock_model: MagicMock, tmp_path: Path, last_stage: str
     ) -> None:
         """FILL should accept re-runs when last_stage is polish or any later stage."""
@@ -266,7 +267,7 @@ class TestFillStageExecute:
     async def test_runs_all_phases(
         self,
         mock_model: MagicMock,
-        grow_graph: Graph,  # noqa: ARG002
+        polish_graph: Graph,  # noqa: ARG002
         tmp_path: Path,
     ) -> None:
         stage = FillStage(project_path=tmp_path)
@@ -285,7 +286,7 @@ class TestFillStageExecute:
     async def test_sets_last_stage(
         self,
         mock_model: MagicMock,
-        grow_graph: Graph,  # noqa: ARG002
+        polish_graph: Graph,  # noqa: ARG002
         tmp_path: Path,
     ) -> None:
         stage = FillStage(project_path=tmp_path)
@@ -299,7 +300,7 @@ class TestFillStageExecute:
     async def test_resume_from_phase(
         self,
         mock_model: MagicMock,
-        grow_graph: Graph,  # noqa: ARG002
+        polish_graph: Graph,  # noqa: ARG002
         tmp_path: Path,
     ) -> None:
         stage = FillStage(project_path=tmp_path)
@@ -323,7 +324,7 @@ class TestFillStageExecute:
     async def test_resume_invalid_phase(
         self,
         mock_model: MagicMock,
-        grow_graph: Graph,  # noqa: ARG002
+        polish_graph: Graph,  # noqa: ARG002
         tmp_path: Path,
     ) -> None:
         stage = FillStage(project_path=tmp_path)
@@ -334,7 +335,7 @@ class TestFillStageExecute:
     async def test_gate_reject_rolls_back(
         self,
         mock_model: MagicMock,
-        grow_graph: Graph,  # noqa: ARG002
+        polish_graph: Graph,  # noqa: ARG002
         tmp_path: Path,
     ) -> None:
         gate = MagicMock()
@@ -355,7 +356,7 @@ class TestFillStageExecute:
     async def test_phase_failure_stops_execution(
         self,
         mock_model: MagicMock,
-        grow_graph: Graph,  # noqa: ARG002
+        polish_graph: Graph,  # noqa: ARG002
         tmp_path: Path,
     ) -> None:
         stage = FillStage(project_path=tmp_path)
@@ -375,7 +376,7 @@ class TestFillStageExecute:
     async def test_progress_callback(
         self,
         mock_model: MagicMock,
-        grow_graph: Graph,  # noqa: ARG002
+        polish_graph: Graph,  # noqa: ARG002
         tmp_path: Path,
     ) -> None:
         progress_calls: list[tuple[str, str, str | None]] = []
@@ -395,7 +396,7 @@ class TestFillStageExecute:
     async def test_project_path_override(
         self,
         mock_model: MagicMock,
-        grow_graph: Graph,  # noqa: ARG002
+        polish_graph: Graph,  # noqa: ARG002
         tmp_path: Path,
     ) -> None:
         stage = FillStage(project_path=Path("/nonexistent"))


### PR DESCRIPTION
## Summary

Documentation drift + test coverage gap from PR #1034 (POLISH inserted into the pipeline).

## What was already fixed

The runtime gate at \`fill.py:462\` was already \`(\"polish\", \"fill\", \"dress\", \"ship\")\`, with the matching \"FILL requires completed POLISH\" error message. So the actual bug from #1201 doesn't reproduce on main today — but the docstrings still pointed at GROW.

## What this PR fixes

**Documentation (#1201 leftovers):**
- \`fill.py\` module docstring: \"validated graph from GROW\" → \"from POLISH\".
- \`execute()\` docstring \`Raises:\` line: \"GROW not completed\" → \"POLISH not completed\".

**Test coverage (#1202):**
- Fixture rename: \`grow_graph\` → \`polish_graph\`. The fixture already set \`last_stage = \"polish\"\`, but the misleading name made the whole class look like it tested GROW-as-predecessor.
- \`test_rejects_pre_grow_stages\` → \`test_rejects_pre_polish_stages\`. Parametrize list now includes \`\"grow\"\` as a rejected predecessor — POLISH creates the passages/choices FILL needs, so a graph that only completed GROW must be rejected. Closes the regression window where a future refactor could re-add \`\"grow\"\` to the accept list and still pass tests.
- \`test_accepts_grow_and_later_stages\` → \`test_accepts_polish_and_later_stages\`.

Closes #1201
Closes #1202

## Test plan
- [x] \`uv run pytest tests/unit/test_fill_stage.py tests/unit/test_fill_models.py tests/unit/test_fill_validation.py tests/unit/test_fill_continuity_warning.py tests/unit/test_fill_context.py\` (397 passed)
- [x] \`uv run ruff check\` + \`uv run mypy\` clean (pre-commit)
- [ ] CI green
- [ ] claude-review approval

🤖 Generated with [Claude Code](https://claude.com/claude-code)