### PR TITLE
docs(spec): align DREAM/BRAINSTORM scope/content_notes worked examples to model (#1515)

### DIFF
--- a/docs/design/procedures/brainstorm.md
+++ b/docs/design/procedures/brainstorm.md
@@ -279,8 +279,14 @@ vision:
     - "morally ambiguous"
   themes: ["forbidden knowledge", "trust", "corruption"]
   audience: "adult readers of literary speculative fiction"
-  scope: short
-  content_notes: ["single protagonist POV", "no explicit magic system", "no graphic violence"]
+  scope:
+    story_size: short
+  content_notes:
+    includes:
+      - "intimate scope (few key relationships)"
+    excludes:
+      - "explicit magic system"
+      - "graphic violence"
   pov_style: third_person_limited
 ```
 

--- a/docs/design/procedures/dream.md
+++ b/docs/design/procedures/dream.md
@@ -245,7 +245,8 @@ vision:
     - "trust"
     - "corruption"
   audience: "adult readers of literary speculative fiction"
-  scope: short                     # enum value — unquoted
+  scope:
+    story_size: short              # enum value — unquoted; one of micro/short/medium/long
   content_notes:
     includes:
       - "intimate scope (few key relationships)"


### PR DESCRIPTION
Closes #1515.

## Summary

- Fixes worked-example drift in two procedure docs: \`scope: short\` was used as a bare string, but \`Scope\` is a nested model with \`story_size\`. Also fixes \`content_notes\` flat-list drift in \`brainstorm.md\` against the \`ContentNotes\` model (which has \`includes\` / \`excludes\`).
- Both worked examples now match the Pydantic \`DreamArtifact\` model exactly. Verified: the YAML deserializes cleanly via \`DreamArtifact(**yaml.safe_load(example))\`.

## Files

- \`docs/design/procedures/dream.md\` — \`scope: short\` → nested form
- \`docs/design/procedures/brainstorm.md\` — \`scope\` + \`content_notes\` both nested

## Test plan

- [x] \`uv run python -c "..."\` deserializes the new worked example into \`DreamArtifact\` without error
- [x] \`grep -rn "scope:" docs/design/\` finds no other bare-string \`scope:\` references
- [x] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)