### PR TITLE
refactor(seed): rename InitialBeat.path_id + also_belongs_to → belongs_to list (#1564)

### DIFF
--- a/docs/superpowers/plans/2026-04-29-belongs-to-list-rename-impl.md
+++ b/docs/superpowers/plans/2026-04-29-belongs-to-list-rename-impl.md
@@ -1,0 +1,541 @@
+# `belongs_to: list[str]` rename — Implementation PR Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Implementation PR (2 of 2) for #1564. Rename `InitialBeat.path_id: str` + `also_belongs_to: str | None` to `belongs_to: list[str]` (`min_length=1, max_length=2`) across the SEED schema, mutation layer, all SEED prompt templates, all production consumers, and all test fixtures. Atomic rename per CLAUDE.md "Replace directly, no compat shim."
+
+**Architecture:** Schema-first refactor. The `InitialBeat` Pydantic model gains a single symmetric `belongs_to: list[str]` field replacing the asymmetric pair. The mutation layer (`graph/mutations.py::_get_path_ids_from_beat`) reads the list directly and creates one `belongs_to` graph edge per element (it already supports 2-edge creation; only the read pattern changes). All prompt templates that describe the SEED beat schema rewrite their schema descriptions and GOOD/BAD examples to use the list shape. Test fixtures replace `path_id=`/`also_belongs_to=` kwargs and YAML keys with `belongs_to=[...]`.
+
+The schema's own `path_id` field is the only one being renamed. `Path.path_id` (the Path node's own identifier) and `Consequence.path_id` (which path a consequence belongs to) are NOT touched — they're the Path node's identity, not an InitialBeat field.
+
+**Tech Stack:** Python 3.11+, `pydantic`, `pytest`, `ruamel.yaml`, `ruff`, `mypy`. Existing patterns: `_migrate_paths_to_path_id` is a `@model_validator(mode="before")` that originally migrated `paths: list[str]` to the asymmetric form — this rename effectively reverses that migration with a new field name.
+
+**Spec:** `docs/superpowers/specs/2026-04-29-belongs-to-list-rename-design.md`. Closes #1564 (part 2/2 — depends on PR #1565 having merged, which it has).
+
+---
+
+## File Structure
+
+**Modified files (~17-25 sites across these groups):**
+
+- **Schema** (1 file): `src/questfoundry/models/seed.py` — `InitialBeat.path_id` and `also_belongs_to` → `belongs_to: list[str]`. Drop `_migrate_paths_to_path_id` (no longer needed; the field name comes back to the original `paths` shape, just renamed). Replace `_also_belongs_to_differs_from_path_id` with a list-uniqueness validator.
+- **Mutation layer** (1 file): `src/questfoundry/graph/mutations.py` — `_get_path_ids_from_beat()` reads `beat["belongs_to"]` (list) instead of the asymmetric pair. Creates one `belongs_to` graph edge per element (already does this; only the read pattern changes).
+- **Production consumers** (a few files): `src/questfoundry/pipeline/stages/seed.py`, `src/questfoundry/agents/serialize.py`, `src/questfoundry/graph/seed_validation.py` — anywhere code reads `beat.path_id` / `beat.also_belongs_to` from an `InitialBeat`. Reads switch to `beat.belongs_to[0]` (primary) and `beat.belongs_to[1]` (sibling, if present).
+- **Prompt templates** (5 files): `prompts/templates/serialize_seed_sections.yaml`, `prompts/templates/summarize_seed_sections.yaml`, `prompts/templates/serialize_seed.yaml`, `prompts/templates/summarize_seed.yaml`, `prompts/templates/discuss_seed.yaml` — schema descriptions, GOOD/BAD examples, FINAL CHECK assertions. Every reference to `path_id` and/or `also_belongs_to` for a SEED beat rewrites to `belongs_to: [...]`.
+- **Tests** (~12-15 files): `tests/unit/test_seed_models.py`, `test_seed_stage.py`, `test_seed_validation.py`, `test_serialize.py`, `test_mutations.py`, `test_grow_*.py`, `test_polish_*.py`, `test_inspection.py`, `tests/integration/test_y_shape_end_to_end.py`, `tests/fixtures/grow_fixtures.py` — every `InitialBeat(path_id=..., also_belongs_to=...)` constructor or YAML/dict fixture using those keys.
+
+**No new files. No new tests beyond what already exists. Test count stays the same; assertions and fixtures are mechanically rewritten.**
+
+---
+
+## Task 1: Inventory + branch confirmation
+
+**Files:** N/A (read-only)
+
+- [ ] **Step 1: Confirm we're on the impl branch and the spec PR (#1565) is merged**
+
+```bash
+git rev-parse --abbrev-ref HEAD
+# expected: refactor/1564-belongs-to-list-impl
+
+git log --oneline origin/main -5 | head -3
+# expected: top commit references #1565 merge (069c1ef9 or later)
+```
+
+- [ ] **Step 2: Inventory `also_belongs_to` sites — these are the high-confidence rename targets**
+
+```bash
+rg -l "also_belongs_to" src/ tests/ prompts/
+# expected: ~17 files
+```
+
+Save this list mentally — every file here MUST be touched.
+
+- [ ] **Step 3: Inventory `InitialBeat`-related `path_id` sites**
+
+```bash
+rg "InitialBeat\(" tests/ src/ | head -30
+```
+
+Every fixture constructor matching `InitialBeat(...path_id=..., ...)` needs updating. Some test files use only `path_id=` (no `also_belongs_to`) for post-commit beats — those still need conversion to `belongs_to=[<path>]`.
+
+```bash
+# Find candidates: path_id appearances NOT inside Path() or Consequence() constructors.
+# Heuristic: lines with `path_id=` in fixtures, broadly.
+rg -n "path_id=" tests/ | head -30
+```
+
+For each hit, check context — is it constructing an `InitialBeat`/initial beat dict, or a `Path`/`Consequence`? Rule: if the surrounding fixture is for a beat (variable/key contains `beat` or `initial_beats`), rename. If it's for a path or consequence, leave alone.
+
+- [ ] **Step 4: Note: this task does not commit anything**
+
+Inventory only. The rewrite happens in Task 2.
+
+---
+
+## Task 2: Schema rename (`InitialBeat`)
+
+**Files:**
+- Modify: `src/questfoundry/models/seed.py` lines ~240-330 (the `InitialBeat` class + `_migrate_paths_to_path_id` + `_also_belongs_to_differs_from_path_id`)
+
+- [ ] **Step 1: Replace the `InitialBeat` class field declarations**
+
+Find (lines ~273-285):
+
+```python
+    path_id: str = Field(
+        min_length=1,
+        description="Primary path this beat belongs to (first belongs_to edge)",
+    )
+    also_belongs_to: str | None = Field(
+        default=None,
+        min_length=1,
+        description=(
+            "Sibling path for pre-commit (Y-shape) beats: creates a second "
+            "belongs_to edge. Must be null for post-commit beats. Must "
+            "reference a path with the same parent dilemma as path_id."
+        ),
+    )
+```
+
+Replace with:
+
+```python
+    belongs_to: list[str] = Field(
+        min_length=1,
+        max_length=2,
+        description=(
+            "Path(s) this beat belongs to. List of length 2 means dual "
+            "membership (pre-commit shared beat — both paths of the same "
+            "dilemma). List of length 1 means singular membership (commit, "
+            "post-commit, or gap beat). Cross-dilemma dual membership is "
+            "rejected by the mutation layer; same-dilemma sibling-pair check "
+            "happens there as well, where path→dilemma resolution is available."
+        ),
+    )
+```
+
+- [ ] **Step 2: Update the class docstring**
+
+Find the existing class docstring (lines ~240-269) that references `path_id` and `also_belongs_to`. Rewrite the relevant paragraphs:
+
+The current docstring says (excerpt):
+```
+* **Post-commit beats** (the default) belong to exactly one path via
+  ``path_id``; ``also_belongs_to`` is ``None``. These beats prove one
+  answer and are exclusive to the path they belong to.
+* **Pre-commit beats** (shared dilemma setup) belong to *both* paths of
+  their dilemma via ``path_id`` and ``also_belongs_to``. This is the
+  Y-shape ratified in #1206/#1208: every player experiences pre-commit
+  beats regardless of which answer they later choose.
+```
+
+Replace with:
+```
+* **Post-commit beats** (the default) belong to exactly one path —
+  ``belongs_to`` is a single-element list. These beats prove one answer
+  and are exclusive to the path they belong to.
+* **Pre-commit beats** (shared dilemma setup) belong to *both* paths of
+  their dilemma — ``belongs_to`` is a two-element list, both referencing
+  paths of the same parent dilemma. This is the Y-shape ratified in
+  #1206/#1208 (and refined to symmetric list form in #1564): every
+  player experiences pre-commit beats regardless of which answer they
+  later choose.
+```
+
+Also replace the `Attributes:` block entries for `path_id` and `also_belongs_to` with a single entry for `belongs_to`:
+
+```
+Attributes:
+    beat_id: Unique identifier for the beat.
+    summary: What happens in this beat.
+    belongs_to: Path(s) this beat belongs to. Single-element list for
+        commit/post-commit/gap beats; two-element list (both paths of
+        the same dilemma) for pre-commit shared beats. Cross-dilemma
+        dual membership is rejected by the mutation layer.
+    dilemma_impacts: How this beat affects dilemmas.
+    entities: Entity IDs present in this beat.
+    location: Primary location entity ID.
+    location_alternatives: Other valid locations (enables intersection flexibility).
+    temporal_hint: Advisory placement relative to another dilemma (consumed by GROW).
+```
+
+- [ ] **Step 3: Replace `_migrate_paths_to_path_id` with a noop / drop it**
+
+The current `_migrate_paths_to_path_id` (lines ~287-323) migrated legacy `paths: list[str]` input data into the asymmetric `path_id` + `also_belongs_to` form. Now that the field IS a list (renamed to `belongs_to`), the migration is no longer needed. Two options:
+
+**Option A (cleaner): drop the validator entirely.** The new `belongs_to: list[str]` field directly accepts list input.
+
+**Option B: keep a slim migrator that maps legacy `paths` → `belongs_to`.** Only useful if there are on-disk artifacts with the old `paths` field. Project memory says #1206 already migrated those, so any pre-#1206 snapshots are dead.
+
+Take **Option A**. Delete the `@model_validator(mode="before")` decorator and the `_migrate_paths_to_path_id` method body in full. Remove the `import warnings` at the top of the file IF nothing else in the file uses it (`grep "warnings\." src/questfoundry/models/seed.py` after deletion — if only the migrator used it, drop the import).
+
+- [ ] **Step 4: Replace `_also_belongs_to_differs_from_path_id` validator with a list-uniqueness check**
+
+Find (lines ~325-330):
+
+```python
+    @model_validator(mode="after")
+    def _also_belongs_to_differs_from_path_id(self) -> InitialBeat:
+        """Dual membership requires two distinct path IDs."""
+        if self.also_belongs_to is not None and self.also_belongs_to == self.path_id:
+            msg = "also_belongs_to must differ from path_id — dual membership needs two paths."
+            raise ValueError(msg)
+        return self
+```
+
+Replace with:
+
+```python
+    @model_validator(mode="after")
+    def _belongs_to_elements_unique(self) -> InitialBeat:
+        """Dual membership requires two distinct path IDs."""
+        if len(self.belongs_to) == 2 and self.belongs_to[0] == self.belongs_to[1]:
+            msg = "belongs_to elements must be distinct — dual membership needs two paths."
+            raise ValueError(msg)
+        return self
+```
+
+The same-dilemma sibling-path check stays in the mutation layer where path→dilemma resolution is available.
+
+- [ ] **Step 5: Run tests just for `models/seed.py` to surface the cascade**
+
+```bash
+uv run --frozen pytest tests/unit/test_seed_models.py -x 2>&1 | tail -20
+```
+
+Expected: many failures. Every test using `InitialBeat(path_id=..., ...)` will fail. That's fine — Task 4 fixes them. Don't try to fix tests yet; this is a sanity check that the model layer compiles.
+
+- [ ] **Step 6: Commit (production code only — tests follow)**
+
+```bash
+git add src/questfoundry/models/seed.py
+git commit -m "refactor(seed): InitialBeat path_id+also_belongs_to → belongs_to: list[str] (#1564)"
+```
+
+Pre-commit hooks (mypy, ruff) will scan the file. mypy may fail because downstream consumers in `pipeline/stages/seed.py`, `agents/serialize.py`, `graph/mutations.py`, `graph/seed_validation.py` still reference `beat.path_id` and `beat.also_belongs_to`. **If mypy fails here, do not bypass.** Move on to Tasks 3 + 4 to fix the consumers, then come back and amend (or do them in one larger commit).
+
+If pre-commit blocks this commit due to mypy errors in unrelated production files, take Option B: skip this commit and bundle it with Tasks 3 and 4 in a single atomic commit. The committer's choice depends on whether the schema change alone passes mypy in isolation.
+
+---
+
+## Task 3: Mutation layer + production consumers
+
+**Files:**
+- Modify: `src/questfoundry/graph/mutations.py` lines ~855-880 (the `_get_path_ids_from_beat()` helper)
+- Modify: `src/questfoundry/graph/seed_validation.py` (every read of `beat.path_id` / `beat.also_belongs_to`)
+- Modify: `src/questfoundry/pipeline/stages/seed.py` (every read)
+- Modify: `src/questfoundry/agents/serialize.py` (every read)
+- Modify: `src/questfoundry/pipeline/stages/brainstorm.py` (1 reference per the count)
+
+- [ ] **Step 1: Rewrite `_get_path_ids_from_beat()` in `mutations.py`**
+
+Find (lines ~855-880):
+
+```python
+def _get_path_ids_from_beat(beat: dict[str, Any]) -> tuple[str, ...]:
+    """...
+    - Y-shape current: ``path_id`` + optional ``also_belongs_to``.
+    - Legacy single: ``path_id`` alone.
+    ...
+    Returns:
+        Tuple of 0, 1, or 2 raw path IDs in declaration order (``path_id``
+        first, then ``also_belongs_to``). A return of 2 always represents a
+        ...
+    """
+    if beat.get("path_id"):
+        primary = str(beat["path_id"])
+        also = beat.get("also_belongs_to")
+        ...
+```
+
+Rewrite the body to read `belongs_to` (a list):
+
+```python
+def _get_path_ids_from_beat(beat: dict[str, Any]) -> tuple[str, ...]:
+    """Extract path IDs from a SEED beat dict, in declaration order.
+
+    Reads the symmetric ``belongs_to`` list (#1564). Returns 0 (no
+    membership — structural beats), 1 (singular — commit / post-commit /
+    gap), or 2 (dual — pre-commit shared) raw path IDs.
+
+    Args:
+        beat: Beat dict (typically from an ``InitialBeat.model_dump()``
+            or graph node data).
+
+    Returns:
+        Tuple of 0, 1, or 2 raw path IDs in declaration order. A return
+        of 2 always represents a shared pre-commit beat with dual
+        ``belongs_to`` to two paths of the same dilemma.
+    """
+    belongs_to = beat.get("belongs_to") or []
+    return tuple(str(p) for p in belongs_to)
+```
+
+The function previously also handled a "legacy single `path_id`" path — drop it. The schema is now uniform.
+
+- [ ] **Step 2: Sweep production code for `beat.path_id` and `beat.also_belongs_to` reads**
+
+```bash
+rg -n "\.path_id\b|\.also_belongs_to\b" src/questfoundry/graph/seed_validation.py src/questfoundry/pipeline/stages/seed.py src/questfoundry/agents/serialize.py src/questfoundry/pipeline/stages/brainstorm.py
+```
+
+For each hit:
+- `beat.path_id` → `beat.belongs_to[0]` (the primary path; first element of the list).
+- `beat.also_belongs_to` → `beat.belongs_to[1] if len(beat.belongs_to) >= 2 else None`.
+
+If the existing code branched on `if beat.also_belongs_to is not None:`, rewrite as `if len(beat.belongs_to) >= 2:`.
+
+If existing code constructed a list of paths from `[beat.path_id, beat.also_belongs_to]` (filtering None), simplify to `beat.belongs_to`.
+
+For dict-based reads (`beat["path_id"]`, `beat["also_belongs_to"]`), apply the same pattern with dict indexing.
+
+- [ ] **Step 3: Run mypy on the production source tree**
+
+```bash
+uv run --frozen mypy src/questfoundry/
+```
+
+Expected: clean. If errors surface, fix them — these are real type issues from incomplete sweep.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/questfoundry/graph/mutations.py src/questfoundry/graph/seed_validation.py src/questfoundry/pipeline/stages/seed.py src/questfoundry/agents/serialize.py src/questfoundry/pipeline/stages/brainstorm.py
+git commit -m "refactor(seed): mutation + consumers read belongs_to: list[str] (#1564)"
+```
+
+If pre-commit hooks fail because tests are still using the old field names, that's expected — Task 4 fixes the tests. mypy on `src/` should pass; pytest on `tests/` will fail until Task 4 completes.
+
+---
+
+## Task 4: Prompt templates
+
+**Files:**
+- Modify: `prompts/templates/serialize_seed_sections.yaml`
+- Modify: `prompts/templates/summarize_seed_sections.yaml`
+- Modify: `prompts/templates/serialize_seed.yaml`
+- Modify: `prompts/templates/summarize_seed.yaml`
+- Modify: `prompts/templates/discuss_seed.yaml`
+
+- [ ] **Step 1: Inventory hits per template**
+
+```bash
+for f in prompts/templates/serialize_seed_sections.yaml prompts/templates/summarize_seed_sections.yaml prompts/templates/serialize_seed.yaml prompts/templates/summarize_seed.yaml prompts/templates/discuss_seed.yaml; do
+  echo "=== $f ==="
+  rg -n "path_id|also_belongs_to" "$f"
+done
+```
+
+Expected: every YAML schema description, GOOD/BAD example, and FINAL CHECK assertion that mentions either field.
+
+- [ ] **Step 2: Rewrite each occurrence**
+
+For each YAML template:
+
+- **Schema description block** (typically: "fields are `beat_id`, `summary`, `path_id`, `also_belongs_to`, ..."): replace with "...`beat_id`, `summary`, `belongs_to` (list of 1 or 2 path IDs), ...".
+- **Field-by-field rule sections** for `path_id` and `also_belongs_to`: collapse into a single `belongs_to` section. The combined section should explain: list shape, length 1 for commit/post-commit/gap beats, length 2 for shared pre-commit beats with both paths from the same dilemma.
+- **GOOD examples** that show `path_id: path::foo, also_belongs_to: path::bar` (or similar JSON): rewrite to `"belongs_to": ["path::foo", "path::bar"]`. For singular GOOD examples (post-commit), use `"belongs_to": ["path::foo"]`.
+- **BAD examples** that target the old asymmetric field bugs: rewrite to target list-shape mistakes (e.g. `"belongs_to": []` is REJECTED — every beat must belong to at least one path; `"belongs_to": ["path::foo", "path::foo"]` is REJECTED — elements must be distinct; `"belongs_to": ["path::foo", "path::bar", "path::baz"]` is REJECTED — at most 2 elements).
+- **FINAL CHECK assertions** that say "every shared beat has `also_belongs_to` set" → rewrite to "every shared beat has `belongs_to` of length 2".
+- **WHAT NOT TO DO entries** mentioning `also_belongs_to` → rewrite for the list shape.
+
+For `discuss_seed.yaml`: it's the creative-LLM brief, not the structured schema, so most occurrences are prose ("decide which beats are shared between paths"). Where the prose explicitly names `path_id` / `also_belongs_to`, switch to `belongs_to` with the list-shape framing.
+
+- [ ] **Step 3: Verify zero survivors per template**
+
+```bash
+for f in prompts/templates/*.yaml; do
+  if rg -q "also_belongs_to|path_id" "$f"; then
+    echo "$f: $(rg -c 'also_belongs_to|path_id' "$f") hits remaining"
+  fi
+done
+```
+
+Expected: zero hits for `also_belongs_to`. Some `path_id` hits may remain if the YAML legitimately references Path's `path_id` field (e.g. in a "valid_path_ids" enumeration) — those are fine. The rename is `InitialBeat.path_id` only.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add prompts/templates/serialize_seed_sections.yaml prompts/templates/summarize_seed_sections.yaml prompts/templates/serialize_seed.yaml prompts/templates/summarize_seed.yaml prompts/templates/discuss_seed.yaml
+git commit -m "refactor(prompts): SEED prompts describe belongs_to: list[str] (#1564)"
+```
+
+---
+
+## Task 5: Test fixtures + assertion sweep
+
+**Files:**
+- Modify: every `.py` file under `tests/` matching `rg -l "InitialBeat\b" tests/` (production code already done in Tasks 2-3).
+- Specifically (from inventory): `tests/unit/test_seed_models.py`, `test_seed_stage.py`, `test_seed_validation.py`, `test_serialize.py`, `test_mutations.py`, `test_grow_models.py`, `test_grow_stage.py`, `test_grow_algorithms.py`, `test_grow_validation_contract.py`, `test_polish_phases.py`, `test_polish_phase5_models.py`, `test_polish_apply.py`, `test_polish_deterministic.py`, `test_polish_phase5_context.py`, `test_polish_llm_phases.py`, `test_inspection.py`, `test_context_compact.py`, `test_entity_naming.py`, `test_ontology_explored.py`, `test_graph_context.py`, `tests/integration/test_y_shape_end_to_end.py`, `tests/integration/test_grow_e2e.py`, `tests/fixtures/grow_fixtures.py`.
+
+- [ ] **Step 1: Sweep every test file for `InitialBeat` constructions**
+
+For each file in the list above, find every `InitialBeat(...)` constructor call and every dict-fixture / YAML fixture that uses `path_id`/`also_belongs_to` keys for an InitialBeat.
+
+Conversion rules:
+- `InitialBeat(path_id="path::foo", also_belongs_to="path::bar", ...)` → `InitialBeat(belongs_to=["path::foo", "path::bar"], ...)`
+- `InitialBeat(path_id="path::foo", ...)` (no `also_belongs_to`) → `InitialBeat(belongs_to=["path::foo"], ...)`
+- `InitialBeat(path_id="path::foo", also_belongs_to=None, ...)` → `InitialBeat(belongs_to=["path::foo"], ...)`
+- Dict fixtures: `{"path_id": "path::foo", "also_belongs_to": "path::bar", ...}` → `{"belongs_to": ["path::foo", "path::bar"], ...}` (and the singular variants analogously).
+- Direct attribute reads in assertions: `assert beat.path_id == "path::foo"` → `assert beat.belongs_to[0] == "path::foo"` (or `assert beat.belongs_to == ["path::foo"]` for the singular case).
+- `assert beat.also_belongs_to == "path::bar"` → `assert beat.belongs_to[1] == "path::bar"` (or `assert beat.belongs_to == ["path::foo", "path::bar"]`).
+- `assert beat.also_belongs_to is None` → `assert len(beat.belongs_to) == 1`.
+
+Distinguish from `Path.path_id` and `Consequence.path_id` — those are NOT changing. The rule of thumb: if the constructor or assertion is on a beat object, rename. If on a Path or Consequence, leave alone.
+
+- [ ] **Step 2: Run test_seed_models.py first — fastest signal**
+
+```bash
+uv run --frozen pytest tests/unit/test_seed_models.py -x 2>&1 | tail -20
+```
+
+Expected: all green after rewrite. If anything fails, fix the surrounding fixture or assertion.
+
+- [ ] **Step 3: Sweep targeted unit tests**
+
+```bash
+uv run --frozen pytest tests/unit/test_seed_models.py tests/unit/test_seed_stage.py tests/unit/test_seed_validation.py tests/unit/test_serialize.py tests/unit/test_mutations.py tests/unit/test_grow_models.py tests/unit/test_grow_stage.py tests/unit/test_grow_algorithms.py tests/unit/test_grow_validation_contract.py tests/unit/test_polish_phases.py tests/unit/test_polish_phase5_models.py tests/unit/test_polish_apply.py tests/unit/test_polish_deterministic.py tests/unit/test_polish_phase5_context.py tests/unit/test_polish_llm_phases.py tests/unit/test_inspection.py tests/unit/test_context_compact.py tests/unit/test_entity_naming.py tests/unit/test_ontology_explored.py tests/unit/test_graph_context.py -x 2>&1 | tail -10
+```
+
+Expected: all green. If failures, fix the offending fixture and re-run.
+
+- [ ] **Step 4: Verify zero `also_belongs_to` survivors anywhere**
+
+```bash
+rg "also_belongs_to" src/ tests/ prompts/
+```
+
+Expected: zero hits.
+
+```bash
+rg "InitialBeat\(.*path_id=" tests/
+```
+
+Expected: zero hits (every `InitialBeat(path_id=...)` should now use `belongs_to=[...]`).
+
+```bash
+rg "InitialBeat\(.*paths=" tests/
+```
+
+Expected: zero hits (the legacy `paths` keyword is gone from fixtures too — the migrator that handled it was dropped).
+
+- [ ] **Step 5: Run mypy and ruff**
+
+```bash
+uv run --frozen mypy src/
+uv run --frozen ruff check src/ tests/
+```
+
+Expected: clean.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add tests/
+git commit -m "refactor(tests): InitialBeat fixtures use belongs_to: list[str] (#1564)"
+```
+
+---
+
+## Task 6: Final verification + draft PR
+
+**Files:** N/A (verification + git only)
+
+- [ ] **Step 1: Full unit test sweep**
+
+```bash
+uv run --frozen pytest tests/unit/ -x -q 2>&1 | tail -10
+```
+
+Expected: all green. (The pre-existing flaky `test_provider_factory.py::test_create_chat_model_ollama_success` may surface — confirm in isolation if so.)
+
+- [ ] **Step 2: Final survivor sweep**
+
+```bash
+rg "also_belongs_to" src/ tests/ prompts/ docs/design/
+```
+
+Expected: ZERO hits. (`docs/design/story-graph-ontology.md` mentions `also_belongs_to` once in the Impact paragraph as historical reference — that's the only allowed survivor and it's intentional. After this PR merges, that reference is the entire historical record of the deprecated form.)
+
+```bash
+rg "InitialBeat\b" src/ tests/ | grep "path_id="
+```
+
+Expected: zero. No InitialBeat construction uses `path_id=` anymore.
+
+- [ ] **Step 3: mypy + ruff**
+
+```bash
+uv run --frozen mypy src/questfoundry/
+uv run --frozen ruff check src/ tests/
+uv run --frozen ruff format --check src/ tests/
+```
+
+Expected: clean.
+
+- [ ] **Step 4: Push branch + open draft PR**
+
+```bash
+git push -u origin refactor/1564-belongs-to-list-impl
+gh pr create --draft --title "refactor: InitialBeat belongs_to: list[str] — schema + mutations + prompts + tests (#1564 part 2/2)" --body "$(cat <<'EOF'
+## Summary
+
+Implementation PR (2 of 2) for #1564. Replaces the asymmetric \`InitialBeat.path_id: str\` + \`also_belongs_to: str | None\` schema with the symmetric \`belongs_to: list[str]\` (\`min_length=1, max_length=2\`) shape that matches the graph layer. Atomic rename per CLAUDE.md \"Replace directly, no compat shim.\"
+
+The asymmetric form was the direct cause of the murder6 production failure: qwen3:4b emitted \`path_id\` set with \`also_belongs_to\` omitted entirely, failing after 3 retry attempts. The list shape is structurally unambiguous — \`min_length=1, max_length=2\` is enforceable at the schema layer, and the model emits a list or doesn't.
+
+This PR depends on PR #1565 (spec PR — the ontology + seed.md doc updates) which has merged.
+
+## Spec + plan
+
+- Design: \`docs/superpowers/specs/2026-04-29-belongs-to-list-rename-design.md\`
+- Plan: \`docs/superpowers/plans/2026-04-29-belongs-to-list-rename-impl.md\`
+- Spec PR (1/2, merged): #1565
+
+## Cascade
+
+- **Schema** (1 file): \`src/questfoundry/models/seed.py\` — \`InitialBeat\` field rename, drop migrator, replace validator.
+- **Mutation layer** (1 file): \`src/questfoundry/graph/mutations.py\` — \`_get_path_ids_from_beat()\` reads list directly.
+- **Production consumers** (~4 files): \`pipeline/stages/seed.py\`, \`agents/serialize.py\`, \`graph/seed_validation.py\`, \`pipeline/stages/brainstorm.py\` — read \`belongs_to[0]\` / \`belongs_to[1]\`.
+- **Prompt templates** (5 files): \`serialize_seed_sections.yaml\`, \`summarize_seed_sections.yaml\`, \`serialize_seed.yaml\`, \`summarize_seed.yaml\`, \`discuss_seed.yaml\` — schema descriptions, GOOD/BAD examples, FINAL CHECK assertions.
+- **Tests** (~15-20 files): every \`InitialBeat\` fixture / assertion in unit + integration tests + \`tests/fixtures/\`.
+
+Closes #1564.
+
+## Test plan
+
+- [x] \`uv run pytest tests/unit/\` — all green
+- [x] \`uv run mypy src/\` — clean
+- [x] \`uv run ruff check src/ tests/\` — clean
+- [x] \`rg \"also_belongs_to\" src/ tests/ prompts/\` — zero hits
+- [x] \`rg \"InitialBeat\\(.*path_id=\" tests/\` — zero hits
+
+## End-to-end smoke (optional, requires LLM access)
+
+- [ ] Re-run \`projects/murder6\` against qwen3:4b — confirm SEED \`shared_beats\` succeeds without retry. The list shape is unambiguous to small models, structurally eliminating the murder6 failure mode.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 5: Wait for bot review loop**
+
+Per CLAUDE.md, address findings in-PR. Gemini may be at quota; claude-review approval is sufficient. Flip ready when claude-review LGTM + all CI green + bot's review body explicitly says "Ready to merge."
+
+---
+
+## Self-Review Notes
+
+Spec coverage check (against `docs/superpowers/specs/2026-04-29-belongs-to-list-rename-design.md`):
+
+- ✅ Spec § Schema → Task 2 (InitialBeat field rewrite, validator replacement, migrator drop)
+- ✅ Spec § Code-side ripples → Task 3 (mutation layer, production consumers)
+- ✅ Spec § Code-side ripples — prompts → Task 4 (5 SEED templates)
+- ✅ Spec § Code-side ripples — tests → Task 5 (~15-20 test files)
+- ✅ Spec § Verification → Task 6
+
+No placeholders. No "implement later" / "similar to Task N" / TBD. Type consistency: `belongs_to: list[str]`, `len(self.belongs_to)`, `belongs_to[0]`, `belongs_to[1]` referenced consistently across tasks.
+
+The plan structures Tasks 2-5 as separate commits but acknowledges they form a single atomic PR. If pre-commit blocks intermediate commits because mypy fails on a half-renamed file, the implementer is told to bundle into one commit.

--- a/prompts/templates/discuss_seed.yaml
+++ b/prompts/templates/discuss_seed.yaml
@@ -116,31 +116,32 @@ system: |
   - Vary locations (not all beats in one place)
   - Impact dilemmas (advance, reveal, commit, complicate)
 
-  **Y-shape beat shape (R-3.6, CRITICAL).** Each beat carries a `path_id`
-  (its primary path). Pre-commit beats — beats SHARED between the two
-  paths of one dilemma — also set `also_belongs_to: <other_path_id>` (a
-  PLAIN STRING, not a list) to declare the dual membership. Commit beats
-  and post-commit beats are exclusive to one path; they set
-  `also_belongs_to: null`.
+  **Y-shape beat shape (R-3.6, CRITICAL).** Each beat carries a `belongs_to`
+  list of path IDs. Pre-commit beats — beats SHARED between the two paths of
+  one dilemma — have a 2-element list containing both path IDs. Commit beats
+  and post-commit beats are exclusive to one path; they have a 1-element list.
 
-  GOOD (Y-shape with `path_id` + `also_belongs_to` as plain string):
+  GOOD (Y-shape with `belongs_to` as a list):
   ```
-  shared pre-commit:  path_id = path::keeper_honest, also_belongs_to = path::keeper_hiding
-  commit (honest):    path_id = path::keeper_honest, also_belongs_to = null
-  post-commit (honest): path_id = path::keeper_honest, also_belongs_to = null
-  commit (hiding):    path_id = path::keeper_hiding, also_belongs_to = null
-  post-commit (hiding): path_id = path::keeper_hiding, also_belongs_to = null
+  shared pre-commit:    belongs_to = [path::keeper_honest, path::keeper_hiding]
+  commit (honest):      belongs_to = [path::keeper_honest]
+  post-commit (honest): belongs_to = [path::keeper_honest]
+  commit (hiding):      belongs_to = [path::keeper_hiding]
+  post-commit (hiding): belongs_to = [path::keeper_hiding]
   ```
 
-  BAD (legacy `paths: [...]` list — DEPRECATED, do not use):
+  BAD (legacy fields — DEPRECATED, do not use):
   ```
-  paths: [path::keeper_honest, path::keeper_hiding]   # DROP — use path_id + also_belongs_to
+  paths: [path::keeper_honest, path::keeper_hiding]   # DROP — use belongs_to list
+  path_id: path::keeper_honest                        # WRONG — use belongs_to: [...]
+  also_belongs_to: path::keeper_hiding                # WRONG — use belongs_to: [...]
   ```
 
-  BAD (`also_belongs_to` as a list — REJECTED by validator):
+  BAD (wrong list shapes — REJECTED by validator):
   ```
-  also_belongs_to: [path::keeper_hiding]   # WRONG — must be a plain string
-  also_belongs_to: path::keeper_hiding     # CORRECT
+  belongs_to: []                                      # WRONG — empty list rejected
+  belongs_to: path::keeper_hiding                     # WRONG — must be a list, not string
+  belongs_to: [path::keeper_honest, path::keeper_honest]  # WRONG — elements must be distinct
   ```
 
   Beats may also carry optional `temporal_hint` (rough scene ordering),

--- a/prompts/templates/serialize_seed.yaml
+++ b/prompts/templates/serialize_seed.yaml
@@ -72,22 +72,24 @@ system: |
 
   ### 5. initial_beats (Y-shape — shared pre-commit + per-path post-commit)
   Each dilemma is Y-shaped: SHARED pre-commit beats (belong to both paths
-  of the dilemma via `path_id` + `also_belongs_to`) + a COMMIT beat per
-  path (`also_belongs_to: null`) + post-commit consequence beats per path
-  (`also_belongs_to: null`). Target counts: {size_shared_beats_per_dilemma}
-  shared beats per dilemma, {size_post_commit_beats_per_path} post-commit
-  beats per path. A dilemma with 2 explored paths and 1 shared + 1 commit
-  + 2 consequence beats per path produces 1 + 2 * 3 = 7 beats.
+  of the dilemma — `belongs_to` is a 2-element list) + a COMMIT beat per
+  path (`belongs_to` is a 1-element list) + post-commit consequence beats
+  per path (`belongs_to` is a 1-element list). Target counts:
+  {size_shared_beats_per_dilemma} shared beats per dilemma,
+  {size_post_commit_beats_per_path} post-commit beats per path. A dilemma
+  with 2 explored paths and 1 shared + 1 commit + 2 consequence beats per
+  path produces 1 + 2 * 3 = 7 beats.
 
-  **Use `path_id` + `also_belongs_to`. Do NOT emit the legacy `paths: [...]` list field — it was deprecated in the Y-shape refactor (#1206) and the serializer rejects it.**
+  **Use `belongs_to: [path_a, path_b]` for shared beats and `belongs_to: [path_a]`
+  for post-commit beats. Do NOT emit the legacy `paths: [...]` or the deprecated
+  `path_id`/`also_belongs_to` fields — the serializer rejects them.**
 
   Example A — SHARED pre-commit beat (dual membership):
   ```json
   {{
     "beat_id": "host_motive_setup_01",
     "summary": "The host greets the guest with calculated warmth",
-    "path_id": "path::host_benevolent_or_selfish__protector",
-    "also_belongs_to": ["path::host_benevolent_or_selfish__manipulator"],
+    "belongs_to": ["path::host_benevolent_or_selfish__protector", "path::host_benevolent_or_selfish__manipulator"],
     "dilemma_impacts": [
       {{
         "dilemma_id": "dilemma::host_benevolent_or_selfish",
@@ -105,8 +107,7 @@ system: |
   {{
     "beat_id": "host_protector_proof_01",
     "summary": "The host shields the guest from a poisoned drink",
-    "path_id": "path::host_benevolent_or_selfish__protector",
-    "also_belongs_to": null,
+    "belongs_to": ["path::host_benevolent_or_selfish__protector"],
     "dilemma_impacts": [
       {{
         "dilemma_id": "dilemma::host_benevolent_or_selfish",
@@ -120,7 +121,7 @@ system: |
   }}
   ```
 
-  POST-COMMIT (aftermath) beats use the same `also_belongs_to: null` shape
+  POST-COMMIT (aftermath) beats use the same `belongs_to: [single_path]` shape
   as Example B, but their `effect` MUST NOT be `commits` — use `advances`,
   `reveals`, or `complicates` instead. Only the single COMMIT beat per path
   carries `effect: commits`; subsequent post-commit beats prove the
@@ -144,10 +145,9 @@ system: |
   - Every path must reference a valid dilemma_id (with `dilemma::` prefix) and answer_id
   - Every consequence must reference a valid path_id (with `path::` prefix)
   - Emit {size_shared_beats_per_dilemma} shared pre-commit beats per
-    dilemma (path_id + also_belongs_to both set; effect != commits) AND
-    {size_post_commit_beats_per_path} post-commit beats per path (path_id
-    only, also_belongs_to = null; exactly one with effect = commits per
-    path).
+    dilemma (belongs_to has 2 elements; effect != commits) AND
+    {size_post_commit_beats_per_path} post-commit beats per path (belongs_to
+    has 1 element; exactly one with effect = commits per path).
   - Every initial_beat must reference valid path IDs (with `path::` prefix)
   - path_importance must be exactly "major" or "minor" (lowercase)
   - effect must be exactly "advances", "reveals", "commits", or "complicates"

--- a/prompts/templates/serialize_seed_sections.yaml
+++ b/prompts/templates/serialize_seed_sections.yaml
@@ -411,9 +411,9 @@ shared_beats_prompt: |
 
   ## YOUR TWO EXPLORED PATHS
 
-  These beats MUST belong to BOTH of these paths:
-  - `path_id` (primary):     `{path_id}`
-  - `also_belongs_to` (sibling): `{also_belongs_to}`
+  These beats MUST belong to BOTH of these paths — emit them as a 2-element list:
+  - primary path:  `{belongs_to_primary}`
+  - sibling path:  `{belongs_to_sibling}`
 
   ## What Are Shared Pre-Commit Beats?
   In QuestFoundry v5, every dilemma is Y-shaped:
@@ -432,8 +432,7 @@ shared_beats_prompt: |
   pre-commit beats (1–2 is the sweet spot for most stories).
 
   Each shared beat:
-    - **MUST have `also_belongs_to` = `{also_belongs_to}` (the sibling path above) — REQUIRED.** This is the single most-frequently-missed field; setting it correctly is what makes the beat a "shared" beat. Omitting it converts the beat to a single-path beat and breaks the Y-shape.
-    - MUST have `path_id` = `{path_id}` (the primary path above).
+    - **MUST have `belongs_to` = `["{belongs_to_primary}", "{belongs_to_sibling}"]` — REQUIRED.** This two-element list is what makes the beat a "shared" beat. A single-element list or missing field is rejected by the Y-shape guard rail.
     - MUST have `effect` in {{advances, reveals, complicates}}. NEVER `commits`.
     - MUST reference the current dilemma in `dilemma_impacts[0].dilemma_id`.
     - SHOULD explore the dilemma's central tension without privileging either answer.
@@ -445,8 +444,7 @@ shared_beats_prompt: |
       {{
         "beat_id": "shared_setup_dilemma_name_01",
         "summary": "A beat that sets up the choice without committing to either answer.",
-        "path_id": "{path_id}",
-        "also_belongs_to": "{also_belongs_to}",
+        "belongs_to": ["{belongs_to_primary}", "{belongs_to_sibling}"],
         "dilemma_impacts": [
           {{
             "dilemma_id": "{dilemma_id}",
@@ -464,27 +462,27 @@ shared_beats_prompt: |
 
   ## WHAT NOT TO DO
   - Do NOT set `effect: commits` on any shared beat.
-  - Do NOT leave `also_belongs_to` null — set it to `{also_belongs_to}`.
-  - Do NOT set `also_belongs_to` to a path from a DIFFERENT dilemma
+  - Do NOT emit `belongs_to` as a single-element list — it MUST contain BOTH path IDs.
+  - Do NOT use paths from a DIFFERENT dilemma in `belongs_to`
     (same-dilemma constraint; Story Graph Ontology Part 8 guard rail 1).
   - Do NOT omit a shared beat for this dilemma — every Y-shape needs at least one.
   - Do NOT use path IDs from other dilemmas.
 
-  ### `also_belongs_to` type contrast
-  This field is the most-frequently-missed value. Type rules:
+  ### `belongs_to` shape rules
+  This field is the most-frequently-missed value. Type and length rules:
   ```
-  GOOD: "also_belongs_to": "{also_belongs_to}"        ← plain string, copy exactly
-  BAD:  "also_belongs_to": null                       ← rejected — this is a SHARED beat
-  BAD:  "also_belongs_to": ["{also_belongs_to}"]      ← rejected — must be a string, not a list
-  BAD:  (field omitted entirely)                      ← rejected — field is REQUIRED
+  GOOD: "belongs_to": ["{belongs_to_primary}", "{belongs_to_sibling}"]   ← list of 2 strings
+  BAD:  "belongs_to": ["{belongs_to_primary}"]                           ← rejected — length 1, must be 2 for shared beats
+  BAD:  "belongs_to": []                                                 ← rejected — empty list
+  BAD:  "belongs_to": ["{belongs_to_primary}", "{belongs_to_primary}"]  ← rejected — elements must be distinct
+  BAD:  (field omitted entirely)                                         ← rejected — field is REQUIRED
   ```
 
   ## FINAL CHECK (verify before output)
   For EACH beat you generate:
-  1. `path_id` is `{path_id}`
-  2. `also_belongs_to` is `{also_belongs_to}`
-  3. `dilemma_impacts[0].dilemma_id` is `{dilemma_id}`
-  4. `effect` is NOT `commits`
+  1. `belongs_to` is `["{belongs_to_primary}", "{belongs_to_sibling}"]` (list of exactly 2)
+  2. `dilemma_impacts[0].dilemma_id` is `{dilemma_id}`
+  3. `effect` is NOT `commits`
 
   ## Output
   Return ONLY valid JSON with the "initial_beats" array.
@@ -499,7 +497,7 @@ per_path_beats_prompt: |
   This path has already been set up by shared pre-commit beats. Your job
   is to generate the COMMIT beat (where this path forks from the sibling)
   plus the aftermath beats that prove THIS answer. All beats in this call
-  are single-membership — `also_belongs_to` MUST be null.
+  are single-membership — `belongs_to` MUST be a single-element list.
 
   ## YOUR PATH ID (MEMORIZE THIS)
 
@@ -514,21 +512,21 @@ per_path_beats_prompt: |
 
   WRONG OUTPUT (will fail validation):
   ```json
-  "path_id": "{dilemma_id}"  // WRONG! This is a DILEMMA ID
+  "belongs_to": ["{dilemma_id}"]  // WRONG! This is a DILEMMA ID
   ```
 
   CORRECT OUTPUT:
   ```json
-  "path_id": "{path_id}"  // RIGHT! This is the PATH ID
+  "belongs_to": ["{path_id}"]  // RIGHT! This is the PATH ID
   ```
 
-  RULE: Dilemma IDs go in `dilemma_impacts[].dilemma_id`, never in `path_id`.
+  RULE: Dilemma IDs go in `dilemma_impacts[].dilemma_id`, never in `belongs_to`.
 
   ## YOUR DILEMMA ID (for dilemma_impacts only)
 
   Parent dilemma: `{dilemma_id}`
 
-  This goes in `dilemma_impacts[].dilemma_id`, NOT in `path_id`.
+  This goes in `dilemma_impacts[].dilemma_id`, NOT in `belongs_to`.
 
   ## BEAT ID NAMING (CRITICAL - ensures uniqueness)
 
@@ -547,7 +545,7 @@ per_path_beats_prompt: |
 
   ALL beats you generate MUST:
   1. Have beat_id starting with `{path_name}_beat_` (see BEAT ID NAMING above)
-  2. Have `path_id: "{path_id}"` (exactly this path ID)
+  2. Have `belongs_to: ["{path_id}"]` (single-element list with exactly this path ID)
   3. Have at least one dilemma_impact with `dilemma_id: "{dilemma_id}"`
   4. Include at least one beat with `effect: "commits"` for `{dilemma_id}`
 
@@ -559,8 +557,7 @@ per_path_beats_prompt: |
       {{
         "beat_id": "{path_name}_beat_01",
         "summary": "What happens in this beat",
-        "path_id": "{path_id}",
-        "also_belongs_to": null,
+        "belongs_to": ["{path_id}"],
         "dilemma_impacts": [
           {{
             "dilemma_id": "{dilemma_id}",
@@ -616,7 +613,7 @@ per_path_beats_prompt: |
   ## Rules
   - Generate exactly {size_post_commit_beats_per_path} beats for path `{path_id}`
   - Beat IDs MUST start with `{path_name}_beat_` (e.g., `{path_name}_beat_01`)
-  - EVERY beat must have `path_id: "{path_id}"`
+  - EVERY beat must have `belongs_to: ["{path_id}"]` (single-element list)
   - EVERY beat must have at least one dilemma_impact for `{dilemma_id}`
   - At least ONE beat must have `effect: "commits"` for `{dilemma_id}`
   - effect must be "advances", "reveals", "commits", or "complicates"
@@ -653,19 +650,19 @@ per_path_beats_prompt: |
   - Do NOT skip the commits beat
   - Do NOT make commits the last beat — a consequence beat MUST follow it
   - Do NOT use IDs not in the manifest
-  - Do NOT put the dilemma ID in the `path_id` field (see COMMON MISTAKE above)
-  - Do NOT set `also_belongs_to` — these are post-commit beats, single-membership only
+  - Do NOT put the dilemma ID in the `belongs_to` list (see COMMON MISTAKE above)
+  - Do NOT emit `belongs_to` with 2 elements — these are post-commit beats, single-membership only
 
   ## FINAL VERIFICATION (check before outputting)
 
   For EACH beat you generate, verify:
-  1. `path_id` is `{path_id}`
+  1. `belongs_to` is `["{path_id}"]` (single-element list with exactly this path ID)
   2. `dilemma_impacts[0].dilemma_id` is `{dilemma_id}`
-  3. `also_belongs_to` is `null` (these are POST-COMMIT beats, exclusive
+  3. `belongs_to` has exactly 1 element (these are POST-COMMIT beats, exclusive
      to one path — never shared)
 
-  If you see a dilemma ID in your `path_id` value, YOU MADE A MISTAKE. Fix it.
-  If `also_belongs_to` is anything other than `null`, YOU MADE A MISTAKE. Fix it.
+  If you see a dilemma ID in your `belongs_to` list, YOU MADE A MISTAKE. Fix it.
+  If `belongs_to` has 2 elements, YOU MADE A MISTAKE. Fix it.
 
   ## Output
   Return ONLY valid JSON with the "initial_beats" array ({size_post_commit_beats_per_path} beats).

--- a/prompts/templates/summarize_seed.yaml
+++ b/prompts/templates/summarize_seed.yaml
@@ -87,25 +87,20 @@ system: |
   - `summary`: one sentence describing what happens
   - `location`: primary location entity ID (must be a retained location)
   - `entities`: key entity IDs present in this beat
-  - `path_id`: the beat's primary path (REQUIRED, single path ID)
-  - `also_belongs_to`: for SHARED pre-commit beats, list the other path(s) this
-    beat is shared with (e.g., `[path::keeper_hiding]` on a shared beat whose
-    `path_id` is `path::keeper_honest`). For COMMIT and POST-COMMIT beats, use
-    `null` (they are exclusive to one path).
-
-  **Do NOT use the legacy `paths: [a, b]` list field — it was deprecated in
-  the Y-shape refactor (#1206) and will be rejected by the serializer.**
+  - `belongs_to`: list of path IDs this beat belongs to (REQUIRED).
+    For SHARED pre-commit beats, list BOTH paths: `[path::keeper_honest, path::keeper_hiding]`.
+    For COMMIT and POST-COMMIT beats, list exactly ONE path: `[path::keeper_honest]`.
 
   **Location Diversity**: Use at least 2 different locations across your beats.
 
   ### VERIFY (run BEFORE moving to Convergence Sketch)
   For EACH dilemma with 2 fully-explored paths, confirm in the summary:
-  1. At least 1 SHARED pre-commit beat exists with `path_id` set to one path
-     AND `also_belongs_to` listing the other path.
-  2. Each path has exactly 1 COMMIT beat (`also_belongs_to: null`, exclusive
+  1. At least 1 SHARED pre-commit beat exists with `belongs_to` of length 2
+     (both explored paths of the dilemma).
+  2. Each path has exactly 1 COMMIT beat (`belongs_to` length 1, exclusive
      to its path).
   3. Each path has at least the configured number of POST-COMMIT beats
-     (`also_belongs_to: null`).
+     (`belongs_to` length 1).
   4. Pre-commit beats appear before commit beats in the listing (or, if `temporal_hint` is set, its `position` is `before_commit`). `temporal_hint` is OPTIONAL — listing order alone is sufficient.
 
   If any of the above is missing, the serializer will fail and the repair

--- a/prompts/templates/summarize_seed_sections.yaml
+++ b/prompts/templates/summarize_seed_sections.yaml
@@ -226,17 +226,14 @@ beats_system: |
   - `summary`: one sentence describing what happens
   - `location`: a RETAINED location entity ID
   - `entities`: key entity IDs present in this beat
-  - `path_id`: the beat's primary path (REQUIRED, single path ID)
-  - `also_belongs_to`: for SHARED pre-commit beats, the sibling path ID as
-    a PLAIN STRING (not a list). E.g., `path::keeper_hiding` on a shared
-    beat whose `path_id` is `path::keeper_honest`. For COMMIT and
-    POST-COMMIT beats, use `null`.
+  - `belongs_to`: list of path IDs this beat belongs to (REQUIRED).
+    For SHARED pre-commit beats, list BOTH explored paths: `[path::keeper_honest, path::keeper_hiding]`.
+    For COMMIT and POST-COMMIT beats, list exactly ONE path: `[path::keeper_honest]`.
 
-    GOOD: `also_belongs_to: path::keeper_hiding`  (plain string)
-    BAD:  `also_belongs_to: [path::keeper_hiding]`  (list — REJECTED)
-
-  **Do NOT use the legacy `paths: [a, b]` list field — it was deprecated
-  in the Y-shape refactor (#1206) and the serializer will reject it.**
+    GOOD: `belongs_to: [path::keeper_honest, path::keeper_hiding]`  (shared — 2 elements)
+    GOOD: `belongs_to: [path::keeper_honest]`  (commit/post-commit — 1 element)
+    BAD:  `belongs_to: []`  (empty — REJECTED)
+    BAD:  `belongs_to: path::keeper_hiding`  (plain string — must be a list)
 
   ## Output Format
   List beats grouped by the dilemma they belong to, then by path.

--- a/src/questfoundry/agents/serialize.py
+++ b/src/questfoundry/agents/serialize.py
@@ -234,7 +234,7 @@ async def serialize_to_artifact(
             attempt — the validator-error dump follows as supporting context.
             Used to echo expected values for constraint-to-value mappings the
             model loses across long context (e.g. SEED shared-beats
-            `also_belongs_to` sibling path id). Per @prompt-engineer Rule 5,
+            `belongs_to` list with both path IDs). Per @prompt-engineer Rule 5,
             the model does not re-read the system prompt on retry — only the
             new user-message — and small models attend disproportionately to
             the opening tokens, so the actionable hint must lead and be
@@ -1183,8 +1183,8 @@ async def _serialize_shared_beats_for_dilemma(
     """Serialize shared pre-commit beats for a single dilemma (Y-shape, #1227).
 
     Issues ONE LLM call that generates the pre-commit beats both explored paths
-    of the dilemma share.  Each returned beat will have ``path_id`` set to the
-    primary explored path and ``also_belongs_to`` set to the sibling path.
+    of the dilemma share.  Each returned beat will have ``belongs_to`` set to a
+    two-element list containing both explored path IDs.
 
     Per Story Graph Ontology Part 8: multi-``belongs_to`` is ONLY valid for
     pre-commit beats within a single dilemma.
@@ -1193,8 +1193,8 @@ async def _serialize_shared_beats_for_dilemma(
         model: Chat model to use.
         dilemma_decision: Dilemma decision dict with dilemma_id, explored, question.
         paths: All serialized paths (for context enrichment).
-        shared_beats_prompt_template: Prompt template with {dilemma_id}, {path_id},
-            {also_belongs_to}, and {dilemma_question} placeholders.
+        shared_beats_prompt_template: Prompt template with {dilemma_id},
+            {belongs_to_primary}, {belongs_to_sibling}, and {dilemma_question} placeholders.
         entity_context: Entity IDs context for character/location references.
         provider_name: Provider name for strategy selection.
         max_retries: Maximum Pydantic validation retries.
@@ -1221,7 +1221,7 @@ async def _serialize_shared_beats_for_dilemma(
     prefixed_dilemma_id = normalize_scoped_id(dilemma_id, SCOPE_DILEMMA)
     dilemma_name = prefixed_dilemma_id.removeprefix(f"{SCOPE_DILEMMA}::")
 
-    # First explored path is primary; second is the sibling (also_belongs_to)
+    # Both explored paths go into belongs_to; primary is first, sibling is second
     primary_path_id = f"path::{dilemma_name}__{explored[0]}"
     sibling_path_id = f"path::{dilemma_name}__{explored[1]}"
 
@@ -1229,8 +1229,8 @@ async def _serialize_shared_beats_for_dilemma(
     prompt = shared_beats_prompt_template.format(
         dilemma_id=prefixed_dilemma_id,
         dilemma_question=question,
-        path_id=primary_path_id,
-        also_belongs_to=sibling_path_id,
+        belongs_to_primary=primary_path_id,
+        belongs_to_sibling=sibling_path_id,
     )
 
     brief = _build_shared_beat_context(dilemma_decision, paths, entity_context)
@@ -1242,33 +1242,31 @@ async def _serialize_shared_beats_for_dilemma(
         sibling_path_id=sibling_path_id,
     )
 
-    # Per-attempt repair hint — the validator's `also_belongs_to`-missing
-    # error names the field but doesn't echo the value, and small models
-    # (qwen3:4b production default) lose the constraint-to-value mapping
-    # across retry attempts (@prompt-engineer Rule 5 small-model repair-loop
-    # blindness — the model doesn't re-read the system prompt on retry).
-    # The hint is dilemma-specific so it always applies to this call.
+    # Per-attempt repair hint — the validator's `belongs_to`-missing or
+    # wrong-length error names the field but doesn't echo the required value,
+    # and small models (qwen3:4b production default) lose the constraint-to-value
+    # mapping across retry attempts (@prompt-engineer Rule 5 small-model
+    # repair-loop blindness — the model doesn't re-read the system prompt on
+    # retry). The hint is dilemma-specific so it always applies to this call.
     #
-    # Format chosen for #1521: leads with a copy-paste JSON snippet, names
-    # the type explicitly (STRING not list/null), and includes a
-    # self-contained mini-checklist mirroring the system prompt FINAL CHECK
-    # so the model doesn't need to re-read upstream context on retry.
-    also_belongs_to_hint = (
+    # Format chosen for #1521 (updated for #1564 list shape): leads with a
+    # copy-paste JSON snippet, names the type explicitly (LIST of two strings),
+    # and includes a self-contained mini-checklist mirroring the system prompt
+    # FINAL CHECK so the model doesn't need to re-read upstream context on retry.
+    belongs_to_repair_hint = (
         "ACTION REQUIRED — your previous output was rejected.\n\n"
-        "Add this to EVERY beat in `initial_beats` (copy exactly):\n\n"
+        "Set `belongs_to` in EVERY beat in `initial_beats` (copy exactly):\n\n"
         "```json\n"
-        f'  "path_id": "{primary_path_id}",\n'
-        f'  "also_belongs_to": "{sibling_path_id}"\n'
+        f'  "belongs_to": ["{primary_path_id}", "{sibling_path_id}"]\n'
         "```\n\n"
-        "Type rules for `also_belongs_to`:\n"
-        "  - It is a STRING (not a list, not null).\n"
-        f"  - For this dilemma, the value MUST be `{sibling_path_id}` exactly.\n"
-        "  - Without it, every beat is rejected by the Y-shape guard rail "
+        "Type rules for `belongs_to`:\n"
+        "  - It is a LIST of exactly 2 strings (not null, not a single string).\n"
+        f"  - For this dilemma, the value MUST be "
+        f'["{primary_path_id}", "{sibling_path_id}"] exactly.\n'
+        "  - Without both path IDs, every beat is rejected by the Y-shape guard rail "
         "(Story Graph Ontology Part 8).\n\n"
         f"Self-check before submitting (for dilemma `{prefixed_dilemma_id}`):\n"
-        f'  [ ] Every beat has `"path_id": "{primary_path_id}"`\n'
-        f'  [ ] Every beat has `"also_belongs_to": "{sibling_path_id}"` '
-        "(STRING, not list)\n"
+        f'  [ ] Every beat has `"belongs_to": ["{primary_path_id}", "{sibling_path_id}"]`\n'
         f'  [ ] No beat has `"effect": "commits"` '
         "(these are pre-commit beats, not commits)\n"
         f"  [ ] Every beat's first dilemma_impact has "
@@ -1284,7 +1282,7 @@ async def _serialize_shared_beats_for_dilemma(
         system_prompt=prompt,
         callbacks=callbacks,
         stage="seed",
-        extra_repair_hints=[also_belongs_to_hint],
+        extra_repair_hints=[belongs_to_repair_hint],
     )
 
     beats = result.model_dump().get("initial_beats", [])
@@ -2347,7 +2345,9 @@ async def serialize_seed_as_function(
                     # per-path post-commit beats.  The initial serialization
                     # at line ~2336 does the same prepend; the retry must match.
                     shared = [
-                        b for b in collected.get("initial_beats", []) if b.get("also_belongs_to")
+                        b
+                        for b in collected.get("initial_beats", [])
+                        if len(b.get("belongs_to") or []) >= 2
                     ]
                     collected["initial_beats"] = shared + beats
                     total_tokens += beats_tokens

--- a/src/questfoundry/agents/serialize.py
+++ b/src/questfoundry/agents/serialize.py
@@ -2130,9 +2130,17 @@ async def serialize_seed_as_function(
                     else:
                         # Fallback for LLM schema deviations: the SharedBeatsSection
                         # validator and prompt schema normally ensure
-                        # dilemma_impacts[0] is present, but parse the dilemma from
-                        # path_id as a last resort if the LLM omits dilemma_impacts.
-                        path_ref = beat.get("path_id", "")
+                        # dilemma_impacts[0] is present, but recover the dilemma from
+                        # belongs_to[0] (post-#1564 schema) as a last resort if the
+                        # LLM omits dilemma_impacts. The path ID format is
+                        # `path::<dilemma>__<answer>`, so the same rsplit logic
+                        # extracts the dilemma name. If belongs_to is also missing or
+                        # empty (truly malformed beat), raw_did stays empty and the
+                        # beat lands in shared_beats_by_dilemma[""] which no per-path
+                        # call consumes — silent discard, surfaced by the seam
+                        # validator.
+                        belongs_to_list = beat.get("belongs_to") or []
+                        path_ref = str(belongs_to_list[0]) if belongs_to_list else ""
                         raw_pid = strip_scope_prefix(path_ref)
                         # path ID format is <dilemma>__<answer>; take the dilemma part
                         raw_did = raw_pid.rsplit("__", 1)[0] if "__" in raw_pid else raw_pid

--- a/src/questfoundry/graph/dilemma_scoring.py
+++ b/src/questfoundry/graph/dilemma_scoring.py
@@ -89,7 +89,7 @@ def _get_paths_for_dilemma(
 
 def _get_beats_for_path(seed_output: SeedOutput, path_id: str) -> list[InitialBeat]:
     """Get all beats that belong to a given path."""
-    return [b for b in seed_output.initial_beats if b.path_id == path_id]
+    return [b for b in seed_output.initial_beats if path_id in b.belongs_to]
 
 
 def _get_consequences_for_path(seed_output: SeedOutput, path_id: str) -> list[Consequence]:

--- a/src/questfoundry/graph/mutations.py
+++ b/src/questfoundry/graph/mutations.py
@@ -853,33 +853,23 @@ def _prefix_entity_id(category: str, raw_id: str) -> str:
 
 
 def _get_path_ids_from_beat(beat: dict[str, Any]) -> tuple[str, ...]:
-    """Extract path IDs from a beat dict, supporting current and legacy formats.
+    """Extract path IDs from a SEED beat dict, in declaration order.
 
-    Supports:
-    - Y-shape current: ``path_id`` + optional ``also_belongs_to``.
-    - Legacy single: ``path_id`` alone.
-    - Legacy list: ``paths: [p]`` or ``paths: [p_a, p_b]`` (pre-Y-shape).
+    Reads the symmetric ``belongs_to`` list (#1564). Returns 0 (no
+    membership — structural beats), 1 (singular — commit / post-commit /
+    gap), or 2 (dual — pre-commit shared) raw path IDs.
 
     Args:
-        beat: Beat dict, either model-dumped or raw LLM output.
+        beat: Beat dict (typically from an ``InitialBeat.model_dump()``
+            or graph node data).
 
     Returns:
-        Tuple of 0, 1, or 2 raw path IDs in declaration order (``path_id``
-        first, then ``also_belongs_to``). A return of 2 always represents a
-        pre-commit Y-shape beat. A return of 0 means the beat has no path
-        reference (caught by validation).
+        Tuple of 0, 1, or 2 raw path IDs in declaration order. A return
+        of 2 always represents a shared pre-commit beat with dual
+        ``belongs_to`` to two paths of the same dilemma.
     """
-    if beat.get("path_id"):
-        primary = str(beat["path_id"])
-        also = beat.get("also_belongs_to")
-        if also:
-            return (primary, str(also))
-        return (primary,)
-    # Legacy fallback.
-    paths = beat.get("paths")
-    if isinstance(paths, list) and paths:
-        return tuple(str(p) for p in paths[:2])
-    return ()
+    belongs_to = beat.get("belongs_to") or []
+    return tuple(str(p) for p in belongs_to)
 
 
 def _resolve_entity_ref(graph: Graph, entity_ref: str) -> str:
@@ -1422,10 +1412,10 @@ def validate_seed_mutations(graph: Graph, output: dict[str, Any]) -> list[SeedVa
                     )
                 )
 
-        # 6. Path references (Y-shape: path_id + optional also_belongs_to).
+        # 6. Path references (belongs_to list — 1 or 2 elements).
         raw_path_ids = _get_path_ids_from_beat(beat)
         for idx, raw_path_id in enumerate(raw_path_ids):
-            field_name = "path_id" if idx == 0 else "also_belongs_to"
+            field_name = f"belongs_to[{idx}]"
             _validate_id(
                 raw_path_id,
                 "path",
@@ -1641,7 +1631,7 @@ def validate_seed_mutations(graph: Graph, output: dict[str, Any]) -> list[SeedVa
     path_beat_effects: dict[str, list[tuple[int, set[str]]]] = {}
     for i, beat in enumerate(output.get("initial_beats", [])):
         # Resolve beat's primary path; pre-commit beats have a second membership
-        # (also_belongs_to) but the commits-per-path accumulator is only
+        # (belongs_to[1]) but the commits-per-path accumulator is only
         # concerned with single-membership commit beats (guard rail 2).
         raw_path_ids = _get_path_ids_from_beat(beat)
         if not raw_path_ids:
@@ -2003,7 +1993,7 @@ def apply_seed_mutations(graph: Graph, output: dict[str, Any]) -> None:
         graph.create_node(beat_id, beat_data)
 
         # Link beat to its path(s). Post-commit beats emit one belongs_to;
-        # pre-commit (Y-shape) beats with ``also_belongs_to`` emit two.
+        # pre-commit (Y-shape) beats with two-element belongs_to emit two.
         raw_path_ids = _get_path_ids_from_beat(beat)
         is_dual = len(raw_path_ids) == 2
 
@@ -2014,26 +2004,26 @@ def apply_seed_mutations(graph: Graph, output: dict[str, Any]) -> None:
             d1 = _path_to_dilemma.get(strip_scope_prefix(raw_path_ids[1]))
             if d0 is None:
                 msg = (
-                    f"beat {raw_id!r}: path_id={raw_path_ids[0]!r} has no known dilemma "
+                    f"beat {raw_id!r}: belongs_to[0]={raw_path_ids[0]!r} has no known dilemma "
                     "(not in output paths); cannot enforce guard rail 1."
                 )
                 raise ValueError(msg)
             if d1 is None:
                 msg = (
-                    f"beat {raw_id!r}: also_belongs_to={raw_path_ids[1]!r} has no known dilemma "
+                    f"beat {raw_id!r}: belongs_to[1]={raw_path_ids[1]!r} has no known dilemma "
                     "(not in output paths); cannot enforce guard rail 1."
                 )
                 raise ValueError(msg)
             if d0 != d1:
                 msg = (
                     "cross-dilemma dual belongs_to is forbidden (guard rail 1). "
-                    f"Beat {raw_id!r} has path_id={raw_path_ids[0]!r} (dilemma={d0!r}) and "
-                    f"also_belongs_to={raw_path_ids[1]!r} (dilemma={d1!r})."
+                    f"Beat {raw_id!r} has belongs_to[0]={raw_path_ids[0]!r} (dilemma={d0!r}) and "
+                    f"belongs_to[1]={raw_path_ids[1]!r} (dilemma={d1!r})."
                 )
                 raise ValueError(msg)
             if strip_scope_prefix(raw_path_ids[0]) == strip_scope_prefix(raw_path_ids[1]):
                 msg = (
-                    f"beat {raw_id!r}: path_id and also_belongs_to must be distinct paths "
+                    f"beat {raw_id!r}: belongs_to elements must be distinct paths "
                     f"({raw_path_ids[0]!r} == {raw_path_ids[1]!r})."
                 )
                 raise ValueError(msg)
@@ -2048,8 +2038,8 @@ def apply_seed_mutations(graph: Graph, output: dict[str, Any]) -> None:
             if has_commit:
                 msg = (
                     "guard rail 2: a beat with effect=commits must have a single "
-                    f"belongs_to (no also_belongs_to). Beat {raw_id!r} has both "
-                    f"a commits impact and also_belongs_to={raw_path_ids[1]!r}."
+                    f"belongs_to (length 1). Beat {raw_id!r} has both "
+                    f"a commits impact and belongs_to[1]={raw_path_ids[1]!r}."
                 )
                 raise ValueError(msg)
 

--- a/src/questfoundry/graph/seed_pruning.py
+++ b/src/questfoundry/graph/seed_pruning.py
@@ -275,11 +275,14 @@ def _prune_demoted_dilemmas(
         c for c in seed_output.consequences if strip_scope_prefix(c.path_id) not in paths_to_drop
     ]
 
-    # 3. Filter beats — each beat belongs to exactly one path
+    # 3. Filter beats — drop any beat whose primary path (belongs_to[0]) is being
+    # pruned.  Pre-commit shared beats (belongs_to of length 2) are also dropped
+    # when their dilemma is demoted to single-path; both paths of a demoted
+    # dilemma are in paths_to_drop, so checking belongs_to[0] suffices.
     pruned_beats: list[InitialBeat] = [
         beat
         for beat in seed_output.initial_beats
-        if strip_scope_prefix(beat.path_id) not in paths_to_drop
+        if strip_scope_prefix(beat.belongs_to[0]) not in paths_to_drop
     ]
 
     dropped_beat_count = len(seed_output.initial_beats) - len(pruned_beats)

--- a/src/questfoundry/graph/seed_pruning.py
+++ b/src/questfoundry/graph/seed_pruning.py
@@ -275,10 +275,13 @@ def _prune_demoted_dilemmas(
         c for c in seed_output.consequences if strip_scope_prefix(c.path_id) not in paths_to_drop
     ]
 
-    # 3. Filter beats — drop any beat whose primary path (belongs_to[0]) is being
-    # pruned.  Pre-commit shared beats (belongs_to of length 2) are also dropped
-    # when their dilemma is demoted to single-path; both paths of a demoted
-    # dilemma are in paths_to_drop, so checking belongs_to[0] suffices.
+    # 3. Filter beats by primary path. Post-commit beats (belongs_to length 1)
+    # are dropped when their sole path is pruned. Pre-commit shared beats
+    # (belongs_to length 2) are dropped only when belongs_to[0] is the
+    # non-canonical path — paths_to_drop contains only non-canonical paths
+    # (line 241 above), so if belongs_to[0] == canonical the shared beat
+    # survives with a now-stale belongs_to[1] reference (silently ignored
+    # by the graph mutation layer when the sibling path node is absent).
     pruned_beats: list[InitialBeat] = [
         beat
         for beat in seed_output.initial_beats

--- a/src/questfoundry/models/seed.py
+++ b/src/questfoundry/models/seed.py
@@ -16,7 +16,6 @@ Terminology (v5):
 
 from __future__ import annotations
 
-import warnings
 from collections import Counter
 from enum import StrEnum
 from typing import Any, Literal
@@ -241,13 +240,15 @@ class InitialBeat(BaseModel):
 
     Beats carry either a single or a dual ``belongs_to`` edge to path nodes:
 
-    * **Post-commit beats** (the default) belong to exactly one path via
-      ``path_id``; ``also_belongs_to`` is ``None``. These beats prove one
-      answer and are exclusive to the path they belong to.
+    * **Post-commit beats** (the default) belong to exactly one path —
+      ``belongs_to`` is a single-element list. These beats prove one answer
+      and are exclusive to the path they belong to.
     * **Pre-commit beats** (shared dilemma setup) belong to *both* paths of
-      their dilemma via ``path_id`` and ``also_belongs_to``. This is the
-      Y-shape ratified in #1206/#1208: every player experiences pre-commit
-      beats regardless of which answer they later choose.
+      their dilemma — ``belongs_to`` is a two-element list, both referencing
+      paths of the same parent dilemma. This is the Y-shape ratified in
+      #1206/#1208 (and refined to symmetric list form in #1564): every
+      player experiences pre-commit beats regardless of which answer they
+      later choose.
 
     The commit beat itself is single-``belongs_to`` — it is the first beat
     exclusive to its path.
@@ -255,12 +256,10 @@ class InitialBeat(BaseModel):
     Attributes:
         beat_id: Unique identifier for the beat.
         summary: What happens in this beat.
-        path_id: Primary path this beat belongs to.
-        also_belongs_to: Sibling path for pre-commit (shared) beats. ``None``
-            for post-commit beats. MUST reference a path that shares the same
-            parent dilemma with ``path_id`` — cross-dilemma dual membership
-            is a Part-8 guard-rail violation and is rejected by the mutation
-            layer.
+        belongs_to: Path(s) this beat belongs to. Single-element list for
+            commit/post-commit/gap beats; two-element list (both paths of
+            the same dilemma) for pre-commit shared beats. Cross-dilemma
+            dual membership is rejected by the mutation layer.
         dilemma_impacts: How this beat affects dilemmas.
         entities: Entity IDs present in this beat.
         location: Primary location entity ID.
@@ -270,63 +269,28 @@ class InitialBeat(BaseModel):
 
     beat_id: str = Field(min_length=1, description="Unique identifier for this beat")
     summary: str = Field(min_length=1, description="What happens in this beat")
-    path_id: str = Field(
+    belongs_to: list[str] = Field(
         min_length=1,
-        description="Primary path this beat belongs to (first belongs_to edge)",
-    )
-    also_belongs_to: str | None = Field(
-        default=None,
-        min_length=1,
+        max_length=2,
         description=(
-            "Sibling path for pre-commit (Y-shape) beats: creates a second "
-            "belongs_to edge. Must be null for post-commit beats. Must "
-            "reference a path with the same parent dilemma as path_id."
+            "Path(s) this beat belongs to. List of length 2 means dual "
+            "membership (pre-commit shared beat — both paths of the same "
+            "dilemma). List of length 1 means singular membership (commit, "
+            "post-commit, or gap beat). Cross-dilemma dual membership is "
+            "rejected by the mutation layer; same-dilemma sibling-pair check "
+            "happens there as well, where path→dilemma resolution is available."
         ),
     )
 
-    @model_validator(mode="before")
-    @classmethod
-    def _migrate_paths_to_path_id(cls, data: Any) -> Any:
-        """Accept legacy ``paths`` and convert to Y-shape (``path_id`` + optional ``also_belongs_to``).
-
-        - ``paths: [single_id]`` → ``path_id = single_id`` (post-commit beat).
-        - ``paths: [p_a, p_b]`` → ``path_id = p_a``, ``also_belongs_to = p_b``
-          (pre-commit beat, Y-shape dual membership).
-        - ``paths: []`` is rejected — every beat must reference at least one path.
-        - ``paths`` with 3+ entries is rejected — dual membership is bounded to
-          the two paths of one dilemma (Part 8 guard rail 1).
-        """
-        if not isinstance(data, dict):
-            return data
-        if "paths" in data and "path_id" not in data:
-            paths = data.pop("paths")
-            if not isinstance(paths, list):
-                return data  # Let Pydantic reject the non-list type.
-            if len(paths) == 0:
-                msg = "InitialBeat.paths is empty — each beat must belong to at least one path."
-                raise ValueError(msg)
-            if len(paths) > 2:
-                msg = (
-                    "InitialBeat.paths has at most 2 entries (Y-shape guard rail 1). "
-                    f"Got {len(paths)}: {paths!r}."
-                )
-                raise ValueError(msg)
-            data["path_id"] = paths[0]
-            if len(paths) == 2:
-                warnings.warn(
-                    f"InitialBeat.paths=[{paths[0]!r}, {paths[1]!r}] is deprecated — use "
-                    "path_id and also_belongs_to directly.",
-                    DeprecationWarning,
-                    stacklevel=2,
-                )
-                data["also_belongs_to"] = paths[1]
-        return data
-
     @model_validator(mode="after")
-    def _also_belongs_to_differs_from_path_id(self) -> InitialBeat:
-        """Dual membership requires two distinct path IDs."""
-        if self.also_belongs_to is not None and self.also_belongs_to == self.path_id:
-            msg = "also_belongs_to must differ from path_id — dual membership needs two paths."
+    def _belongs_to_elements_valid(self) -> InitialBeat:
+        """Validate belongs_to element constraints."""
+        for path_id in self.belongs_to:
+            if not path_id:
+                msg = "belongs_to elements must be non-empty strings."
+                raise ValueError(msg)
+        if len(self.belongs_to) == 2 and self.belongs_to[0] == self.belongs_to[1]:
+            msg = "belongs_to elements must be distinct — dual membership needs two paths."
             raise ValueError(msg)
         return self
 
@@ -714,8 +678,8 @@ class SharedBeatsSection(BaseModel):
 
     Used by per-dilemma shared-beat serialization (Y-shape, issue #1227).
     One LLM call per dilemma generates the pre-commit beats that both explored
-    paths share.  Each beat MUST have both ``path_id`` and ``also_belongs_to``
-    set to the two explored paths of the dilemma (Story Graph Ontology Part 8).
+    paths share.  Each beat MUST have ``belongs_to`` set to a two-element list
+    containing both explored paths of the dilemma (Story Graph Ontology Part 8).
 
     A minimum of 1 beat is required so that every dilemma has at least one
     shared setup scene.  The maximum of 4 prevents over-stuffing the shared
@@ -735,26 +699,26 @@ class SharedBeatsSection(BaseModel):
         return self
 
     @model_validator(mode="after")
-    def _require_also_belongs_to(self) -> SharedBeatsSection:
-        """Assert every shared beat has also_belongs_to set (Part 8 guard rail 2).
+    def _require_dual_belongs_to(self) -> SharedBeatsSection:
+        """Assert every shared beat has belongs_to of length 2 (Part 8 guard rail 2).
 
         Shared pre-commit beats MUST carry dual ``belongs_to`` edges — one to
-        each explored path of their dilemma.  A beat with ``also_belongs_to``
-        unset would silently become a single-membership post-commit beat,
+        each explored path of their dilemma.  A beat with ``belongs_to`` of
+        length 1 would silently become a single-membership post-commit beat,
         violating the Y-shape invariant.
 
         Story Graph Ontology Part 8 guard rail 2: multi-``belongs_to`` is ONLY
-        valid for pre-commit beats; ``also_belongs_to`` is the field that signals
-        pre-commit membership.
+        valid for pre-commit beats; a two-element ``belongs_to`` list signals
+        pre-commit shared membership.
         """
-        offending = [b.beat_id for b in self.initial_beats if b.also_belongs_to is None]
+        offending = [b.beat_id for b in self.initial_beats if len(b.belongs_to) < 2]
         if offending:
             beat_ids_str = ", ".join(f"`{bid}`" for bid in offending)
             msg = (
-                "SharedBeatsSection: every shared beat must have `also_belongs_to` set "
+                "SharedBeatsSection: every shared beat must have `belongs_to` of length 2 "
                 "(Story Graph Ontology Part 8 guard rail 2 — pre-commit beats carry dual "
                 "belongs_to edges, one per explored path of their dilemma). "
-                f"Beats missing `also_belongs_to`: {beat_ids_str}"
+                f"Beats with single-element `belongs_to`: {beat_ids_str}"
             )
             raise ValueError(msg)
         return self

--- a/src/questfoundry/pipeline/stages/brainstorm.py
+++ b/src/questfoundry/pipeline/stages/brainstorm.py
@@ -420,7 +420,7 @@ class BrainstormStage:
         # ≥1 entity via `central_entity_ids`. Pydantic now enforces this with
         # min_length=1 (#1524), but a hint is still cheap to ship: it leads
         # the repair message with the value to populate, mirroring the SEED
-        # also_belongs_to fix from #1522. See @prompt-engineer Rule 5
+        # belongs_to list shape fix from #1521/#1564. See @prompt-engineer Rule 5
         # (small-model repair-loop blindness).
         central_entity_hint = (
             "ACTION REQUIRED — your previous output was rejected.\n\n"

--- a/src/questfoundry/pipeline/stages/seed.py
+++ b/src/questfoundry/pipeline/stages/seed.py
@@ -602,11 +602,11 @@ def _log_beat_summary_stats(artifact_data: dict[str, Any]) -> None:
     """Advisory warnings about Y-shape beat counts.
 
     Under Y-shape, beats come in two kinds:
-    - Shared pre-commit beats (``also_belongs_to`` set) — only multi-path
+    - Shared pre-commit beats (``belongs_to`` of length 2) — only multi-path
       dilemmas need them; they form the chain that diverges into per-path
       commit beats. Single-path soft dilemmas (locked-dilemma shadow) have
       no Y-divergence and need no shared beat.
-    - Post-commit beats (``also_belongs_to`` null) — one per path, including
+    - Post-commit beats (``belongs_to`` of length 1) — one per path, including
       the commit and its consequences.
 
     A healthy SEED output has ~1-2 shared beats per *multi-path* dilemma
@@ -621,8 +621,8 @@ def _log_beat_summary_stats(artifact_data: dict[str, Any]) -> None:
     paths_per_dilemma = Counter(p.get("dilemma_id") for p in paths if p.get("dilemma_id"))
     multi_path_dilemmas = sum(1 for n in paths_per_dilemma.values() if n >= 2)
 
-    shared = [b for b in beats if b.get("also_belongs_to")]
-    post_commit = [b for b in beats if not b.get("also_belongs_to")]
+    shared = [b for b in beats if len(b.get("belongs_to") or []) >= 2]
+    post_commit = [b for b in beats if len(b.get("belongs_to") or []) < 2]
 
     shared_avg = (len(shared) / multi_path_dilemmas) if multi_path_dilemmas else 0.0
     post_avg = (len(post_commit) / path_count) if path_count else 0.0

--- a/tests/integration/test_y_shape_end_to_end.py
+++ b/tests/integration/test_y_shape_end_to_end.py
@@ -219,8 +219,10 @@ def _make_seed_output() -> dict[str, Any]:
             {
                 "beat_id": "shared_setup",
                 "summary": "The mentor delivers a cryptic warning.",
-                "path_id": "trust_protector_or_manipulator__protector",
-                "also_belongs_to": "trust_protector_or_manipulator__manipulator",
+                "belongs_to": [
+                    "trust_protector_or_manipulator__protector",
+                    "trust_protector_or_manipulator__manipulator",
+                ],
                 "dilemma_impacts": [
                     {
                         "dilemma_id": "trust_protector_or_manipulator",
@@ -234,7 +236,7 @@ def _make_seed_output() -> dict[str, Any]:
             {
                 "beat_id": "commit_protector",
                 "summary": "Kay chooses to trust the mentor.",
-                "path_id": "trust_protector_or_manipulator__protector",
+                "belongs_to": ["trust_protector_or_manipulator__protector"],
                 "dilemma_impacts": [
                     {
                         "dilemma_id": "trust_protector_or_manipulator",
@@ -248,7 +250,7 @@ def _make_seed_output() -> dict[str, Any]:
             {
                 "beat_id": "post_protector",
                 "summary": "The mentor shields Kay from danger.",
-                "path_id": "trust_protector_or_manipulator__protector",
+                "belongs_to": ["trust_protector_or_manipulator__protector"],
                 "dilemma_impacts": [
                     {
                         "dilemma_id": "trust_protector_or_manipulator",
@@ -261,7 +263,7 @@ def _make_seed_output() -> dict[str, Any]:
             {
                 "beat_id": "post_protector_2",
                 "summary": "Kay gains the mentor's full support.",
-                "path_id": "trust_protector_or_manipulator__protector",
+                "belongs_to": ["trust_protector_or_manipulator__protector"],
                 "dilemma_impacts": [
                     {
                         "dilemma_id": "trust_protector_or_manipulator",
@@ -275,7 +277,7 @@ def _make_seed_output() -> dict[str, Any]:
             {
                 "beat_id": "commit_manipulator",
                 "summary": "Kay chooses to distrust the mentor.",
-                "path_id": "trust_protector_or_manipulator__manipulator",
+                "belongs_to": ["trust_protector_or_manipulator__manipulator"],
                 "dilemma_impacts": [
                     {
                         "dilemma_id": "trust_protector_or_manipulator",
@@ -289,7 +291,7 @@ def _make_seed_output() -> dict[str, Any]:
             {
                 "beat_id": "post_manipulator",
                 "summary": "The mentor manipulates Kay's choices.",
-                "path_id": "trust_protector_or_manipulator__manipulator",
+                "belongs_to": ["trust_protector_or_manipulator__manipulator"],
                 "dilemma_impacts": [
                     {
                         "dilemma_id": "trust_protector_or_manipulator",
@@ -302,7 +304,7 @@ def _make_seed_output() -> dict[str, Any]:
             {
                 "beat_id": "post_manipulator_2",
                 "summary": "Kay confronts the mentor's betrayal.",
-                "path_id": "trust_protector_or_manipulator__manipulator",
+                "belongs_to": ["trust_protector_or_manipulator__manipulator"],
                 "dilemma_impacts": [
                     {
                         "dilemma_id": "trust_protector_or_manipulator",

--- a/tests/unit/test_entity_naming.py
+++ b/tests/unit/test_entity_naming.py
@@ -404,8 +404,7 @@ def _make_complete_seed_output(entities: list[dict[str, Any]]) -> dict[str, Any]
             {
                 "beat_id": "discovery",
                 "summary": "Protagonist learns the secret.",
-                "path_id": "truth_or_secret__reveal",
-                "also_belongs_to": "truth_or_secret__conceal",
+                "belongs_to": ["truth_or_secret__reveal", "truth_or_secret__conceal"],
                 "entities": ["character::butler"],
                 "dilemma_impacts": [
                     {
@@ -418,7 +417,7 @@ def _make_complete_seed_output(entities: list[dict[str, Any]]) -> dict[str, Any]
             {
                 "beat_id": "reveal_choice",
                 "summary": "Protagonist tells the truth.",
-                "path_id": "truth_or_secret__reveal",
+                "belongs_to": ["truth_or_secret__reveal"],
                 "entities": ["character::lady_beatrice"],
                 "dilemma_impacts": [
                     {
@@ -431,7 +430,7 @@ def _make_complete_seed_output(entities: list[dict[str, Any]]) -> dict[str, Any]
             {
                 "beat_id": "reveal_aftermath_1",
                 "summary": "Aftermath of revelation.",
-                "path_id": "truth_or_secret__reveal",
+                "belongs_to": ["truth_or_secret__reveal"],
                 "entities": ["character::lady_beatrice"],
                 "dilemma_impacts": [
                     {
@@ -444,7 +443,7 @@ def _make_complete_seed_output(entities: list[dict[str, Any]]) -> dict[str, Any]
             {
                 "beat_id": "reveal_aftermath_2",
                 "summary": "Resolution of revelation.",
-                "path_id": "truth_or_secret__reveal",
+                "belongs_to": ["truth_or_secret__reveal"],
                 "entities": ["character::butler"],
                 "dilemma_impacts": [
                     {
@@ -457,7 +456,7 @@ def _make_complete_seed_output(entities: list[dict[str, Any]]) -> dict[str, Any]
             {
                 "beat_id": "conceal_choice",
                 "summary": "Protagonist keeps the secret.",
-                "path_id": "truth_or_secret__conceal",
+                "belongs_to": ["truth_or_secret__conceal"],
                 "entities": ["character::butler"],
                 "dilemma_impacts": [
                     {
@@ -470,7 +469,7 @@ def _make_complete_seed_output(entities: list[dict[str, Any]]) -> dict[str, Any]
             {
                 "beat_id": "conceal_aftermath_1",
                 "summary": "Tension from keeping secret.",
-                "path_id": "truth_or_secret__conceal",
+                "belongs_to": ["truth_or_secret__conceal"],
                 "entities": ["character::lady_beatrice"],
                 "dilemma_impacts": [
                     {
@@ -483,7 +482,7 @@ def _make_complete_seed_output(entities: list[dict[str, Any]]) -> dict[str, Any]
             {
                 "beat_id": "conceal_aftermath_2",
                 "summary": "Secret remains hidden.",
-                "path_id": "truth_or_secret__conceal",
+                "belongs_to": ["truth_or_secret__conceal"],
                 "entities": ["character::butler"],
                 "dilemma_impacts": [
                     {

--- a/tests/unit/test_grow_algorithms.py
+++ b/tests/unit/test_grow_algorithms.py
@@ -7899,8 +7899,10 @@ class TestApplyIntersectionMarkGuardRail3:
                 {
                     "beat_id": "shared_setup",
                     "summary": "Both players see this setup.",
-                    "path_id": "trust_protector_or_manipulator__protector",
-                    "also_belongs_to": "trust_protector_or_manipulator__manipulator",
+                    "belongs_to": [
+                        "trust_protector_or_manipulator__protector",
+                        "trust_protector_or_manipulator__manipulator",
+                    ],
                     "entities": ["character::mentor"],
                     "dilemma_impacts": [
                         {
@@ -7913,8 +7915,10 @@ class TestApplyIntersectionMarkGuardRail3:
                 {
                     "beat_id": "shared_reveal",
                     "summary": "Both players see this reveal.",
-                    "path_id": "trust_protector_or_manipulator__protector",
-                    "also_belongs_to": "trust_protector_or_manipulator__manipulator",
+                    "belongs_to": [
+                        "trust_protector_or_manipulator__protector",
+                        "trust_protector_or_manipulator__manipulator",
+                    ],
                     "entities": ["character::mentor"],
                     "dilemma_impacts": [
                         {
@@ -7927,7 +7931,7 @@ class TestApplyIntersectionMarkGuardRail3:
                 {
                     "beat_id": "commit_protector",
                     "summary": "Protector commits.",
-                    "path_id": "trust_protector_or_manipulator__protector",
+                    "belongs_to": ["trust_protector_or_manipulator__protector"],
                     "entities": ["character::mentor"],
                     "dilemma_impacts": [
                         {
@@ -7940,7 +7944,7 @@ class TestApplyIntersectionMarkGuardRail3:
                 {
                     "beat_id": "post_protector",
                     "summary": "Protector aftermath.",
-                    "path_id": "trust_protector_or_manipulator__protector",
+                    "belongs_to": ["trust_protector_or_manipulator__protector"],
                     "entities": ["character::mentor"],
                     "dilemma_impacts": [
                         {
@@ -7953,7 +7957,7 @@ class TestApplyIntersectionMarkGuardRail3:
                 {
                     "beat_id": "post_protector_2",
                     "summary": "Protector resolution.",
-                    "path_id": "trust_protector_or_manipulator__protector",
+                    "belongs_to": ["trust_protector_or_manipulator__protector"],
                     "entities": ["character::mentor"],
                     "dilemma_impacts": [
                         {
@@ -7966,7 +7970,7 @@ class TestApplyIntersectionMarkGuardRail3:
                 {
                     "beat_id": "commit_manipulator",
                     "summary": "Manipulator commits.",
-                    "path_id": "trust_protector_or_manipulator__manipulator",
+                    "belongs_to": ["trust_protector_or_manipulator__manipulator"],
                     "entities": ["character::mentor"],
                     "dilemma_impacts": [
                         {
@@ -7979,7 +7983,7 @@ class TestApplyIntersectionMarkGuardRail3:
                 {
                     "beat_id": "post_manipulator",
                     "summary": "Manipulator aftermath.",
-                    "path_id": "trust_protector_or_manipulator__manipulator",
+                    "belongs_to": ["trust_protector_or_manipulator__manipulator"],
                     "entities": ["character::mentor"],
                     "dilemma_impacts": [
                         {
@@ -7992,7 +7996,7 @@ class TestApplyIntersectionMarkGuardRail3:
                 {
                     "beat_id": "post_manipulator_2",
                     "summary": "Manipulator resolution.",
-                    "path_id": "trust_protector_or_manipulator__manipulator",
+                    "belongs_to": ["trust_protector_or_manipulator__manipulator"],
                     "entities": ["character::mentor"],
                     "dilemma_impacts": [
                         {

--- a/tests/unit/test_mutations.py
+++ b/tests/unit/test_mutations.py
@@ -378,50 +378,49 @@ class TestApplyMutations:
                 {
                     "beat_id": "shared_pre",
                     "summary": "Both players encounter the mentor's cryptic hint.",
-                    "path_id": "trust__protector",
-                    "also_belongs_to": "trust__manipulator",
+                    "belongs_to": ["trust__protector", "trust__manipulator"],
                     "dilemma_impacts": [{"dilemma_id": "trust", "effect": "advances"}],
                     "entities": ["mentor"],
                 },
                 {
                     "beat_id": "commit_protector",
                     "summary": "Protagonist trusts the mentor.",
-                    "path_id": "trust__protector",
+                    "belongs_to": ["trust__protector"],
                     "dilemma_impacts": [{"dilemma_id": "trust", "effect": "commits"}],
                     "entities": ["mentor"],
                 },
                 {
                     "beat_id": "post_protector_1",
                     "summary": "Mentor reveals a vital secret.",
-                    "path_id": "trust__protector",
+                    "belongs_to": ["trust__protector"],
                     "dilemma_impacts": [{"dilemma_id": "trust", "effect": "advances"}],
                     "entities": ["mentor"],
                 },
                 {
                     "beat_id": "post_protector_2",
                     "summary": "Ally bond confirmed.",
-                    "path_id": "trust__protector",
+                    "belongs_to": ["trust__protector"],
                     "dilemma_impacts": [{"dilemma_id": "trust", "effect": "advances"}],
                     "entities": ["mentor"],
                 },
                 {
                     "beat_id": "commit_manipulator",
                     "summary": "Protagonist distrusts the mentor.",
-                    "path_id": "trust__manipulator",
+                    "belongs_to": ["trust__manipulator"],
                     "dilemma_impacts": [{"dilemma_id": "trust", "effect": "commits"}],
                     "entities": ["mentor"],
                 },
                 {
                     "beat_id": "post_manipulator_1",
                     "summary": "Mentor's true motive surfaces.",
-                    "path_id": "trust__manipulator",
+                    "belongs_to": ["trust__manipulator"],
                     "dilemma_impacts": [{"dilemma_id": "trust", "effect": "advances"}],
                     "entities": ["mentor"],
                 },
                 {
                     "beat_id": "post_manipulator_2",
                     "summary": "Protagonist faces danger alone.",
-                    "path_id": "trust__manipulator",
+                    "belongs_to": ["trust__manipulator"],
                     "dilemma_impacts": [{"dilemma_id": "trust", "effect": "advances"}],
                     "entities": ["mentor"],
                 },
@@ -1600,21 +1599,21 @@ class TestSeedMutations:
                 {
                     "beat_id": "commit",
                     "summary": "Trust decided.",
-                    "path_id": "trust__protector",
+                    "belongs_to": ["trust__protector"],
                     "dilemma_impacts": [{"dilemma_id": "trust", "effect": "commits"}],
                     "entities": ["mentor"],
                 },
                 {
                     "beat_id": "post_1",
                     "summary": "Aftermath follows.",
-                    "path_id": "trust__protector",
+                    "belongs_to": ["trust__protector"],
                     "dilemma_impacts": [{"dilemma_id": "trust", "effect": "advances"}],
                     "entities": ["mentor"],
                 },
                 {
                     "beat_id": "post_2",
                     "summary": "Ally bond forms.",
-                    "path_id": "trust__protector",
+                    "belongs_to": ["trust__protector"],
                     "dilemma_impacts": [{"dilemma_id": "trust", "effect": "advances"}],
                     "entities": ["mentor"],
                 },
@@ -1704,7 +1703,7 @@ class TestSeedMutations:
                 {
                     "beat_id": "resolution",
                     "summary": "Mentor's true nature revealed.",
-                    "path_id": "path_mentor_trust",
+                    "belongs_to": ["path_mentor_trust"],
                     "dilemma_impacts": [
                         {"dilemma_id": "mentor_trust", "effect": "commits", "note": "Locked in"}
                     ],
@@ -1713,7 +1712,7 @@ class TestSeedMutations:
                 {
                     "beat_id": "resolution_post",
                     "summary": "Consequences of the revelation.",
-                    "path_id": "path_mentor_trust",
+                    "belongs_to": ["path_mentor_trust"],
                     "dilemma_impacts": [
                         {"dilemma_id": "mentor_trust", "effect": "advances", "note": "Fallout"}
                     ],
@@ -1722,7 +1721,7 @@ class TestSeedMutations:
                 {
                     "beat_id": "resolution_post_2",
                     "summary": "Aftermath settles.",
-                    "path_id": "path_mentor_trust",
+                    "belongs_to": ["path_mentor_trust"],
                     "dilemma_impacts": [
                         {"dilemma_id": "mentor_trust", "effect": "advances", "note": "Settling"}
                     ],
@@ -1731,21 +1730,21 @@ class TestSeedMutations:
                 {
                     "beat_id": "trust_commit",
                     "summary": "Trust resolved.",
-                    "path_id": "trust__protector",
+                    "belongs_to": ["trust__protector"],
                     "dilemma_impacts": [{"dilemma_id": "trust", "effect": "commits"}],
                     "entities": ["mentor"],
                 },
                 {
                     "beat_id": "trust_post_1",
                     "summary": "Trust aftermath.",
-                    "path_id": "trust__protector",
+                    "belongs_to": ["trust__protector"],
                     "dilemma_impacts": [{"dilemma_id": "trust", "effect": "advances"}],
                     "entities": ["mentor"],
                 },
                 {
                     "beat_id": "trust_post_2",
                     "summary": "Trust settled.",
-                    "path_id": "trust__protector",
+                    "belongs_to": ["trust__protector"],
                     "dilemma_impacts": [{"dilemma_id": "trust", "effect": "advances"}],
                     "entities": ["mentor"],
                 },
@@ -1843,15 +1842,14 @@ class TestSeedMutations:
                 {
                     "beat_id": "shared_setup",
                     "summary": "Both paths share this setup beat.",
-                    "path_id": "mentor_protects",
-                    "also_belongs_to": "mentor_manipulates",
+                    "belongs_to": ["mentor_protects", "mentor_manipulates"],
                     "dilemma_impacts": [{"dilemma_id": "trust", "effect": "advances"}],
                     "entities": ["mentor"],
                 },
                 {
                     "beat_id": "protects_beat_01",
                     "summary": "Mentor reveals protection.",
-                    "path_id": "mentor_protects",
+                    "belongs_to": ["mentor_protects"],
                     "dilemma_impacts": [
                         {"dilemma_id": "trust", "effect": "commits", "note": "Locked"}
                     ],
@@ -1860,7 +1858,7 @@ class TestSeedMutations:
                 {
                     "beat_id": "protects_beat_02",
                     "summary": "Protection confirmed.",
-                    "path_id": "mentor_protects",
+                    "belongs_to": ["mentor_protects"],
                     "dilemma_impacts": [
                         {"dilemma_id": "trust", "effect": "advances", "note": "Fallout"}
                     ],
@@ -1869,7 +1867,7 @@ class TestSeedMutations:
                 {
                     "beat_id": "protects_beat_03",
                     "summary": "Ally bond solidifies.",
-                    "path_id": "mentor_protects",
+                    "belongs_to": ["mentor_protects"],
                     "dilemma_impacts": [
                         {"dilemma_id": "trust", "effect": "advances", "note": "Growth"}
                     ],
@@ -1878,7 +1876,7 @@ class TestSeedMutations:
                 {
                     "beat_id": "manipulates_beat_01",
                     "summary": "Mentor reveals manipulation.",
-                    "path_id": "mentor_manipulates",
+                    "belongs_to": ["mentor_manipulates"],
                     "dilemma_impacts": [
                         {"dilemma_id": "trust", "effect": "commits", "note": "Locked"}
                     ],
@@ -1887,7 +1885,7 @@ class TestSeedMutations:
                 {
                     "beat_id": "manipulates_beat_02",
                     "summary": "Manipulation confirmed.",
-                    "path_id": "mentor_manipulates",
+                    "belongs_to": ["mentor_manipulates"],
                     "dilemma_impacts": [
                         {"dilemma_id": "trust", "effect": "advances", "note": "Fallout"}
                     ],
@@ -1896,7 +1894,7 @@ class TestSeedMutations:
                 {
                     "beat_id": "manipulates_beat_03",
                     "summary": "Protagonist must stand alone.",
-                    "path_id": "mentor_manipulates",
+                    "belongs_to": ["mentor_manipulates"],
                     "dilemma_impacts": [
                         {"dilemma_id": "trust", "effect": "advances", "note": "Hardship"}
                     ],
@@ -1991,12 +1989,11 @@ class TestSeedMutations:
                 },
             ],
             "initial_beats": [
-                # Shared pre-commit beat (dual belongs_to via also_belongs_to)
+                # Shared pre-commit beat (dual belongs_to — two-element list)
                 {
                     "beat_id": "opening_001",
                     "summary": "Kay meets the mentor for the first time",
-                    "path_id": "trust__protector",
-                    "also_belongs_to": "trust__manipulator",
+                    "belongs_to": ["trust__protector", "trust__manipulator"],
                     "dilemma_impacts": [{"dilemma_id": "trust", "effect": "advances"}],
                     "entities": ["kay", "mentor"],
                     "location": "archive",
@@ -2005,7 +2002,7 @@ class TestSeedMutations:
                 {
                     "beat_id": "commit_protector",
                     "summary": "Kay decides to trust the mentor.",
-                    "path_id": "trust__protector",
+                    "belongs_to": ["trust__protector"],
                     "dilemma_impacts": [{"dilemma_id": "trust", "effect": "commits"}],
                     "entities": ["kay", "mentor"],
                 },
@@ -2013,14 +2010,14 @@ class TestSeedMutations:
                 {
                     "beat_id": "post_protector_1",
                     "summary": "Mentor reveals a vital secret.",
-                    "path_id": "trust__protector",
+                    "belongs_to": ["trust__protector"],
                     "dilemma_impacts": [{"dilemma_id": "trust", "effect": "advances"}],
                     "entities": ["mentor"],
                 },
                 {
                     "beat_id": "post_protector_2",
                     "summary": "Ally bond confirmed.",
-                    "path_id": "trust__protector",
+                    "belongs_to": ["trust__protector"],
                     "dilemma_impacts": [{"dilemma_id": "trust", "effect": "advances"}],
                     "entities": ["mentor"],
                 },
@@ -2028,7 +2025,7 @@ class TestSeedMutations:
                 {
                     "beat_id": "commit_manipulator",
                     "summary": "Kay distrusts the mentor.",
-                    "path_id": "trust__manipulator",
+                    "belongs_to": ["trust__manipulator"],
                     "dilemma_impacts": [{"dilemma_id": "trust", "effect": "commits"}],
                     "entities": ["kay", "mentor"],
                 },
@@ -2036,14 +2033,14 @@ class TestSeedMutations:
                 {
                     "beat_id": "post_manipulator_1",
                     "summary": "Mentor's true motive surfaces.",
-                    "path_id": "trust__manipulator",
+                    "belongs_to": ["trust__manipulator"],
                     "dilemma_impacts": [{"dilemma_id": "trust", "effect": "advances"}],
                     "entities": ["mentor"],
                 },
                 {
                     "beat_id": "post_manipulator_2",
                     "summary": "Protagonist faces danger alone.",
-                    "path_id": "trust__manipulator",
+                    "belongs_to": ["trust__manipulator"],
                     "dilemma_impacts": [{"dilemma_id": "trust", "effect": "advances"}],
                     "entities": ["kay"],
                 },
@@ -2175,8 +2172,7 @@ class TestSeedMutations:
                 {
                     "beat_id": "trust_pre",
                     "summary": "Protagonist encounters the mentor",
-                    "path_id": "trust__protector",
-                    "also_belongs_to": "trust__manipulator",
+                    "belongs_to": ["trust__protector", "trust__manipulator"],
                     "dilemma_impacts": [{"dilemma_id": "trust", "effect": "advances"}],
                     "entities": ["mentor"],
                 },
@@ -2184,7 +2180,7 @@ class TestSeedMutations:
                 {
                     "beat_id": "opening_001",
                     "summary": "Kay decides to trust the mentor",
-                    "path_id": "trust__protector",
+                    "belongs_to": ["trust__protector"],
                     "dilemma_impacts": [{"dilemma_id": "trust", "effect": "commits"}],
                     "entities": ["mentor"],
                     "temporal_hint": {
@@ -2196,14 +2192,14 @@ class TestSeedMutations:
                 {
                     "beat_id": "post_protector_1",
                     "summary": "Mentor shares vital information.",
-                    "path_id": "trust__protector",
+                    "belongs_to": ["trust__protector"],
                     "dilemma_impacts": [{"dilemma_id": "trust", "effect": "advances"}],
                     "entities": ["mentor"],
                 },
                 {
                     "beat_id": "post_protector_2",
                     "summary": "Ally bond confirmed.",
-                    "path_id": "trust__protector",
+                    "belongs_to": ["trust__protector"],
                     "dilemma_impacts": [{"dilemma_id": "trust", "effect": "advances"}],
                     "entities": ["mentor"],
                 },
@@ -2211,7 +2207,7 @@ class TestSeedMutations:
                 {
                     "beat_id": "commit_manipulator",
                     "summary": "Kay distrusts the mentor.",
-                    "path_id": "trust__manipulator",
+                    "belongs_to": ["trust__manipulator"],
                     "dilemma_impacts": [{"dilemma_id": "trust", "effect": "commits"}],
                     "entities": ["mentor"],
                 },
@@ -2219,14 +2215,14 @@ class TestSeedMutations:
                 {
                     "beat_id": "post_manipulator_1",
                     "summary": "Mentor's true motive surfaces.",
-                    "path_id": "trust__manipulator",
+                    "belongs_to": ["trust__manipulator"],
                     "dilemma_impacts": [{"dilemma_id": "trust", "effect": "advances"}],
                     "entities": ["mentor"],
                 },
                 {
                     "beat_id": "post_manipulator_2",
                     "summary": "Protagonist faces danger alone.",
-                    "path_id": "trust__manipulator",
+                    "belongs_to": ["trust__manipulator"],
                     "dilemma_impacts": [{"dilemma_id": "trust", "effect": "advances"}],
                     "entities": ["mentor"],
                 },
@@ -2234,8 +2230,7 @@ class TestSeedMutations:
                 {
                     "beat_id": "fight_pre",
                     "summary": "Danger approaches.",
-                    "path_id": "fight_or_flee__fight",
-                    "also_belongs_to": "fight_or_flee__flee",
+                    "belongs_to": ["fight_or_flee__fight", "fight_or_flee__flee"],
                     "dilemma_impacts": [{"dilemma_id": "fight_or_flee", "effect": "advances"}],
                     "entities": ["mentor"],
                 },
@@ -2243,14 +2238,14 @@ class TestSeedMutations:
                 {
                     "beat_id": "commit_fight",
                     "summary": "Character stands and fights.",
-                    "path_id": "fight_or_flee__fight",
+                    "belongs_to": ["fight_or_flee__fight"],
                     "dilemma_impacts": [{"dilemma_id": "fight_or_flee", "effect": "commits"}],
                     "entities": ["mentor"],
                 },
                 {
                     "beat_id": "commit_flee",
                     "summary": "Character flees the danger.",
-                    "path_id": "fight_or_flee__flee",
+                    "belongs_to": ["fight_or_flee__flee"],
                     "dilemma_impacts": [{"dilemma_id": "fight_or_flee", "effect": "commits"}],
                     "entities": ["mentor"],
                 },
@@ -2258,28 +2253,28 @@ class TestSeedMutations:
                 {
                     "beat_id": "post_fight_1",
                     "summary": "Wounds slow the journey.",
-                    "path_id": "fight_or_flee__fight",
+                    "belongs_to": ["fight_or_flee__fight"],
                     "dilemma_impacts": [{"dilemma_id": "fight_or_flee", "effect": "advances"}],
                     "entities": ["mentor"],
                 },
                 {
                     "beat_id": "post_fight_2",
                     "summary": "Victory is hollow.",
-                    "path_id": "fight_or_flee__fight",
+                    "belongs_to": ["fight_or_flee__fight"],
                     "dilemma_impacts": [{"dilemma_id": "fight_or_flee", "effect": "advances"}],
                     "entities": ["mentor"],
                 },
                 {
                     "beat_id": "post_flee_1",
                     "summary": "Cowardice haunts.",
-                    "path_id": "fight_or_flee__flee",
+                    "belongs_to": ["fight_or_flee__flee"],
                     "dilemma_impacts": [{"dilemma_id": "fight_or_flee", "effect": "advances"}],
                     "entities": ["mentor"],
                 },
                 {
                     "beat_id": "post_flee_2",
                     "summary": "Escape has a price.",
-                    "path_id": "fight_or_flee__flee",
+                    "belongs_to": ["fight_or_flee__flee"],
                     "dilemma_impacts": [{"dilemma_id": "fight_or_flee", "effect": "advances"}],
                     "entities": ["mentor"],
                 },
@@ -2318,7 +2313,7 @@ class TestSeedMutations:
         """Build a fully contract-compliant SEED output using only the trust dilemma.
 
         Provides two paths (trust__protector, trust__manipulator) with:
-        - one shared pre-commit beat (dual belongs_to via also_belongs_to)
+        - one shared pre-commit beat (dual belongs_to — two-element list)
         - one commit beat per path
         - two post-commit beats per path
         - consequences with ripples
@@ -2330,7 +2325,7 @@ class TestSeedMutations:
         commit_beat: dict[str, Any] = {
             "beat_id": "opening_001",
             "summary": "Kay decides to trust the mentor",
-            "path_id": "trust__protector",
+            "belongs_to": ["trust__protector"],
             "dilemma_impacts": [{"dilemma_id": "trust", "effect": "commits"}],
             "entities": ["mentor"],
         }
@@ -2383,8 +2378,7 @@ class TestSeedMutations:
                 {
                     "beat_id": "trust_pre",
                     "summary": "Protagonist encounters the mentor",
-                    "path_id": "trust__protector",
-                    "also_belongs_to": "trust__manipulator",
+                    "belongs_to": ["trust__protector", "trust__manipulator"],
                     "dilemma_impacts": [{"dilemma_id": "trust", "effect": "advances"}],
                     "entities": ["mentor"],
                 },
@@ -2394,14 +2388,14 @@ class TestSeedMutations:
                 {
                     "beat_id": "post_protector_1",
                     "summary": "Mentor shares vital information.",
-                    "path_id": "trust__protector",
+                    "belongs_to": ["trust__protector"],
                     "dilemma_impacts": [{"dilemma_id": "trust", "effect": "advances"}],
                     "entities": ["mentor"],
                 },
                 {
                     "beat_id": "post_protector_2",
                     "summary": "Ally bond confirmed.",
-                    "path_id": "trust__protector",
+                    "belongs_to": ["trust__protector"],
                     "dilemma_impacts": [{"dilemma_id": "trust", "effect": "advances"}],
                     "entities": ["mentor"],
                 },
@@ -2409,7 +2403,7 @@ class TestSeedMutations:
                 {
                     "beat_id": "commit_manipulator",
                     "summary": "Kay distrusts the mentor.",
-                    "path_id": "trust__manipulator",
+                    "belongs_to": ["trust__manipulator"],
                     "dilemma_impacts": [{"dilemma_id": "trust", "effect": "commits"}],
                     "entities": ["mentor"],
                 },
@@ -2417,14 +2411,14 @@ class TestSeedMutations:
                 {
                     "beat_id": "post_manipulator_1",
                     "summary": "Mentor's true motive surfaces.",
-                    "path_id": "trust__manipulator",
+                    "belongs_to": ["trust__manipulator"],
                     "dilemma_impacts": [{"dilemma_id": "trust", "effect": "advances"}],
                     "entities": ["mentor"],
                 },
                 {
                     "beat_id": "post_manipulator_2",
                     "summary": "Protagonist faces danger alone.",
-                    "path_id": "trust__manipulator",
+                    "belongs_to": ["trust__manipulator"],
                     "dilemma_impacts": [{"dilemma_id": "trust", "effect": "advances"}],
                     "entities": ["mentor"],
                 },
@@ -2534,7 +2528,7 @@ class TestSeedCompletenessValidation:
                 {
                     "beat_id": "discovery",
                     "summary": "Trust questioned",
-                    "paths": ["trust_arc"],
+                    "belongs_to": ["trust_arc"],
                     "dilemma_impacts": [
                         {"dilemma_id": "trust", "effect": "advances", "note": "Tension builds"}
                     ],
@@ -2542,7 +2536,7 @@ class TestSeedCompletenessValidation:
                 {
                     "beat_id": "resolution",
                     "summary": "Trust resolved",
-                    "paths": ["trust_arc"],
+                    "belongs_to": ["trust_arc"],
                     "dilemma_impacts": [
                         {"dilemma_id": "trust", "effect": "commits", "note": "Locked in"}
                     ],
@@ -2550,7 +2544,7 @@ class TestSeedCompletenessValidation:
                 {
                     "beat_id": "aftermath",
                     "summary": "Consequences unfold",
-                    "paths": ["trust_arc"],
+                    "belongs_to": ["trust_arc"],
                     "dilemma_impacts": [
                         {"dilemma_id": "trust", "effect": "advances", "note": "Fallout"}
                     ],
@@ -3030,7 +3024,7 @@ class TestBeatDilemmaAlignment:
             {
                 "beat_id": "opening",
                 "summary": "Start",
-                "paths": ["trust_arc"],
+                "belongs_to": ["trust_arc"],
                 "dilemma_impacts": [
                     # Wrong dilemma - should be 'trust' for path trust_arc
                     {"dilemma_id": "loyalty", "effect": "commits", "note": "Wrong"}
@@ -3053,7 +3047,7 @@ class TestBeatDilemmaAlignment:
             {
                 "beat_id": "opening",
                 "summary": "Start",
-                "paths": ["trust_arc"],
+                "belongs_to": ["trust_arc"],
                 # No dilemma_impacts at all
             }
         ]
@@ -3071,7 +3065,7 @@ class TestBeatDilemmaAlignment:
             {
                 "beat_id": "opening",
                 "summary": "Start",
-                "paths": ["trust_arc"],
+                "belongs_to": ["trust_arc"],
                 "dilemma_impacts": [
                     {"dilemma_id": "trust", "effect": "advances", "note": "Begins"}
                 ],
@@ -3102,7 +3096,7 @@ class TestBeatDilemmaAlignment:
             {
                 "beat_id": "opening",
                 "summary": "Start",
-                "paths": ["trust_arc"],
+                "belongs_to": ["trust_arc"],
                 "dilemma_impacts": [
                     {"dilemma_id": "trust", "effect": "commits", "note": "Primary"},
                     {"dilemma_id": "loyalty", "effect": "advances", "note": "Secondary"},
@@ -3111,7 +3105,7 @@ class TestBeatDilemmaAlignment:
             {
                 "beat_id": "opening_post",
                 "summary": "Trust aftermath",
-                "paths": ["trust_arc"],
+                "belongs_to": ["trust_arc"],
                 "dilemma_impacts": [
                     {"dilemma_id": "trust", "effect": "advances", "note": "Fallout"},
                 ],
@@ -3119,7 +3113,7 @@ class TestBeatDilemmaAlignment:
             {
                 "beat_id": "loyalty_commit",
                 "summary": "Loyalty locked",
-                "paths": ["loyalty_arc"],
+                "belongs_to": ["loyalty_arc"],
                 "dilemma_impacts": [
                     {"dilemma_id": "loyalty", "effect": "commits", "note": "Locked"}
                 ],
@@ -3127,7 +3121,7 @@ class TestBeatDilemmaAlignment:
             {
                 "beat_id": "loyalty_commit_post",
                 "summary": "Loyalty aftermath",
-                "paths": ["loyalty_arc"],
+                "belongs_to": ["loyalty_arc"],
                 "dilemma_impacts": [
                     {"dilemma_id": "loyalty", "effect": "advances", "note": "Fallout"}
                 ],
@@ -3155,14 +3149,14 @@ class TestBeatDilemmaAlignment:
             {
                 "beat_id": "trust_commit",
                 "summary": "Trust resolved",
-                "paths": ["trust_arc"],
+                "belongs_to": ["trust_arc"],
                 "dilemma_impacts": [{"dilemma_id": "trust", "effect": "commits", "note": "Locked"}],
             },
             # loyalty_arc has no commits beat
             {
                 "beat_id": "loyalty_advance",
                 "summary": "Loyalty tested",
-                "paths": ["loyalty_arc"],
+                "belongs_to": ["loyalty_arc"],
                 "dilemma_impacts": [
                     {"dilemma_id": "loyalty", "effect": "advances", "note": "Tested"}
                 ],
@@ -3191,13 +3185,13 @@ class TestBeatDilemmaAlignment:
             {
                 "beat_id": "trust_commit",
                 "summary": "Trust resolved",
-                "paths": ["trust_arc"],
+                "belongs_to": ["trust_arc"],
                 "dilemma_impacts": [{"dilemma_id": "trust", "effect": "commits", "note": "Locked"}],
             },
             {
                 "beat_id": "trust_commit_post",
                 "summary": "Trust aftermath",
-                "paths": ["trust_arc"],
+                "belongs_to": ["trust_arc"],
                 "dilemma_impacts": [
                     {"dilemma_id": "trust", "effect": "advances", "note": "Fallout"}
                 ],
@@ -3205,7 +3199,7 @@ class TestBeatDilemmaAlignment:
             {
                 "beat_id": "loyalty_commit",
                 "summary": "Loyalty locked",
-                "paths": ["loyalty_arc"],
+                "belongs_to": ["loyalty_arc"],
                 "dilemma_impacts": [
                     {"dilemma_id": "loyalty", "effect": "commits", "note": "Locked"}
                 ],
@@ -3213,7 +3207,7 @@ class TestBeatDilemmaAlignment:
             {
                 "beat_id": "loyalty_commit_post",
                 "summary": "Loyalty aftermath",
-                "paths": ["loyalty_arc"],
+                "belongs_to": ["loyalty_arc"],
                 "dilemma_impacts": [
                     {"dilemma_id": "loyalty", "effect": "advances", "note": "Fallout"}
                 ],
@@ -3272,7 +3266,7 @@ class TestSeedArcStructureValidation:
                 {
                     "beat_id": "develop",
                     "summary": "Trust tested",
-                    "paths": ["trust_arc"],
+                    "belongs_to": ["trust_arc"],
                     "dilemma_impacts": [
                         {"dilemma_id": "trust", "effect": "advances", "note": "Builds tension"}
                     ],
@@ -3280,7 +3274,7 @@ class TestSeedArcStructureValidation:
                 {
                     "beat_id": "commit",
                     "summary": "Trust decided",
-                    "paths": ["trust_arc"],
+                    "belongs_to": ["trust_arc"],
                     "dilemma_impacts": [
                         {"dilemma_id": "trust", "effect": "commits", "note": "Locked in"}
                     ],
@@ -3288,7 +3282,7 @@ class TestSeedArcStructureValidation:
                 {
                     "beat_id": "aftermath",
                     "summary": "Consequences",
-                    "paths": ["trust_arc"],
+                    "belongs_to": ["trust_arc"],
                     "dilemma_impacts": [
                         {"dilemma_id": "trust", "effect": "advances", "note": "Fallout"}
                     ],
@@ -3308,7 +3302,7 @@ class TestSeedArcStructureValidation:
                 {
                     "beat_id": "reveal",
                     "summary": "Secret uncovered",
-                    "paths": ["trust_arc"],
+                    "belongs_to": ["trust_arc"],
                     "dilemma_impacts": [
                         {"dilemma_id": "trust", "effect": "reveals", "note": "Truth emerges"}
                     ],
@@ -3316,7 +3310,7 @@ class TestSeedArcStructureValidation:
                 {
                     "beat_id": "commit",
                     "summary": "Trust decided",
-                    "paths": ["trust_arc"],
+                    "belongs_to": ["trust_arc"],
                     "dilemma_impacts": [
                         {"dilemma_id": "trust", "effect": "commits", "note": "Locked in"}
                     ],
@@ -3324,7 +3318,7 @@ class TestSeedArcStructureValidation:
                 {
                     "beat_id": "aftermath",
                     "summary": "Consequences",
-                    "paths": ["trust_arc"],
+                    "belongs_to": ["trust_arc"],
                     "dilemma_impacts": [
                         {"dilemma_id": "trust", "effect": "advances", "note": "Fallout"}
                     ],
@@ -3344,7 +3338,7 @@ class TestSeedArcStructureValidation:
                 {
                     "beat_id": "commit",
                     "summary": "Trust decided",
-                    "paths": ["trust_arc"],
+                    "belongs_to": ["trust_arc"],
                     "dilemma_impacts": [
                         {"dilemma_id": "trust", "effect": "commits", "note": "Locked in"}
                     ],
@@ -3352,7 +3346,7 @@ class TestSeedArcStructureValidation:
                 {
                     "beat_id": "aftermath",
                     "summary": "Consequences",
-                    "paths": ["trust_arc"],
+                    "belongs_to": ["trust_arc"],
                     "dilemma_impacts": [
                         {"dilemma_id": "trust", "effect": "advances", "note": "Fallout"}
                     ],
@@ -3379,7 +3373,7 @@ class TestSeedArcStructureValidation:
                 {
                     "beat_id": "develop",
                     "summary": "Trust tested",
-                    "paths": ["trust_arc"],
+                    "belongs_to": ["trust_arc"],
                     "dilemma_impacts": [
                         {"dilemma_id": "trust", "effect": "advances", "note": "Builds tension"}
                     ],
@@ -3387,7 +3381,7 @@ class TestSeedArcStructureValidation:
                 {
                     "beat_id": "commit",
                     "summary": "Trust decided",
-                    "paths": ["trust_arc"],
+                    "belongs_to": ["trust_arc"],
                     "dilemma_impacts": [
                         {"dilemma_id": "trust", "effect": "commits", "note": "Locked in"}
                     ],
@@ -3414,7 +3408,7 @@ class TestSeedArcStructureValidation:
                 {
                     "beat_id": "commit",
                     "summary": "Trust decided",
-                    "paths": ["trust_arc"],
+                    "belongs_to": ["trust_arc"],
                     "dilemma_impacts": [
                         {"dilemma_id": "trust", "effect": "commits", "note": "Locked in"}
                     ],
@@ -3441,7 +3435,7 @@ class TestSeedArcStructureValidation:
                 {
                     "beat_id": "complication",
                     "summary": "Things get harder",
-                    "paths": ["trust_arc"],
+                    "belongs_to": ["trust_arc"],
                     "dilemma_impacts": [
                         {"dilemma_id": "trust", "effect": "complicates", "note": "Setback"}
                     ],
@@ -3449,7 +3443,7 @@ class TestSeedArcStructureValidation:
                 {
                     "beat_id": "commit",
                     "summary": "Trust decided",
-                    "paths": ["trust_arc"],
+                    "belongs_to": ["trust_arc"],
                     "dilemma_impacts": [
                         {"dilemma_id": "trust", "effect": "commits", "note": "Locked in"}
                     ],
@@ -3457,7 +3451,7 @@ class TestSeedArcStructureValidation:
                 {
                     "beat_id": "aftermath",
                     "summary": "Consequences",
-                    "paths": ["trust_arc"],
+                    "belongs_to": ["trust_arc"],
                     "dilemma_impacts": [
                         {"dilemma_id": "trust", "effect": "advances", "note": "Fallout"}
                     ],
@@ -3537,8 +3531,7 @@ class TestSeedArcStructureValidation:
                 {
                     "beat_id": "trust_pre",
                     "summary": "Protagonist encounters the mentor",
-                    "path_id": "trust__protector",
-                    "also_belongs_to": "trust__manipulator",
+                    "belongs_to": ["trust__protector", "trust__manipulator"],
                     "dilemma_impacts": [{"dilemma_id": "trust", "effect": "advances"}],
                     "entities": ["mentor"],
                 },
@@ -3546,7 +3539,7 @@ class TestSeedArcStructureValidation:
                 {
                     "beat_id": "commit_protector",
                     "summary": "Trust decided — protagonist sides with mentor.",
-                    "path_id": "trust__protector",
+                    "belongs_to": ["trust__protector"],
                     "dilemma_impacts": [{"dilemma_id": "trust", "effect": "commits"}],
                     "entities": ["mentor"],
                 },
@@ -3554,14 +3547,14 @@ class TestSeedArcStructureValidation:
                 {
                     "beat_id": "post_protector_1",
                     "summary": "Mentor reveals a vital secret.",
-                    "path_id": "trust__protector",
+                    "belongs_to": ["trust__protector"],
                     "dilemma_impacts": [{"dilemma_id": "trust", "effect": "advances"}],
                     "entities": ["mentor"],
                 },
                 {
                     "beat_id": "post_protector_2",
                     "summary": "Ally bond confirmed.",
-                    "path_id": "trust__protector",
+                    "belongs_to": ["trust__protector"],
                     "dilemma_impacts": [{"dilemma_id": "trust", "effect": "advances"}],
                     "entities": ["mentor"],
                 },
@@ -3569,7 +3562,7 @@ class TestSeedArcStructureValidation:
                 {
                     "beat_id": "commit_manipulator",
                     "summary": "Trust betrayed — protagonist distrusts mentor.",
-                    "path_id": "trust__manipulator",
+                    "belongs_to": ["trust__manipulator"],
                     "dilemma_impacts": [{"dilemma_id": "trust", "effect": "commits"}],
                     "entities": ["mentor"],
                 },
@@ -3577,14 +3570,14 @@ class TestSeedArcStructureValidation:
                 {
                     "beat_id": "post_manipulator_1",
                     "summary": "Mentor's true motive surfaces.",
-                    "path_id": "trust__manipulator",
+                    "belongs_to": ["trust__manipulator"],
                     "dilemma_impacts": [{"dilemma_id": "trust", "effect": "advances"}],
                     "entities": ["mentor"],
                 },
                 {
                     "beat_id": "post_manipulator_2",
                     "summary": "Protagonist faces danger alone.",
-                    "path_id": "trust__manipulator",
+                    "belongs_to": ["trust__manipulator"],
                     "dilemma_impacts": [{"dilemma_id": "trust", "effect": "advances"}],
                     "entities": ["mentor"],
                 },
@@ -3617,7 +3610,7 @@ class TestSeedArcStructureValidation:
                 {
                     "beat_id": "develop",
                     "summary": "Trust tested",
-                    "paths": ["trust_arc"],
+                    "belongs_to": ["trust_arc"],
                     "dilemma_impacts": [
                         {"dilemma_id": "trust", "effect": "advances", "note": "Builds tension"}
                     ],
@@ -3859,8 +3852,7 @@ class TestMutationIntegration:
                 {
                     "beat_id": "opening",
                     "summary": "Kay meets the mentor for the first time",
-                    "path_id": "mentor_trust__protector",
-                    "also_belongs_to": "mentor_trust__manipulator",
+                    "belongs_to": ["mentor_trust__protector", "mentor_trust__manipulator"],
                     "dilemma_impacts": [{"dilemma_id": "mentor_trust", "effect": "advances"}],
                     "entities": ["kay", "mentor"],
                 },
@@ -3868,7 +3860,7 @@ class TestMutationIntegration:
                 {
                     "beat_id": "commit_protector",
                     "summary": "Kay decides to trust the mentor",
-                    "path_id": "mentor_trust__protector",
+                    "belongs_to": ["mentor_trust__protector"],
                     "dilemma_impacts": [{"dilemma_id": "mentor_trust", "effect": "commits"}],
                     "entities": ["mentor"],
                 },
@@ -3876,14 +3868,14 @@ class TestMutationIntegration:
                 {
                     "beat_id": "post_protector_1",
                     "summary": "The mentor reveals a vital secret.",
-                    "path_id": "mentor_trust__protector",
+                    "belongs_to": ["mentor_trust__protector"],
                     "dilemma_impacts": [{"dilemma_id": "mentor_trust", "effect": "advances"}],
                     "entities": ["mentor"],
                 },
                 {
                     "beat_id": "post_protector_2",
                     "summary": "Ally bond confirmed.",
-                    "path_id": "mentor_trust__protector",
+                    "belongs_to": ["mentor_trust__protector"],
                     "dilemma_impacts": [{"dilemma_id": "mentor_trust", "effect": "advances"}],
                     "entities": ["mentor"],
                 },
@@ -3891,7 +3883,7 @@ class TestMutationIntegration:
                 {
                     "beat_id": "commit_manipulator",
                     "summary": "Kay distrusts the mentor.",
-                    "path_id": "mentor_trust__manipulator",
+                    "belongs_to": ["mentor_trust__manipulator"],
                     "dilemma_impacts": [{"dilemma_id": "mentor_trust", "effect": "commits"}],
                     "entities": ["mentor"],
                 },
@@ -3899,14 +3891,14 @@ class TestMutationIntegration:
                 {
                     "beat_id": "opening_post",
                     "summary": "The mentor's nature becomes clear",
-                    "path_id": "mentor_trust__manipulator",
+                    "belongs_to": ["mentor_trust__manipulator"],
                     "dilemma_impacts": [{"dilemma_id": "mentor_trust", "effect": "advances"}],
                     "entities": ["mentor"],
                 },
                 {
                     "beat_id": "manipulator_end",
                     "summary": "Protagonist faces danger alone.",
-                    "path_id": "mentor_trust__manipulator",
+                    "belongs_to": ["mentor_trust__manipulator"],
                     "dilemma_impacts": [{"dilemma_id": "mentor_trust", "effect": "advances"}],
                     "entities": ["kay"],
                 },
@@ -4264,7 +4256,7 @@ class TestScopedIdValidation:
                 {
                     "beat_id": "resolution",
                     "summary": "Trust resolved",
-                    "paths": ["trust_arc"],
+                    "belongs_to": ["trust_arc"],
                     "dilemma_impacts": [
                         {"dilemma_id": "dilemma::trust", "effect": "commits", "note": "Locked in"}
                     ],
@@ -4272,7 +4264,7 @@ class TestScopedIdValidation:
                 {
                     "beat_id": "resolution_post",
                     "summary": "Trust aftermath",
-                    "paths": ["trust_arc"],
+                    "belongs_to": ["trust_arc"],
                     "dilemma_impacts": [
                         {"dilemma_id": "dilemma::trust", "effect": "advances", "note": "Fallout"}
                     ],
@@ -4308,7 +4300,7 @@ class TestScopedIdValidation:
                 {
                     "beat_id": "opening",
                     "summary": "The beginning",
-                    "paths": ["path::mentor"],  # Scoped path ID
+                    "belongs_to": ["path::mentor"],  # Scoped path ID
                     "entities": ["entity::hero"],
                     "dilemma_impacts": [
                         {"dilemma_id": "dilemma::trust", "effect": "commits", "note": "Locked in"}
@@ -4317,7 +4309,7 @@ class TestScopedIdValidation:
                 {
                     "beat_id": "opening_post",
                     "summary": "Trust aftermath",
-                    "paths": ["path::mentor"],
+                    "belongs_to": ["path::mentor"],
                     "dilemma_impacts": [
                         {"dilemma_id": "dilemma::trust", "effect": "advances", "note": "Fallout"}
                     ],
@@ -4393,7 +4385,7 @@ class TestScopedIdValidation:
                 {
                     "beat_id": "opening",
                     "summary": "The beginning",
-                    "paths": ["entity::mentor"],  # Wrong scope - should be path::
+                    "belongs_to": ["entity::mentor"],  # Wrong scope - should be path::
                 }
             ],
         }
@@ -4500,7 +4492,7 @@ class TestScopedIdValidation:
                     "summary": "Meet mentor",
                     "entities": ["entity::hero", "entity::mentor"],  # Scoped IDs
                     "location": "entity::hero",  # Scoped location
-                    "paths": ["path::mentor_arc"],
+                    "belongs_to": ["path::mentor_arc"],
                     "dilemma_impacts": [
                         {"dilemma_id": "dilemma::trust", "effect": "commits", "note": "Locked in"}
                     ],
@@ -4508,7 +4500,7 @@ class TestScopedIdValidation:
                 {
                     "beat_id": "opening_post",
                     "summary": "Trust aftermath",
-                    "paths": ["path::mentor_arc"],
+                    "belongs_to": ["path::mentor_arc"],
                     "dilemma_impacts": [
                         {"dilemma_id": "dilemma::trust", "effect": "advances", "note": "Fallout"}
                     ],
@@ -4544,7 +4536,7 @@ class TestScopedIdValidation:
                 {
                     "beat_id": "opening",
                     "summary": "Build trust",
-                    "paths": ["path::mentor_arc"],
+                    "belongs_to": ["path::mentor_arc"],
                     "dilemma_impacts": [
                         {"dilemma_id": "dilemma::trust", "effect": "advances"}  # Scoped ID
                     ],
@@ -4552,13 +4544,13 @@ class TestScopedIdValidation:
                 {
                     "beat_id": "resolution",
                     "summary": "Trust locked in",
-                    "paths": ["path::mentor_arc"],
+                    "belongs_to": ["path::mentor_arc"],
                     "dilemma_impacts": [{"dilemma_id": "dilemma::trust", "effect": "commits"}],
                 },
                 {
                     "beat_id": "resolution_post",
                     "summary": "Trust aftermath",
-                    "paths": ["path::mentor_arc"],
+                    "belongs_to": ["path::mentor_arc"],
                     "dilemma_impacts": [{"dilemma_id": "dilemma::trust", "effect": "advances"}],
                 },
             ],
@@ -4598,7 +4590,7 @@ class TestScopedIdValidation:
                 {
                     "beat_id": "resolution",
                     "summary": "Trust resolved",
-                    "paths": ["mentor_arc"],
+                    "belongs_to": ["mentor_arc"],
                     "dilemma_impacts": [
                         {"dilemma_id": "dilemma::trust", "effect": "commits", "note": "Locked in"}
                     ],
@@ -4606,7 +4598,7 @@ class TestScopedIdValidation:
                 {
                     "beat_id": "resolution_post",
                     "summary": "Trust aftermath",
-                    "paths": ["mentor_arc"],
+                    "belongs_to": ["mentor_arc"],
                     "dilemma_impacts": [
                         {"dilemma_id": "dilemma::trust", "effect": "advances", "note": "Fallout"}
                     ],
@@ -4653,7 +4645,7 @@ class TestScopedIdValidation:
                 {
                     "beat_id": "resolution",
                     "summary": "Trust resolved",
-                    "paths": ["path::mentor_arc"],
+                    "belongs_to": ["path::mentor_arc"],
                     "dilemma_impacts": [
                         {"dilemma_id": "dilemma::trust", "effect": "commits", "note": "Locked in"}
                     ],
@@ -4661,7 +4653,7 @@ class TestScopedIdValidation:
                 {
                     "beat_id": "resolution_post",
                     "summary": "Trust aftermath",
-                    "paths": ["path::mentor_arc"],
+                    "belongs_to": ["path::mentor_arc"],
                     "dilemma_impacts": [
                         {"dilemma_id": "dilemma::trust", "effect": "advances", "note": "Fallout"}
                     ],
@@ -5584,7 +5576,7 @@ class TestValidation11cPathAlternativeInExplored:
                 {
                     "beat_id": "b1",
                     "summary": "Test",
-                    "paths": ["path1"],
+                    "belongs_to": ["path1"],
                     "dilemma_impacts": [
                         {"dilemma_id": "choice_a_or_b", "effect": "commits", "note": "Commits"}
                     ],
@@ -5592,7 +5584,7 @@ class TestValidation11cPathAlternativeInExplored:
                 {
                     "beat_id": "b2",
                     "summary": "Test",
-                    "paths": ["path2"],
+                    "belongs_to": ["path2"],
                     "dilemma_impacts": [
                         {"dilemma_id": "choice_a_or_b", "effect": "commits", "note": "Commits"}
                     ],
@@ -5646,7 +5638,7 @@ class TestValidation11cPathAlternativeInExplored:
                 {
                     "beat_id": "b1",
                     "summary": "Test",
-                    "paths": ["path1"],
+                    "belongs_to": ["path1"],
                     "dilemma_impacts": [
                         {"dilemma_id": "choice_a_or_b", "effect": "commits", "note": "Commits"}
                     ],
@@ -5654,7 +5646,7 @@ class TestValidation11cPathAlternativeInExplored:
                 {
                     "beat_id": "b2",
                     "summary": "Test",
-                    "paths": ["path2"],
+                    "belongs_to": ["path2"],
                     "dilemma_impacts": [
                         {"dilemma_id": "choice_a_or_b", "effect": "commits", "note": "Commits"}
                     ],
@@ -5705,7 +5697,7 @@ class TestValidation11cPathAlternativeInExplored:
                 {
                     "beat_id": "b1",
                     "summary": "Test",
-                    "paths": ["path1"],
+                    "belongs_to": ["path1"],
                     "dilemma_impacts": [
                         {"dilemma_id": "choice_a_or_b", "effect": "commits", "note": "Commits"}
                     ],
@@ -5753,7 +5745,7 @@ class TestValidation11cPathAlternativeInExplored:
                 {
                     "beat_id": "b1",
                     "summary": "Test",
-                    "paths": ["path1"],
+                    "belongs_to": ["path1"],
                     "dilemma_impacts": [
                         {"dilemma_id": "choice_a_or_b", "effect": "commits", "note": "Commits"}
                     ],
@@ -5833,8 +5825,7 @@ class TestBackfillIntegrationWithApplySeedMutations:
                 {
                     "beat_id": "trust_pre",
                     "summary": "Protagonist encounters the mentor",
-                    "path_id": "trust__protector",
-                    "also_belongs_to": "trust__manipulator",
+                    "belongs_to": ["trust__protector", "trust__manipulator"],
                     "dilemma_impacts": [{"dilemma_id": "trust", "effect": "advances"}],
                     "entities": ["mentor"],
                 },
@@ -5842,14 +5833,14 @@ class TestBackfillIntegrationWithApplySeedMutations:
                 {
                     "beat_id": "b1",
                     "summary": "Kay trusts the mentor.",
-                    "path_id": "trust__protector",
+                    "belongs_to": ["trust__protector"],
                     "dilemma_impacts": [{"dilemma_id": "trust", "effect": "commits"}],
                     "entities": ["mentor"],
                 },
                 {
                     "beat_id": "b2",
                     "summary": "Kay distrusts the mentor.",
-                    "path_id": "trust__manipulator",
+                    "belongs_to": ["trust__manipulator"],
                     "dilemma_impacts": [{"dilemma_id": "trust", "effect": "commits"}],
                     "entities": ["mentor"],
                 },
@@ -5857,28 +5848,28 @@ class TestBackfillIntegrationWithApplySeedMutations:
                 {
                     "beat_id": "b1_post",
                     "summary": "Protector path aftermath",
-                    "path_id": "trust__protector",
+                    "belongs_to": ["trust__protector"],
                     "dilemma_impacts": [{"dilemma_id": "trust", "effect": "advances"}],
                     "entities": ["mentor"],
                 },
                 {
                     "beat_id": "b1_post2",
                     "summary": "Protector path continues",
-                    "path_id": "trust__protector",
+                    "belongs_to": ["trust__protector"],
                     "dilemma_impacts": [{"dilemma_id": "trust", "effect": "advances"}],
                     "entities": ["mentor"],
                 },
                 {
                     "beat_id": "b2_post",
                     "summary": "Manipulator path aftermath",
-                    "path_id": "trust__manipulator",
+                    "belongs_to": ["trust__manipulator"],
                     "dilemma_impacts": [{"dilemma_id": "trust", "effect": "advances"}],
                     "entities": ["mentor"],
                 },
                 {
                     "beat_id": "b2_post2",
                     "summary": "Manipulator path continues",
-                    "path_id": "trust__manipulator",
+                    "belongs_to": ["trust__manipulator"],
                     "dilemma_impacts": [{"dilemma_id": "trust", "effect": "advances"}],
                     "entities": ["mentor"],
                 },
@@ -6233,50 +6224,49 @@ class TestApplySeedConvergenceAnalysis:
                 {
                     "beat_id": "trust_pre",
                     "summary": "Mentor encounter",
-                    "path_id": "trust__protector",
-                    "also_belongs_to": "trust__manipulator",
+                    "belongs_to": ["trust__protector", "trust__manipulator"],
                     "dilemma_impacts": [{"dilemma_id": "trust", "effect": "advances"}],
                     "entities": ["mentor"],
                 },
                 {
                     "beat_id": "trust_commit_protector",
                     "summary": "Kay trusts the mentor.",
-                    "path_id": "trust__protector",
+                    "belongs_to": ["trust__protector"],
                     "dilemma_impacts": [{"dilemma_id": "trust", "effect": "commits"}],
                     "entities": ["mentor"],
                 },
                 {
                     "beat_id": "trust_post_p1",
                     "summary": "Mentor reveals vital secret.",
-                    "path_id": "trust__protector",
+                    "belongs_to": ["trust__protector"],
                     "dilemma_impacts": [{"dilemma_id": "trust", "effect": "advances"}],
                     "entities": ["mentor"],
                 },
                 {
                     "beat_id": "trust_post_p2",
                     "summary": "Ally bond confirmed.",
-                    "path_id": "trust__protector",
+                    "belongs_to": ["trust__protector"],
                     "dilemma_impacts": [{"dilemma_id": "trust", "effect": "advances"}],
                     "entities": ["mentor"],
                 },
                 {
                     "beat_id": "trust_commit_manipulator",
                     "summary": "Kay distrusts the mentor.",
-                    "path_id": "trust__manipulator",
+                    "belongs_to": ["trust__manipulator"],
                     "dilemma_impacts": [{"dilemma_id": "trust", "effect": "commits"}],
                     "entities": ["mentor"],
                 },
                 {
                     "beat_id": "trust_post_m1",
                     "summary": "Mentor's true motive surfaces.",
-                    "path_id": "trust__manipulator",
+                    "belongs_to": ["trust__manipulator"],
                     "dilemma_impacts": [{"dilemma_id": "trust", "effect": "advances"}],
                     "entities": ["mentor"],
                 },
                 {
                     "beat_id": "trust_post_m2",
                     "summary": "Protagonist faces danger alone.",
-                    "path_id": "trust__manipulator",
+                    "belongs_to": ["trust__manipulator"],
                     "dilemma_impacts": [{"dilemma_id": "trust", "effect": "advances"}],
                     "entities": ["mentor"],
                 },
@@ -6284,50 +6274,49 @@ class TestApplySeedConvergenceAnalysis:
                 {
                     "beat_id": "ton_pre",
                     "summary": "Trust question arises.",
-                    "path_id": "trust_or_not__trust",
-                    "also_belongs_to": "trust_or_not__distrust",
+                    "belongs_to": ["trust_or_not__trust", "trust_or_not__distrust"],
                     "dilemma_impacts": [{"dilemma_id": "trust_or_not", "effect": "advances"}],
                     "entities": ["mentor"],
                 },
                 {
                     "beat_id": "b_trust",
                     "summary": "Commit trust",
-                    "path_id": "trust_or_not__trust",
+                    "belongs_to": ["trust_or_not__trust"],
                     "dilemma_impacts": [{"dilemma_id": "trust_or_not", "effect": "commits"}],
                     "entities": ["mentor"],
                 },
                 {
                     "beat_id": "b_trust_post",
                     "summary": "Trust aftermath",
-                    "path_id": "trust_or_not__trust",
+                    "belongs_to": ["trust_or_not__trust"],
                     "dilemma_impacts": [{"dilemma_id": "trust_or_not", "effect": "advances"}],
                     "entities": ["mentor"],
                 },
                 {
                     "beat_id": "b_trust_post2",
                     "summary": "Trust confirmed.",
-                    "path_id": "trust_or_not__trust",
+                    "belongs_to": ["trust_or_not__trust"],
                     "dilemma_impacts": [{"dilemma_id": "trust_or_not", "effect": "advances"}],
                     "entities": ["mentor"],
                 },
                 {
                     "beat_id": "b_distrust",
                     "summary": "Commit distrust",
-                    "path_id": "trust_or_not__distrust",
+                    "belongs_to": ["trust_or_not__distrust"],
                     "dilemma_impacts": [{"dilemma_id": "trust_or_not", "effect": "commits"}],
                     "entities": ["mentor"],
                 },
                 {
                     "beat_id": "b_distrust_post",
                     "summary": "Distrust aftermath",
-                    "path_id": "trust_or_not__distrust",
+                    "belongs_to": ["trust_or_not__distrust"],
                     "dilemma_impacts": [{"dilemma_id": "trust_or_not", "effect": "advances"}],
                     "entities": ["mentor"],
                 },
                 {
                     "beat_id": "b_distrust_post2",
                     "summary": "Distrust confirmed.",
-                    "path_id": "trust_or_not__distrust",
+                    "belongs_to": ["trust_or_not__distrust"],
                     "dilemma_impacts": [{"dilemma_id": "trust_or_not", "effect": "advances"}],
                     "entities": ["mentor"],
                 },
@@ -6335,50 +6324,49 @@ class TestApplySeedConvergenceAnalysis:
                 {
                     "beat_id": "sog_pre",
                     "summary": "The choice to stay or leave.",
-                    "path_id": "stay_or_go__stay",
-                    "also_belongs_to": "stay_or_go__go",
+                    "belongs_to": ["stay_or_go__stay", "stay_or_go__go"],
                     "dilemma_impacts": [{"dilemma_id": "stay_or_go", "effect": "advances"}],
                     "entities": ["mentor"],
                 },
                 {
                     "beat_id": "b_stay",
                     "summary": "Commit stay",
-                    "path_id": "stay_or_go__stay",
+                    "belongs_to": ["stay_or_go__stay"],
                     "dilemma_impacts": [{"dilemma_id": "stay_or_go", "effect": "commits"}],
                     "entities": ["mentor"],
                 },
                 {
                     "beat_id": "b_stay_post",
                     "summary": "Stay aftermath",
-                    "path_id": "stay_or_go__stay",
+                    "belongs_to": ["stay_or_go__stay"],
                     "dilemma_impacts": [{"dilemma_id": "stay_or_go", "effect": "advances"}],
                     "entities": ["mentor"],
                 },
                 {
                     "beat_id": "b_stay_post2",
                     "summary": "Safety confirmed.",
-                    "path_id": "stay_or_go__stay",
+                    "belongs_to": ["stay_or_go__stay"],
                     "dilemma_impacts": [{"dilemma_id": "stay_or_go", "effect": "advances"}],
                     "entities": ["mentor"],
                 },
                 {
                     "beat_id": "b_go",
                     "summary": "Commit go",
-                    "path_id": "stay_or_go__go",
+                    "belongs_to": ["stay_or_go__go"],
                     "dilemma_impacts": [{"dilemma_id": "stay_or_go", "effect": "commits"}],
                     "entities": ["mentor"],
                 },
                 {
                     "beat_id": "b_go_post",
                     "summary": "Go aftermath",
-                    "path_id": "stay_or_go__go",
+                    "belongs_to": ["stay_or_go__go"],
                     "dilemma_impacts": [{"dilemma_id": "stay_or_go", "effect": "advances"}],
                     "entities": ["mentor"],
                 },
                 {
                     "beat_id": "b_go_post2",
                     "summary": "Discovery confirmed.",
-                    "path_id": "stay_or_go__go",
+                    "belongs_to": ["stay_or_go__go"],
                     "dilemma_impacts": [{"dilemma_id": "stay_or_go", "effect": "advances"}],
                     "entities": ["mentor"],
                 },
@@ -6864,50 +6852,49 @@ class TestApplySeedConcurrentOrdering:
                 {
                     "beat_id": "trust_pre",
                     "summary": "Mentor encounter",
-                    "path_id": "trust__protector",
-                    "also_belongs_to": "trust__manipulator",
+                    "belongs_to": ["trust__protector", "trust__manipulator"],
                     "dilemma_impacts": [{"dilemma_id": "trust", "effect": "advances"}],
                     "entities": ["mentor"],
                 },
                 {
                     "beat_id": "trust_cp",
                     "summary": "Kay trusts.",
-                    "path_id": "trust__protector",
+                    "belongs_to": ["trust__protector"],
                     "dilemma_impacts": [{"dilemma_id": "trust", "effect": "commits"}],
                     "entities": ["mentor"],
                 },
                 {
                     "beat_id": "trust_pp1",
                     "summary": "Secret revealed.",
-                    "path_id": "trust__protector",
+                    "belongs_to": ["trust__protector"],
                     "dilemma_impacts": [{"dilemma_id": "trust", "effect": "advances"}],
                     "entities": ["mentor"],
                 },
                 {
                     "beat_id": "trust_pp2",
                     "summary": "Bond confirmed.",
-                    "path_id": "trust__protector",
+                    "belongs_to": ["trust__protector"],
                     "dilemma_impacts": [{"dilemma_id": "trust", "effect": "advances"}],
                     "entities": ["mentor"],
                 },
                 {
                     "beat_id": "trust_cm",
                     "summary": "Kay distrusts.",
-                    "path_id": "trust__manipulator",
+                    "belongs_to": ["trust__manipulator"],
                     "dilemma_impacts": [{"dilemma_id": "trust", "effect": "commits"}],
                     "entities": ["mentor"],
                 },
                 {
                     "beat_id": "trust_pm1",
                     "summary": "Motive exposed.",
-                    "path_id": "trust__manipulator",
+                    "belongs_to": ["trust__manipulator"],
                     "dilemma_impacts": [{"dilemma_id": "trust", "effect": "advances"}],
                     "entities": ["mentor"],
                 },
                 {
                     "beat_id": "trust_pm2",
                     "summary": "Danger alone.",
-                    "path_id": "trust__manipulator",
+                    "belongs_to": ["trust__manipulator"],
                     "dilemma_impacts": [{"dilemma_id": "trust", "effect": "advances"}],
                     "entities": ["mentor"],
                 },
@@ -6915,50 +6902,49 @@ class TestApplySeedConcurrentOrdering:
                 {
                     "beat_id": "mt_pre",
                     "summary": "Trust question",
-                    "path_id": "mentor_trust__yes",
-                    "also_belongs_to": "mentor_trust__no",
+                    "belongs_to": ["mentor_trust__yes", "mentor_trust__no"],
                     "dilemma_impacts": [{"dilemma_id": "mentor_trust", "effect": "advances"}],
                     "entities": ["mentor"],
                 },
                 {
                     "beat_id": "b1",
                     "summary": "Commit mentor trust",
-                    "path_id": "mentor_trust__yes",
+                    "belongs_to": ["mentor_trust__yes"],
                     "dilemma_impacts": [{"dilemma_id": "mentor_trust", "effect": "commits"}],
                     "entities": ["mentor"],
                 },
                 {
                     "beat_id": "b1_post",
                     "summary": "After mentor trust",
-                    "path_id": "mentor_trust__yes",
+                    "belongs_to": ["mentor_trust__yes"],
                     "dilemma_impacts": [{"dilemma_id": "mentor_trust", "effect": "advances"}],
                     "entities": ["mentor"],
                 },
                 {
                     "beat_id": "b1_post2",
                     "summary": "Trust confirmed.",
-                    "path_id": "mentor_trust__yes",
+                    "belongs_to": ["mentor_trust__yes"],
                     "dilemma_impacts": [{"dilemma_id": "mentor_trust", "effect": "advances"}],
                     "entities": ["mentor"],
                 },
                 {
                     "beat_id": "b1_no",
                     "summary": "Commit no trust",
-                    "path_id": "mentor_trust__no",
+                    "belongs_to": ["mentor_trust__no"],
                     "dilemma_impacts": [{"dilemma_id": "mentor_trust", "effect": "commits"}],
                     "entities": ["mentor"],
                 },
                 {
                     "beat_id": "b1_no_post",
                     "summary": "Distrust aftermath.",
-                    "path_id": "mentor_trust__no",
+                    "belongs_to": ["mentor_trust__no"],
                     "dilemma_impacts": [{"dilemma_id": "mentor_trust", "effect": "advances"}],
                     "entities": ["mentor"],
                 },
                 {
                     "beat_id": "b1_no_post2",
                     "summary": "Distrust confirmed.",
-                    "path_id": "mentor_trust__no",
+                    "belongs_to": ["mentor_trust__no"],
                     "dilemma_impacts": [{"dilemma_id": "mentor_trust", "effect": "advances"}],
                     "entities": ["mentor"],
                 },
@@ -6966,50 +6952,49 @@ class TestApplySeedConcurrentOrdering:
                 {
                     "beat_id": "zl_pre",
                     "summary": "Later question",
-                    "path_id": "z_later__yes",
-                    "also_belongs_to": "z_later__no",
+                    "belongs_to": ["z_later__yes", "z_later__no"],
                     "dilemma_impacts": [{"dilemma_id": "z_later", "effect": "advances"}],
                     "entities": ["mentor"],
                 },
                 {
                     "beat_id": "b2",
                     "summary": "Commit z later",
-                    "path_id": "z_later__yes",
+                    "belongs_to": ["z_later__yes"],
                     "dilemma_impacts": [{"dilemma_id": "z_later", "effect": "commits"}],
                     "entities": ["mentor"],
                 },
                 {
                     "beat_id": "b2_post",
                     "summary": "After z later",
-                    "path_id": "z_later__yes",
+                    "belongs_to": ["z_later__yes"],
                     "dilemma_impacts": [{"dilemma_id": "z_later", "effect": "advances"}],
                     "entities": ["mentor"],
                 },
                 {
                     "beat_id": "b2_post2",
                     "summary": "Later confirmed.",
-                    "path_id": "z_later__yes",
+                    "belongs_to": ["z_later__yes"],
                     "dilemma_impacts": [{"dilemma_id": "z_later", "effect": "advances"}],
                     "entities": ["mentor"],
                 },
                 {
                     "beat_id": "b2_no",
                     "summary": "Commit go now",
-                    "path_id": "z_later__no",
+                    "belongs_to": ["z_later__no"],
                     "dilemma_impacts": [{"dilemma_id": "z_later", "effect": "commits"}],
                     "entities": ["mentor"],
                 },
                 {
                     "beat_id": "b2_no_post",
                     "summary": "Now aftermath.",
-                    "path_id": "z_later__no",
+                    "belongs_to": ["z_later__no"],
                     "dilemma_impacts": [{"dilemma_id": "z_later", "effect": "advances"}],
                     "entities": ["mentor"],
                 },
                 {
                     "beat_id": "b2_no_post2",
                     "summary": "Now confirmed.",
-                    "path_id": "z_later__no",
+                    "belongs_to": ["z_later__no"],
                     "dilemma_impacts": [{"dilemma_id": "z_later", "effect": "advances"}],
                     "entities": ["mentor"],
                 },
@@ -7112,22 +7097,22 @@ class TestApplySeedConcurrentOrdering:
 def test_get_path_ids_from_beat_post_commit_returns_one() -> None:
     from questfoundry.graph.mutations import _get_path_ids_from_beat
 
-    beat = {"path_id": "path::a"}
+    beat = {"belongs_to": ["path::a"]}
     assert _get_path_ids_from_beat(beat) == ("path::a",)
 
 
 def test_get_path_ids_from_beat_pre_commit_returns_both() -> None:
     from questfoundry.graph.mutations import _get_path_ids_from_beat
 
-    beat = {"path_id": "path::a", "also_belongs_to": "path::b"}
+    beat = {"belongs_to": ["path::a", "path::b"]}
     assert _get_path_ids_from_beat(beat) == ("path::a", "path::b")
 
 
-def test_get_path_ids_from_beat_legacy_paths_list_returns_all() -> None:
+def test_get_path_ids_from_beat_single_returns_one() -> None:
     from questfoundry.graph.mutations import _get_path_ids_from_beat
 
-    beat = {"paths": ["path::a", "path::b"]}
-    assert _get_path_ids_from_beat(beat) == ("path::a", "path::b")
+    beat = {"belongs_to": ["path::a"]}
+    assert _get_path_ids_from_beat(beat) == ("path::a",)
 
 
 def test_get_path_ids_from_beat_empty_returns_empty_tuple() -> None:
@@ -7239,8 +7224,10 @@ def _trust_seed_output(initial_beats: list[dict[str, Any]] | None = None) -> dic
             {
                 "beat_id": "shared_setup",
                 "summary": "Protagonist observes the mentor's first move.",
-                "path_id": "trust_protector_or_manipulator__protector",
-                "also_belongs_to": "trust_protector_or_manipulator__manipulator",
+                "belongs_to": [
+                    "trust_protector_or_manipulator__protector",
+                    "trust_protector_or_manipulator__manipulator",
+                ],
                 "entities": ["character::mentor"],
                 "dilemma_impacts": [
                     {
@@ -7253,7 +7240,7 @@ def _trust_seed_output(initial_beats: list[dict[str, Any]] | None = None) -> dic
             {
                 "beat_id": "commit_protector",
                 "summary": "Protagonist decides to trust the mentor.",
-                "path_id": "trust_protector_or_manipulator__protector",
+                "belongs_to": ["trust_protector_or_manipulator__protector"],
                 "entities": ["character::mentor"],
                 "dilemma_impacts": [
                     {
@@ -7266,7 +7253,7 @@ def _trust_seed_output(initial_beats: list[dict[str, Any]] | None = None) -> dic
             {
                 "beat_id": "post_protector_1",
                 "summary": "Mentor reveals hidden allies.",
-                "path_id": "trust_protector_or_manipulator__protector",
+                "belongs_to": ["trust_protector_or_manipulator__protector"],
                 "entities": ["character::mentor"],
                 "dilemma_impacts": [
                     {
@@ -7279,7 +7266,7 @@ def _trust_seed_output(initial_beats: list[dict[str, Any]] | None = None) -> dic
             {
                 "beat_id": "post_protector_2",
                 "summary": "Protagonist gains mentor's full support.",
-                "path_id": "trust_protector_or_manipulator__protector",
+                "belongs_to": ["trust_protector_or_manipulator__protector"],
                 "entities": ["character::mentor"],
                 "dilemma_impacts": [
                     {
@@ -7292,7 +7279,7 @@ def _trust_seed_output(initial_beats: list[dict[str, Any]] | None = None) -> dic
             {
                 "beat_id": "commit_manipulator",
                 "summary": "Protagonist sees through the mentor's deception.",
-                "path_id": "trust_protector_or_manipulator__manipulator",
+                "belongs_to": ["trust_protector_or_manipulator__manipulator"],
                 "entities": ["character::mentor"],
                 "dilemma_impacts": [
                     {
@@ -7305,7 +7292,7 @@ def _trust_seed_output(initial_beats: list[dict[str, Any]] | None = None) -> dic
             {
                 "beat_id": "post_manipulator_1",
                 "summary": "Protagonist confronts the mentor.",
-                "path_id": "trust_protector_or_manipulator__manipulator",
+                "belongs_to": ["trust_protector_or_manipulator__manipulator"],
                 "entities": ["character::mentor"],
                 "dilemma_impacts": [
                     {
@@ -7318,7 +7305,7 @@ def _trust_seed_output(initial_beats: list[dict[str, Any]] | None = None) -> dic
             {
                 "beat_id": "post_manipulator_2",
                 "summary": "Mentor escapes with stolen knowledge.",
-                "path_id": "trust_protector_or_manipulator__manipulator",
+                "belongs_to": ["trust_protector_or_manipulator__manipulator"],
                 "entities": ["character::mentor"],
                 "dilemma_impacts": [
                     {
@@ -7503,42 +7490,42 @@ def _two_dilemma_seed_output(initial_beats: list[dict[str, Any]] | None = None) 
             {
                 "beat_id": "commit_a",
                 "summary": "Dilemma A commits.",
-                "path_id": "dilemma_a__answer_a1",
+                "belongs_to": ["dilemma_a__answer_a1"],
                 "entities": ["character::mentor"],
                 "dilemma_impacts": [{"dilemma_id": "dilemma_a", "effect": "commits", "note": "x"}],
             },
             {
                 "beat_id": "post_a_1",
                 "summary": "Dilemma A aftermath.",
-                "path_id": "dilemma_a__answer_a1",
+                "belongs_to": ["dilemma_a__answer_a1"],
                 "entities": ["character::mentor"],
                 "dilemma_impacts": [{"dilemma_id": "dilemma_a", "effect": "advances", "note": "x"}],
             },
             {
                 "beat_id": "post_a_2",
                 "summary": "Dilemma A resolution.",
-                "path_id": "dilemma_a__answer_a1",
+                "belongs_to": ["dilemma_a__answer_a1"],
                 "entities": ["character::mentor"],
                 "dilemma_impacts": [{"dilemma_id": "dilemma_a", "effect": "advances", "note": "x"}],
             },
             {
                 "beat_id": "commit_b",
                 "summary": "Dilemma B commits.",
-                "path_id": "dilemma_b__answer_b1",
+                "belongs_to": ["dilemma_b__answer_b1"],
                 "entities": ["character::mentor"],
                 "dilemma_impacts": [{"dilemma_id": "dilemma_b", "effect": "commits", "note": "x"}],
             },
             {
                 "beat_id": "post_b_1",
                 "summary": "Dilemma B aftermath.",
-                "path_id": "dilemma_b__answer_b1",
+                "belongs_to": ["dilemma_b__answer_b1"],
                 "entities": ["character::mentor"],
                 "dilemma_impacts": [{"dilemma_id": "dilemma_b", "effect": "advances", "note": "x"}],
             },
             {
                 "beat_id": "post_b_2",
                 "summary": "Dilemma B resolution.",
-                "path_id": "dilemma_b__answer_b1",
+                "belongs_to": ["dilemma_b__answer_b1"],
                 "entities": ["character::mentor"],
                 "dilemma_impacts": [{"dilemma_id": "dilemma_b", "effect": "advances", "note": "x"}],
             },
@@ -7610,7 +7597,7 @@ def _two_dilemma_seed_output(initial_beats: list[dict[str, Any]] | None = None) 
 
 
 def test_apply_seed_mutations_emits_dual_belongs_to_for_pre_commit_beat() -> None:
-    """Pre-commit beats with ``also_belongs_to`` get two ``belongs_to`` edges."""
+    """Pre-commit beats with two-element ``belongs_to`` get two ``belongs_to`` edges."""
     from questfoundry.graph.mutations import apply_seed_mutations
 
     graph = _trust_graph()
@@ -7619,8 +7606,10 @@ def test_apply_seed_mutations_emits_dual_belongs_to_for_pre_commit_beat() -> Non
             {
                 "beat_id": "shared_setup",
                 "summary": "Both players see this setup.",
-                "path_id": "trust_protector_or_manipulator__protector",
-                "also_belongs_to": "trust_protector_or_manipulator__manipulator",
+                "belongs_to": [
+                    "trust_protector_or_manipulator__protector",
+                    "trust_protector_or_manipulator__manipulator",
+                ],
                 "entities": ["character::mentor"],
                 "dilemma_impacts": [
                     {
@@ -7634,7 +7623,7 @@ def test_apply_seed_mutations_emits_dual_belongs_to_for_pre_commit_beat() -> Non
             {
                 "beat_id": "commit_protector",
                 "summary": "Protector path commits.",
-                "path_id": "trust_protector_or_manipulator__protector",
+                "belongs_to": ["trust_protector_or_manipulator__protector"],
                 "entities": ["character::mentor"],
                 "dilemma_impacts": [
                     {
@@ -7647,7 +7636,7 @@ def test_apply_seed_mutations_emits_dual_belongs_to_for_pre_commit_beat() -> Non
             {
                 "beat_id": "post_protector_1",
                 "summary": "Protector aftermath begins.",
-                "path_id": "trust_protector_or_manipulator__protector",
+                "belongs_to": ["trust_protector_or_manipulator__protector"],
                 "entities": ["character::mentor"],
                 "dilemma_impacts": [
                     {
@@ -7660,7 +7649,7 @@ def test_apply_seed_mutations_emits_dual_belongs_to_for_pre_commit_beat() -> Non
             {
                 "beat_id": "post_protector_2",
                 "summary": "Protector path resolves.",
-                "path_id": "trust_protector_or_manipulator__protector",
+                "belongs_to": ["trust_protector_or_manipulator__protector"],
                 "entities": ["character::mentor"],
                 "dilemma_impacts": [
                     {
@@ -7673,7 +7662,7 @@ def test_apply_seed_mutations_emits_dual_belongs_to_for_pre_commit_beat() -> Non
             {
                 "beat_id": "commit_manipulator",
                 "summary": "Manipulator path commits.",
-                "path_id": "trust_protector_or_manipulator__manipulator",
+                "belongs_to": ["trust_protector_or_manipulator__manipulator"],
                 "entities": ["character::mentor"],
                 "dilemma_impacts": [
                     {
@@ -7686,7 +7675,7 @@ def test_apply_seed_mutations_emits_dual_belongs_to_for_pre_commit_beat() -> Non
             {
                 "beat_id": "post_manipulator_1",
                 "summary": "Manipulator aftermath begins.",
-                "path_id": "trust_protector_or_manipulator__manipulator",
+                "belongs_to": ["trust_protector_or_manipulator__manipulator"],
                 "entities": ["character::mentor"],
                 "dilemma_impacts": [
                     {
@@ -7699,7 +7688,7 @@ def test_apply_seed_mutations_emits_dual_belongs_to_for_pre_commit_beat() -> Non
             {
                 "beat_id": "post_manipulator_2",
                 "summary": "Manipulator path resolves.",
-                "path_id": "trust_protector_or_manipulator__manipulator",
+                "belongs_to": ["trust_protector_or_manipulator__manipulator"],
                 "entities": ["character::mentor"],
                 "dilemma_impacts": [
                     {
@@ -7738,8 +7727,7 @@ def test_apply_seed_mutations_rejects_cross_dilemma_dual_belongs_to() -> None:
             {
                 "beat_id": "bad_dual",
                 "summary": "Cross-dilemma.",
-                "path_id": "dilemma_a__answer_a1",
-                "also_belongs_to": "dilemma_b__answer_b1",
+                "belongs_to": ["dilemma_a__answer_a1", "dilemma_b__answer_b1"],
                 "dilemma_impacts": [
                     {"dilemma_id": "dilemma_a", "effect": "advances", "note": "x"},
                 ],
@@ -7748,25 +7736,25 @@ def test_apply_seed_mutations_rejects_cross_dilemma_dual_belongs_to() -> None:
             {
                 "beat_id": "commit_a",
                 "summary": "Dilemma A commits.",
-                "path_id": "dilemma_a__answer_a1",
+                "belongs_to": ["dilemma_a__answer_a1"],
                 "dilemma_impacts": [{"dilemma_id": "dilemma_a", "effect": "commits", "note": "x"}],
             },
             {
                 "beat_id": "post_a",
                 "summary": "Dilemma A aftermath.",
-                "path_id": "dilemma_a__answer_a1",
+                "belongs_to": ["dilemma_a__answer_a1"],
                 "dilemma_impacts": [{"dilemma_id": "dilemma_a", "effect": "advances", "note": "x"}],
             },
             {
                 "beat_id": "commit_b",
                 "summary": "Dilemma B commits.",
-                "path_id": "dilemma_b__answer_b1",
+                "belongs_to": ["dilemma_b__answer_b1"],
                 "dilemma_impacts": [{"dilemma_id": "dilemma_b", "effect": "commits", "note": "x"}],
             },
             {
                 "beat_id": "post_b",
                 "summary": "Dilemma B aftermath.",
-                "path_id": "dilemma_b__answer_b1",
+                "belongs_to": ["dilemma_b__answer_b1"],
                 "dilemma_impacts": [{"dilemma_id": "dilemma_b", "effect": "advances", "note": "x"}],
             },
         ]
@@ -7776,8 +7764,8 @@ def test_apply_seed_mutations_rejects_cross_dilemma_dual_belongs_to() -> None:
         apply_seed_mutations(graph, seed)
 
 
-def test_apply_seed_mutations_rejects_also_belongs_to_equal_path_id() -> None:
-    """Raw-dict input with path_id == also_belongs_to must be rejected (defense-in-depth)."""
+def test_apply_seed_mutations_rejects_duplicate_belongs_to_elements() -> None:
+    """Raw-dict input with duplicate elements in belongs_to must be rejected (defense-in-depth)."""
     # Bypass Pydantic by constructing the seed dict directly.
     from questfoundry.graph.mutations import apply_seed_mutations
 
@@ -7787,8 +7775,7 @@ def test_apply_seed_mutations_rejects_also_belongs_to_equal_path_id() -> None:
             {
                 "beat_id": "bad_beat",
                 "summary": "Same path twice.",
-                "path_id": "dilemma_a__answer_a1",
-                "also_belongs_to": "dilemma_a__answer_a1",
+                "belongs_to": ["dilemma_a__answer_a1", "dilemma_a__answer_a1"],
                 "dilemma_impacts": [
                     {
                         "dilemma_id": "dilemma_a",
@@ -7800,25 +7787,25 @@ def test_apply_seed_mutations_rejects_also_belongs_to_equal_path_id() -> None:
             {
                 "beat_id": "commit_a",
                 "summary": "Dilemma A commits.",
-                "path_id": "dilemma_a__answer_a1",
+                "belongs_to": ["dilemma_a__answer_a1"],
                 "dilemma_impacts": [{"dilemma_id": "dilemma_a", "effect": "commits", "note": "x"}],
             },
             {
                 "beat_id": "post_a",
                 "summary": "Dilemma A aftermath.",
-                "path_id": "dilemma_a__answer_a1",
+                "belongs_to": ["dilemma_a__answer_a1"],
                 "dilemma_impacts": [{"dilemma_id": "dilemma_a", "effect": "advances", "note": "x"}],
             },
             {
                 "beat_id": "commit_b",
                 "summary": "Dilemma B commits.",
-                "path_id": "dilemma_b__answer_b1",
+                "belongs_to": ["dilemma_b__answer_b1"],
                 "dilemma_impacts": [{"dilemma_id": "dilemma_b", "effect": "commits", "note": "x"}],
             },
             {
                 "beat_id": "post_b",
                 "summary": "Dilemma B aftermath.",
-                "path_id": "dilemma_b__answer_b1",
+                "belongs_to": ["dilemma_b__answer_b1"],
                 "dilemma_impacts": [{"dilemma_id": "dilemma_b", "effect": "advances", "note": "x"}],
             },
         ]
@@ -7844,8 +7831,10 @@ def test_apply_seed_mutations_rejects_dual_on_commit_beat() -> None:
             {
                 "beat_id": "bad_commit",
                 "summary": "A commit beat cannot be pre-commit.",
-                "path_id": "trust_protector_or_manipulator__protector",
-                "also_belongs_to": "trust_protector_or_manipulator__manipulator",
+                "belongs_to": [
+                    "trust_protector_or_manipulator__protector",
+                    "trust_protector_or_manipulator__manipulator",
+                ],
                 "dilemma_impacts": [
                     {
                         "dilemma_id": "trust_protector_or_manipulator",
@@ -7858,7 +7847,7 @@ def test_apply_seed_mutations_rejects_dual_on_commit_beat() -> None:
             {
                 "beat_id": "commit_protector",
                 "summary": "Protector commits.",
-                "path_id": "trust_protector_or_manipulator__protector",
+                "belongs_to": ["trust_protector_or_manipulator__protector"],
                 "dilemma_impacts": [
                     {
                         "dilemma_id": "trust_protector_or_manipulator",
@@ -7870,7 +7859,7 @@ def test_apply_seed_mutations_rejects_dual_on_commit_beat() -> None:
             {
                 "beat_id": "post_protector",
                 "summary": "Protector aftermath.",
-                "path_id": "trust_protector_or_manipulator__protector",
+                "belongs_to": ["trust_protector_or_manipulator__protector"],
                 "dilemma_impacts": [
                     {
                         "dilemma_id": "trust_protector_or_manipulator",
@@ -7882,7 +7871,7 @@ def test_apply_seed_mutations_rejects_dual_on_commit_beat() -> None:
             {
                 "beat_id": "commit_manipulator",
                 "summary": "Manipulator commits.",
-                "path_id": "trust_protector_or_manipulator__manipulator",
+                "belongs_to": ["trust_protector_or_manipulator__manipulator"],
                 "dilemma_impacts": [
                     {
                         "dilemma_id": "trust_protector_or_manipulator",
@@ -7894,7 +7883,7 @@ def test_apply_seed_mutations_rejects_dual_on_commit_beat() -> None:
             {
                 "beat_id": "post_manipulator",
                 "summary": "Manipulator aftermath.",
-                "path_id": "trust_protector_or_manipulator__manipulator",
+                "belongs_to": ["trust_protector_or_manipulator__manipulator"],
                 "dilemma_impacts": [
                     {
                         "dilemma_id": "trust_protector_or_manipulator",
@@ -7927,8 +7916,7 @@ def test_apply_seed_mutations_rejects_precommit_with_mismatched_dilemmas() -> No
             {
                 "beat_id": "bad_precommit",
                 "summary": "Cross-dilemma pre-commit beat.",
-                "path_id": "dilemma_a__answer_a1",
-                "also_belongs_to": "dilemma_b__answer_b1",
+                "belongs_to": ["dilemma_a__answer_a1", "dilemma_b__answer_b1"],
                 "dilemma_impacts": [
                     {"dilemma_id": "dilemma_a", "effect": "advances", "note": "x"},
                 ],
@@ -7937,25 +7925,25 @@ def test_apply_seed_mutations_rejects_precommit_with_mismatched_dilemmas() -> No
             {
                 "beat_id": "commit_a",
                 "summary": "Dilemma A commits.",
-                "path_id": "dilemma_a__answer_a1",
+                "belongs_to": ["dilemma_a__answer_a1"],
                 "dilemma_impacts": [{"dilemma_id": "dilemma_a", "effect": "commits", "note": "x"}],
             },
             {
                 "beat_id": "post_a",
                 "summary": "Dilemma A aftermath.",
-                "path_id": "dilemma_a__answer_a1",
+                "belongs_to": ["dilemma_a__answer_a1"],
                 "dilemma_impacts": [{"dilemma_id": "dilemma_a", "effect": "advances", "note": "x"}],
             },
             {
                 "beat_id": "commit_b",
                 "summary": "Dilemma B commits.",
-                "path_id": "dilemma_b__answer_b1",
+                "belongs_to": ["dilemma_b__answer_b1"],
                 "dilemma_impacts": [{"dilemma_id": "dilemma_b", "effect": "commits", "note": "x"}],
             },
             {
                 "beat_id": "post_b",
                 "summary": "Dilemma B aftermath.",
-                "path_id": "dilemma_b__answer_b1",
+                "belongs_to": ["dilemma_b__answer_b1"],
                 "dilemma_impacts": [{"dilemma_id": "dilemma_b", "effect": "advances", "note": "x"}],
             },
         ]
@@ -7970,8 +7958,8 @@ def test_apply_seed_mutations_rejects_precommit_with_mismatched_dilemmas() -> No
 # Task 12 (#1283): post-apply property test — no beat has cross-dilemma
 # belongs_to edges in the resulting graph (R-3.9).
 #
-# This test covers the *broader* prohibition: not just the primary path_id +
-# also_belongs_to pair, but any beat in the graph after apply completes.
+# This test covers the *broader* prohibition: not just the dual-element belongs_to
+# list, but any beat in the graph after apply completes.
 # If future code adds a second belongs_to write path this test catches it.
 # ---------------------------------------------------------------------------
 
@@ -7984,8 +7972,8 @@ def test_apply_seed_mutations_never_produces_cross_dilemma_belongs_to() -> None:
     independently of fixture completeness. This is a property test of the write
     path, not of the exit validator.
 
-    Broader than Task 11 (#1282): that test guards the primary path_id +
-    also_belongs_to pair; this test inspects the full resulting graph."""
+    Broader than Task 11 (#1282): that test guards the dual-element belongs_to list;
+    this test inspects the full resulting graph."""
     from unittest.mock import patch
 
     from questfoundry.graph.mutations import apply_seed_mutations
@@ -7996,25 +7984,25 @@ def test_apply_seed_mutations_never_produces_cross_dilemma_belongs_to() -> None:
             {
                 "beat_id": "commit_a",
                 "summary": "Dilemma A commits.",
-                "path_id": "dilemma_a__answer_a1",
+                "belongs_to": ["dilemma_a__answer_a1"],
                 "dilemma_impacts": [{"dilemma_id": "dilemma_a", "effect": "commits", "note": "x"}],
             },
             {
                 "beat_id": "post_a",
                 "summary": "Dilemma A aftermath.",
-                "path_id": "dilemma_a__answer_a1",
+                "belongs_to": ["dilemma_a__answer_a1"],
                 "dilemma_impacts": [{"dilemma_id": "dilemma_a", "effect": "advances", "note": "x"}],
             },
             {
                 "beat_id": "commit_b",
                 "summary": "Dilemma B commits.",
-                "path_id": "dilemma_b__answer_b1",
+                "belongs_to": ["dilemma_b__answer_b1"],
                 "dilemma_impacts": [{"dilemma_id": "dilemma_b", "effect": "commits", "note": "x"}],
             },
             {
                 "beat_id": "post_b",
                 "summary": "Dilemma B aftermath.",
-                "path_id": "dilemma_b__answer_b1",
+                "belongs_to": ["dilemma_b__answer_b1"],
                 "dilemma_impacts": [{"dilemma_id": "dilemma_b", "effect": "advances", "note": "x"}],
             },
         ]

--- a/tests/unit/test_ontology_explored.py
+++ b/tests/unit/test_ontology_explored.py
@@ -386,7 +386,7 @@ class TestPruningImmutability:
                     InitialBeat(
                         beat_id=f"beat_{path_id}",
                         summary="Summary",
-                        paths=[path_id],
+                        belongs_to=[path_id],
                         entities=["character::placeholder"],
                         dilemma_impacts=[
                             {"dilemma_id": tid, "effect": "commits", "note": "Commits the dilemma"}
@@ -496,7 +496,7 @@ class TestScopedIdStandardization:
                 InitialBeat(
                     beat_id="artifact_beat_01",
                     summary="Discovery of the artifact",
-                    path_id="path::artifact_natural",  # Scoped! belongs to natural path
+                    belongs_to=["path::artifact_natural"],  # Scoped! belongs to natural path
                     entities=["entity::artifact"],
                     dilemma_impacts=[
                         {
@@ -509,7 +509,7 @@ class TestScopedIdStandardization:
                 InitialBeat(
                     beat_id="artifact_beat_02",
                     summary="Beat only for crafted path",
-                    path_id="path::artifact_crafted",  # Scoped! belongs to crafted path
+                    belongs_to=["path::artifact_crafted"],  # Scoped! belongs to crafted path
                     entities=["entity::artifact"],
                     dilemma_impacts=[
                         {
@@ -538,7 +538,7 @@ class TestScopedIdStandardization:
 
         # Beat 1 should still point to natural path (scoped ID preserved)
         beat_1 = next(b for b in pruned.initial_beats if b.beat_id == "artifact_beat_01")
-        assert beat_1.path_id == "path::artifact_natural"
+        assert beat_1.belongs_to[0] == "path::artifact_natural"
         # Demoted dilemma should keep canonical and move non-canonical to unexplored
         pruned_dilemma = next(
             d for d in pruned.dilemmas if d.dilemma_id == "dilemma::artifact_origin"
@@ -592,7 +592,7 @@ class TestScopedIdStandardization:
                 InitialBeat(
                     beat_id="beat_1",
                     summary="Test beat",
-                    paths=["path::th_a"],
+                    belongs_to=["path::th_a"],
                     entities=["character::placeholder"],
                     dilemma_impacts=[{"dilemma_id": "t1", "effect": "commits", "note": "n"}],
                 ),
@@ -643,7 +643,7 @@ class TestScopedIdStandardization:
                 InitialBeat(
                     beat_id="keeper_beat_1",
                     summary="Meeting the keeper",
-                    path_id="path::keeper_protector",  # Scoped!
+                    belongs_to=["path::keeper_protector"],  # Scoped!
                     entities=["character::keeper"],
                     dilemma_impacts=[
                         {
@@ -773,7 +773,7 @@ class TestCanonicalAnswerFromGraph:
                 InitialBeat(
                     beat_id="beat_1",
                     summary="Test",
-                    path_id="path_b",  # Belongs to the graph-default path
+                    belongs_to=["path_b"],  # Belongs to the graph-default path
                     entities=["character::protagonist"],
                     dilemma_impacts=[{"dilemma_id": "t1", "effect": "commits", "note": "n"}],
                 ),
@@ -824,7 +824,7 @@ class TestCanonicalAnswerFromGraph:
                 InitialBeat(
                     beat_id="beat_1",
                     summary="Test",
-                    path_id="path_a",  # Belongs to explored[0] (canonical without graph)
+                    belongs_to=["path_a"],  # Belongs to explored[0] (canonical without graph)
                     entities=["character::protagonist"],
                     dilemma_impacts=[{"dilemma_id": "t1", "effect": "commits", "note": "n"}],
                 ),

--- a/tests/unit/test_seed_models.py
+++ b/tests/unit/test_seed_models.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import warnings
 from typing import ClassVar
 
 import pytest
@@ -213,13 +212,13 @@ class TestPathBeatsSectionDedup:
     _BEAT_A: ClassVar[dict] = {
         "beat_id": "beat_a",
         "summary": "Something happens",
-        "path_id": "path::trust_or_betray__trust",
+        "belongs_to": ["path::trust_or_betray__trust"],
         "entities": ["character::protagonist"],
     }
     _BEAT_B: ClassVar[dict] = {
         "beat_id": "beat_b",
         "summary": "Something else happens",
-        "path_id": "path::trust_or_betray__trust",
+        "belongs_to": ["path::trust_or_betray__trust"],
         "entities": ["character::protagonist"],
     }
 
@@ -250,7 +249,7 @@ class TestPathBeatsSectionDedup:
             {
                 "beat_id": f"beat_{i}",
                 "summary": f"Beat {i}",
-                "path_id": "path::trust_or_betray__trust",
+                "belongs_to": ["path::trust_or_betray__trust"],
                 "entities": ["character::protagonist"],
             }
             for i in range(5)
@@ -673,15 +672,20 @@ class TestDilemmaRelationshipsSectionDedup:
 def _make_shared_beat_dict(
     beat_id: str = "shared_01",
     path_id: str = "path::trust_or_betray__trust",
-    also_belongs_to: str | None = "path::trust_or_betray__betray",
+    sibling_path_id: str | None = "path::trust_or_betray__betray",
     summary: str = "The hero meets the informant.",
 ) -> dict:
-    """Build a minimal shared beat dict for testing."""
+    """Build a minimal shared beat dict for testing.
+
+    Uses the ``belongs_to`` list form. ``sibling_path_id=None`` maps to
+    a single-element list (which will fail SharedBeatsSection validation as
+    intended — that guard rail checks length < 2).
+    """
+    belongs_to = [path_id] if sibling_path_id is None else [path_id, sibling_path_id]
     return {
         "beat_id": beat_id,
         "summary": summary,
-        "path_id": path_id,
-        "also_belongs_to": also_belongs_to,
+        "belongs_to": belongs_to,
         "entities": ["character::protagonist"],
         "dilemma_impacts": [
             {
@@ -694,44 +698,44 @@ def _make_shared_beat_dict(
 
 
 class TestSharedBeatsSectionValidator:
-    """SharedBeatsSection must enforce also_belongs_to on every beat (Part 8 guard rail 2)."""
+    """SharedBeatsSection must enforce belongs_to of length 2 on every beat (Part 8 guard rail 2)."""
 
-    def test_valid_section_all_beats_have_also_belongs_to(self) -> None:
-        """Section with all beats having also_belongs_to passes validation."""
+    def test_valid_section_all_beats_have_dual_belongs_to(self) -> None:
+        """Section with all beats having belongs_to of length 2 passes validation."""
         section = SharedBeatsSection(
             initial_beats=[
                 _make_shared_beat_dict(beat_id="shared_01"),
                 _make_shared_beat_dict(
                     beat_id="shared_02",
                     path_id="path::trust_or_betray__trust",
-                    also_belongs_to="path::trust_or_betray__betray",
+                    sibling_path_id="path::trust_or_betray__betray",
                     summary="The hero learns the truth.",
                 ),
             ]
         )
         assert len(section.initial_beats) == 2
-        assert all(b.also_belongs_to is not None for b in section.initial_beats)
+        assert all(len(b.belongs_to) == 2 for b in section.initial_beats)
 
-    def test_single_beat_with_also_belongs_to_accepted(self) -> None:
-        """Minimum valid case: one beat with also_belongs_to set."""
+    def test_single_beat_with_dual_belongs_to_accepted(self) -> None:
+        """Minimum valid case: one beat with belongs_to of length 2."""
         section = SharedBeatsSection(initial_beats=[_make_shared_beat_dict()])
         assert len(section.initial_beats) == 1
-        assert section.initial_beats[0].also_belongs_to is not None
+        assert len(section.initial_beats[0].belongs_to) == 2
 
-    def test_beat_missing_also_belongs_to_raises_value_error(self) -> None:
-        """A beat with also_belongs_to=None violates Part 8 guard rail 2 and must raise."""
+    def test_beat_single_element_belongs_to_raises_value_error(self) -> None:
+        """A beat with belongs_to of length 1 violates Part 8 guard rail 2 and must raise."""
         with pytest.raises(ValidationError) as exc_info:
             SharedBeatsSection(
                 initial_beats=[
-                    _make_shared_beat_dict(also_belongs_to=None),
+                    _make_shared_beat_dict(sibling_path_id=None),
                 ]
             )
         error_text = str(exc_info.value)
-        assert "also_belongs_to" in error_text
+        assert "belongs_to" in error_text
         assert "guard rail" in error_text.lower() or "Part 8" in error_text
 
-    def test_mixed_beats_some_missing_also_belongs_to_raises(self) -> None:
-        """If ANY beat in the section lacks also_belongs_to, validation fails.
+    def test_mixed_beats_some_single_element_raises(self) -> None:
+        """If ANY beat in the section has belongs_to of length 1, validation fails.
 
         The offending beat ID must be named in the error message.
         """
@@ -739,18 +743,18 @@ class TestSharedBeatsSectionValidator:
             SharedBeatsSection(
                 initial_beats=[
                     _make_shared_beat_dict(beat_id="good_beat"),
-                    _make_shared_beat_dict(beat_id="bad_beat", also_belongs_to=None),
+                    _make_shared_beat_dict(beat_id="bad_beat", sibling_path_id=None),
                 ]
             )
         assert "bad_beat" in str(exc_info.value)
 
-    def test_all_beats_missing_also_belongs_to_names_all_offenders(self) -> None:
-        """When all beats are missing also_belongs_to, all beat IDs appear in the error."""
+    def test_all_beats_single_element_names_all_offenders(self) -> None:
+        """When all beats have belongs_to of length 1, all beat IDs appear in the error."""
         with pytest.raises(ValidationError) as exc_info:
             SharedBeatsSection(
                 initial_beats=[
-                    _make_shared_beat_dict(beat_id="beat_a", also_belongs_to=None),
-                    _make_shared_beat_dict(beat_id="beat_b", also_belongs_to=None),
+                    _make_shared_beat_dict(beat_id="beat_a", sibling_path_id=None),
+                    _make_shared_beat_dict(beat_id="beat_b", sibling_path_id=None),
                 ]
             )
         error_text = str(exc_info.value)
@@ -969,7 +973,7 @@ class TestMakeConstrainedDilemmasSection:
 _BEAT_KWARGS: dict[str, str | list] = {
     "beat_id": "trust_beat_01",
     "summary": "The protagonist confronts the mentor about the hidden letter.",
-    "path_id": "path::trust_or_betray__trust",
+    "belongs_to": ["path::trust_or_betray__trust"],
     "entities": ["character::protagonist"],
 }
 
@@ -1046,134 +1050,104 @@ class TestInitialBeatTemporalHint:
 
 
 # ---------------------------------------------------------------------------
-# InitialBeat.path_id (singular path, #983)
+# InitialBeat.belongs_to (path membership list, #1564; previously path_id #983)
 # ---------------------------------------------------------------------------
 
 
-class TestInitialBeatPathId:
-    """InitialBeat.path_id enforces singular path ownership."""
+class TestInitialBeatBelongsTo:
+    """InitialBeat.belongs_to enforces path membership (single or dual)."""
 
-    def test_path_id_stored(self) -> None:
+    def test_single_element_belongs_to_stored(self) -> None:
         beat = InitialBeat(
             beat_id="b1",
             summary="Test",
-            path_id="path::trust__yes",
+            belongs_to=["path::trust__yes"],
             entities=["character::protagonist"],
         )
-        assert beat.path_id == "path::trust__yes"
+        assert beat.belongs_to == ["path::trust__yes"]
 
-    def test_legacy_paths_list_migrated(self) -> None:
-        """Legacy single-element paths list is accepted and migrated."""
+    def test_dual_element_belongs_to_stored(self) -> None:
+        """Two-element belongs_to list is accepted (pre-commit shared beat)."""
         beat = InitialBeat(
             beat_id="b1",
             summary="Test",
-            paths=["path::trust__yes"],
+            belongs_to=["path::a__x", "path::b__y"],
             entities=["character::protagonist"],
         )
-        assert beat.path_id == "path::trust__yes"
+        assert beat.belongs_to == ["path::a__x", "path::b__y"]
 
-    def test_legacy_multi_paths_warns(self) -> None:
-        """Two-element paths list triggers deprecation warning and maps to Y-shape dual."""
-        with pytest.warns(DeprecationWarning, match="also_belongs_to"):
-            beat = InitialBeat(
-                beat_id="b1",
-                summary="Test",
-                paths=["path::a__x", "path::b__y"],
-                entities=["character::protagonist"],
-            )
-        assert beat.path_id == "path::a__x"
-        assert beat.also_belongs_to == "path::b__y"
-
-    def test_empty_path_id_rejected(self) -> None:
-        with pytest.raises(ValidationError, match="path_id"):
+    def test_empty_belongs_to_rejected(self) -> None:
+        """Empty belongs_to violates min_length=1."""
+        with pytest.raises(ValidationError):
             InitialBeat(
                 beat_id="b1",
                 summary="Test",
-                path_id="",
+                belongs_to=[],
                 entities=["character::protagonist"],
             )
 
-    def test_legacy_empty_paths_rejected(self) -> None:
-        """Empty paths list raises ValueError — beats must belong to a path."""
-        with pytest.raises(ValidationError, match="must belong to at least one path"):
+    def test_three_element_belongs_to_rejected(self) -> None:
+        """More than 2 elements violates max_length=2."""
+        with pytest.raises(ValidationError):
             InitialBeat(
                 beat_id="b1",
                 summary="Test",
-                paths=[],
+                belongs_to=["path::a__x", "path::b__y", "path::c__z"],
+                entities=["character::protagonist"],
+            )
+
+    def test_missing_belongs_to_rejected(self) -> None:
+        """Missing belongs_to field is rejected."""
+        with pytest.raises(ValidationError):
+            InitialBeat(
+                beat_id="b1",
+                summary="Test",
                 entities=["character::protagonist"],
             )
 
 
 def test_initial_beat_pre_commit_dual_belongs_to() -> None:
-    """Pre-commit beats carry ``also_belongs_to`` pointing at the sibling path."""
+    """Pre-commit beats carry a 2-element belongs_to pointing at both paths."""
     beat = InitialBeat(
         beat_id="b1",
         summary="Shared setup before the fork.",
-        path_id="path::trust__protector",
-        also_belongs_to="path::trust__manipulator",
+        belongs_to=["path::trust__protector", "path::trust__manipulator"],
         entities=["character::protagonist"],
     )
-    assert beat.path_id == "path::trust__protector"
-    assert beat.also_belongs_to == "path::trust__manipulator"
+    assert beat.belongs_to[0] == "path::trust__protector"
+    assert beat.belongs_to[1] == "path::trust__manipulator"
 
 
-def test_initial_beat_post_commit_single_belongs_to_default() -> None:
-    """Post-commit beats default to ``also_belongs_to = None``."""
+def test_initial_beat_post_commit_single_belongs_to() -> None:
+    """Post-commit beats carry a 1-element belongs_to."""
     beat = InitialBeat(
         beat_id="b1",
         summary="Payoff beat.",
-        path_id="path::trust__protector",
+        belongs_to=["path::trust__protector"],
         entities=["character::protagonist"],
     )
-    assert beat.also_belongs_to is None
+    assert len(beat.belongs_to) == 1
+    assert beat.belongs_to[0] == "path::trust__protector"
 
 
-def test_initial_beat_also_belongs_to_equal_path_id_is_rejected() -> None:
-    """``also_belongs_to`` must differ from ``path_id`` — dual membership needs two paths."""
-    with pytest.raises(ValidationError, match="also_belongs_to must differ from path_id"):
+def test_initial_beat_belongs_to_duplicate_elements_is_rejected() -> None:
+    """``belongs_to`` elements must be distinct — dual membership needs two different paths."""
+    with pytest.raises(ValidationError, match="belongs_to elements must be distinct"):
         InitialBeat(
             beat_id="b1",
             summary="Broken dual.",
-            path_id="path::trust__protector",
-            also_belongs_to="path::trust__protector",
+            belongs_to=["path::trust__protector", "path::trust__protector"],
             entities=["character::protagonist"],
         )
 
 
-def test_initial_beat_legacy_paths_two_elements_becomes_dual() -> None:
-    """Legacy ``paths: [p_a, p_b]`` migrates to Y-shape dual membership."""
-    with warnings.catch_warnings(record=True) as caught:
-        warnings.simplefilter("always")
-        beat = InitialBeat(
-            beat_id="b1",
-            summary="Legacy dual.",
-            paths=["path::trust__protector", "path::trust__manipulator"],
-            entities=["character::protagonist"],
-        )
-
-    assert beat.path_id == "path::trust__protector"
-    assert beat.also_belongs_to == "path::trust__manipulator"
-    assert any(issubclass(w.category, DeprecationWarning) for w in caught)
-
-
-def test_initial_beat_legacy_paths_three_elements_is_rejected() -> None:
-    """A list of three or more paths is a schema error — not a migration target."""
-    with pytest.raises(ValidationError, match="at most 2 entries"):
-        InitialBeat(
-            beat_id="b1",
-            summary="Bad.",
-            paths=["p_a", "p_b", "p_c"],
-            entities=["character::protagonist"],
-        )
-
-
-def test_initial_beat_also_belongs_to_empty_string_is_rejected() -> None:
+def test_initial_beat_belongs_to_empty_string_element_is_rejected() -> None:
+    """Empty string inside belongs_to violates min_length constraint on list elements."""
     with pytest.raises(ValidationError):
         InitialBeat(
             beat_id="b1",
             summary="Test.",
-            path_id="path::trust__protector",
-            also_belongs_to="",
+            belongs_to=[""],
             entities=["character::protagonist"],
         )
 
@@ -1196,7 +1170,7 @@ def test_initial_beat_role_accepts_setup_and_epilogue(role: str | None) -> None:
     beat = InitialBeat(
         beat_id="b1",
         summary="The story begins.",
-        path_id="path::trust_or_betray__trust",
+        belongs_to=["path::trust_or_betray__trust"],
         entities=["character::protagonist"],
         role=role,
     )
@@ -1208,7 +1182,7 @@ def test_initial_beat_role_defaults_to_none() -> None:
     beat = InitialBeat(
         beat_id="b1",
         summary="A dilemma beat.",
-        path_id="path::trust_or_betray__trust",
+        belongs_to=["path::trust_or_betray__trust"],
         entities=["character::protagonist"],
     )
     assert beat.role is None
@@ -1220,7 +1194,7 @@ def test_initial_beat_role_rejects_invalid_values() -> None:
         InitialBeat(
             beat_id="b1",
             summary="Invalid role.",
-            path_id="path::trust_or_betray__trust",
+            belongs_to=["path::trust_or_betray__trust"],
             entities=["character::protagonist"],
             role="something_else",  # type: ignore[arg-type]
         )
@@ -1266,7 +1240,7 @@ def test_initial_beat_entities_must_be_non_empty() -> None:
         InitialBeat(
             beat_id="b1",
             summary="A beat with no entities.",
-            path_id="path::trust_or_betray__trust",
+            belongs_to=["path::trust_or_betray__trust"],
             entities=[],  # R-3.13 violation
         )
 
@@ -1276,7 +1250,7 @@ def test_initial_beat_entities_with_one_entity_accepted() -> None:
     beat = InitialBeat(
         beat_id="b1",
         summary="A beat.",
-        path_id="path::trust_or_betray__trust",
+        belongs_to=["path::trust_or_betray__trust"],
         entities=["character::protagonist"],
     )
     assert beat.entities == ["character::protagonist"]
@@ -1287,7 +1261,7 @@ def test_initial_beat_entities_with_multiple_accepted() -> None:
     beat = InitialBeat(
         beat_id="b1",
         summary="A beat.",
-        path_id="path::trust_or_betray__trust",
+        belongs_to=["path::trust_or_betray__trust"],
         entities=["character::protagonist", "location::manor"],
     )
     assert len(beat.entities) == 2

--- a/tests/unit/test_seed_stage.py
+++ b/tests/unit/test_seed_stage.py
@@ -154,7 +154,7 @@ async def test_execute_calls_all_three_phases() -> None:
                 {
                     "beat_id": "beat1",
                     "summary": "Opening beat",
-                    "path_id": "path::trust__yes",
+                    "belongs_to": ["path::trust__yes"],
                     "entities": ["entity::kay"],
                 }
             ],
@@ -422,7 +422,7 @@ async def test_execute_returns_artifact_as_dict() -> None:
                 {
                     "beat_id": "beat1",
                     "summary": "Test beat",
-                    "path_id": "path::t1__a1",
+                    "belongs_to": ["path::t1__a1"],
                     "entities": ["entity::kay"],
                 }
             ],
@@ -519,7 +519,7 @@ def test_seed_output_model_validates() -> None:
             {
                 "beat_id": "beat1",
                 "summary": "Opening scene",
-                "path_id": "path::trust__yes",
+                "belongs_to": ["path::trust__yes"],
                 "entities": ["entity::kay"],
             }
         ],
@@ -1067,7 +1067,7 @@ class TestPathBeatsSectionValidation:
             InitialBeat(
                 beat_id=f"beat_{i}",
                 summary=f"Beat {i}",
-                paths=["path_a"],
+                belongs_to=["path_a"],
                 entities=["char_x"],
             )
             for i in range(4)
@@ -1080,8 +1080,12 @@ class TestPathBeatsSectionValidation:
         from questfoundry.models.seed import InitialBeat, PathBeatsSection
 
         beats = [
-            InitialBeat(beat_id="beat_0", summary="Start", paths=["path_a"], entities=["char_x"]),
-            InitialBeat(beat_id="beat_1", summary="End", paths=["path_a"], entities=["char_x"]),
+            InitialBeat(
+                beat_id="beat_0", summary="Start", belongs_to=["path_a"], entities=["char_x"]
+            ),
+            InitialBeat(
+                beat_id="beat_1", summary="End", belongs_to=["path_a"], entities=["char_x"]
+            ),
         ]
         section = PathBeatsSection(initial_beats=beats)
         assert len(section.initial_beats) == 2
@@ -1096,7 +1100,10 @@ class TestPathBeatsSectionValidation:
             PathBeatsSection(
                 initial_beats=[
                     InitialBeat(
-                        beat_id="beat_0", summary="Only one", paths=["path_a"], entities=["char_x"]
+                        beat_id="beat_0",
+                        summary="Only one",
+                        belongs_to=["path_a"],
+                        entities=["char_x"],
                     ),
                 ]
             )
@@ -1111,7 +1118,7 @@ class TestPathBeatsSectionValidation:
             InitialBeat(
                 beat_id=f"beat_{i}",
                 summary=f"Beat {i}",
-                paths=["path_a"],
+                belongs_to=["path_a"],
                 entities=["char_x"],
             )
             for i in range(7)
@@ -1126,8 +1133,12 @@ class TestPathBeatsSectionValidation:
         from questfoundry.models.seed import InitialBeat, PathBeatsSection
 
         beats = [
-            InitialBeat(beat_id="same_id", summary="First", paths=["path_a"], entities=["char_x"]),
-            InitialBeat(beat_id="same_id", summary="Second", paths=["path_a"], entities=["char_x"]),
+            InitialBeat(
+                beat_id="same_id", summary="First", belongs_to=["path_a"], entities=["char_x"]
+            ),
+            InitialBeat(
+                beat_id="same_id", summary="Second", belongs_to=["path_a"], entities=["char_x"]
+            ),
         ]
         with pytest.raises(ValidationError, match="Duplicates found for beat_id"):
             PathBeatsSection(initial_beats=beats)
@@ -1154,37 +1165,33 @@ def test_seed_advisory_warning_splits_shared_vs_post_commit(caplog) -> None:
         "initial_beats": [
             {
                 "beat_id": "b1",
-                "path_id": "p_a1",
-                "also_belongs_to": "p_a2",
+                "belongs_to": ["p_a1", "p_a2"],
                 "dilemma_impacts": [{"dilemma_id": "d_a", "effect": "advances"}],
             },
             {
                 "beat_id": "b2",
-                "path_id": "p_a1",
-                "also_belongs_to": "p_a2",
+                "belongs_to": ["p_a1", "p_a2"],
                 "dilemma_impacts": [{"dilemma_id": "d_a", "effect": "advances"}],
             },
             {
                 "beat_id": "b3",
-                "path_id": "p_b1",
-                "also_belongs_to": "p_b2",
+                "belongs_to": ["p_b1", "p_b2"],
                 "dilemma_impacts": [{"dilemma_id": "d_b", "effect": "advances"}],
             },
             {
                 "beat_id": "b4",
-                "path_id": "p_b1",
-                "also_belongs_to": "p_b2",
+                "belongs_to": ["p_b1", "p_b2"],
                 "dilemma_impacts": [{"dilemma_id": "d_b", "effect": "advances"}],
             },
             # 2 post-commit per path (only for p_a1 here — light fixture):
             {
                 "beat_id": "b5",
-                "path_id": "p_a1",
+                "belongs_to": ["p_a1"],
                 "dilemma_impacts": [{"dilemma_id": "d_a", "effect": "commits"}],
             },
             {
                 "beat_id": "b6",
-                "path_id": "p_a1",
+                "belongs_to": ["p_a1"],
                 "dilemma_impacts": [{"dilemma_id": "d_a", "effect": "advances"}],
             },
         ],
@@ -1238,13 +1245,13 @@ def test_seed_advisory_no_shared_warning_when_some_dilemmas_single_path(caplog) 
         ],
         "initial_beats": [
             # 2 shared beats on each multi-path dilemma — 4 total.
-            {"beat_id": "s_0_1", "path_id": "p_0a", "also_belongs_to": "p_0b"},
-            {"beat_id": "s_0_2", "path_id": "p_0a", "also_belongs_to": "p_0b"},
-            {"beat_id": "s_1_1", "path_id": "p_1a", "also_belongs_to": "p_1b"},
-            {"beat_id": "s_1_2", "path_id": "p_1a", "also_belongs_to": "p_1b"},
+            {"beat_id": "s_0_1", "belongs_to": ["p_0a", "p_0b"]},
+            {"beat_id": "s_0_2", "belongs_to": ["p_0a", "p_0b"]},
+            {"beat_id": "s_1_1", "belongs_to": ["p_1a", "p_1b"]},
+            {"beat_id": "s_1_2", "belongs_to": ["p_1a", "p_1b"]},
             # ≥2 post-commit beats per path so the post warning doesn't fire.
             *(
-                {"beat_id": f"pc_{i}", "path_id": p_id}
+                {"beat_id": f"pc_{i}", "belongs_to": [p_id]}
                 for i, p_id in enumerate(
                     [
                         "p_0a",
@@ -1296,10 +1303,10 @@ def test_seed_advisory_warns_when_multi_path_dilemma_lacks_shared_beat(caplog) -
         ],
         "initial_beats": [
             # Only one shared beat across both multi-path dilemmas → 1/2 = 0.5 < 1.0.
-            {"beat_id": "s_only", "path_id": "p_a1", "also_belongs_to": "p_a2"},
+            {"beat_id": "s_only", "belongs_to": ["p_a1", "p_a2"]},
             # Plenty of post-commit so we isolate the shared warning.
             *(
-                {"beat_id": f"pc_{i}", "path_id": p_id}
+                {"beat_id": f"pc_{i}", "belongs_to": [p_id]}
                 for i, p_id in enumerate(
                     ["p_a1", "p_a1", "p_a2", "p_a2", "p_b1", "p_b1", "p_b2", "p_b2"]
                 )

--- a/tests/unit/test_serialize.py
+++ b/tests/unit/test_serialize.py
@@ -388,18 +388,17 @@ class TestHelperFunctions:
         error so small models (qwen3:4b) can recover from constraint-to-value
         mapping loss across long context. See @prompt-engineer Rule 5.
         """
-        errors = ["beats.0.also_belongs_to: Field required"]
+        errors = ["beats.0.belongs_to: Field required"]
         hint = (
             "ACTION REQUIRED — your previous output was rejected.\n"
-            "  - `path_id` MUST be `path::x__a`\n"
-            "  - `also_belongs_to` MUST be `path::x__b`"
+            '  - `belongs_to` MUST be `["path::x__a", "path::x__b"]`'
         )
 
         feedback = _build_error_feedback(errors, extra_hints=[hint])
 
         # Validator output still present
         assert "validation errors" in feedback.lower()
-        assert "beats.0.also_belongs_to" in feedback
+        assert "beats.0.belongs_to" in feedback
         # Hint preserved verbatim — sibling path id ECHOED (not just named)
         assert "path::x__b" in feedback
         assert "ACTION REQUIRED" in feedback
@@ -413,7 +412,7 @@ class TestHelperFunctions:
         message) and out-attends the directive at the end. The fix
         reverses ordering — hint-block first, validator errors after.
         """
-        errors = ["beats.0.also_belongs_to: Field required"]
+        errors = ["beats.0.belongs_to: Field required"]
         hint_marker = "ACTION REQUIRED — your previous output was rejected."
 
         feedback = _build_error_feedback(errors, extra_hints=[hint_marker])
@@ -1252,7 +1251,7 @@ class TestBeatRetryAndContextRefresh:
 
     @pytest.mark.asyncio
     async def test_beats_retry_preserves_shared_beats(self) -> None:
-        """Shared pre-commit beats (with also_belongs_to) must survive beats retry.
+        """Shared pre-commit beats (with dual belongs_to) must survive beats retry.
 
         Regression for #1246: the retry code replaced collected["initial_beats"]
         with only per-path beats, dropping all shared beats and destroying the
@@ -1274,13 +1273,12 @@ class TestBeatRetryAndContextRefresh:
             )
         ]
 
-        # Per-path beats returned by retry (no also_belongs_to)
+        # Per-path beats returned by retry (single-element belongs_to)
         retried_per_path_beats = [
             {
                 "beat_id": "path_beat_01",
                 "summary": "Post-commit beat",
-                "path_id": "path::test_dilemma__alt1",
-                "also_belongs_to": None,
+                "belongs_to": ["path::test_dilemma__alt1"],
                 "dilemma_impacts": [
                     {"dilemma_id": "dilemma::test_dilemma", "effect": "commits", "note": "x"}
                 ],
@@ -1319,8 +1317,7 @@ class TestBeatRetryAndContextRefresh:
         shared_beat = {
             "beat_id": "shared_setup_01",
             "summary": "Shared beat",
-            "path_id": "path::test_dilemma__alt1",
-            "also_belongs_to": "path::test_dilemma__alt2",
+            "belongs_to": ["path::test_dilemma__alt1", "path::test_dilemma__alt2"],
             "dilemma_impacts": [
                 {"dilemma_id": "dilemma::test_dilemma", "effect": "reveals", "note": "x"}
             ],
@@ -1366,7 +1363,7 @@ class TestBeatRetryAndContextRefresh:
 
             # Critical: shared beat must survive the retry
             beats = result.artifact.model_dump()["initial_beats"]
-            shared_in_output = [b for b in beats if b.get("also_belongs_to")]
+            shared_in_output = [b for b in beats if len(b.get("belongs_to") or []) >= 2]
             assert len(shared_in_output) == 1, (
                 f"Shared beat dropped during retry! "
                 f"Found {len(shared_in_output)} shared beats, expected 1"
@@ -2265,7 +2262,7 @@ class TestBuildPerPathBeatContext:
         summary: str = "The hero enters the tavern.",
         dilemma_id: str = "dilemma::dilemma_a",
         path_id: str = "path::dilemma_a__answer_x",
-        also_belongs_to: str = "path::dilemma_a__answer_y",
+        sibling_path_id: str = "path::dilemma_a__answer_y",
         location: str | None = "location::tavern",
         entities: list[str] | None = None,
         effect: str = "advances",
@@ -2274,8 +2271,7 @@ class TestBuildPerPathBeatContext:
         return {
             "beat_id": beat_id,
             "summary": summary,
-            "path_id": path_id,
-            "also_belongs_to": also_belongs_to,
+            "belongs_to": [path_id, sibling_path_id],
             "location": location,
             "entities": entities or ["character::hero"],
             "dilemma_impacts": [{"dilemma_id": dilemma_id, "effect": effect, "note": note}],
@@ -2424,7 +2420,9 @@ _MOCK_PATHS_FOR_BINARY = [
     },
 ]
 
-_SHARED_BEAT_PROMPT = "DID={dilemma_id} Q={dilemma_question} PID={path_id} SIB={also_belongs_to}"
+_SHARED_BEAT_PROMPT = (
+    "DID={dilemma_id} Q={dilemma_question} PID={belongs_to_primary} SIB={belongs_to_sibling}"
+)
 
 
 class TestSerializeSharedBeatsForDilemma:
@@ -2482,7 +2480,7 @@ class TestSerializeSharedBeatsForDilemma:
 
     @pytest.mark.asyncio
     async def test_beat_path_ids_returned_from_llm(self) -> None:
-        """Returned beats should carry path_id and also_belongs_to as set by the LLM."""
+        """Returned beats should carry belongs_to list as set by the LLM."""
         from questfoundry.agents.serialize import _serialize_shared_beats_for_dilemma
 
         primary = "path::host_benevolent_or_selfish__benevolent"
@@ -2490,8 +2488,7 @@ class TestSerializeSharedBeatsForDilemma:
         beat = {
             "beat_id": "shared_setup_01",
             "summary": "A shared scene",
-            "path_id": primary,
-            "also_belongs_to": sibling,
+            "belongs_to": [primary, sibling],
             "dilemma_impacts": [],
             "entities": [],
             "location": None,
@@ -2518,8 +2515,7 @@ class TestSerializeSharedBeatsForDilemma:
             )
 
         assert len(beats) == 1
-        assert beats[0]["path_id"] == primary
-        assert beats[0]["also_belongs_to"] == sibling
+        assert beats[0]["belongs_to"] == [primary, sibling]
 
     @pytest.mark.asyncio
     async def test_prompt_interpolated_with_dilemma_context(self) -> None:
@@ -2784,8 +2780,10 @@ class TestSerializeSeedAsFunctionSharedBeats:
         shared_beat = {
             "beat_id": "shared_host_01",
             "summary": "Shared setup",
-            "path_id": "path::host_benevolent_or_selfish__benevolent",
-            "also_belongs_to": "path::host_benevolent_or_selfish__selfish",
+            "belongs_to": [
+                "path::host_benevolent_or_selfish__benevolent",
+                "path::host_benevolent_or_selfish__selfish",
+            ],
             "dilemma_impacts": [],
             "entities": ["char_test"],
             "location": None,
@@ -2795,8 +2793,7 @@ class TestSerializeSeedAsFunctionSharedBeats:
         per_path_beat = {
             "beat_id": "benevolent_beat_01",
             "summary": "Post-commit beat",
-            "path_id": "path::host_benevolent_or_selfish__benevolent",
-            "also_belongs_to": None,
+            "belongs_to": ["path::host_benevolent_or_selfish__benevolent"],
             "dilemma_impacts": [],
             "entities": ["char_test"],
             "location": None,

--- a/tests/unit/test_serialize.py
+++ b/tests/unit/test_serialize.py
@@ -2897,6 +2897,93 @@ class TestSerializeSeedAsFunctionSharedBeats:
         # 3 sections * 10 + 15 paths + 77 shared + 20 per_path = 142
         assert result.tokens_used == 142
 
+    @pytest.mark.asyncio
+    async def test_orphan_beat_fallback_uses_belongs_to_not_path_id(self) -> None:
+        """Regression: when a shared beat has dilemma_impacts=[] the grouping loop
+        must read belongs_to[0] to extract the dilemma name.  Before the fix it
+        read the dead path_id field (removed in #1564), which always returned ""
+        causing every orphan beat to land in shared_beats_by_dilemma[""] — a key
+        no per-path call ever queries, silently discarding the beat.
+
+        Verifies that shared_beats_by_dilemma["trust_or_betray"] is populated when
+        belongs_to=["path::trust_or_betray__trust"] even though dilemma_impacts=[].
+        """
+        from questfoundry.agents.serialize import serialize_seed_as_function
+
+        orphan_beat = {
+            "beat_id": "shared_setup_01",
+            "summary": "An orphaned shared beat",
+            # belongs_to carries the path ID; dilemma_impacts is empty (LLM deviation)
+            "belongs_to": ["path::trust_or_betray__trust"],
+            "dilemma_impacts": [],
+            "entities": ["character::protagonist"],  # min_length=1 required by InitialBeat
+            "location": None,
+            "location_alternatives": [],
+            "temporal_hint": None,
+        }
+        mock_path = {
+            "path_id": "path::trust_or_betray__trust",
+            "dilemma_id": "dilemma::trust_or_betray",
+            "answer_id": "trust",
+            "name": "Trust",
+            "description": "desc",
+            "path_importance": "major",
+            "unexplored_answer_ids": ["betray"],
+        }
+        mock_dilemma_two = {
+            "dilemma_id": "dilemma::trust_or_betray",
+            "explored": ["trust", "betray"],
+            "unexplored": [],
+        }
+
+        captured_shared_by_dilemma: list[dict[str, Any]] = []
+
+        async def _mock_per_path(
+            *_args: Any, shared_beats_by_dilemma: Any = None, **_kw: Any
+        ) -> tuple[list[Any], int]:
+            if shared_beats_by_dilemma is not None:
+                captured_shared_by_dilemma.append(dict(shared_beats_by_dilemma))
+            return [], 0
+
+        with (
+            patch("questfoundry.agents.serialize.serialize_to_artifact") as mock_serialize,
+            patch(
+                "questfoundry.agents.serialize._serialize_paths_per_dilemma",
+                return_value=([mock_path], 10),
+            ),
+            patch(
+                "questfoundry.agents.serialize._serialize_shared_beats_per_dilemma",
+                return_value=([orphan_beat], 5),
+            ),
+            patch(
+                "questfoundry.agents.serialize._serialize_beats_per_path",
+                side_effect=_mock_per_path,
+            ),
+        ):
+            mock_serialize.side_effect = [
+                (MagicMock(model_dump=lambda: {"entities": []}), 10, 1),
+                (MagicMock(model_dump=lambda: {"dilemmas": [mock_dilemma_two]}), 10, 1),
+                (MagicMock(model_dump=lambda: {"consequences": []}), 10, 1),
+            ]
+            with patch("questfoundry.agents.serialize.validate_seed_mutations", return_value=[]):
+                await serialize_seed_as_function(
+                    model=MagicMock(),
+                    brief="brief",
+                    graph=MagicMock(),
+                )
+
+        assert len(captured_shared_by_dilemma) == 1, "_serialize_beats_per_path was not called"
+        grouped = captured_shared_by_dilemma[0]
+        # The orphan beat must land under "trust_or_betray", NOT under "" (the dead
+        # path_id fallback that the pre-fix code always produced).
+        assert "trust_or_betray" in grouped, (
+            f"expected dilemma key 'trust_or_betray' in shared_beats_by_dilemma, got: {list(grouped.keys())}"
+        )
+        assert "" not in grouped, (
+            "empty key '' must not appear — that is the dead path_id fallback bucket"
+        )
+        assert grouped["trust_or_betray"] == [orphan_beat]
+
 
 class TestBuildSharedBeatContext:
     """Unit tests for _build_shared_beat_context."""


### PR DESCRIPTION
## Summary

Atomic rename of `InitialBeat.path_id: str` + `also_belongs_to: str | None` → `belongs_to: list[str]` (min_length=1, max_length=2) across schema, mutation layer, all 5 SEED prompt templates, all production consumers, and all test fixtures.

Fixes the production failure (murder6 project) where `qwen3:4b` emitted `path_id` set but `also_belongs_to` omitted entirely, failing after 3 retries.

**Changes:**
- `InitialBeat` schema: single `belongs_to: list[str]` field with validators for non-empty elements and no duplicates; drops legacy migrator
- `SharedBeatsSection._require_dual_belongs_to`: checks `len(b.belongs_to) < 2`
- `mutations._get_path_ids_from_beat`: reads `belongs_to` list directly
- `dilemma_scoring`, `seed_pruning`: updated attribute access
- `serialize.py`: `belongs_to_primary`/`belongs_to_sibling` prompt kwargs; dual-beat filter uses list length check
- 5 SEED prompt templates: GOOD/BAD examples updated; `{path_id}`/`{also_belongs_to}` placeholders replaced
- All unit + integration test fixtures: `path_id=`/`also_belongs_to=`/`paths=[...]` → `belongs_to=[...]`

No backward-compatibility shim. Spec PR #1565 already merged.

Closes #1564

## Test plan

- [x] `uv run mypy src/questfoundry/` — clean (129 files)
- [x] `uv run ruff check src/ tests/` — clean
- [x] `uv run pytest tests/unit/ -x -q` — 3934 passed (1 pre-existing network failure in `test_provider_factory.py` unrelated to this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)