### PR TITLE
fix(grow): remove stale entry-beat block from detect_temporal_hint_conflicts

### DIFF
--- a/src/questfoundry/graph/grow_algorithms.py
+++ b/src/questfoundry/graph/grow_algorithms.py
@@ -2976,20 +2976,15 @@ def detect_temporal_hint_conflicts(graph: Graph) -> list[TemporalHintConflict]:
                 for prereq in sorted(prereq_commits):
                     for dependent in sorted(dependent_commits):
                         _sim_add(dependent, prereq)
-
-            # Entry beats follow the same relative ordering as commit beats —
-            # MUST match interleave_cross_path_beats (#1186).
-            first_beats_a = {seq[0] for seq in ordered_a if seq}
-            first_beats_b = {seq[0] for seq in ordered_b if seq}
-            if first_beats_a and first_beats_b:
-                if dilemma_a < dilemma_b:
-                    for fa in sorted(first_beats_a):
-                        for fb in sorted(first_beats_b):
-                            _sim_add(fb, fa)
-                else:
-                    for fb in sorted(first_beats_b):
-                        for fa in sorted(first_beats_a):
-                            _sim_add(fa, fb)
+            # Entry-beat ordering across dilemmas is intentionally omitted from
+            # the simulated DAG. Entry-beat edges in interleave_cross_path_beats
+            # are added as soft heuristics via `_add_predecessor(...,
+            # from_hint=False)`, which soft-skip cycle conflicts with previously-
+            # applied hints. Including them in the simulated base DAG would
+            # promote the heuristic to a hard constraint, causing valid
+            # hints that override the heuristic to be classified as mandatory
+            # solo drops. The peer function `_build_hint_base_dag` makes the
+            # same omission for the same reason.
 
     # Order entry beats within the alphabetically first dilemma —
     # MUST match interleave_cross_path_beats (#1192).

--- a/src/questfoundry/graph/grow_algorithms.py
+++ b/src/questfoundry/graph/grow_algorithms.py
@@ -3203,9 +3203,10 @@ def _build_hint_base_dag(
 
     Concurrent entry-beat ordering is intentionally absent from this base DAG.
     Entry-beat ordering is a soft heuristic that must yield to hints rather than
-    block them.  Cycle-safety for accepted hints against entry-beat edges is
-    guaranteed by ``detect_temporal_hint_conflicts``, which simulates entry-beat
-    edges when testing each hint individually.
+    block them.  Cycle-safety is preserved at apply time: in
+    ``interleave_cross_path_beats`` the entry-beat heuristic is added with
+    ``from_hint=False``, so cycle conflicts with previously-applied hints are
+    soft-skipped rather than rejecting the hint.
 
     Args:
         graph: The story graph.
@@ -3820,8 +3821,9 @@ def interleave_cross_path_beats(graph: Graph) -> int:
     # so that a hint accepted by build_hint_conflict_graph cannot create a cycle here
     # due to a narrower incremental DAG (#1147).  Entry-beat ordering is intentionally
     # absent from _build_hint_base_dag — it is a soft heuristic that must yield to hints
-    # rather than block them.  detect_temporal_hint_conflicts simulates entry-beat edges
-    # when testing each hint, so accepted hints are already safe against that ordering.
+    # rather than block them.  Below, the entry-beat heuristic is applied with
+    # ``from_hint=False``, so cycle conflicts with previously-applied hints soft-skip
+    # the heuristic edge instead of rejecting the hint.
     #
     # ``_base_edges`` contains real graph edges + simulated heuristic edges.
     # ``successors`` is derived from the full base and is used for cycle detection.


### PR DESCRIPTION
## Summary

Cleanup follow-up to #1186/#1191. The peer function \`_build_hint_base_dag\` already documents that entry-beat ordering across dilemmas must NOT appear in the simulated base DAG (see its docstring lines 3209-3213): in \`interleave_cross_path_beats\` those edges are added with \`from_hint=False\`, so they soft-skip cycle conflicts with previously-applied hints. Promoting them to hard constraints in a simulated DAG would classify valid hints that override the heuristic as mandatory solo drops.

\`detect_temporal_hint_conflicts\` had the inverse — it was simulating the inter-dilemma entry-beat block. No production caller still uses this function (\`build_hint_conflict_graph\` replaced it), but the inconsistency is worth removing for any future test or debug caller that exercises it.

## Scope notes

- The original issue (#1191) reported \`_build_hint_base_dag\` having the same bug; that has since been independently fixed (the function explicitly omits the block now). This PR just brings \`detect_temporal_hint_conflicts\` into alignment.
- The intra-dilemma entry-beat block immediately below (\"first dilemma\" / single-root #1192) is left in place — that's a separate single-root guarantee for multi-path stories and is independent of the hint-override issue here.

Closes #1191

## Test plan
- [x] \`uv run pytest tests/unit/test_grow_algorithms.py -k \"interleave or temporal_hint or hint_conflict or detect_temporal\"\` (29 passed)
- [x] \`uv run pytest tests/unit/test_grow_algorithms.py tests/unit/test_grow_validators.py tests/unit/test_grow_models.py tests/unit/test_grow_validation_contract.py\` (414 passed)
- [x] \`uv run ruff check\` + \`uv run mypy\` clean (pre-commit)
- [ ] CI green
- [ ] claude-review approval

🤖 Generated with [Claude Code](https://claude.com/claude-code)