### PR TITLE
fix(vram): FP16 embedding surcharge for huge-vocab models + KNOWN_MODELS cap honored (#1523)

### DIFF
--- a/src/questfoundry/providers/factory.py
+++ b/src/questfoundry/providers/factory.py
@@ -196,6 +196,7 @@ def _preprocess_provider_kwargs(
             num_ctx: int | None = None
 
             if max_vram is not None and max_vram > 0 and show_data is not None:
+                from questfoundry.providers.model_info import KNOWN_MODELS
                 from questfoundry.providers.vram import (
                     VramTooSmallError,
                     calculate_max_context,
@@ -209,12 +210,16 @@ def _preprocess_provider_kwargs(
                     # (e.g., gemma4:e2b reports 128K architecturally but
                     # 16K is the practical ceiling) — letting the calculator
                     # exceed it produces silent CPU spillover. See #1523.
-                    from questfoundry.providers.model_info import KNOWN_MODELS
-
                     provider_models = KNOWN_MODELS.get("ollama", {})
                     if model in provider_models:
                         registry_max = provider_models[model].context_window
                         if architectural_max is None or registry_max < architectural_max:
+                            log.debug(
+                                "vram_registry_cap_applied",
+                                model=model,
+                                architectural_max=architectural_max,
+                                registry_max=registry_max,
+                            )
                             architectural_max = registry_max
                     num_ctx = calculate_max_context(
                         max_vram, show_data, architectural_max=architectural_max

--- a/src/questfoundry/providers/factory.py
+++ b/src/questfoundry/providers/factory.py
@@ -203,6 +203,19 @@ def _preprocess_provider_kwargs(
 
                 try:
                     architectural_max = _extract_architectural_max_from_show(show_data, model)
+                    # Cap at the KNOWN_MODELS registry value when the registry
+                    # is tighter than the architectural maximum. The registry
+                    # encodes empirical "max usable on consumer GPUs" caps
+                    # (e.g., gemma4:e2b reports 128K architecturally but
+                    # 16K is the practical ceiling) — letting the calculator
+                    # exceed it produces silent CPU spillover. See #1523.
+                    from questfoundry.providers.model_info import KNOWN_MODELS
+
+                    provider_models = KNOWN_MODELS.get("ollama", {})
+                    if model in provider_models:
+                        registry_max = provider_models[model].context_window
+                        if architectural_max is None or registry_max < architectural_max:
+                            architectural_max = registry_max
                     num_ctx = calculate_max_context(
                         max_vram, show_data, architectural_max=architectural_max
                     )

--- a/src/questfoundry/providers/vram.py
+++ b/src/questfoundry/providers/vram.py
@@ -212,7 +212,31 @@ def calculate_max_context(
     head_count = cast("int", head_count)
     head_count_kv = cast("int", head_count_kv)
 
+    # Base weights estimate at the quantized rate, then add an FP16
+    # surcharge for huge-vocab models (≥100K tokens). Embedding +
+    # untied lm_head matrices are stored at FP16 in GGUF even when the
+    # transformer blocks are quantized — for Gemma-class vocab sizes
+    # (~262K) this adds ≥1 GB that the flat-rate formula misses (#1523).
+    # Conservative assumption: lm_head is untied (separate from embedding).
+    # If the model is actually tied, the surcharge over-estimates by ~50%
+    # which is the safer side: under-estimating causes silent CPU
+    # spillover; over-estimating just yields a smaller-than-optimal num_ctx.
     weights_gb = parameters_b * bytes_per_weight
+    vocab_size = _extract_arch_field(model_info, ".vocab_size")
+    if vocab_size is not None and vocab_size >= 100_000:
+        # The base weights estimate counts these params at the quantized rate;
+        # add only the FP16 ↔ quantized *delta* to avoid double-counting.
+        # FP16 = 2 bytes/element; embedding + untied lm_head = 2 matrices.
+        delta_bytes_per_param = max(2.0 - bytes_per_weight, 0.0)
+        embedding_params = 2 * vocab_size * embedding_length
+        embedding_surcharge_gb = (embedding_params * delta_bytes_per_param) / 1e9
+        weights_gb += embedding_surcharge_gb
+        log.debug(
+            "vram_huge_vocab_surcharge_applied",
+            vocab_size=vocab_size,
+            embedding_length=embedding_length,
+            surcharge_gb=round(embedding_surcharge_gb, 3),
+        )
     overhead_gb = 0.55 + 0.08 * parameters_b
 
     available_for_kv_gb = vram_gb - weights_gb - overhead_gb

--- a/src/questfoundry/providers/vram.py
+++ b/src/questfoundry/providers/vram.py
@@ -234,12 +234,13 @@ def calculate_max_context(
         embedding_params = 2 * vocab_size * embedding_length
         embedding_surcharge_gb = (embedding_params * delta_bytes_per_param) / 1e9
         weights_gb += embedding_surcharge_gb
-        log.debug(
-            "vram_huge_vocab_surcharge_applied",
-            vocab_size=vocab_size,
-            embedding_length=embedding_length,
-            surcharge_gb=round(embedding_surcharge_gb, 3),
-        )
+        if embedding_surcharge_gb > 0.0:
+            log.debug(
+                "vram_huge_vocab_surcharge_applied",
+                vocab_size=vocab_size,
+                embedding_length=embedding_length,
+                surcharge_gb=round(embedding_surcharge_gb, 3),
+            )
     overhead_gb = 0.55 + 0.08 * parameters_b
 
     available_for_kv_gb = vram_gb - weights_gb - overhead_gb

--- a/src/questfoundry/providers/vram.py
+++ b/src/questfoundry/providers/vram.py
@@ -11,7 +11,10 @@ The formula (from https://localllm.in/blog/interactive-vram-calculator):
     VRAM = model_weights + overhead + kv_cache
 
 where:
-    model_weights = P * b_w                      # params * bytes/weight
+    model_weights = P * b_w + fp16_surcharge     # params * bytes/weight
+                                                 # huge-vocab models add an
+                                                 # FP16 embedding+lm_head delta
+                                                 # — see #1523
     overhead      = 0.55 + 0.08 * P              # CUDA buffers + scratchpad
     kv_cache      = B * N * 2 * L * (d/g) * b_kv / 1e9
 

--- a/tests/unit/test_provider_factory.py
+++ b/tests/unit/test_provider_factory.py
@@ -517,6 +517,62 @@ def _llama8b_show_response() -> dict[str, Any]:
     }
 
 
+def test_create_chat_model_ollama_known_models_caps_max_vram_calculation() -> None:
+    """KNOWN_MODELS context_window caps the VRAM calculator's architectural_max.
+
+    Regression for #1523: previously the calculator received only the
+    architectural max from /api/show, not the registry's empirical cap.
+    For models like gemma4:e2b (architecturally 128K, registry-capped 16K
+    "model claims more but is unusable above 16K on consumer GPUs") this
+    let the calculator climb to 131072 and Ollama then spilled weights to
+    CPU. Verifies the registry cap wins when tighter.
+    """
+    from questfoundry.providers.model_info import KNOWN_MODELS, ModelProperties
+
+    mock_chat = MagicMock()
+    show_response = {
+        "details": {
+            "family": "llama",
+            "parameter_size": "8.0B",
+            "quantization_level": "Q4_K_M",
+        },
+        "model_info": {
+            "general.architecture": "llama",
+            "llama.block_count": 32,
+            "llama.embedding_length": 4096,
+            "llama.attention.head_count": 32,
+            "llama.attention.head_count_kv": 8,
+            "llama.context_length": 131_072,  # arch supports 128K
+        },
+        "parameters": "",
+    }
+    # Inject a registry entry that caps tighter than architectural max.
+    capped_models = dict(KNOWN_MODELS)
+    capped_models["ollama"] = dict(KNOWN_MODELS["ollama"])
+    capped_models["ollama"]["test-capped"] = ModelProperties(context_window=16_384)
+
+    with (
+        patch.dict("os.environ", {"OLLAMA_HOST": "http://test:11434"}, clear=False),
+        patch.dict("questfoundry.providers.model_info.KNOWN_MODELS", capped_models, clear=True),
+        patch(
+            "questfoundry.providers.factory._query_ollama_show",
+            return_value=show_response,
+        ),
+        patch(
+            "questfoundry.providers.factory._init_chat_model_safe",
+            return_value=mock_chat,
+        ) as mock_init,
+    ):
+        # Generous VRAM budget — calculator would otherwise climb to ~128K.
+        create_chat_model("ollama", "test-capped", max_vram=64.0)
+
+    call_kwargs = mock_init.call_args[1]
+    # Registry cap is 16K; the calculator must not exceed it.
+    assert call_kwargs["num_ctx"] <= 16_384, (
+        f"registry cap of 16K bypassed; calculator returned {call_kwargs['num_ctx']}"
+    )
+
+
 def test_create_chat_model_ollama_max_vram_kwarg_drives_num_ctx() -> None:
     """max_vram kwarg triggers VRAM-aware num_ctx calculation for Ollama."""
     mock_chat = MagicMock()

--- a/tests/unit/test_provider_vram.py
+++ b/tests/unit/test_provider_vram.py
@@ -85,6 +85,30 @@ def _llama8b_show_fixture(quant: str = "Q4_K_M") -> dict[str, Any]:
     }
 
 
+def _gemma4_e2b_show_fixture(quant: str = "Q4_K_M") -> dict[str, Any]:
+    """Realistic /api/show shape for gemma4:e2b (5.1B params, 262K vocab).
+
+    Captures the huge-vocab pattern that breaks the flat-rate weights
+    formula — see #1523 for the field-observed mismatch (calculator
+    predicted 2.9 GB weights, Ollama loaded 5.4 GB onto CPU).
+    """
+    return {
+        "details": {
+            "family": "gemma3",
+            "parameter_size": "5.1B",
+            "quantization_level": quant,
+        },
+        "model_info": {
+            "general.architecture": "gemma3",
+            "gemma3.block_count": 30,
+            "gemma3.embedding_length": 2304,
+            "gemma3.attention.head_count": 8,
+            "gemma3.attention.head_count_kv": 4,
+            "gemma3.vocab_size": 262_144,
+        },
+    }
+
+
 class TestCalculateMaxContext:
     def test_typical_8b_q4_at_12gb(self) -> None:
         """8B Q4_K_M at 12 GB VRAM yields a reasonable context (≥16K)."""
@@ -157,3 +181,45 @@ class TestCalculateMaxContext:
         ctx_with_gqa = calculate_max_context(12.0, with_gqa)
         # GQA factor 4 means 4x smaller KV cache → much larger ctx
         assert ctx_with_gqa > ctx_no_gqa
+
+    def test_huge_vocab_applies_fp16_embedding_surcharge(self) -> None:
+        """Models with vocab_size ≥ 100K get an FP16 embedding+lm_head surcharge.
+
+        Regression for #1523: gemma4-class models (262K vocab) actually use
+        ~5.4 GB for weights when the flat-rate formula predicts only 2.9 GB,
+        because embedding/lm_head matrices stay at FP16 while the rest of the
+        model is quantized. Without this surcharge the calculator silently
+        over-estimates available KV-cache budget and Ollama spills weights
+        to CPU at runtime.
+        """
+        # Same model run twice, only difference is presence of vocab_size hint.
+        gemma_with_vocab = _gemma4_e2b_show_fixture()
+        gemma_no_vocab = _gemma4_e2b_show_fixture()
+        del gemma_no_vocab["model_info"]["gemma3.vocab_size"]
+
+        ctx_with_surcharge = calculate_max_context(7.5, gemma_with_vocab)
+        ctx_no_surcharge = calculate_max_context(7.5, gemma_no_vocab)
+
+        # The surcharge eats VRAM that would otherwise go to KV cache, so the
+        # context with surcharge applied is strictly smaller.
+        assert ctx_with_surcharge < ctx_no_surcharge, (
+            f"FP16 embedding surcharge must reduce context budget; "
+            f"got {ctx_with_surcharge} (with) >= {ctx_no_surcharge} (without)"
+        )
+        # And the gap should be sizeable for a 262K-vocab model — at Q4_K_M,
+        # the surcharge is ~1.7 GB, plenty to noticeably shrink num_ctx.
+        assert ctx_no_surcharge - ctx_with_surcharge >= 8 * NUM_CTX_ALIGNMENT
+
+    def test_normal_vocab_no_surcharge_applied(self) -> None:
+        """Models with vocab_size < 100K skip the FP16 surcharge (boundary)."""
+        # Llama-3-8B has vocab_size ≈ 128K which IS ≥ 100K — but qwen2.5/Mistral
+        # families use ~32K. Test with an explicit small vocab.
+        small_vocab = _llama8b_show_fixture()
+        small_vocab["model_info"]["llama.vocab_size"] = 32_000
+
+        small_no_vocab_field = _llama8b_show_fixture()  # no vocab_size key
+
+        ctx_small = calculate_max_context(12.0, small_vocab)
+        ctx_no_field = calculate_max_context(12.0, small_no_vocab_field)
+        # No surcharge in either case → identical num_ctx.
+        assert ctx_small == ctx_no_field


### PR DESCRIPTION
Closes #1523.

## Summary

Two field-observed bugs in the VRAM-aware num_ctx calculator from \`projects/murder5\` (gemma4:e2b on a 4060 8 GB):

1. **Weights formula under-estimates huge-vocab models.** Embedding + (typically untied) lm_head stay at FP16 in GGUF even when the rest of the model is Q4_K_M. For 262K-vocab Gemma-class models this is ~1.7 GB the formula silently misses. Adds an FP16 surcharge for \`vocab_size >= 100_000\`, computing only the delta over the already-counted quantized rate.
2. **KNOWN_MODELS cap bypassed.** \`gemma4:e2b\` reports 131072 architecturally but is registry-capped at 16K (\"unusable above 16K on consumer GPUs\"). Factory previously passed only the architectural max — registry cap was ignored. Now \`min(architectural_max, registry_max)\` when registry is tighter.

## Files

- \`src/questfoundry/providers/vram.py\` — FP16 surcharge in \`calculate_max_context\`
- \`src/questfoundry/providers/factory.py\` — registry cap composition
- \`tests/unit/test_provider_vram.py\` — gemma4 fixture + 2 new tests
- \`tests/unit/test_provider_factory.py\` — registry-cap test

## Test plan

- [x] \`test_huge_vocab_applies_fp16_embedding_surcharge\` (262K vocab → smaller num_ctx)
- [x] \`test_normal_vocab_no_surcharge_applied\` (boundary at 100K)
- [x] \`test_create_chat_model_ollama_known_models_caps_max_vram_calculation\` (registry < architectural → registry wins)
- [x] All 151 existing factory + vram + model_info tests pass
- [x] \`uv run ruff check\`, \`ruff format\`, \`mypy\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)