### PR TITLE
fix(seed): SeedStageError recovery hint scales with min_arcs_required (#1555)

### DIFF
--- a/src/questfoundry/pipeline/stages/seed.py
+++ b/src/questfoundry/pipeline/stages/seed.py
@@ -520,9 +520,9 @@ class SeedStage:
             dilemmas_fully_explored = sum(
                 1 for d in pruned_artifact.dilemmas if len(d.explored) >= 2
             )
-            # arc_count = 2^n where n = fully-explored dilemmas; the user-facing
-            # recovery hint must scale with min_arcs_required (#1555). For long
-            # stories (max_arcs=32, min_arcs_required=8) this is 3, not 2.
+            # arc_count = 2^n where n = fully-explored dilemmas; the recovery
+            # hint must scale with min_arcs_required. For long stories
+            # (max_arcs=32, min_arcs_required=8) this is 3, not 2.
             min_fully_explored = max(1, math.ceil(math.log2(min_arcs_required)))
             raise SeedStageError(
                 f"SEED produced only {final_arc_count} arc(s) "

--- a/src/questfoundry/pipeline/stages/seed.py
+++ b/src/questfoundry/pipeline/stages/seed.py
@@ -15,6 +15,7 @@ Requires BRAINSTORM stage to have completed (reads brainstorm from graph).
 from __future__ import annotations
 
 import inspect
+import math
 from collections import Counter
 from pathlib import Path  # noqa: TC003 - used at runtime for Graph.load()
 from typing import TYPE_CHECKING, Any
@@ -519,12 +520,17 @@ class SeedStage:
             dilemmas_fully_explored = sum(
                 1 for d in pruned_artifact.dilemmas if len(d.explored) >= 2
             )
+            # arc_count = 2^n where n = fully-explored dilemmas; the user-facing
+            # recovery hint must scale with min_arcs_required (#1555). For long
+            # stories (max_arcs=32, min_arcs_required=8) this is 3, not 2.
+            min_fully_explored = max(1, math.ceil(math.log2(min_arcs_required)))
             raise SeedStageError(
                 f"SEED produced only {final_arc_count} arc(s) "
                 f"({'a linear story' if final_arc_count == 1 else 'minimal branching'}) — "
                 f"minimum required is {min_arcs_required}. "
                 f"Only {dilemmas_fully_explored} dilemma(s) have both answers explored. "
-                f"For interactive fiction, explore BOTH answers for at least 2 dilemmas "
+                f"For interactive fiction, explore BOTH answers for at least "
+                f"{min_fully_explored} dilemma{'s' if min_fully_explored != 1 else ''} "
                 f"to produce {min_arcs_required}+ arcs."
             )
 

--- a/tests/unit/test_seed_stage.py
+++ b/tests/unit/test_seed_stage.py
@@ -927,6 +927,74 @@ async def test_low_arc_count_raises_seed_stage_error() -> None:
             )
 
 
+@pytest.mark.parametrize(
+    ("preset", "expected_min_fully_explored", "expected_phrase"),
+    [
+        # max_arcs=2  → min_arcs_required=2 → log2(2)=1 → "at least 1 dilemma"
+        ("micro", 1, "at least 1 dilemma"),
+        # max_arcs=8  → min_arcs_required=2 → log2(2)=1 → "at least 1 dilemma"
+        ("short", 1, "at least 1 dilemma"),
+        # max_arcs=16 → min_arcs_required=4 → log2(4)=2 → "at least 2 dilemmas"
+        ("medium", 2, "at least 2 dilemmas"),
+        # max_arcs=32 → min_arcs_required=8 → log2(8)=3 → "at least 3 dilemmas"
+        ("long", 3, "at least 3 dilemmas"),
+    ],
+)
+@pytest.mark.asyncio
+async def test_low_arc_error_message_scales_with_size_preset(
+    preset: str, expected_min_fully_explored: int, expected_phrase: str
+) -> None:
+    """SeedStageError recovery hint scales with min_arcs_required (#1555).
+
+    The hardcoded "at least 2 dilemmas" was wrong for `long` stories where
+    min_arcs_required=8 and the user actually needs 3+ fully-explored.
+    The message now derives the count from log2(min_arcs_required).
+    """
+    from questfoundry.pipeline.size import get_size_profile
+
+    stage = SeedStage()
+
+    mock_model = MagicMock()
+    mock_graph = MagicMock()
+    mock_graph.get_nodes_by_type.side_effect = lambda t: (
+        {"entity1": {"type": "entity"}} if t == "entity" else {}
+    )
+    mock_graph.get_edges.return_value = []
+
+    mock_artifact = SeedOutput(entities=[], dilemmas=[], paths=[], initial_beats=[])
+    size_profile = get_size_profile(preset)
+
+    with (
+        patch("questfoundry.pipeline.stages.seed.Graph") as MockGraph,
+        patch("questfoundry.pipeline.stages.seed.run_discuss_phase") as mock_discuss,
+        patch("questfoundry.pipeline.stages.seed.summarize_seed_chunked") as mock_summarize,
+        patch("questfoundry.pipeline.stages.seed.serialize_seed_as_function") as mock_serialize,
+        patch("questfoundry.pipeline.stages.seed.get_all_research_tools") as mock_tools,
+        patch("questfoundry.pipeline.stages.seed.compute_arc_count", return_value=0),
+    ):
+        MockGraph.load.return_value = mock_graph
+        mock_tools.return_value = []
+        mock_discuss.return_value = ([], 1, 100)
+        mock_summarize.return_value = (_MOCK_SECTION_BRIEFS, 50)
+        mock_serialize.return_value = SerializeResult(
+            artifact=mock_artifact, tokens_used=100, semantic_errors=[]
+        )
+
+        with pytest.raises(SeedStageError) as exc_info:
+            await stage.execute(
+                model=mock_model,
+                user_prompt="test",
+                project_path=Path("/test/project"),
+                size_profile=size_profile,
+            )
+
+    msg = str(exc_info.value)
+    assert expected_phrase in msg, (
+        f"Expected message to contain {expected_phrase!r} for preset={preset!r} "
+        f"(min_fully_explored={expected_min_fully_explored}); got: {msg!r}"
+    )
+
+
 # --- Path Freeze Approval Gate Tests (R-6.4) ---
 
 

--- a/tests/unit/test_seed_stage.py
+++ b/tests/unit/test_seed_stage.py
@@ -928,27 +928,28 @@ async def test_low_arc_count_raises_seed_stage_error() -> None:
 
 
 @pytest.mark.parametrize(
-    ("preset", "expected_min_fully_explored", "expected_phrase"),
+    ("preset", "expected_phrase"),
     [
         # max_arcs=2  → min_arcs_required=2 → log2(2)=1 → "at least 1 dilemma"
-        ("micro", 1, "at least 1 dilemma"),
+        ("micro", "at least 1 dilemma"),
         # max_arcs=8  → min_arcs_required=2 → log2(2)=1 → "at least 1 dilemma"
-        ("short", 1, "at least 1 dilemma"),
+        ("short", "at least 1 dilemma"),
         # max_arcs=16 → min_arcs_required=4 → log2(4)=2 → "at least 2 dilemmas"
-        ("medium", 2, "at least 2 dilemmas"),
+        ("medium", "at least 2 dilemmas"),
         # max_arcs=32 → min_arcs_required=8 → log2(8)=3 → "at least 3 dilemmas"
-        ("long", 3, "at least 3 dilemmas"),
+        ("long", "at least 3 dilemmas"),
     ],
 )
 @pytest.mark.asyncio
 async def test_low_arc_error_message_scales_with_size_preset(
-    preset: str, expected_min_fully_explored: int, expected_phrase: str
+    preset: str, expected_phrase: str
 ) -> None:
-    """SeedStageError recovery hint scales with min_arcs_required (#1555).
+    """SeedStageError recovery hint scales with min_arcs_required.
 
-    The hardcoded "at least 2 dilemmas" was wrong for `long` stories where
-    min_arcs_required=8 and the user actually needs 3+ fully-explored.
-    The message now derives the count from log2(min_arcs_required).
+    The recovery message must derive the "at least N" dilemma count from
+    log2(min_arcs_required), so long stories (min_arcs_required=8)
+    correctly tell the user to fully-explore 3+ dilemmas instead of the
+    historical hardcoded 2.
     """
     from questfoundry.pipeline.size import get_size_profile
 
@@ -990,8 +991,7 @@ async def test_low_arc_error_message_scales_with_size_preset(
 
     msg = str(exc_info.value)
     assert expected_phrase in msg, (
-        f"Expected message to contain {expected_phrase!r} for preset={preset!r} "
-        f"(min_fully_explored={expected_min_fully_explored}); got: {msg!r}"
+        f"Expected message to contain {expected_phrase!r} for preset={preset!r}; got: {msg!r}"
     )
 
 


### PR DESCRIPTION
## Summary

The user-facing \`SeedStageError\` recovery message at \`src/questfoundry/pipeline/stages/seed.py:527\` hardcoded \"explore BOTH answers for at least 2 dilemmas\" — wrong for \`long\` stories where \`min_arcs_required=8\` and the user actually needs 3+ fully-explored. The message now computes the count from \`log2(min_arcs_required)\` and pluralizes correctly.

## Math

\`arc_count = 2^n\` where \`n\` = fully-explored dilemmas.
\`min_fully_explored = max(1, math.ceil(math.log2(min_arcs_required)))\`.

| preset | max_arcs | min_arcs_required | message says |
|--------|---------:|------------------:|--------------|
| micro  |        2 |                 2 | "at least 1 dilemma"  |
| short  |        8 |                 2 | "at least 1 dilemma"  |
| medium |       16 |                 4 | "at least 2 dilemmas" |
| long   |       32 |                 8 | "at least 3 dilemmas" |

## Tests

New parametrized test \`test_low_arc_error_message_scales_with_size_preset\` covers all 4 presets — asserts the rendered \`SeedStageError\` message contains the correct \"at least N dilemma(s)\" phrasing.

## Background

User-facing twin of the prompt-side prevention fix that landed in PR #1554 (#1236 \`SizeProfile.fully_explored\` wiring). #1554 prevented the failure at the prompt layer; this PR improves the recovery guidance once the failure occurs anyway.

Surfaced by the \`@prompt-engineer\` post-mortem during PR #1554's bot review cycle.

Closes #1555.

## Test plan

- [x] \`uv run pytest tests/unit/test_seed_stage.py::test_low_arc_error_message_scales_with_size_preset\` — 4 passed
- [x] \`uv run mypy src/questfoundry/pipeline/stages/seed.py\` — clean
- [x] \`uv run ruff check src/questfoundry/pipeline/stages/seed.py tests/unit/test_seed_stage.py\` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)