### PR TITLE
fix(prompts): discuss_seed BAD example uses {size_fully_explored} (#1556)

### DIFF
--- a/prompts/templates/discuss_seed.yaml
+++ b/prompts/templates/discuss_seed.yaml
@@ -89,7 +89,7 @@ system: |
 
   BAD (only canonical answers explored):
   - All dilemmas: explored = `[canonical_answer_only]` → linear story, 0 choices
-  - Only 1 dilemma fully explored → story has only one fork; POLISH Phase 4c produces ≤2 choices
+  - Fewer than {size_fully_explored} dilemmas fully explored → story underbranches; POLISH Phase 4c produces too few choices
 
   Pick at least {size_fully_explored} dilemmas where exploring both answers serves
   the story (per the Identity-defining / Genuine dilemma / Distinct content tests


### PR DESCRIPTION
## Summary

\`prompts/templates/discuss_seed.yaml:92\` had a BAD example "Only 1 dilemma fully explored → story has only one fork" that contradicted the HARD CONSTRAINT just above for micro stories where \`size_fully_explored=1\` (the constraint says "at least 1 MUST" but this bullet calls 1 bad).

Replaced with size-aware phrasing per Option A from issue #1556:
\`Fewer than {size_fully_explored} dilemmas fully explored → story underbranches; POLISH Phase 4c produces too few choices\`

## Cascading-nits sweep

Per the phase3_cluster_state memory note about PR #1554's 8-round bot-review cycle, before pushing I grepped across all SEED prompt templates:

\`\`\`
rg "fully explored|fully_explored|at least [0-9]|fewer than [0-9]" prompts/templates/
\`\`\`

Result: PR #1554 already fixed \`serialize_seed_sections.yaml\` and \`summarize_seed_sections.yaml\` to use \`{size_fully_explored}\` everywhere. \`discuss_seed.yaml:92\` was the only remaining stale hardcode. No additional cascading-nit fixes needed in this PR.

## Background

Surfaced by \`@prompt-engineer\` post-mortem during PR #1554's review. Filed as #1556 for separate cleanup since #1554 was already at round-6 and the BAD-example contradiction was tagged "lower severity, benign in practice" by the bot.

Closes #1556.

## Test plan

- [x] \`rg "Only 1 dilemma|Only [0-9]+ dilemma|only one fork" prompts/templates/\` — zero hits
- [x] \`uv run pytest tests/unit/test_seed_prompts.py\` — 9 passed
- [x] Manual: discuss_seed prompt now reads consistently for all 4 size presets (micro=1, short=3, medium=4, long=5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)