### PR TITLE
fix(polish): Phase 5e residue skip propagates to plan.warnings (#1537)

### DIFF
--- a/src/questfoundry/pipeline/stages/polish/llm_phases.py
+++ b/src/questfoundry/pipeline/stages/polish/llm_phases.py
@@ -1032,6 +1032,18 @@ class _PolishLLMPhaseMixin:
                                 "with a path_id; residue beat skipped."
                             ),
                         )
+                        # Propagate to plan.warnings so operators see this in
+                        # the plan artifact, mirroring Phase 4b's symmetric skip
+                        # path (deterministic.py:487-490). The two phases skip
+                        # for the same R-5.5 root cause but at different decision
+                        # points, so the message labels Phase 5e explicitly.
+                        plan_node = graph.get_node("polish_plan::current") or {}
+                        prior_warnings = list(plan_node.get("warnings", []))
+                        prior_warnings.append(
+                            f"Phase 5e residue beat skipped for unmapped flag {flag} on "
+                            f"passage {passage_id} (R-5.5 path attribution)."
+                        )
+                        graph.update_node("polish_plan::current", warnings=prior_warnings)
                         continue
                     passage_raw = passage_id.split("::")[-1]
                     residue_specs.append(

--- a/src/questfoundry/pipeline/stages/polish/llm_phases.py
+++ b/src/questfoundry/pipeline/stages/polish/llm_phases.py
@@ -1032,11 +1032,7 @@ class _PolishLLMPhaseMixin:
                                 "with a path_id; residue beat skipped."
                             ),
                         )
-                        # Propagate to plan.warnings so operators see this in
-                        # the plan artifact, mirroring Phase 4b's symmetric skip
-                        # path (deterministic.py:487-490). The two phases skip
-                        # for the same R-5.5 root cause but at different decision
-                        # points, so the message labels Phase 5e explicitly.
+                        # R-5.5 skip must surface in the plan artifact, not just structlog.
                         plan_node = graph.get_node("polish_plan::current") or {}
                         prior_warnings = list(plan_node.get("warnings", []))
                         prior_warnings.append(

--- a/tests/unit/test_polish_phases.py
+++ b/tests/unit/test_polish_phases.py
@@ -687,6 +687,82 @@ class TestPhase5eAmbiguousFeasibility:
         residue_specs = plan_data.get("residue_specs", [])
         assert residue_specs == []
 
+    def test_residue_skip_propagates_warning_to_plan(self) -> None:
+        """When Phase 5e skips a residue spec for an unmapped flag, the
+        warning must surface in ``plan.warnings`` so operators inspecting the
+        plan artifact see the skip — mirroring Phase 4b's symmetric path
+        (``deterministic.py`` `compute_prose_feasibility` warnings).
+        """
+        from questfoundry.models.polish import (
+            AmbiguousFeasibilityCase,
+            FeasibilityDecisionItem,
+            PassageSpec,
+            Phase5eOutput,
+        )
+
+        graph = Graph.empty()
+        passage = PassageSpec(
+            passage_id="passage::ambig_x",
+            beat_ids=["beat::x"],
+            summary="Ambiguous passage with unmapped flag",
+            entities=["entity::hero"],
+            grouping_type="singleton",
+        )
+        ambiguous = AmbiguousFeasibilityCase(
+            passage_id="passage::ambig_x",
+            passage_summary="Ambiguous passage with unmapped flag",
+            entities=["entity::hero"],
+            flags=["dilemma::heavy:path::orphan"],
+        )
+        # No derived_from→consequence mapping: residue spec will be skipped.
+        graph.create_node(
+            "polish_plan::current",
+            {
+                "type": "polish_plan",
+                "raw_id": "current",
+                "passage_count": 1,
+                "variant_count": 0,
+                "residue_count": 0,
+                "choice_count": 0,
+                "candidate_count": 0,
+                "warnings": [],
+                "passage_specs": [passage.model_dump()],
+                "variant_specs": [],
+                "residue_specs": [],
+                "choice_specs": [],
+                "false_branch_candidates": [],
+                "false_branch_specs": [],
+                "feasibility_annotations": {},
+                "ambiguous_specs": [ambiguous.model_dump()],
+                "arc_traversals": {},
+            },
+        )
+
+        llm_output = Phase5eOutput(
+            feasibility_decisions=[
+                FeasibilityDecisionItem(
+                    passage_id="passage::ambig_x",
+                    flag_index=0,
+                    decision="residue",
+                )
+            ]
+        )
+
+        host = _FakePolishLLMHost(llm_output)
+        result = asyncio.run(host._phase_5_llm_enrichment(graph, MagicMock()))  # type: ignore[arg-type]
+
+        assert result.status == "completed"
+
+        plan_data = graph.get_nodes_by_type("polish_plan").get("polish_plan::current", {})
+        warnings = plan_data.get("warnings", [])
+        assert any(
+            "Phase 5e residue beat skipped" in w
+            and "dilemma::heavy:path::orphan" in w
+            and "passage::ambig_x" in w
+            and "R-5.5" in w
+            for w in warnings
+        ), f"expected Phase 5e skip warning in plan.warnings, got: {warnings}"
+
     def test_skipped_when_no_ambiguous_cases(self) -> None:
         """Phase 5e is skipped when ambiguous_specs is empty."""
         from questfoundry.models.polish import Phase5eOutput


### PR DESCRIPTION
Closes #1537.

## Summary

- Phase 4b (\`compute_prose_feasibility\`) and Phase 5e (\`_phase_5_llm_enrichment\`) both skip residue specs when a state_flag lacks a \`derived_from→consequence→path_id\` mapping (R-5.5). Phase 4b appended to \`plan.warnings\`; Phase 5e only logged. The skip became invisible in the plan artifact.
- Mirrors Phase 4b's symmetric path. Skip message labels Phase 5e explicitly.

## Files

- \`src/questfoundry/pipeline/stages/polish/llm_phases.py\` — read \`polish_plan::current\`, append warning, \`update_node\`.
- \`tests/unit/test_polish_phases.py\` — new test \`test_residue_skip_propagates_warning_to_plan\`.

## Test plan

- [x] New unit test passes (asserts skip message contains flag, passage, R-5.5)
- [x] Sibling test \`test_residue_decision_with_unmapped_flag_skips_spec\` still passes
- [x] All 125 polish unit tests pass
- [x] \`ruff check\`, \`ruff format\`, \`mypy\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)