### PR TITLE
fix(prompts): SEED commit beat MUST be first exclusive beat (#1572 part 2/2)

### DIFF
--- a/prompts/templates/serialize_seed_sections.yaml
+++ b/prompts/templates/serialize_seed_sections.yaml
@@ -668,8 +668,10 @@ per_path_beats_prompt: |
     Beat 1: effect: "advances"  ← "passive listening" feels less decisive
     Beat 2: effect: "commits"   ← "active suppression" feels more dramatic
     Beat 3: effect: "reveals"   ← aftermath
-  The beat ordering above VIOLATES the Y-fork contract. The validator checks that
-  the FIRST exclusive beat is the commit beat and will reject this output.
+  The beat ordering above VIOLATES the Y-fork contract. Downstream validation
+  (GROW R-1.4 Y-fork postcondition, see seed.md R-3.11) rejects this output —
+  the failure surfaces after SEED at the GROW exit-validator, requiring a full
+  re-serialize pass.
 
   ## What NOT to Do
   - Do NOT use generic beat IDs like `beat_001` (must include path name prefix)

--- a/prompts/templates/serialize_seed_sections.yaml
+++ b/prompts/templates/serialize_seed_sections.yaml
@@ -644,11 +644,10 @@ per_path_beats_prompt: |
   This beat represents the moment where this path's dilemma is locked in.
   The commits beat MUST NOT be the last beat — at least one consequence beat MUST follow it.
 
-  WRONG (rejected): commits is the last beat — no consequence
-  `[advances, commits]` or `[advances, reveals, commits]` ← pipeline fails
+  WRONG (commits not first): `[advances, commits, advances]` or `[reveals, commits, complicates]` ← position violation; see COMMIT BEAT POSITION below
+  WRONG (commits last): `[commits, advances, commits]` ← cardinality violation, no aftermath after the second commits
 
-  RIGHT (valid): aftermath beat follows the decision
-  `[advances, commits, advances]` or `[reveals, commits, complicates]` ← passes
+  RIGHT: `[commits, advances]` or `[commits, advances, reveals]` or `[commits, reveals, complicates]` ← passes
 
   ## COMMIT BEAT POSITION (HARD CONSTRAINT — structural, not narrative)
 

--- a/prompts/templates/serialize_seed_sections.yaml
+++ b/prompts/templates/serialize_seed_sections.yaml
@@ -624,13 +624,20 @@ per_path_beats_prompt: |
     its primary location
 
   ## ARC STRUCTURE (CRITICAL — determines beat ordering)
-  Beats must follow this arc pattern for a complete path scaffold:
-  1. **Setup** (advances/reveals): Introduce tensions, reveal information
-  2. **Turning point** (commits): The moment the dilemma locks in — NOT the last beat
-  3. **Aftermath**: At least one beat AFTER commits showing consequences
 
-  WRONG: [advances, reveals, commits] — commits is last, no aftermath
-  RIGHT: [advances, commits, reveals] — aftermath beat follows the turning point
+  Beat 1 (commits): STRUCTURAL SLOT — always the first beat. The moment the
+    path diverges structurally. This is NOT about dramatic weight; even a
+    quiet, passive moment is the commit beat if it is the first exclusive
+    beat of this path.
+  Beats 2–N (advances / reveals / complicates): Aftermath beats that prove
+    the answer. At least one is required.
+
+  WRONG: Deciding beat 1 is "setup" and beat 2 is "commits" because beat 2
+    feels more dramatically decisive. The structural slot is fixed — beat 1 IS
+    the commit beat. Always.
+
+  WRONG sequence: [advances, commits] — no aftermath beat
+  RIGHT sequence: [commits, advances] or [commits, reveals, complicates]
 
   ## COMMITS BEAT REQUIREMENT (HARD CONSTRAINT)
   You MUST include exactly one beat with `effect: "commits"` for `{dilemma_id}`.
@@ -643,12 +650,35 @@ per_path_beats_prompt: |
   RIGHT (valid): aftermath beat follows the decision
   `[advances, commits, advances]` or `[reveals, commits, complicates]` ← passes
 
+  ## COMMIT BEAT POSITION (HARD CONSTRAINT — structural, not narrative)
+
+  The FIRST beat in your list MUST have `effect: "commits"` in `dilemma_impacts`.
+
+  WHY: In the Y-shape, the commit beat IS defined as the first beat exclusive to this
+  path (Story Graph Ontology Part 1, seed.md R-3.11). Its slot is fixed by graph
+  structure, not by when the decision "feels dramatic." Even if the first exclusive
+  moment is quiet or passive, it is still the structural commit beat. You prove the
+  answer in the beats that FOLLOW it.
+
+  GOOD (structurally correct):
+    Beat 1: effect: "commits"  ← first exclusive beat, regardless of dramatic weight
+    Beat 2: effect: "advances" ← plays out consequences
+    Beat 3: effect: "reveals"  ← proves the answer
+
+  BAD (structurally wrong — the murder-haiku failure pattern):
+    Beat 1: effect: "advances"  ← "passive listening" feels less decisive
+    Beat 2: effect: "commits"   ← "active suppression" feels more dramatic
+    Beat 3: effect: "reveals"   ← aftermath
+  The beat ordering above VIOLATES the Y-fork contract. The validator checks that
+  the FIRST exclusive beat is the commit beat and will reject this output.
+
   ## What NOT to Do
   - Do NOT use generic beat IDs like `beat_001` (must include path name prefix)
   - Do NOT generate beats for other paths
   - Do NOT reference other dilemma_ids in your first dilemma_impact
   - Do NOT skip the commits beat
   - Do NOT make commits the last beat — a consequence beat MUST follow it
+  - Do NOT place `effect: "commits"` on beat 2 or later — it MUST be beat 1
   - Do NOT use IDs not in the manifest
   - Do NOT put the dilemma ID in the `belongs_to` list (see COMMON MISTAKE above)
   - Do NOT emit `belongs_to` with 2 elements — these are post-commit beats, single-membership only
@@ -660,9 +690,12 @@ per_path_beats_prompt: |
   2. `dilemma_impacts[0].dilemma_id` is `{dilemma_id}`
   3. `belongs_to` has exactly 1 element (these are POST-COMMIT beats, exclusive
      to one path — never shared)
+  4. The FIRST beat in your list has `dilemma_impacts[0].effect == "commits"` —
+     beat 1 is the commit beat by structural definition (seed.md R-3.11).
 
   If you see a dilemma ID in your `belongs_to` list, YOU MADE A MISTAKE. Fix it.
   If `belongs_to` has 2 elements, YOU MADE A MISTAKE. Fix it.
+  If beat 1 has `effect` other than `"commits"`, YOU MADE A MISTAKE. Fix it.
 
   ## Output
   Return ONLY valid JSON with the "initial_beats" array ({size_post_commit_beats_per_path} beats).

--- a/prompts/templates/summarize_seed.yaml
+++ b/prompts/templates/summarize_seed.yaml
@@ -102,6 +102,11 @@ system: |
   3. Each path has at least the configured number of POST-COMMIT beats
      (`belongs_to` length 1).
   4. Pre-commit beats appear before commit beats in the listing (or, if `temporal_hint` is set, its `position` is `before_commit`). `temporal_hint` is OPTIONAL — listing order alone is sufficient.
+  5. For each path, the FIRST post-commit beat listed under that path has
+     `effect: commits` (or the beat labeled as the commit beat appears FIRST
+     in the path's exclusive-beat sequence). The commit beat is ALWAYS beat 1
+     of the exclusive sequence — placing it at position 2+ is a structural
+     violation (seed.md R-3.11 / SGO Part 1).
 
   If any of the above is missing, the serializer will fail and the repair
   loop will rebuild the section from scratch — fix the gap here.

--- a/prompts/templates/summarize_seed.yaml
+++ b/prompts/templates/summarize_seed.yaml
@@ -106,8 +106,10 @@ system: |
      `effect: commits`. The commit beat is ALWAYS beat 1 of the exclusive sequence;
      placing it at position 2+ is a structural violation (seed.md R-3.11 / SGO Part 1).
 
-  If any of the above is missing, the serializer will fail and the repair
-  loop will rebuild the section from scratch — fix the gap here.
+  If items 1–4 are missing, the serializer will fail and the repair loop
+  will rebuild the section from scratch. Item 5 (commit-beat position) is
+  validated downstream at GROW R-1.4 — fixing it here saves a full GROW
+  re-serialize pass. Fix all gaps here.
 
   ### Convergence Sketch
   - convergence_points: where paths should merge

--- a/prompts/templates/summarize_seed.yaml
+++ b/prompts/templates/summarize_seed.yaml
@@ -102,14 +102,20 @@ system: |
   3. Each path has at least the configured number of POST-COMMIT beats
      (`belongs_to` length 1).
   4. Pre-commit beats appear before commit beats in the listing (or, if `temporal_hint` is set, its `position` is `before_commit`). `temporal_hint` is OPTIONAL — listing order alone is sufficient.
-  5. For each path, the FIRST exclusive (post-pre-commit) beat listed has
-     `effect: commits`. The commit beat is ALWAYS beat 1 of the exclusive sequence;
-     placing it at position 2+ is a structural violation (seed.md R-3.11 / SGO Part 1).
+  5. For each path, the FIRST exclusive (post-pre-commit) beat listed IS
+     that path's commit beat — the moment the dilemma decision becomes
+     binding for that path. The commit beat is ALWAYS beat 1 of the
+     exclusive sequence; placing any `advances` / `reveals` / `complicates`
+     beat before it is a structural violation (seed.md R-3.11 / SGO Part 1).
+     Note: the `effect` field itself is set by the per-path serializer in
+     the next stage — your job here is to put the structurally-correct beat
+     in the first exclusive slot so the serializer assigns `effect: commits`
+     to it.
 
   If items 1–4 are missing, the serializer will fail and the repair loop
   will rebuild the section from scratch. Item 5 (commit-beat position) is
-  validated downstream at GROW R-1.4 — fixing it here saves a full GROW
-  re-serialize pass. Fix all gaps here.
+  validated downstream at GROW R-1.4 (Y-fork postcondition) — fixing it
+  here saves a full GROW re-serialize pass. Fix all gaps here.
 
   ### Convergence Sketch
   - convergence_points: where paths should merge

--- a/prompts/templates/summarize_seed.yaml
+++ b/prompts/templates/summarize_seed.yaml
@@ -102,11 +102,9 @@ system: |
   3. Each path has at least the configured number of POST-COMMIT beats
      (`belongs_to` length 1).
   4. Pre-commit beats appear before commit beats in the listing (or, if `temporal_hint` is set, its `position` is `before_commit`). `temporal_hint` is OPTIONAL — listing order alone is sufficient.
-  5. For each path, the FIRST post-commit beat listed under that path has
-     `effect: commits` (or the beat labeled as the commit beat appears FIRST
-     in the path's exclusive-beat sequence). The commit beat is ALWAYS beat 1
-     of the exclusive sequence — placing it at position 2+ is a structural
-     violation (seed.md R-3.11 / SGO Part 1).
+  5. For each path, the FIRST exclusive (post-pre-commit) beat listed has
+     `effect: commits`. The commit beat is ALWAYS beat 1 of the exclusive sequence;
+     placing it at position 2+ is a structural violation (seed.md R-3.11 / SGO Part 1).
 
   If any of the above is missing, the serializer will fail and the repair
   loop will rebuild the section from scratch — fix the gap here.


### PR DESCRIPTION
## Summary

Prompt PR (2 of 2) for #1572. Adds the structural-position rule to the SEED prompts so the LLM places \`effect: commits\` on the first exclusive beat per path — not on the beat that narratively feels most committal. Closes the murder-haiku 2026-04-29 R-1.4 Y-fork failure at the prompt layer.

Depends on PR #1573 (spec PR — seed.md R-3.11 + Output Contracts + Violations table) which **has merged**.

## Background

\`projects/murder-haiku\` (claude-haiku-4-5, 2026-04-29) failed at GROW R-1.4 Y-fork postcondition. Diagnostic traced into \`graph.db\`:

- Both \`belongs_to\` graph edges on the shared pre-commit beat exist correctly.
- The bug is in \`dilemma_impacts.effect\` placement: SEED's LLM emitted \`effect: commits\` on \`__conspirator_beat_02\` (\"active suppression\" — narratively decisive) instead of \`__conspirator_beat_01\` (the structurally first exclusive beat).

Same root-cause class as the \`also_belongs_to\` murder6 bug (#1564): small/medium models miss a structural constraint when it's expressed in semantic terms. The previous prompt enforced cardinality (\"exactly one commits beat\") and tail rule (\"not last\") but never the position (\"MUST be first\").

## Spec + plan

- Design: \`docs/superpowers/specs/2026-04-29-commit-beat-position-design.md\`
- Spec PR (1/2, merged): #1573

## Cascade (5 edits in 2 files)

\`prompts/templates/serialize_seed_sections.yaml\` per_path_beats_prompt:

1. **ARC STRUCTURE section** rewritten: drop \"Turning point\" semantic label, reframe Beat 1 as STRUCTURAL SLOT (\"always the first beat... NOT about dramatic weight\").
2. **New \`## COMMIT BEAT POSITION (HARD CONSTRAINT)\` block** inserted after COMMITS BEAT REQUIREMENT. Includes the WHY, a GOOD example, and a BAD example using the murder-haiku failure pattern (\"passive listening / active suppression\").
3. **WHAT NOT TO DO list** gains: \"Do NOT place \`effect: 'commits'\` on beat 2 or later — it MUST be beat 1\".
4. **FINAL VERIFICATION checklist** gains item 4: first beat \`dilemma_impacts[0].effect == 'commits'\`, plus a matching catch-it reminder.

\`prompts/templates/summarize_seed.yaml\` VERIFY block:

5. Add item 5: first post-commit beat has \`effect: commits\`. Prevents the summarize phase from pre-biasing the serialize phase toward placing commits on beat 2+.

\`discuss_seed.yaml\` is intentionally not touched (creative discussion phase should not be burdened with positional slot constraints; the structural rule lives in summarize + serialize).

Closes #1572.

## Test plan

- [x] \`uv run pytest tests/unit/test_seed_prompts.py\` — 9 passed
- [x] No code changes; CI passes trivially.

End-to-end smoke (manual, requires LLM access):

- [ ] Re-run \`projects/murder-haiku\` against claude-haiku-4-5 — confirm SEED produces symmetric Y-fork (every path's first exclusive beat has \`effect: commits\`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)