### PR TITLE
fix(prompts): wire SizeProfile.fully_explored into SEED dilemmas prompt (#1236)

### DIFF
--- a/prompts/templates/discuss_seed.yaml
+++ b/prompts/templates/discuss_seed.yaml
@@ -75,10 +75,11 @@ system: |
 
   ## MINIMUM BRANCHING REQUIREMENT (CRITICAL)
 
-  **At least 2 dilemmas MUST have BOTH answers explored.** Without at least
-  one Y-fork, POLISH Phase 4c produces 0 choice edges (see seed.md §Overview)
-  and the story collapses to a linear track. The downstream pipeline assumes
-  a real branching structure.
+  **At least {size_fully_explored} dilemmas MUST have BOTH answers explored.**
+  Without enough Y-forks, POLISH Phase 4c produces too few choice edges (see
+  seed.md §Overview) and the story collapses toward a linear track. The
+  downstream pipeline assumes real branching that scales with story size:
+  small stories need at least one fork; longer stories need more.
 
   GOOD (3 dilemmas, 2 fully explored):
   - `dilemma::keeper_honest_or_hiding`: explored = `[honest, hiding]` — both answers
@@ -89,9 +90,10 @@ system: |
   - All dilemmas: explored = `[canonical_answer_only]` → linear story, 0 choices
   - Only 1 dilemma fully explored → story has only one fork; POLISH Phase 4c produces ≤2 choices
 
-  Pick at least 2 dilemmas where exploring both answers serves the story (per the
-  Identity-defining / Genuine dilemma / Distinct content tests above). Beyond
-  that minimum, explore more if compelling — the size preset bounds the upper end.
+  Pick at least {size_fully_explored} dilemmas where exploring both answers serves
+  the story (per the Identity-defining / Genuine dilemma / Distinct content tests
+  above). Beyond that minimum, explore more if compelling — the size preset bounds
+  the upper end.
 
   ### 3. Create Paths from Explored Answers
 

--- a/prompts/templates/discuss_seed.yaml
+++ b/prompts/templates/discuss_seed.yaml
@@ -81,7 +81,8 @@ system: |
   downstream pipeline assumes real branching that scales with story size:
   small stories need at least one fork; longer stories need more.
 
-  GOOD (3 dilemmas, 2 fully explored):
+  GOOD (structure example — showing what "fully explored" vs "canonical only"
+  looks like; your story needs at least {size_fully_explored} fully explored):
   - `dilemma::keeper_honest_or_hiding`: explored = `[honest, hiding]` — both answers
   - `dilemma::artifact_blessed_or_cursed`: explored = `[blessed, cursed]` — both answers
   - `dilemma::weather_storm_or_clear`: explored = `[clear]` — canonical only (atmospheric)

--- a/prompts/templates/serialize_seed_sections.yaml
+++ b/prompts/templates/serialize_seed_sections.yaml
@@ -109,11 +109,12 @@ dilemmas_prompt: |
   {"dilemma_id": "dilemma::host_benevolent_or_selfish", "explored": ["protector"], "unexplored": ["manipulator"]},
   {"dilemma_id": "dilemma::artifact_safe_or_dangerous", "explored": ["safe"], "unexplored": ["dangerous"]}
   ```
-  GOOD (valid): 2 dilemmas fully explored → 4 arcs → passes
+  GOOD (structure example — both answers in `explored`, none in `unexplored`):
   ```json
   {"dilemma_id": "dilemma::host_benevolent_or_selfish", "explored": ["protector", "manipulator"], "unexplored": []},
   {"dilemma_id": "dilemma::artifact_safe_or_dangerous", "explored": ["safe", "dangerous"], "unexplored": []}
   ```
+  Repeat this shape until you have at least {size_fully_explored} fully-explored dilemmas.
 
   ## DEFAULT ANSWER RULE
   In the manifest, one answer per dilemma is marked `(default)`.

--- a/prompts/templates/serialize_seed_sections.yaml
+++ b/prompts/templates/serialize_seed_sections.yaml
@@ -99,9 +99,10 @@ dilemmas_prompt: |
 
   ## MINIMUM BRANCHING REQUIREMENT (HARD CONSTRAINT — READ FIRST)
 
-  At least 2 dilemmas MUST have ALL their answers in `explored` (nothing in `unexplored`).
-  This is required for the story to have meaningful branching. A story with fewer than
-  2 fully-explored dilemmas produces a near-linear story and WILL BE REJECTED by validation.
+  At least {size_fully_explored} dilemmas MUST have ALL their answers in `explored`
+  (nothing in `unexplored`). This is required for the story to have meaningful branching.
+  A story with fewer than {size_fully_explored} fully-explored dilemmas produces a
+  near-linear story and WILL BE REJECTED by validation.
 
   BAD (rejected): only default answers explored → no real branching → pipeline fails
   ```json
@@ -169,9 +170,9 @@ dilemmas_prompt: |
 
   ## FINAL CHECK before returning
   Count how many of your dilemmas have ALL answers in `explored` (nothing in `unexplored`).
-  If that count is less than 2, GO BACK and fully explore at least 2 dilemmas
-  by moving ALL their answers from `unexplored` into `explored`.
-  A story with fewer than 2 fully-explored dilemmas is REJECTED by validation.
+  If that count is less than {size_fully_explored}, GO BACK and fully explore at least
+  {size_fully_explored} dilemmas by moving ALL their answers from `unexplored` into `explored`.
+  A story with fewer than {size_fully_explored} fully-explored dilemmas is REJECTED by validation.
 
   ## Output
   Return ONLY valid JSON with the "dilemmas" array.

--- a/prompts/templates/serialize_seed_sections.yaml
+++ b/prompts/templates/serialize_seed_sections.yaml
@@ -135,14 +135,14 @@ dilemmas_prompt: |
   to drive branching. Leaving the alternative unexplored is a deliberate scope reduction,
   not a default behavior.
 
-  GOOD branching distribution for 8 dilemmas:
-  - 4 fully explored (both answers in `explored`): creates 8 branching arcs
-  - 4 default-only (only default in `explored`): adds 4 flavor arcs
-  - TOTAL: 12 arcs, 8 branching — passes validation, rich story
+  GOOD branching distribution: at least {size_fully_explored} fully explored
+  (both answers in `explored`) — these drive branching arcs. Remaining dilemmas
+  may be default-only (only default in `explored`) for flavor without
+  multiplying arcs. The fully-explored count is what determines whether the
+  story passes validation.
 
-  BAD distribution for 8 dilemmas:
-  - 0 fully explored: 8 arcs total, all default-only, no branching
-  - 0 arcs with real choices → FAILS validation
+  BAD distribution: 0 fully explored — all dilemmas default-only, no real
+  branching, FAILS validation regardless of total dilemma count.
 
   ## Rules
   - dilemma_id must include the `dilemma::` prefix and match EXACTLY an ID from the manifest

--- a/prompts/templates/summarize_seed_sections.yaml
+++ b/prompts/templates/summarize_seed_sections.yaml
@@ -96,14 +96,14 @@ dilemmas_system: |
   to drive branching. Leaving the alternative unexplored is a deliberate scope reduction,
   not a default behavior.
 
-  GOOD branching distribution for 8 dilemmas:
-  - 4 fully explored (both answers in `explored`): creates 8 branching arcs
-  - 4 default-only (only default in `explored`): adds 4 flavor arcs
-  - TOTAL: 12 arcs, 8 branching — passes validation, rich story
+  GOOD branching distribution: at least {size_fully_explored} fully explored
+  (both answers in `explored`) — these drive branching arcs. Remaining dilemmas
+  may be default-only (only default in `explored`) for flavor without
+  multiplying arcs. The fully-explored count is what determines whether the
+  story passes validation.
 
-  BAD distribution for 8 dilemmas:
-  - 0 fully explored: 8 arcs total, all default-only, no branching
-  - 0 arcs with real choices → FAILS validation downstream
+  BAD distribution: 0 fully explored — all dilemmas default-only, no real
+  branching, FAILS validation downstream regardless of total dilemma count.
 
   ## Required Dilemma IDs ({dilemma_count} total)
   {dilemma_manifest}

--- a/prompts/templates/summarize_seed_sections.yaml
+++ b/prompts/templates/summarize_seed_sections.yaml
@@ -50,9 +50,10 @@ dilemmas_system: |
 
   ## MINIMUM BRANCHING REQUIREMENT (HARD CONSTRAINT — READ FIRST)
 
-  At least 2 dilemmas MUST have ALL their answers in `explored` (with `unexplored=[]`).
-  This is required for the story to have meaningful branching. A story with fewer than
-  2 fully-explored dilemmas produces a near-linear story and WILL BE REJECTED downstream.
+  At least {size_fully_explored} dilemmas MUST have ALL their answers in `explored`
+  (with `unexplored=[]`). This is required for the story to have meaningful branching.
+  A story with fewer than {size_fully_explored} fully-explored dilemmas produces a
+  near-linear story and WILL BE REJECTED downstream.
 
   BAD (rejected): only one answer per dilemma in `explored` → no real branching → pipeline fails
   ```
@@ -142,13 +143,14 @@ dilemmas_system: |
 
   ## FINAL CHECK before returning
   Count how many of your dilemmas have ALL answers in `explored` (`unexplored=[]`).
-  If that count is less than 2, **OVERRIDE the discussion's exploration choices**:
-  for any dilemma whose discussion did NOT explicitly say "explore both", you
-  MAY move its non-default answer from `unexplored` into `explored` (and clear
-  it from `unexplored`) until the fully-explored count reaches 2. Pick whichever
-  remaining dilemmas best serve the story.
-  A story with fewer than 2 fully-explored dilemmas is REJECTED downstream;
-  the override is required, not optional.
+  If that count is less than {size_fully_explored}, **OVERRIDE the discussion's
+  exploration choices**: for any dilemma whose discussion did NOT explicitly say
+  "explore both", you MAY move its non-default answer from `unexplored` into
+  `explored` (and clear it from `unexplored`) until the fully-explored count
+  reaches {size_fully_explored}. Pick whichever remaining dilemmas best serve
+  the story.
+  A story with fewer than {size_fully_explored} fully-explored dilemmas is
+  REJECTED downstream; the override is required, not optional.
 
   VERIFY: Your list MUST have exactly {dilemma_count} items.
   VERIFY: For each dilemma, EVERY answer ID MUST appear in EITHER explored OR unexplored (not both, not missing).

--- a/prompts/templates/summarize_seed_sections.yaml
+++ b/prompts/templates/summarize_seed_sections.yaml
@@ -122,8 +122,9 @@ dilemmas_system: |
   dilemma names.
 
   ## Output Format
-  List EVERY dilemma with its decision. The example below shows a healthy 4-fully + 4-default-only
-  distribution for an 8-dilemma story (50% soft cap):
+  List EVERY dilemma with its decision. The example below shows the output format
+  (4 fully explored + 4 default-only, for illustration — your story's minimum is
+  {size_fully_explored}):
   ```
   - dilemma::host_benevolent_or_selfish: explored=[protector, manipulator], unexplored=[]
   - dilemma::artifact_safe_or_dangerous: explored=[safe, dangerous], unexplored=[]

--- a/prompts/templates/summarize_seed_sections.yaml
+++ b/prompts/templates/summarize_seed_sections.yaml
@@ -59,11 +59,12 @@ dilemmas_system: |
   - dilemma::host_benevolent_or_selfish: explored=[protector], unexplored=[manipulator]
   - dilemma::artifact_safe_or_dangerous: explored=[safe], unexplored=[dangerous]
   ```
-  GOOD (valid): 2 dilemmas fully explored → 4 arcs → passes
+  GOOD (structure example — both answers in `explored`, none in `unexplored`):
   ```
   - dilemma::host_benevolent_or_selfish: explored=[protector, manipulator], unexplored=[]
   - dilemma::artifact_safe_or_dangerous: explored=[safe, dangerous], unexplored=[]
   ```
+  Repeat this shape until you have enough fully-explored dilemmas for the story size.
 
   ## EXTRACTION FIDELITY (CRITICAL)
   If the discussion says "EXPLORE BOTH" / "explore both answers" / similar for a dilemma,

--- a/src/questfoundry/agents/prompts.py
+++ b/src/questfoundry/agents/prompts.py
@@ -343,6 +343,7 @@ def get_seed_section_summarize_prompts(
             dilemma_manifest=dilemma_manifest or "(No dilemmas)",
             dilemma_answers=dilemma_answers or "(No answer IDs available)",
             output_language_instruction=lang,
+            size_fully_explored=svars["size_fully_explored"],
         ),
         "paths": _render(
             "paths_system",

--- a/src/questfoundry/agents/serialize.py
+++ b/src/questfoundry/agents/serialize.py
@@ -1865,10 +1865,15 @@ async def serialize_seed_as_function(
 
     prompts = dict(_load_seed_section_prompts())  # Copy — cached original is immutable
 
-    # Inject size-aware beat count ranges into the Y-shape beat prompts
+    # Inject size-aware ranges into the Y-shape beat prompts and the
+    # dilemma-branching minimum into the dilemmas prompt. The dilemmas
+    # prompt's "fully explore at least N" hard constraint must scale with
+    # the size preset; long stories require ≥3 fully-explored to satisfy
+    # the arc-count check (#1236).
     size_vars = size_template_vars(size_profile)
     shared_range = size_vars["size_shared_beats_per_dilemma"]
     post_range = size_vars["size_post_commit_beats_per_path"]
+    fully_explored = size_vars["size_fully_explored"]
     if "shared_beats" in prompts:
         prompts["shared_beats"] = prompts["shared_beats"].replace(
             "{size_shared_beats_per_dilemma}", shared_range
@@ -1877,6 +1882,8 @@ async def serialize_seed_as_function(
         prompts["per_path_beats"] = prompts["per_path_beats"].replace(
             "{size_post_commit_beats_per_path}", post_range
         )
+    if "dilemmas" in prompts:
+        prompts["dilemmas"] = prompts["dilemmas"].replace("{size_fully_explored}", fully_explored)
 
     total_tokens = 0
 

--- a/src/questfoundry/agents/serialize.py
+++ b/src/questfoundry/agents/serialize.py
@@ -1885,8 +1885,10 @@ async def serialize_seed_as_function(
         prompts["per_path_beats"] = prompts["per_path_beats"].replace(
             "{size_post_commit_beats_per_path}", post_range
         )
-    if "dilemmas" in prompts:
-        prompts["dilemmas"] = prompts["dilemmas"].replace("{size_fully_explored}", fully_explored)
+    # `dilemmas` is a required section key (validated in `_load_seed_section_prompts`),
+    # so call `.replace()` directly — no `in prompts` guard. The matching guards
+    # above on `shared_beats` / `per_path_beats` are equally dead but pre-existing.
+    prompts["dilemmas"] = prompts["dilemmas"].replace("{size_fully_explored}", fully_explored)
 
     total_tokens = 0
 

--- a/src/questfoundry/pipeline/size.py
+++ b/src/questfoundry/pipeline/size.py
@@ -266,5 +266,6 @@ def size_template_vars(profile: SizeProfile | None = None) -> dict[str, str]:
         "size_est_passages": p.range_str("est_passages"),
         "size_est_words": p.range_str("est_words"),
         "size_tone_words": p.range_str("tone_words"),
+        "size_fully_explored": str(p.fully_explored),
         "size_preset": p.preset,
     }

--- a/tests/unit/test_serialize.py
+++ b/tests/unit/test_serialize.py
@@ -2078,6 +2078,10 @@ class TestSizeProfileInjectedIntoBeatPrompts:
         assert "at least 2 dilemmas" not in prompts["dilemmas"]
         assert "less than 2" not in prompts["dilemmas"]
         assert "fewer than 2" not in prompts["dilemmas"]
+        # The GOOD example label must not claim "2 dilemmas → passes" — under
+        # `long` (size_fully_explored=5) that contradicts the HARD constraint
+        # and gives small models a fallback anchor (caught in PR #1554 review).
+        assert "2 dilemmas fully explored" not in prompts["dilemmas"]
 
 
 class TestDilemmasPromptStructure:

--- a/tests/unit/test_serialize.py
+++ b/tests/unit/test_serialize.py
@@ -2083,6 +2083,29 @@ class TestSizeProfileInjectedIntoBeatPrompts:
         # and gives small models a fallback anchor (caught in PR #1554 review).
         assert "2 dilemmas fully explored" not in prompts["dilemmas"]
 
+    def test_summarize_dilemmas_prompt_size_fully_explored_resolved(self) -> None:
+        # #1554 review: the SUMMARIZE phase's dilemmas section must also be
+        # wired with {size_fully_explored}. After rendering with a `long`
+        # profile, the rendered prompt should contain the resolved value (5)
+        # and no hardcoded "2 dilemmas" / "fewer than 2" survivors.
+        from questfoundry.agents.prompts import get_seed_section_summarize_prompts
+        from questfoundry.pipeline.size import get_size_profile
+
+        rendered = get_seed_section_summarize_prompts(
+            entity_count=3,
+            dilemma_count=8,
+            entity_manifest="entity::a, entity::b",
+            dilemma_manifest="dilemma::a, dilemma::b",
+            dilemma_answers="(answers)",
+            size_profile=get_size_profile("long"),
+        )["dilemmas"]
+        assert "{size_fully_explored}" not in rendered  # placeholder resolved
+        assert "5" in rendered  # long preset's fully_explored value
+        assert "at least 2 dilemmas" not in rendered
+        assert "less than 2" not in rendered
+        assert "fewer than 2" not in rendered
+        assert "2 dilemmas fully explored" not in rendered
+
 
 class TestDilemmasPromptStructure:
     """Structural tests for the dilemmas_prompt section (#1234).

--- a/tests/unit/test_serialize.py
+++ b/tests/unit/test_serialize.py
@@ -2065,6 +2065,20 @@ class TestSizeProfileInjectedIntoBeatPrompts:
         size_vars = size_template_vars(None)
         assert size_vars["size_post_commit_beats_per_path"] == "2-3"
 
+    def test_dilemmas_prompt_size_fully_explored_placeholder_present(self) -> None:
+        # #1236: the dilemmas prompt's HARD constraint and FINAL CHECK must use
+        # {size_fully_explored} so the "at least N" branching minimum scales
+        # with the size preset (long stories need >=3 fully-explored).
+        from questfoundry.agents.serialize import _load_seed_section_prompts
+
+        _load_seed_section_prompts.cache_clear()
+        prompts = _load_seed_section_prompts()
+        assert "{size_fully_explored}" in prompts["dilemmas"]
+        # Hardcoded "at least 2" must be gone in both the constraint and FINAL CHECK
+        assert "at least 2 dilemmas" not in prompts["dilemmas"]
+        assert "less than 2" not in prompts["dilemmas"]
+        assert "fewer than 2" not in prompts["dilemmas"]
+
 
 class TestDilemmasPromptStructure:
     """Structural tests for the dilemmas_prompt section (#1234).

--- a/tests/unit/test_size.py
+++ b/tests/unit/test_size.py
@@ -269,6 +269,7 @@ class TestSizeTemplateVars:
             "size_est_passages",
             "size_est_words",
             "size_tone_words",
+            "size_fully_explored",
             "size_preset",
         }
         assert set(vars_.keys()) == expected
@@ -278,3 +279,12 @@ class TestSizeTemplateVars:
         vars_ = size_template_vars(profile)
         assert vars_["size_shared_beats_per_dilemma"] == "1-2"
         assert vars_["size_post_commit_beats_per_path"] == "2-3"
+
+    def test_size_fully_explored_scales_with_preset(self) -> None:
+        # The dilemmas prompt's branching minimum scales with the size
+        # preset (#1236) — long stories need >=3 fully-explored to hit
+        # the arc-count check, so the prompt's "at least N" must scale.
+        assert size_template_vars(get_size_profile("micro"))["size_fully_explored"] == "1"
+        assert size_template_vars(get_size_profile("short"))["size_fully_explored"] == "3"
+        assert size_template_vars(get_size_profile("medium"))["size_fully_explored"] == "4"
+        assert size_template_vars(get_size_profile("long"))["size_fully_explored"] == "5"


### PR DESCRIPTION
## Summary

The dilemmas prompt's "at least 2 dilemmas MUST be fully explored" hard
constraint was hardcoded everywhere. PR #1235 fixed the prompt structure
but left the magic 2 — fine for short/medium, insufficient for `long`.
With `max_arcs=32`, validation requires `min_arcs_required=8` arcs
(`max(2, max_arcs // 4)`), which means at least 3 fully-explored
dilemmas (`arc_count = 2^n`). The prompt asking for 2 falls short and
the run hits `SeedStageError`.

This wires `SizeProfile.fully_explored` (already a field — just not
exposed) through `size_template_vars()` and into:

- `serialize_seed_sections.yaml` `dilemmas_prompt` — HARD CONSTRAINT + FINAL CHECK
- `discuss_seed.yaml` — MINIMUM BRANCHING REQUIREMENT

`serialize.py::serialize_seed_as_function` now applies the
`{size_fully_explored}` substitution alongside the existing beat-range
substitutions. The `discuss_seed.yaml` substitution rides on the
existing `**size_template_vars(...)` `.format()` call in
`agents/prompts.py::get_seed_discuss_prompt` — no extra wiring needed.

### Profile values (TARGET, always >= validation MIN)

| preset | max_arcs | min required | `size_fully_explored` |
|--------|---------:|-------------:|----------------------:|
| micro  |        2 |            1 |                     1 |
| short  |        8 |            1 |                     3 |
| medium |       16 |            2 |                     4 |
| long   |       32 |            3 |                     5 |

The profile target is always `>=` the validation minimum, so the
prompt asks for slightly more than what's strictly needed — which is
the right direction (LLM tries for more, falls short of TARGET, but
still satisfies validation).

Closes #1236

## Test plan

- [x] `uv run mypy src/questfoundry/pipeline/size.py src/questfoundry/agents/serialize.py` → Success
- [x] `uv run ruff check` → All checks passed
- [x] `uv run pytest tests/unit/test_size.py tests/unit/test_serialize.py` → 142 passed
- [x] New test `test_size_fully_explored_scales_with_preset` asserts the new key for all 4 presets
- [x] New test `test_dilemmas_prompt_size_fully_explored_placeholder_present` asserts no hardcoded "at least 2" / "less than 2" / "fewer than 2" strings survive in the dilemmas prompt

🤖 Generated with [Claude Code](https://claude.com/claude-code)