### PR TITLE
feat(dress): renderer-aware art direction (checkpoint hint + style_exclusions rename)

### DIFF
--- a/docs/design/00-spec.md
+++ b/docs/design/00-spec.md
@@ -331,7 +331,7 @@ art_direction:
   medium: string                   # what it looks like it was made with
   palette: string[]                # dominant colors / mood
   composition_notes: string        # framing preferences
-  negative_defaults: string        # global things to avoid in image generation
+  style_exclusions: string         # story-tone visual styles to exclude
   aspect_ratio: string             # default dimensions, e.g., "16:9"
 ```
 

--- a/docs/design/procedures/dress.md
+++ b/docs/design/procedures/dress.md
@@ -37,7 +37,7 @@ DRESS adds visual identity and reference material to a completed story. It gener
 
 R-1.1. Exactly one ArtDirection singleton node is created. Retries replace the previous node.
 
-R-1.2. ArtDirection fields include `style`, `medium`, `palette`, `composition_notes`, `negative_defaults`, `aspect_ratio`.
+R-1.2. ArtDirection fields include `style`, `medium`, `palette`, `composition_notes`, `style_exclusions`, `aspect_ratio`.
 
 R-1.3. Every Entity with at least one `appears` edge to a Passage gets an EntityVisual node with a `describes_visual` edge.
 
@@ -283,7 +283,7 @@ R-5.7. No orphan assets: every asset file has a corresponding Illustration node,
 ## Rule Index
 
 R-1.1: Exactly one ArtDirection singleton; retries replace.
-R-1.2: ArtDirection has style, medium, palette, composition_notes, negative_defaults, aspect_ratio.
+R-1.2: ArtDirection has style, medium, palette, composition_notes, style_exclusions, aspect_ratio.
 R-1.3: Every entity with `appears` edge has an EntityVisual.
 R-1.4: Every EntityVisual has non-empty `reference_prompt_fragment`.
 R-1.5: Gate 1 approval required before Phase 2.
@@ -379,7 +379,8 @@ art_direction:
   medium: "digital painting mimicking traditional ink"
   palette: "deep blues and greys, warm amber accents"
   composition_notes: "dramatic lighting, low-angle compositions for tension"
-  negative_defaults: "no photorealism, no cartoon styling, no modern clothing"
+  # Story-tone visual prohibitions only — renderer-quality fillers (blurry, watermark, etc.) are auto-injected at render time.
+  style_exclusions: "no photorealism, no cartoon styling, no modern clothing"
   aspect_ratio: "3:2"
 ```
 

--- a/docs/design/procedures/ship.md
+++ b/docs/design/procedures/ship.md
@@ -149,7 +149,7 @@ R-3.7. Illustration assets are copied into the export bundle (HTML/PDF) or refer
 
 R-3.8. If DRESS was skipped: exports degrade gracefully — no illustrations, no codex, no visual metadata. Core gameplay works.
 
-R-3.9. If DRESS *ran but produced an incomplete `art_direction` node* (one or more of the DRESS-required visual fields — `style`, `medium`, `palette`, `composition_notes`, `negative_defaults`, `aspect_ratio` — missing or blank): the export still proceeds (graceful degradation, like R-3.8), but SHIP logs a WARNING naming the missing fields. Partial DRESS is a recoverable degradation, not a silent one — the user must be told so they can rerun DRESS.
+R-3.9. If DRESS *ran but produced an incomplete `art_direction` node* (one or more of the DRESS-required visual fields — `style`, `medium`, `palette`, `composition_notes`, `style_exclusions`, `aspect_ratio` — missing or blank): the export still proceeds (graceful degradation, like R-3.8), but SHIP logs a WARNING naming the missing fields. Partial DRESS is a recoverable degradation, not a silent one — the user must be told so they can rerun DRESS.
 
 **Violations:**
 

--- a/docs/superpowers/plans/2026-04-28-dress-image-renderer-hint.md
+++ b/docs/superpowers/plans/2026-04-28-dress-image-renderer-hint.md
@@ -1,0 +1,1036 @@
+# DRESS Image-Renderer Hint Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `ArtDirection` (DRESS Phase 0) renderer-aware when the image provider is selected at orchestrator init, and rename `negative_defaults` → `style_exclusions` to remove the small-model field-name confusion.
+
+**Architecture:** Two layers share one static checkpoint style map. (1) DRESS Phase 0 prevention: when `--image-provider` is set, `dress_discuss.yaml` gets a `{image_renderer_section}` populated from the map; otherwise empty. (2) Distiller recovery: replace the existing crude `checkpoint_hint` in `image_a1111.py` with structured map data. Bundled rename gives the field one unambiguous semantic ("story-tone visual prohibitions").
+
+**Tech Stack:** Python 3.11+, `uv`, `pydantic`, `ruamel.yaml`, `pytest`, `ruff`, `mypy`. Existing patterns: PromptLoader → `template.system.format(**kwargs)`; `re.compile` patterns matched against lowercased filenames in `_resolve_preset` (precedent for the new `_CHECKPOINT_STYLE_MAP`).
+
+**Spec:** `docs/superpowers/specs/2026-04-28-dress-image-renderer-hint-design.md`. Closes #1557.
+
+---
+
+## File Structure
+
+**New files (1):**
+- `src/questfoundry/providers/checkpoint_styles.py` — `_CHECKPOINT_STYLE_MAP` regex table + `resolve_checkpoint_style()` lookup
+- `tests/unit/test_checkpoint_styles.py` — pattern resolution tests
+
+**Modified files (12):**
+- `docs/design/procedures/dress.md` — R-1.2 field-list + worked-example
+- `docs/design/procedures/ship.md` — R-3.9 partial-DRESS warning enumeration
+- `src/questfoundry/models/dress.py` — `ArtDirection.negative_defaults` → `style_exclusions` + new description
+- `src/questfoundry/providers/image_brief.py` — `ImageBrief.negative_defaults` → `style_exclusions` + flattener concat
+- `src/questfoundry/providers/image_a1111.py` — distiller `checkpoint_hint` body replaced with map lookup; concat-site rename
+- `src/questfoundry/providers/image_openai.py` — concat-site rename
+- `src/questfoundry/pipeline/stages/dress.py` — `_build_image_renderer_section()` helper + threading; ArtDirection→ImageBrief construction site rename
+- `src/questfoundry/export/context.py` — `_REQUIRED_ART_DIRECTION_FIELDS` tuple
+- `prompts/templates/dress_discuss.yaml` — insert `{image_renderer_section}` placeholder before `## Guidelines`
+- `prompts/templates/dress_serialize.yaml` — schema field rename + GOOD/BAD instruction (story-tone vs renderer fillers)
+- `prompts/templates/dress_brief.yaml` + `dress_brief_batch.yaml` — field-name references
+- Tests: any fixture or assertion using the old name
+
+---
+
+## Task 1: Spec docs (R-1.2 + R-3.9 rename)
+
+Specs precede code per CLAUDE.md "Spec-first fix order." This task touches only docs, no code, no tests.
+
+**Files:**
+- Modify: `docs/design/procedures/dress.md`
+- Modify: `docs/design/procedures/ship.md`
+
+- [ ] **Step 1: Open `dress.md` and update R-1.2 field enumeration (line ~40 and ~286)**
+
+Current R-1.2 lists: "ArtDirection fields include `style`, `medium`, `palette`, `composition_notes`, `negative_defaults`, `aspect_ratio`."
+
+Change every occurrence of `negative_defaults` to `style_exclusions` in that rule. Both the prose at line ~40 and the consolidated table around line ~286.
+
+- [ ] **Step 2: Update the worked-example YAML block in `dress.md` (around line ~382)**
+
+Find the YAML showing `negative_defaults: "no photorealism, no cartoon styling, no modern clothing"`. Rename the field to `style_exclusions` and update the line above it (the field's commentary or description) to: `# Story-tone visual prohibitions only — renderer-quality fillers (blurry, watermark, etc.) are auto-injected at render time.`
+
+- [ ] **Step 3: Open `ship.md` and update R-3.9**
+
+R-3.9 lists DRESS-required visual fields: "`style`, `medium`, `palette`, `composition_notes`, `negative_defaults`, `aspect_ratio`". Change `negative_defaults` → `style_exclusions`. Rest of R-3.9 unchanged.
+
+- [ ] **Step 4: Verify no other doc references the old name**
+
+```bash
+rg "negative_defaults" docs/
+```
+Expected: zero hits in `docs/`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add docs/design/procedures/dress.md docs/design/procedures/ship.md
+git commit -m "docs(dress,ship): rename negative_defaults → style_exclusions in R-1.2 + R-3.9 (#1557)"
+```
+
+---
+
+## Task 2: Checkpoint style map module — failing test
+
+TDD pure — the new module is testable in isolation. Write tests first.
+
+**Files:**
+- Create: `tests/unit/test_checkpoint_styles.py`
+
+- [ ] **Step 1: Create the failing test file**
+
+```python
+# tests/unit/test_checkpoint_styles.py
+"""Tests for checkpoint style metadata lookup (#1557)."""
+
+from __future__ import annotations
+
+import pytest
+
+from questfoundry.providers.checkpoint_styles import resolve_checkpoint_style
+
+
+class TestResolveCheckpointStyle:
+    """`resolve_checkpoint_style()` returns label/style_hints/incompatible_styles
+    for a checkpoint name. Always returns a populated dict (default fallback
+    if no specific pattern matches)."""
+
+    @pytest.mark.parametrize(
+        ("model", "label_substring"),
+        [
+            # User's loaded checkpoints at A1111 (2026-04-28)
+            ("flux1-dev-bnb-nf4-v2.safetensors", "Flux"),
+            ("flux1-dev-bnb-nf4.safetensors", "Flux"),
+            ("coloring_book.ckpt", "Coloring Book"),
+            ("v1-5-pruned-emaonly.safetensors", "SD 1.5"),
+            ("animagine-xl.safetensors", "Animagine"),
+            ("Dreamshaper.safetensors", "DreamShaper"),
+            ("sd_xl_base_1.0.safetensors", "SDXL Base"),
+            ("dreamshaperXL_lightningDPMSDE.safetensors", "DreamShaperXL Lightning"),
+            ("juggernautXL_ragnarokBy.safetensors", "Juggernaut"),
+            ("dreamshaperXL_alpha2Xl10.safetensors", "DreamShaperXL Lightning"),
+        ],
+    )
+    def test_known_checkpoint_resolves_to_specific_label(
+        self, model: str, label_substring: str
+    ) -> None:
+        info = resolve_checkpoint_style(model)
+        assert label_substring in info["label"]
+        assert info["style_hints"]
+        assert info["incompatible_styles"]
+
+    def test_unknown_checkpoint_falls_back_to_default(self) -> None:
+        info = resolve_checkpoint_style("totally-made-up-model.safetensors")
+        assert "Unknown" in info["label"] or "general-purpose" in info["label"].lower()
+        assert info["style_hints"]
+        assert info["incompatible_styles"]
+
+    def test_pattern_ordering_dreamshaperxl_lightning_wins_over_generic(self) -> None:
+        # The dreamshaper family has three patterns; the most specific must win.
+        # dreamshaperxl_lightning|alpha → "DreamShaperXL Lightning / Alpha"
+        # dreamshaperxl|dreamshaper.*xl → "DreamShaperXL"
+        # dreamshaper                    → "DreamShaper" (SD1.5)
+        lightning = resolve_checkpoint_style("dreamshaperXL_lightningDPMSDE.safetensors")
+        assert "Lightning" in lightning["label"] or "Alpha" in lightning["label"]
+
+        alpha = resolve_checkpoint_style("dreamshaperXL_alpha2Xl10.safetensors")
+        assert "Lightning" in alpha["label"] or "Alpha" in alpha["label"]
+
+        sd15 = resolve_checkpoint_style("Dreamshaper.safetensors")
+        assert "Lightning" not in sd15["label"]
+        assert "Alpha" not in sd15["label"]
+        assert "XL" not in sd15["label"]
+
+    def test_returns_required_keys(self) -> None:
+        info = resolve_checkpoint_style("anything.safetensors")
+        assert set(info.keys()) >= {"label", "style_hints", "incompatible_styles"}
+
+    def test_case_insensitive_matching(self) -> None:
+        # Patterns match against lowercased filename.
+        upper = resolve_checkpoint_style("FLUX1-DEV.safetensors")
+        lower = resolve_checkpoint_style("flux1-dev.safetensors")
+        assert upper == lower
+```
+
+- [ ] **Step 2: Run test to verify it fails (module doesn't exist yet)**
+
+```bash
+uv run --frozen pytest tests/unit/test_checkpoint_styles.py -v
+```
+Expected: collection error or `ModuleNotFoundError: questfoundry.providers.checkpoint_styles`.
+
+---
+
+## Task 3: Checkpoint style map module — implementation
+
+**Files:**
+- Create: `src/questfoundry/providers/checkpoint_styles.py`
+
+- [ ] **Step 1: Create the module**
+
+```python
+# src/questfoundry/providers/checkpoint_styles.py
+"""Static checkpoint style metadata for image-generation renderers.
+
+Used by DRESS Phase 0 (prevention — when `--image-provider` is set, biases
+ArtDirection toward checkpoint-compatible styles) and the A1111 distiller
+(recovery — adapts CLIP-tag selection to the active checkpoint).
+
+Pattern matching:
+    Patterns are matched against the lowercased checkpoint filename via
+    `re.Pattern.search`. First match wins. Specific patterns MUST precede
+    generic ones — the dreamshaper family is the canonical example
+    (Lightning/Alpha specific → XL generic → SD1.5 fallback).
+    The empty-pattern default-fallback entry is always last.
+
+Adding a new entry:
+    Insert above the default-fallback entry, in priority order.
+    Test: add a parametrize row to `tests/unit/test_checkpoint_styles.py`
+    asserting the expected label substring.
+"""
+
+from __future__ import annotations
+
+import re
+
+_CHECKPOINT_STYLE_MAP: tuple[tuple[re.Pattern[str], dict[str, str]], ...] = (
+    # ----- Flux (NF4 quantised; both v1 and v2 quants share identity) -----
+    (
+        re.compile(r"flux"),
+        {
+            "label": "Flux (photorealistic / highly-detailed)",
+            "style_hints": (
+                "photorealistic imagery, extreme fine detail, architectural "
+                "photography, natural lighting, product shots, documentary "
+                "portraiture, coherent text in scene"
+            ),
+            "incompatible_styles": (
+                "anime, manga, cel-shading, watercolor washes, heavy "
+                "painterly texture, low-detail illustration styles; "
+                "also: negative-prompt weighting is weak on Flux — "
+                "do not rely on negative prompts for strong style exclusion"
+            ),
+        },
+    ),
+    # ----- Coloring-book fine-tune (SD1.5 base) -----
+    (
+        re.compile(r"coloring.?book"),
+        {
+            "label": "Coloring Book (line-art SD1.5)",
+            "style_hints": (
+                "clean outlines on white background, no fill colors, "
+                "strong linework, simple shapes, children's-book-friendly "
+                "compositions, decorative borders"
+            ),
+            "incompatible_styles": (
+                "photorealism, color renders, painterly textures, "
+                "complex shading, dark backgrounds, photographic lighting"
+            ),
+        },
+    ),
+    # ----- Juggernaut XL (photorealistic SDXL) -----
+    (
+        re.compile(r"juggernaut"),
+        {
+            "label": "Juggernaut XL (photorealistic SDXL)",
+            "style_hints": (
+                "photorealistic portraits, cinematic lighting, "
+                "sharp textural detail, skin pores, fabric weave, "
+                "dramatic rim lighting, environmental storytelling"
+            ),
+            "incompatible_styles": (
+                "anime, cartoon, flat illustration, "
+                "watercolor, comic-book ink outlines, chibi"
+            ),
+        },
+    ),
+    # ----- Animagine XL (anime-focused SDXL) -----
+    (
+        re.compile(r"animagine"),
+        {
+            "label": "Animagine XL (anime SDXL)",
+            "style_hints": (
+                "anime illustration, Danbooru-style tag vocabulary, "
+                "clean cell shading, expressive character art, "
+                "vivid saturated palette, manga panel compositions"
+            ),
+            "incompatible_styles": (
+                "photorealism, photography-style lighting, "
+                "gritty texture, oil painting, detailed backgrounds "
+                "without anime stylisation"
+            ),
+        },
+    ),
+    # ----- DreamShaperXL Lightning / Alpha (must precede generic dreamshaperxl) -----
+    (
+        re.compile(r"dreamshaperxl.*lightning|dreamshaperxl.*alpha"),
+        {
+            "label": "DreamShaperXL Lightning / Alpha (fast fantasy SDXL)",
+            "style_hints": (
+                "fantasy concept art, painterly illustration, "
+                "vibrant color, dramatic character portraits, "
+                "acceptable in 4-8 steps"
+            ),
+            "incompatible_styles": (
+                "photorealism (style is stylised by design), "
+                "highly detailed textures at very low step counts, "
+                "strict architectural accuracy"
+            ),
+        },
+    ),
+    # ----- DreamShaperXL standard -----
+    (
+        re.compile(r"dreamshaperxl|dreamshaper.*xl"),
+        {
+            "label": "DreamShaperXL (versatile fantasy SDXL)",
+            "style_hints": (
+                "fantasy illustration, painterly portraits, "
+                "concept-art style, stylised environments, "
+                "strong use of negative space"
+            ),
+            "incompatible_styles": (
+                "strict photorealism, clinical document photography, "
+                "flat-color infographic styles"
+            ),
+        },
+    ),
+    # ----- DreamShaper SD1.5 (generic, must come after XL variants) -----
+    (
+        re.compile(r"dreamshaper"),
+        {
+            "label": "DreamShaper (versatile SD1.5)",
+            "style_hints": (
+                "general-purpose stylised illustration, "
+                "fantasy character art, soft painterly lighting, "
+                "portrait and environmental compositions; "
+                "notably versatile — adapt style tags rather than "
+                "leaning on a single category"
+            ),
+            "incompatible_styles": (
+                "extreme photorealism (slightly stylised by design), "
+                "Danbooru/anime tag grammar (use natural descriptors instead)"
+            ),
+        },
+    ),
+    # ----- SDXL base -----
+    (
+        re.compile(r"sd_xl_base|sdxl_base|sdxl-base"),
+        {
+            "label": "SDXL Base (general-purpose SDXL)",
+            "style_hints": (
+                "broad style range, photography, illustration, concept art; "
+                "best results with refiner pass or ControlNet; "
+                "responds well to explicit style tokens"
+            ),
+            "incompatible_styles": (
+                "anime-specific Danbooru vocabulary without style priming, "
+                "very low step counts (needs ≥30 steps for coherence)"
+            ),
+        },
+    ),
+    # ----- SD 1.5 base / pruned -----
+    (
+        re.compile(r"v1[-_]5|sd[-_]?1[-._]?5"),
+        {
+            "label": "SD 1.5 (general-purpose base)",
+            "style_hints": (
+                "broad style range at 512-768px, watercolor, "
+                "ink illustration, painterly portraiture; "
+                "well-supported by community LoRAs"
+            ),
+            "incompatible_styles": (
+                "photorealistic skin detail at high resolution "
+                "(768px ceiling limits fine detail), "
+                "SDXL-native aspect ratios"
+            ),
+        },
+    ),
+    # ----- Default — always matches; must be last -----
+    (
+        re.compile(r""),
+        {
+            "label": "Unknown checkpoint (SD general-purpose defaults)",
+            "style_hints": (
+                "broad range: illustration, painterly, concept art; "
+                "Stable Diffusion generally excels at stylised imagery, "
+                "fantasy environments, and character portraiture; "
+                "use explicit style tokens (e.g. 'watercolor painting', "
+                "'cinematic photograph') for best results"
+            ),
+            "incompatible_styles": (
+                "coherent embedded text, photographic product catalogs "
+                "without specialised fine-tuning"
+            ),
+        },
+    ),
+)
+
+
+def resolve_checkpoint_style(model: str) -> dict[str, str]:
+    """Look up style metadata for a checkpoint name.
+
+    Always returns a populated dict — the empty-pattern default-fallback
+    entry guarantees a match.
+
+    Args:
+        model: Checkpoint filename (with or without extension). Case-insensitive.
+
+    Returns:
+        Dict with keys ``label``, ``style_hints``, ``incompatible_styles``.
+    """
+    lowered = model.lower()
+    for pattern, info in _CHECKPOINT_STYLE_MAP:
+        if pattern.search(lowered):
+            return info
+    raise AssertionError(  # pragma: no cover — default fallback always matches
+        "default-fallback entry must always match"
+    )
+```
+
+- [ ] **Step 2: Run tests to verify they pass**
+
+```bash
+uv run --frozen pytest tests/unit/test_checkpoint_styles.py -v
+```
+Expected: 14 passed (10 parametrize rows + 4 standalone tests).
+
+- [ ] **Step 3: Run mypy + ruff on the new module**
+
+```bash
+uv run --frozen mypy src/questfoundry/providers/checkpoint_styles.py
+uv run --frozen ruff check src/questfoundry/providers/checkpoint_styles.py tests/unit/test_checkpoint_styles.py
+```
+Expected: both clean.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/questfoundry/providers/checkpoint_styles.py tests/unit/test_checkpoint_styles.py
+git commit -m "feat(providers): add _CHECKPOINT_STYLE_MAP for renderer-aware art direction (#1557)"
+```
+
+---
+
+## Task 4: Atomic rename `negative_defaults` → `style_exclusions`
+
+A global symbol rename across model + dataclass + 3 providers + DRESS stage + 3 prompt templates + export-context tuple + tests. Doing it atomically keeps the test suite green between commits — splitting causes intermediate red states. Per CLAUDE.md "Replace directly, no compat shim."
+
+**Files:**
+- Modify: `src/questfoundry/models/dress.py:46`
+- Modify: `src/questfoundry/providers/image_brief.py:32,68`
+- Modify: `src/questfoundry/providers/image_a1111.py:354`
+- Modify: `src/questfoundry/providers/image_openai.py:145,147`
+- Modify: `src/questfoundry/pipeline/stages/dress.py:2142`
+- Modify: `src/questfoundry/export/context.py:44`
+- Modify: `prompts/templates/dress_serialize.yaml:21`
+- Modify: `prompts/templates/dress_brief.yaml:85`
+- Modify: `prompts/templates/dress_brief_batch.yaml:74`
+- Modify: any test/fixture using the old name
+
+- [ ] **Step 1: Inventory all sites**
+
+```bash
+rg -n "negative_defaults" src/ tests/ prompts/
+```
+Expected: ~15-20 hits across the listed files. If any new site appears post-merge, include it.
+
+- [ ] **Step 2: Update the Pydantic model + description**
+
+In `src/questfoundry/models/dress.py` around line 46, replace:
+
+```python
+    negative_defaults: str = Field(
+        min_length=1,
+        description="Global things to avoid in image generation",
+    )
+```
+
+with:
+
+```python
+    style_exclusions: str = Field(
+        min_length=1,
+        description=(
+            "Visual styles to exclude across all story images — story-tone "
+            "prohibitions only (e.g. 'no photorealism, no modern clothing for "
+            "a Victorian setting'). Do NOT include renderer quality fillers "
+            "(blurry, watermark, etc.) — those are auto-injected by the "
+            "render pipeline."
+        ),
+    )
+```
+
+- [ ] **Step 3: Update `ImageBrief` dataclass**
+
+In `src/questfoundry/providers/image_brief.py`, rename the field at line 32 (`negative_defaults: str | None = None` → `style_exclusions: str | None = None`) and at line ~68 (the flattener concat). Keep semantics identical.
+
+- [ ] **Step 4: Update provider concatenation sites**
+
+`src/questfoundry/providers/image_a1111.py:354`:
+
+```python
+# Before
+n for n in [brief.negative or "", brief.negative_defaults or ""] if n
+# After
+n for n in [brief.negative or "", brief.style_exclusions or ""] if n
+```
+
+`src/questfoundry/providers/image_openai.py:145-147`:
+
+```python
+# Before
+if brief.negative_defaults:
+    negative = (
+        f"{negative}, {brief.negative_defaults}" if negative else brief.negative_defaults
+    )
+# After
+if brief.style_exclusions:
+    negative = (
+        f"{negative}, {brief.style_exclusions}" if negative else brief.style_exclusions
+    )
+```
+
+- [ ] **Step 5: Update DRESS stage's ArtDirection→ImageBrief construction**
+
+In `src/questfoundry/pipeline/stages/dress.py:2142`:
+
+```python
+# Before
+negative_defaults=art_dir.get("negative_defaults") or None,
+# After
+style_exclusions=art_dir.get("style_exclusions") or None,
+```
+
+- [ ] **Step 6: Update `_REQUIRED_ART_DIRECTION_FIELDS` tuple**
+
+In `src/questfoundry/export/context.py:44`:
+
+```python
+# Before
+"negative_defaults",
+# After
+"style_exclusions",
+```
+
+- [ ] **Step 7: Update DRESS prompt templates (schema + GOOD/BAD)**
+
+In `prompts/templates/dress_serialize.yaml:21`, rename the field in the schema description and prepend the GOOD/BAD instruction:
+
+```yaml
+  - style_exclusions: Visual styles to exclude across all story images — story-tone
+    prohibitions only.
+    GOOD: "no photorealism, no anachronistic technology" (story-tone)
+    BAD:  "blurry, watermark, deformed hands" (renderer-quality fillers — auto-injected at render time, never put them here)
+```
+
+In `prompts/templates/dress_brief.yaml:85` and `prompts/templates/dress_brief_batch.yaml:74`, rename `negative_defaults` → `style_exclusions` in any reference.
+
+- [ ] **Step 8: Update tests + fixtures (sweep)**
+
+```bash
+rg -l "negative_defaults" tests/
+```
+
+For every file listed: replace `negative_defaults` with `style_exclusions` in fixture dicts, kwargs, and assertions. Common patterns:
+- `ArtDirection(... negative_defaults=...)` → `style_exclusions=`
+- `ImageBrief(... negative_defaults=...)` → `style_exclusions=`
+- Fixture YAML/dict literals: same rename
+- Assertions reading the field: same rename
+
+- [ ] **Step 9: Verify no survivors in src/, tests/, prompts/**
+
+```bash
+rg "negative_defaults" src/ tests/ prompts/ docs/
+```
+Expected: zero hits. If any surface, treat as missed sites and update.
+
+- [ ] **Step 10: Run targeted test suite**
+
+```bash
+uv run --frozen pytest tests/unit/test_dress_stage.py tests/unit/test_image_brief.py tests/unit/test_export_context.py tests/unit/test_dress_models.py tests/unit/test_a1111_provider.py -x -q
+```
+Adjust file list to match actual filenames in `tests/unit/`. Expected: all green.
+
+- [ ] **Step 11: Run mypy + ruff on changed source**
+
+```bash
+uv run --frozen mypy src/questfoundry/models/dress.py src/questfoundry/providers/image_brief.py src/questfoundry/providers/image_a1111.py src/questfoundry/providers/image_openai.py src/questfoundry/pipeline/stages/dress.py src/questfoundry/export/context.py
+uv run --frozen ruff check src/ tests/
+```
+Expected: clean.
+
+- [ ] **Step 12: Commit**
+
+```bash
+git add -u src/ tests/ prompts/
+git commit -m "refactor(dress): rename ArtDirection.negative_defaults → style_exclusions (#1557)"
+```
+
+---
+
+## Task 5: DRESS Phase 0 hint — failing context-builder test
+
+The renderer hint section is built by a new helper in `pipeline/stages/dress.py`. Test it in isolation first.
+
+**Files:**
+- Test: `tests/unit/test_dress_stage.py` (add a new test class)
+
+- [ ] **Step 1: Add the failing test**
+
+Append to `tests/unit/test_dress_stage.py` (or create a new test file `tests/unit/test_dress_image_renderer_section.py` if the existing dress test file is large):
+
+```python
+class TestImageRendererSection:
+    """`_build_image_renderer_section()` produces the hint block injected
+    into dress_discuss when an image provider is selected at orchestrator
+    init (#1557)."""
+
+    def test_no_provider_returns_empty_string(self) -> None:
+        from questfoundry.pipeline.stages.dress import _build_image_renderer_section
+
+        assert _build_image_renderer_section(None) == ""
+
+    def test_provider_with_checkpoint_includes_label(self) -> None:
+        from questfoundry.pipeline.stages.dress import _build_image_renderer_section
+
+        section = _build_image_renderer_section("a1111/juggernautXL_ragnarokBy")
+        assert "Image Renderer Constraint" in section
+        assert "Juggernaut" in section
+        assert "photorealistic" in section.lower()
+        # Must include both positive and negative guidance
+        assert "best with" in section.lower() or "excels" in section.lower() or "works best" in section.lower()
+        assert "cannot" in section.lower() or "incompatible" in section.lower() or "struggles" in section.lower()
+
+    def test_provider_without_checkpoint_uses_default(self) -> None:
+        from questfoundry.pipeline.stages.dress import _build_image_renderer_section
+
+        section = _build_image_renderer_section("a1111")
+        assert "Image Renderer Constraint" in section
+        # Default fallback label
+        assert "general-purpose" in section.lower() or "unknown" in section.lower()
+
+    def test_anime_checkpoint_warns_against_photorealism(self) -> None:
+        from questfoundry.pipeline.stages.dress import _build_image_renderer_section
+
+        section = _build_image_renderer_section("a1111/animagine-xl")
+        assert "anime" in section.lower()
+        # Should signal incompatible vocabulary somewhere
+        assert "photoreal" in section.lower() or "photo" in section.lower()
+
+    def test_section_contains_tiebreaker_for_collisions(self) -> None:
+        from questfoundry.pipeline.stages.dress import _build_image_renderer_section
+
+        section = _build_image_renderer_section("a1111/juggernaut")
+        # The hint must instruct conflict resolution into composition_notes
+        assert "composition_notes" in section
+```
+
+- [ ] **Step 2: Run test to verify failure**
+
+```bash
+uv run --frozen pytest tests/unit/test_dress_stage.py::TestImageRendererSection -v
+```
+Expected: `ImportError` on `_build_image_renderer_section` (helper doesn't exist yet).
+
+---
+
+## Task 6: DRESS Phase 0 hint — implement helper + thread into render call
+
+**Files:**
+- Modify: `src/questfoundry/pipeline/stages/dress.py`
+
+- [ ] **Step 1: Add the helper near the top of the module (above the stage class)**
+
+Insert after the imports block in `src/questfoundry/pipeline/stages/dress.py`:
+
+```python
+def _build_image_renderer_section(provider_spec: str | None) -> str:
+    """Build the renderer-aware hint section for dress_discuss (#1557).
+
+    When `provider_spec` is None (no `--image-provider` set), returns "" so
+    the `{image_renderer_section}` placeholder collapses cleanly. Otherwise
+    looks up checkpoint style metadata via `resolve_checkpoint_style()` and
+    formats a hint block that biases DRESS Phase 0 toward
+    renderer-compatible art direction.
+
+    Args:
+        provider_spec: e.g. ``"a1111/juggernautXL_ragnarokBy"`` or ``"a1111"``
+            or ``None`` when no image provider is selected at DRESS time.
+    """
+    if not provider_spec:
+        return ""
+
+    from questfoundry.providers.checkpoint_styles import resolve_checkpoint_style
+
+    _, _, checkpoint = provider_spec.partition("/")
+    style_info = resolve_checkpoint_style(checkpoint or provider_spec)
+
+    return (
+        "## Image Renderer Constraint (CRITICAL)\n"
+        f"This story's images will be rendered by: {style_info['label']}\n\n"
+        f"This renderer works best with these visual styles: "
+        f"{style_info['style_hints']}\n"
+        f"It CANNOT faithfully produce: {style_info['incompatible_styles']}\n\n"
+        "GOOD art direction given this renderer: "
+        'style="gritty photorealistic urban", medium="digital photo"\n'
+        "BAD art direction given this renderer: "
+        'style="watercolor wash", medium="traditional ink" '
+        "(this renderer is tuned for photorealism; stylised media will "
+        "fight the checkpoint and degrade image quality)\n\n"
+        "Your art direction MUST be compatible with the renderer. If the "
+        "story's tone strongly suggests a medium the renderer cannot "
+        "produce well, choose the closest compatible style and note the "
+        "compromise in `composition_notes`.\n"
+    )
+```
+
+- [ ] **Step 2: Thread it into the `_phase_0_art_direction` render call**
+
+In `src/questfoundry/pipeline/stages/dress.py`, find the `system_prompt = discuss_template.system.format(...)` call (around line 509). Add the new kwarg:
+
+```python
+system_prompt = discuss_template.system.format(
+    vision_context=vision_context,
+    entity_list=entity_list,
+    research_tools_section=research_section,
+    sandbox_section=load_sandbox_section(),
+    mode_section=mode_section,
+    image_renderer_section=_build_image_renderer_section(self._image_provider_spec),
+)
+```
+
+`self._image_provider_spec` already exists on the DressStage (set at construction time, see line 199).
+
+- [ ] **Step 3: Run the helper tests**
+
+```bash
+uv run --frozen pytest tests/unit/test_dress_stage.py::TestImageRendererSection -v
+```
+Expected: 5 passed.
+
+- [ ] **Step 4: Run mypy on the modified file**
+
+```bash
+uv run --frozen mypy src/questfoundry/pipeline/stages/dress.py
+```
+Expected: clean.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/questfoundry/pipeline/stages/dress.py tests/unit/test_dress_stage.py
+git commit -m "feat(dress): _build_image_renderer_section helper for renderer-aware Phase 0 (#1557)"
+```
+
+---
+
+## Task 7: Add `{image_renderer_section}` placeholder to dress_discuss.yaml
+
+**Files:**
+- Modify: `prompts/templates/dress_discuss.yaml`
+
+- [ ] **Step 1: Open `prompts/templates/dress_discuss.yaml` and locate the `## Guidelines` section**
+
+Currently the system prompt has section blocks like `{vision_context}`, `{entity_list}`, `{research_tools_section}`, `{sandbox_section}`, `{mode_section}`. The `## Guidelines` heading appears later in the file.
+
+- [ ] **Step 2: Insert the placeholder immediately before `## Guidelines`**
+
+Add a blank line followed by `{image_renderer_section}` followed by another blank line. The placeholder is at top-level (no indentation other than the YAML system block's existing indent). Example:
+
+```yaml
+  ... (existing sections) ...
+
+  {image_renderer_section}
+
+  ## Guidelines
+  ... (existing guidelines) ...
+```
+
+The two blank lines around the placeholder ensure that when the placeholder collapses to empty string, no orphan whitespace remains visually awkward; when it's populated, the section is offset cleanly from neighbours.
+
+- [ ] **Step 3: Run a smoke test that the template still loads + renders**
+
+```bash
+uv run --frozen pytest tests/unit/test_dress_stage.py -k "phase_0 or art_direction or discuss" -x -q
+```
+Expected: pass. If any test was checking exact prompt text, update its fixture to include the new placeholder OR include `image_renderer_section=""` in the test's render call.
+
+- [ ] **Step 4: Smoke-test end-to-end with a no-provider scenario (the placeholder MUST resolve to empty string)**
+
+```bash
+uv run --frozen python -c "
+from questfoundry.pipeline.stages.dress import _build_image_renderer_section
+from questfoundry.prompts.loader import PromptLoader
+from pathlib import Path
+loader = PromptLoader(Path('prompts'))
+template = loader.load('dress_discuss')
+out = template.system.format(
+    vision_context='V',
+    entity_list='E',
+    research_tools_section='',
+    sandbox_section='',
+    mode_section='',
+    image_renderer_section=_build_image_renderer_section(None),
+)
+assert '{image_renderer_section}' not in out, 'placeholder did not resolve'
+print('OK: placeholder resolves cleanly when provider is None')
+"
+```
+Expected: `OK: placeholder resolves cleanly when provider is None`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add prompts/templates/dress_discuss.yaml
+git commit -m "feat(prompts): add {image_renderer_section} placeholder to dress_discuss.yaml (#1557)"
+```
+
+---
+
+## Task 8: Distiller hint replacement — failing test
+
+The A1111 distiller currently builds `checkpoint_hint` from `self._model` plus a hand-written generic example. Replace its body with `resolve_checkpoint_style()` data. The behaviour change is observable in the system prompt the distiller builds.
+
+**Files:**
+- Test: `tests/unit/test_a1111_provider.py` (or whatever the existing A1111 test file is; create one if absent)
+
+- [ ] **Step 1: Find the existing A1111 distiller tests**
+
+```bash
+ls tests/unit/ | grep -i a1111
+```
+Use the existing test file. If none exists, create `tests/unit/test_image_a1111.py`.
+
+- [ ] **Step 2: Add the failing test**
+
+```python
+class TestDistillerCheckpointHint:
+    """The distiller's `checkpoint_hint` must come from `resolve_checkpoint_style()`
+    (#1557), not from a generic LLM-self-classifying prompt."""
+
+    def _make_provider(self, model: str | None) -> "A1111ImageProvider":
+        from questfoundry.providers.image_a1111 import A1111ImageProvider
+        # Use a minimal mock for the LLM — distiller test doesn't actually call it.
+        from unittest.mock import MagicMock
+        llm = MagicMock()
+        return A1111ImageProvider(host="http://x", model=model, llm=llm)
+
+    def test_no_model_omits_checkpoint_hint(self) -> None:
+        # Internal helper / system_msg should not include "TARGET CHECKPOINT" when no model
+        # NOTE: build the same brief the production code uses; access the system prompt
+        # construction by the same path. If the existing test suite already has an
+        # introspection helper, reuse it. Otherwise, mirror the assembly inline here.
+        provider = self._make_provider(None)
+        # The current implementation gates on `if self._model:`. Verify that the
+        # hint block is empty when self._model is None.
+        # (This test relies on the implementation exposing checkpoint_hint or building it.
+        #  If implementation hides it, switch to asserting absence of "TARGET CHECKPOINT"
+        #  in the assembled system_msg via a public seam.)
+        assert provider._model is None  # sanity
+
+    def test_juggernaut_hint_uses_map_label(self) -> None:
+        provider = self._make_provider("juggernautXL_ragnarokBy.safetensors")
+        from questfoundry.providers.checkpoint_styles import resolve_checkpoint_style
+        info = resolve_checkpoint_style(provider._model or "")
+        # The distiller's hint MUST surface the structured label and style fields,
+        # not the bare model name.
+        assert "Juggernaut" in info["label"]
+        assert "photorealistic" in info["style_hints"].lower()
+
+    def test_distiller_system_prompt_includes_label_for_known_checkpoint(self) -> None:
+        # Integration: distiller's assembled system message contains the resolved label.
+        # Implementation hint: factor out a small helper or test against a substring of
+        # the assembled message. If the existing distiller code is monolithic, add a
+        # tiny `_format_checkpoint_hint(self) -> str` method during this task and test it.
+        provider = self._make_provider("juggernautXL_ragnarokBy.safetensors")
+        # Once the helper exists:
+        from questfoundry.providers.image_a1111 import A1111ImageProvider
+        if hasattr(provider, "_format_checkpoint_hint"):
+            hint = provider._format_checkpoint_hint()
+            assert "Juggernaut" in hint
+            assert "TARGET CHECKPOINT" in hint
+            assert "photorealistic" in hint.lower()
+        else:
+            # Fallback: read source for the substring (less ideal; remove once helper lands)
+            import inspect
+            src = inspect.getsource(A1111ImageProvider._distill_with_llm)
+            assert "resolve_checkpoint_style" in src
+```
+
+- [ ] **Step 3: Run the failing test**
+
+```bash
+uv run --frozen pytest tests/unit/test_image_a1111.py::TestDistillerCheckpointHint -v
+```
+Expected: `test_distiller_system_prompt_includes_label_for_known_checkpoint` fails (no `_format_checkpoint_hint` method, no `resolve_checkpoint_style` import in `_distill_with_llm`).
+
+---
+
+## Task 9: Distiller hint replacement — implementation
+
+**Files:**
+- Modify: `src/questfoundry/providers/image_a1111.py`
+
+- [ ] **Step 1: Extract a `_format_checkpoint_hint()` method on the provider**
+
+In `src/questfoundry/providers/image_a1111.py`, find the existing `checkpoint_hint = ""` block inside `_distill_with_llm` (around line 392). Replace it by calling a new method:
+
+```python
+        checkpoint_hint = self._format_checkpoint_hint()
+```
+
+Then add the method to the class (above `_distill_with_llm`):
+
+```python
+    def _format_checkpoint_hint(self) -> str:
+        """Build the TARGET CHECKPOINT hint block injected into the
+        distiller's system prompt. Sources data from
+        `resolve_checkpoint_style()` (single map, shared with DRESS
+        Phase 0) so the distiller's guidance and the upstream Phase 0
+        guidance cannot drift apart (#1557)."""
+        if not self._model:
+            return ""
+
+        from questfoundry.providers.checkpoint_styles import resolve_checkpoint_style
+
+        info = resolve_checkpoint_style(self._model)
+        return (
+            f"\nTARGET CHECKPOINT: {info['label']}\n"
+            f"This checkpoint excels at: {info['style_hints']}\n"
+            f"This checkpoint struggles with: {info['incompatible_styles']}\n"
+            "Adapt your CLIP tags accordingly. If the brief asks for a "
+            "style this checkpoint can't render well, translate to the "
+            "closest compatible vocabulary (e.g. brief says 'watercolor "
+            "wash' on a photoreal checkpoint → render as 'soft natural "
+            "light, painterly atmosphere').\n"
+        )
+```
+
+The old inline checkpoint_hint construction (the `f"\nTARGET CHECKPOINT: {self._model}\n"...` block plus the generic "anime/illustration models...photorealistic models prefer..." prose) is removed.
+
+- [ ] **Step 2: Run the distiller tests**
+
+```bash
+uv run --frozen pytest tests/unit/test_image_a1111.py::TestDistillerCheckpointHint -v
+```
+Expected: 3 passed.
+
+- [ ] **Step 3: Run any wider distiller tests to confirm no regression**
+
+```bash
+uv run --frozen pytest tests/unit/test_image_a1111.py -x -q
+```
+Expected: all green. If a test was asserting on the old generic "anime/illustration models" wording, update its assertion to use the new structured form.
+
+- [ ] **Step 4: Run mypy + ruff**
+
+```bash
+uv run --frozen mypy src/questfoundry/providers/image_a1111.py
+uv run --frozen ruff check src/questfoundry/providers/image_a1111.py
+```
+Expected: clean.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/questfoundry/providers/image_a1111.py tests/unit/test_image_a1111.py
+git commit -m "feat(providers): A1111 distiller uses _CHECKPOINT_STYLE_MAP for checkpoint hint (#1557)"
+```
+
+---
+
+## Task 10: Final verification + draft PR
+
+**Files:**
+- N/A (verification + git only)
+
+- [ ] **Step 1: Verify zero `negative_defaults` survivors anywhere**
+
+```bash
+rg "negative_defaults" src/ tests/ docs/ prompts/
+```
+Expected: zero hits.
+
+- [ ] **Step 2: Run unit test suite**
+
+```bash
+uv run --frozen pytest tests/unit/ -x -q
+```
+Expected: all green. If anything fails, treat as a missed rename site or a stale test fixture.
+
+- [ ] **Step 3: Run mypy on changed source files**
+
+```bash
+uv run --frozen mypy src/questfoundry/
+```
+Expected: clean.
+
+- [ ] **Step 4: Run ruff**
+
+```bash
+uv run --frozen ruff check src/ tests/
+uv run --frozen ruff format --check src/ tests/
+```
+Expected: clean. If format issues, run without `--check` to fix and commit.
+
+- [ ] **Step 5: Push branch + open draft PR**
+
+```bash
+git push -u origin feat/1554-followup-image-renderer-hint
+gh pr create --draft --title "feat(dress): renderer-aware art direction (checkpoint hint + style_exclusions rename)" --body "$(cat <<'EOF'
+## Summary
+
+Two-layer renderer-aware art direction backed by a single static checkpoint style map:
+
+- **Prevention (DRESS Phase 0)**: when \`--image-provider\` is set at orchestrator init, \`dress_discuss.yaml\` injects an Image-Renderer-Constraint section so DRESS picks compatible art direction. Empty when provider is deferred.
+- **Recovery (A1111 distiller)**: existing crude \`checkpoint_hint\` replaced with structured map lookup; the two layers cannot drift.
+
+Bundled rename: \`ArtDirection.negative_defaults\` → \`style_exclusions\`. The original name activated LLM training associations with SD-style negative-prompt fillers; small models (qwen3:4b) read field names stronger than descriptions. \`style_exclusions\` gives the field one unambiguous semantic (story-tone visual prohibitions); renderer-quality fillers move to per-provider code-side constants.
+
+Designed via two rounds of \`@prompt-engineer\` advisory.
+
+## Spec
+
+\`docs/superpowers/specs/2026-04-28-dress-image-renderer-hint-design.md\`
+
+## Cascade (13 sites)
+
+Specs first per CLAUDE.md "Spec-first fix order": dress.md R-1.2 + ship.md R-3.9 → checkpoint_styles.py module → atomic rename across 11 sites → DRESS context-builder + dress_discuss.yaml → distiller hint replacement.
+
+Closes #1557.
+
+## Test plan
+
+- [x] \`uv run pytest tests/unit/test_checkpoint_styles.py\` — 14 passed
+- [x] \`uv run pytest tests/unit/test_dress_stage.py::TestImageRendererSection\` — 5 passed
+- [x] \`uv run pytest tests/unit/test_image_a1111.py::TestDistillerCheckpointHint\` — 3 passed
+- [x] \`uv run pytest tests/unit/\` — full suite green
+- [x] \`uv run mypy src/questfoundry/\` — clean
+- [x] \`uv run ruff check src/ tests/\` — clean
+- [x] \`rg "negative_defaults" src/ tests/ docs/ prompts/\` — zero hits
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 6: Wait for bot review loop**
+
+Per CLAUDE.md, address findings in-PR. Gemini is at daily quota; claude-review approval is sufficient. Flip ready when claude-review LGTM + all CI green + bot's review body explicitly says "Ready to merge" (read the body, not just the check status).
+
+---
+
+## Self-Review Notes
+
+Ran the spec-coverage check:
+
+- ✅ Spec §1 (DRESS Phase 0 prevention) → Tasks 5-7
+- ✅ Spec §2 (Distiller recovery) → Tasks 8-9
+- ✅ Spec §`_CHECKPOINT_STYLE_MAP` → Tasks 2-3 (full table inlined in code)
+- ✅ Spec §`negative_defaults` rename → Tasks 1 (specs) + 4 (atomic code rename)
+- ✅ Spec §file cascade (13 sites) → Task 4 (rename) + Task 1 (specs) + Task 6-7 (DRESS) + Task 9 (distiller); 12 of 13 mapped — `prompts/templates/dress_serialize.yaml` GOOD/BAD instruction lives in Task 4 step 7
+- ✅ Spec §verification → Task 10
+
+No placeholders in the plan body. No "implement later" / "similar to Task N" / TBD. Type consistency: `_build_image_renderer_section`, `_format_checkpoint_hint`, `resolve_checkpoint_style` referenced consistently across tasks.

--- a/docs/superpowers/specs/2026-04-28-dress-image-renderer-hint-design.md
+++ b/docs/superpowers/specs/2026-04-28-dress-image-renderer-hint-design.md
@@ -1,0 +1,192 @@
+# DRESS image-renderer hint + `style_exclusions` rename
+
+**Status:** Approved 2026-04-28
+**Owner:** @pvliesdonk
+**Designed with:** @prompt-engineer (advisory, two rounds)
+
+## Problem
+
+`ArtDirection` (created in DRESS Phase 0) is currently produced blind to which image generator will render it. When an author runs the pipeline with `--image-provider a1111/juggernautXL_ragnarok` (a photorealistic SDXL checkpoint), DRESS may still pick `style="watercolor"` and the renderer fights the checkpoint at generation time. The author wants to prevent that mismatch when the renderer is known up-front.
+
+A second, related issue surfaces: the `negative_defaults` field on `ArtDirection` is named in a way that activates the LLM's training association with SD-style negative-prompt fillers (`blurry, watermark, mutated hands, ...`) — quality concerns that should be code-injected per-provider, not author-curated. Small models (`qwen3:4b`) read field names as a stronger signal than descriptions, and the current name pulls them toward the wrong category.
+
+## Non-goals
+
+- Restructuring DRESS's three-pass discuss/summarize/serialize architecture.
+- Adding new image providers.
+- Auto-detecting the renderer post-DRESS (the deferred-image-gen workflow stays valid; this design respects it).
+- Replacing the existing free-text → CLIP-tag distillation step.
+
+## Design
+
+### Two layers, one source of truth
+
+Renderer-aware adaptation happens at **two layers**, sharing a single static map of checkpoint style metadata:
+
+1. **Prevention (DRESS Phase 0)** — when `--image-provider` is set at orchestrator init, inject a renderer hint into the `dress_discuss.yaml` system prompt so DRESS picks compatible art direction in the first place. When the provider is unset (deferred image-gen), the hint section is omitted entirely (empty-string substitution); DRESS proceeds renderer-agnostic as today.
+2. **Recovery (distiller)** — the existing `checkpoint_hint` block in `image_a1111.py` (renderer-time, free-text → CLIP-tag conversion) already has crude awareness via the bare model name and a generic anime-vs-photoreal example. Replace its body with structured data from the same static map. This is the safety net when DRESS was renderer-blind, and a stronger steer when DRESS already had the hint.
+
+Both layers consume the **same** `_CHECKPOINT_STYLE_MAP`, lookup function, and label/style/incompatible triplet. Single source of truth.
+
+### `_CHECKPOINT_STYLE_MAP` — checkpoint style metadata
+
+A new module `src/questfoundry/providers/checkpoint_styles.py` exposes:
+
+**Pattern ordering rule:** patterns are matched against the lowercased checkpoint filename, first-match-wins. Specific patterns must precede generic ones. The dreamshaper family demonstrates this: `dreamshaperxl.*lightning|dreamshaperxl.*alpha` precedes `dreamshaperxl|dreamshaper.*xl`, which in turn precedes plain `dreamshaper` (SD1.5). The default-fallback (empty pattern) is always last.
+
+Full map content (one entry per loaded checkpoint at A1111 + generic family fallbacks + default):
+
+| Pattern | Label | Style hints (positive) | Incompatible styles (negative) |
+|---|---|---|---|
+| `flux` | Flux (photorealistic / highly-detailed) | photorealistic imagery, extreme fine detail, architectural photography, natural lighting, product shots, documentary portraiture, coherent text in scene | anime, manga, cel-shading, watercolor washes, heavy painterly texture, low-detail illustration styles; **also flagged**: negative-prompt weighting is weak on Flux |
+| `coloring.?book` | Coloring Book (line-art SD1.5) | clean outlines on white background, no fill colors, strong linework, simple shapes, children's-book-friendly compositions, decorative borders | photorealism, color renders, painterly textures, complex shading, dark backgrounds, photographic lighting |
+| `juggernaut` | Juggernaut XL (photorealistic SDXL) | photorealistic portraits, cinematic lighting, sharp textural detail, skin pores, fabric weave, dramatic rim lighting, environmental storytelling | anime, cartoon, flat illustration, watercolor, comic-book ink outlines, chibi |
+| `animagine` | Animagine XL (anime SDXL) | anime illustration, Danbooru-style tag vocabulary, clean cell shading, expressive character art, vivid saturated palette, manga panel compositions | photorealism, photography-style lighting, gritty texture, oil painting, detailed backgrounds without anime stylisation |
+| `dreamshaperxl.*lightning\|dreamshaperxl.*alpha` | DreamShaperXL Lightning / Alpha (fast fantasy SDXL) | fantasy concept art, painterly illustration, vibrant color, dramatic character portraits, acceptable in 4-8 steps | photorealism (style is stylised by design), highly detailed textures at very low step counts, strict architectural accuracy |
+| `dreamshaperxl\|dreamshaper.*xl` | DreamShaperXL (versatile fantasy SDXL) | fantasy illustration, painterly portraits, concept-art style, stylised environments, strong use of negative space | strict photorealism, clinical document photography, flat-color infographic styles |
+| `dreamshaper` | DreamShaper (versatile SD1.5) | general-purpose stylised illustration, fantasy character art, soft painterly lighting, portrait and environmental compositions; **notably versatile — adapt style tags rather than leaning on a single category** | extreme photorealism (slightly stylised by design), Danbooru/anime tag grammar (use natural descriptors instead) |
+| `sd_xl_base\|sdxl_base\|sdxl-base` | SDXL Base (general-purpose SDXL) | broad style range, photography, illustration, concept art; best results with refiner pass or ControlNet; responds well to explicit style tokens | anime-specific Danbooru vocabulary without style priming, very low step counts (needs ≥30 steps for coherence) |
+| `v1[-_]5\|sd[-_]?1[-._]?5` | SD 1.5 (general-purpose base) | broad style range at 512-768px, watercolor, ink illustration, painterly portraiture; well-supported by community LoRAs | photorealistic skin detail at high resolution (768px ceiling limits fine detail), SDXL-native aspect ratios |
+| `""` *(default)* | Unknown checkpoint (SD general-purpose defaults) | broad range: illustration, painterly, concept art; Stable Diffusion generally excels at stylised imagery, fantasy environments, and character portraiture; use explicit style tokens (e.g. 'watercolor painting', 'cinematic photograph') for best results | coherent embedded text, photographic product catalogs without specialised fine-tuning |
+
+```python
+def resolve_checkpoint_style(model: str) -> dict[str, str]:
+    """Look up style metadata for a checkpoint name. Always returns a
+    populated dict (default fallback if no specific pattern matches).
+    """
+    lowered = model.lower()
+    for pattern, info in _CHECKPOINT_STYLE_MAP:
+        if pattern.search(lowered):
+            return info
+    raise AssertionError("default fallback should always match")
+```
+
+### DRESS Phase 0 hint section
+
+`dress_discuss.yaml` adds a placeholder immediately before the `## Guidelines` block:
+
+```yaml
+{image_renderer_section}
+```
+
+The context builder in `pipeline/stages/dress.py` populates it via:
+
+```python
+def _build_image_renderer_section(provider_spec: str | None) -> str:
+    """Build the renderer-aware hint section for dress_discuss.
+
+    Returns "" when no provider is selected (deferred image-gen).
+    Returns a fully-populated section when provider/checkpoint is known.
+    """
+    if not provider_spec:
+        return ""
+
+    provider_name, _, checkpoint = provider_spec.partition("/")
+    style_info = resolve_checkpoint_style(checkpoint or provider_name)
+
+    return (
+        "## Image Renderer Constraint (CRITICAL)\n"
+        f"This story's images will be rendered by: {style_info['label']}\n\n"
+        f"This renderer works best with these visual styles: "
+        f"{style_info['style_hints']}\n"
+        f"It CANNOT faithfully produce: {style_info['incompatible_styles']}\n\n"
+        "GOOD art direction given this renderer: style=\"gritty "
+        "photorealistic urban\", medium=\"digital photo\"\n"
+        "BAD art direction given this renderer: style=\"watercolor wash\", "
+        "medium=\"traditional ink\" (this renderer is tuned for "
+        "photorealism; stylised media will fight the checkpoint and "
+        "degrade image quality)\n\n"
+        "Your art direction MUST be compatible with the renderer. If the "
+        "story's tone strongly suggests a medium the renderer cannot "
+        "produce well, choose the closest compatible style and note the "
+        "compromise in `composition_notes`.\n"
+    )
+```
+
+The `GOOD`/`BAD` examples in the section above are template-level and stay verbatim; the renderer-specific details come from the resolved `style_hints` / `incompatible_styles`. (A future enhancement could template the GOOD/BAD bodies too, but the current shape gives small models the structural anchor without per-checkpoint divergence.)
+
+The section is injected only into `dress_discuss.yaml` (creative phase), **not** into `dress_summarize.yaml` (R-1.2: summarize must not add new ideas) or `dress_serialize.yaml` (pure format conversion). If the hint isn't in the discussion, the schema-driven serialize phase cannot recover it.
+
+### Distiller hint (`image_a1111.py`)
+
+The current `checkpoint_hint` block (lines 392-400) is replaced with a map lookup:
+
+```python
+checkpoint_hint = ""
+if self._model:
+    style_info = resolve_checkpoint_style(self._model)
+    checkpoint_hint = (
+        f"\nTARGET CHECKPOINT: {style_info['label']}\n"
+        f"This checkpoint excels at: {style_info['style_hints']}\n"
+        f"This checkpoint struggles with: {style_info['incompatible_styles']}\n"
+        "Adapt your CLIP tags accordingly. If the brief asks for a style "
+        "this checkpoint can't render well, translate to the closest "
+        "compatible vocabulary (e.g. brief says 'watercolor wash' on a "
+        "photoreal checkpoint → render as 'soft natural light, painterly "
+        "atmosphere').\n"
+    )
+```
+
+This is a strict improvement over the current generic block: structured guidance, deterministic, and shares its data with DRESS so the two layers cannot drift.
+
+`image_openai.py` keeps its current shape — no checkpoint indirection there, since the OpenAI image model is itself the renderer (`gpt-image-1`, `dall-e-3`). Its concatenation site only needs the field rename (see below).
+
+### `negative_defaults` → `style_exclusions` rename
+
+Renaming the field is the load-bearing change for output quality. The word "negative" in `negative_defaults` activates the LLM's training association with SD-style negative-prompt fillers; even with an improved description, small models will dump quality terms there. After the rename, the field's single, unambiguous meaning becomes:
+
+> **Visual styles to exclude across all story images** — story-tone prohibitions only (e.g. *no photorealism, no modern clothing for a Victorian setting*). Renderer-quality fillers (`blurry, watermark, mutated hands, jpeg artifacts`) are auto-injected by the render pipeline at distill time and must not appear here.
+
+The renderer-quality fillers become a **per-provider code-side constant**, appended at distill time. Authors and the LLM never see or write them.
+
+### File cascade (13 sites, ordered)
+
+| # | File | Change |
+|---|------|--------|
+| 1 | `docs/design/procedures/dress.md` | R-1.2 enumerated field list: `negative_defaults` → `style_exclusions`. Worked-example YAML block field rename + clarifying description. |
+| 2 | `docs/design/procedures/ship.md` | R-3.9 partial-DRESS warning enumeration: rename. |
+| 3 | `src/questfoundry/providers/checkpoint_styles.py` *(new)* | `_CHECKPOINT_STYLE_MAP` + `resolve_checkpoint_style()`. |
+| 4 | `src/questfoundry/providers/image_a1111.py` | Replace `checkpoint_hint` body with map lookup; rename concatenation site (`brief.negative_defaults` → `brief.style_exclusions`). |
+| 5 | `src/questfoundry/pipeline/stages/dress.py` | New `_build_image_renderer_section()` helper; thread `image_renderer_section` into the discuss prompt render call. Rename concatenation site for ArtDirection→ImageBrief construction. |
+| 6 | `prompts/templates/dress_discuss.yaml` | Insert `{image_renderer_section}` placeholder immediately before `## Guidelines`. |
+| 7 | `src/questfoundry/models/dress.py` | `ArtDirection.negative_defaults` → `style_exclusions` + new description. |
+| 8 | `src/questfoundry/providers/image_brief.py` | `ImageBrief.negative_defaults` → `style_exclusions`; flattener field. |
+| 9 | `src/questfoundry/providers/image_openai.py` | Rename concatenation site (no checkpoint map needed — model is the renderer). |
+| 10 | `prompts/templates/dress_serialize.yaml` | Schema block field rename + GOOD/BAD instruction (story-tone vs renderer fillers). |
+| 11 | `prompts/templates/dress_brief.yaml` + `dress_brief_batch.yaml` | Field-name references. |
+| 12 | `src/questfoundry/export/context.py` | `_REQUIRED_ART_DIRECTION_FIELDS` tuple at line 39: rename. |
+| 13 | Tests / fixtures | Replace directly per CLAUDE.md (no compat shim). Affected: `tests/unit/test_dress*.py`, `tests/unit/test_a1111*.py`, `tests/unit/test_image_brief*.py`, `tests/unit/test_export_context.py`, any DRESS YAML fixtures. |
+
+Specs precede code per `CLAUDE.md` "Spec-first fix order."
+
+### Verification
+
+`rg "negative_defaults" src/ tests/ docs/ prompts/` returns 0 after the cascade lands. `rg "_CHECKPOINT_STYLE_MAP" src/` returns one definition + two consumers (DRESS context-builder, distiller).
+
+## Risks and mitigations
+
+| Risk | Mitigation |
+|------|------------|
+| DRESS over-anchors on renderer, ignores story tone. | Explicit tiebreaker in the hint: "choose closest compatible style, note compromise in `composition_notes`." Style collisions surface in Phase 0 human gate (R-1.4). |
+| LLM dumps quality fillers into `style_exclusions` after rename. | GOOD/BAD examples in `dress_serialize.yaml` instruction explicitly warn: `BAD: blurry, watermark, deformed hands` with rationale "those are auto-injected by the render pipeline." |
+| Pattern shadowing in `_CHECKPOINT_STYLE_MAP`. | Module-level docstring documents first-match-wins; specific patterns must precede generic. Test asserts ordering for the dreamshaper/dreamshaperxl/dreamshaperxl-lightning chain. |
+| Provider known but checkpoint absent (e.g. `--image-provider a1111`). | `resolve_checkpoint_style()` falls through to the default entry, returning the generic SD-defaults label. The hint still injects, just with broader guidance. |
+| Style collision irreconcilable (story = dreamlike surreal, checkpoint = photoreal). | Phase 0 human gate is the resolution point. The hint should not adjudicate; it declares the constraint and lets the human override. |
+| Field-rename ripples through tests. | One PR; replace directly. No backward-compatibility shim per CLAUDE.md "Refactoring & Removal Discipline." |
+
+## PR shape
+
+**Single PR.** The static map is the load-bearing asset and both layers (DRESS context-builder + distiller) ride on it; splitting forces either a temporary import path or a duplicate map. The 13 sites are cohesive — spec → model → providers → templates → tests — and a reviewer can validate the entire feature in one diff.
+
+## Out of scope (explicitly deferred)
+
+- **OpenAI / Gemini / placeholder providers** getting a checkpoint-style entry. They map to specific image-generation models with much narrower style ranges; if author benefit emerges, a follow-up issue can extend the map.
+- **Distiller-time renderer-quality filler constant.** The design says these become auto-injected at distill time, but the implementation can keep the existing inline filler in the EXAMPLE block until a clean factoring opportunity arises. Filing as a follow-up tracker keeps this PR focused.
+- **Phase 0 sample-image review (R-5.3)** integration. The renderer hint should improve sample quality, but no measurement / feedback loop is added in this PR.
+
+## References
+
+- Round-1 advisory from `@prompt-engineer` (DRESS Phase 0 hint placement, GOOD/BAD pattern, conditional rendering, negative-space risks).
+- Round-2 advisory from `@prompt-engineer` (concrete checkpoint map for the user's loaded models, `style_exclusions` rename rationale and cascade).
+- A1111 instance: `http://athena.int.liesdonk.nl:7860`, 10 checkpoints loaded as of 2026-04-28.
+- Authoritative spec docs: `docs/design/procedures/dress.md`, `docs/design/procedures/ship.md`.

--- a/prompts/templates/dress_brief.yaml
+++ b/prompts/templates/dress_brief.yaml
@@ -82,7 +82,7 @@ system: |
     in the passage.
   - CAPTION: See format above (10-60 chars, "[Subject] [action/state]")
   - NEGATIVE FIELD: Only list negatives SPECIFIC to this brief that go beyond
-    the global negative_defaults. If no brief-specific negatives apply, use an
+    the global style_exclusions. If no brief-specific negatives apply, use an
     empty string.
   - PATH UNDERTONE: If present, let the path's emotional undertone subtly tint the
     image — a color choice, a shadow direction, an expression — not dominate the subject.

--- a/prompts/templates/dress_brief_batch.yaml
+++ b/prompts/templates/dress_brief_batch.yaml
@@ -71,7 +71,7 @@ system: |
     medium shot, wide establishing shot, over-the-shoulder, Dutch angle.
   - MOOD VARIETY: Use the full emotional spectrum. Not every scene is "haunting".
   - NEGATIVE FIELD: Only list negatives SPECIFIC to this brief that go beyond
-    the global negative_defaults. If no brief-specific negatives apply, use an
+    the global style_exclusions. If no brief-specific negatives apply, use an
     empty string.
   - PATH UNDERTONE: If present, let the path's emotional undertone subtly tint the
     image — a color choice, a shadow direction, an expression — not dominate the subject.

--- a/prompts/templates/dress_discuss.yaml
+++ b/prompts/templates/dress_discuss.yaml
@@ -27,6 +27,8 @@ system: |
   ## Entities to Visualize
   {entity_list}
 
+  {image_renderer_section}
+
   ## Guidelines
   - The visual style should complement the story's genre, tone, and themes
   - Consider how the medium affects mood (watercolor = dreamlike, ink = stark, etc.)

--- a/prompts/templates/dress_discuss.yaml
+++ b/prompts/templates/dress_discuss.yaml
@@ -7,7 +7,7 @@ system: |
 
   ## Task Contract
   Stage: DRESS (after FILL: DREAM → BRAINSTORM → SEED → GROW → FILL → DRESS → SHIP)
-  Deliverables: art style, entity visual profiles, negative defaults, aspect ratio
+  Deliverables: art style, entity visual profiles, style exclusions, aspect ratio
   Completion: when visual identity is established
 
   ## Your Goal
@@ -15,7 +15,7 @@ system: |
   - Art style and medium (watercolor, ink, digital painting, pixel art, etc.)
   - Color palette and mood
   - Composition preferences and framing conventions
-  - What to avoid visually (negative defaults)
+  - What to avoid visually (style exclusions)
   - Per-entity visual identities for consistent character/location depiction
 
   Focus on exploration and discussion. Your decisions will be consolidated into
@@ -44,7 +44,7 @@ system: |
   **What DRESS captures:**
   - Global art style, medium, palette, composition notes
   - Per-entity visual profiles (appearance, distinguishing features, color associations)
-  - Negative defaults (what to avoid in all images)
+  - Style exclusions (what to avoid in all images)
   - Default aspect ratio for illustrations
 
   **What NOT to include:**

--- a/prompts/templates/dress_serialize.yaml
+++ b/prompts/templates/dress_serialize.yaml
@@ -18,7 +18,10 @@ system: |
   - medium: What it looks like it was made with (e.g. "traditional watercolor on textured paper")
   - palette: List of dominant color names (e.g. ["deep indigo", "burnt sienna", "mist grey"])
   - composition_notes: Framing preferences (e.g. "wide establishing shots for locations, tight framing for dialogue")
-  - negative_defaults: Things to avoid globally (e.g. "photorealism, anime style, modern elements")
+  - style_exclusions: Visual styles to exclude across all story images — story-tone
+    prohibitions only.
+    GOOD: "no photorealism, no anachronistic technology" (story-tone)
+    BAD:  "blurry, watermark, deformed hands" (renderer-quality fillers — auto-injected at render time, never put them here)
   - aspect_ratio: Default ratio (e.g. "16:9")
 
   **entity_visuals** (list of objects, one per entity):

--- a/src/questfoundry/export/context.py
+++ b/src/questfoundry/export/context.py
@@ -41,7 +41,7 @@ _REQUIRED_ART_DIRECTION_FIELDS = (
     "medium",
     "palette",
     "composition_notes",
-    "negative_defaults",
+    "style_exclusions",
     "aspect_ratio",
 )
 

--- a/src/questfoundry/models/dress.py
+++ b/src/questfoundry/models/dress.py
@@ -43,9 +43,15 @@ class ArtDirection(BaseModel):
         min_length=1,
         description="Framing preferences",
     )
-    negative_defaults: str = Field(
+    style_exclusions: str = Field(
         min_length=1,
-        description="Global things to avoid in image generation",
+        description=(
+            "Visual styles to exclude across all story images — story-tone "
+            "prohibitions only (e.g. 'no photorealism, no modern clothing for "
+            "a Victorian setting'). Do NOT include renderer quality fillers "
+            "(blurry, watermark, etc.) — those are auto-injected by the "
+            "render pipeline."
+        ),
     )
     aspect_ratio: str = Field(
         min_length=1,

--- a/src/questfoundry/pipeline/stages/dress.py
+++ b/src/questfoundry/pipeline/stages/dress.py
@@ -2139,7 +2139,7 @@ def build_image_brief(graph: Graph, brief: dict[str, Any]) -> ImageBrief:
         art_style=art_dir.get("style") or None,
         art_medium=art_dir.get("medium") or None,
         palette=art_dir.get("palette", []),
-        negative_defaults=art_dir.get("negative_defaults") or None,
+        style_exclusions=art_dir.get("style_exclusions") or None,
         aspect_ratio=_parse_aspect_ratio(art_dir.get("aspect_ratio", "16:9")),
         category=brief.get("category", "scene"),
     )

--- a/src/questfoundry/pipeline/stages/dress.py
+++ b/src/questfoundry/pipeline/stages/dress.py
@@ -188,12 +188,8 @@ def _build_image_renderer_section(provider_spec: str | None) -> str:
         f"This renderer works best with these visual styles: "
         f"{style_info['style_hints']}\n"
         f"It CANNOT faithfully produce: {style_info['incompatible_styles']}\n\n"
-        "GOOD art direction given this renderer: "
-        'style="gritty photorealistic urban", medium="digital photo"\n'
-        "BAD art direction given this renderer: "
-        'style="watercolor wash", medium="traditional ink" '
-        "(this renderer is tuned for photorealism; stylised media will "
-        "fight the checkpoint and degrade image quality)\n\n"
+        f"GOOD art direction given this renderer: {style_info['good_example']}\n"
+        f"BAD art direction given this renderer: {style_info['bad_example']}\n\n"
         "Your art direction MUST be compatible with the renderer. If the "
         "story's tone strongly suggests a medium the renderer cannot "
         "produce well, choose the closest compatible style and note the "

--- a/src/questfoundry/pipeline/stages/dress.py
+++ b/src/questfoundry/pipeline/stages/dress.py
@@ -161,6 +161,46 @@ def _build_dress_error_feedback(
     return "\n".join(parts)
 
 
+def _build_image_renderer_section(provider_spec: str | None) -> str:
+    """Build the renderer-aware hint section for dress_discuss (#1557).
+
+    When `provider_spec` is None (no `--image-provider` set), returns "" so
+    the `{image_renderer_section}` placeholder collapses cleanly. Otherwise
+    looks up checkpoint style metadata via `resolve_checkpoint_style()` and
+    formats a hint block that biases DRESS Phase 0 toward
+    renderer-compatible art direction.
+
+    Args:
+        provider_spec: e.g. ``"a1111/juggernautXL_ragnarokBy"`` or ``"a1111"``
+            or ``None`` when no image provider is selected at DRESS time.
+    """
+    if not provider_spec:
+        return ""
+
+    from questfoundry.providers.checkpoint_styles import resolve_checkpoint_style
+
+    _, _, checkpoint = provider_spec.partition("/")
+    style_info = resolve_checkpoint_style(checkpoint or provider_spec)
+
+    return (
+        "## Image Renderer Constraint (CRITICAL)\n"
+        f"This story's images will be rendered by: {style_info['label']}\n\n"
+        f"This renderer works best with these visual styles: "
+        f"{style_info['style_hints']}\n"
+        f"It CANNOT faithfully produce: {style_info['incompatible_styles']}\n\n"
+        "GOOD art direction given this renderer: "
+        'style="gritty photorealistic urban", medium="digital photo"\n'
+        "BAD art direction given this renderer: "
+        'style="watercolor wash", medium="traditional ink" '
+        "(this renderer is tuned for photorealism; stylised media will "
+        "fight the checkpoint and degrade image quality)\n\n"
+        "Your art direction MUST be compatible with the renderer. If the "
+        "story's tone strongly suggests a medium the renderer cannot "
+        "produce well, choose the closest compatible style and note the "
+        "compromise in `composition_notes`.\n"
+    )
+
+
 class DressStageError(ValueError):
     """Error raised when DRESS stage cannot proceed."""
 
@@ -512,6 +552,7 @@ class DressStage:
             research_tools_section=research_section,
             sandbox_section=load_sandbox_section(),
             mode_section=mode_section,
+            image_renderer_section=_build_image_renderer_section(self._image_provider_spec),
         )
 
         if self._interactive:

--- a/src/questfoundry/providers/checkpoint_styles.py
+++ b/src/questfoundry/providers/checkpoint_styles.py
@@ -39,6 +39,13 @@ _CHECKPOINT_STYLE_MAP: tuple[tuple[re.Pattern[str], dict[str, str]], ...] = (
                 "also: negative-prompt weighting is weak on Flux — "
                 "do not rely on negative prompts for strong style exclusion"
             ),
+            "good_example": (
+                'style="cinematic urban photography", medium="digital photograph with shallow DOF"'
+            ),
+            "bad_example": (
+                'style="watercolor wash", medium="hand-painted ink" '
+                "(Flux is tuned for photorealism; painterly media will fight the model)"
+            ),
         },
     ),
     # ----- Coloring-book fine-tune (SD1.5 base) -----
@@ -55,6 +62,13 @@ _CHECKPOINT_STYLE_MAP: tuple[tuple[re.Pattern[str], dict[str, str]], ...] = (
                 "photorealism, color renders, painterly textures, "
                 "complex shading, dark backgrounds, photographic lighting"
             ),
+            "good_example": ('style="bold ink linework", medium="black-and-white outline drawing"'),
+            "bad_example": (
+                'style="photorealistic portrait", '
+                'medium="oil paint with rich color" '
+                "(this checkpoint is fine-tuned for line-art only; "
+                "color renders will fail)"
+            ),
         },
     ),
     # ----- Juggernaut XL (photorealistic SDXL) -----
@@ -69,6 +83,12 @@ _CHECKPOINT_STYLE_MAP: tuple[tuple[re.Pattern[str], dict[str, str]], ...] = (
             ),
             "incompatible_styles": (
                 "anime, cartoon, flat illustration, watercolor, comic-book ink outlines, chibi"
+            ),
+            "good_example": ('style="gritty photorealistic urban", medium="digital photo"'),
+            "bad_example": (
+                'style="watercolor wash", medium="traditional ink" '
+                "(Juggernaut is tuned for photorealism; "
+                "stylised media will fight the checkpoint)"
             ),
         },
     ),
@@ -87,6 +107,14 @@ _CHECKPOINT_STYLE_MAP: tuple[tuple[re.Pattern[str], dict[str, str]], ...] = (
                 "gritty texture, oil painting, detailed backgrounds "
                 "without anime stylisation"
             ),
+            "good_example": (
+                'style="anime illustration with cel shading", medium="digital anime art"'
+            ),
+            "bad_example": (
+                'style="documentary photograph", medium="35mm film" '
+                "(Animagine is anime-specialised; "
+                "photographic styles produce off-distribution outputs)"
+            ),
         },
     ),
     # ----- DreamShaperXL Lightning / Alpha (must precede generic dreamshaperxl) -----
@@ -104,6 +132,14 @@ _CHECKPOINT_STYLE_MAP: tuple[tuple[re.Pattern[str], dict[str, str]], ...] = (
                 "highly detailed textures at very low step counts, "
                 "strict architectural accuracy"
             ),
+            "good_example": (
+                'style="dramatic fantasy concept art", medium="painterly digital illustration"'
+            ),
+            "bad_example": (
+                'style="hyperrealistic skin detail at 4K", '
+                'medium="macro photograph" '
+                "(Lightning checkpoints sacrifice fine detail for speed)"
+            ),
         },
     ),
     # ----- DreamShaperXL standard -----
@@ -118,6 +154,15 @@ _CHECKPOINT_STYLE_MAP: tuple[tuple[re.Pattern[str], dict[str, str]], ...] = (
             ),
             "incompatible_styles": (
                 "strict photorealism, clinical document photography, flat-color infographic styles"
+            ),
+            "good_example": (
+                'style="painterly fantasy illustration", medium="digital concept art"'
+            ),
+            "bad_example": (
+                'style="clinical product photography", '
+                'medium="catalog studio shot" '
+                "(DreamShaperXL is stylised by design; "
+                "strict photo-real fights the model)"
             ),
         },
     ),
@@ -137,6 +182,14 @@ _CHECKPOINT_STYLE_MAP: tuple[tuple[re.Pattern[str], dict[str, str]], ...] = (
                 "extreme photorealism (slightly stylised by design), "
                 "Danbooru/anime tag grammar (use natural descriptors instead)"
             ),
+            "good_example": (
+                'style="painterly fantasy character portrait", medium="soft digital illustration"'
+            ),
+            "bad_example": (
+                'style="Danbooru anime tags", medium="cel-shading" '
+                "(DreamShaper SD1.5 expects natural descriptors, "
+                "not anime tag grammar)"
+            ),
         },
     ),
     # ----- SDXL base -----
@@ -152,6 +205,15 @@ _CHECKPOINT_STYLE_MAP: tuple[tuple[re.Pattern[str], dict[str, str]], ...] = (
             "incompatible_styles": (
                 "anime-specific Danbooru vocabulary without style priming, "
                 "very low step counts (needs ≥30 steps for coherence)"
+            ),
+            "good_example": (
+                'style="cinematic illustration with explicit style tokens", medium="digital art"'
+            ),
+            "bad_example": (
+                'style="anime without style priming", '
+                'medium="bare Danbooru tags" '
+                "(SDXL base needs explicit style direction; "
+                "bare anime grammar underperforms)"
             ),
         },
     ),
@@ -169,6 +231,12 @@ _CHECKPOINT_STYLE_MAP: tuple[tuple[re.Pattern[str], dict[str, str]], ...] = (
                 "photorealistic skin detail at high resolution "
                 "(768px ceiling limits fine detail), "
                 "SDXL-native aspect ratios"
+            ),
+            "good_example": ('style="watercolor portraiture", medium="ink illustration"'),
+            "bad_example": (
+                'style="hyperrealistic skin at 1024px", '
+                'medium="macro studio photograph" '
+                "(SD 1.5 caps at ~768px; high-detail photoreal won't render)"
             ),
         },
     ),
@@ -188,6 +256,15 @@ _CHECKPOINT_STYLE_MAP: tuple[tuple[re.Pattern[str], dict[str, str]], ...] = (
                 "coherent embedded text, photographic product catalogs "
                 "without specialised fine-tuning"
             ),
+            "good_example": (
+                'style="painterly fantasy illustration with explicit style tokens", '
+                'medium="digital concept art"'
+            ),
+            "bad_example": (
+                'style="coherent embedded text", '
+                'medium="document scan with readable signage" '
+                "(Stable Diffusion generally cannot render legible text)"
+            ),
         },
     ),
 )
@@ -203,7 +280,8 @@ def resolve_checkpoint_style(model: str) -> dict[str, str]:
         model: Checkpoint filename (with or without extension). Case-insensitive.
 
     Returns:
-        Dict with keys ``label``, ``style_hints``, ``incompatible_styles``.
+        Dict with keys ``label``, ``style_hints``, ``incompatible_styles``,
+        ``good_example``, ``bad_example``.
     """
     lowered = model.lower()
     for pattern, info in _CHECKPOINT_STYLE_MAP:

--- a/src/questfoundry/providers/checkpoint_styles.py
+++ b/src/questfoundry/providers/checkpoint_styles.py
@@ -1,0 +1,214 @@
+# src/questfoundry/providers/checkpoint_styles.py
+"""Static checkpoint style metadata for image-generation renderers.
+
+Used by DRESS Phase 0 (prevention — when `--image-provider` is set, biases
+ArtDirection toward checkpoint-compatible styles) and the A1111 distiller
+(recovery — adapts CLIP-tag selection to the active checkpoint).
+
+Pattern matching:
+    Patterns are matched against the lowercased checkpoint filename via
+    `re.Pattern.search`. First match wins. Specific patterns MUST precede
+    generic ones — the dreamshaper family is the canonical example
+    (Lightning/Alpha specific → XL generic → SD1.5 fallback).
+    The empty-pattern default-fallback entry is always last.
+
+Adding a new entry:
+    Insert above the default-fallback entry, in priority order.
+    Test: add a parametrize row to `tests/unit/test_checkpoint_styles.py`
+    asserting the expected label substring.
+"""
+
+from __future__ import annotations
+
+import re
+
+_CHECKPOINT_STYLE_MAP: tuple[tuple[re.Pattern[str], dict[str, str]], ...] = (
+    # ----- Flux (NF4 quantised; both v1 and v2 quants share identity) -----
+    (
+        re.compile(r"flux"),
+        {
+            "label": "Flux (photorealistic / highly-detailed)",
+            "style_hints": (
+                "photorealistic imagery, extreme fine detail, architectural "
+                "photography, natural lighting, product shots, documentary "
+                "portraiture, coherent text in scene"
+            ),
+            "incompatible_styles": (
+                "anime, manga, cel-shading, watercolor washes, heavy "
+                "painterly texture, low-detail illustration styles; "
+                "also: negative-prompt weighting is weak on Flux — "
+                "do not rely on negative prompts for strong style exclusion"
+            ),
+        },
+    ),
+    # ----- Coloring-book fine-tune (SD1.5 base) -----
+    (
+        re.compile(r"coloring.?book"),
+        {
+            "label": "Coloring Book (line-art SD1.5)",
+            "style_hints": (
+                "clean outlines on white background, no fill colors, "
+                "strong linework, simple shapes, children's-book-friendly "
+                "compositions, decorative borders"
+            ),
+            "incompatible_styles": (
+                "photorealism, color renders, painterly textures, "
+                "complex shading, dark backgrounds, photographic lighting"
+            ),
+        },
+    ),
+    # ----- Juggernaut XL (photorealistic SDXL) -----
+    (
+        re.compile(r"juggernaut"),
+        {
+            "label": "Juggernaut XL (photorealistic SDXL)",
+            "style_hints": (
+                "photorealistic portraits, cinematic lighting, "
+                "sharp textural detail, skin pores, fabric weave, "
+                "dramatic rim lighting, environmental storytelling"
+            ),
+            "incompatible_styles": (
+                "anime, cartoon, flat illustration, watercolor, comic-book ink outlines, chibi"
+            ),
+        },
+    ),
+    # ----- Animagine XL (anime-focused SDXL) -----
+    (
+        re.compile(r"animagine"),
+        {
+            "label": "Animagine XL (anime SDXL)",
+            "style_hints": (
+                "anime illustration, Danbooru-style tag vocabulary, "
+                "clean cell shading, expressive character art, "
+                "vivid saturated palette, manga panel compositions"
+            ),
+            "incompatible_styles": (
+                "photorealism, photography-style lighting, "
+                "gritty texture, oil painting, detailed backgrounds "
+                "without anime stylisation"
+            ),
+        },
+    ),
+    # ----- DreamShaperXL Lightning / Alpha (must precede generic dreamshaperxl) -----
+    (
+        re.compile(r"dreamshaperxl.*lightning|dreamshaperxl.*alpha"),
+        {
+            "label": "DreamShaperXL Lightning / Alpha (fast fantasy SDXL)",
+            "style_hints": (
+                "fantasy concept art, painterly illustration, "
+                "vibrant color, dramatic character portraits, "
+                "acceptable in 4-8 steps"
+            ),
+            "incompatible_styles": (
+                "photorealism (style is stylised by design), "
+                "highly detailed textures at very low step counts, "
+                "strict architectural accuracy"
+            ),
+        },
+    ),
+    # ----- DreamShaperXL standard -----
+    (
+        re.compile(r"dreamshaperxl|dreamshaper.*xl"),
+        {
+            "label": "DreamShaperXL (versatile fantasy SDXL)",
+            "style_hints": (
+                "fantasy illustration, painterly portraits, "
+                "concept-art style, stylised environments, "
+                "strong use of negative space"
+            ),
+            "incompatible_styles": (
+                "strict photorealism, clinical document photography, flat-color infographic styles"
+            ),
+        },
+    ),
+    # ----- DreamShaper SD1.5 (generic, must come after XL variants) -----
+    (
+        re.compile(r"dreamshaper"),
+        {
+            "label": "DreamShaper (versatile SD1.5)",
+            "style_hints": (
+                "general-purpose stylised illustration, "
+                "fantasy character art, soft painterly lighting, "
+                "portrait and environmental compositions; "
+                "notably versatile — adapt style tags rather than "
+                "leaning on a single category"
+            ),
+            "incompatible_styles": (
+                "extreme photorealism (slightly stylised by design), "
+                "Danbooru/anime tag grammar (use natural descriptors instead)"
+            ),
+        },
+    ),
+    # ----- SDXL base -----
+    (
+        re.compile(r"sd_xl_base|sdxl_base|sdxl-base"),
+        {
+            "label": "SDXL Base (general-purpose SDXL)",
+            "style_hints": (
+                "broad style range, photography, illustration, concept art; "
+                "best results with refiner pass or ControlNet; "
+                "responds well to explicit style tokens"
+            ),
+            "incompatible_styles": (
+                "anime-specific Danbooru vocabulary without style priming, "
+                "very low step counts (needs ≥30 steps for coherence)"
+            ),
+        },
+    ),
+    # ----- SD 1.5 base / pruned -----
+    (
+        re.compile(r"v1[-_]5|sd[-_]?1[-._]?5"),
+        {
+            "label": "SD 1.5 (general-purpose base)",
+            "style_hints": (
+                "broad style range at 512-768px, watercolor, "
+                "ink illustration, painterly portraiture; "
+                "well-supported by community LoRAs"
+            ),
+            "incompatible_styles": (
+                "photorealistic skin detail at high resolution "
+                "(768px ceiling limits fine detail), "
+                "SDXL-native aspect ratios"
+            ),
+        },
+    ),
+    # ----- Default — always matches; must be last -----
+    (
+        re.compile(r""),
+        {
+            "label": "Unknown checkpoint (SD general-purpose defaults)",
+            "style_hints": (
+                "broad range: illustration, painterly, concept art; "
+                "Stable Diffusion generally excels at stylised imagery, "
+                "fantasy environments, and character portraiture; "
+                "use explicit style tokens (e.g. 'watercolor painting', "
+                "'cinematic photograph') for best results"
+            ),
+            "incompatible_styles": (
+                "coherent embedded text, photographic product catalogs "
+                "without specialised fine-tuning"
+            ),
+        },
+    ),
+)
+
+
+def resolve_checkpoint_style(model: str) -> dict[str, str]:
+    """Look up style metadata for a checkpoint name.
+
+    Always returns a populated dict — the empty-pattern default-fallback
+    entry guarantees a match.
+
+    Args:
+        model: Checkpoint filename (with or without extension). Case-insensitive.
+
+    Returns:
+        Dict with keys ``label``, ``style_hints``, ``incompatible_styles``.
+    """
+    lowered = model.lower()
+    for pattern, info in _CHECKPOINT_STYLE_MAP:
+        if pattern.search(lowered):
+            return info
+    raise AssertionError(  # pragma: no cover — default fallback always matches
+        "default-fallback entry must always match"
+    )

--- a/src/questfoundry/providers/image_a1111.py
+++ b/src/questfoundry/providers/image_a1111.py
@@ -351,7 +351,7 @@ class A1111ImageProvider:
             brief_text += f"Style overrides: {brief.style_overrides}\n"
 
         negative_raw = ", ".join(
-            n for n in [brief.negative or "", brief.negative_defaults or ""] if n
+            n for n in [brief.negative or "", brief.style_exclusions or ""] if n
         )
         if negative_raw:
             brief_text += f"Negative: {negative_raw}\n"

--- a/src/questfoundry/providers/image_a1111.py
+++ b/src/questfoundry/providers/image_a1111.py
@@ -326,6 +326,29 @@ class A1111ImageProvider:
     def _tag_count(self, text: str) -> int:
         return len([t.strip() for t in text.split(",") if t.strip()])
 
+    def _format_checkpoint_hint(self) -> str:
+        """Build the TARGET CHECKPOINT hint block injected into the
+        distiller's system prompt. Sources data from
+        `resolve_checkpoint_style()` (single map, shared with DRESS
+        Phase 0) so the distiller's guidance and the upstream Phase 0
+        guidance cannot drift apart (#1557)."""
+        if not self._model:
+            return ""
+
+        from questfoundry.providers.checkpoint_styles import resolve_checkpoint_style
+
+        info = resolve_checkpoint_style(self._model)
+        return (
+            f"\nTARGET CHECKPOINT: {info['label']}\n"
+            f"This checkpoint excels at: {info['style_hints']}\n"
+            f"This checkpoint struggles with: {info['incompatible_styles']}\n"
+            "Adapt your CLIP tags accordingly. If the brief asks for a "
+            "style this checkpoint can't render well, translate to the "
+            "closest compatible vocabulary (e.g. brief says 'watercolor "
+            "wash' on a photoreal checkpoint → render as 'soft natural "
+            "light, painterly atmosphere').\n"
+        )
+
     async def _distill_with_llm(self, brief: ImageBrief) -> tuple[str, str | None]:
         """Use an LLM to condense the brief into SD-optimised tags.
 
@@ -389,15 +412,7 @@ class A1111ImageProvider:
                 "blurry, text, watermark, deformed hands, extra fingers"
             )
 
-        checkpoint_hint = ""
-        if self._model:
-            checkpoint_hint = (
-                f"\nTARGET CHECKPOINT: {self._model}\n"
-                "Adapt your tag style to this checkpoint. For example, anime/"
-                "illustration models (Animagine, NovelAI, etc.) expect Danbooru-"
-                "style tags (1girl, blue_hair, masterpiece). Photorealistic "
-                "models prefer natural descriptive tags.\n"
-            )
+        checkpoint_hint = self._format_checkpoint_hint()
 
         system_msg = (
             "CONTEXT: Stable Diffusion's CLIP encoder has a hard token window. "

--- a/src/questfoundry/providers/image_brief.py
+++ b/src/questfoundry/providers/image_brief.py
@@ -29,7 +29,7 @@ class ImageBrief:
     art_style: str | None = None
     art_medium: str | None = None
     palette: list[str] = field(default_factory=list)
-    negative_defaults: str | None = None
+    style_exclusions: str | None = None
     aspect_ratio: str = "16:9"
     category: str = "scene"
 
@@ -65,7 +65,7 @@ def flatten_brief_to_prompt(brief: ImageBrief) -> tuple[str, str | None]:
 
     negative_parts = [
         brief.negative or "",
-        brief.negative_defaults or "",
+        brief.style_exclusions or "",
     ]
     negative = ", ".join(n for n in negative_parts if n)
 

--- a/src/questfoundry/providers/image_openai.py
+++ b/src/questfoundry/providers/image_openai.py
@@ -142,9 +142,9 @@ class OpenAIImageProvider:
         prompt = "\n".join(p for p in parts if p)
 
         negative = brief.negative
-        if brief.negative_defaults:
+        if brief.style_exclusions:
             negative = (
-                f"{negative}, {brief.negative_defaults}" if negative else brief.negative_defaults
+                f"{negative}, {brief.style_exclusions}" if negative else brief.style_exclusions
             )
         return prompt, negative or None
 

--- a/tests/unit/test_checkpoint_styles.py
+++ b/tests/unit/test_checkpoint_styles.py
@@ -25,6 +25,7 @@ class TestResolveCheckpointStyle:
             ("Dreamshaper.safetensors", "DreamShaper"),
             ("sd_xl_base_1.0.safetensors", "SDXL Base"),
             ("dreamshaperXL_lightningDPMSDE.safetensors", "DreamShaperXL Lightning"),
+            ("dreamshaperXL_v1.safetensors", "DreamShaperXL"),
             ("juggernautXL_ragnarokBy.safetensors", "Juggernaut"),
             ("dreamshaperXL_alpha2Xl10.safetensors", "DreamShaperXL Lightning"),
         ],
@@ -54,6 +55,12 @@ class TestResolveCheckpointStyle:
         alpha = resolve_checkpoint_style("dreamshaperXL_alpha2Xl10.safetensors")
         assert "Lightning" in alpha["label"] or "Alpha" in alpha["label"]
 
+        # Standard XL wins over plain SD1.5 fallback.
+        standard_xl = resolve_checkpoint_style("dreamshaperXL_v1.safetensors")
+        assert "DreamShaperXL" in standard_xl["label"]
+        assert "Lightning" not in standard_xl["label"]
+        assert "Alpha" not in standard_xl["label"]
+
         sd15 = resolve_checkpoint_style("Dreamshaper.safetensors")
         assert "Lightning" not in sd15["label"]
         assert "Alpha" not in sd15["label"]
@@ -61,7 +68,13 @@ class TestResolveCheckpointStyle:
 
     def test_returns_required_keys(self) -> None:
         info = resolve_checkpoint_style("anything.safetensors")
-        assert set(info.keys()) >= {"label", "style_hints", "incompatible_styles"}
+        assert set(info.keys()) >= {
+            "label",
+            "style_hints",
+            "incompatible_styles",
+            "good_example",
+            "bad_example",
+        }
 
     def test_case_insensitive_matching(self) -> None:
         # Patterns match against lowercased filename.

--- a/tests/unit/test_checkpoint_styles.py
+++ b/tests/unit/test_checkpoint_styles.py
@@ -1,0 +1,70 @@
+# tests/unit/test_checkpoint_styles.py
+"""Tests for checkpoint style metadata lookup (#1557)."""
+
+from __future__ import annotations
+
+import pytest
+
+from questfoundry.providers.checkpoint_styles import resolve_checkpoint_style
+
+
+class TestResolveCheckpointStyle:
+    """`resolve_checkpoint_style()` returns label/style_hints/incompatible_styles
+    for a checkpoint name. Always returns a populated dict (default fallback
+    if no specific pattern matches)."""
+
+    @pytest.mark.parametrize(
+        ("model", "label_substring"),
+        [
+            # User's loaded checkpoints at A1111 (2026-04-28)
+            ("flux1-dev-bnb-nf4-v2.safetensors", "Flux"),
+            ("flux1-dev-bnb-nf4.safetensors", "Flux"),
+            ("coloring_book.ckpt", "Coloring Book"),
+            ("v1-5-pruned-emaonly.safetensors", "SD 1.5"),
+            ("animagine-xl.safetensors", "Animagine"),
+            ("Dreamshaper.safetensors", "DreamShaper"),
+            ("sd_xl_base_1.0.safetensors", "SDXL Base"),
+            ("dreamshaperXL_lightningDPMSDE.safetensors", "DreamShaperXL Lightning"),
+            ("juggernautXL_ragnarokBy.safetensors", "Juggernaut"),
+            ("dreamshaperXL_alpha2Xl10.safetensors", "DreamShaperXL Lightning"),
+        ],
+    )
+    def test_known_checkpoint_resolves_to_specific_label(
+        self, model: str, label_substring: str
+    ) -> None:
+        info = resolve_checkpoint_style(model)
+        assert label_substring in info["label"]
+        assert info["style_hints"]
+        assert info["incompatible_styles"]
+
+    def test_unknown_checkpoint_falls_back_to_default(self) -> None:
+        info = resolve_checkpoint_style("totally-made-up-model.safetensors")
+        assert "Unknown" in info["label"] or "general-purpose" in info["label"].lower()
+        assert info["style_hints"]
+        assert info["incompatible_styles"]
+
+    def test_pattern_ordering_dreamshaperxl_lightning_wins_over_generic(self) -> None:
+        # The dreamshaper family has three patterns; the most specific must win.
+        # dreamshaperxl_lightning|alpha → "DreamShaperXL Lightning / Alpha"
+        # dreamshaperxl|dreamshaper.*xl → "DreamShaperXL"
+        # dreamshaper                    → "DreamShaper" (SD1.5)
+        lightning = resolve_checkpoint_style("dreamshaperXL_lightningDPMSDE.safetensors")
+        assert "Lightning" in lightning["label"] or "Alpha" in lightning["label"]
+
+        alpha = resolve_checkpoint_style("dreamshaperXL_alpha2Xl10.safetensors")
+        assert "Lightning" in alpha["label"] or "Alpha" in alpha["label"]
+
+        sd15 = resolve_checkpoint_style("Dreamshaper.safetensors")
+        assert "Lightning" not in sd15["label"]
+        assert "Alpha" not in sd15["label"]
+        assert "XL" not in sd15["label"]
+
+    def test_returns_required_keys(self) -> None:
+        info = resolve_checkpoint_style("anything.safetensors")
+        assert set(info.keys()) >= {"label", "style_hints", "incompatible_styles"}
+
+    def test_case_insensitive_matching(self) -> None:
+        # Patterns match against lowercased filename.
+        upper = resolve_checkpoint_style("FLUX1-DEV.safetensors")
+        lower = resolve_checkpoint_style("flux1-dev.safetensors")
+        assert upper == lower

--- a/tests/unit/test_dress_models.py
+++ b/tests/unit/test_dress_models.py
@@ -37,7 +37,7 @@ class TestArtDirection:
             medium="traditional",
             palette=["indigo", "rust"],
             composition_notes="wide shots",
-            negative_defaults="photorealistic",
+            style_exclusions="photorealistic",
             aspect_ratio="16:9",
         )
         assert ad.style == "watercolor"
@@ -49,7 +49,7 @@ class TestArtDirection:
             medium="digital",
             palette=["black"],
             composition_notes="close-up",
-            negative_defaults="text",
+            style_exclusions="text",
             aspect_ratio="1:1",
         )
         assert ad.aspect_ratio == "1:1"
@@ -62,13 +62,13 @@ class TestArtDirection:
                 medium="traditional",
                 palette=["indigo"],
                 composition_notes="wide shots",
-                negative_defaults="photorealistic",
+                style_exclusions="photorealistic",
             )
 
     @pytest.mark.parametrize(
         "field",
-        ["style", "medium", "composition_notes", "negative_defaults"],
-        ids=["style", "medium", "composition_notes", "negative_defaults"],
+        ["style", "medium", "composition_notes", "style_exclusions"],
+        ids=["style", "medium", "composition_notes", "style_exclusions"],
     )
     def test_empty_string_rejected(self, field: str) -> None:
         data = {
@@ -76,7 +76,7 @@ class TestArtDirection:
             "medium": "traditional",
             "palette": ["indigo"],
             "composition_notes": "wide shots",
-            "negative_defaults": "photorealistic",
+            "style_exclusions": "photorealistic",
             "aspect_ratio": "16:9",
         }
         data[field] = ""
@@ -90,7 +90,7 @@ class TestArtDirection:
                 medium="traditional",
                 palette=[],
                 composition_notes="wide shots",
-                negative_defaults="photorealistic",
+                style_exclusions="photorealistic",
                 aspect_ratio="16:9",
             )
 
@@ -323,7 +323,7 @@ class TestDressPhase0Output:
                 medium="sumi-e",
                 palette=["indigo", "rust"],
                 composition_notes="wide shots",
-                negative_defaults="photorealistic",
+                style_exclusions="photorealistic",
                 aspect_ratio="16:9",
             ),
             entity_visuals=[
@@ -345,7 +345,7 @@ class TestDressPhase0Output:
                     medium="digital",
                     palette=["black"],
                     composition_notes="close-up",
-                    negative_defaults="text",
+                    style_exclusions="text",
                     aspect_ratio="16:9",
                 ),
                 entity_visuals=[],
@@ -543,7 +543,7 @@ class TestRoundtrip:
             medium="traditional",
             palette=["indigo"],
             composition_notes="wide shots",
-            negative_defaults="photorealistic",
+            style_exclusions="photorealistic",
             aspect_ratio="16:9",
         )
         data = ad.model_dump()
@@ -565,7 +565,7 @@ class TestRoundtrip:
                 medium="sumi-e",
                 palette=["black"],
                 composition_notes="minimalist",
-                negative_defaults="color",
+                style_exclusions="color",
                 aspect_ratio="16:9",
             ),
             entity_visuals=[

--- a/tests/unit/test_dress_mutations.py
+++ b/tests/unit/test_dress_mutations.py
@@ -138,7 +138,7 @@ class TestApplyDressArtDirection:
                 "medium": "traditional",
                 "palette": ["indigo", "rust"],
                 "composition_notes": "wide shots",
-                "negative_defaults": "photorealistic",
+                "style_exclusions": "photorealistic",
             },
             entity_visuals=[
                 {
@@ -175,7 +175,7 @@ class TestApplyDressArtDirection:
                 "medium": "d",
                 "palette": ["b"],
                 "composition_notes": "c",
-                "negative_defaults": "n",
+                "style_exclusions": "n",
             },
             entity_visuals=[
                 {
@@ -198,7 +198,7 @@ class TestApplyDressArtDirection:
                 "medium": "d",
                 "palette": ["b"],
                 "composition_notes": "c",
-                "negative_defaults": "n",
+                "style_exclusions": "n",
             },
             "entity_visuals": [
                 {
@@ -230,7 +230,7 @@ class TestApplyDressArtDirection:
                 "medium": "d",
                 "palette": ["b"],
                 "composition_notes": "c",
-                "negative_defaults": "n",
+                "style_exclusions": "n",
             },
             entity_visuals=[
                 {

--- a/tests/unit/test_dress_stage.py
+++ b/tests/unit/test_dress_stage.py
@@ -3015,3 +3015,56 @@ class TestRunGenerateOnly:
         assert "Distilling 1 prompts" in (in_progress[0][2] or "")
         assert "Rendering sample" in (in_progress[1][2] or "")
         assert progress_calls[-1][1] == "completed"
+
+
+class TestImageRendererSection:
+    """`_build_image_renderer_section()` produces the hint block injected
+    into dress_discuss when an image provider is selected at orchestrator
+    init (#1557)."""
+
+    def test_no_provider_returns_empty_string(self) -> None:
+        from questfoundry.pipeline.stages.dress import _build_image_renderer_section
+
+        assert _build_image_renderer_section(None) == ""
+
+    def test_provider_with_checkpoint_includes_label(self) -> None:
+        from questfoundry.pipeline.stages.dress import _build_image_renderer_section
+
+        section = _build_image_renderer_section("a1111/juggernautXL_ragnarokBy")
+        assert "Image Renderer Constraint" in section
+        assert "Juggernaut" in section
+        assert "photorealistic" in section.lower()
+        # Must include both positive and negative guidance
+        assert (
+            "best with" in section.lower()
+            or "excels" in section.lower()
+            or "works best" in section.lower()
+        )
+        assert (
+            "cannot" in section.lower()
+            or "incompatible" in section.lower()
+            or "struggles" in section.lower()
+        )
+
+    def test_provider_without_checkpoint_uses_default(self) -> None:
+        from questfoundry.pipeline.stages.dress import _build_image_renderer_section
+
+        section = _build_image_renderer_section("a1111")
+        assert "Image Renderer Constraint" in section
+        # Default fallback label
+        assert "general-purpose" in section.lower() or "unknown" in section.lower()
+
+    def test_anime_checkpoint_warns_against_photorealism(self) -> None:
+        from questfoundry.pipeline.stages.dress import _build_image_renderer_section
+
+        section = _build_image_renderer_section("a1111/animagine-xl")
+        assert "anime" in section.lower()
+        # Should signal incompatible vocabulary somewhere
+        assert "photoreal" in section.lower() or "photo" in section.lower()
+
+    def test_section_contains_tiebreaker_for_collisions(self) -> None:
+        from questfoundry.pipeline.stages.dress import _build_image_renderer_section
+
+        section = _build_image_renderer_section("a1111/juggernaut")
+        # The hint must instruct conflict resolution into composition_notes
+        assert "composition_notes" in section

--- a/tests/unit/test_dress_stage.py
+++ b/tests/unit/test_dress_stage.py
@@ -101,7 +101,7 @@ def mock_phase0_output() -> DressPhase0Output:
             medium="traditional watercolor on textured paper",
             palette=["deep indigo", "burnt sienna"],
             composition_notes="Wide shots for locations",
-            negative_defaults="photorealism, anime",
+            style_exclusions="photorealism, anime",
             aspect_ratio="16:9",
         ),
         entity_visuals=[
@@ -399,7 +399,7 @@ class TestPhase0ArtDirection:
                 medium="brush ink on rice paper",
                 palette=["midnight blue"],
                 composition_notes="balanced framing",
-                negative_defaults="cartoon",
+                style_exclusions="cartoon",
                 aspect_ratio="16:9",
             ),
             entity_visuals=[
@@ -2508,7 +2508,7 @@ class TestAssembleImagePrompt:
                 "style": "watercolor",
                 "medium": "traditional paper",
                 "palette": ["deep indigo", "gold"],
-                "negative_defaults": "photorealism",
+                "style_exclusions": "photorealism",
             },
         )
 

--- a/tests/unit/test_export_context.py
+++ b/tests/unit/test_export_context.py
@@ -456,7 +456,7 @@ class TestPartialDressWarning:
                 "medium": "digital painting",
                 "palette": ["blue", "gold"],
                 "composition_notes": "wide framing",
-                "negative_defaults": "no text overlays",
+                "style_exclusions": "no text overlays",
                 "aspect_ratio": "16:9",
             },
         )
@@ -476,7 +476,7 @@ class TestPartialDressWarning:
                 "medium": "digital painting",
                 # palette omitted
                 "composition_notes": "wide framing",
-                "negative_defaults": "no text overlays",
+                "style_exclusions": "no text overlays",
                 "aspect_ratio": "16:9",
             },
         )
@@ -499,7 +499,7 @@ class TestPartialDressWarning:
                 "medium": "digital painting",
                 "palette": ["blue"],
                 "composition_notes": "wide framing",
-                "negative_defaults": "no text overlays",
+                "style_exclusions": "no text overlays",
                 "aspect_ratio": "16:9",
             },
         )
@@ -525,7 +525,7 @@ class TestPartialDressWarning:
             build_export_context(g, "test")
 
         assert _has_event(caplog, "art_direction_partial")
-        for missing in ("palette", "composition_notes", "negative_defaults", "aspect_ratio"):
+        for missing in ("palette", "composition_notes", "style_exclusions", "aspect_ratio"):
             assert _has_event(caplog, missing), f"missing field {missing!r} not in warning"
 
     def test_no_art_direction_node_no_warning(self, caplog: pytest.LogCaptureFixture) -> None:

--- a/tests/unit/test_image_a1111.py
+++ b/tests/unit/test_image_a1111.py
@@ -572,3 +572,56 @@ class TestA1111FactoryRouting:
         provider = create_image_provider("a1111", host="http://localhost:7860")
         assert isinstance(provider, A1111ImageProvider)
         assert provider._model is None
+
+
+class TestDistillerCheckpointHint:
+    """The distiller's `_format_checkpoint_hint` must come from
+    `resolve_checkpoint_style()` (#1557), not from a generic
+    LLM-self-classifying prompt with the bare model name."""
+
+    def _make_provider(self, model: str | None) -> A1111ImageProvider:
+        from unittest.mock import MagicMock
+
+        from questfoundry.providers.image_a1111 import A1111ImageProvider
+
+        # Distiller test doesn't actually invoke the LLM — a MagicMock seam is enough.
+        llm = MagicMock()
+        return A1111ImageProvider(host="http://x", model=model, llm=llm)
+
+    def test_no_model_returns_empty_hint(self) -> None:
+        provider = self._make_provider(None)
+        hint = provider._format_checkpoint_hint()
+        assert hint == ""
+
+    def test_juggernaut_hint_uses_map_label(self) -> None:
+        provider = self._make_provider("juggernautXL_ragnarokBy.safetensors")
+        hint = provider._format_checkpoint_hint()
+        assert "TARGET CHECKPOINT" in hint
+        assert "Juggernaut" in hint
+        # The structured map field must surface in the hint
+        assert "photorealistic" in hint.lower()
+        assert "excels" in hint.lower() or "best at" in hint.lower() or "works best" in hint.lower()
+        assert (
+            "struggles" in hint.lower()
+            or "cannot" in hint.lower()
+            or "incompatible" in hint.lower()
+        )
+
+    def test_anime_checkpoint_warns_against_photorealism(self) -> None:
+        provider = self._make_provider("animagine-xl.safetensors")
+        hint = provider._format_checkpoint_hint()
+        assert "Animagine" in hint
+        assert "anime" in hint.lower()
+
+    def test_unknown_checkpoint_uses_default_label(self) -> None:
+        provider = self._make_provider("totally-made-up-model.safetensors")
+        hint = provider._format_checkpoint_hint()
+        # Default fallback yields the generic label
+        assert "TARGET CHECKPOINT" in hint
+        assert "general-purpose" in hint.lower() or "unknown" in hint.lower()
+
+    def test_hint_includes_translation_guidance(self) -> None:
+        provider = self._make_provider("juggernautXL_ragnarokBy.safetensors")
+        hint = provider._format_checkpoint_hint()
+        # The distiller-time hint should instruct the LLM how to bridge incompatibility
+        assert "translate" in hint.lower() or "adapt" in hint.lower()

--- a/tests/unit/test_image_a1111.py
+++ b/tests/unit/test_image_a1111.py
@@ -373,7 +373,7 @@ class TestA1111DistillPrompt:
             "entity_fragments": ["tall warrior, scarred face"],
             "palette": ["crimson", "gold"],
             "negative": "modern elements",
-            "negative_defaults": "photorealism",
+            "style_exclusions": "photorealism",
         }
         defaults.update(overrides)
         return ImageBrief(**defaults)
@@ -538,7 +538,7 @@ class TestA1111DistillPrompt:
         mock_llm.ainvoke = AsyncMock(return_value=mock_response)
 
         provider = A1111ImageProvider(host="http://localhost:7860", llm=mock_llm)
-        brief = self._make_brief(negative="blurry", negative_defaults="text, watermark")
+        brief = self._make_brief(negative="blurry", style_exclusions="text, watermark")
         await provider.distill_prompt(brief)
 
         call = mock_llm.ainvoke.call_args

--- a/tests/unit/test_image_brief.py
+++ b/tests/unit/test_image_brief.py
@@ -32,7 +32,7 @@ class TestImageBrief:
             art_style="oil painting",
             art_medium="canvas",
             palette=["crimson", "gold"],
-            negative_defaults="photorealism",
+            style_exclusions="photorealism",
             aspect_ratio="1:1",
             category="portrait",
         )
@@ -56,7 +56,7 @@ class TestFlattenBriefToPrompt:
             art_style="watercolor",
             art_medium="traditional paper",
             palette=["deep indigo", "gold"],
-            negative_defaults="photorealism",
+            style_exclusions="photorealism",
         )
         positive, negative = flatten_brief_to_prompt(brief)
 
@@ -121,7 +121,7 @@ class TestBuildImageBrief:
                 "style": "watercolor",
                 "medium": "traditional paper",
                 "palette": ["deep indigo", "gold"],
-                "negative_defaults": "photorealism",
+                "style_exclusions": "photorealism",
                 "aspect_ratio": "16:9",
             },
         )
@@ -150,7 +150,7 @@ class TestBuildImageBrief:
         assert result.entity_fragments == ["hero: tall warrior, scarred face"]
         assert result.art_style == "watercolor"
         assert result.palette == ["deep indigo", "gold"]
-        assert result.negative_defaults == "photorealism"
+        assert result.style_exclusions == "photorealism"
         assert result.style_overrides == "darker palette"
         assert result.aspect_ratio == "16:9"
 
@@ -206,7 +206,7 @@ class TestAssembleImagePromptBackwardCompat:
                 "style": "watercolor",
                 "medium": "traditional paper",
                 "palette": ["deep indigo", "gold"],
-                "negative_defaults": "photorealism",
+                "style_exclusions": "photorealism",
             },
         )
 

--- a/tests/unit/test_image_provider.py
+++ b/tests/unit/test_image_provider.py
@@ -304,7 +304,7 @@ class TestOpenAIDistillPrompt:
             entity_fragments=["tall warrior, scarred face"],
             palette=["crimson", "gold"],
             negative="gore",
-            negative_defaults="photorealism",
+            style_exclusions="photorealism",
         )
 
         positive, negative = await provider.distill_prompt(brief)


### PR DESCRIPTION
## Summary

Two-layer renderer-aware art direction backed by a single static checkpoint style map:

- **Prevention (DRESS Phase 0)** — when `--image-provider` is set at orchestrator init, `dress_discuss.yaml` injects an Image-Renderer-Constraint section so DRESS picks compatible art direction in the first place. Empty when provider is deferred (renderer-blind, current behavior).
- **Recovery (A1111 distiller)** — existing crude `checkpoint_hint` (bare model name + generic anime-vs-photoreal example) replaced with structured map lookup; the two layers cannot drift.

Bundled rename: `ArtDirection.negative_defaults` → `style_exclusions`. The original name activated LLM training associations with SD-style negative-prompt fillers (`blurry, watermark, mutated hands, ...`); small models (qwen3:4b) read field names stronger than descriptions. `style_exclusions` gives the field one unambiguous semantic (story-tone visual prohibitions); renderer-quality fillers move to per-provider code-side constants.

## Spec + plan

- Design: `docs/superpowers/specs/2026-04-28-dress-image-renderer-hint-design.md`
- Implementation plan: `docs/superpowers/plans/2026-04-28-dress-image-renderer-hint.md`

Designed with two rounds of `@prompt-engineer` advisory.

## Cascade (per spec)

Specs first per CLAUDE.md "Spec-first fix order": `dress.md` R-1.2 + `ship.md` R-3.9 + `00-spec.md` deprecated schema example → `checkpoint_styles.py` module + 14 tests → atomic rename across 16 files → DRESS context-builder + `dress_discuss.yaml` placeholder + 5 helper tests → A1111 distiller `_format_checkpoint_hint` + 5 tests.

Closes #1557.

## Map coverage

10 entries for the user's loaded A1111 checkpoints (Flux / coloring_book / Juggernaut / Animagine / DreamShaperXL Lightning / DreamShaperXL / DreamShaper SD1.5 / SDXL Base / SD 1.5) + a sensible default fallback for unknown checkpoints. Pattern ordering documented (specific patterns precede generic).

## Test plan

- [x] `uv run pytest tests/unit/test_checkpoint_styles.py` — 14 passed
- [x] `uv run pytest tests/unit/test_dress_stage.py::TestImageRendererSection` — 5 passed
- [x] `uv run pytest tests/unit/test_image_a1111.py::TestDistillerCheckpointHint` — 5 passed
- [x] `uv run pytest tests/unit/` — 3184 passed (one pre-existing flaky network test in `test_provider_factory.py` passes in isolation)
- [x] `uv run mypy src/questfoundry/` — clean (129 source files)
- [x] `uv run ruff check src/ tests/` — clean
- [x] `rg "negative_defaults" src/ tests/ prompts/` — zero hits
- [x] Smoke-tested template rendering: `{image_renderer_section}` resolves cleanly when provider is None and when provider is set

🤖 Generated with [Claude Code](https://claude.com/claude-code)