### PR TITLE
fix: retry-aware llm_calls counter — serialize_to_artifact returns attempt count

### DIFF
--- a/src/questfoundry/agents/serialize.py
+++ b/src/questfoundry/agents/serialize.py
@@ -207,7 +207,7 @@ async def serialize_to_artifact(
     semantic_error_class: type[SemanticErrorFormatter] | None = None,
     stage: str = "unknown",
     extra_repair_hints: list[str] | None = None,
-) -> tuple[T, int]:
+) -> tuple[T, int, int]:
     """Serialize a brief into a structured artifact.
 
     Uses LangChain's structured output with a validation/repair loop.
@@ -241,7 +241,10 @@ async def serialize_to_artifact(
             self-contained.
 
     Returns:
-        Tuple of (validated_artifact, tokens_used).
+        Tuple of (validated_artifact, tokens_used, attempts_made). The
+        `attempts_made` value is the number of LLM calls actually issued
+        (1 on first-try success, 2..max_retries when retries occurred).
+        Callers use this to keep `llm_calls` counters retry-aware (#1452).
 
     Raises:
         SerializationError: If all attempts fail validation.
@@ -330,7 +333,7 @@ async def serialize_to_artifact(
                         attempt=attempt,
                         tokens=total_tokens,
                     )
-                    return result, total_tokens
+                    return result, total_tokens, attempt
 
                 # If result is a dict, validate and convert
                 if isinstance(result, dict):
@@ -357,7 +360,7 @@ async def serialize_to_artifact(
                         attempt=attempt,
                         tokens=total_tokens,
                     )
-                    return artifact, total_tokens
+                    return artifact, total_tokens, attempt
 
                 # Unexpected result type — retry will follow
                 last_errors = [f"Unexpected result type: {type(result).__name__}"]
@@ -703,7 +706,7 @@ async def _serialize_dilemma_paths(
         explored_count=len(explored),
     )
 
-    result, tokens = await serialize_to_artifact(
+    result, tokens, _ = await serialize_to_artifact(
         model=model,
         brief=brief,
         schema=DilemmaPathsSection,
@@ -996,7 +999,7 @@ async def _serialize_path_beats(
         dilemma_id=dilemma_id,
     )
 
-    result, tokens = await serialize_to_artifact(
+    result, tokens, _ = await serialize_to_artifact(
         model=model,
         brief=brief,
         schema=PathBeatsSection,
@@ -1272,7 +1275,7 @@ async def _serialize_shared_beats_for_dilemma(
         f'`"dilemma_id": "{prefixed_dilemma_id}"`'
     )
 
-    result, tokens = await serialize_to_artifact(
+    result, tokens, _ = await serialize_to_artifact(
         model=model,
         brief=brief,
         schema=SharedBeatsSection,
@@ -1682,7 +1685,7 @@ async def _early_validate_dilemma_answers(
         # Re-serialize dilemmas with corrections
         corrected_prompt = f"{section_prompt}\n\n{corrections}"
         try:
-            result, tokens = await serialize_to_artifact(
+            result, tokens, _ = await serialize_to_artifact(
                 model=model,
                 brief=build_brief_fn(),
                 schema=schema,
@@ -1983,7 +1986,7 @@ async def serialize_seed_as_function(
             section_prompt = f"{section_prompt}\n\n{path_ids_context}"
             log.debug("path_ids_injected_into_consequences_prompt")
 
-        section_result, section_tokens = await serialize_to_artifact(
+        section_result, section_tokens, _ = await serialize_to_artifact(
             model=model,
             brief=current_brief,
             schema=schema,
@@ -2229,7 +2232,7 @@ async def serialize_seed_as_function(
                     current_brief = enhanced_brief
 
                 try:
-                    section_result, section_tokens = await serialize_to_artifact(
+                    section_result, section_tokens, _ = await serialize_to_artifact(
                         model=model,
                         brief=current_brief,
                         schema=schema,
@@ -2441,7 +2444,7 @@ async def serialize_convergence_analysis(
         if on_phase_progress is not None:
             on_phase_progress("Classifying dilemma convergence", "section_7", "")
 
-        section7_result, section7_tokens = await serialize_to_artifact(
+        section7_result, section7_tokens, section7_calls = await serialize_to_artifact(
             model=model,
             brief=dilemma_context,
             schema=DilemmaAnalysisSection,
@@ -2456,8 +2459,9 @@ async def serialize_convergence_analysis(
             "convergence_analysis_complete",
             analyses=len(dilemma_analyses),
             tokens=section7_tokens,
+            calls=section7_calls,
         )
-        return dilemma_analyses, section7_tokens, 1
+        return dilemma_analyses, section7_tokens, section7_calls
     except Exception as e:
         log.warning(
             "seed_analysis_defaulted",
@@ -2528,7 +2532,7 @@ async def serialize_dilemma_relationships(
             candidate_pairs_context=candidates_context
         )
 
-        section8_result, section8_tokens = await serialize_to_artifact(
+        section8_result, section8_tokens, section8_calls = await serialize_to_artifact(
             model=model,
             brief=candidates_context,
             schema=DilemmaRelationshipsSection,
@@ -2559,8 +2563,9 @@ async def serialize_dilemma_relationships(
             "post_prune_section8_complete",
             relationships=len(dilemma_relationships),
             tokens=section8_tokens,
+            calls=section8_calls,
         )
-        return dilemma_relationships, section8_tokens, 1
+        return dilemma_relationships, section8_tokens, section8_calls
     except Exception as e:
         log.warning(
             "seed_analysis_defaulted",

--- a/src/questfoundry/pipeline/stages/brainstorm.py
+++ b/src/questfoundry/pipeline/stages/brainstorm.py
@@ -388,7 +388,7 @@ class BrainstormStage:
         entities_prompt = get_brainstorm_serialize_entities_prompt(
             output_language_instruction=lang_instruction,
         )
-        entities_artifact, entities_tokens = await serialize_to_artifact(
+        entities_artifact, entities_tokens, entities_calls = await serialize_to_artifact(
             model=chosen_serialize_model,
             brief=brief,
             schema=BrainstormEntitiesOutput,
@@ -399,7 +399,7 @@ class BrainstormStage:
             semantic_error_class=BrainstormMutationError,
             stage="brainstorm",
         )
-        total_llm_calls += 1
+        total_llm_calls += entities_calls
         total_tokens += entities_tokens
 
         entities_dump = [e.model_dump() for e in entities_artifact.entities]
@@ -436,7 +436,7 @@ class BrainstormStage:
             "  [ ] Every ID is from the `### Valid Entity IDs` section "
             "(no invented IDs)."
         )
-        dilemmas_artifact, dilemmas_tokens = await serialize_to_artifact(
+        dilemmas_artifact, dilemmas_tokens, dilemmas_calls = await serialize_to_artifact(
             model=chosen_serialize_model,
             brief=brief,
             schema=BrainstormDilemmasOutput,
@@ -448,7 +448,7 @@ class BrainstormStage:
             stage="brainstorm",
             extra_repair_hints=[central_entity_hint],
         )
-        total_llm_calls += 1
+        total_llm_calls += dilemmas_calls
         total_tokens += dilemmas_tokens
 
         if on_phase_progress is not None:

--- a/src/questfoundry/pipeline/stages/dream.py
+++ b/src/questfoundry/pipeline/stages/dream.py
@@ -172,7 +172,7 @@ class DreamStage:
 
         # Phase 3: Serialize (use serialize_model if provided)
         log.debug("dream_phase", phase="serialize")
-        artifact, serialize_tokens = await serialize_to_artifact(
+        artifact, serialize_tokens, serialize_calls = await serialize_to_artifact(
             model=serialize_model or model,
             brief=brief,
             schema=DreamArtifact,
@@ -182,7 +182,7 @@ class DreamStage:
         )
         if on_phase_progress is not None:
             on_phase_progress("serialize", "completed", None)
-        total_llm_calls += 1  # Count as 1 even with retries (simplification)
+        total_llm_calls += serialize_calls
         total_tokens += serialize_tokens
 
         # Convert to dict for return

--- a/src/questfoundry/pipeline/stages/dress.py
+++ b/src/questfoundry/pipeline/stages/dress.py
@@ -570,7 +570,7 @@ class DressStage:
             "REMINDER — Valid entity IDs for `entity_visuals[].entity_id` "
             f"(use ONLY these — raw IDs, no `entity::` prefix):\n{entity_ids}",
         ]
-        output, serialize_tokens = await serialize_to_artifact(
+        output, serialize_tokens, serialize_calls = await serialize_to_artifact(
             model=self._serialize_model or model,
             brief=brief,
             schema=DressPhase0Output,
@@ -580,7 +580,7 @@ class DressStage:
             stage="dress",
             extra_repair_hints=serialize_repair_hints,
         )
-        total_llm_calls += 1
+        total_llm_calls += serialize_calls
         total_tokens += serialize_tokens
 
         # Apply to graph

--- a/tests/unit/test_brainstorm_stage.py
+++ b/tests/unit/test_brainstorm_stage.py
@@ -233,6 +233,71 @@ async def test_execute_calls_all_three_phases() -> None:
 
 
 @pytest.mark.asyncio
+async def test_execute_counts_serialize_retries() -> None:
+    """Regression for #1452: serialize retries (both passes) increment total_llm_calls.
+
+    Pre-fix, the two-pass split (#1451) doubled the under-counting opportunity.
+    Post-fix the third tuple element from each `serialize_to_artifact` call is
+    the actual attempt count.
+    """
+    stage = BrainstormStage()
+    mock_model = MagicMock()
+    mock_graph = MagicMock()
+    _setup_mock_graph_with_vision(mock_graph)
+
+    with (
+        patch("questfoundry.pipeline.stages.brainstorm.Graph") as MockGraph,
+        patch("questfoundry.pipeline.stages.brainstorm.run_discuss_phase") as mock_discuss,
+        patch("questfoundry.pipeline.stages.brainstorm.summarize_discussion") as mock_summarize,
+        patch("questfoundry.pipeline.stages.brainstorm.serialize_to_artifact") as mock_serialize,
+        patch("questfoundry.pipeline.stages.brainstorm.get_all_research_tools") as mock_tools,
+    ):
+        MockGraph.load.return_value = mock_graph
+        mock_tools.return_value = []
+        mock_discuss.return_value = ([HumanMessage(content="hi"), AIMessage(content="ok")], 2, 500)
+        mock_summarize.return_value = ("Brief", 100)
+        entities_artifact, dilemmas_artifact = _two_pass_artifacts(
+            entities=[
+                {
+                    "entity_id": "character::hero",
+                    "entity_category": "character",
+                    "name": "Hero",
+                    "concept": "A warrior",
+                }
+            ],
+            dilemmas=[
+                {
+                    "dilemma_id": "dilemma::test",
+                    "question": "?",
+                    "answers": [
+                        {"answer_id": "y", "description": "y", "is_canonical": True},
+                        {"answer_id": "n", "description": "n", "is_canonical": False},
+                    ],
+                    "central_entity_ids": ["character::hero"],
+                    "why_it_matters": "test",
+                }
+            ],
+        )
+        # Pass 1 (entities) succeeded after 2 attempts; pass 2 (dilemmas) after 3.
+        mock_serialize.side_effect = [
+            (entities_artifact, 100, 2),
+            (dilemmas_artifact, 100, 3),
+        ]
+
+        _artifact, llm_calls, _tokens = await stage.execute(
+            model=mock_model,
+            user_prompt="t",
+            project_path=Path("/test/project"),
+        )
+
+        # 2 discuss + 1 summarize + 2 serialize-pass-1 + 3 serialize-pass-2 = 8
+        assert llm_calls == 8, (
+            f"Expected total_llm_calls to reflect both serialize passes' retries: "
+            f"discuss(2) + summarize(1) + entities(2) + dilemmas(3) = 8; got {llm_calls}"
+        )
+
+
+@pytest.mark.asyncio
 async def test_execute_emits_phase_progress() -> None:
     """Execute emits phase-level progress callbacks when provided."""
     stage = BrainstormStage()

--- a/tests/unit/test_brainstorm_stage.py
+++ b/tests/unit/test_brainstorm_stage.py
@@ -212,7 +212,7 @@ async def test_execute_calls_all_three_phases() -> None:
                 }
             ],
         )
-        mock_serialize.side_effect = [(entities_artifact, 100), (dilemmas_artifact, 100)]
+        mock_serialize.side_effect = [(entities_artifact, 100, 1), (dilemmas_artifact, 100, 1)]
 
         artifact, llm_calls, tokens = await stage.execute(
             model=mock_model,
@@ -258,7 +258,7 @@ async def test_execute_emits_phase_progress() -> None:
         )
         mock_summarize.return_value = ("Brief summary", 100)
         entities_artifact, dilemmas_artifact = _two_pass_artifacts()
-        mock_serialize.side_effect = [(entities_artifact, 100), (dilemmas_artifact, 100)]
+        mock_serialize.side_effect = [(entities_artifact, 100, 1), (dilemmas_artifact, 100, 1)]
 
         await stage.execute(
             model=mock_model,
@@ -309,7 +309,7 @@ async def test_execute_passes_vision_context_to_discuss() -> None:
         mock_discuss.return_value = ([], 1, 100)
         mock_summarize.return_value = ("Brief", 50)
         entities_artifact, dilemmas_artifact = _two_pass_artifacts()
-        mock_serialize.side_effect = [(entities_artifact, 100), (dilemmas_artifact, 100)]
+        mock_serialize.side_effect = [(entities_artifact, 100, 1), (dilemmas_artifact, 100, 1)]
 
         await stage.execute(
             model=mock_model,
@@ -346,7 +346,7 @@ async def test_execute_passes_two_pass_serialize_schemas() -> None:
         mock_discuss.return_value = ([], 1, 100)
         mock_summarize.return_value = ("Brief", 50)
         entities_artifact, dilemmas_artifact = _two_pass_artifacts()
-        mock_serialize.side_effect = [(entities_artifact, 100), (dilemmas_artifact, 100)]
+        mock_serialize.side_effect = [(entities_artifact, 100, 1), (dilemmas_artifact, 100, 1)]
 
         await stage.execute(
             model=mock_model,
@@ -388,7 +388,7 @@ async def test_execute_uses_brainstorm_summarize_prompt() -> None:
         mock_discuss.return_value = ([], 1, 100)
         mock_summarize.return_value = ("Brief", 50)
         entities_artifact, dilemmas_artifact = _two_pass_artifacts()
-        mock_serialize.side_effect = [(entities_artifact, 100), (dilemmas_artifact, 100)]
+        mock_serialize.side_effect = [(entities_artifact, 100, 1), (dilemmas_artifact, 100, 1)]
 
         await stage.execute(
             model=mock_model,
@@ -455,7 +455,7 @@ async def test_execute_returns_artifact_as_dict() -> None:
                 }
             ],
         )
-        mock_serialize.side_effect = [(entities_artifact, 60), (dilemmas_artifact, 40)]
+        mock_serialize.side_effect = [(entities_artifact, 60, 1), (dilemmas_artifact, 40, 1)]
 
         artifact, _, _ = await stage.execute(
             model=mock_model,

--- a/tests/unit/test_dream_stage.py
+++ b/tests/unit/test_dream_stage.py
@@ -59,7 +59,7 @@ async def test_execute_calls_all_three_phases() -> None:
             themes=["heroism"],
             scope=Scope(story_size="medium"),
         )
-        mock_serialize.return_value = (mock_artifact, 200)
+        mock_serialize.return_value = (mock_artifact, 200, 1)
 
         # Execute
         artifact, llm_calls, tokens = await stage.execute(
@@ -106,7 +106,7 @@ async def test_execute_emits_phase_progress() -> None:
             themes=["heroism"],
             scope=Scope(story_size="medium"),
         )
-        mock_serialize.return_value = (mock_artifact, 200)
+        mock_serialize.return_value = (mock_artifact, 200, 1)
 
         await stage.execute(
             model=mock_model,
@@ -144,7 +144,7 @@ async def test_execute_passes_model_to_all_phases() -> None:
             themes=["justice"],
             scope=Scope(story_size="medium"),
         )
-        mock_serialize.return_value = (mock_artifact, 100)
+        mock_serialize.return_value = (mock_artifact, 100, 1)
 
         await stage.execute(model=mock_model, user_prompt="A mystery")
 
@@ -175,7 +175,7 @@ async def test_execute_passes_user_prompt_to_discuss() -> None:
             themes=["exploration"],
             scope=Scope(story_size="medium"),
         )
-        mock_serialize.return_value = (mock_artifact, 100)
+        mock_serialize.return_value = (mock_artifact, 100, 1)
 
         await stage.execute(model=MagicMock(), user_prompt="A space adventure")
 
@@ -208,7 +208,7 @@ async def test_execute_passes_messages_to_summarize() -> None:
             themes=["magic"],
             scope=Scope(story_size="medium"),
         )
-        mock_serialize.return_value = (mock_artifact, 100)
+        mock_serialize.return_value = (mock_artifact, 100, 1)
 
         await stage.execute(model=MagicMock(), user_prompt="test")
 
@@ -236,7 +236,7 @@ async def test_execute_passes_brief_to_serialize() -> None:
             themes=["adventure"],
             scope=Scope(story_size="medium"),
         )
-        mock_serialize.return_value = (mock_artifact, 100)
+        mock_serialize.return_value = (mock_artifact, 100, 1)
 
         await stage.execute(model=MagicMock(), user_prompt="test")
 
@@ -264,7 +264,7 @@ async def test_execute_passes_provider_name_to_serialize() -> None:
             themes=["fear"],
             scope=Scope(story_size="medium"),
         )
-        mock_serialize.return_value = (mock_artifact, 100)
+        mock_serialize.return_value = (mock_artifact, 100, 1)
 
         await stage.execute(
             model=MagicMock(),
@@ -296,7 +296,7 @@ async def test_execute_passes_dream_artifact_schema() -> None:
             themes=["love"],
             scope=Scope(story_size="medium"),
         )
-        mock_serialize.return_value = (mock_artifact, 100)
+        mock_serialize.return_value = (mock_artifact, 100, 1)
 
         await stage.execute(model=MagicMock(), user_prompt="test")
 
@@ -325,7 +325,7 @@ async def test_execute_returns_artifact_as_dict() -> None:
             themes=["paranoia"],
             scope=Scope(story_size="medium"),
         )
-        mock_serialize.return_value = (mock_artifact, 100)
+        mock_serialize.return_value = (mock_artifact, 100, 1)
 
         artifact, _, _ = await stage.execute(model=MagicMock(), user_prompt="test")
 
@@ -358,7 +358,7 @@ async def test_execute_uses_research_tools() -> None:
             themes=["secrets"],
             scope=Scope(story_size="medium"),
         )
-        mock_serialize.return_value = (mock_artifact, 100)
+        mock_serialize.return_value = (mock_artifact, 100, 1)
 
         await stage.execute(model=MagicMock(), user_prompt="test")
 
@@ -389,7 +389,7 @@ def _mock_phases(
     mock_tools.return_value = []
     mock_discuss.return_value = ([], 1, 100)
     mock_summarize.return_value = ("Brief", 50)
-    mock_serialize.return_value = (artifact, 100)
+    mock_serialize.return_value = (artifact, 100, 1)
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_dream_stage.py
+++ b/tests/unit/test_dream_stage.py
@@ -80,6 +80,52 @@ async def test_execute_calls_all_three_phases() -> None:
 
 
 @pytest.mark.asyncio
+async def test_execute_counts_serialize_retries() -> None:
+    """Regression for #1452: serialize retries must increment total_llm_calls.
+
+    Pre-fix: serialize_to_artifact's hardcoded `+= 1` undercounted retries —
+    a 3-attempt repair loop was reported as 1 call. Post-fix the third
+    element of the returned tuple is the actual attempt count.
+    """
+    stage = DreamStage()
+    mock_model = MagicMock()
+
+    with (
+        patch("questfoundry.pipeline.stages.dream.run_discuss_phase") as mock_discuss,
+        patch("questfoundry.pipeline.stages.dream.summarize_discussion") as mock_summarize,
+        patch("questfoundry.pipeline.stages.dream.serialize_to_artifact") as mock_serialize,
+        patch("questfoundry.pipeline.stages.dream.get_all_research_tools") as mock_tools,
+    ):
+        mock_tools.return_value = []
+        mock_discuss.return_value = (
+            [HumanMessage(content="hi"), AIMessage(content="hello")],
+            2,
+            500,
+        )
+        mock_summarize.return_value = ("Brief summary", 100)
+        mock_artifact = DreamArtifact(
+            genre="fantasy",
+            tone=["epic"],
+            audience="adult",
+            themes=["heroism"],
+            scope=Scope(story_size="medium"),
+        )
+        # Serialize took 3 attempts (1 success + 2 retries' worth of LLM calls).
+        mock_serialize.return_value = (mock_artifact, 200, 3)
+
+        _artifact, llm_calls, _tokens = await stage.execute(
+            model=mock_model,
+            user_prompt="An epic quest",
+        )
+
+        # 2 discuss + 1 summarize + 3 serialize = 6
+        assert llm_calls == 6, (
+            f"Expected total_llm_calls to reflect serialize retries: "
+            f"discuss(2) + summarize(1) + serialize(3) = 6; got {llm_calls}"
+        )
+
+
+@pytest.mark.asyncio
 async def test_execute_emits_phase_progress() -> None:
     """Execute emits phase-level progress callbacks when provided."""
     stage = DreamStage()

--- a/tests/unit/test_dress_stage.py
+++ b/tests/unit/test_dress_stage.py
@@ -335,7 +335,7 @@ class TestPhase0ArtDirection:
             patch(
                 "questfoundry.pipeline.stages.dress.serialize_to_artifact",
                 new_callable=AsyncMock,
-                return_value=(mock_phase0_output, 300),
+                return_value=(mock_phase0_output, 300, 1),
             ),
             patch.object(
                 stage,
@@ -435,7 +435,7 @@ class TestPhase0ArtDirection:
             patch(
                 "questfoundry.pipeline.stages.dress.serialize_to_artifact",
                 new_callable=AsyncMock,
-                return_value=(partial_output, 100),
+                return_value=(partial_output, 100, 1),
             ),
             pytest.raises(DressStageError, match="EntityVisual coverage"),
         ):
@@ -470,7 +470,7 @@ class TestPhase0ArtDirection:
             patch(
                 "questfoundry.pipeline.stages.dress.serialize_to_artifact",
                 new_callable=AsyncMock,
-                return_value=(mock_phase0_output, 250),
+                return_value=(mock_phase0_output, 250, 1),
             ),
         ):
             stage.gate = reject_gate
@@ -514,7 +514,7 @@ class TestPhase0ArtDirection:
             patch(
                 "questfoundry.pipeline.stages.dress.serialize_to_artifact",
                 new_callable=AsyncMock,
-                return_value=(mock_phase0_output, 100),
+                return_value=(mock_phase0_output, 100, 1),
             ),
         ):
             await stage.execute(MagicMock(), "Make it look like Studio Ghibli")

--- a/tests/unit/test_dress_stage.py
+++ b/tests/unit/test_dress_stage.py
@@ -483,6 +483,49 @@ class TestPhase0ArtDirection:
         assert tokens == 1000
 
     @pytest.mark.asyncio()
+    async def test_phase0_counts_serialize_retries(
+        self,
+        tmp_path: Path,
+        dress_graph: Graph,  # noqa: ARG002
+        mock_phase0_output: DressPhase0Output,
+    ) -> None:
+        """Regression for #1452: serialize retries increment total_llm_calls.
+
+        Pre-fix: serialize counted as 1 even when the repair loop retried.
+        Post-fix the third tuple element from `serialize_to_artifact` is the
+        actual attempt count.
+        """
+        stage = DressStage(project_path=tmp_path)
+        reject_gate = AsyncMock()
+        reject_gate.on_phase_complete = AsyncMock(return_value="reject")
+
+        with (
+            patch(
+                "questfoundry.pipeline.stages.dress.run_discuss_phase",
+                new_callable=AsyncMock,
+                return_value=([AIMessage(content="ok")], 3, 600),
+            ),
+            patch(
+                "questfoundry.pipeline.stages.dress.summarize_discussion",
+                new_callable=AsyncMock,
+                return_value=("brief", 150),
+            ),
+            patch(
+                "questfoundry.pipeline.stages.dress.serialize_to_artifact",
+                new_callable=AsyncMock,
+                return_value=(mock_phase0_output, 250, 3),
+            ),
+        ):
+            stage.gate = reject_gate
+            _artifact, llm_calls, _tokens = await stage.execute(MagicMock(), "test")
+
+        # discuss(3) + summarize(1) + serialize(3) = 7
+        assert llm_calls == 7, (
+            f"Expected total_llm_calls to reflect serialize retries: "
+            f"discuss(3) + summarize(1) + serialize(3) = 7; got {llm_calls}"
+        )
+
+    @pytest.mark.asyncio()
     async def test_phase0_passes_custom_prompt(
         self,
         tmp_path: Path,

--- a/tests/unit/test_serialize.py
+++ b/tests/unit/test_serialize.py
@@ -54,7 +54,7 @@ class TestSerializeToArtifact:
         expected = SimpleSchema(title="Test", count=5)
         mock_model.with_structured_output.return_value.ainvoke = AsyncMock(return_value=expected)
 
-        artifact, _tokens = await serialize_to_artifact(
+        artifact, _tokens, _calls = await serialize_to_artifact(
             mock_model,
             "A test brief",
             SimpleSchema,
@@ -70,7 +70,7 @@ class TestSerializeToArtifact:
             return_value={"title": "Test", "count": 5}
         )
 
-        artifact, _tokens = await serialize_to_artifact(
+        artifact, _tokens, _calls = await serialize_to_artifact(
             mock_model,
             "A test brief",
             SimpleSchema,
@@ -89,7 +89,7 @@ class TestSerializeToArtifact:
             return_value={"title": "Test", "count": 5, "optional_field": None}
         )
 
-        artifact, _tokens = await serialize_to_artifact(
+        artifact, _tokens, _calls = await serialize_to_artifact(
             mock_model,
             "A test brief",
             SimpleSchema,
@@ -110,7 +110,7 @@ class TestSerializeToArtifact:
         )
         mock_model.with_structured_output.return_value.ainvoke = mock_invoke
 
-        artifact, _tokens = await serialize_to_artifact(
+        artifact, _tokens, _calls = await serialize_to_artifact(
             mock_model,
             "A test brief",
             SimpleSchema,
@@ -150,7 +150,7 @@ class TestSerializeToArtifact:
         with patch(
             "questfoundry.agents.serialize.extract_tokens", return_value=150
         ) as mock_extract:
-            _artifact, tokens = await serialize_to_artifact(
+            _artifact, tokens, _calls = await serialize_to_artifact(
                 mock_model,
                 "A test brief",
                 SimpleSchema,
@@ -173,7 +173,7 @@ class TestSerializeToArtifact:
 
         # Return 100 tokens per call
         with patch("questfoundry.agents.serialize.extract_tokens", return_value=100):
-            _artifact, tokens = await serialize_to_artifact(
+            _artifact, tokens, _calls = await serialize_to_artifact(
                 mock_model,
                 "A test brief",
                 SimpleSchema,
@@ -193,7 +193,7 @@ class TestSerializeToArtifact:
         )
         mock_model.with_structured_output.return_value.ainvoke = mock_invoke
 
-        artifact, _tokens = await serialize_to_artifact(
+        artifact, _tokens, _calls = await serialize_to_artifact(
             mock_model,
             "A test brief",
             SimpleSchema,
@@ -267,7 +267,7 @@ class TestSerializeToArtifact:
         )
         mock_model.with_structured_output.return_value.ainvoke = mock_invoke
 
-        artifact, _tokens = await serialize_to_artifact(
+        artifact, _tokens, _calls = await serialize_to_artifact(
             mock_model,
             "A test brief",
             SimpleSchema,
@@ -538,9 +538,9 @@ class TestSerializeResult:
             ),
         ):
             mock_ser.side_effect = [
-                (MagicMock(model_dump=lambda: {"entities": []}), 10),
-                (MagicMock(model_dump=lambda: {"dilemmas": [_MOCK_DILEMMA]}), 10),
-                (MagicMock(model_dump=lambda: {"consequences": []}), 10),
+                (MagicMock(model_dump=lambda: {"entities": []}), 10, 1),
+                (MagicMock(model_dump=lambda: {"dilemmas": [_MOCK_DILEMMA]}), 10, 1),
+                (MagicMock(model_dump=lambda: {"consequences": []}), 10, 1),
             ]
 
             with patch(
@@ -603,10 +603,10 @@ class TestSerializeResult:
         ):
             # 3 initial sections + 1 retry for entities (semantic error triggers retry)
             mock_ser.side_effect = [
-                (MagicMock(model_dump=lambda: {"entities": []}), 10),
-                (MagicMock(model_dump=lambda: {"dilemmas": [_MOCK_DILEMMA]}), 10),
-                (MagicMock(model_dump=lambda: {"consequences": []}), 10),
-                (MagicMock(model_dump=lambda: {"entities": []}), 10),  # retry
+                (MagicMock(model_dump=lambda: {"entities": []}), 10, 1),
+                (MagicMock(model_dump=lambda: {"dilemmas": [_MOCK_DILEMMA]}), 10, 1),
+                (MagicMock(model_dump=lambda: {"consequences": []}), 10, 1),
+                (MagicMock(model_dump=lambda: {"entities": []}), 10, 1),  # retry
             ]
 
             # Return same errors on every validation call (errors persist after retry)
@@ -680,9 +680,9 @@ class TestSerializeSeedAsFunction:
             # Sections: entities, dilemmas, consequences
             # (paths handled by _serialize_paths_per_dilemma, beats by _serialize_beats_per_path)
             mock_serialize.side_effect = [
-                (MagicMock(model_dump=lambda: {"entities": []}), 10),
-                (MagicMock(model_dump=lambda: {"dilemmas": [_MOCK_DILEMMA]}), 10),
-                (MagicMock(model_dump=lambda: {"consequences": []}), 10),
+                (MagicMock(model_dump=lambda: {"entities": []}), 10, 1),
+                (MagicMock(model_dump=lambda: {"dilemmas": [_MOCK_DILEMMA]}), 10, 1),
+                (MagicMock(model_dump=lambda: {"consequences": []}), 10, 1),
             ]
 
             with patch("questfoundry.agents.serialize.validate_seed_mutations", return_value=[]):
@@ -730,9 +730,9 @@ class TestSerializeSeedAsFunction:
         ):
             mock_serialize.side_effect = [
                 # Initial 3 sections (paths + beats handled separately)
-                (MagicMock(model_dump=lambda: {"entities": []}), 10),
-                (MagicMock(model_dump=lambda: {"dilemmas": [_MOCK_DILEMMA]}), 10),
-                (MagicMock(model_dump=lambda: {"consequences": []}), 10),
+                (MagicMock(model_dump=lambda: {"entities": []}), 10, 1),
+                (MagicMock(model_dump=lambda: {"dilemmas": [_MOCK_DILEMMA]}), 10, 1),
+                (MagicMock(model_dump=lambda: {"consequences": []}), 10, 1),
             ]
 
             with patch(
@@ -770,9 +770,9 @@ class TestSerializeSeedAsFunction:
         ):
             # 3 sections (paths + beats handled separately)
             mock_serialize.side_effect = [
-                (MagicMock(model_dump=lambda: {"entities": []}), 10),
-                (MagicMock(model_dump=lambda: {"dilemmas": [_MOCK_DILEMMA]}), 10),
-                (MagicMock(model_dump=lambda: {"consequences": []}), 10),
+                (MagicMock(model_dump=lambda: {"entities": []}), 10, 1),
+                (MagicMock(model_dump=lambda: {"dilemmas": [_MOCK_DILEMMA]}), 10, 1),
+                (MagicMock(model_dump=lambda: {"consequences": []}), 10, 1),
             ]
 
             with patch("questfoundry.agents.serialize.validate_seed_mutations") as mock_validate:
@@ -822,7 +822,7 @@ class TestSerializeSeedAsFunction:
                 5: "entities",
             }
             section = section_map.get(call_count[0], "unknown")
-            return (create_section_mock(section), 10)
+            return (create_section_mock(section), 10, 1)
 
         with (
             patch(
@@ -883,7 +883,7 @@ class TestSerializeSeedAsFunction:
             }
             section = section_map.get(call_count[0], "unknown")
             data = [_MOCK_DILEMMA] if section == "dilemmas" else []
-            return (MagicMock(model_dump=lambda d=data, s=section: {s: d}), 10)
+            return (MagicMock(model_dump=lambda d=data, s=section: {s: d}), 10, 1)
 
         with (
             patch(
@@ -946,7 +946,7 @@ class TestSerializeSeedAsFunction:
             }
             section = section_map.get(call_count[0], "unknown")
             data = [_MOCK_DILEMMA] if section == "dilemmas" else []
-            return (MagicMock(model_dump=lambda d=data, s=section: {s: d}), 10)
+            return (MagicMock(model_dump=lambda d=data, s=section: {s: d}), 10, 1)
 
         with (
             patch(
@@ -1233,9 +1233,9 @@ class TestBeatRetryAndContextRefresh:
         ):
             # 3 sections (paths + beats handled separately)
             mock_serialize.side_effect = [
-                (MagicMock(model_dump=lambda: {"entities": []}), 10),
-                (MagicMock(model_dump=lambda: {"dilemmas": [_MOCK_DILEMMA]}), 10),
-                (MagicMock(model_dump=lambda: {"consequences": []}), 10),
+                (MagicMock(model_dump=lambda: {"entities": []}), 10, 1),
+                (MagicMock(model_dump=lambda: {"dilemmas": [_MOCK_DILEMMA]}), 10, 1),
+                (MagicMock(model_dump=lambda: {"consequences": []}), 10, 1),
             ]
 
             result = await serialize_seed_as_function(
@@ -1348,9 +1348,9 @@ class TestBeatRetryAndContextRefresh:
             ),
         ):
             mock_serialize.side_effect = [
-                (MagicMock(model_dump=lambda: {"entities": []}), 10),
-                (MagicMock(model_dump=lambda: {"dilemmas": [_MOCK_DILEMMA]}), 10),
-                (MagicMock(model_dump=lambda: {"consequences": []}), 10),
+                (MagicMock(model_dump=lambda: {"entities": []}), 10, 1),
+                (MagicMock(model_dump=lambda: {"dilemmas": [_MOCK_DILEMMA]}), 10, 1),
+                (MagicMock(model_dump=lambda: {"consequences": []}), 10, 1),
             ]
 
             result = await serialize_seed_as_function(
@@ -1427,7 +1427,7 @@ class TestBeatRetryAndContextRefresh:
             }
             section = section_map.get(call_count[0], "unknown")
             data = [_MOCK_DILEMMA] if section == "dilemmas" else []
-            return (MagicMock(model_dump=lambda d=data, s=section: {s: d}), 10)
+            return (MagicMock(model_dump=lambda d=data, s=section: {s: d}), 10, 1)
 
         with (
             patch(
@@ -1534,9 +1534,9 @@ class TestBeatRetryAndContextRefresh:
         ):
             # 3 sections (paths + beats handled separately)
             mock_serialize.side_effect = [
-                (MagicMock(model_dump=lambda: {"entities": []}), 10),
-                (MagicMock(model_dump=lambda: {"dilemmas": [_MOCK_DILEMMA]}), 10),
-                (MagicMock(model_dump=lambda: {"consequences": []}), 10),
+                (MagicMock(model_dump=lambda: {"entities": []}), 10, 1),
+                (MagicMock(model_dump=lambda: {"dilemmas": [_MOCK_DILEMMA]}), 10, 1),
+                (MagicMock(model_dump=lambda: {"consequences": []}), 10, 1),
             ]
 
             result = await serialize_seed_as_function(
@@ -1837,7 +1837,7 @@ class TestEarlyValidateDilemmaAnswers:
         )
 
         with patch("questfoundry.agents.serialize.serialize_to_artifact") as mock_serialize:
-            mock_serialize.return_value = (corrected, 50)
+            mock_serialize.return_value = (corrected, 50, 1)
 
             result, tokens = await _early_validate_dilemma_answers(
                 model=mock_model,
@@ -2422,7 +2422,7 @@ class TestSerializeSharedBeatsForDilemma:
         with patch(
             "questfoundry.agents.serialize.serialize_to_artifact",
             new_callable=AsyncMock,
-            return_value=(mock_section, 42),
+            return_value=(mock_section, 42, 1),
         ) as mock_sat:
             beats, tokens = await _serialize_shared_beats_for_dilemma(
                 model=MagicMock(),
@@ -2463,7 +2463,7 @@ class TestSerializeSharedBeatsForDilemma:
         with patch(
             "questfoundry.agents.serialize.serialize_to_artifact",
             new_callable=AsyncMock,
-            return_value=(mock_section, 10),
+            return_value=(mock_section, 10, 1),
         ):
             beats, _tokens = await _serialize_shared_beats_for_dilemma(
                 model=MagicMock(),
@@ -2487,11 +2487,11 @@ class TestSerializeSharedBeatsForDilemma:
 
         captured: list[str] = []
 
-        async def _capture(**kw: Any) -> tuple[Any, int]:
+        async def _capture(**kw: Any) -> tuple[Any, int, int]:
             captured.append(kw.get("system_prompt", ""))
             sec = MagicMock()
             sec.model_dump.return_value = {"initial_beats": []}
-            return sec, 5
+            return sec, 5, 1
 
         with patch("questfoundry.agents.serialize.serialize_to_artifact", side_effect=_capture):
             await _serialize_shared_beats_for_dilemma(
@@ -2532,11 +2532,11 @@ class TestSerializeSharedBeatsForDilemma:
 
         captured: list[str] = []
 
-        async def _capture(**kw: Any) -> tuple[Any, int]:
+        async def _capture(**kw: Any) -> tuple[Any, int, int]:
             captured.append(kw.get("system_prompt", ""))
             sec = MagicMock()
             sec.model_dump.return_value = {"initial_beats": []}
-            return sec, 5
+            return sec, 5, 1
 
         with patch("questfoundry.agents.serialize.serialize_to_artifact", side_effect=_capture):
             await _serialize_shared_beats_for_dilemma(
@@ -2722,9 +2722,9 @@ class TestSerializeSeedAsFunctionSharedBeats:
             ),
         ):
             mock_serialize.side_effect = [
-                (MagicMock(model_dump=lambda: {"entities": []}), 10),
-                (MagicMock(model_dump=lambda: {"dilemmas": [mock_dilemma_two]}), 10),
-                (MagicMock(model_dump=lambda: {"consequences": []}), 10),
+                (MagicMock(model_dump=lambda: {"entities": []}), 10, 1),
+                (MagicMock(model_dump=lambda: {"dilemmas": [mock_dilemma_two]}), 10, 1),
+                (MagicMock(model_dump=lambda: {"consequences": []}), 10, 1),
             ]
             with patch("questfoundry.agents.serialize.validate_seed_mutations", return_value=[]):
                 await serialize_seed_as_function(
@@ -2793,9 +2793,9 @@ class TestSerializeSeedAsFunctionSharedBeats:
             ),
         ):
             mock_serialize.side_effect = [
-                (MagicMock(model_dump=lambda: {"entities": []}), 10),
-                (MagicMock(model_dump=lambda: {"dilemmas": [mock_dilemma_two]}), 10),
-                (MagicMock(model_dump=lambda: {"consequences": []}), 10),
+                (MagicMock(model_dump=lambda: {"entities": []}), 10, 1),
+                (MagicMock(model_dump=lambda: {"dilemmas": [mock_dilemma_two]}), 10, 1),
+                (MagicMock(model_dump=lambda: {"consequences": []}), 10, 1),
             ]
             with patch("questfoundry.agents.serialize.validate_seed_mutations", return_value=[]):
                 result = await serialize_seed_as_function(
@@ -2845,9 +2845,9 @@ class TestSerializeSeedAsFunctionSharedBeats:
             ),
         ):
             mock_serialize.side_effect = [
-                (MagicMock(model_dump=lambda: {"entities": []}), 10),
-                (MagicMock(model_dump=lambda: {"dilemmas": [mock_dilemma_two]}), 10),
-                (MagicMock(model_dump=lambda: {"consequences": []}), 10),
+                (MagicMock(model_dump=lambda: {"entities": []}), 10, 1),
+                (MagicMock(model_dump=lambda: {"dilemmas": [mock_dilemma_two]}), 10, 1),
+                (MagicMock(model_dump=lambda: {"consequences": []}), 10, 1),
             ]
             with patch("questfoundry.agents.serialize.validate_seed_mutations", return_value=[]):
                 result = await serialize_seed_as_function(


### PR DESCRIPTION
## Summary

Fix systematic under-counting of \`llm_calls\` across DREAM, BRAINSTORM, DRESS, and SEED phase-7/8. Pre-fix, every \`serialize_to_artifact\` call incremented \`total_llm_calls\` by 1 regardless of internal repair-loop retries. Tokens accumulated correctly; the call count did not.

## Surface change

\`serialize_to_artifact\` now returns \`tuple[T, int, int]\` (was \`tuple[T, int]\`). The third element is \`attempts_made\` — actual LLM calls issued (1 on first-try success, 2..max_retries on retries).

## Updated direct callers

- **DREAM** (\`pipeline/stages/dream.py\`): \`total_llm_calls += serialize_calls\` (was hardcoded \`+= 1\`).
- **BRAINSTORM** (\`pipeline/stages/brainstorm.py\`): both pass-1 (entities) and pass-2 (dilemmas) sites — addresses the doubled exposure introduced by the two-pass split (#1451).
- **DRESS** (\`pipeline/stages/dress.py\`): Phase 0 art-direction call site.
- **SEED phase-7/8** helpers in \`agents/serialize.py\` (\`serialize_dilemma_analyses\`, \`serialize_dilemma_relationships\`): previously returned \`(..., tokens, 1)\` with hardcoded \`1\`; now use the actual attempt count.

## SEED orchestrator (deferred)

The SEED inner wrappers (\`_serialize_dilemma_paths\`, \`_serialize_path_beats\`, \`_serialize_shared_beats_for_dilemma\`) still return 2-tuples and discard the new attempt count. \`pipeline/stages/seed.py:427\` keeps its \`total_llm_calls += 6\` hardcode.

Threading the count through the SEED orchestrator end-to-end requires a \`SerializeResult.call_count\` field plus updates to ~8 helpers across ~60 call sites — too large to bundle without making review unwieldy. **Filed as #1550** for a follow-up PR.

## Tests

- \`tests/unit/test_serialize.py\`, \`test_dream_stage.py\`, \`test_brainstorm_stage.py\`, \`test_dress_stage.py\`: every mock that returned a 2-tuple from \`serialize_to_artifact\` updated to a 3-tuple. Internal-helper mocks (\`_serialize_paths_per_dilemma\` etc.) keep their 2-tuple shape.
- 3157 unit tests pass; the only failure is an unrelated ollama DNS env issue.

Closes #1452

## Test plan
- [x] \`uv run pytest tests/unit/\` (3157 passed; 1 unrelated failure: \`test_provider_factory.py::test_create_chat_model_ollama_success\` — DNS \`Name or service not known\`)
- [x] \`uv run ruff check src/ tests/\` clean
- [x] \`uv run mypy\` clean (pre-commit)
- [ ] CI green
- [ ] claude-review approval

🤖 Generated with [Claude Code](https://claude.com/claude-code)