### PR TITLE
fix(prompts): grow_phase3 shared_entities uses category-scoped prefix (#1563)

### DIFF
--- a/prompts/templates/grow_phase3_intersections.yaml
+++ b/prompts/templates/grow_phase3_intersections.yaml
@@ -63,7 +63,8 @@ system: |
     square" rather than "unknown").
   - shared_entities: list of entity IDs shared between the intersecting beats — use the
     full scoped ID format from the beat descriptions (e.g., "character::merchant",
-    "location::market", "object::artifact"). Do NOT use the generic "entity::" prefix —
+    "location::market", "object::artifact", "faction::guild"). Do NOT use the generic
+    "entity::" prefix —
     use the actual category prefix shown in the beat context above. If no entities are
     shared, use an empty list []. Do NOT invent entity IDs — use only IDs that appear in
     the candidate group descriptions above.
@@ -102,8 +103,8 @@ user: |
   - resolved_location: pick the best-fit location from the beat descriptions
     when uncertain (the schema requires a non-empty string).
   - shared_entities MUST use the scoped category prefix from the beat
-    context (e.g., "character::merchant", "location::market", "object::artifact")
-    — NOT the generic "entity::" prefix — or be an empty list [].
+    context (e.g., "character::merchant", "location::market", "object::artifact",
+    "faction::guild") — NOT the generic "entity::" prefix — or be an empty list [].
   - rationale MUST explain WHY the beats belong in one scene, not just that they share a location.
   {structural_feedback}
 

--- a/prompts/templates/grow_phase3_intersections.yaml
+++ b/prompts/templates/grow_phase3_intersections.yaml
@@ -62,9 +62,11 @@ system: |
     location mentioned in any of the beat descriptions (e.g., "the village
     square" rather than "unknown").
   - shared_entities: list of entity IDs shared between the intersecting beats — use the
-    full "entity::<name>" format (e.g., "entity::merchant", "entity::artifact"). If no
-    entities are shared, use an empty list []. Do NOT invent entity IDs — use only IDs
-    that appear in the candidate group descriptions above.
+    full scoped ID format from the beat descriptions (e.g., "character::merchant",
+    "location::market", "object::artifact"). Do NOT use the generic "entity::" prefix —
+    use the actual category prefix shown in the beat context above. If no entities are
+    shared, use an empty list []. Do NOT invent entity IDs — use only IDs that appear in
+    the candidate group descriptions above.
   - rationale: one sentence explaining WHY the beats belong in one scene — mention what
     narrative or physical element draws them together, not just that they share a location.
     BAD: "These beats share the market location." GOOD: "Both beats require the merchant's
@@ -76,7 +78,7 @@ system: |
       {{
         "beat_ids": ["beat::market_encounter", "beat::artifact_reveal"],
         "resolved_location": "the central market",
-        "shared_entities": ["entity::merchant", "entity::artifact"],
+        "shared_entities": ["character::merchant", "object::artifact"],
         "rationale": "Both beats require the merchant's presence, so staging them together avoids a redundant scene."
       }},
       {{
@@ -99,7 +101,9 @@ user: |
   - Each beat may appear in at most ONE intersection.
   - resolved_location: pick the best-fit location from the beat descriptions
     when uncertain (the schema requires a non-empty string).
-  - shared_entities MUST use "entity::<name>" format or be an empty list [].
+  - shared_entities MUST use the scoped category prefix from the beat
+    context (e.g., "character::merchant", "location::market", "object::artifact")
+    — NOT the generic "entity::" prefix — or be an empty list [].
   - rationale MUST explain WHY the beats belong in one scene, not just that they share a location.
   {structural_feedback}
 


### PR DESCRIPTION
## Summary

\`prompts/templates/grow_phase3_intersections.yaml\` prescribed \`"entity::<name>"\` as the format for \`shared_entities\` (lines 65 and 104), but the graph uses category-scoped IDs (\`character::\`, \`location::\`, \`object::\`, \`faction::\`). A model following the example would produce IDs the graph cannot resolve.

Two edits:

1. Replace the format guidance text + example JSON with category-scoped form (\`"character::merchant"\`, \`"object::artifact"\` etc.).
2. Convert remaining \`"entity::"\` mentions into explicit negative warnings ("Do NOT use the generic 'entity::' prefix") so the LLM is steered away from the deprecated shape rather than toward it.

## Context

Surfaced during the \`@prompt-engineer\` post-mortem of \`murder6\`/\`murder-haiku\` failures (PR #1554's review cycle). Soft terminology fix; distinct from:

- #1561 (SEED prompt patches — superseded by #1564 / merged via PRs #1565 and #1566)
- #1562 (GROW R-1.4 Y-fork wiring code investigation — unaffected by this prompt change)

Closes #1563.

## Test plan

- [x] \`rg "entity::" prompts/templates/grow_phase3_intersections.yaml\` — only 2 hits, both inside intentional "Do NOT use this" warnings.
- [x] No code changes; CI passes trivially.

🤖 Generated with [Claude Code](https://claude.com/claude-code)