### PR TITLE
chore: drop requires_state_flags back-compat fallback (#1547)

### DIFF
--- a/src/questfoundry/export/base.py
+++ b/src/questfoundry/export/base.py
@@ -30,7 +30,7 @@ class ExportChoice:
     from_passage: str
     to_passage: str
     label: str
-    requires_codewords: list[str] = field(default_factory=list)
+    requires: list[str] = field(default_factory=list)
     grants: list[str] = field(default_factory=list)
     is_return: bool = False
 

--- a/src/questfoundry/export/context.py
+++ b/src/questfoundry/export/context.py
@@ -138,13 +138,7 @@ def _extract_choices(graph: Graph) -> list[ExportChoice]:
             from_passage=edge["from"],
             to_passage=edge["to"],
             label=edge.get("label", "continue"),
-            # POLISH writes the gate-condition key as `"requires"` (see
-            # `_create_choice_edge` in pipeline/stages/polish/deterministic.py).
-            # Older fixtures used `requires_state_flags` / `requires_codewords`
-            # — those fallbacks are kept for migration safety.
-            requires_codewords=edge.get(
-                "requires", edge.get("requires_state_flags", edge.get("requires_codewords", []))
-            ),
+            requires=edge.get("requires", []),
             grants=edge.get("grants", []),
             is_return=edge.get("is_return", False),
         )

--- a/src/questfoundry/export/html_exporter.py
+++ b/src/questfoundry/export/html_exporter.py
@@ -271,10 +271,8 @@ def _render_passage_div(
             label = html.escape(choice.label)
             requires_attr = ""
             grants_attr = ""
-            if choice.requires_codewords:
-                requires_attr = (
-                    f' data-requires="{html.escape(json.dumps(choice.requires_codewords))}"'
-                )
+            if choice.requires:
+                requires_attr = f' data-requires="{html.escape(json.dumps(choice.requires))}"'
             if choice.grants:
                 grants_attr = f' data-grants="{html.escape(json.dumps(choice.grants))}"'
             parts.append(

--- a/src/questfoundry/export/pdf_exporter.py
+++ b/src/questfoundry/export/pdf_exporter.py
@@ -544,7 +544,7 @@ def _render_choices(
 
         parts.append('<p class="choice">')
 
-        # Handle conditional choices (requires codewords)
+        # Handle conditional (gated) choices
         if choice.requires:
             codeword_names = ", ".join(
                 f'<span class="codeword-name">{html.escape(_format_codeword_name(cw))}</span>'

--- a/src/questfoundry/export/pdf_exporter.py
+++ b/src/questfoundry/export/pdf_exporter.py
@@ -545,10 +545,10 @@ def _render_choices(
         parts.append('<p class="choice">')
 
         # Handle conditional choices (requires codewords)
-        if choice.requires_codewords:
+        if choice.requires:
             codeword_names = ", ".join(
                 f'<span class="codeword-name">{html.escape(_format_codeword_name(cw))}</span>'
-                for cw in choice.requires_codewords
+                for cw in choice.requires
             )
             parts.append(f'<span class="choice-requires">{if_you_have} {codeword_names}: </span>')
 

--- a/src/questfoundry/export/twee_exporter.py
+++ b/src/questfoundry/export/twee_exporter.py
@@ -241,8 +241,8 @@ def _render_choice(choice: ExportChoice) -> str:
     else:
         link = f"[[{choice.label}->{target}]]"
 
-    if choice.requires_codewords:
-        conditions = " and ".join(_codeword_var(cw) for cw in choice.requires_codewords)
+    if choice.requires:
+        conditions = " and ".join(_codeword_var(cw) for cw in choice.requires)
         return f"<<if {conditions}>>{link}<</if>>"
     return link
 

--- a/src/questfoundry/graph/polish_validation.py
+++ b/src/questfoundry/graph/polish_validation.py
@@ -911,13 +911,11 @@ def check_gate_satisfiability(graph: Graph) -> ValidationCheck:
         grants = edge.get("grants", []) or []
         grantable.update(grants)
 
-    # Check each choice edge's requires list. POLISH writes `requires`; older
-    # code paths used `requires_state_flags`. Read both for back-compat.
     unsatisfiable: list[str] = []
 
     sorted_edges = sorted(choice_edges, key=_choice_edge_label)
     for edge in sorted_edges:
-        requires = edge.get("requires") or edge.get("requires_state_flags") or []
+        requires = edge.get("requires") or []
         for req in requires:
             if req not in grantable:
                 unsatisfiable.append(f"{_choice_edge_label(edge)} requires '{req}'")
@@ -981,13 +979,11 @@ def check_gate_co_satisfiability(graph: Graph) -> ValidationCheck:
                     sfs.add(sf)
         arc_state_flags[arc_id] = sfs
 
-    # Check each gated choice edge. POLISH writes `requires`; older code paths
-    # used `requires_state_flags`. Read both for back-compat.
     paradoxical: list[str] = []
 
     sorted_edges = sorted(choice_edges, key=_choice_edge_label)
     for edge in sorted_edges:
-        requires = set(edge.get("requires") or edge.get("requires_state_flags") or [])
+        requires = set(edge.get("requires") or [])
         if not requires:
             continue
 
@@ -1303,8 +1299,7 @@ def check_state_flag_gate_coverage(graph: Graph) -> ValidationCheck:
 
     consumed: set[str] = set()
     for edge in graph.get_edges(edge_type="choice"):
-        # POLISH writes `requires`; older code paths used `requires_state_flags`.
-        consumed.update(edge.get("requires") or edge.get("requires_state_flags") or [])
+        consumed.update(edge.get("requires") or [])
 
     # Overlays are embedded arrays on entity nodes (type="entity"),
     # not separate typed nodes.
@@ -1367,7 +1362,7 @@ def check_forward_path_reachability(graph: Graph) -> ValidationCheck:
         forward = [c for c in outgoing if not c.get("is_return") and not c.get("is_routing")]
         if not forward:
             continue  # ending passage or routing-only — no forward choices
-        ungated = [c for c in forward if not (c.get("requires") or c.get("requires_state_flags"))]
+        ungated = [c for c in forward if not c.get("requires")]
         if not ungated:
             soft_locked.append(pid)
 
@@ -1465,11 +1460,9 @@ def check_routing_coverage(graph: Graph) -> list[ValidationCheck]:
         if not covering_arcs:
             continue
 
-        # Extract requires sets from routing choice edges. POLISH writes
-        # `requires`; older code paths used `requires_state_flags`.
         route_requires: list[set[str]] = []
         for rc in routing_choices:
-            reqs = rc.get("requires") or rc.get("requires_state_flags") or []
+            reqs = rc.get("requires") or []
             route_requires.append(set(reqs) if isinstance(reqs, list) else set())
 
         # Select state flag scope: ending splits use "ending" scope (exhaustive),

--- a/src/questfoundry/models/__init__.py
+++ b/src/questfoundry/models/__init__.py
@@ -66,7 +66,6 @@ from questfoundry.models.fill import (
 from questfoundry.models.grow import (
     Arc,
     AtmosphericDetail,
-    Choice,
     EntityArcDescriptor,
     EntityOverlay,
     GapProposal,
@@ -167,7 +166,6 @@ __all__ = [
     "BrainstormEntitiesOutput",
     "BrainstormOutput",
     "CharacterArcMetadata",
-    "Choice",
     "ChoiceLabelItem",
     "ChoiceSpec",
     "CodexEntry",

--- a/src/questfoundry/models/grow.py
+++ b/src/questfoundry/models/grow.py
@@ -73,17 +73,6 @@ class StateFlag(BaseModel):
     flag_type: Literal["granted"] = "granted"
 
 
-class Choice(BaseModel):
-    """A player choice linking two passages (future Phase 9)."""
-
-    from_passage: str = Field(min_length=1)
-    to_passage: str = Field(min_length=1)
-    label: str = Field(min_length=1)
-    requires_state_flags: list[str] = Field(default_factory=list)
-    grants: list[str] = Field(default_factory=list)
-    is_return: bool = Field(default=False, description="True for spoke→hub return links")
-
-
 class EntityOverlay(BaseModel):
     """Conditional entity details activated by state flags (future Phase 8c)."""
 

--- a/tests/unit/test_export_context.py
+++ b/tests/unit/test_export_context.py
@@ -57,7 +57,7 @@ def _minimal_graph() -> Graph:
         "passage::intro",
         "passage::choice_a",
         label="Enter the castle",
-        requires_codewords=[],
+        requires=[],
         grants=["codeword::entered_castle"],
     )
     g.add_edge(
@@ -65,7 +65,7 @@ def _minimal_graph() -> Graph:
         "passage::intro",
         "passage::choice_b",
         label="Flee to the forest",
-        requires_codewords=[],
+        requires=[],
         grants=[],
     )
     return g
@@ -164,9 +164,9 @@ class TestBuildExportContext:
     def test_choice_requires_round_trips_polish_edge_key(self) -> None:
         # Regression for #1532 follow-up: POLISH writes the gate-condition
         # key as `"requires"` (see _create_choice_edge in
-        # pipeline/stages/polish/deterministic.py:1430). The export must read
-        # the same key — the prior fallback chain (requires_state_flags →
-        # requires_codewords → []) silently dropped POLISH's gate values.
+        # pipeline/stages/polish/deterministic.py:1430). The export must
+        # read the same key — earlier code looked under legacy names and
+        # silently dropped POLISH's gate values.
         g = Graph()
         g.create_node("passage::a", {"type": "passage", "raw_id": "a", "prose": "."})
         g.create_node("passage::b", {"type": "passage", "raw_id": "b", "prose": "."})
@@ -180,7 +180,7 @@ class TestBuildExportContext:
         )
         ctx = build_export_context(g, "test")
         assert len(ctx.choices) == 1
-        assert ctx.choices[0].requires_codewords == ["state_flag::has_key"]
+        assert ctx.choices[0].requires == ["state_flag::has_key"]
 
     def test_start_passage_detected(self) -> None:
         g = _minimal_graph()
@@ -206,7 +206,7 @@ class TestBuildExportContext:
             "passage::intro",
             "passage::spoke_0",
             label="Look around",
-            requires_codewords=[],
+            requires=[],
             grants=[],
         )
         g.add_edge(
@@ -215,7 +215,7 @@ class TestBuildExportContext:
             "passage::intro",
             label="Return",
             is_return=True,
-            requires_codewords=[],
+            requires=[],
             grants=[],
         )
 

--- a/tests/unit/test_grow_models.py
+++ b/tests/unit/test_grow_models.py
@@ -8,7 +8,6 @@ from pydantic import ValidationError
 from questfoundry.models.grow import (
     Arc,
     AtmosphericDetail,
-    Choice,
     EntityArcDescriptor,
     EntityOverlay,
     GapProposal,
@@ -144,28 +143,6 @@ class TestStateFlag:
     def test_invalid_flag_type_rejected(self) -> None:
         with pytest.raises(ValidationError, match="flag_type"):
             StateFlag(flag_id="sf1", derived_from="c1", flag_type="revoked")  # type: ignore[arg-type]
-
-
-class TestChoice:
-    def test_valid_choice(self) -> None:
-        choice = Choice(
-            from_passage="p1",
-            to_passage="p2",
-            label="Go left",
-            requires_state_flags=["sf1"],
-            grants=["sf2"],
-        )
-        assert choice.from_passage == "p1"
-        assert choice.requires_state_flags == ["sf1"]
-
-    def test_empty_requires_grants_allowed(self) -> None:
-        choice = Choice(from_passage="p1", to_passage="p2", label="Continue")
-        assert choice.requires_state_flags == []
-        assert choice.grants == []
-
-    def test_empty_label_rejected(self) -> None:
-        with pytest.raises(ValidationError, match="label"):
-            Choice(from_passage="p1", to_passage="p2", label="")
 
 
 class TestEntityOverlay:

--- a/tests/unit/test_html_exporter.py
+++ b/tests/unit/test_html_exporter.py
@@ -89,7 +89,7 @@ class TestHtmlExporter:
                     from_passage="p1",
                     to_passage="p2",
                     label="Enter",
-                    requires_codewords=["codeword::has_key"],
+                    requires=["codeword::has_key"],
                 ),
             ],
         )

--- a/tests/unit/test_json_exporter.py
+++ b/tests/unit/test_json_exporter.py
@@ -25,7 +25,7 @@ def _simple_context() -> ExportContext:
                 from_passage="p1",
                 to_passage="p2",
                 label="Continue",
-                requires_codewords=[],
+                requires=[],
                 grants=["codeword::done"],
             ),
         ],

--- a/tests/unit/test_pdf_exporter.py
+++ b/tests/unit/test_pdf_exporter.py
@@ -241,7 +241,7 @@ class TestRenderHtml:
                     from_passage="p1",
                     to_passage="p2",
                     label="Open the door",
-                    requires_codewords=["codeword::golden_key"],
+                    requires=["codeword::golden_key"],
                 ),
             ],
         )

--- a/tests/unit/test_polish_passage_validation.py
+++ b/tests/unit/test_polish_passage_validation.py
@@ -1312,7 +1312,7 @@ class TestCheckRoutingCoverage:
                 "to_passage": "passage::end1",
                 "label": "r1",
                 "is_routing": True,
-                "requires_state_flags": ["state_flag::cw1"],
+                "requires": ["state_flag::cw1"],
                 "grants": [],
             },
         )

--- a/tests/unit/test_ship_format_consistency.py
+++ b/tests/unit/test_ship_format_consistency.py
@@ -69,7 +69,7 @@ def _multi_format_context() -> ExportContext:
                 from_passage="passage::trial",
                 to_passage="passage::defeat",
                 label="Refuse the mentor",
-                requires_codewords=["codeword::wary"],
+                requires=["codeword::wary"],
             ),
         ],
         entities=[

--- a/tests/unit/test_twee_exporter.py
+++ b/tests/unit/test_twee_exporter.py
@@ -143,7 +143,7 @@ class TestTweeExporter:
                     from_passage="p1",
                     to_passage="p2",
                     label="Enter secret room",
-                    requires_codewords=["codeword::has_key"],
+                    requires=["codeword::has_key"],
                 ),
             ],
         )
@@ -190,7 +190,7 @@ class TestTweeExporter:
                     from_passage="p1",
                     to_passage="p2",
                     label="Use key",
-                    requires_codewords=["codeword::has_key"],
+                    requires=["codeword::has_key"],
                     grants=["codeword::door_opened"],
                 ),
             ],


### PR DESCRIPTION
## Summary

POLISH writes the choice-edge gate field as `requires`. Earlier code carried a
`requires` → `requires_state_flags` → `requires_codewords` fallback chain to
read pre-#1532 fixtures. After PR #1545 migrated all production sites + test
fixtures to the choice-edge model with `requires`, the fallback is dead
weight that obscures every read site.

This drops it everywhere and renames the related public-ish surface so the
field name matches POLISH's actual edge-key naming and the data the field
actually holds (state flags, not codewords — the `codewords` name predates
the StateFlag rename).

## Scope

- `graph/polish_validation.py` — 5 sites read `edge.get("requires") or []` directly.
- `export/context.py::_extract_choices` — single `edge.get("requires", [])` read.
- `export/base.py::ExportChoice.requires_codewords` → `requires`. Three exporter consumers (`twee`, `pdf`, `html`) updated; six exporter test files updated.
- `models/grow.py::Choice` — removed. Never instantiated in production; only used by 3 unit tests in `test_grow_models.py::TestChoice`. The `models/__init__.py` re-export and the tests are removed alongside.
- `tests/unit/test_polish_passage_validation.py` — one fixture key renamed to `requires`.

## Verification

```sh
$ rg "requires_state_flags|requires_codewords" src/ tests/
# (no output)
```

## Why bundle the rename + Choice removal

The issue's verification grep wants 0 matches in `src/` *and* `tests/`. The dataclass field name and the unused `Choice` Pydantic model are both part of the same legacy-naming surface; leaving either in place fails the grep. The Choice model removal is a strict subset of the same back-compat surface (the field's only writer is the model itself; the model has no production callers).

Closes #1547

## Test plan

- [x] `uv run mypy src/questfoundry/...` (8 changed src files) → Success
- [x] `uv run ruff check` → All checks passed
- [x] `uv run pytest tests/unit/test_polish_passage_validation.py tests/unit/test_export_context.py tests/unit/test_html_exporter.py tests/unit/test_pdf_exporter.py tests/unit/test_twee_exporter.py tests/unit/test_json_exporter.py tests/unit/test_ship_format_consistency.py tests/unit/test_grow_models.py` → 295 passed
- [x] `uv run pytest tests/unit/` → 3154 passed (one unrelated flaky network test that passes in isolation)
- [x] `rg "requires_state_flags|requires_codewords" src/ tests/` → 0 matches

🤖 Generated with [Claude Code](https://claude.com/claude-code)