### PR TITLE
feat(seed): thread retry-aware llm_calls counter through SEED inner serialize helpers (#1550)

### DIFF
--- a/src/questfoundry/agents/serialize.py
+++ b/src/questfoundry/agents/serialize.py
@@ -90,6 +90,9 @@ class SerializeResult:
     Attributes:
         artifact: The successfully serialized SeedOutput, or None if failed.
         tokens_used: Total tokens consumed during serialization.
+        call_count: Total LLM calls including Pydantic-retry attempts across
+            all sections, per-dilemma helpers, per-path helpers, shared-beat
+            helpers, early-validation corrections, and semantic-retry passes.
         semantic_errors: List of semantic validation errors (if any).
     """
 
@@ -98,6 +101,7 @@ class SerializeResult:
     # returns a SeedOutput (or raises SerializationError on Pydantic failure).
     artifact: SeedOutput | None
     tokens_used: int
+    call_count: int = 0
     semantic_errors: list[SeedValidationError] = field(default_factory=list)
 
     @property
@@ -639,7 +643,7 @@ async def _serialize_dilemma_paths(
     provider_name: str | None,
     max_retries: int,
     callbacks: list[BaseCallbackHandler] | None,
-) -> tuple[list[dict[str, Any]], int]:
+) -> tuple[list[dict[str, Any]], int, int]:
     """Serialize paths for a single dilemma.
 
     Uses a constrained prompt with the dilemma's ID and explored answers hard-coded.
@@ -654,7 +658,7 @@ async def _serialize_dilemma_paths(
         callbacks: LangChain callback handlers.
 
     Returns:
-        Tuple of (list of path dicts, tokens used).
+        Tuple of (list of path dicts, tokens used, LLM calls including retries).
     """
     from questfoundry.models.seed import DilemmaPathsSection
 
@@ -673,7 +677,7 @@ async def _serialize_dilemma_paths(
             dilemma_id=dilemma_id,
             reason="no_explored_answers",
         )
-        return [], 0
+        return [], 0, 0
 
     # Build explored/unexplored answer text
     explored_text = "\n".join(f"- `{a}` — generate a path for this answer" for a in explored)
@@ -706,7 +710,7 @@ async def _serialize_dilemma_paths(
         explored_count=len(explored),
     )
 
-    result, tokens, _ = await serialize_to_artifact(
+    result, tokens, calls = await serialize_to_artifact(
         model=model,
         brief=brief,
         schema=DilemmaPathsSection,
@@ -724,9 +728,10 @@ async def _serialize_dilemma_paths(
         dilemma_id=dilemma_id,
         path_count=len(paths),
         tokens=tokens,
+        calls=calls,
     )
 
-    return paths, tokens
+    return paths, tokens, calls
 
 
 async def _serialize_paths_per_dilemma(
@@ -739,7 +744,7 @@ async def _serialize_paths_per_dilemma(
     callbacks: list[BaseCallbackHandler] | None,
     on_phase_progress: PhaseProgressFn | None = None,
     max_concurrency: int = 2,
-) -> tuple[list[dict[str, Any]], int]:
+) -> tuple[list[dict[str, Any]], int, int]:
     """Serialize paths for all dilemmas with bounded concurrency.
 
     Filters to dilemmas with explored answers, then generates paths for each
@@ -757,7 +762,7 @@ async def _serialize_paths_per_dilemma(
         max_concurrency: Max parallel LLM requests (default 2).
 
     Returns:
-        Tuple of (all paths merged, total tokens used).
+        Tuple of (all paths merged, total tokens used, total LLM calls).
     """
     # Filter to dilemmas with explored answers
     active_dilemmas = [d for d in dilemma_decisions if d.get("explored")]
@@ -769,13 +774,13 @@ async def _serialize_paths_per_dilemma(
     )
 
     if not active_dilemmas:
-        return [], 0
+        return [], 0, 0
 
     semaphore = asyncio.Semaphore(max_concurrency)
 
     async def _limited_serialize(
         dilemma: dict[str, Any],
-    ) -> tuple[list[dict[str, Any]], int]:
+    ) -> tuple[list[dict[str, Any]], int, int]:
         async with semaphore:
             return await _serialize_dilemma_paths(
                 model=model,
@@ -794,11 +799,13 @@ async def _serialize_paths_per_dilemma(
 
     all_paths: list[dict[str, Any]] = []
     total_tokens = 0
+    total_calls = 0
     dilemma_count = len(active_dilemmas)
 
-    for i, (paths, tokens) in enumerate(results, start=1):
+    for i, (paths, tokens, calls) in enumerate(results, start=1):
         all_paths.extend(paths)
         total_tokens += tokens
+        total_calls += calls
         if on_phase_progress is not None:
             did = dilemma_ids[i - 1]
             detail = f"{did} ({len(paths)} paths)" if did else f"{len(paths)} paths"
@@ -809,9 +816,10 @@ async def _serialize_paths_per_dilemma(
         dilemma_count=len(active_dilemmas),
         total_paths=len(all_paths),
         total_tokens=total_tokens,
+        total_calls=total_calls,
     )
 
-    return all_paths, total_tokens
+    return all_paths, total_tokens, total_calls
 
 
 def _build_per_path_beat_context(
@@ -946,7 +954,7 @@ async def _serialize_path_beats(
     callbacks: list[BaseCallbackHandler] | None,
     all_paths: list[dict[str, Any]] | None = None,
     shared_beats_by_dilemma: dict[str, list[dict[str, Any]]] | None = None,
-) -> tuple[list[dict[str, Any]], int]:
+) -> tuple[list[dict[str, Any]], int, int]:
     """Serialize beats for a single path.
 
     Uses a constrained prompt with the path's ID and dilemma hard-coded.
@@ -965,7 +973,7 @@ async def _serialize_path_beats(
             (criterion 3 of #1227).
 
     Returns:
-        Tuple of (list of beat dicts, tokens used).
+        Tuple of (list of beat dicts, tokens used, LLM calls including retries).
     """
     from questfoundry.models.seed import PathBeatsSection
 
@@ -999,7 +1007,7 @@ async def _serialize_path_beats(
         dilemma_id=dilemma_id,
     )
 
-    result, tokens, _ = await serialize_to_artifact(
+    result, tokens, calls = await serialize_to_artifact(
         model=model,
         brief=brief,
         schema=PathBeatsSection,
@@ -1017,9 +1025,10 @@ async def _serialize_path_beats(
         path_id=path_id,
         beat_count=len(beats),
         tokens=tokens,
+        calls=calls,
     )
 
-    return beats, tokens
+    return beats, tokens, calls
 
 
 async def _serialize_beats_per_path(
@@ -1033,7 +1042,7 @@ async def _serialize_beats_per_path(
     on_phase_progress: PhaseProgressFn | None = None,
     max_concurrency: int = 2,
     shared_beats_by_dilemma: dict[str, list[dict[str, Any]]] | None = None,
-) -> tuple[list[dict[str, Any]], int]:
+) -> tuple[list[dict[str, Any]], int, int]:
     """Serialize beats for all paths with bounded concurrency.
 
     Creates tasks for all paths but limits how many run simultaneously
@@ -1057,7 +1066,7 @@ async def _serialize_beats_per_path(
             the pre-commit setup (#1227 criterion 3).
 
     Returns:
-        Tuple of (all beats merged, total tokens used).
+        Tuple of (all beats merged, total tokens used, total LLM calls).
     """
     log.info(
         "serialize_beats_per_path_started",
@@ -1068,7 +1077,7 @@ async def _serialize_beats_per_path(
     path_count = len(paths)
     semaphore = asyncio.Semaphore(max_concurrency)
 
-    async def _limited_serialize(path: dict[str, Any]) -> tuple[list[dict[str, Any]], int]:
+    async def _limited_serialize(path: dict[str, Any]) -> tuple[list[dict[str, Any]], int, int]:
         async with semaphore:
             return await _serialize_path_beats(
                 model=model,
@@ -1083,8 +1092,8 @@ async def _serialize_beats_per_path(
             )
 
     # Create tasks for all paths (semaphore limits actual concurrency)
-    tasks: list[asyncio.Future[tuple[list[dict[str, Any]], int]]] = []
-    task_to_path_id: dict[asyncio.Future[tuple[list[dict[str, Any]], int]], str] = {}
+    tasks: list[asyncio.Future[tuple[list[dict[str, Any]], int, int]]] = []
+    task_to_path_id: dict[asyncio.Future[tuple[list[dict[str, Any]], int, int]], str] = {}
     for path in paths:
         task = asyncio.create_task(_limited_serialize(path))
         tasks.append(task)
@@ -1093,11 +1102,13 @@ async def _serialize_beats_per_path(
     # Collect results as they complete (allows per-path progress reporting)
     all_beats: list[dict[str, Any]] = []
     total_tokens = 0
+    total_calls = 0
 
     for i, future in enumerate(asyncio.as_completed(tasks), start=1):
-        beats, tokens = await future
+        beats, tokens, calls = await future
         all_beats.extend(beats)
         total_tokens += tokens
+        total_calls += calls
         if on_phase_progress is not None:
             path_id = task_to_path_id.get(future, "")
             detail = f"{path_id} ({len(beats)} beats)" if path_id else f"{len(beats)} beats"
@@ -1108,9 +1119,10 @@ async def _serialize_beats_per_path(
         path_count=len(paths),
         total_beats=len(all_beats),
         total_tokens=total_tokens,
+        total_calls=total_calls,
     )
 
-    return all_beats, total_tokens
+    return all_beats, total_tokens, total_calls
 
 
 def _build_shared_beat_context(
@@ -1179,7 +1191,7 @@ async def _serialize_shared_beats_for_dilemma(
     provider_name: str | None,
     max_retries: int,
     callbacks: list[BaseCallbackHandler] | None,
-) -> tuple[list[dict[str, Any]], int]:
+) -> tuple[list[dict[str, Any]], int, int]:
     """Serialize shared pre-commit beats for a single dilemma (Y-shape, #1227).
 
     Issues ONE LLM call that generates the pre-commit beats both explored paths
@@ -1201,7 +1213,7 @@ async def _serialize_shared_beats_for_dilemma(
         callbacks: LangChain callback handlers.
 
     Returns:
-        Tuple of (list of shared beat dicts, tokens used).
+        Tuple of (list of shared beat dicts, tokens used, LLM calls including retries).
     """
     from questfoundry.models.seed import SharedBeatsSection
 
@@ -1216,7 +1228,7 @@ async def _serialize_shared_beats_for_dilemma(
             reason="fewer_than_2_explored_answers",
             explored_count=len(explored),
         )
-        return [], 0
+        return [], 0, 0
 
     prefixed_dilemma_id = normalize_scoped_id(dilemma_id, SCOPE_DILEMMA)
     dilemma_name = prefixed_dilemma_id.removeprefix(f"{SCOPE_DILEMMA}::")
@@ -1273,7 +1285,7 @@ async def _serialize_shared_beats_for_dilemma(
         f'`"dilemma_id": "{prefixed_dilemma_id}"`'
     )
 
-    result, tokens, _ = await serialize_to_artifact(
+    result, tokens, calls = await serialize_to_artifact(
         model=model,
         brief=brief,
         schema=SharedBeatsSection,
@@ -1292,9 +1304,10 @@ async def _serialize_shared_beats_for_dilemma(
         dilemma_id=dilemma_id,
         beat_count=len(beats),
         tokens=tokens,
+        calls=calls,
     )
 
-    return beats, tokens
+    return beats, tokens, calls
 
 
 async def _serialize_shared_beats_per_dilemma(
@@ -1308,7 +1321,7 @@ async def _serialize_shared_beats_per_dilemma(
     callbacks: list[BaseCallbackHandler] | None,
     on_phase_progress: PhaseProgressFn | None = None,
     max_concurrency: int = 2,
-) -> tuple[list[dict[str, Any]], int]:
+) -> tuple[list[dict[str, Any]], int, int]:
     """Serialize shared pre-commit beats for all dilemmas with bounded concurrency.
 
     Filters to dilemmas with at least two explored answers (required for Y-shape
@@ -1331,7 +1344,7 @@ async def _serialize_shared_beats_per_dilemma(
         max_concurrency: Max parallel LLM requests (default 2).
 
     Returns:
-        Tuple of (all shared beats merged, total tokens used).
+        Tuple of (all shared beats merged, total tokens used, total LLM calls).
     """
     # Filter to dilemmas with 2+ explored answers (Y-shape requires dual membership)
     active_dilemmas = [d for d in dilemma_decisions if len(d.get("explored", [])) >= 2]
@@ -1344,13 +1357,13 @@ async def _serialize_shared_beats_per_dilemma(
     )
 
     if not active_dilemmas:
-        return [], 0
+        return [], 0, 0
 
     semaphore = asyncio.Semaphore(max_concurrency)
 
     async def _limited_serialize(
         dilemma: dict[str, Any],
-    ) -> tuple[list[dict[str, Any]], int]:
+    ) -> tuple[list[dict[str, Any]], int, int]:
         async with semaphore:
             return await _serialize_shared_beats_for_dilemma(
                 model=model,
@@ -1370,11 +1383,13 @@ async def _serialize_shared_beats_per_dilemma(
 
     all_shared_beats: list[dict[str, Any]] = []
     total_tokens = 0
+    total_calls = 0
     dilemma_count = len(active_dilemmas)
 
-    for i, (beats, tokens) in enumerate(results, start=1):
+    for i, (beats, tokens, calls) in enumerate(results, start=1):
         all_shared_beats.extend(beats)
         total_tokens += tokens
+        total_calls += calls
         if on_phase_progress is not None:
             did = dilemma_ids[i - 1]
             detail = f"{did} ({len(beats)} beats)" if did else f"{len(beats)} beats"
@@ -1387,9 +1402,10 @@ async def _serialize_shared_beats_per_dilemma(
         dilemma_count=len(active_dilemmas),
         total_beats=len(all_shared_beats),
         total_tokens=total_tokens,
+        total_calls=total_calls,
     )
 
-    return all_shared_beats, total_tokens
+    return all_shared_beats, total_tokens, total_calls
 
 
 # Maps SeedOutput field_path prefixes to section names used in serialization.
@@ -1605,7 +1621,7 @@ async def _early_validate_dilemma_answers(
     max_early_retries: int = 1,
     dilemma_schema: type[BaseModel] | None = None,
     brainstorm_answers: dict[str, list[str]] | None = None,
-) -> tuple[list[dict[str, Any]], int]:
+) -> tuple[list[dict[str, Any]], int, int]:
     """Validate dilemma answer IDs against brainstorm truth and fix if needed.
 
     Checks every explored/unexplored answer ID against the authoritative
@@ -1630,7 +1646,7 @@ async def _early_validate_dilemma_answers(
             already have this data).
 
     Returns:
-        Tuple of (corrected dilemma decisions, tokens used for corrections).
+        Tuple of (corrected dilemma decisions, tokens used, LLM calls used).
     """
     from questfoundry.models.seed import DilemmasSection
 
@@ -1639,6 +1655,7 @@ async def _early_validate_dilemma_answers(
     if brainstorm_answers is None:
         brainstorm_answers = get_brainstorm_answer_ids(graph)
     total_tokens = 0
+    total_calls = 0
 
     for attempt in range(max_early_retries):
         # Collect invalid answer IDs
@@ -1653,7 +1670,7 @@ async def _early_validate_dilemma_answers(
                     invalid.append((did, ans, valid))
 
         if not invalid:
-            return dilemma_decisions, total_tokens
+            return dilemma_decisions, total_tokens, total_calls
 
         log.info(
             "early_dilemma_validation_failed",
@@ -1683,7 +1700,7 @@ async def _early_validate_dilemma_answers(
         # Re-serialize dilemmas with corrections
         corrected_prompt = f"{section_prompt}\n\n{corrections}"
         try:
-            result, tokens, _ = await serialize_to_artifact(
+            result, tokens, calls = await serialize_to_artifact(
                 model=model,
                 brief=build_brief_fn(),
                 schema=schema,
@@ -1694,6 +1711,7 @@ async def _early_validate_dilemma_answers(
                 stage="seed",
             )
             total_tokens += tokens
+            total_calls += calls
             section_data = result.model_dump()
             corrected_dilemmas = section_data.get("dilemmas")
             if not corrected_dilemmas:
@@ -1704,12 +1722,13 @@ async def _early_validate_dilemma_answers(
                 "early_dilemma_validation_corrected",
                 attempt=attempt + 1,
                 tokens=tokens,
+                calls=calls,
             )
         except SerializationError as e:
             log.warning("early_dilemma_correction_failed", error=str(e))
             break
 
-    return dilemma_decisions, total_tokens
+    return dilemma_decisions, total_tokens, total_calls
 
 
 def _suggest_closest(bad_id: str, valid_ids: list[str]) -> str | None:
@@ -1889,6 +1908,7 @@ async def serialize_seed_as_function(
     prompts["dilemmas"] = prompts["dilemmas"].replace("{size_fully_explored}", fully_explored)
 
     total_tokens = 0
+    total_llm_calls = 0
 
     def _build_section_brief(section_name: str) -> str:
         """Build the brief for a specific section.
@@ -1993,7 +2013,7 @@ async def serialize_seed_as_function(
             section_prompt = f"{section_prompt}\n\n{path_ids_context}"
             log.debug("path_ids_injected_into_consequences_prompt")
 
-        section_result, section_tokens, _ = await serialize_to_artifact(
+        section_result, section_tokens, section_calls = await serialize_to_artifact(
             model=model,
             brief=current_brief,
             schema=schema,
@@ -2004,6 +2024,7 @@ async def serialize_seed_as_function(
             stage="seed",
         )
         total_tokens += section_tokens
+        total_llm_calls += section_calls
 
         section_data = section_result.model_dump()
         if output_field not in section_data:
@@ -2052,7 +2073,11 @@ async def serialize_seed_as_function(
             # Catches hallucinated answer IDs (e.g., "trust_strength" instead of
             # "strength") before they cascade to path generation.
             if graph is not None:
-                collected["dilemmas"], early_tokens = await _early_validate_dilemma_answers(
+                (
+                    collected["dilemmas"],
+                    early_tokens,
+                    early_calls,
+                ) = await _early_validate_dilemma_answers(
                     model=model,
                     dilemma_decisions=collected["dilemmas"],
                     graph=graph,
@@ -2065,6 +2090,7 @@ async def serialize_seed_as_function(
                     brainstorm_answers=brainstorm_answers,
                 )
                 total_tokens += early_tokens
+                total_llm_calls += early_calls
 
             # Enrich dilemma decisions with question from graph for prompt.
             # Must run AFTER _early_validate_dilemma_answers because that
@@ -2078,7 +2104,7 @@ async def serialize_seed_as_function(
                         d["question"] = node.get("question", "")
 
             # Generate paths per-dilemma
-            paths, paths_tokens = await _serialize_paths_per_dilemma(
+            paths, paths_tokens, paths_calls = await _serialize_paths_per_dilemma(
                 model=model,
                 dilemma_decisions=collected["dilemmas"],
                 per_dilemma_prompt=prompts["per_dilemma_paths"],
@@ -2090,6 +2116,7 @@ async def serialize_seed_as_function(
             )
             collected["paths"] = paths
             total_tokens += paths_tokens
+            total_llm_calls += paths_calls
 
             # Inject path IDs for consequences and beats
             if collected.get("paths"):
@@ -2104,7 +2131,11 @@ async def serialize_seed_as_function(
             # consumers see the shared setup first.
             shared_beats_by_dilemma: dict[str, list[dict[str, Any]]] = {}
             if collected.get("paths") and collected.get("dilemmas"):
-                shared_beats, shared_beats_tokens = await _serialize_shared_beats_per_dilemma(
+                (
+                    shared_beats,
+                    shared_beats_tokens,
+                    shared_beats_calls,
+                ) = await _serialize_shared_beats_per_dilemma(
                     model=model,
                     dilemma_decisions=collected["dilemmas"],
                     paths=collected["paths"],
@@ -2117,6 +2148,7 @@ async def serialize_seed_as_function(
                 )
                 collected["initial_beats"] = shared_beats
                 total_tokens += shared_beats_tokens
+                total_llm_calls += shared_beats_calls
 
                 # Group shared beats by raw dilemma ID so per-path calls receive
                 # only the beats relevant to their own dilemma (#1227 criterion 3).
@@ -2152,7 +2184,7 @@ async def serialize_seed_as_function(
             # shared_beats_by_dilemma is passed so each per-path call knows what
             # the shared setup established (#1227 criterion 3).
             if collected.get("paths"):
-                beats, beats_tokens = await _serialize_beats_per_path(
+                beats, beats_tokens, beats_calls = await _serialize_beats_per_path(
                     model=model,
                     paths=collected["paths"],
                     per_path_prompt=prompts["per_path_beats"],
@@ -2169,6 +2201,7 @@ async def serialize_seed_as_function(
                 existing_beats = collected.get("initial_beats", [])
                 collected["initial_beats"] = existing_beats + beats
                 total_tokens += beats_tokens
+                total_llm_calls += beats_calls
 
         log.debug(
             "serialize_section_completed",
@@ -2247,7 +2280,7 @@ async def serialize_seed_as_function(
                     current_brief = enhanced_brief
 
                 try:
-                    section_result, section_tokens, _ = await serialize_to_artifact(
+                    section_result, section_tokens, section_calls = await serialize_to_artifact(
                         model=model,
                         brief=current_brief,
                         schema=schema,
@@ -2258,6 +2291,7 @@ async def serialize_seed_as_function(
                         stage="seed",
                     )
                     total_tokens += section_tokens
+                    total_llm_calls += section_calls
                     section_data = section_result.model_dump()
                     if output_field in section_data:
                         collected[output_field] = section_data[output_field]
@@ -2300,7 +2334,7 @@ async def serialize_seed_as_function(
                 if path_corrections:
                     path_prompt = f"{path_prompt}\n\n{path_corrections}"
                 try:
-                    paths, paths_tokens = await _serialize_paths_per_dilemma(
+                    paths, paths_tokens, paths_calls = await _serialize_paths_per_dilemma(
                         model=model,
                         dilemma_decisions=collected["dilemmas"],
                         per_dilemma_prompt=path_prompt,
@@ -2312,6 +2346,7 @@ async def serialize_seed_as_function(
                     )
                     collected["paths"] = paths
                     total_tokens += paths_tokens
+                    total_llm_calls += paths_calls
                     # Refresh path_ids_context
                     path_ids_context = format_path_ids_context(collected["paths"])
                     if path_ids_context:
@@ -2337,8 +2372,8 @@ async def serialize_seed_as_function(
                     beat_prompt = f"{beat_prompt}\n\n{beat_corrections}"
                 try:
                     # Re-generate all beats with current (possibly corrected) paths.
-                    # If paths is empty, _serialize_beats_per_path returns ([], 0) gracefully.
-                    beats, beats_tokens = await _serialize_beats_per_path(
+                    # If paths is empty, _serialize_beats_per_path returns ([], 0, 0) gracefully.
+                    beats, beats_tokens, beats_calls = await _serialize_beats_per_path(
                         model=model,
                         paths=collected["paths"],
                         per_path_prompt=beat_prompt,
@@ -2359,6 +2394,7 @@ async def serialize_seed_as_function(
                     ]
                     collected["initial_beats"] = shared + beats
                     total_tokens += beats_tokens
+                    total_llm_calls += beats_calls
                     retried_any = True
                 except SerializationError as e:
                     log.warning(
@@ -2395,6 +2431,7 @@ async def serialize_seed_as_function(
             return SerializeResult(
                 artifact=seed_output,
                 tokens_used=total_tokens,
+                call_count=total_llm_calls,
                 semantic_errors=blocking_errors,
             )
 
@@ -2406,11 +2443,13 @@ async def serialize_seed_as_function(
         consequences=len(seed_output.consequences),
         beats=len(seed_output.initial_beats),
         tokens=total_tokens,
+        calls=total_llm_calls,
     )
 
     return SerializeResult(
         artifact=seed_output,
         tokens_used=total_tokens,
+        call_count=total_llm_calls,
         semantic_errors=[],
     )
 

--- a/src/questfoundry/agents/serialize.py
+++ b/src/questfoundry/agents/serialize.py
@@ -93,6 +93,9 @@ class SerializeResult:
         call_count: Total LLM calls including Pydantic-retry attempts across
             all sections, per-dilemma helpers, per-path helpers, shared-beat
             helpers, early-validation corrections, and semantic-retry passes.
+            Defaults to 0 for back-compat with existing constructors; new
+            callers in this module MUST pass the summed count or operator
+            llm-call totals will under-report (see #1550).
         semantic_errors: List of semantic validation errors (if any).
     """
 

--- a/src/questfoundry/pipeline/stages/seed.py
+++ b/src/questfoundry/pipeline/stages/seed.py
@@ -423,9 +423,7 @@ class SeedStage:
                 on_phase_progress=on_phase_progress,
                 size_profile=size_profile,
             )
-            # Iterative serialization makes one call per section plus potential retries
-            # (actual count depends on serialize_seed_as_function implementation)
-            total_llm_calls += 6
+            total_llm_calls += result.call_count
             total_tokens += result.tokens_used
 
             # Success - break out of outer loop

--- a/tests/unit/test_seed_stage.py
+++ b/tests/unit/test_seed_stage.py
@@ -160,7 +160,7 @@ async def test_execute_calls_all_three_phases() -> None:
             ],
         )
         mock_serialize.return_value = SerializeResult(
-            artifact=mock_artifact, tokens_used=200, semantic_errors=[]
+            artifact=mock_artifact, tokens_used=200, call_count=6, semantic_errors=[]
         )
         # Convergence analysis: (analyses, tokens, llm_calls)
         mock_convergence.return_value = ([], 30, 1)
@@ -226,7 +226,7 @@ async def test_execute_emits_phase_progress() -> None:
         mock_summarize.return_value = (_MOCK_SECTION_BRIEFS, 100)
         mock_artifact = SeedOutput(entities=[], dilemmas=[], paths=[], initial_beats=[])
         mock_serialize.return_value = SerializeResult(
-            artifact=mock_artifact, tokens_used=200, semantic_errors=[]
+            artifact=mock_artifact, tokens_used=200, call_count=6, semantic_errors=[]
         )
 
         await stage.execute(

--- a/tests/unit/test_serialize.py
+++ b/tests/unit/test_serialize.py
@@ -529,11 +529,11 @@ class TestSerializeResult:
             patch("questfoundry.agents.serialize.serialize_to_artifact") as mock_ser,
             patch(
                 "questfoundry.agents.serialize._serialize_paths_per_dilemma",
-                return_value=([mock_path], 15),
+                return_value=([mock_path], 15, 1),
             ),
             patch(
                 "questfoundry.agents.serialize._serialize_beats_per_path",
-                return_value=([], 20),
+                return_value=([], 20, 1),
             ),
         ):
             mock_ser.side_effect = [
@@ -593,11 +593,11 @@ class TestSerializeResult:
             patch("questfoundry.agents.serialize.serialize_to_artifact") as mock_ser,
             patch(
                 "questfoundry.agents.serialize._serialize_paths_per_dilemma",
-                return_value=([mock_path], 15),
+                return_value=([mock_path], 15, 1),
             ),
             patch(
                 "questfoundry.agents.serialize._serialize_beats_per_path",
-                return_value=([], 20),
+                return_value=([], 20, 1),
             ),
         ):
             # 3 initial sections + 1 retry for entities (semantic error triggers retry)
@@ -669,11 +669,11 @@ class TestSerializeSeedAsFunction:
             patch("questfoundry.agents.serialize.serialize_to_artifact") as mock_serialize,
             patch(
                 "questfoundry.agents.serialize._serialize_paths_per_dilemma",
-                return_value=([mock_path], 15),  # Returns (paths_list, tokens)
+                return_value=([mock_path], 15, 1),  # Returns (paths_list, tokens)
             ),
             patch(
                 "questfoundry.agents.serialize._serialize_beats_per_path",
-                return_value=([], 20),  # Returns (beats_list, tokens)
+                return_value=([], 20, 1),  # Returns (beats_list, tokens)
             ),
         ):
             # Sections: entities, dilemmas, consequences
@@ -697,6 +697,67 @@ class TestSerializeSeedAsFunction:
                 assert result.semantic_errors == []
                 # 3 sections * 10 tokens + 15 from paths + 20 from beats
                 assert result.tokens_used == 65
+                # 3 sections (1 each) + 1 paths + 1 beats = 5 calls
+                assert result.call_count == 5
+
+    @pytest.mark.asyncio
+    async def test_call_count_reflects_retry_attempts(self) -> None:
+        """SerializeResult.call_count must include Pydantic-retry attempts.
+
+        Regression for #1550: previously seed.py hardcoded ``+= 6`` for the
+        whole serialization phase, so retries were invisible to the operator.
+        Each call to ``serialize_to_artifact`` returns ``(result, tokens, calls)``
+        where ``calls`` ≥ 1 when retries occurred. The orchestrator must sum
+        these into ``SerializeResult.call_count``.
+        """
+        from questfoundry.agents.serialize import SerializeResult, serialize_seed_as_function
+
+        mock_model = MagicMock()
+        mock_graph = MagicMock()
+
+        mock_path = {
+            "path_id": "path::test_dilemma__alt1",
+            "dilemma_id": "dilemma::test_dilemma",
+            "answer_id": "alt1",
+            "name": "Test Path",
+            "description": "A test path",
+            "unexplored_answer_ids": [],
+            "path_importance": "major",
+        }
+
+        with (
+            patch("questfoundry.agents.serialize.serialize_to_artifact") as mock_serialize,
+            # Helpers: one retry on the per-dilemma path call (calls=2), and
+            # the per-path beats call (calls=1).
+            patch(
+                "questfoundry.agents.serialize._serialize_paths_per_dilemma",
+                return_value=([mock_path], 15, 2),
+            ),
+            patch(
+                "questfoundry.agents.serialize._serialize_beats_per_path",
+                return_value=([], 20, 1),
+            ),
+        ):
+            # Section calls: entities=1, dilemmas=3 (Pydantic retried twice),
+            # consequences=1. Total direct serialize_to_artifact calls = 5,
+            # plus paths=2 and beats=1 from the helpers = 8 LLM calls.
+            mock_serialize.side_effect = [
+                (MagicMock(model_dump=lambda: {"entities": []}), 10, 1),
+                (MagicMock(model_dump=lambda: {"dilemmas": [_MOCK_DILEMMA]}), 30, 3),
+                (MagicMock(model_dump=lambda: {"consequences": []}), 10, 1),
+            ]
+
+            with patch("questfoundry.agents.serialize.validate_seed_mutations", return_value=[]):
+                result = await serialize_seed_as_function(
+                    model=mock_model,
+                    brief="Test brief",
+                    graph=mock_graph,
+                )
+
+                assert isinstance(result, SerializeResult)
+                # entities(1) + dilemmas(3 — two retries) + consequences(1)
+                # + paths(2) + beats(1) = 8
+                assert result.call_count == 8
 
     @pytest.mark.asyncio
     async def test_returns_result_with_errors_when_semantic_validation_fails(self) -> None:
@@ -720,11 +781,11 @@ class TestSerializeSeedAsFunction:
             patch("questfoundry.agents.serialize.serialize_to_artifact") as mock_serialize,
             patch(
                 "questfoundry.agents.serialize._serialize_paths_per_dilemma",
-                return_value=([], 15),
+                return_value=([], 15, 1),
             ),
             patch(
                 "questfoundry.agents.serialize._serialize_beats_per_path",
-                return_value=([], 20),
+                return_value=([], 20, 1),
             ),
         ):
             mock_serialize.side_effect = [
@@ -760,11 +821,11 @@ class TestSerializeSeedAsFunction:
             patch("questfoundry.agents.serialize.serialize_to_artifact") as mock_serialize,
             patch(
                 "questfoundry.agents.serialize._serialize_paths_per_dilemma",
-                return_value=([], 15),
+                return_value=([], 15, 1),
             ),
             patch(
                 "questfoundry.agents.serialize._serialize_beats_per_path",
-                return_value=([], 20),
+                return_value=([], 20, 1),
             ),
         ):
             # 3 sections (paths + beats handled separately)
@@ -830,11 +891,11 @@ class TestSerializeSeedAsFunction:
             ),
             patch(
                 "questfoundry.agents.serialize._serialize_paths_per_dilemma",
-                return_value=([], 15),
+                return_value=([], 15, 1),
             ),
             patch(
                 "questfoundry.agents.serialize._serialize_beats_per_path",
-                return_value=([], 20),
+                return_value=([], 20, 1),
             ),
             patch("questfoundry.agents.serialize.validate_seed_mutations", return_value=errors),
         ):
@@ -891,11 +952,11 @@ class TestSerializeSeedAsFunction:
             ),
             patch(
                 "questfoundry.agents.serialize._serialize_paths_per_dilemma",
-                return_value=([], 15),
+                return_value=([], 15, 1),
             ),
             patch(
                 "questfoundry.agents.serialize._serialize_beats_per_path",
-                return_value=([], 20),
+                return_value=([], 20, 1),
             ),
             patch("questfoundry.agents.serialize.validate_seed_mutations", return_value=errors),
         ):
@@ -954,11 +1015,11 @@ class TestSerializeSeedAsFunction:
             ),
             patch(
                 "questfoundry.agents.serialize._serialize_paths_per_dilemma",
-                return_value=([], 15),
+                return_value=([], 15, 1),
             ),
             patch(
                 "questfoundry.agents.serialize._serialize_beats_per_path",
-                return_value=([], 20),
+                return_value=([], 20, 1),
             ),
             patch("questfoundry.agents.serialize.validate_seed_mutations", return_value=errors),
         ):
@@ -1190,7 +1251,7 @@ class TestBeatRetryAndContextRefresh:
 
         def increment_and_return(*_args, **_kwargs):
             beat_retry_count[0] += 1
-            return ([], 20)
+            return ([], 20, 1)
 
         mock_beats = AsyncMock(side_effect=increment_and_return)
 
@@ -1219,7 +1280,7 @@ class TestBeatRetryAndContextRefresh:
             patch("questfoundry.agents.serialize.serialize_to_artifact") as mock_serialize,
             patch(
                 "questfoundry.agents.serialize._serialize_paths_per_dilemma",
-                return_value=([mock_path], 15),
+                return_value=([mock_path], 15, 1),
             ),
             patch(
                 "questfoundry.agents.serialize._serialize_beats_per_path",
@@ -1291,7 +1352,7 @@ class TestBeatRetryAndContextRefresh:
 
         def mock_beats_retry(*_args, **_kwargs):
             retry_count[0] += 1
-            return (retried_per_path_beats, 20)
+            return (retried_per_path_beats, 20, 1)
 
         mock_beats = AsyncMock(side_effect=mock_beats_retry)
 
@@ -1329,7 +1390,7 @@ class TestBeatRetryAndContextRefresh:
             patch("questfoundry.agents.serialize.serialize_to_artifact") as mock_serialize,
             patch(
                 "questfoundry.agents.serialize._serialize_paths_per_dilemma",
-                return_value=([mock_path], 15),
+                return_value=([mock_path], 15, 1),
             ),
             patch(
                 "questfoundry.agents.serialize._serialize_beats_per_path",
@@ -1337,7 +1398,7 @@ class TestBeatRetryAndContextRefresh:
             ),
             patch(
                 "questfoundry.agents.serialize._serialize_shared_beats_per_dilemma",
-                return_value=([shared_beat], 10),
+                return_value=([shared_beat], 10, 1),
             ),
             patch(
                 "questfoundry.agents.serialize.validate_seed_mutations",
@@ -1403,7 +1464,7 @@ class TestBeatRetryAndContextRefresh:
 
         async def mock_paths_fn(*_args, **_kwargs):
             path_call_count[0] += 1
-            return ([mock_path], 15)
+            return ([mock_path], 15, 1)
 
         validation_call_count = [0]
 
@@ -1437,7 +1498,7 @@ class TestBeatRetryAndContextRefresh:
             ),
             patch(
                 "questfoundry.agents.serialize._serialize_beats_per_path",
-                return_value=([], 20),
+                return_value=([], 20, 1),
             ),
             patch(
                 "questfoundry.agents.serialize.validate_seed_mutations",
@@ -1484,7 +1545,7 @@ class TestBeatRetryAndContextRefresh:
             call_count[0] += 1
             if call_count[0] == 1:
                 # First call succeeds (initial beat generation)
-                return ([], 20)
+                return ([], 20, 1)
             # Retry call fails with SerializationError
             raise SerializationError(
                 "Beat serialization failed",
@@ -1518,7 +1579,7 @@ class TestBeatRetryAndContextRefresh:
             patch("questfoundry.agents.serialize.serialize_to_artifact") as mock_serialize,
             patch(
                 "questfoundry.agents.serialize._serialize_paths_per_dilemma",
-                return_value=([mock_path], 15),
+                return_value=([mock_path], 15, 1),
             ),
             patch(
                 "questfoundry.agents.serialize._serialize_beats_per_path",
@@ -1643,7 +1704,9 @@ class TestSerializeBeatsPerPathConcurrency:
         current_concurrent = 0
         lock = asyncio.Lock()
 
-        async def _mock_serialize_path_beats(**_kwargs: Any) -> tuple[list[dict[str, Any]], int]:
+        async def _mock_serialize_path_beats(
+            **_kwargs: Any,
+        ) -> tuple[list[dict[str, Any]], int, int]:
             nonlocal peak_concurrent, current_concurrent
             async with lock:
                 current_concurrent += 1
@@ -1651,7 +1714,7 @@ class TestSerializeBeatsPerPathConcurrency:
             await asyncio.sleep(0.05)
             async with lock:
                 current_concurrent -= 1
-            return [{"beat_id": "b1"}], 100
+            return [{"beat_id": "b1"}], 100, 1
 
         paths = [{"path_id": f"path_{i}"} for i in range(6)]
 
@@ -1659,7 +1722,7 @@ class TestSerializeBeatsPerPathConcurrency:
             "questfoundry.agents.serialize._serialize_path_beats",
             side_effect=_mock_serialize_path_beats,
         ):
-            beats, tokens = await _serialize_beats_per_path(
+            beats, tokens, calls = await _serialize_beats_per_path(
                 model=MagicMock(),
                 paths=paths,
                 per_path_prompt="test",
@@ -1672,6 +1735,7 @@ class TestSerializeBeatsPerPathConcurrency:
 
         assert len(beats) == 6
         assert tokens == 600
+        assert calls == 6
         # Semaphore should cap concurrency at 2
         assert peak_concurrent <= 2
 
@@ -1779,7 +1843,7 @@ class TestEarlyValidateDilemmaAnswers:
             {"dilemma_id": "trust_or_betray", "explored": ["trust"], "unexplored": ["betray"]}
         ]
 
-        result, tokens = await _early_validate_dilemma_answers(
+        result, tokens, calls = await _early_validate_dilemma_answers(
             model=mock_model,
             dilemma_decisions=decisions,
             graph=mock_graph,
@@ -1792,6 +1856,7 @@ class TestEarlyValidateDilemmaAnswers:
 
         assert result == decisions
         assert tokens == 0
+        assert calls == 0
 
     @pytest.mark.asyncio
     async def test_invalid_answer_triggers_reserialize(self) -> None:
@@ -1836,7 +1901,7 @@ class TestEarlyValidateDilemmaAnswers:
         with patch("questfoundry.agents.serialize.serialize_to_artifact") as mock_serialize:
             mock_serialize.return_value = (corrected, 50, 1)
 
-            result, tokens = await _early_validate_dilemma_answers(
+            result, tokens, calls = await _early_validate_dilemma_answers(
                 model=mock_model,
                 dilemma_decisions=decisions,
                 graph=mock_graph,
@@ -1849,6 +1914,7 @@ class TestEarlyValidateDilemmaAnswers:
 
         # Should have re-serialized and returned corrected data
         assert tokens == 50
+        assert calls == 1
         assert result[0]["explored"] == ["trust"]
         mock_serialize.assert_called_once()
 
@@ -2435,7 +2501,7 @@ class TestSerializeSharedBeatsForDilemma:
 
         mock_model = MagicMock()
 
-        beats, tokens = await _serialize_shared_beats_for_dilemma(
+        beats, tokens, _calls = await _serialize_shared_beats_for_dilemma(
             model=mock_model,
             dilemma_decision=_MOCK_DILEMMA_SINGLE,
             paths=[],
@@ -2463,7 +2529,7 @@ class TestSerializeSharedBeatsForDilemma:
             new_callable=AsyncMock,
             return_value=(mock_section, 42, 1),
         ) as mock_sat:
-            beats, tokens = await _serialize_shared_beats_for_dilemma(
+            beats, tokens, _calls = await _serialize_shared_beats_for_dilemma(
                 model=MagicMock(),
                 dilemma_decision=_MOCK_DILEMMA_BINARY,
                 paths=_MOCK_PATHS_FOR_BINARY,
@@ -2503,7 +2569,7 @@ class TestSerializeSharedBeatsForDilemma:
             new_callable=AsyncMock,
             return_value=(mock_section, 10, 1),
         ):
-            beats, _tokens = await _serialize_shared_beats_for_dilemma(
+            beats, _tokens, _calls = await _serialize_shared_beats_for_dilemma(
                 model=MagicMock(),
                 dilemma_decision=_MOCK_DILEMMA_BINARY,
                 paths=_MOCK_PATHS_FOR_BINARY,
@@ -2625,15 +2691,15 @@ class TestSerializeSharedBeatsPerDilemma:
 
         call_count: list[int] = [0]
 
-        async def _mock_single(**_kw: Any) -> tuple[list[Any], int]:
+        async def _mock_single(**_kw: Any) -> tuple[list[Any], int, int]:
             call_count[0] += 1
-            return [], 10
+            return [], 10, 1
 
         with patch(
             "questfoundry.agents.serialize._serialize_shared_beats_for_dilemma",
             side_effect=_mock_single,
         ):
-            beats, tokens = await _serialize_shared_beats_per_dilemma(
+            beats, tokens, _calls = await _serialize_shared_beats_per_dilemma(
                 model=MagicMock(),
                 dilemma_decisions=[dilemma_a, dilemma_b, dilemma_single],
                 paths=[],
@@ -2653,7 +2719,7 @@ class TestSerializeSharedBeatsPerDilemma:
         """Should return empty + 0 tokens when no dilemma has 2+ explored."""
         from questfoundry.agents.serialize import _serialize_shared_beats_per_dilemma
 
-        beats, tokens = await _serialize_shared_beats_per_dilemma(
+        beats, tokens, _calls = await _serialize_shared_beats_per_dilemma(
             model=MagicMock(),
             dilemma_decisions=[_MOCK_DILEMMA_SINGLE],
             paths=[],
@@ -2685,15 +2751,15 @@ class TestSerializeSharedBeatsPerDilemma:
             "question": "Q?",
         }
 
-        async def _mock_single(**kw: Any) -> tuple[list[Any], int]:
+        async def _mock_single(**kw: Any) -> tuple[list[Any], int, int]:
             did = kw["dilemma_decision"]["dilemma_id"].replace("dilemma::", "")
-            return [{"beat_id": f"shared_{did}_01", "summary": "s"}], 5
+            return [{"beat_id": f"shared_{did}_01", "summary": "s"}], 5, 1
 
         with patch(
             "questfoundry.agents.serialize._serialize_shared_beats_for_dilemma",
             side_effect=_mock_single,
         ):
-            beats, tokens = await _serialize_shared_beats_per_dilemma(
+            beats, tokens, _calls = await _serialize_shared_beats_per_dilemma(
                 model=MagicMock(),
                 dilemma_decisions=[dilemma_a, dilemma_b],
                 paths=[],
@@ -2720,13 +2786,13 @@ class TestSerializeSeedAsFunctionSharedBeats:
 
         call_order: list[str] = []
 
-        async def _mock_shared(*_args: Any, **_kwargs: Any) -> tuple[list[Any], int]:
+        async def _mock_shared(*_args: Any, **_kwargs: Any) -> tuple[list[Any], int, int]:
             call_order.append("shared")
-            return [], 5
+            return [], 5, 1
 
-        async def _mock_per_path(*_args: Any, **_kwargs: Any) -> tuple[list[Any], int]:
+        async def _mock_per_path(*_args: Any, **_kwargs: Any) -> tuple[list[Any], int, int]:
             call_order.append("per_path")
-            return [], 5
+            return [], 5, 1
 
         mock_path = {
             "path_id": "path::host_benevolent_or_selfish__benevolent",
@@ -2747,7 +2813,7 @@ class TestSerializeSeedAsFunctionSharedBeats:
             patch("questfoundry.agents.serialize.serialize_to_artifact") as mock_serialize,
             patch(
                 "questfoundry.agents.serialize._serialize_paths_per_dilemma",
-                return_value=([mock_path], 10),
+                return_value=([mock_path], 10, 1),
             ),
             patch(
                 "questfoundry.agents.serialize._serialize_shared_beats_per_dilemma",
@@ -2819,15 +2885,15 @@ class TestSerializeSeedAsFunctionSharedBeats:
             patch("questfoundry.agents.serialize.serialize_to_artifact") as mock_serialize,
             patch(
                 "questfoundry.agents.serialize._serialize_paths_per_dilemma",
-                return_value=([mock_path], 10),
+                return_value=([mock_path], 10, 1),
             ),
             patch(
                 "questfoundry.agents.serialize._serialize_shared_beats_per_dilemma",
-                return_value=([shared_beat], 5),
+                return_value=([shared_beat], 5, 1),
             ),
             patch(
                 "questfoundry.agents.serialize._serialize_beats_per_path",
-                return_value=([per_path_beat], 5),
+                return_value=([per_path_beat], 5, 1),
             ),
         ):
             mock_serialize.side_effect = [
@@ -2871,15 +2937,15 @@ class TestSerializeSeedAsFunctionSharedBeats:
             patch("questfoundry.agents.serialize.serialize_to_artifact") as mock_serialize,
             patch(
                 "questfoundry.agents.serialize._serialize_paths_per_dilemma",
-                return_value=([mock_path], 15),
+                return_value=([mock_path], 15, 1),
             ),
             patch(
                 "questfoundry.agents.serialize._serialize_shared_beats_per_dilemma",
-                return_value=([], 77),
+                return_value=([], 77, 1),
             ),
             patch(
                 "questfoundry.agents.serialize._serialize_beats_per_path",
-                return_value=([], 20),
+                return_value=([], 20, 1),
             ),
         ):
             mock_serialize.side_effect = [
@@ -2940,20 +3006,20 @@ class TestSerializeSeedAsFunctionSharedBeats:
 
         async def _mock_per_path(
             *_args: Any, shared_beats_by_dilemma: Any = None, **_kw: Any
-        ) -> tuple[list[Any], int]:
+        ) -> tuple[list[Any], int, int]:
             if shared_beats_by_dilemma is not None:
                 captured_shared_by_dilemma.append(dict(shared_beats_by_dilemma))
-            return [], 0
+            return [], 0, 0
 
         with (
             patch("questfoundry.agents.serialize.serialize_to_artifact") as mock_serialize,
             patch(
                 "questfoundry.agents.serialize._serialize_paths_per_dilemma",
-                return_value=([mock_path], 10),
+                return_value=([mock_path], 10, 1),
             ),
             patch(
                 "questfoundry.agents.serialize._serialize_shared_beats_per_dilemma",
-                return_value=([orphan_beat], 5),
+                return_value=([orphan_beat], 5, 1),
             ),
             patch(
                 "questfoundry.agents.serialize._serialize_beats_per_path",

--- a/tests/unit/test_serialize.py
+++ b/tests/unit/test_serialize.py
@@ -709,6 +709,11 @@ class TestSerializeSeedAsFunction:
         Each call to ``serialize_to_artifact`` returns ``(result, tokens, calls)``
         where ``calls`` ≥ 1 when retries occurred. The orchestrator must sum
         these into ``SerializeResult.call_count``.
+
+        Uses a two-explored-answer dilemma so ``_serialize_shared_beats_per_dilemma``
+        fires (binary dilemmas trigger Y-shape shared-beats generation), exercising
+        every aggregation path: direct sections, per-dilemma paths, shared beats,
+        per-path beats.
         """
         from questfoundry.agents.serialize import SerializeResult, serialize_seed_as_function
 
@@ -724,14 +729,24 @@ class TestSerializeSeedAsFunction:
             "unexplored_answer_ids": [],
             "path_importance": "major",
         }
+        # Two-explored dilemma so _serialize_shared_beats_per_dilemma fires.
+        mock_dilemma_two = {
+            "dilemma_id": "dilemma::test_dilemma",
+            "explored": ["alt1", "alt2"],
+            "unexplored": [],
+        }
 
         with (
             patch("questfoundry.agents.serialize.serialize_to_artifact") as mock_serialize,
-            # Helpers: one retry on the per-dilemma path call (calls=2), and
-            # the per-path beats call (calls=1).
+            # Helpers: one retry on the per-dilemma path call (calls=2),
+            # shared-beats called once (calls=1), per-path beats (calls=1).
             patch(
                 "questfoundry.agents.serialize._serialize_paths_per_dilemma",
                 return_value=([mock_path], 15, 2),
+            ),
+            patch(
+                "questfoundry.agents.serialize._serialize_shared_beats_per_dilemma",
+                return_value=([], 5, 1),
             ),
             patch(
                 "questfoundry.agents.serialize._serialize_beats_per_path",
@@ -740,10 +755,10 @@ class TestSerializeSeedAsFunction:
         ):
             # Section calls: entities=1, dilemmas=3 (Pydantic retried twice),
             # consequences=1. Total direct serialize_to_artifact calls = 5,
-            # plus paths=2 and beats=1 from the helpers = 8 LLM calls.
+            # plus paths=2 + shared=1 + beats=1 from helpers = 9 LLM calls.
             mock_serialize.side_effect = [
                 (MagicMock(model_dump=lambda: {"entities": []}), 10, 1),
-                (MagicMock(model_dump=lambda: {"dilemmas": [_MOCK_DILEMMA]}), 30, 3),
+                (MagicMock(model_dump=lambda: {"dilemmas": [mock_dilemma_two]}), 30, 3),
                 (MagicMock(model_dump=lambda: {"consequences": []}), 10, 1),
             ]
 
@@ -756,8 +771,8 @@ class TestSerializeSeedAsFunction:
 
                 assert isinstance(result, SerializeResult)
                 # entities(1) + dilemmas(3 — two retries) + consequences(1)
-                # + paths(2) + beats(1) = 8
-                assert result.call_count == 8
+                # + paths(2) + shared(1) + beats(1) = 9
+                assert result.call_count == 9
 
     @pytest.mark.asyncio
     async def test_returns_result_with_errors_when_semantic_validation_fails(self) -> None:

--- a/tests/unit/test_serialize.py
+++ b/tests/unit/test_serialize.py
@@ -1324,6 +1324,9 @@ class TestBeatRetryAndContextRefresh:
             assert beat_retry_count[0] == 2
             # Should succeed after retry
             assert result.success is True
+            # Semantic-retry accumulator must include the retried beats helper
+            # call: 3 sections + initial beats + retried beats = at least 5.
+            assert result.call_count >= 5
 
     @pytest.mark.asyncio
     async def test_beats_retry_preserves_shared_beats(self) -> None:
@@ -1445,6 +1448,9 @@ class TestBeatRetryAndContextRefresh:
                 f"Found {len(shared_in_output)} shared beats, expected 1"
             )
             assert shared_in_output[0]["beat_id"] == "shared_setup_01"
+            # Semantic-retry accumulator must include the retried beats helper.
+            # 3 sections + paths + shared + initial beats + retried beats = 7+.
+            assert result.call_count >= 7
 
     @pytest.mark.asyncio
     async def test_path_retry_refreshes_context(self) -> None:
@@ -1530,6 +1536,9 @@ class TestBeatRetryAndContextRefresh:
             # Path retry happened (initial + retry = 2 calls)
             assert path_call_count[0] == 2
             assert result.success is True
+            # Semantic-retry accumulator must include the retried paths helper.
+            # 3 sections + initial paths + retried paths + initial beats = 6+.
+            assert result.call_count >= 6
 
     @pytest.mark.asyncio
     async def test_beat_retry_failure_continues_gracefully(self) -> None:


### PR DESCRIPTION
Closes #1550. Follow-up to PR #1551 (#1452).

## Summary

- PR #1551 made \`serialize_to_artifact\` return \`(artifact, tokens, calls)\`. DREAM/BRAINSTORM/DRESS used it; SEED's **inner** helpers still discarded the attempt count via \`result, tokens, _\` and returned 2-tuples. The pipeline stage compensated with a hardcoded \`total_llm_calls += 6\` — making any retry inside a section invisible to the operator.
- Adds \`SerializeResult.call_count: int\`. Threads call counts through all inner helpers + per-dilemma/per-path/per-shared aggregators + early-validate. \`serialize_seed_as_function\` sums them. \`pipeline/stages/seed.py\` replaces the \`+= 6\` hardcode with \`+= result.call_count\`.

## Files

- \`src/questfoundry/agents/serialize.py\` — 7 helper signature changes, accumulators in 3 per-X loops, summation in orchestrator
- \`src/questfoundry/pipeline/stages/seed.py\` — \`+= 6\` → \`+= result.call_count\`
- \`tests/unit/test_serialize.py\` — mock 3-tuples for all helper return values + new \`test_call_count_reflects_retry_attempts\`
- \`tests/unit/test_seed_stage.py\` — \`SerializeResult(...)\` mocks pass \`call_count=6\`

## Test plan

- [x] \`uv run pytest tests/unit/\` — 4037 tests pass (1 unrelated network-flaky test deselected)
- [x] New \`test_call_count_reflects_retry_attempts\` asserts that a section returning \`calls=3\` (two Pydantic retries) is correctly summed (8 = 1+3+1 sections + 2 paths + 1 beats)
- [x] All 7 \`TestSerializeSeedAsFunction\` tests pass
- [x] \`uv run ruff check\`, \`ruff format\`, \`mypy\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)