### PR TITLE
fix(types): narrow pyright file-level suppressions in langchain_callbacks + orchestrator

### DIFF
--- a/src/questfoundry/observability/langchain_callbacks.py
+++ b/src/questfoundry/observability/langchain_callbacks.py
@@ -4,9 +4,6 @@ Provides callback handlers that integrate with QuestFoundry's logging system,
 including JSONL logging for LLM calls.
 """
 
-# pyright: reportAttributeAccessIssue=false
-# TODO(#1353): langchain API drift — BaseMessage.tool_calls and Generation.message attribute access; tracked in issue #1353
-
 # ruff: noqa: ARG002 - Callback interface methods require unused parameters
 
 from __future__ import annotations
@@ -211,17 +208,22 @@ class LLMLoggingCallback(BaseCallbackHandler):
             gen = response.generations[0][0]  # First generation, first batch
             content = gen.text if hasattr(gen, "text") else str(gen)
 
-            # Check for tool calls in the message
+            # Check for tool calls in the message. The langchain stubs don't
+            # expose `Generation.message` or `BaseMessage.tool_calls` even
+            # though both are runtime-accessible on chat-model generations
+            # (langchain has its own type-narrowing protocol). The hasattr
+            # guards keep this safe; the per-line ignores narrow what would
+            # otherwise need a file-level pyright suppression.
             if hasattr(gen, "message"):
-                msg = gen.message
-                if hasattr(msg, "tool_calls") and msg.tool_calls:
+                msg = gen.message  # pyright: ignore[reportAttributeAccessIssue]
+                if hasattr(msg, "tool_calls") and msg.tool_calls:  # pyright: ignore[reportAttributeAccessIssue]
                     tool_calls = [
                         {
                             "id": tc.get("id", ""),
                             "name": tc.get("name", ""),
                             "arguments": tc.get("args", {}),
                         }
-                        for tc in msg.tool_calls
+                        for tc in msg.tool_calls  # pyright: ignore[reportAttributeAccessIssue]
                     ]
 
         # Extract token usage from multiple locations.

--- a/src/questfoundry/observability/langchain_callbacks.py
+++ b/src/questfoundry/observability/langchain_callbacks.py
@@ -208,12 +208,7 @@ class LLMLoggingCallback(BaseCallbackHandler):
             gen = response.generations[0][0]  # First generation, first batch
             content = gen.text if hasattr(gen, "text") else str(gen)
 
-            # Check for tool calls in the message. The langchain stubs don't
-            # expose `Generation.message` or `BaseMessage.tool_calls` even
-            # though both are runtime-accessible on chat-model generations
-            # (langchain has its own type-narrowing protocol). The hasattr
-            # guards keep this safe; the per-line ignores narrow what would
-            # otherwise need a file-level pyright suppression.
+            # langchain stubs omit Generation.message and BaseMessage.tool_calls; hasattr guards keep this safe.
             if hasattr(gen, "message"):
                 msg = gen.message  # pyright: ignore[reportAttributeAccessIssue]
                 if hasattr(msg, "tool_calls") and msg.tool_calls:  # pyright: ignore[reportAttributeAccessIssue]

--- a/src/questfoundry/pipeline/orchestrator.py
+++ b/src/questfoundry/pipeline/orchestrator.py
@@ -1,8 +1,5 @@
 """Pipeline orchestrator for stage execution."""
 
-# pyright: reportReturnType=false, reportAttributeAccessIssue=false
-# TODO(#1354): cleanup during orchestrator tuple-return widening work
-
 from __future__ import annotations
 
 import os
@@ -308,7 +305,11 @@ class PipelineOrchestrator:
 
         chat_model = create_chat_model(provider_name, model, **kwargs)
 
-        # Add callbacks for logging if enabled
+        # `with_config` returns a `Runnable[..., AIMessage]`. The function's
+        # callers consume it as a chat model (via shared abstractions that
+        # accept either the bare model or a `Runnable` wrapping it). Cast
+        # back to `BaseChatModel` to keep the public return shape stable;
+        # the runtime object is still callable as a chat model.
         if self._callbacks:
             chat_model = chat_model.with_config(callbacks=self._callbacks)  # type: ignore[assignment]
 
@@ -320,7 +321,7 @@ class PipelineOrchestrator:
             temperature=kwargs.get("temperature"),
         )
 
-        return chat_model, provider_name, model
+        return chat_model, provider_name, model  # pyright: ignore[reportReturnType]
 
     def _ensure_callbacks_initialized(self) -> None:
         """Initialize logging callbacks if needed and enabled.
@@ -853,9 +854,13 @@ class PipelineOrchestrator:
             await unload_ollama_model(self._structured_model)
 
         if self._creative_model is not None:
-            # Some chat models may have async close methods
+            # Some chat models (Ollama wrappers, etc.) expose an async `close`
+            # method that langchain's BaseChatModel stub doesn't declare.
+            # The hasattr guard makes this safe at runtime; the per-line
+            # ignores narrow what would otherwise be a file-level
+            # pyright suppression.
             if hasattr(self._creative_model, "close"):
-                close_method = self._creative_model.close
+                close_method = self._creative_model.close  # pyright: ignore[reportAttributeAccessIssue]
                 if callable(close_method):
                     result = close_method()
                     if hasattr(result, "__await__"):

--- a/src/questfoundry/pipeline/orchestrator.py
+++ b/src/questfoundry/pipeline/orchestrator.py
@@ -305,11 +305,7 @@ class PipelineOrchestrator:
 
         chat_model = create_chat_model(provider_name, model, **kwargs)
 
-        # `with_config` returns a `Runnable[..., AIMessage]`. The function's
-        # callers consume it as a chat model (via shared abstractions that
-        # accept either the bare model or a `Runnable` wrapping it). Cast
-        # back to `BaseChatModel` to keep the public return shape stable;
-        # the runtime object is still callable as a chat model.
+        # `with_config` widens the return to `Runnable[..., AIMessage]`; callers consume it as a chat model.
         if self._callbacks:
             chat_model = chat_model.with_config(callbacks=self._callbacks)  # type: ignore[assignment]
 
@@ -854,11 +850,7 @@ class PipelineOrchestrator:
             await unload_ollama_model(self._structured_model)
 
         if self._creative_model is not None:
-            # Some chat models (Ollama wrappers, etc.) expose an async `close`
-            # method that langchain's BaseChatModel stub doesn't declare.
-            # The hasattr guard makes this safe at runtime; the per-line
-            # ignores narrow what would otherwise be a file-level
-            # pyright suppression.
+            # Some chat models (Ollama, etc.) expose an async `close` that BaseChatModel stubs don't declare.
             if hasattr(self._creative_model, "close"):
                 close_method = self._creative_model.close  # pyright: ignore[reportAttributeAccessIssue]
                 if callable(close_method):


### PR DESCRIPTION
## Summary

PR #1352 introduced two file-level `# pyright: reportXxx=false` suppressions to unblock the pyright-alongside-mypy migration, each tagged with a TODO pointing at a follow-up issue. This narrows both to per-line `# pyright: ignore[code]` annotations on the specific runtime-safe accesses that pyright cannot verify through langchain's stubs, restoring full pyright coverage on the rest of each file.

- **#1353** (`observability/langchain_callbacks.py`): `Generation.message` and `BaseMessage.tool_calls` are runtime-accessible on chat-model generations but not exposed by `langchain-core` stubs. The `hasattr` guards already make access safe.
- **#1354** (`pipeline/orchestrator.py`): `chat_model.with_config(...)` widens to `Runnable[..., AIMessage]`; the return-tuple ignore documents that callers consume the result through shared abstractions accepting either form. The Ollama-style async `.close()` access is similarly stub-divergent and guarded by `hasattr`.

No runtime behavior change — pure type-annotation narrowing.

Closes #1353
Closes #1354

## Test plan

- [x] `uv run pyright src/questfoundry/observability/langchain_callbacks.py src/questfoundry/pipeline/orchestrator.py` → 0 errors
- [x] `uv run mypy src/questfoundry/observability/langchain_callbacks.py src/questfoundry/pipeline/orchestrator.py` → no issues
- [x] `uv run ruff check` → all checks passed
- [x] `uv run pytest tests/unit/test_langchain_callbacks.py tests/unit/test_orchestrator.py` → 88 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)