### PR TITLE
fix(prompts): polish templates use category-scoped entity prefix (#1570)

### DIFF
--- a/prompts/templates/polish_phase2_pacing.yaml
+++ b/prompts/templates/polish_phase2_pacing.yaml
@@ -67,7 +67,7 @@ system: |
       {{
         "after_beat_id": "beat::tense_confrontation",
         "summary": "A heavy silence settles over the room as both parties consider what was said",
-        "entity_ids": ["entity::mentor", "entity::protagonist"]
+        "entity_ids": ["character::mentor", "character::protagonist"]
       }}
     ]
   }}

--- a/prompts/templates/polish_phase3_arcs.yaml
+++ b/prompts/templates/polish_phase3_arcs.yaml
@@ -64,7 +64,7 @@ system: |
   {{
     "character_arcs": [
       {{
-        "entity_id": "entity::mentor",
+        "entity_id": "character::mentor",
         "start": "The mentor appears as a calm authority figure, offering guidance",
         "pivots": [
           {{

--- a/prompts/templates/polish_phase5c_false_branches.yaml
+++ b/prompts/templates/polish_phase5c_false_branches.yaml
@@ -45,7 +45,7 @@ system: |
         "decision": "sidetrack",
         "details": "A brief encounter adds character depth",
         "sidetrack_summary": "A mysterious stranger offers cryptic advice",
-        "sidetrack_entities": ["entity::stranger"],
+        "sidetrack_entities": ["character::stranger"],
         "choice_label_enter": "Approach the stranger",
         "choice_label_return": "Continue on your way"
       }}


### PR DESCRIPTION
## Summary

Three POLISH-stage templates used the generic \`entity::\` prefix in example JSON values — same class of bug fixed for \`grow_phase3_intersections.yaml\` in PR #1569 (#1563). The graph uses category-scoped IDs (\`character::\`, \`location::\`, \`object::\`, \`faction::\`); a model following the example would produce IDs the graph cannot resolve.

All three example values reference **characters** in their surrounding prose (mentor, protagonist, stranger) — converted to \`character::\` prefix:

| File | Line | Field | Before | After |
|------|-----:|-------|--------|-------|
| \`polish_phase3_arcs.yaml\` | 67 | \`entity_id\` | \`"entity::mentor"\` | \`"character::mentor"\` |
| \`polish_phase2_pacing.yaml\` | 70 | \`entity_ids\` | \`["entity::mentor", "entity::protagonist"]\` | \`["character::mentor", "character::protagonist"]\` |
| \`polish_phase5c_false_branches.yaml\` | 48 | \`sidetrack_entities\` | \`["entity::stranger"]\` | \`["character::stranger"]\` |

## Background

Bot review on PR #1569 explicitly flagged these as the same class of bug, in different stage, with different field names. PR #1569 was scoped to GROW Phase 3 only; this PR completes the cleanup for the POLISH templates.

Cascade-nits sweep: \`rg "entity::" prompts/templates/polish_*.yaml\` returns zero hits after the fix.

Closes #1570.

## Test plan

- [x] \`rg "entity::" prompts/templates/polish_*.yaml\` — zero hits
- [x] No code changes; CI passes trivially.

🤖 Generated with [Claude Code](https://claude.com/claude-code)