### PR TITLE
feat(providers): natural-language prompt distillation for Flux on Forge Neo (#1559)

### DIFF
--- a/docs/superpowers/plans/2026-04-29-flux-natural-language-distill.md
+++ b/docs/superpowers/plans/2026-04-29-flux-natural-language-distill.md
@@ -1,0 +1,574 @@
+# Flux natural-language prompt distillation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a per-checkpoint `prompt_format` toggle (`"clip_tags"` vs `"natural_language"`) so the A1111 distiller skips LLM-driven CLIP-tag distillation for Flux on Forge Neo and flattens the brief's prose fields directly via the existing `flatten_brief_to_prompt()`.
+
+**Architecture:** Single source of truth: `_CHECKPOINT_STYLE_MAP` gains a `prompt_format` key on every entry. New helper `prompt_format_for_checkpoint()` is a thin wrapper. `A1111ImageProvider.distill_prompt` branches on the format — NL mode calls `flatten_brief_to_prompt(brief)` directly (no LLM call); clip_tags mode keeps the current `_distill_with_llm` path. Existing tests for clip_tags behavior stay green; the LLM-required assertion narrows to the clip_tags branch.
+
+**Tech Stack:** Python 3.11+, `uv`, `pytest`, `mypy`, `ruff`. Existing patterns: `re.compile` regex map (`_CHECKPOINT_STYLE_MAP`), `dataclasses.dataclass(frozen=True)` for `ImageBrief`, async `distill_prompt` returning `tuple[str, str | None]`.
+
+**Spec:** `docs/superpowers/specs/2026-04-28-flux-natural-language-distill-design.md`. Closes #1559. Builds on #1558 (merged).
+
+---
+
+## File Structure
+
+**Modified files (4):**
+- `src/questfoundry/providers/checkpoint_styles.py` — add `prompt_format` key to all 10 map entries; new `prompt_format_for_checkpoint()` helper; update module docstring.
+- `tests/unit/test_checkpoint_styles.py` — add `prompt_format` assertions to existing test class + parametrize coverage for the new helper.
+- `src/questfoundry/providers/image_a1111.py` — `distill_prompt` branches on `prompt_format_for_checkpoint(self._model)`; LLM assertion moves inside the clip_tags branch; new imports.
+- `tests/unit/test_image_a1111.py` — failing test asserting NL mode skips the LLM and returns `flatten_brief_to_prompt(brief)` verbatim; existing clip_tags tests stay green.
+
+**No new files. No prompt template changes. No spec doc changes (those are in the spec file already committed).**
+
+---
+
+## Task 1: Add `prompt_format` field + helper — failing tests
+
+TDD strict: write the test before any production change.
+
+**Files:**
+- Test: `tests/unit/test_checkpoint_styles.py`
+
+- [ ] **Step 1: Append failing tests for `prompt_format` field + helper**
+
+Append to `tests/unit/test_checkpoint_styles.py` (end of file, after the existing `TestResolveCheckpointStyle` class):
+
+```python
+class TestPromptFormat:
+    """`prompt_format` field on each map entry + `prompt_format_for_checkpoint()`
+    helper. Drives the A1111 distiller's clip_tags vs natural_language
+    branching for Flux on Forge Neo (#1559)."""
+
+    def test_resolve_checkpoint_style_returns_prompt_format(self) -> None:
+        # Every entry must carry a prompt_format key.
+        info = resolve_checkpoint_style("anything.safetensors")
+        assert "prompt_format" in info
+        assert info["prompt_format"] in {"clip_tags", "natural_language"}
+
+    def test_flux_uses_natural_language(self) -> None:
+        from questfoundry.providers.checkpoint_styles import (
+            prompt_format_for_checkpoint,
+        )
+
+        assert prompt_format_for_checkpoint("flux1-dev-bnb-nf4-v2.safetensors") == "natural_language"
+        assert prompt_format_for_checkpoint("flux1-dev-bnb-nf4.safetensors") == "natural_language"
+
+    @pytest.mark.parametrize(
+        "model",
+        [
+            "coloring_book.ckpt",
+            "v1-5-pruned-emaonly.safetensors",
+            "animagine-xl.safetensors",
+            "Dreamshaper.safetensors",
+            "sd_xl_base_1.0.safetensors",
+            "dreamshaperXL_lightningDPMSDE.safetensors",
+            "juggernautXL_ragnarokBy.safetensors",
+            "dreamshaperXL_alpha2Xl10.safetensors",
+            "dreamshaperXL_v1.safetensors",
+        ],
+    )
+    def test_non_flux_checkpoints_use_clip_tags(self, model: str) -> None:
+        from questfoundry.providers.checkpoint_styles import (
+            prompt_format_for_checkpoint,
+        )
+
+        assert prompt_format_for_checkpoint(model) == "clip_tags"
+
+    def test_unknown_checkpoint_uses_clip_tags(self) -> None:
+        from questfoundry.providers.checkpoint_styles import (
+            prompt_format_for_checkpoint,
+        )
+
+        # Default fallback: SD-family is the long tail; safer assumption is CLIP.
+        assert prompt_format_for_checkpoint("totally-made-up-model.safetensors") == "clip_tags"
+
+    def test_no_model_uses_clip_tags(self) -> None:
+        # When no model is set, preserve the LLM-distill default path.
+        from questfoundry.providers.checkpoint_styles import (
+            prompt_format_for_checkpoint,
+        )
+
+        assert prompt_format_for_checkpoint(None) == "clip_tags"
+        assert prompt_format_for_checkpoint("") == "clip_tags"
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+uv run --frozen pytest tests/unit/test_checkpoint_styles.py::TestPromptFormat -v
+```
+
+Expected: failures. The first test (`test_resolve_checkpoint_style_returns_prompt_format`) fails with `AssertionError: 'prompt_format' not in info`. The other tests fail with `ImportError: cannot import name 'prompt_format_for_checkpoint'`.
+
+- [ ] **Step 3: Commit the failing tests**
+
+```bash
+git add tests/unit/test_checkpoint_styles.py
+git commit -m "test(providers): failing tests for prompt_format field + helper (#1559)"
+```
+
+If pre-commit hooks block the failing-test commit, leave the file uncommitted in the working tree and report DONE_WITH_CONCERNS — the controller will commit it together with Task 2's implementation. Do NOT use `--no-verify`.
+
+---
+
+## Task 2: Implement `prompt_format` field + helper
+
+**Files:**
+- Modify: `src/questfoundry/providers/checkpoint_styles.py`
+
+- [ ] **Step 1: Add `prompt_format` to all 10 map entries**
+
+Open `src/questfoundry/providers/checkpoint_styles.py`. For each of the 10 entries in `_CHECKPOINT_STYLE_MAP`, add `"prompt_format"` as a new key. Flux gets `"natural_language"`; everything else gets `"clip_tags"`. Place `"prompt_format"` consistently at the end of each entry's dict (after `bad_example`).
+
+Concretely:
+
+```python
+# Flux entry — natural_language
+(
+    re.compile(r"flux"),
+    {
+        "label": "Flux (photorealistic / highly-detailed)",
+        # ... existing keys: style_hints, incompatible_styles, good_example, bad_example ...
+        "prompt_format": "natural_language",
+    },
+),
+```
+
+```python
+# All other 9 entries — clip_tags
+(
+    re.compile(r"coloring.?book"),
+    {
+        # ... existing keys ...
+        "prompt_format": "clip_tags",
+    },
+),
+# ... and so on for juggernaut, animagine, dreamshaperxl_lightning|alpha,
+#     dreamshaperxl|dreamshaper.*xl, dreamshaper, sd_xl_base, v1[-_]5, default ...
+```
+
+The default-fallback entry (empty pattern, last in tuple) gets `"prompt_format": "clip_tags"`.
+
+- [ ] **Step 2: Add the helper function below `resolve_checkpoint_style()`**
+
+Append to `src/questfoundry/providers/checkpoint_styles.py`, after the existing `resolve_checkpoint_style()` definition:
+
+```python
+def prompt_format_for_checkpoint(model: str | None) -> str:
+    """Return the prompt format the active checkpoint expects.
+
+    Returns ``"clip_tags"`` when no model is set — preserves the LLM-distill
+    default path through ``A1111ImageProvider.distill_prompt``. CLIP-encoder
+    checkpoints (SDXL, SD1.5, etc.) take ``"clip_tags"``; T5-encoder
+    checkpoints (Flux) take ``"natural_language"``. See PR #1559.
+
+    Args:
+        model: Checkpoint filename (with or without extension), or None / empty
+            string when no checkpoint is selected.
+
+    Returns:
+        ``"clip_tags"`` or ``"natural_language"``.
+    """
+    if not model:
+        return "clip_tags"
+    return resolve_checkpoint_style(model)["prompt_format"]
+```
+
+- [ ] **Step 3: Update module docstring**
+
+In the module docstring at the top of `checkpoint_styles.py`, add a short sentence to the "Used by" paragraph noting the new prompt-format usage. The current docstring says:
+
+```
+Used by DRESS Phase 0 (prevention — when `--image-provider` is set, biases
+ArtDirection toward checkpoint-compatible styles) and the A1111 distiller
+(recovery — adapts CLIP-tag selection to the active checkpoint).
+```
+
+Append:
+
+```
+The A1111 distiller also reads `prompt_format` (via
+`prompt_format_for_checkpoint`) to choose between LLM-driven CLIP-tag
+distillation (CLIP-encoder checkpoints) and direct prose flattening
+(T5-encoder checkpoints like Flux on Forge Neo) — see PR #1559.
+```
+
+- [ ] **Step 4: Run the new tests and confirm they pass**
+
+```bash
+uv run --frozen pytest tests/unit/test_checkpoint_styles.py -v
+```
+
+Expected: all `TestResolveCheckpointStyle` tests still green (no regression) AND all new `TestPromptFormat` tests pass.
+
+- [ ] **Step 5: Run mypy + ruff**
+
+```bash
+uv run --frozen mypy src/questfoundry/providers/checkpoint_styles.py
+uv run --frozen ruff check src/questfoundry/providers/checkpoint_styles.py tests/unit/test_checkpoint_styles.py
+```
+
+Expected: both clean.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/questfoundry/providers/checkpoint_styles.py
+git commit -m "feat(providers): add prompt_format field + helper for Flux NL mode (#1559)"
+```
+
+---
+
+## Task 3: A1111 distiller branch — failing test
+
+**Files:**
+- Test: `tests/unit/test_image_a1111.py`
+
+- [ ] **Step 1: Append failing tests for the distill_prompt branch**
+
+Append to `tests/unit/test_image_a1111.py` (end of file, after the existing `TestDistillerCheckpointHint` class):
+
+```python
+class TestDistillPromptFormatBranch:
+    """`distill_prompt` branches on `prompt_format_for_checkpoint(self._model)`.
+    Flux (T5 encoder) skips the LLM distill entirely and flattens the brief's
+    prose fields via `flatten_brief_to_prompt()`. Standard SD/SDXL checkpoints
+    keep the existing LLM-distill path (#1559)."""
+
+    def _make_brief(self) -> "ImageBrief":
+        from questfoundry.providers.image_brief import ImageBrief
+
+        return ImageBrief(
+            subject="warrior on a stone bridge",
+            composition="wide shot, low angle",
+            mood="tense, golden hour",
+            entity_fragments=["scarred warrior with leather armor"],
+            art_style="cinematic photography",
+            art_medium="digital photo",
+            palette=["amber", "slate"],
+            style_exclusions="no anime, no anachronistic technology",
+            aspect_ratio="16:9",
+            category="scene",
+        )
+
+    @pytest.mark.asyncio
+    async def test_flux_skips_llm_and_uses_flattener(self) -> None:
+        from unittest.mock import AsyncMock, MagicMock
+
+        from questfoundry.providers.image_a1111 import A1111ImageProvider
+        from questfoundry.providers.image_brief import flatten_brief_to_prompt
+
+        # MagicMock LLM whose method usage we can audit.
+        llm = MagicMock()
+        llm.ainvoke = AsyncMock()  # would be called by _distill_with_llm
+        provider = A1111ImageProvider(
+            host="http://x", model="flux1-dev-bnb-nf4-v2.safetensors", llm=llm
+        )
+
+        brief = self._make_brief()
+        result = await provider.distill_prompt(brief)
+
+        # NL mode: result equals flatten_brief_to_prompt() output exactly.
+        expected = flatten_brief_to_prompt(brief)
+        assert result == expected
+
+        # NL mode: LLM is never invoked.
+        assert llm.ainvoke.await_count == 0
+
+    @pytest.mark.asyncio
+    async def test_clip_tags_checkpoint_still_uses_llm_distill(self) -> None:
+        # Sanity: a non-Flux checkpoint must still go through _distill_with_llm.
+        # We verify by stubbing _distill_with_llm and checking it was called.
+        from unittest.mock import AsyncMock, MagicMock, patch
+
+        from questfoundry.providers.image_a1111 import A1111ImageProvider
+
+        llm = MagicMock()
+        provider = A1111ImageProvider(
+            host="http://x", model="juggernautXL_ragnarokBy.safetensors", llm=llm
+        )
+
+        brief = self._make_brief()
+        with patch.object(
+            provider, "_distill_with_llm", new=AsyncMock(return_value=("pos", "neg"))
+        ) as mock_distill:
+            result = await provider.distill_prompt(brief)
+
+        assert result == ("pos", "neg")
+        mock_distill.assert_awaited_once_with(brief)
+
+    @pytest.mark.asyncio
+    async def test_flux_works_without_llm(self) -> None:
+        # NL mode should not require an LLM at all — `_llm=None` is OK.
+        from questfoundry.providers.image_a1111 import A1111ImageProvider
+        from questfoundry.providers.image_brief import flatten_brief_to_prompt
+
+        provider = A1111ImageProvider(
+            host="http://x", model="flux1-dev-bnb-nf4-v2.safetensors", llm=None
+        )
+
+        brief = self._make_brief()
+        result = await provider.distill_prompt(brief)
+
+        assert result == flatten_brief_to_prompt(brief)
+
+    @pytest.mark.asyncio
+    async def test_clip_tags_without_llm_raises(self) -> None:
+        # Sanity: clip_tags branch still raises when no LLM is provided.
+        from questfoundry.providers.image_a1111 import A1111ImageProvider
+        from questfoundry.providers.base import ImageProviderError
+
+        provider = A1111ImageProvider(
+            host="http://x", model="juggernautXL_ragnarokBy.safetensors", llm=None
+        )
+
+        brief = self._make_brief()
+        with pytest.raises(ImageProviderError):
+            await provider.distill_prompt(brief)
+```
+
+If `pytest_asyncio` isn't already configured for this test file, the `@pytest.mark.asyncio` decorator may need a different invocation pattern. Check how the existing async tests in `tests/unit/test_image_a1111.py` are structured — copy their pattern. (If existing tests use plain `async def` without the marker because of project-wide `asyncio_mode = "auto"` config, drop the decorators here too.)
+
+- [ ] **Step 2: Run the failing tests**
+
+```bash
+uv run --frozen pytest tests/unit/test_image_a1111.py::TestDistillPromptFormatBranch -v
+```
+
+Expected:
+- `test_flux_skips_llm_and_uses_flattener` fails — Flux currently goes through `_distill_with_llm` which would either invoke the LLM mock or fail.
+- `test_flux_works_without_llm` fails — current code raises `ImageProviderError` when `_llm is None` regardless of checkpoint.
+- `test_clip_tags_checkpoint_still_uses_llm_distill` may pass already (it tests existing behavior) — that's OK.
+- `test_clip_tags_without_llm_raises` may pass already — also OK.
+
+The two failing tests are the load-bearing ones for the branch.
+
+- [ ] **Step 3: Commit the failing tests**
+
+```bash
+git add tests/unit/test_image_a1111.py
+git commit -m "test(providers): failing tests for distill_prompt prompt_format branch (#1559)"
+```
+
+If pre-commit hooks block, report DONE_WITH_CONCERNS and leave uncommitted. Do NOT use `--no-verify`.
+
+---
+
+## Task 4: A1111 distiller branch — implementation
+
+**Files:**
+- Modify: `src/questfoundry/providers/image_a1111.py`
+
+- [ ] **Step 1: Add the import for `prompt_format_for_checkpoint` + `flatten_brief_to_prompt`**
+
+In `src/questfoundry/providers/image_a1111.py`, find the existing imports block. Add:
+
+```python
+from questfoundry.providers.checkpoint_styles import (
+    prompt_format_for_checkpoint,
+    resolve_checkpoint_style,  # may already be imported via _format_checkpoint_hint;
+                                # if so, add prompt_format_for_checkpoint to the same line
+)
+from questfoundry.providers.image_brief import (
+    ImageBrief,                    # may already be imported
+    flatten_brief_to_prompt,
+)
+```
+
+Match the existing import style — if `image_brief.ImageBrief` is already imported, just add `flatten_brief_to_prompt` to the same import statement. Same for `checkpoint_styles.resolve_checkpoint_style` (added in PR #1558).
+
+- [ ] **Step 2: Branch in `distill_prompt`**
+
+Replace the existing `distill_prompt` method body (around line 227-239):
+
+```python
+    async def distill_prompt(self, brief: ImageBrief) -> tuple[str, str | None]:
+        """Transform a structured brief into SD-optimised prompts via LLM.
+
+        Raises:
+            ImageProviderError: If no LLM was provided at construction.
+        """
+        if self._llm is None:
+            raise ImageProviderError(
+                "a1111",
+                "A1111 prompt distillation requires an LLM. "
+                "Pass --provider to generate-images or set QF_PROVIDER.",
+            )
+        return await self._distill_with_llm(brief)
+```
+
+with:
+
+```python
+    async def distill_prompt(self, brief: ImageBrief) -> tuple[str, str | None]:
+        """Transform a structured brief into a renderer-shaped prompt.
+
+        Branches on the active checkpoint's prompt format (#1559):
+
+        - ``"natural_language"`` (Flux on Forge Neo, T5 encoder, ~512-token
+          window): skip LLM distillation entirely. The structured brief
+          already encodes subject/composition/mood/entities/style/medium/
+          palette as comma-joined prose via :func:`flatten_brief_to_prompt`,
+          which is the shape T5 was trained on.
+        - ``"clip_tags"`` (SDXL, SD1.5, etc.): LLM-distill into the comma-tag
+          form CLIP expects, using the existing :meth:`_distill_with_llm`.
+
+        Raises:
+            ImageProviderError: If the active checkpoint requires
+                ``clip_tags`` distillation but no LLM was provided at
+                construction. ``natural_language`` mode runs without an LLM.
+        """
+        if prompt_format_for_checkpoint(self._model) == "natural_language":
+            return flatten_brief_to_prompt(brief)
+
+        if self._llm is None:
+            raise ImageProviderError(
+                "a1111",
+                "A1111 prompt distillation requires an LLM. "
+                "Pass --provider to generate-images or set QF_PROVIDER.",
+            )
+        return await self._distill_with_llm(brief)
+```
+
+- [ ] **Step 3: Run the failing tests; confirm green**
+
+```bash
+uv run --frozen pytest tests/unit/test_image_a1111.py::TestDistillPromptFormatBranch -v
+```
+
+Expected: 4 passed.
+
+- [ ] **Step 4: Run the wider distiller test file to confirm no regression**
+
+```bash
+uv run --frozen pytest tests/unit/test_image_a1111.py -x -q
+```
+
+Expected: all green. The existing `TestDistillerCheckpointHint` class (PR #1558) covers `_format_checkpoint_hint` independently and is unaffected by the new branch.
+
+- [ ] **Step 5: Run mypy + ruff**
+
+```bash
+uv run --frozen mypy src/questfoundry/providers/image_a1111.py
+uv run --frozen ruff check src/questfoundry/providers/image_a1111.py
+```
+
+Expected: both clean.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/questfoundry/providers/image_a1111.py tests/unit/test_image_a1111.py
+git commit -m "feat(providers): A1111 distill_prompt branches on prompt_format for Flux (#1559)"
+```
+
+If Task 3's failing-test commit was held back due to pre-commit, this commit picks up both the test additions and the implementation in one shot.
+
+---
+
+## Task 5: Final verification + draft PR
+
+**Files:**
+- N/A (verification + git only)
+
+- [ ] **Step 1: Run the unit test suite**
+
+```bash
+uv run --frozen pytest tests/unit/ -x -q
+```
+
+Expected: all green (the same pre-existing flaky `test_provider_factory.py::test_create_chat_model_ollama_success` may surface — confirm it passes in isolation if so).
+
+- [ ] **Step 2: Run mypy on changed source files**
+
+```bash
+uv run --frozen mypy src/questfoundry/providers/checkpoint_styles.py src/questfoundry/providers/image_a1111.py src/questfoundry/providers/image_brief.py
+```
+
+Expected: clean.
+
+- [ ] **Step 3: Run ruff**
+
+```bash
+uv run --frozen ruff check src/ tests/
+uv run --frozen ruff format --check src/ tests/
+```
+
+Expected: clean. If format issues, run without `--check` to fix and re-commit.
+
+- [ ] **Step 4: Verify the new fields and helper exist where expected**
+
+```bash
+rg "prompt_format" src/questfoundry/providers/checkpoint_styles.py
+```
+
+Expected: 10 entry-key occurrences (one per map entry) + the helper signature + at least one docstring mention. Roughly 13-15 hits.
+
+```bash
+rg "prompt_format_for_checkpoint" src/questfoundry/
+```
+
+Expected: 1 definition in `checkpoint_styles.py` + 1 use in `image_a1111.py`.
+
+- [ ] **Step 5: Push branch + open draft PR**
+
+```bash
+git push -u origin feat/forge-flux-natural-language-distill
+gh pr create --draft --title "feat(providers): natural-language prompt distillation for Flux on Forge Neo (#1559)" --body "$(cat <<'EOF'
+## Summary
+
+Adds a per-checkpoint \`prompt_format\` toggle to \`_CHECKPOINT_STYLE_MAP\` (\`"clip_tags"\` default; \`"natural_language"\` for Flux). \`A1111ImageProvider.distill_prompt\` branches on the format: Flux (T5 encoder, 512-token window) skips LLM distillation entirely and flattens the brief's prose fields via the existing \`flatten_brief_to_prompt()\`. Standard SDXL/SD1.5/Animagine/Juggernaut/etc. keep the LLM-driven CLIP-tag distillation unchanged.
+
+The user's A1111 instance has been replaced with **Forge Neo** (API-compatible with A1111), which hosts Flux alongside standard SD checkpoints. The toggle is per-checkpoint, not per-provider — provider identifier stays \`a1111\`.
+
+## Spec + plan
+
+- Design: \`docs/superpowers/specs/2026-04-28-flux-natural-language-distill-design.md\`
+- Implementation plan: \`docs/superpowers/plans/2026-04-29-flux-natural-language-distill.md\`
+
+Builds on PR #1558 (merged 2026-04-28).
+
+Closes #1559.
+
+## Cascade (4 files)
+
+1. \`src/questfoundry/providers/checkpoint_styles.py\` — \`prompt_format\` field on all 10 map entries + new \`prompt_format_for_checkpoint()\` helper
+2. \`src/questfoundry/providers/image_a1111.py\` — \`distill_prompt\` branches on format; LLM assertion narrows to \`clip_tags\` branch
+3. \`tests/unit/test_checkpoint_styles.py\` — \`TestPromptFormat\` class (5 tests covering field presence, Flux NL mode, 9 non-Flux checkpoints in clip_tags mode, default fallback, no-model fallback)
+4. \`tests/unit/test_image_a1111.py\` — \`TestDistillPromptFormatBranch\` class (4 tests covering Flux→flatten, clip_tags→LLM, Flux without LLM, clip_tags without LLM raises)
+
+## Test plan
+
+- [x] \`uv run pytest tests/unit/test_checkpoint_styles.py\` — green
+- [x] \`uv run pytest tests/unit/test_image_a1111.py\` — green
+- [x] \`uv run pytest tests/unit/\` — full suite green (modulo pre-existing flaky network test)
+- [x] \`uv run mypy src/questfoundry/\` — clean
+- [x] \`uv run ruff check src/ tests/\` — clean
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 6: Wait for bot review loop**
+
+Per CLAUDE.md, address findings in-PR. Gemini may be at daily quota; claude-review approval is sufficient. Flip ready when claude-review LGTM + all CI green + bot's review body explicitly says "Ready to merge" (read the body, not the check status).
+
+---
+
+## Self-Review Notes
+
+Spec coverage check:
+
+- ✅ Spec §`prompt_format` field on each map entry → Task 2 step 1
+- ✅ Spec §`prompt_format_for_checkpoint()` helper → Task 2 step 2
+- ✅ Spec §`A1111ImageProvider.distill_prompt` branch → Task 4 step 2
+- ✅ Spec §LLM assertion narrowing → Task 4 step 2 (the `if self._llm is None` check moves below the NL-mode early return)
+- ✅ Spec §What flows through to T5 (`flatten_brief_to_prompt` reuse) → Task 4 step 2 + Task 3 test asserting equality with the flattener output
+- ✅ Spec §file cascade (4 sites) → Tasks 1-4 (one task per file pair: test + impl)
+- ✅ Spec §verification (`pytest`, `rg "prompt_format" src/questfoundry/providers/`) → Task 5
+- ✅ Spec §risks: contract change for consumers expecting strict-equal key sets → covered by Task 1 step 1 (`test_returns_required_keys` already uses `>=` per spec; no regression)
+
+No placeholders. No "implement later" / "similar to Task N" / TBD. Type consistency: `prompt_format`, `prompt_format_for_checkpoint`, `flatten_brief_to_prompt` referenced consistently across tasks.

--- a/docs/superpowers/specs/2026-04-28-flux-natural-language-distill-design.md
+++ b/docs/superpowers/specs/2026-04-28-flux-natural-language-distill-design.md
@@ -1,0 +1,137 @@
+# Flux natural-language prompt distillation on Forge Neo
+
+**Status:** Approved 2026-04-28
+**Owner:** @pvliesdonk
+**Tracking:** #1559
+**Builds on:** #1558 (merged) — checkpoint-style map
+
+## Problem
+
+PR #1558 added a static `_CHECKPOINT_STYLE_MAP` and an A1111 distiller `_format_checkpoint_hint` that adapt CLIP-tag-format prompts to the active checkpoint. The distiller's output format is hardcoded: comma-separated CLIP tags with a `tag_limit = 75 if is_xl else 40` budget and a `BREAK`-separated scene/style chunking pattern.
+
+The user has replaced their A1111 instance with **Forge Neo**, which is API-compatible with A1111 (same HTTP endpoints, same WebUI) but hosts **Flux** alongside standard SD checkpoints. Flux uses a **T5 text encoder** with a ~512-token window, trained on natural-language prose — the opposite end of the spectrum from CLIP's ~77-token tag-soup. Distilling to CLIP tags on Flux:
+
+- discards narrative cues T5 was trained on;
+- produces the wrong prompt shape (comma-tag form is not how T5 expects input);
+- defeats the point of the larger token window.
+
+The user's Forge Neo instance hosts both Flux *and* standard SDXL/SD1.5 checkpoints. The format toggle must therefore be **per-checkpoint**, not per-provider.
+
+## Non-goals
+
+- Replacing the A1111 provider class. Forge Neo is API-compatible; the HTTP layer in `image_a1111.py` works unchanged.
+- LLM-driven natural-language distillation. This spec picks the simpler path: skip LLM distillation entirely for NL-mode checkpoints, flatten the brief's prose fields directly. If the flatten approach underperforms on Flux output quality, an LLM-distill-to-prose mode can be added later.
+- Touching `image_openai.py`. The OpenAI image providers already produce NL prompts; no changes needed.
+- Renaming the `a1111` provider identifier. Forge Neo presents the same API; users keep `--image-provider a1111/<checkpoint>`.
+
+## Design
+
+### `prompt_format` field on each map entry
+
+`_CHECKPOINT_STYLE_MAP` entries gain a `prompt_format` key with values:
+
+- `"clip_tags"` — current behavior. CLIP-encoder checkpoints (SDXL, SD1.5, Animagine, Juggernaut, DreamShaper variants, SDXL Base, Coloring Book). LLM-distilled to comma-tag format.
+- `"natural_language"` — T5-encoder checkpoints (Flux). Direct flatten via `flatten_brief_to_prompt()`; no LLM call.
+
+Existing entries: every entry except Flux gets `"clip_tags"`. Flux gets `"natural_language"`. Default-fallback entry stays on `"clip_tags"` (SD-family is the long tail; the safer assumption is CLIP).
+
+### `prompt_format_for_checkpoint()` helper
+
+A new sibling of `resolve_checkpoint_style()`:
+
+```python
+def prompt_format_for_checkpoint(model: str | None) -> Literal["clip_tags", "natural_language"]:
+    """Return the prompt format the active checkpoint expects.
+
+    Returns ``"clip_tags"`` when no model is set — preserves the LLM-distill
+    default path through ``A1111ImageProvider.distill_prompt``.
+    """
+    if not model:
+        return "clip_tags"
+    return resolve_checkpoint_style(model)["prompt_format"]
+```
+
+The function is a thin wrapper around `resolve_checkpoint_style()` so the static map remains the single source of truth.
+
+### `A1111ImageProvider.distill_prompt` branch
+
+Currently:
+
+```python
+async def distill_prompt(self, brief: ImageBrief) -> tuple[str, str | None]:
+    if self._llm is None:
+        raise RuntimeError("A1111 prompt distillation requires an LLM. ...")
+    return await self._distill_with_llm(brief)
+```
+
+After:
+
+```python
+async def distill_prompt(self, brief: ImageBrief) -> tuple[str, str | None]:
+    if prompt_format_for_checkpoint(self._model) == "natural_language":
+        # T5-encoder checkpoints (Flux): the structured brief already encodes
+        # subject/composition/mood/entities/style/medium/palette as comma-joined
+        # prose; T5's larger token window and natural-language training make
+        # CLIP-tag distillation counterproductive (#1559).
+        return flatten_brief_to_prompt(brief)
+
+    if self._llm is None:
+        raise RuntimeError("A1111 prompt distillation requires an LLM. ...")
+    return await self._distill_with_llm(brief)
+```
+
+The LLM-required assertion narrows to the `clip_tags` branch. NL mode runs without an LLM, since `flatten_brief_to_prompt()` is pure.
+
+### What flows through to T5
+
+`flatten_brief_to_prompt()` (already in `image_brief.py`) produces a comma-joined positive prompt assembled from:
+
+```
+[entity_fragments] and [entity_fragments], [subject], [composition], [mood], [art_style], [art_medium] style, [palette] palette, [style_overrides]
+```
+
+This is human-readable, narrative-flavored prose with light comma structure — exactly the shape T5 expects. Negative prompt joins `negative` + `style_exclusions`.
+
+The DRESS Phase 0 renderer-hint section (PR #1558) already biases the brief itself toward Flux-friendly art direction when the renderer is known at orchestrator init. The distiller's only remaining job in NL mode is to format the brief's existing prose; no further LLM-driven adaptation is needed.
+
+## File cascade (4 sites)
+
+| # | File | Change |
+|---|---|---|
+| 1 | `src/questfoundry/providers/checkpoint_styles.py` | Add `prompt_format` key to all 10 `_CHECKPOINT_STYLE_MAP` entries (Flux: `"natural_language"`; everything else: `"clip_tags"`). Add `prompt_format_for_checkpoint()` helper. Update module docstring. |
+| 2 | `tests/unit/test_checkpoint_styles.py` | Failing test asserting Flux returns `"natural_language"` and 9 other entries return `"clip_tags"`; default fallback returns `"clip_tags"`; `None` model returns `"clip_tags"`. |
+| 3 | `src/questfoundry/providers/image_a1111.py` | `distill_prompt` branches on `prompt_format_for_checkpoint(self._model)`. NL mode calls `flatten_brief_to_prompt(brief)`. LLM assertion narrows to clip_tags branch. Import `flatten_brief_to_prompt` and `prompt_format_for_checkpoint`. |
+| 4 | `tests/unit/test_image_a1111.py` | Failing test: `distill_prompt` on a Flux model returns `flatten_brief_to_prompt(brief)` output verbatim, with the LLM mock receiving zero calls; clip_tags model still goes through the LLM path. |
+
+## Verification
+
+```sh
+$ uv run pytest tests/unit/test_checkpoint_styles.py tests/unit/test_image_a1111.py -v
+# green
+
+$ rg "prompt_format" src/questfoundry/providers/
+# 10+ map-entry hits + 1 helper definition + 1 distiller branch
+```
+
+## Risks and mitigations
+
+| Risk | Mitigation |
+|------|------------|
+| `flatten_brief_to_prompt()` output too sparse for Flux's 512-token window. | If output quality on Flux underperforms, add an LLM-distill-to-prose mode (option (a) from brainstorm) as a follow-up. The static `prompt_format` field can grow a third value `"natural_language_distilled"` later. |
+| Comma-joined prose isn't what T5 wants — T5 may prefer flowing sentences. | The brief's structured layout (subject + composition + mood as separate fields) is already prose-friendly; commas separate semantic chunks. If observation in practice shows it underperforms, restructure `flatten_brief_to_prompt()` to produce flowing sentences for NL mode. Same surface, different formatter. |
+| User sets `--image-provider a1111/flux1-dev-bnb-nf4` but the orchestrator path still requires `_llm` for some other reason. | The `_llm` parameter on `A1111ImageProvider.__init__` stays `Optional`; only `distill_prompt`'s `clip_tags` branch asserts it's not None. NL mode initializes cleanly without an LLM. |
+| Adding `prompt_format` to existing entries is a contract change for any consumer that does `set(info.keys()) == {...}` exact-equality. | The existing test `test_returns_required_keys` uses `>=` (subset check), not equality. No regression. |
+
+## Out of scope
+
+- The OpenAI image provider (`image_openai.py`) and the placeholder provider (`image_placeholder.py`) — both already produce NL prompts via their own paths; no `prompt_format` consumption needed there.
+- Spec-doc updates to `dress.md` / `ship.md` — `ArtDirection` schema is unchanged; renderer behavior change is internal to the providers.
+- DRESS Phase 0 prompt updates — the renderer-hint section (PR #1558) already biases the brief toward checkpoint-compatible styles; no additional Phase 0 changes needed for this PR.
+
+## References
+
+- PR #1558 (merged) — checkpoint-style map and DRESS Phase 0 renderer hint.
+- `_CHECKPOINT_STYLE_MAP` Flux entry: "negative-prompt weighting is weak on Flux — do not rely on negative prompts for strong style exclusion." (Already shipped in #1558; complementary to this PR's natural-language distillation.)
+- `flatten_brief_to_prompt()` in `src/questfoundry/providers/image_brief.py:37` — the existing default flattener that NL mode reuses.
+- Forge Neo: A1111-API-compatible Stable Diffusion WebUI fork that hosts Flux (T5) alongside standard SD checkpoints (CLIP).
+- Closes #1559.

--- a/src/questfoundry/providers/checkpoint_styles.py
+++ b/src/questfoundry/providers/checkpoint_styles.py
@@ -26,6 +26,7 @@ Adding a new entry:
 from __future__ import annotations
 
 import re
+from typing import Literal, cast
 
 _CHECKPOINT_STYLE_MAP: tuple[tuple[re.Pattern[str], dict[str, str]], ...] = (
     # ----- Flux (NF4 quantised; both v1 and v2 quants share identity) -----
@@ -296,7 +297,7 @@ def resolve_checkpoint_style(model: str) -> dict[str, str]:
 
     Returns:
         Dict with keys ``label``, ``style_hints``, ``incompatible_styles``,
-        ``good_example``, ``bad_example``.
+        ``good_example``, ``bad_example``, ``prompt_format``.
     """
     lowered = model.lower()
     for pattern, info in _CHECKPOINT_STYLE_MAP:
@@ -307,7 +308,9 @@ def resolve_checkpoint_style(model: str) -> dict[str, str]:
     )
 
 
-def prompt_format_for_checkpoint(model: str | None) -> str:
+def prompt_format_for_checkpoint(
+    model: str | None,
+) -> Literal["clip_tags", "natural_language"]:
     """Return the prompt format the active checkpoint expects.
 
     Returns ``"clip_tags"`` when no model is set — preserves the LLM-distill
@@ -324,4 +327,6 @@ def prompt_format_for_checkpoint(model: str | None) -> str:
     """
     if not model:
         return "clip_tags"
-    return resolve_checkpoint_style(model)["prompt_format"]
+    return cast(
+        "Literal['clip_tags', 'natural_language']", resolve_checkpoint_style(model)["prompt_format"]
+    )

--- a/src/questfoundry/providers/checkpoint_styles.py
+++ b/src/questfoundry/providers/checkpoint_styles.py
@@ -5,6 +5,11 @@ Used by DRESS Phase 0 (prevention — when `--image-provider` is set, biases
 ArtDirection toward checkpoint-compatible styles) and the A1111 distiller
 (recovery — adapts CLIP-tag selection to the active checkpoint).
 
+The A1111 distiller also reads `prompt_format` (via
+`prompt_format_for_checkpoint`) to choose between LLM-driven CLIP-tag
+distillation (CLIP-encoder checkpoints) and direct prose flattening
+(T5-encoder checkpoints like Flux on Forge Neo) — see PR #1559.
+
 Pattern matching:
     Patterns are matched against the lowercased checkpoint filename via
     `re.Pattern.search`. First match wins. Specific patterns MUST precede
@@ -46,6 +51,7 @@ _CHECKPOINT_STYLE_MAP: tuple[tuple[re.Pattern[str], dict[str, str]], ...] = (
                 'style="watercolor wash", medium="hand-painted ink" '
                 "(Flux is tuned for photorealism; painterly media will fight the model)"
             ),
+            "prompt_format": "natural_language",
         },
     ),
     # ----- Coloring-book fine-tune (SD1.5 base) -----
@@ -69,6 +75,7 @@ _CHECKPOINT_STYLE_MAP: tuple[tuple[re.Pattern[str], dict[str, str]], ...] = (
                 "(this checkpoint is fine-tuned for line-art only; "
                 "color renders will fail)"
             ),
+            "prompt_format": "clip_tags",
         },
     ),
     # ----- Juggernaut XL (photorealistic SDXL) -----
@@ -90,6 +97,7 @@ _CHECKPOINT_STYLE_MAP: tuple[tuple[re.Pattern[str], dict[str, str]], ...] = (
                 "(Juggernaut is tuned for photorealism; "
                 "stylised media will fight the checkpoint)"
             ),
+            "prompt_format": "clip_tags",
         },
     ),
     # ----- Animagine XL (anime-focused SDXL) -----
@@ -115,6 +123,7 @@ _CHECKPOINT_STYLE_MAP: tuple[tuple[re.Pattern[str], dict[str, str]], ...] = (
                 "(Animagine is anime-specialised; "
                 "photographic styles produce off-distribution outputs)"
             ),
+            "prompt_format": "clip_tags",
         },
     ),
     # ----- DreamShaperXL Lightning / Alpha (must precede generic dreamshaperxl) -----
@@ -140,6 +149,7 @@ _CHECKPOINT_STYLE_MAP: tuple[tuple[re.Pattern[str], dict[str, str]], ...] = (
                 'medium="macro photograph" '
                 "(Lightning checkpoints sacrifice fine detail for speed)"
             ),
+            "prompt_format": "clip_tags",
         },
     ),
     # ----- DreamShaperXL standard -----
@@ -164,6 +174,7 @@ _CHECKPOINT_STYLE_MAP: tuple[tuple[re.Pattern[str], dict[str, str]], ...] = (
                 "(DreamShaperXL is stylised by design; "
                 "strict photo-real fights the model)"
             ),
+            "prompt_format": "clip_tags",
         },
     ),
     # ----- DreamShaper SD1.5 (generic, must come after XL variants) -----
@@ -190,6 +201,7 @@ _CHECKPOINT_STYLE_MAP: tuple[tuple[re.Pattern[str], dict[str, str]], ...] = (
                 "(DreamShaper SD1.5 expects natural descriptors, "
                 "not anime tag grammar)"
             ),
+            "prompt_format": "clip_tags",
         },
     ),
     # ----- SDXL base -----
@@ -215,6 +227,7 @@ _CHECKPOINT_STYLE_MAP: tuple[tuple[re.Pattern[str], dict[str, str]], ...] = (
                 "(SDXL base needs explicit style direction; "
                 "bare anime grammar underperforms)"
             ),
+            "prompt_format": "clip_tags",
         },
     ),
     # ----- SD 1.5 base / pruned -----
@@ -238,6 +251,7 @@ _CHECKPOINT_STYLE_MAP: tuple[tuple[re.Pattern[str], dict[str, str]], ...] = (
                 'medium="macro studio photograph" '
                 "(SD 1.5 caps at ~768px; high-detail photoreal won't render)"
             ),
+            "prompt_format": "clip_tags",
         },
     ),
     # ----- Default — always matches; must be last -----
@@ -265,6 +279,7 @@ _CHECKPOINT_STYLE_MAP: tuple[tuple[re.Pattern[str], dict[str, str]], ...] = (
                 'medium="document scan with readable signage" '
                 "(Stable Diffusion generally cannot render legible text)"
             ),
+            "prompt_format": "clip_tags",
         },
     ),
 )
@@ -290,3 +305,23 @@ def resolve_checkpoint_style(model: str) -> dict[str, str]:
     raise AssertionError(  # pragma: no cover — default fallback always matches
         "default-fallback entry must always match"
     )
+
+
+def prompt_format_for_checkpoint(model: str | None) -> str:
+    """Return the prompt format the active checkpoint expects.
+
+    Returns ``"clip_tags"`` when no model is set — preserves the LLM-distill
+    default path through ``A1111ImageProvider.distill_prompt``. CLIP-encoder
+    checkpoints (SDXL, SD1.5, etc.) take ``"clip_tags"``; T5-encoder
+    checkpoints (Flux) take ``"natural_language"``. See PR #1559.
+
+    Args:
+        model: Checkpoint filename (with or without extension), or None / empty
+            string when no checkpoint is selected.
+
+    Returns:
+        ``"clip_tags"`` or ``"natural_language"``.
+    """
+    if not model:
+        return "clip_tags"
+    return resolve_checkpoint_style(model)["prompt_format"]

--- a/src/questfoundry/providers/image_a1111.py
+++ b/src/questfoundry/providers/image_a1111.py
@@ -21,7 +21,10 @@ from typing import TYPE_CHECKING, Any
 import httpx
 
 from questfoundry.observability.logging import get_logger
-from questfoundry.providers.checkpoint_styles import prompt_format_for_checkpoint
+from questfoundry.providers.checkpoint_styles import (
+    prompt_format_for_checkpoint,
+    resolve_checkpoint_style,
+)
 from questfoundry.providers.image import (
     ImageProviderConnectionError,
     ImageProviderError,
@@ -154,6 +157,21 @@ _SDXL_LIGHTNING_PRESET = _A1111Preset(
     quality_tier="high",
 )
 
+_FLUX_PRESET = _A1111Preset(
+    sizes={
+        "1:1": (1024, 1024),
+        "16:9": (1360, 768),
+        "9:16": (768, 1360),
+        "3:2": (1216, 832),
+        "2:3": (832, 1216),
+    },
+    steps=20,
+    sampler="Euler",
+    scheduler="simple",
+    cfg_scale=1.0,
+    quality_tier="high",
+)
+
 _XL_TAGS = ("sdxl", "xl_", "_xl", "-xl")
 _LIGHTNING_TAGS = ("lightning", "turbo")
 
@@ -162,13 +180,16 @@ def _resolve_preset(model: str | None) -> _A1111Preset:
     """Choose generation preset based on checkpoint name.
 
     Detection order:
-    1. Lightning/Turbo SDXL — low steps, low CFG, DPM++ SDE
-    2. Standard SDXL — matches "sdxl", "xl_", "_xl", "-xl"
-    3. SD 1.5 — fallback default
+    1. Flux — matches "flux"; uses low CFG (1.0), Euler/simple, 1024px
+    2. Lightning/Turbo SDXL — low steps, low CFG, DPM++ SDE
+    3. Standard SDXL — matches "sdxl", "xl_", "_xl", "-xl"
+    4. SD 1.5 — fallback default
     """
     if not model:
         return _SD15_PRESET
     lower = model.lower()
+    if "flux" in lower:
+        return _FLUX_PRESET
     is_xl = any(tag in lower for tag in _XL_TAGS)
     is_lightning = any(tag in lower for tag in _LIGHTNING_TAGS)
     if is_xl and is_lightning:
@@ -247,6 +268,11 @@ class A1111ImageProvider:
                 construction. ``natural_language`` mode runs without an LLM.
         """
         if prompt_format_for_checkpoint(self._model) == "natural_language":
+            log.info(
+                "image_prompt_distilled_nl",
+                subject=brief.subject[:80],
+                model=self._model,
+            )
             return flatten_brief_to_prompt(brief)
 
         if self._llm is None:
@@ -353,8 +379,6 @@ class A1111ImageProvider:
         guidance cannot drift apart (#1557)."""
         if not self._model:
             return ""
-
-        from questfoundry.providers.checkpoint_styles import resolve_checkpoint_style
 
         info = resolve_checkpoint_style(self._model)
         return (

--- a/src/questfoundry/providers/image_a1111.py
+++ b/src/questfoundry/providers/image_a1111.py
@@ -21,10 +21,14 @@ from typing import TYPE_CHECKING, Any
 import httpx
 
 from questfoundry.observability.logging import get_logger
+from questfoundry.providers.checkpoint_styles import prompt_format_for_checkpoint
 from questfoundry.providers.image import (
     ImageProviderConnectionError,
     ImageProviderError,
     ImageResult,
+)
+from questfoundry.providers.image_brief import (
+    flatten_brief_to_prompt,
 )
 from questfoundry.providers.settings import (
     _detect_model_variant,
@@ -225,11 +229,26 @@ class A1111ImageProvider:
     # -- PromptDistiller implementation ------------------------------------
 
     async def distill_prompt(self, brief: ImageBrief) -> tuple[str, str | None]:
-        """Transform a structured brief into SD-optimised prompts via LLM.
+        """Transform a structured brief into a renderer-shaped prompt.
+
+        Branches on the active checkpoint's prompt format (#1559):
+
+        - ``"natural_language"`` (Flux on Forge Neo, T5 encoder, ~512-token
+          window): skip LLM distillation entirely. The structured brief
+          already encodes subject/composition/mood/entities/style/medium/
+          palette as comma-joined prose via :func:`flatten_brief_to_prompt`,
+          which is the shape T5 was trained on.
+        - ``"clip_tags"`` (SDXL, SD1.5, etc.): LLM-distill into the comma-tag
+          form CLIP expects, using the existing :meth:`_distill_with_llm`.
 
         Raises:
-            ImageProviderError: If no LLM was provided at construction.
+            ImageProviderError: If the active checkpoint requires
+                ``clip_tags`` distillation but no LLM was provided at
+                construction. ``natural_language`` mode runs without an LLM.
         """
+        if prompt_format_for_checkpoint(self._model) == "natural_language":
+            return flatten_brief_to_prompt(brief)
+
         if self._llm is None:
             raise ImageProviderError(
                 "a1111",

--- a/tests/unit/test_checkpoint_styles.py
+++ b/tests/unit/test_checkpoint_styles.py
@@ -81,3 +81,63 @@ class TestResolveCheckpointStyle:
         upper = resolve_checkpoint_style("FLUX1-DEV.safetensors")
         lower = resolve_checkpoint_style("flux1-dev.safetensors")
         assert upper == lower
+
+
+class TestPromptFormat:
+    """`prompt_format` field on each map entry + `prompt_format_for_checkpoint()`
+    helper. Drives the A1111 distiller's clip_tags vs natural_language
+    branching for Flux on Forge Neo (#1559)."""
+
+    def test_resolve_checkpoint_style_returns_prompt_format(self) -> None:
+        # Every entry must carry a prompt_format key.
+        info = resolve_checkpoint_style("anything.safetensors")
+        assert "prompt_format" in info
+        assert info["prompt_format"] in {"clip_tags", "natural_language"}
+
+    def test_flux_uses_natural_language(self) -> None:
+        from questfoundry.providers.checkpoint_styles import (
+            prompt_format_for_checkpoint,
+        )
+
+        assert (
+            prompt_format_for_checkpoint("flux1-dev-bnb-nf4-v2.safetensors") == "natural_language"
+        )
+        assert prompt_format_for_checkpoint("flux1-dev-bnb-nf4.safetensors") == "natural_language"
+
+    @pytest.mark.parametrize(
+        "model",
+        [
+            "coloring_book.ckpt",
+            "v1-5-pruned-emaonly.safetensors",
+            "animagine-xl.safetensors",
+            "Dreamshaper.safetensors",
+            "sd_xl_base_1.0.safetensors",
+            "dreamshaperXL_lightningDPMSDE.safetensors",
+            "juggernautXL_ragnarokBy.safetensors",
+            "dreamshaperXL_alpha2Xl10.safetensors",
+            "dreamshaperXL_v1.safetensors",
+        ],
+    )
+    def test_non_flux_checkpoints_use_clip_tags(self, model: str) -> None:
+        from questfoundry.providers.checkpoint_styles import (
+            prompt_format_for_checkpoint,
+        )
+
+        assert prompt_format_for_checkpoint(model) == "clip_tags"
+
+    def test_unknown_checkpoint_uses_clip_tags(self) -> None:
+        from questfoundry.providers.checkpoint_styles import (
+            prompt_format_for_checkpoint,
+        )
+
+        # Default fallback: SD-family is the long tail; safer assumption is CLIP.
+        assert prompt_format_for_checkpoint("totally-made-up-model.safetensors") == "clip_tags"
+
+    def test_no_model_uses_clip_tags(self) -> None:
+        # When no model is set, preserve the LLM-distill default path.
+        from questfoundry.providers.checkpoint_styles import (
+            prompt_format_for_checkpoint,
+        )
+
+        assert prompt_format_for_checkpoint(None) == "clip_tags"
+        assert prompt_format_for_checkpoint("") == "clip_tags"

--- a/tests/unit/test_checkpoint_styles.py
+++ b/tests/unit/test_checkpoint_styles.py
@@ -74,6 +74,7 @@ class TestResolveCheckpointStyle:
             "incompatible_styles",
             "good_example",
             "bad_example",
+            "prompt_format",
         }
 
     def test_case_insensitive_matching(self) -> None:

--- a/tests/unit/test_image_a1111.py
+++ b/tests/unit/test_image_a1111.py
@@ -11,6 +11,7 @@ import pytest
 
 from questfoundry.providers.image import ImageProviderConnectionError, ImageProviderError
 from questfoundry.providers.image_a1111 import (
+    _FLUX_PRESET,
     _SD15_PRESET,
     _SDXL_LIGHTNING_PRESET,
     _SDXL_PRESET,
@@ -286,6 +287,29 @@ class TestA1111Provider:
             await provider.aclose()
 
         mock_close.assert_called_once()
+
+
+class TestResolvePresetFlux:
+    """Flux checkpoints must use the Flux-tuned preset, not the SD1.5
+    fallback (#1560 review)."""
+
+    def test_flux_dev_resolves_to_flux_preset(self) -> None:
+        assert _resolve_preset("flux1-dev-bnb-nf4-v2.safetensors") is _FLUX_PRESET
+        assert _resolve_preset("flux1-dev-bnb-nf4.safetensors") is _FLUX_PRESET
+
+    def test_flux_preset_uses_low_cfg_and_xl_resolution(self) -> None:
+        assert _FLUX_PRESET.cfg_scale == 1.0
+        assert _FLUX_PRESET.sizes["1:1"] == (1024, 1024)
+        assert _FLUX_PRESET.sampler == "Euler"
+        assert _FLUX_PRESET.scheduler == "simple"
+
+    def test_flux_does_not_fall_through_to_sd15(self) -> None:
+        preset = _resolve_preset("flux1-dev-bnb-nf4-v2.safetensors")
+        assert preset is not _SD15_PRESET
+        assert preset.cfg_scale != 7.0
+
+    def test_flux_case_insensitive(self) -> None:
+        assert _resolve_preset("FLUX1_DEV.safetensors") is _FLUX_PRESET
 
 
 class TestA1111Presets:
@@ -719,5 +743,5 @@ class TestDistillPromptFormatBranch:
         )
 
         brief = self._make_brief()
-        with pytest.raises(ImageProviderError):
+        with pytest.raises(ImageProviderError, match="requires an LLM"):
             await provider.distill_prompt(brief)

--- a/tests/unit/test_image_a1111.py
+++ b/tests/unit/test_image_a1111.py
@@ -625,3 +625,99 @@ class TestDistillerCheckpointHint:
         hint = provider._format_checkpoint_hint()
         # The distiller-time hint should instruct the LLM how to bridge incompatibility
         assert "translate" in hint.lower() or "adapt" in hint.lower()
+
+
+class TestDistillPromptFormatBranch:
+    """`distill_prompt` branches on `prompt_format_for_checkpoint(self._model)`.
+    Flux (T5 encoder) skips the LLM distill entirely and flattens the brief's
+    prose fields via `flatten_brief_to_prompt()`. Standard SD/SDXL checkpoints
+    keep the existing LLM-distill path (#1559)."""
+
+    def _make_brief(self) -> ImageBrief:
+        return ImageBrief(
+            subject="warrior on a stone bridge",
+            composition="wide shot, low angle",
+            mood="tense, golden hour",
+            entity_fragments=["scarred warrior with leather armor"],
+            art_style="cinematic photography",
+            art_medium="digital photo",
+            palette=["amber", "slate"],
+            style_exclusions="no anime, no anachronistic technology",
+            aspect_ratio="16:9",
+            category="scene",
+        )
+
+    @pytest.mark.asyncio()
+    async def test_flux_skips_llm_and_uses_flattener(self) -> None:
+        from unittest.mock import AsyncMock, MagicMock
+
+        from questfoundry.providers.image_a1111 import A1111ImageProvider
+        from questfoundry.providers.image_brief import flatten_brief_to_prompt
+
+        # MagicMock LLM whose method usage we can audit.
+        llm = MagicMock()
+        llm.ainvoke = AsyncMock()  # would be called by _distill_with_llm
+        provider = A1111ImageProvider(
+            host="http://x", model="flux1-dev-bnb-nf4-v2.safetensors", llm=llm
+        )
+
+        brief = self._make_brief()
+        result = await provider.distill_prompt(brief)
+
+        # NL mode: result equals flatten_brief_to_prompt() output exactly.
+        expected = flatten_brief_to_prompt(brief)
+        assert result == expected
+
+        # NL mode: LLM is never invoked.
+        assert llm.ainvoke.await_count == 0
+
+    @pytest.mark.asyncio()
+    async def test_clip_tags_checkpoint_still_uses_llm_distill(self) -> None:
+        # Sanity: a non-Flux checkpoint must still go through _distill_with_llm.
+        # We verify by stubbing _distill_with_llm and checking it was called.
+        from unittest.mock import AsyncMock, MagicMock, patch
+
+        from questfoundry.providers.image_a1111 import A1111ImageProvider
+
+        llm = MagicMock()
+        provider = A1111ImageProvider(
+            host="http://x", model="juggernautXL_ragnarokBy.safetensors", llm=llm
+        )
+
+        brief = self._make_brief()
+        with patch.object(
+            provider, "_distill_with_llm", new=AsyncMock(return_value=("pos", "neg"))
+        ) as mock_distill:
+            result = await provider.distill_prompt(brief)
+
+        assert result == ("pos", "neg")
+        mock_distill.assert_awaited_once_with(brief)
+
+    @pytest.mark.asyncio()
+    async def test_flux_works_without_llm(self) -> None:
+        # NL mode should not require an LLM at all — `_llm=None` is OK.
+        from questfoundry.providers.image_a1111 import A1111ImageProvider
+        from questfoundry.providers.image_brief import flatten_brief_to_prompt
+
+        provider = A1111ImageProvider(
+            host="http://x", model="flux1-dev-bnb-nf4-v2.safetensors", llm=None
+        )
+
+        brief = self._make_brief()
+        result = await provider.distill_prompt(brief)
+
+        assert result == flatten_brief_to_prompt(brief)
+
+    @pytest.mark.asyncio()
+    async def test_clip_tags_without_llm_raises(self) -> None:
+        # Sanity: clip_tags branch still raises when no LLM is provided.
+        from questfoundry.providers.image import ImageProviderError
+        from questfoundry.providers.image_a1111 import A1111ImageProvider
+
+        provider = A1111ImageProvider(
+            host="http://x", model="juggernautXL_ragnarokBy.safetensors", llm=None
+        )
+
+        brief = self._make_brief()
+        with pytest.raises(ImageProviderError):
+            await provider.distill_prompt(brief)


### PR DESCRIPTION
## Summary

Adds a per-checkpoint `prompt_format` toggle to `_CHECKPOINT_STYLE_MAP` (`"clip_tags"` default; `"natural_language"` for Flux). `A1111ImageProvider.distill_prompt` branches on the format: Flux (T5 encoder, 512-token window) skips LLM distillation entirely and flattens the brief's prose fields via the existing `flatten_brief_to_prompt()`. Standard SDXL/SD1.5/Animagine/Juggernaut/etc. keep the LLM-driven CLIP-tag distillation unchanged.

The user's A1111 instance has been replaced with **Forge Neo** (API-compatible with A1111), which hosts Flux alongside standard SD checkpoints. The toggle is per-checkpoint, not per-provider — provider identifier stays `a1111`.

## Spec + plan

- Design: `docs/superpowers/specs/2026-04-28-flux-natural-language-distill-design.md`
- Implementation plan: `docs/superpowers/plans/2026-04-29-flux-natural-language-distill.md`

Builds on PR #1558 (merged 2026-04-28).

Closes #1559.

## Cascade (4 files)

1. `src/questfoundry/providers/checkpoint_styles.py` — `prompt_format` field on all 10 map entries + new `prompt_format_for_checkpoint()` helper
2. `src/questfoundry/providers/image_a1111.py` — `distill_prompt` branches on format; LLM assertion narrows to `clip_tags` branch
3. `tests/unit/test_checkpoint_styles.py` — `TestPromptFormat` class (13 tests via parametrize covering field presence, Flux NL mode, 9 non-Flux checkpoints in clip_tags mode, default fallback, no-model fallback)
4. `tests/unit/test_image_a1111.py` — `TestDistillPromptFormatBranch` class (4 tests covering Flux→flatten, clip_tags→LLM, Flux without LLM, clip_tags without LLM raises)

## Test plan

- [x] `uv run pytest tests/unit/test_checkpoint_styles.py tests/unit/test_image_a1111.py` — 80 passed
- [x] `uv run mypy src/questfoundry/providers/checkpoint_styles.py src/questfoundry/providers/image_a1111.py src/questfoundry/providers/image_brief.py` — clean
- [x] `uv run ruff check src/ tests/` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)