### PR TITLE
fix: migrate choice_from/choice_to consumers to choice edge model

### DIFF
--- a/src/questfoundry/graph/fill_context.py
+++ b/src/questfoundry/graph/fill_context.py
@@ -449,33 +449,19 @@ def get_pending_spoke_labels(graph: Graph, hub_passage_id: str) -> list[dict[str
     Returns:
         List of dicts with choice_id, spoke_summary, and label_style.
     """
-    # Find all choice_from edges where to=hub_passage_id
-    # (choice_from edges go FROM choice TO source-passage)
-    from_edges = graph.get_edges(to_id=hub_passage_id, edge_type="choice_from")
-    if not from_edges:
+    # `choice` edges go directly between passages: e["from"] = source passage,
+    # e["to"] = target passage. Find outgoing edges from the hub.
+    out_edges = graph.get_edges(from_id=hub_passage_id, edge_type="choice")
+    if not out_edges:
         return []
 
     pending = []
-    for from_edge in from_edges:
-        choice_id = from_edge.get("from")
-        if not choice_id:
+    for edge in out_edges:
+        # Skip edges that already carry a label.
+        if edge.get("label"):
             continue
 
-        choice_data = graph.get_node(choice_id)
-        if not choice_data:
-            continue
-
-        # Check if label is missing or empty (both None and "" are falsy)
-        current_label = choice_data.get("label")
-        if current_label:
-            continue  # Already has a label
-
-        # Find the target passage via choice_to edge
-        to_edges = graph.get_edges(from_id=choice_id, edge_type="choice_to")
-        if not to_edges:
-            continue
-
-        to_passage_id = to_edges[0].get("to")
+        to_passage_id = edge.get("to")
         if not to_passage_id:
             continue
 
@@ -483,16 +469,24 @@ def get_pending_spoke_labels(graph: Graph, hub_passage_id: str) -> list[dict[str
         if not to_passage:
             continue
 
-        # Check if the target is a spoke passage (raw_id starts with "spoke_")
+        # Target must be a spoke passage (raw_id starts with "spoke_").
         raw_id = to_passage.get("raw_id", "")
         if not raw_id.startswith("spoke_"):
             continue
 
+        # No discrete `choice` node exists in the edge model. Synthesize a
+        # stable identifier from the (source, target) passage pair so the LLM
+        # can refer back to a specific spoke when returning labels. The FILL
+        # consumer side of this contract still updates a `choice` node and is
+        # therefore inert today (see followup tracker for spoke-label
+        # architectural rework).
+        synthesized_choice_id = f"choice::{strip_scope_prefix(hub_passage_id)}__{raw_id}"
+
         pending.append(
             {
-                "choice_id": choice_id,
+                "choice_id": synthesized_choice_id,
                 "spoke_summary": to_passage.get("summary", ""),
-                "label_style": choice_data.get("label_style", "functional"),
+                "label_style": str(edge.get("label_style", "functional")),
             }
         )
 
@@ -1726,22 +1720,18 @@ def format_path_arc_context(graph: Graph, passage_id: str, arc_id: str) -> str:
 def compute_is_ending(graph: Graph, passage_id: str) -> bool:
     """Determine if a passage is a story ending (no outgoing choices).
 
-    A passage is an ending if no ``choice_from`` edge has this passage
-    as its target (``to_id``). The ``choice_from`` edge convention is
-    FROM choice TO originating passage, so ``to_id=passage_id`` finds
-    choices that originate from this passage.
-
-    See ``grow_validation.py:212`` for the edge direction reference.
+    A passage is an ending if no `choice` edge originates from it. In the
+    edge model `choice` edges go directly between passages, so
+    ``from_id=passage_id`` finds choices that originate from this passage.
 
     Args:
-        graph: Graph containing passage and choice nodes.
+        graph: Graph containing passage and choice edges.
         passage_id: Full node ID of the passage (e.g. ``passage::intro``).
 
     Returns:
         True if the passage has no outgoing choices.
     """
-    choice_from_edges = graph.get_edges(to_id=passage_id, edge_type="choice_from")
-    return len(choice_from_edges) == 0
+    return not graph.get_edges(from_id=passage_id, edge_type="choice")
 
 
 def format_ending_guidance(

--- a/src/questfoundry/graph/grow_validation.py
+++ b/src/questfoundry/graph/grow_validation.py
@@ -632,19 +632,18 @@ def passages_with_forward_incoming(graph: Graph) -> set[str]:
     passages are still recognised as start passages when they have no
     other incoming edges.
     """
-    choice_nodes = graph.get_nodes_by_type("choice")
     has_incoming: set[str] = set()
-    for choice_data in choice_nodes.values():
-        if choice_data.get("is_return"):
+    for edge in graph.get_edges(edge_type="choice"):
+        if edge.get("is_return"):
             continue
-        to_p = choice_data.get("to_passage")
+        to_p = edge.get("to")
         if to_p:
             has_incoming.add(to_p)
     return has_incoming
 
 
 def build_passage_adjacency(graph: Graph) -> dict[str, list[str]]:
-    """Build passage → successor passages adjacency list from choice nodes.
+    """Build passage → successor passages adjacency list from `choice` edges.
 
     Args:
         graph: The story graph.
@@ -652,18 +651,17 @@ def build_passage_adjacency(graph: Graph) -> dict[str, list[str]]:
     Returns:
         Dict mapping each passage ID to a list of successor passage IDs.
     """
-    choices = graph.get_nodes_by_type("choice")
     adjacency: dict[str, list[str]] = {}
-    for _cid, cdata in choices.items():
-        from_p = cdata.get("from_passage", "")
-        to_p = cdata.get("to_passage", "")
+    for edge in graph.get_edges(edge_type="choice"):
+        from_p = edge.get("from", "")
+        to_p = edge.get("to", "")
         if from_p and to_p:
             adjacency.setdefault(from_p, []).append(to_p)
     return adjacency
 
 
 def build_outgoing_count(graph: Graph) -> dict[str, int]:
-    """Count outgoing choices per passage from choice_from edges.
+    """Count outgoing choices per passage from `choice` edges.
 
     Args:
         graph: The story graph.
@@ -671,11 +669,11 @@ def build_outgoing_count(graph: Graph) -> dict[str, int]:
     Returns:
         Dict mapping passage ID to number of outgoing choices.
     """
-    # choice_from edges point choice → source_passage, so e["to"] = source passage.
-    choice_from_edges = graph.get_edges(edge_type="choice_from")
+    # `choice` edges go directly between passages: e["from"] is the source.
+    choice_edges = graph.get_edges(edge_type="choice")
     outgoing_count: dict[str, int] = {}
-    for edge in choice_from_edges:
-        source = edge["to"]
+    for edge in choice_edges:
+        source = edge["from"]
         outgoing_count[source] = outgoing_count.get(source, 0) + 1
     return outgoing_count
 
@@ -919,10 +917,11 @@ def check_single_root_beat(graph: Graph) -> ValidationCheck:
 
 
 def check_single_start(graph: Graph) -> ValidationCheck:
-    """Verify exactly one start passage exists (no incoming choice_to edges).
+    """Verify exactly one start passage exists.
 
-    A start passage is one with no incoming choice_to edges. There must be
-    exactly one for a well-formed story graph.
+    A start passage is one with no forward incoming `choice` edges
+    (excluding `is_return` spoke→hub back-links). There must be exactly
+    one for a well-formed story graph.
     """
     passage_nodes = graph.get_nodes_by_type("passage")
     if not passage_nodes:
@@ -1032,8 +1031,8 @@ def check_passage_dag_cycles(graph: Graph) -> ValidationCheck:
             message="No passages to check",
         )
 
-    choice_nodes = graph.get_nodes_by_type("choice")
-    if not choice_nodes:
+    choice_edges = graph.get_edges(edge_type="choice")
+    if not choice_edges:
         return ValidationCheck(
             name="passage_dag_cycles",
             severity="pass",
@@ -1044,12 +1043,12 @@ def check_passage_dag_cycles(graph: Graph) -> ValidationCheck:
     in_degree: dict[str, int] = dict.fromkeys(passage_nodes, 0)
     successors: dict[str, list[str]] = {pid: [] for pid in passage_nodes}
 
-    for choice_data in choice_nodes.values():
+    for edge in choice_edges:
         # Skip is_return edges (spoke→hub back-links) — they are intentional cycles
-        if choice_data.get("is_return"):
+        if edge.get("is_return"):
             continue
-        from_p = choice_data.get("from_passage")
-        to_p = choice_data.get("to_passage")
+        from_p = edge.get("from")
+        to_p = edge.get("to")
         if from_p and to_p and from_p in passage_nodes and to_p in passage_nodes:
             in_degree[to_p] += 1
             successors[from_p].append(to_p)

--- a/src/questfoundry/graph/polish_validation.py
+++ b/src/questfoundry/graph/polish_validation.py
@@ -108,8 +108,14 @@ def validate_polish_output(graph: Graph) -> list[str]:
     _check_false_branch_role_name(graph, errors)
     _check_choice_label_distinctness(graph, errors)
 
-    # TODO: check_all_endings_reachable and check_gate_satisfiability use the old
-    # choice_from/choice_to edge model and are DEAD — see issue #1165 for migration.
+    # Reachability + gate satisfiability now that they read the `choice` edge
+    # model (was: gated behind a TODO awaiting #1165 migration).
+    endings_check = check_all_endings_reachable(graph)
+    if endings_check.severity == "fail":
+        errors.append(endings_check.message)
+    gate_check = check_gate_satisfiability(graph)
+    if gate_check.severity == "fail":
+        errors.append(gate_check.message)
 
     return errors
 
@@ -758,16 +764,15 @@ def _find_start_passage_for_check(graph: Graph) -> str | None:
 
 
 def _build_passage_successors(graph: Graph) -> dict[str, list[str]]:
-    """Build passage->passage successor map from choice nodes.
+    """Build passage→passage successor map from `choice` edges.
 
-    Each choice node has from_passage and to_passage fields defining
-    the directed edge in the passage graph.
+    Each `choice` edge goes directly between passages: e["from"] is the
+    source passage, e["to"] is the target passage.
     """
-    choice_nodes = graph.get_nodes_by_type("choice")
     successors: dict[str, list[str]] = {}
-    for choice_data in choice_nodes.values():
-        from_p = choice_data.get("from_passage")
-        to_p = choice_data.get("to_passage")
+    for edge in graph.get_edges(edge_type="choice"):
+        from_p = edge.get("from")
+        to_p = edge.get("to")
         if from_p and to_p:
             successors.setdefault(from_p, []).append(to_p)
     return successors
@@ -789,7 +794,7 @@ def _bfs_reachable(start: str, successors: dict[str, list[str]]) -> set[str]:
 def check_all_passages_reachable(graph: Graph) -> ValidationCheck:
     """Verify all passages are reachable from the start passage via choice edges.
 
-    BFS from the start passage (no incoming choice_to edges) via choice_to edges.
+    BFS from the start passage (no incoming `choice` edges) via `choice` edges.
     Reports any unreachable passages.
     """
     passage_nodes = graph.get_nodes_by_type("passage")
@@ -828,12 +833,11 @@ def check_all_passages_reachable(graph: Graph) -> ValidationCheck:
 def check_all_endings_reachable(graph: Graph) -> ValidationCheck:
     """Verify at least one ending is reachable from the start passage.
 
-    Endings are passages with no outgoing choice_from edges. At least one
+    Endings are passages with no outgoing `choice` edges. At least one
     ending must be reachable for the story to be completable.
 
-    Edge semantics:
-    - choice_from: choice -> originating_passage (passage the choice leads FROM)
-    - choice_to: choice -> destination_passage (passage the choice leads TO)
+    `choice` edges go directly between passages (e["from"] = source
+    passage, e["to"] = target passage).
     """
     passage_nodes = graph.get_nodes_by_type("passage")
     if not passage_nodes:
@@ -851,9 +855,9 @@ def check_all_endings_reachable(graph: Graph) -> ValidationCheck:
             message="Cannot check endings: no unique start passage",
         )
 
-    # Find endings: passages with no outgoing choices (choice_from -> passage)
-    choice_from_edges = graph.get_edges(from_id=None, to_id=None, edge_type="choice_from")
-    passages_with_outgoing: set[str] = {edge["to"] for edge in choice_from_edges}
+    # Find endings: passages with no outgoing choice edges.
+    choice_edges = graph.get_edges(edge_type="choice")
+    passages_with_outgoing: set[str] = {edge["from"] for edge in choice_edges}
     endings = [pid for pid in passage_nodes if pid not in passages_with_outgoing]
 
     if not endings:
@@ -881,14 +885,15 @@ def check_all_endings_reachable(graph: Graph) -> ValidationCheck:
 
 
 def check_gate_satisfiability(graph: Graph) -> ValidationCheck:
-    """Verify all choice requires are satisfiable (required state flags exist globally).
+    """Verify all choice `requires` are satisfiable (required state flags exist globally).
 
-    Collects all grantable state flags (union of all grants lists). For each
-    choice with non-empty requires, verifies every required state flag is in
-    the global grantable set.
+    Collects all grantable state flags (union of all `grants` lists across
+    `choice` edges). For each edge with non-empty `requires`, verifies every
+    required state flag is in the global grantable set. Edge semantics:
+    `choice` edges go passage→passage and carry `grants` / `requires` lists.
     """
-    choice_nodes = graph.get_nodes_by_type("choice")
-    if not choice_nodes:
+    choice_edges = graph.get_edges(edge_type="choice")
+    if not choice_edges:
         return ValidationCheck(
             name="gate_satisfiability",
             severity="pass",
@@ -897,17 +902,23 @@ def check_gate_satisfiability(graph: Graph) -> ValidationCheck:
 
     # Collect all globally grantable state flags
     grantable: set[str] = set()
-    for choice_data in choice_nodes.values():
-        grants = choice_data.get("grants", [])
+    for edge in choice_edges:
+        grants = edge.get("grants", []) or []
         grantable.update(grants)
 
-    # Check each choice's requires_state_flags
+    # Check each choice edge's requires list. POLISH writes `requires`; older
+    # code paths used `requires_state_flags`. Read both for back-compat.
     unsatisfiable: list[str] = []
-    for choice_id, choice_data in sorted(choice_nodes.items()):
-        requires = choice_data.get("requires_state_flags", [])
+
+    def _edge_label(edge: dict[str, Any]) -> str:
+        return f"{edge.get('from', '?')} → {edge.get('to', '?')}"
+
+    sorted_edges = sorted(choice_edges, key=_edge_label)
+    for edge in sorted_edges:
+        requires = edge.get("requires") or edge.get("requires_state_flags") or []
         for req in requires:
             if req not in grantable:
-                unsatisfiable.append(f"{choice_id} requires_state_flags '{req}'")
+                unsatisfiable.append(f"{_edge_label(edge)} requires '{req}'")
 
     if not unsatisfiable:
         return ValidationCheck(
@@ -929,8 +940,8 @@ def check_gate_co_satisfiability(graph: Graph) -> ValidationCheck:
     provides ALL required state flags.  A gate that requires state flags from
     mutually exclusive paths is paradoxical — the player can never satisfy it.
     """
-    choice_nodes = graph.get_nodes_by_type("choice")
-    if not choice_nodes:
+    choice_edges = graph.get_edges(edge_type="choice")
+    if not choice_edges:
         return ValidationCheck(
             name="gate_co_satisfiability",
             severity="pass",
@@ -968,17 +979,23 @@ def check_gate_co_satisfiability(graph: Graph) -> ValidationCheck:
                     sfs.add(sf)
         arc_state_flags[arc_id] = sfs
 
-    # Check each gated choice
+    # Check each gated choice edge. POLISH writes `requires`; older code paths
+    # used `requires_state_flags`. Read both for back-compat.
     paradoxical: list[str] = []
-    for choice_id, choice_data in sorted(choice_nodes.items()):
-        requires = set(choice_data.get("requires_state_flags", []))
+
+    def _edge_label(edge: dict[str, Any]) -> str:
+        return f"{edge.get('from', '?')} → {edge.get('to', '?')}"
+
+    sorted_edges = sorted(choice_edges, key=_edge_label)
+    for edge in sorted_edges:
+        requires = set(edge.get("requires") or edge.get("requires_state_flags") or [])
         if not requires:
             continue
 
         # A gate is satisfiable if ANY arc provides all required state flags
         satisfiable = any(requires <= sfs for sfs in arc_state_flags.values())
         if not satisfiable:
-            paradoxical.append(f"{choice_id} requires {sorted(requires)}")
+            paradoxical.append(f"{_edge_label(edge)} requires {sorted(requires)}")
 
     if not paradoxical:
         return ValidationCheck(
@@ -1274,7 +1291,7 @@ def check_state_flag_gate_coverage(graph: Graph) -> ValidationCheck:
     """Check that every state flag is consumed by a gate or overlay condition.
 
     Implements the "Residue Must Be Read" invariant: checks that each
-    state flag appears in at least one ``choice.requires_state_flags`` gate or
+    state flag appears in at least one ``choice.requires`` gate or
     ``overlay.when`` condition.
     """
     state_flag_nodes = graph.get_nodes_by_type("state_flag")
@@ -1285,10 +1302,10 @@ def check_state_flag_gate_coverage(graph: Graph) -> ValidationCheck:
             message="No state flags in graph",
         )
 
-    choice_nodes = graph.get_nodes_by_type("choice")
     consumed: set[str] = set()
-    for choice_data in choice_nodes.values():
-        consumed.update(choice_data.get("requires_state_flags") or [])
+    for edge in graph.get_edges(edge_type="choice"):
+        # POLISH writes `requires`; older code paths used `requires_state_flags`.
+        consumed.update(edge.get("requires") or edge.get("requires_state_flags") or [])
 
     # Overlays are embedded arrays on entity nodes (type="entity"),
     # not separate typed nodes.
@@ -1311,7 +1328,7 @@ def check_state_flag_gate_coverage(graph: Graph) -> ValidationCheck:
         severity="warn",
         message=(
             f"{len(unconsumed)} of {len(state_flag_nodes)} state flag(s) not consumed "
-            f"by any choice.requires_state_flags or overlay.when: {', '.join(unconsumed[:5])}"
+            f"by any choice.requires or overlay.when: {', '.join(unconsumed[:5])}"
             f"{'...' if len(unconsumed) > 5 else ''}"
         ),
     )
@@ -1327,31 +1344,31 @@ def check_forward_path_reachability(graph: Graph) -> ValidationCheck:
     v1 simplification: does not check whether requires are already
     satisfiable (would require path simulation).
     """
-    choice_nodes = graph.get_nodes_by_type("choice")
-    if not choice_nodes:
+    choice_edges = graph.get_edges(edge_type="choice")
+    if not choice_edges:
         return ValidationCheck(
             name="forward_path_reachability",
             severity="pass",
             message="No choices in graph",
         )
 
-    # Build from_passage → list of choice data
+    # Build from_passage → list of outgoing choice edges
     from_passage_choices: dict[str, list[dict[str, object]]] = {}
-    for choice_data in choice_nodes.values():
-        fp = choice_data.get("from_passage")
+    for edge in choice_edges:
+        fp = edge.get("from")
         if fp:
-            from_passage_choices.setdefault(fp, []).append(choice_data)
+            from_passage_choices.setdefault(fp, []).append(edge)
 
     # Identify endings (no outgoing choices at all, or only return links)
     passages = graph.get_nodes_by_type("passage")
     soft_locked: list[str] = []
 
     for pid in sorted(passages):
-        choices = from_passage_choices.get(pid, [])
-        forward = [c for c in choices if not c.get("is_return") and not c.get("is_routing")]
+        outgoing = from_passage_choices.get(pid, [])
+        forward = [c for c in outgoing if not c.get("is_return") and not c.get("is_routing")]
         if not forward:
             continue  # ending passage or routing-only — no forward choices
-        ungated = [c for c in forward if not c.get("requires_state_flags")]
+        ungated = [c for c in forward if not (c.get("requires") or c.get("requires_state_flags"))]
         if not ungated:
             soft_locked.append(pid)
 
@@ -1390,7 +1407,7 @@ def check_routing_coverage(graph: Graph) -> list[ValidationCheck]:
     """
     from questfoundry.graph.grow_algorithms import build_arc_state_flags
 
-    choices = graph.get_nodes_by_type("choice")
+    choice_edges = graph.get_edges(edge_type="choice")
     arc_nodes = graph.get_nodes_by_type("arc")
 
     if not arc_nodes:
@@ -1411,17 +1428,17 @@ def check_routing_coverage(graph: Graph) -> list[ValidationCheck]:
     arc_state_flags_ending = build_arc_state_flags(graph, arc_nodes, scope="ending")
     arc_state_flags_routing = build_arc_state_flags(graph, arc_nodes, scope="routing")
 
-    # Group routing choices by source passage; also detect fallback choices
+    # Group routing choices by source passage; also detect fallback choices.
+    # `choice` edges go passage→passage; e["from"] is the source.
     routing_sets: dict[str, list[dict[str, object]]] = {}
-    # Source passages that also have a non-routing fallback choice
     has_fallback: set[str] = set()
-    for _cid, cdata in choices.items():
-        source = str(cdata.get("from_passage", ""))
-        if cdata.get("is_routing"):
-            routing_sets.setdefault(source, []).append(cdata)
+    for edge in choice_edges:
+        source = str(edge.get("from", ""))
+        if edge.get("is_routing"):
+            routing_sets.setdefault(source, []).append(edge)
         else:
             # A non-routing choice from a source that has routing choices
-            # is a fallback — it covers arcs that don't match any variant
+            # is a fallback — it covers arcs that don't match any variant.
             if source:
                 has_fallback.add(source)
 
@@ -1449,10 +1466,11 @@ def check_routing_coverage(graph: Graph) -> list[ValidationCheck]:
         if not covering_arcs:
             continue
 
-        # Extract requires sets from routing choices
+        # Extract requires sets from routing choice edges. POLISH writes
+        # `requires`; older code paths used `requires_state_flags`.
         route_requires: list[set[str]] = []
         for rc in routing_choices:
-            reqs = rc.get("requires_state_flags", [])
+            reqs = rc.get("requires") or rc.get("requires_state_flags") or []
             route_requires.append(set(reqs) if isinstance(reqs, list) else set())
 
         # Select state flag scope: ending splits use "ending" scope (exhaustive),

--- a/src/questfoundry/graph/polish_validation.py
+++ b/src/questfoundry/graph/polish_validation.py
@@ -884,6 +884,11 @@ def check_all_endings_reachable(graph: Graph) -> ValidationCheck:
     )
 
 
+def _choice_edge_label(edge: dict[str, Any]) -> str:
+    """Format a `choice` edge as ``"from → to"`` for diagnostic messages."""
+    return f"{edge.get('from', '?')} → {edge.get('to', '?')}"
+
+
 def check_gate_satisfiability(graph: Graph) -> ValidationCheck:
     """Verify all choice `requires` are satisfiable (required state flags exist globally).
 
@@ -910,15 +915,12 @@ def check_gate_satisfiability(graph: Graph) -> ValidationCheck:
     # code paths used `requires_state_flags`. Read both for back-compat.
     unsatisfiable: list[str] = []
 
-    def _edge_label(edge: dict[str, Any]) -> str:
-        return f"{edge.get('from', '?')} → {edge.get('to', '?')}"
-
-    sorted_edges = sorted(choice_edges, key=_edge_label)
+    sorted_edges = sorted(choice_edges, key=_choice_edge_label)
     for edge in sorted_edges:
         requires = edge.get("requires") or edge.get("requires_state_flags") or []
         for req in requires:
             if req not in grantable:
-                unsatisfiable.append(f"{_edge_label(edge)} requires '{req}'")
+                unsatisfiable.append(f"{_choice_edge_label(edge)} requires '{req}'")
 
     if not unsatisfiable:
         return ValidationCheck(
@@ -983,10 +985,7 @@ def check_gate_co_satisfiability(graph: Graph) -> ValidationCheck:
     # used `requires_state_flags`. Read both for back-compat.
     paradoxical: list[str] = []
 
-    def _edge_label(edge: dict[str, Any]) -> str:
-        return f"{edge.get('from', '?')} → {edge.get('to', '?')}"
-
-    sorted_edges = sorted(choice_edges, key=_edge_label)
+    sorted_edges = sorted(choice_edges, key=_choice_edge_label)
     for edge in sorted_edges:
         requires = set(edge.get("requires") or edge.get("requires_state_flags") or [])
         if not requires:
@@ -995,7 +994,7 @@ def check_gate_co_satisfiability(graph: Graph) -> ValidationCheck:
         # A gate is satisfiable if ANY arc provides all required state flags
         satisfiable = any(requires <= sfs for sfs in arc_state_flags.values())
         if not satisfiable:
-            paradoxical.append(f"{_edge_label(edge)} requires {sorted(requires)}")
+            paradoxical.append(f"{_choice_edge_label(edge)} requires {sorted(requires)}")
 
     if not paradoxical:
         return ValidationCheck(

--- a/src/questfoundry/inspection.py
+++ b/src/questfoundry/inspection.py
@@ -223,22 +223,22 @@ def _branching_stats(graph: Graph) -> BranchingStats | None:
     if not passages:
         return None
 
-    choices = graph.get_nodes_by_type("choice")
+    # `choice` is now an edge type (passage→passage), not a node type.
+    choice_edges = graph.get_edges(edge_type="choice")
 
     # Classify by graph structure: count outgoing choices per source passage.
-    # choice_from edges point choice→source_passage, so e["to"] = source passage.
-    choice_from_edges_all = graph.get_edges(edge_type="choice_from")
-    outgoing_per_passage: dict[str, int] = Counter(e["to"] for e in choice_from_edges_all)
+    # In the edge model the source passage is `e["from"]`.
+    outgoing_per_passage: dict[str, int] = Counter(e["from"] for e in choice_edges)
 
     meaningful = 0
     contextual = 0
     continue_count = 0
-    for _cid, cdata in choices.items():
-        from_passage = cdata.get("from_passage", "")
+    for edge in choice_edges:
+        from_passage = edge["from"]
         outgoing = outgoing_per_passage.get(from_passage, 1)
         if outgoing >= 2:
             meaningful += 1
-        elif cdata.get("label", "continue") == "continue":
+        elif edge.get("label", "continue") == "continue":
             continue_count += 1
         else:
             contextual += 1
@@ -274,25 +274,20 @@ def _branching_stats(graph: Graph) -> BranchingStats | None:
     # Compute max consecutive linear using shared BFS (with confront/resolve exemptions)
     max_linear = find_max_consecutive_linear(graph)
 
-    # Start and ending passages
+    # Start and ending passages.
     # A passage is a "start" when it has no *forward* incoming choices.
-    # Exclude hub-spoke return links (spoke→hub with is_return=True), otherwise
-    # hubs can incorrectly appear to have incoming edges and start_count becomes 0.
-    choice_nodes = graph.get_nodes_by_type("choice")
+    # Exclude hub-spoke return links (`is_return=True`); otherwise hubs would
+    # appear to have incoming edges and `start_count` would be 0.
     has_incoming: set[str] = {
-        data["to_passage"]
-        for data in choice_nodes.values()
-        if data.get("to_passage") and not data.get("is_return")
+        e["to"] for e in choice_edges if e.get("to") and not e.get("is_return")
     }
-    # For outgoing, it's more direct to use the `choice_from` edges.
-    choice_from_edges = graph.get_edges(edge_type="choice_from")
-    has_outgoing = {e["to"] for e in choice_from_edges}
+    has_outgoing = {e["from"] for e in choice_edges}
 
     start_count = sum(1 for pid in passages if pid not in has_incoming)
     ending_count = sum(1 for pid in passages if pid not in has_outgoing)
 
     return BranchingStats(
-        total_choices=len(choices),
+        total_choices=len(choice_edges),
         meaningful_choices=meaningful,
         contextual_choices=contextual,
         continue_choices=continue_count,
@@ -342,8 +337,8 @@ def _branching_quality_score(
     )
 
     # Terminal count + ending variants
-    choice_from_edges = graph.get_edges(edge_type="choice_from")
-    has_outgoing = {e["to"] for e in choice_from_edges}
+    choice_edges = graph.get_edges(edge_type="choice")
+    has_outgoing = {e["from"] for e in choice_edges}
     passages = graph.get_nodes_by_type("passage")
     ending_ids = [pid for pid in passages if pid not in has_outgoing]
 
@@ -435,7 +430,7 @@ def _prose_neutrality_stats(graph: Graph) -> ProseNeutralityStats | None:
     """Analyze prose-layer neutrality for shared passages."""
     arc_nodes = graph.get_nodes_by_type("arc")
     passage_nodes = graph.get_nodes_by_type("passage")
-    choice_nodes = graph.get_nodes_by_type("choice")
+    choice_edges = graph.get_edges(edge_type="choice")
     dilemma_nodes = graph.get_nodes_by_type("dilemma")
 
     if not arc_nodes or not passage_nodes:
@@ -454,13 +449,11 @@ def _prose_neutrality_stats(graph: Graph) -> ProseNeutralityStats | None:
         if from_beat and len(beat_arcs.get(from_beat, set())) >= 2:
             shared.append(pid)
 
-    # Find routed passages
-    routed: set[str] = set()
-    for _cid, cdata in choice_nodes.items():
-        if cdata.get("is_routing"):
-            source = str(cdata.get("from_passage", ""))
-            if source:
-                routed.add(source)
+    # Find routed passages — choice edges with `is_routing=True` originate
+    # from passages that route on state-flag combinations.
+    routed: set[str] = {
+        edge["from"] for edge in choice_edges if edge.get("is_routing") and edge.get("from")
+    }
 
     routed_shared = [p for p in shared if p in routed]
 

--- a/tests/unit/test_fill_context.py
+++ b/tests/unit/test_fill_context.py
@@ -1375,16 +1375,14 @@ class TestIsEnding:
     """Tests for compute_is_ending."""
 
     def test_passage_with_outgoing_choice_is_not_ending(self, fill_graph: Graph) -> None:
-        # Add a choice_from edge: passage::p_opening has an outgoing choice
-        fill_graph.create_node(
-            "choice::opening_to_explanation",
-            {"type": "choice", "raw_id": "opening_to_explanation"},
+        # Add a `choice` edge: passage::p_opening has an outgoing choice.
+        fill_graph.add_edge(
+            "choice", "passage::p_opening", "passage::p_explanation", label="Continue"
         )
-        fill_graph.add_edge("choice_from", "choice::opening_to_explanation", "passage::p_opening")
         assert compute_is_ending(fill_graph, "passage::p_opening") is False
 
     def test_passage_without_outgoing_choice_is_ending(self, fill_graph: Graph) -> None:
-        # p_aftermath has no choice_from edges pointing to it
+        # p_aftermath has no outgoing `choice` edges.
         assert compute_is_ending(fill_graph, "passage::p_aftermath") is True
 
 
@@ -2422,21 +2420,18 @@ class TestGetPendingSpokeLabels:
                 "summary": "Examine the mysterious artifact",
             },
         )
-        # Choice without label (pending)
-        g.create_node(
-            "choice::hub__spoke_0",
-            {
-                "type": "choice",
-                # no label field
-                "label_style": "evocative",
-            },
+        # Choice edge without label (pending)
+        g.add_edge(
+            "choice",
+            "passage::hub",
+            "passage::spoke_hub_0",
+            label_style="evocative",
         )
-        g.add_edge("choice_from", "choice::hub__spoke_0", "passage::hub")
-        g.add_edge("choice_to", "choice::hub__spoke_0", "passage::spoke_hub_0")
 
         result = get_pending_spoke_labels(g, "passage::hub")
         assert len(result) == 1
-        assert result[0]["choice_id"] == "choice::hub__spoke_0"
+        # The synthesized choice_id mirrors the (hub, spoke) pair.
+        assert result[0]["choice_id"] == "choice::hub__spoke_hub_0"
         assert result[0]["spoke_summary"] == "Examine the mysterious artifact"
         assert result[0]["label_style"] == "evocative"
 
@@ -2450,13 +2445,13 @@ class TestGetPendingSpokeLabels:
             "passage::spoke_hub_0",
             {"type": "passage", "raw_id": "spoke_hub_0", "summary": "Some spoke"},
         )
-        # Choice WITH label (not pending)
-        g.create_node(
-            "choice::hub__spoke_0",
-            {"type": "choice", "label": "Examine the clock"},
+        # Choice edge WITH label (not pending)
+        g.add_edge(
+            "choice",
+            "passage::hub",
+            "passage::spoke_hub_0",
+            label="Examine the clock",
         )
-        g.add_edge("choice_from", "choice::hub__spoke_0", "passage::hub")
-        g.add_edge("choice_to", "choice::hub__spoke_0", "passage::spoke_hub_0")
 
         result = get_pending_spoke_labels(g, "passage::hub")
         assert result == []
@@ -2472,12 +2467,8 @@ class TestGetPendingSpokeLabels:
             "passage::next_scene",
             {"type": "passage", "raw_id": "next_scene", "summary": "Continue story"},
         )
-        g.create_node(
-            "choice::hub__next",
-            {"type": "choice"},  # No label
-        )
-        g.add_edge("choice_from", "choice::hub__next", "passage::hub")
-        g.add_edge("choice_to", "choice::hub__next", "passage::next_scene")
+        # Choice edge without label, target is NOT a spoke (raw_id mismatch).
+        g.add_edge("choice", "passage::hub", "passage::next_scene")
 
         result = get_pending_spoke_labels(g, "passage::hub")
         assert result == []
@@ -2505,12 +2496,12 @@ class TestFormatSpokeContext:
             "passage::spoke_hub_0",
             {"type": "passage", "raw_id": "spoke_hub_0", "summary": "Examine the map"},
         )
-        g.create_node(
-            "choice::hub__spoke_0",
-            {"type": "choice", "label_style": "functional"},
+        g.add_edge(
+            "choice",
+            "passage::hub",
+            "passage::spoke_hub_0",
+            label_style="functional",
         )
-        g.add_edge("choice_from", "choice::hub__spoke_0", "passage::hub")
-        g.add_edge("choice_to", "choice::hub__spoke_0", "passage::spoke_hub_0")
 
         result = format_spoke_context(g, "passage::hub")
         assert "Exploration Options" in result

--- a/tests/unit/test_grow_validation.py
+++ b/tests/unit/test_grow_validation.py
@@ -39,33 +39,9 @@ def _make_linear_passage_graph() -> Graph:
             {"type": "passage", "raw_id": pid, "from_beat": f"beat::{pid}", "summary": pid},
         )
 
-    # Choices: p1->p2, p2->p3
-    graph.create_node(
-        "choice::p1__p2",
-        {
-            "type": "choice",
-            "from_passage": "passage::p1",
-            "to_passage": "passage::p2",
-            "label": "continue",
-            "requires_state_flags": [],
-            "grants": [],
-        },
-    )
-    graph.create_node(
-        "choice::p2__p3",
-        {
-            "type": "choice",
-            "from_passage": "passage::p2",
-            "to_passage": "passage::p3",
-            "label": "continue",
-            "requires_state_flags": [],
-            "grants": [],
-        },
-    )
-    graph.add_edge("choice_from", "choice::p1__p2", "passage::p1")
-    graph.add_edge("choice_to", "choice::p1__p2", "passage::p2")
-    graph.add_edge("choice_from", "choice::p2__p3", "passage::p2")
-    graph.add_edge("choice_to", "choice::p2__p3", "passage::p3")
+    # Choice edges: p1->p2, p2->p3
+    graph.add_edge("choice", "passage::p1", "passage::p2", label="continue", requires=[], grants=[])
+    graph.add_edge("choice", "passage::p2", "passage::p3", label="continue", requires=[], grants=[])
 
     # Dilemma + path so enumerate_arcs() produces a spine arc
     graph.create_node("dilemma::d1", {"type": "dilemma", "raw_id": "d1"})
@@ -107,7 +83,7 @@ class TestSingleStart:
 
     def test_single_start_multiple_starts(self) -> None:
         graph = _make_linear_passage_graph()
-        # Add an orphan passage with no incoming choice_to
+        # Add an orphan passage with no incoming `choice` edge
         graph.create_node(
             "passage::orphan",
             {"type": "passage", "raw_id": "orphan", "from_beat": "beat::x", "summary": "x"},
@@ -130,31 +106,9 @@ class TestSingleStart:
                 f"passage::{pid}",
                 {"type": "passage", "raw_id": pid, "from_beat": f"beat::{pid}", "summary": pid},
             )
-        # Create a cycle: p1->p2 and p2->p1
-        graph.create_node(
-            "choice::p1_p2",
-            {
-                "type": "choice",
-                "from_passage": "passage::p1",
-                "to_passage": "passage::p2",
-                "label": "go",
-                "requires_state_flags": [],
-                "grants": [],
-            },
-        )
-        graph.create_node(
-            "choice::p2_p1",
-            {
-                "type": "choice",
-                "from_passage": "passage::p2",
-                "to_passage": "passage::p1",
-                "label": "back",
-                "requires_state_flags": [],
-                "grants": [],
-            },
-        )
-        graph.add_edge("choice_to", "choice::p1_p2", "passage::p2")
-        graph.add_edge("choice_to", "choice::p2_p1", "passage::p1")
+        # Create a cycle: p1->p2 and p2->p1.
+        graph.add_edge("choice", "passage::p1", "passage::p2", label="go", requires=[], grants=[])
+        graph.add_edge("choice", "passage::p2", "passage::p1", label="back", requires=[], grants=[])
         result = check_single_start(graph)
         assert result.severity == "fail"
         assert "No start passage" in result.message
@@ -173,34 +127,24 @@ class TestSingleStart:
                 "is_synthetic": True,
             },
         )
-        graph.create_node(
-            "choice::p1_spoke_0",
-            {
-                "type": "choice",
-                "from_passage": "passage::p1",
-                "to_passage": "passage::spoke_0",
-                "label": "Look around",
-                "requires_state_flags": [],
-                "grants": [],
-            },
+        graph.add_edge(
+            "choice",
+            "passage::p1",
+            "passage::spoke_0",
+            label="Look around",
+            requires=[],
+            grants=[],
         )
-        graph.add_edge("choice_from", "choice::p1_spoke_0", "passage::p1")
-        graph.add_edge("choice_to", "choice::p1_spoke_0", "passage::spoke_0")
-        # Return link: spoke->p1 with is_return=True
-        graph.create_node(
-            "choice::spoke_0_return",
-            {
-                "type": "choice",
-                "from_passage": "passage::spoke_0",
-                "to_passage": "passage::p1",
-                "label": "Return",
-                "is_return": True,
-                "requires_state_flags": [],
-                "grants": [],
-            },
+        # Return link: spoke->p1 with is_return=True.
+        graph.add_edge(
+            "choice",
+            "passage::spoke_0",
+            "passage::p1",
+            label="Return",
+            is_return=True,
+            requires=[],
+            grants=[],
         )
-        graph.add_edge("choice_from", "choice::spoke_0_return", "passage::spoke_0")
-        graph.add_edge("choice_to", "choice::spoke_0_return", "passage::p1")
 
         result = check_single_start(graph)
         assert result.severity == "pass"
@@ -268,28 +212,8 @@ class TestPassageDagCycles:
                 {"type": "passage", "raw_id": pid, "from_beat": f"beat::{pid}", "summary": pid},
             )
         # Cycle: p1->p2 and p2->p1
-        graph.create_node(
-            "choice::c1",
-            {
-                "type": "choice",
-                "from_passage": "passage::p1",
-                "to_passage": "passage::p2",
-                "label": "go",
-                "requires_state_flags": [],
-                "grants": [],
-            },
-        )
-        graph.create_node(
-            "choice::c2",
-            {
-                "type": "choice",
-                "from_passage": "passage::p2",
-                "to_passage": "passage::p1",
-                "label": "back",
-                "requires_state_flags": [],
-                "grants": [],
-            },
-        )
+        graph.add_edge("choice", "passage::p1", "passage::p2", label="go", requires=[], grants=[])
+        graph.add_edge("choice", "passage::p2", "passage::p1", label="back", requires=[], grants=[])
         result = check_passage_dag_cycles(graph)
         assert result.severity == "fail"
         assert "Cycle" in result.message

--- a/tests/unit/test_inspection.py
+++ b/tests/unit/test_inspection.py
@@ -43,33 +43,23 @@ def _make_full_graph() -> Graph:
         ["The hero stood tall in the morning light.", "She ran through the dark forest quickly."]
     )
 
-    # Add choices
-    graph.create_node(
-        "choice::p0__p1",
-        {
-            "type": "choice",
-            "from_passage": "passage::p0",
-            "to_passage": "passage::p1",
-            "label": "Enter the forest",
-            "requires_state_flags": [],
-            "grants": [],
-        },
+    # Add choice edges
+    graph.add_edge(
+        "choice",
+        "passage::p0",
+        "passage::p1",
+        label="Enter the forest",
+        requires=[],
+        grants=[],
     )
-    graph.create_node(
-        "choice::p0__p1_continue",
-        {
-            "type": "choice",
-            "from_passage": "passage::p0",
-            "to_passage": "passage::p1",
-            "label": "continue",
-            "requires_state_flags": [],
-            "grants": [],
-        },
+    graph.add_edge(
+        "choice",
+        "passage::p0",
+        "passage::p1",
+        label="continue",
+        requires=[],
+        grants=[],
     )
-    graph.add_edge("choice_from", "choice::p0__p1", "passage::p0")
-    graph.add_edge("choice_to", "choice::p0__p1", "passage::p1")
-    graph.add_edge("choice_from", "choice::p0__p1_continue", "passage::p0")
-    graph.add_edge("choice_to", "choice::p0__p1_continue", "passage::p1")
 
     # Add entities
     graph.create_node(
@@ -105,7 +95,11 @@ class TestGraphSummary:
         assert summary.total_nodes > 0
         assert summary.total_edges > 0
         assert "passage" in summary.node_counts
-        assert "choice" in summary.node_counts
+        # `choice` is now an edge type, not a node type, so it appears in
+        # edge counts rather than node_counts. Just verify the build had
+        # both nodes (passages) and edges (choice) without asserting on the
+        # specific shape of node_counts.
+        assert summary.total_edges >= 2  # 2 choice edges + HasEntry
 
     def test_node_counts_sorted_by_count(self, tmp_path: Path) -> None:
         graph = _make_full_graph()
@@ -193,34 +187,24 @@ class TestBranchingStats:
             )
 
         # p0 → p1: single outgoing, contextual label
-        graph.create_node(
-            "choice::p0__p1",
-            {
-                "type": "choice",
-                "from_passage": "passage::p0",
-                "to_passage": "passage::p1",
-                "label": "Search the room",
-                "requires_state_flags": [],
-                "grants": [],
-            },
+        graph.add_edge(
+            "choice",
+            "passage::p0",
+            "passage::p1",
+            label="Search the room",
+            requires=[],
+            grants=[],
         )
-        graph.add_edge("choice_from", "choice::p0__p1", "passage::p0")
-        graph.add_edge("choice_to", "choice::p0__p1", "passage::p1")
 
         # p1 → p2: single outgoing, continue label
-        graph.create_node(
-            "choice::p1__p2",
-            {
-                "type": "choice",
-                "from_passage": "passage::p1",
-                "to_passage": "passage::p2",
-                "label": "continue",
-                "requires_state_flags": [],
-                "grants": [],
-            },
+        graph.add_edge(
+            "choice",
+            "passage::p1",
+            "passage::p2",
+            label="continue",
+            requires=[],
+            grants=[],
         )
-        graph.add_edge("choice_from", "choice::p1__p2", "passage::p1")
-        graph.add_edge("choice_to", "choice::p1__p2", "passage::p2")
 
         stats = _branching_stats(graph)
 
@@ -265,46 +249,31 @@ class TestBranchingStats:
         )
 
         # Ensure p0 has 2 outgoing (hub), then add a return link spoke→p0.
-        graph.create_node(
-            "choice::p0__p1",
-            {
-                "type": "choice",
-                "from_passage": "passage::p0",
-                "to_passage": "passage::p1",
-                "label": "continue",
-                "requires_state_flags": [],
-                "grants": [],
-            },
+        graph.add_edge(
+            "choice",
+            "passage::p0",
+            "passage::p1",
+            label="continue",
+            requires=[],
+            grants=[],
         )
-        graph.add_edge("choice_from", "choice::p0__p1", "passage::p0")
-        graph.add_edge("choice_to", "choice::p0__p1", "passage::p1")
-        graph.create_node(
-            "choice::p0__spoke_0",
-            {
-                "type": "choice",
-                "from_passage": "passage::p0",
-                "to_passage": "passage::spoke_0",
-                "label": "Look around",
-                "requires_state_flags": [],
-                "grants": [],
-            },
+        graph.add_edge(
+            "choice",
+            "passage::p0",
+            "passage::spoke_0",
+            label="Look around",
+            requires=[],
+            grants=[],
         )
-        graph.add_edge("choice_from", "choice::p0__spoke_0", "passage::p0")
-        graph.add_edge("choice_to", "choice::p0__spoke_0", "passage::spoke_0")
-        graph.create_node(
-            "choice::spoke_0_return",
-            {
-                "type": "choice",
-                "from_passage": "passage::spoke_0",
-                "to_passage": "passage::p0",
-                "label": "Return",
-                "is_return": True,
-                "requires_state_flags": [],
-                "grants": [],
-            },
+        graph.add_edge(
+            "choice",
+            "passage::spoke_0",
+            "passage::p0",
+            label="Return",
+            is_return=True,
+            requires=[],
+            grants=[],
         )
-        graph.add_edge("choice_from", "choice::spoke_0_return", "passage::spoke_0")
-        graph.add_edge("choice_to", "choice::spoke_0_return", "passage::p0")
 
         stats = _branching_stats(graph)
         assert stats is not None
@@ -585,19 +554,14 @@ class TestBranchingQualityScore:
             },
         )
         graph.add_edge("grouped_in", "beat::s0", "passage::mid")
-        graph.create_node(
-            "choice::mid__ending",
-            {
-                "type": "choice",
-                "from_passage": "passage::mid",
-                "to_passage": "passage::ending",
-                "label": "Continue",
-                "requires_state_flags": [],
-                "grants": [],
-            },
+        graph.add_edge(
+            "choice",
+            "passage::mid",
+            "passage::ending",
+            label="Continue",
+            requires=[],
+            grants=[],
         )
-        graph.add_edge("choice_from", "choice::mid__ending", "passage::mid")
-        graph.add_edge("choice_to", "choice::mid__ending", "passage::ending")
 
         # Give each path a different state flag via consequence
         graph.create_node(
@@ -679,19 +643,14 @@ class TestBranchingQualityScore:
             },
         )
         graph.add_edge("grouped_in", "beat::s2", "passage::mid")
-        graph.create_node(
-            "choice::mid__ending",
-            {
-                "type": "choice",
-                "from_passage": "passage::mid",
-                "to_passage": "passage::ending",
-                "label": "Finish",
-                "requires_state_flags": [],
-                "grants": [],
-            },
+        graph.add_edge(
+            "choice",
+            "passage::mid",
+            "passage::ending",
+            label="Finish",
+            requires=[],
+            grants=[],
         )
-        graph.add_edge("choice_from", "choice::mid__ending", "passage::mid")
-        graph.add_edge("choice_to", "choice::mid__ending", "passage::ending")
 
         result = _branching_quality_score(graph, None)
         assert result is not None
@@ -749,10 +708,8 @@ class TestBranchingQualityScore:
             "choice::to_1",
             {"type": "choice", "raw_id": "to_1"},
         )
-        graph.add_edge("choice_from", "choice::to_0", "passage::hub")
-        graph.add_edge("choice_to", "choice::to_0", "passage::ending_0")
-        graph.add_edge("choice_from", "choice::to_1", "passage::hub")
-        graph.add_edge("choice_to", "choice::to_1", "passage::ending_1")
+        graph.add_edge("choice", "passage::hub", "passage::ending_0")
+        graph.add_edge("choice", "passage::hub", "passage::ending_1")
 
         result = _branching_quality_score(graph, None)
         assert result is not None

--- a/tests/unit/test_polish_contract.py
+++ b/tests/unit/test_polish_contract.py
@@ -222,21 +222,7 @@ def _polish_passage_baseline(graph: Graph) -> None:
             graph.add_edge("grouped_in", bid, passage_id)
 
     for idx, to_id in enumerate(("passage::prot", "passage::mani")):
-        choice_id = f"choice::pre_to_{to_id.rsplit('::', 1)[-1]}"
-        graph.create_node(
-            choice_id,
-            {
-                "type": "choice",
-                "raw_id": choice_id.split("::", 1)[-1],
-                "from_passage": "passage::pre",
-                "to_passage": to_id,
-                "label": f"Choice {idx + 1}",
-                "requires": [],
-            },
-        )
-        graph.add_edge("choice_from", choice_id, "passage::pre")
-        graph.add_edge("choice_to", choice_id, to_id)
-        # Add the proper choice edge from passage to passage (R-4c.2 requirement)
+        # Choice is now an edge directly between passages (R-4c.2).
         graph.add_edge("choice", "passage::pre", to_id, label=f"Choice {idx + 1}")
 
     # Character arc on the recurring entity.
@@ -472,10 +458,9 @@ def test_phase_4c_linear_only_still_raises_contract_error() -> None:
 
 
 def test_R_4c_2_zero_choice_edges_fails(compliant_polish_graph: Graph) -> None:
-    # Delete choice nodes (which cascade-delete choice_from/choice_to edges)
-    for cid in list(compliant_polish_graph.get_nodes_by_type("choice")):
-        compliant_polish_graph.delete_node(cid, cascade=True)
-    # Also delete any remaining choice edges (passage→passage edges, not connected to nodes)
+    # Delete every `choice` edge (passage→passage). The legacy `choice` node
+    # type is no longer produced by the pipeline so there's nothing to
+    # cascade-delete.
     for edge in list(compliant_polish_graph.get_edges(edge_type="choice")):
         compliant_polish_graph.remove_edge("choice", edge["from"], edge["to"])
     errors = validate_polish_output(compliant_polish_graph)

--- a/tests/unit/test_polish_passage_validation.py
+++ b/tests/unit/test_polish_passage_validation.py
@@ -43,33 +43,9 @@ def _make_linear_passage_graph() -> Graph:
         )
         graph.add_edge("grouped_in", f"beat::{pid}", f"passage::{pid}")
 
-    # Choices: p1->p2, p2->p3
-    graph.create_node(
-        "choice::p1__p2",
-        {
-            "type": "choice",
-            "from_passage": "passage::p1",
-            "to_passage": "passage::p2",
-            "label": "continue",
-            "requires_state_flags": [],
-            "grants": [],
-        },
-    )
-    graph.create_node(
-        "choice::p2__p3",
-        {
-            "type": "choice",
-            "from_passage": "passage::p2",
-            "to_passage": "passage::p3",
-            "label": "continue",
-            "requires_state_flags": [],
-            "grants": [],
-        },
-    )
-    graph.add_edge("choice_from", "choice::p1__p2", "passage::p1")
-    graph.add_edge("choice_to", "choice::p1__p2", "passage::p2")
-    graph.add_edge("choice_from", "choice::p2__p3", "passage::p2")
-    graph.add_edge("choice_to", "choice::p2__p3", "passage::p3")
+    # Choices (edge model): p1->p2, p2->p3
+    graph.add_edge("choice", "passage::p1", "passage::p2", label="continue", requires=[], grants=[])
+    graph.add_edge("choice", "passage::p2", "passage::p3", label="continue", requires=[], grants=[])
 
     # Add a spine arc so validation passes the spine check
     graph.create_node(
@@ -150,20 +126,14 @@ def _make_chain_graph(passage_ids: list[str], beat_data: dict[str, dict] | None 
     for i in range(len(passage_ids) - 1):
         from_p = passage_ids[i]
         to_p = passage_ids[i + 1]
-        cid = f"choice::{from_p}__{to_p}"
-        graph.create_node(
-            cid,
-            {
-                "type": "choice",
-                "from_passage": f"passage::{from_p}",
-                "to_passage": f"passage::{to_p}",
-                "label": "continue",
-                "requires_state_flags": [],
-                "grants": [],
-            },
+        graph.add_edge(
+            "choice",
+            f"passage::{from_p}",
+            f"passage::{to_p}",
+            label="continue",
+            requires=[],
+            grants=[],
         )
-        graph.add_edge("choice_from", cid, f"passage::{from_p}")
-        graph.add_edge("choice_to", cid, f"passage::{to_p}")
 
     return graph
 
@@ -231,23 +201,19 @@ def _make_routing_graph(
             },
         )
 
-    # Routing choices
+    # Routing choice edges
     for i, (choice_raw, reqs) in enumerate(route_requires.items()):
         target = f"passage::end{i}"
         graph.create_node(target, {"type": "passage", "raw_id": f"end{i}", "summary": f"end{i}"})
-        graph.create_node(
-            f"choice::{choice_raw}",
-            {
-                "type": "choice",
-                "from_passage": "passage::hub",
-                "to_passage": target,
-                "label": choice_raw,
-                "is_routing": True,
-                "requires_state_flags": [f"state_flag::{cw}" for cw in reqs],
-                "grants": [],
-            },
+        graph.add_edge(
+            "choice",
+            "passage::hub",
+            target,
+            label=choice_raw,
+            is_routing=True,
+            requires=[f"state_flag::{cw}" for cw in reqs],
+            grants=[],
         )
-        graph.add_edge("choice_from", f"choice::{choice_raw}", "passage::hub")
 
     return graph
 
@@ -327,19 +293,15 @@ def _make_shared_passage_graph(
                 "is_residue": True,
             },
         )
-        graph.create_node(
-            "choice::r1",
-            {
-                "type": "choice",
-                "from_passage": "passage::shared",
-                "to_passage": "passage::v1",
-                "label": "r1",
-                "is_routing": True,
-                "requires_state_flags": ["state_flag::cw1"],
-                "grants": [],
-            },
+        graph.add_edge(
+            "choice",
+            "passage::shared",
+            "passage::v1",
+            label="r1",
+            is_routing=True,
+            requires=["state_flag::cw1"],
+            grants=[],
         )
-        graph.add_edge("choice_from", "choice::r1", "passage::shared")
 
     return graph
 
@@ -363,19 +325,17 @@ class TestReachability:
             "passage::isolated",
             {"type": "passage", "raw_id": "isolated", "from_beat": "beat::x", "summary": "x"},
         )
-        # Give it an incoming edge so it's not a second start (from a non-reachable source)
-        graph.create_node(
-            "choice::phantom_to_isolated",
-            {
-                "type": "choice",
-                "from_passage": "passage::isolated",
-                "to_passage": "passage::isolated",
-                "label": "self",
-                "requires_state_flags": [],
-                "grants": [],
-            },
+        # Give it an incoming edge so it's not a second start (from a non-reachable source).
+        # A self-loop choice puts `passage::isolated` in `has_incoming` without
+        # making it reachable from p1.
+        graph.add_edge(
+            "choice",
+            "passage::isolated",
+            "passage::isolated",
+            label="self",
+            requires=[],
+            grants=[],
         )
-        graph.add_edge("choice_to", "choice::phantom_to_isolated", "passage::isolated")
         result = check_all_passages_reachable(graph)
         assert result.severity == "fail"
         assert "unreachable" in result.message
@@ -411,35 +371,14 @@ class TestEndingsReachable:
             "passage::middle",
             {"type": "passage", "raw_id": "middle", "from_beat": "beat::m", "summary": "m"},
         )
-        # start -> middle
-        graph.create_node(
-            "choice::s_m",
-            {
-                "type": "choice",
-                "from_passage": "passage::start",
-                "to_passage": "passage::middle",
-                "label": "go",
-                "requires_state_flags": [],
-                "grants": [],
-            },
+        # start <-> middle (cycle, no endings)
+        graph.add_edge(
+            "choice", "passage::start", "passage::middle", label="go", requires=[], grants=[]
         )
-        graph.add_edge("choice_from", "choice::s_m", "passage::start")
-        graph.add_edge("choice_to", "choice::s_m", "passage::middle")
-        # middle -> start (cycle)
-        graph.create_node(
-            "choice::m_s",
-            {
-                "type": "choice",
-                "from_passage": "passage::middle",
-                "to_passage": "passage::start",
-                "label": "back",
-                "requires_state_flags": [],
-                "grants": [],
-            },
+        graph.add_edge(
+            "choice", "passage::middle", "passage::start", label="back", requires=[], grants=[]
         )
-        graph.add_edge("choice_from", "choice::m_s", "passage::middle")
-        graph.add_edge("choice_to", "choice::m_s", "passage::start")
-        # Both passages have choice_from -> no endings; both have choice_to -> no start
+        # Both passages are sources AND targets → no endings, no unique start.
         result = check_all_endings_reachable(graph)
         assert result.severity == "fail"
 
@@ -465,29 +404,23 @@ class TestGateSatisfiability:
             "passage::p2",
             {"type": "passage", "raw_id": "p2", "from_beat": "beat::b2", "summary": "s"},
         )
-        # Choice that grants "cw1"
-        graph.create_node(
-            "choice::c1",
-            {
-                "type": "choice",
-                "from_passage": "passage::p1",
-                "to_passage": "passage::p2",
-                "label": "go",
-                "requires_state_flags": [],
-                "grants": ["state_flag::cw1"],
-            },
+        # Choice edge that grants "cw1"
+        graph.add_edge(
+            "choice",
+            "passage::p1",
+            "passage::p2",
+            label="go",
+            requires=[],
+            grants=["state_flag::cw1"],
         )
-        # Choice that requires "cw1" (satisfiable because c1 grants it)
-        graph.create_node(
-            "choice::c2",
-            {
-                "type": "choice",
-                "from_passage": "passage::p2",
-                "to_passage": "passage::p1",
-                "label": "back",
-                "requires_state_flags": ["state_flag::cw1"],
-                "grants": [],
-            },
+        # Choice edge that requires "cw1" (satisfiable because the first edge grants it)
+        graph.add_edge(
+            "choice",
+            "passage::p2",
+            "passage::p1",
+            label="back",
+            requires=["state_flag::cw1"],
+            grants=[],
         )
         result = check_gate_satisfiability(graph)
         assert result.severity == "pass"
@@ -502,17 +435,14 @@ class TestGateSatisfiability:
             "passage::p2",
             {"type": "passage", "raw_id": "p2", "from_beat": "beat::b2", "summary": "s"},
         )
-        # Choice that requires ungrantable state flag
-        graph.create_node(
-            "choice::c1",
-            {
-                "type": "choice",
-                "from_passage": "passage::p1",
-                "to_passage": "passage::p2",
-                "label": "go",
-                "requires_state_flags": ["state_flag::never_granted"],
-                "grants": [],
-            },
+        # Choice edge that requires an ungrantable state flag.
+        graph.add_edge(
+            "choice",
+            "passage::p1",
+            "passage::p2",
+            label="go",
+            requires=["state_flag::never_granted"],
+            grants=[],
         )
         result = check_gate_satisfiability(graph)
         assert result.severity == "fail"
@@ -544,18 +474,15 @@ class TestGateCoSatisfiability:
             "arc::a1",
             {"type": "arc", "arc_type": "branch", "paths": ["p1"], "sequence": []},
         )
-        # Choice requiring cw1 -- arc a1 provides it
+        # Choice edge requiring cw1 — arc a1 provides it.
         graph.create_node("passage::p", {"type": "passage", "raw_id": "p", "from_beat": "b"})
-        graph.create_node(
-            "choice::g1",
-            {
-                "type": "choice",
-                "from_passage": "passage::p",
-                "to_passage": "passage::p",
-                "label": "go",
-                "requires_state_flags": ["state_flag::cw1"],
-                "grants": [],
-            },
+        graph.add_edge(
+            "choice",
+            "passage::p",
+            "passage::p",
+            label="go",
+            requires=["state_flag::cw1"],
+            grants=[],
         )
         result = check_gate_co_satisfiability(graph)
         assert result.severity == "pass"
@@ -581,18 +508,15 @@ class TestGateCoSatisfiability:
             "arc::a2",
             {"type": "arc", "arc_type": "branch", "paths": ["p2"], "sequence": []},
         )
-        # Choice requiring BOTH state flags -- no single arc provides both
+        # Choice edge requiring BOTH state flags — no single arc provides both.
         graph.create_node("passage::p", {"type": "passage", "raw_id": "p", "from_beat": "b"})
-        graph.create_node(
-            "choice::g1",
-            {
-                "type": "choice",
-                "from_passage": "passage::p",
-                "to_passage": "passage::p",
-                "label": "go",
-                "requires_state_flags": ["state_flag::p1_cw", "state_flag::p2_cw"],
-                "grants": [],
-            },
+        graph.add_edge(
+            "choice",
+            "passage::p",
+            "passage::p",
+            label="go",
+            requires=["state_flag::p1_cw", "state_flag::p2_cw"],
+            grants=[],
         )
         result = check_gate_co_satisfiability(graph)
         assert result.severity == "fail"
@@ -895,19 +819,14 @@ class TestMaxConsecutiveLinear:
             "passage::alt",
             {"type": "passage", "raw_id": "alt", "from_beat": "beat::alt", "summary": "Alt"},
         )
-        graph.create_node(
-            "choice::b__alt",
-            {
-                "type": "choice",
-                "from_passage": "passage::b",
-                "to_passage": "passage::alt",
-                "label": "Take alternative",
-                "requires_state_flags": [],
-                "grants": [],
-            },
+        graph.add_edge(
+            "choice",
+            "passage::b",
+            "passage::alt",
+            label="Take alternative",
+            requires=[],
+            grants=[],
         )
-        graph.add_edge("choice_from", "choice::b__alt", "passage::b")
-        graph.add_edge("choice_to", "choice::b__alt", "passage::alt")
 
         # Now: a(1)->b(2)->c(1)->d(1)->e(0)
         # b has 2 outgoing so it's not linear -- resets counter
@@ -962,19 +881,7 @@ class TestMaxConsecutiveLinear:
             {"type": "passage", "raw_id": "x", "from_beat": "beat::x", "summary": "X"},
         )
         graph.create_node("beat::x", {"type": "beat"})
-        graph.create_node(
-            "choice::x__c",
-            {
-                "type": "choice",
-                "from_passage": "passage::x",
-                "to_passage": "passage::c",
-                "label": "go",
-                "requires_state_flags": [],
-                "grants": [],
-            },
-        )
-        graph.add_edge("choice_from", "choice::x__c", "passage::x")
-        graph.add_edge("choice_to", "choice::x__c", "passage::c")
+        graph.add_edge("choice", "passage::x", "passage::c", label="go", requires=[], grants=[])
 
         result = check_max_consecutive_linear(graph, max_run=2)
         assert result.severity == "warn"
@@ -1075,16 +982,15 @@ class TestStateFlagGateCoverage:
     def test_all_consumed_passes(self) -> None:
         graph = Graph.empty()
         graph.create_node("state_flag::cw1", {"type": "state_flag", "raw_id": "cw1"})
-        graph.create_node(
-            "choice::a_b",
-            {
-                "type": "choice",
-                "from_passage": "passage::a",
-                "to_passage": "passage::b",
-                "label": "go",
-                "requires_state_flags": ["state_flag::cw1"],
-                "grants": [],
-            },
+        graph.create_node("passage::a", {"type": "passage", "raw_id": "a"})
+        graph.create_node("passage::b", {"type": "passage", "raw_id": "b"})
+        graph.add_edge(
+            "choice",
+            "passage::a",
+            "passage::b",
+            label="go",
+            requires=["state_flag::cw1"],
+            grants=[],
         )
         result = check_state_flag_gate_coverage(graph)
         assert result.severity == "pass"
@@ -1093,16 +999,15 @@ class TestStateFlagGateCoverage:
         graph = Graph.empty()
         graph.create_node("state_flag::cw1", {"type": "state_flag", "raw_id": "cw1"})
         graph.create_node("state_flag::cw2", {"type": "state_flag", "raw_id": "cw2"})
-        graph.create_node(
-            "choice::a_b",
-            {
-                "type": "choice",
-                "from_passage": "passage::a",
-                "to_passage": "passage::b",
-                "label": "go",
-                "requires_state_flags": ["state_flag::cw1"],
-                "grants": [],
-            },
+        graph.create_node("passage::a", {"type": "passage", "raw_id": "a"})
+        graph.create_node("passage::b", {"type": "passage", "raw_id": "b"})
+        graph.add_edge(
+            "choice",
+            "passage::a",
+            "passage::b",
+            label="go",
+            requires=["state_flag::cw1"],
+            grants=[],
         )
         result = check_state_flag_gate_coverage(graph)
         assert result.severity == "warn"
@@ -1186,35 +1091,20 @@ class TestForwardPathReachability:
 
     def test_ungated_path_passes(self) -> None:
         graph = self._make_passage_graph()
-        graph.create_node(
-            "choice::a_b",
-            {
-                "type": "choice",
-                "from_passage": "passage::a",
-                "to_passage": "passage::b",
-                "label": "go",
-                "requires_state_flags": [],
-                "grants": [],
-            },
-        )
-        graph.add_edge("choice_from", "choice::a_b", "passage::a")
+        graph.add_edge("choice", "passage::a", "passage::b", label="go", requires=[], grants=[])
         result = check_forward_path_reachability(graph)
         assert result.severity == "pass"
 
     def test_all_gated_warns(self) -> None:
         graph = self._make_passage_graph()
-        graph.create_node(
-            "choice::a_b",
-            {
-                "type": "choice",
-                "from_passage": "passage::a",
-                "to_passage": "passage::b",
-                "label": "go",
-                "requires_state_flags": ["state_flag::x"],
-                "grants": [],
-            },
+        graph.add_edge(
+            "choice",
+            "passage::a",
+            "passage::b",
+            label="go",
+            requires=["state_flag::x"],
+            grants=[],
         )
-        graph.add_edge("choice_from", "choice::a_b", "passage::a")
         result = check_forward_path_reachability(graph)
         assert result.severity == "warn"
         assert "passage::a" in result.message
@@ -1229,31 +1119,23 @@ class TestForwardPathReachability:
     def test_return_links_excluded(self) -> None:
         """is_return choices should not count as forward paths."""
         graph = self._make_passage_graph()
-        graph.create_node(
-            "choice::a_b",
-            {
-                "type": "choice",
-                "from_passage": "passage::a",
-                "to_passage": "passage::b",
-                "label": "return",
-                "requires_state_flags": [],
-                "grants": [],
-                "is_return": True,
-            },
+        graph.add_edge(
+            "choice",
+            "passage::a",
+            "passage::b",
+            label="return",
+            requires=[],
+            grants=[],
+            is_return=True,
         )
-        graph.add_edge("choice_from", "choice::a_b", "passage::a")
-        graph.create_node(
-            "choice::a_c",
-            {
-                "type": "choice",
-                "from_passage": "passage::a",
-                "to_passage": "passage::c",
-                "label": "go",
-                "requires_state_flags": ["state_flag::x"],
-                "grants": [],
-            },
+        graph.add_edge(
+            "choice",
+            "passage::a",
+            "passage::c",
+            label="go",
+            requires=["state_flag::x"],
+            grants=[],
         )
-        graph.add_edge("choice_from", "choice::a_c", "passage::a")
         # Only non-return choice is gated, but the return link doesn't count
         result = check_forward_path_reachability(graph)
         assert result.severity == "warn"
@@ -1271,45 +1153,32 @@ class TestForwardPathReachability:
             "passage::next",
             {"type": "passage", "raw_id": "next", "from_beat": "beat::next", "summary": "next"},
         )
-        graph.create_node(
-            "choice::normal",
-            {
-                "type": "choice",
-                "from_passage": "passage::hub",
-                "to_passage": "passage::next",
-                "label": "continue",
-                "requires_state_flags": [],
-                "grants": [],
-            },
+        graph.add_edge(
+            "choice",
+            "passage::hub",
+            "passage::next",
+            label="continue",
+            requires=[],
+            grants=[],
         )
-        graph.add_edge("choice_from", "choice::normal", "passage::hub")
-        # Add routing choices (all gated) -- these should NOT trigger a warning
-        graph.create_node(
-            "choice::r1",
-            {
-                "type": "choice",
-                "from_passage": "passage::hub",
-                "to_passage": "passage::end1",
-                "label": "route1",
-                "is_routing": True,
-                "requires_state_flags": ["state_flag::cw1"],
-                "grants": [],
-            },
-        )
-        graph.add_edge("choice_from", "choice::r1", "passage::hub")
-        graph.create_node(
-            "choice::r2",
-            {
-                "type": "choice",
-                "from_passage": "passage::hub",
-                "to_passage": "passage::end2",
-                "label": "route2",
-                "is_routing": True,
-                "requires_state_flags": ["state_flag::cw2"],
-                "grants": [],
-            },
-        )
-        graph.add_edge("choice_from", "choice::r2", "passage::hub")
+        # Add routing choices (all gated) — these should NOT trigger a warning.
+        for raw, target_raw, flag in [
+            ("r1", "end1", "cw1"),
+            ("r2", "end2", "cw2"),
+        ]:
+            target = f"passage::{target_raw}"
+            graph.create_node(
+                target, {"type": "passage", "raw_id": target_raw, "summary": target_raw}
+            )
+            graph.add_edge(
+                "choice",
+                "passage::hub",
+                target,
+                label=raw,
+                is_routing=True,
+                requires=[f"state_flag::{flag}"],
+                grants=[],
+            )
         result = check_forward_path_reachability(graph)
         # The only forward (non-routing) choice is ungated, so pass
         assert result.severity == "pass"
@@ -1398,24 +1267,20 @@ class TestCheckRoutingCoverage:
             arc_paths={"a1": ["p1"], "a2": ["p2"]},
             route_requires={"r1": ["p1"], "r2": ["p2"]},
         )
-        # Add a fallback routing choice with empty requires
+        # Add a fallback routing choice edge with empty requires.
         graph.create_node(
             "passage::fallback",
             {"type": "passage", "raw_id": "fallback", "summary": "fallback"},
         )
-        graph.create_node(
-            "choice::fallback",
-            {
-                "type": "choice",
-                "from_passage": "passage::hub",
-                "to_passage": "passage::fallback",
-                "label": "fallback",
-                "is_routing": True,
-                "requires_state_flags": [],
-                "grants": [],
-            },
+        graph.add_edge(
+            "choice",
+            "passage::hub",
+            "passage::fallback",
+            label="fallback",
+            is_routing=True,
+            requires=[],
+            grants=[],
         )
-        graph.add_edge("choice_from", "choice::fallback", "passage::hub")
         result = check_routing_coverage(graph)
         # Fallback with empty requires is ignored; CE+ME still valid
         assert len(result) == 1


### PR DESCRIPTION
## Summary

Several modules still queried the old \`choice\` node + \`choice_from\` / \`choice_to\` edge model. The pipeline produces \`choice\` edges directly between passages now (\`e[\"from\"]\` = source, \`e[\"to\"]\` = target). Result: the old-model checks silently passed (no data → no errors) and were DEAD.

## Production migrations

- **\`inspection.py\`** — \`_branching_stats\`, \`_branching_quality_score\`, \`_prose_neutrality_stats\` now read \`choice\` edges. Start/ending/routed-passage detection follows.
- **\`graph/grow_validation.py\`** — \`build_outgoing_count\`, \`passages_with_forward_incoming\`, \`build_passage_adjacency\`, \`check_passage_dag_cycles\`.
- **\`graph/fill_context.py\`** — \`get_pending_spoke_labels\` synthesizes a \`(hub, spoke)\` choice_id from edge endpoints (with a comment that the FILL consumer-side spoke-label feature is inert pending architectural rework). \`compute_is_ending\` reads outgoing \`choice\` edges directly.
- **\`graph/polish_validation.py\`** — \`_build_passage_successors\`, \`check_all_endings_reachable\`, \`check_gate_satisfiability\`, \`check_gate_co_satisfiability\`, \`check_state_flag_gate_coverage\`, \`check_forward_path_reachability\`, \`check_routing_coverage\` all migrated. \`validate_polish_output\` re-enables endings + gate-satisfiability checks (was gated behind a #1165 TODO).

\`requires\` is the field POLISH writes; \`requires_state_flags\` is read as a back-compat fallback in validators that consume gate data.

## Test migrations

5 test files updated: \`test_inspection.py\`, \`test_grow_validation.py\`, \`test_polish_passage_validation.py\`, \`test_polish_contract.py\`, \`test_fill_context.py\`. Every fixture that built \`choice\` nodes + \`choice_from\` / \`choice_to\` edges replaced with \`choice\` edges. A one-off Python migration script handled the bulk.

## Verification

- \`rg \"choice_from|choice_to\" src/questfoundry/\` → 0 matches (issue acceptance criterion).
- 742 unit tests pass across affected modules.

Closes #1165

## Test plan
- [x] \`uv run pytest\` on 14 affected test files (742 passed)
- [x] \`uv run ruff check\` + \`uv run mypy src/questfoundry/graph/polish_validation.py\` clean (pre-commit)
- [ ] CI green
- [ ] claude-review approval

🤖 Generated with [Claude Code](https://claude.com/claude-code)