### PR TITLE
fix(providers): respect HTTP 429 rate limits across retry-loop sites

### DIFF
--- a/src/questfoundry/agents/serialize.py
+++ b/src/questfoundry/agents/serialize.py
@@ -39,6 +39,8 @@ from questfoundry.observability.tracing import (
     traceable,
 )
 from questfoundry.pipeline.size import size_template_vars
+from questfoundry.providers.base import ProviderRateLimitError
+from questfoundry.providers.rate_limit import ainvoke_with_rate_limit_retry
 from questfoundry.providers.structured_output import (
     StructuredOutputStrategy,
     unwrap_structured_result,
@@ -309,8 +311,16 @@ async def serialize_to_artifact(
                     callbacks=callbacks,
                 )
 
-                # Invoke structured output
-                raw_result = await structured_model.ainvoke(messages, config=config)
+                # Invoke structured output through the rate-limit-aware helper
+                # so transport-level 429s back off (sleeping retry_after) without
+                # consuming this loop's semantic-retry budget. See #1581: the
+                # bare ``except Exception`` below was absorbing rate-limit
+                # errors and routing them through schema repair, which both
+                # burned attempts and grew the prompt — making the rate-limit
+                # pressure worse on each "retry".
+                raw_result = await ainvoke_with_rate_limit_retry(
+                    structured_model, messages, config=config
+                )
 
                 # Extract token usage from response if available
                 tokens = extract_tokens(raw_result)
@@ -401,6 +411,13 @@ async def serialize_to_artifact(
                     messages.append(HumanMessage(content=error_feedback))
 
             except (KeyboardInterrupt, asyncio.CancelledError):
+                raise
+
+            except ProviderRateLimitError:
+                # Rate-limit helper exhausted its own backoff budget. This is a
+                # hard transport-level failure, NOT a schema/validation error —
+                # surface it to the caller instead of routing through the
+                # schema-repair retry path. See #1581.
                 raise
 
             except Exception as e:

--- a/src/questfoundry/pipeline/config.py
+++ b/src/questfoundry/pipeline/config.py
@@ -58,6 +58,12 @@ class ProvidersConfig:
         structured: Optional provider override for structured role (alias: serialize).
         image: Optional image generation provider (opt-in, no default).
         settings: Role/phase-specific model settings (temperature, top_p, seed).
+        max_concurrency: Optional cap on parallel LLM calls within a stage. When
+            ``None``, falls back to env var ``QF_MAX_CONCURRENCY`` and then the
+            per-provider default in :mod:`questfoundry.providers.model_info`.
+            Useful when a project's API key has a tighter rate limit than the
+            generic provider default — e.g. Anthropic Haiku-tier keys may need
+            ``max_concurrency: 2`` (#1581).
     """
 
     default: str
@@ -66,6 +72,7 @@ class ProvidersConfig:
     structured: str | None = None
     image: str | None = None
     settings: dict[str, PhaseSettings] = field(default_factory=dict)
+    max_concurrency: int | None = None
 
     # Legacy aliases — read-only properties for backwards compatibility
     @property
@@ -187,6 +194,34 @@ class ProvidersConfig:
         balanced = data.get("balanced") or data.get("summarize")
         structured = data.get("structured") or data.get("serialize")
 
+        # Optional concurrency cap. Reject non-positive values rather than
+        # storing them — a 0 or negative cap would deadlock every parallel
+        # call site, so we treat invalid input as "unset" (falls back to env
+        # var and per-provider default).  ``isinstance(True, int)`` is True
+        # in Python, so guard against ``True``/``False`` being mistaken for
+        # an integer cap.
+        raw_concurrency = data.get("max_concurrency")
+        max_concurrency: int | None
+        if (
+            isinstance(raw_concurrency, int)
+            and not isinstance(raw_concurrency, bool)
+            and raw_concurrency > 0
+        ):
+            max_concurrency = raw_concurrency
+        else:
+            max_concurrency = None
+            if raw_concurrency is not None:
+                # User wrote something for ``max_concurrency`` but it didn't
+                # parse — flag it so a typo (``"two"``, ``2.5``, ``True``)
+                # doesn't silently fall back to per-provider defaults.
+                from questfoundry.observability.logging import get_logger
+
+                get_logger(__name__).warning(
+                    "invalid_max_concurrency",
+                    value=raw_concurrency,
+                    value_type=type(raw_concurrency).__name__,
+                )
+
         return cls(
             default=default,
             creative=creative,
@@ -194,6 +229,7 @@ class ProvidersConfig:
             structured=structured,
             image=data.get("image"),
             settings=settings,
+            max_concurrency=max_concurrency,
         )
 
 

--- a/src/questfoundry/pipeline/config.py
+++ b/src/questfoundry/pipeline/config.py
@@ -8,8 +8,12 @@ from typing import TYPE_CHECKING, Any
 
 from ruamel.yaml import YAML
 
+from questfoundry.observability.logging import get_logger
+
 if TYPE_CHECKING:
     from questfoundry.providers.settings import PhaseSettings
+
+log = get_logger(__name__)
 
 # Default configuration values
 DEFAULT_PROVIDER = "ollama"
@@ -214,9 +218,7 @@ class ProvidersConfig:
                 # User wrote something for ``max_concurrency`` but it didn't
                 # parse — flag it so a typo (``"two"``, ``2.5``, ``True``)
                 # doesn't silently fall back to per-provider defaults.
-                from questfoundry.observability.logging import get_logger
-
-                get_logger(__name__).warning(
+                log.warning(
                     "invalid_max_concurrency",
                     value=raw_concurrency,
                     value_type=type(raw_concurrency).__name__,

--- a/src/questfoundry/pipeline/orchestrator.py
+++ b/src/questfoundry/pipeline/orchestrator.py
@@ -226,6 +226,14 @@ class PipelineOrchestrator:
 
             self.config = create_default_config("unnamed")
 
+        # Apply project.yaml's optional concurrency override to the
+        # process-global so per-call-site get_model_info() picks it up
+        # without needing to thread the value through every parallel
+        # batch site (#1581). Env var QF_MAX_CONCURRENCY still wins.
+        from questfoundry.providers.model_info import set_max_concurrency_override
+
+        set_max_concurrency_override(self.config.providers.max_concurrency)
+
         # Load global user config (lowest priority)
         from questfoundry.pipeline.user_config import load_user_config
 

--- a/src/questfoundry/pipeline/stages/dress.py
+++ b/src/questfoundry/pipeline/stages/dress.py
@@ -72,9 +72,11 @@ from questfoundry.observability.tracing import traceable
 from questfoundry.pipeline.batching import batch_llm_calls
 from questfoundry.pipeline.gates import AutoApprovePhaseGate
 from questfoundry.prompts.compiler import safe_format
+from questfoundry.providers.base import ProviderRateLimitError
 from questfoundry.providers.image import PromptDistiller
 from questfoundry.providers.image_brief import ImageBrief, flatten_brief_to_prompt
 from questfoundry.providers.image_factory import create_image_provider
+from questfoundry.providers.rate_limit import ainvoke_with_rate_limit_retry
 from questfoundry.providers.structured_output import (
     StructuredOutputStrategy,
     unwrap_structured_result,
@@ -743,7 +745,12 @@ class DressStage:
             )
 
             try:
-                raw_result = await structured_model.ainvoke(messages, config=config)
+                # Rate-limit-aware invocation: transport-level 429s back off
+                # transparently without consuming this loop's semantic-retry
+                # budget (#1581).
+                raw_result = await ainvoke_with_rate_limit_retry(
+                    structured_model, messages, config=config
+                )
                 llm_calls += 1
                 total_tokens += extract_tokens(raw_result)
 
@@ -754,6 +761,11 @@ class DressStage:
                     else output_schema.model_validate(result)
                 )
                 return validated, llm_calls, total_tokens
+
+            except ProviderRateLimitError:
+                # Backoff exhausted — surface as a hard transport failure,
+                # not a schema-repair attempt (#1581).
+                raise
 
             except (ValidationError, TypeError) as e:
                 log.warning(

--- a/src/questfoundry/pipeline/stages/fill.py
+++ b/src/questfoundry/pipeline/stages/fill.py
@@ -92,6 +92,8 @@ from questfoundry.observability.tracing import traceable
 from questfoundry.pipeline.batching import batch_llm_calls
 from questfoundry.pipeline.gates import AutoApprovePhaseGate
 from questfoundry.prompts.compiler import safe_format
+from questfoundry.providers.base import ProviderRateLimitError
+from questfoundry.providers.rate_limit import ainvoke_with_rate_limit_retry
 from questfoundry.providers.structured_output import (
     unwrap_structured_result,
     with_structured_output,
@@ -725,7 +727,12 @@ class FillStage:
             )
 
             try:
-                raw_result = await structured_model.ainvoke(messages, config=config)
+                # Rate-limit-aware invocation: transport-level 429s back off
+                # transparently without consuming this loop's semantic-retry
+                # budget (#1581).
+                raw_result = await ainvoke_with_rate_limit_retry(
+                    structured_model, messages, config=config
+                )
                 llm_calls += 1
                 total_tokens += extract_tokens(raw_result)
 
@@ -737,6 +744,11 @@ class FillStage:
                 )
                 log.debug("fill_llm_validation_pass", template=template_name)
                 return validated, llm_calls, total_tokens
+
+            except ProviderRateLimitError:
+                # Backoff budget exhausted — surface as a hard transport
+                # failure, NOT a schema-repair attempt (#1581).
+                raise
 
             except (ValidationError, TypeError) as e:
                 failure_type, missing, invalid = _classify_validation_error(e)

--- a/src/questfoundry/pipeline/stages/grow/llm_helper.py
+++ b/src/questfoundry/pipeline/stages/grow/llm_helper.py
@@ -32,6 +32,8 @@ from questfoundry.pipeline.stages.grow._helpers import (
     log,
 )
 from questfoundry.prompts.compiler import safe_format
+from questfoundry.providers.base import ProviderRateLimitError
+from questfoundry.providers.rate_limit import ainvoke_with_rate_limit_retry
 from questfoundry.providers.structured_output import (
     unwrap_structured_result,
     with_structured_output,
@@ -137,7 +139,11 @@ class _LLMHelperMixin:
             )
 
             try:
-                raw_result = await structured_model.ainvoke(messages, config=config)
+                # Rate-limit-aware invocation: 429s back off transparently
+                # without consuming this loop's semantic-retry budget (#1581).
+                raw_result = await ainvoke_with_rate_limit_retry(
+                    structured_model, messages, config=config
+                )
                 llm_calls += 1
                 total_tokens += extract_tokens(raw_result)
 
@@ -178,6 +184,11 @@ class _LLMHelperMixin:
                         # Below threshold or last attempt: return for caller to filter
 
                 return validated, llm_calls, total_tokens
+
+            except ProviderRateLimitError:
+                # Backoff exhausted — surface as a hard transport failure,
+                # not a schema-repair attempt (#1581).
+                raise
 
             except (ValidationError, TypeError) as e:
                 log.info(

--- a/src/questfoundry/pipeline/stages/polish/llm_helper.py
+++ b/src/questfoundry/pipeline/stages/polish/llm_helper.py
@@ -24,6 +24,8 @@ from questfoundry.pipeline.stages.polish._helpers import (
     log,
 )
 from questfoundry.prompts.compiler import safe_format
+from questfoundry.providers.base import ProviderRateLimitError
+from questfoundry.providers.rate_limit import ainvoke_with_rate_limit_retry
 from questfoundry.providers.structured_output import (
     unwrap_structured_result,
     with_structured_output,
@@ -127,7 +129,11 @@ class _PolishLLMHelperMixin:
             )
 
             try:
-                raw_result = await structured_model.ainvoke(messages, config=config)
+                # Rate-limit-aware invocation: 429s back off transparently
+                # without consuming this loop's semantic-retry budget (#1581).
+                raw_result = await ainvoke_with_rate_limit_retry(
+                    structured_model, messages, config=config
+                )
                 llm_calls += 1
                 total_tokens += extract_tokens(raw_result)
 
@@ -140,6 +146,11 @@ class _PolishLLMHelperMixin:
                 log.debug("polish_llm_validation_pass", template=template_name)
 
                 return validated, llm_calls, total_tokens
+
+            except ProviderRateLimitError:
+                # Backoff exhausted — surface as a hard transport failure,
+                # not a schema-repair attempt (#1581).
+                raise
 
             except (ValidationError, TypeError) as e:
                 log.warning(

--- a/src/questfoundry/providers/__init__.py
+++ b/src/questfoundry/providers/__init__.py
@@ -25,6 +25,10 @@ from questfoundry.providers.model_info import (
     ModelInfo,
     get_model_info,
 )
+from questfoundry.providers.rate_limit import (
+    ainvoke_with_rate_limit_retry,
+    classify_rate_limit_error,
+)
 from questfoundry.providers.structured_output import (
     StructuredOutputStrategy,
     get_default_strategy,
@@ -46,6 +50,8 @@ __all__ = [
     "ProviderModelError",
     "ProviderRateLimitError",
     "StructuredOutputStrategy",
+    "ainvoke_with_rate_limit_retry",
+    "classify_rate_limit_error",
     "create_chat_model",
     "create_image_provider",
     "create_model_for_structured_output",

--- a/src/questfoundry/providers/base.py
+++ b/src/questfoundry/providers/base.py
@@ -18,9 +18,22 @@ class ProviderConnectionError(ProviderError):
 
 
 class ProviderRateLimitError(ProviderError):
-    """Raised when rate limit is exceeded."""
+    """Raised when rate limit is exceeded.
 
-    pass
+    Carries an optional ``retry_after_seconds`` hint extracted from the provider
+    response (HTTP ``Retry-After`` header or equivalent). Used by the rate-limit
+    helper to schedule backoff and by callers that need to surface the wait
+    window — see ``providers/rate_limit.py``.
+    """
+
+    def __init__(
+        self,
+        provider: str,
+        message: str,
+        retry_after_seconds: float | None = None,
+    ) -> None:
+        super().__init__(provider, message)
+        self.retry_after_seconds = retry_after_seconds
 
 
 class ProviderModelError(ProviderError):

--- a/src/questfoundry/providers/model_info.py
+++ b/src/questfoundry/providers/model_info.py
@@ -192,6 +192,50 @@ _PROVIDER_MAX_CONCURRENCY: dict[str, int] = {
 }
 
 
+# Process-global concurrency override, set from project.yaml's
+# ``providers.max_concurrency`` by the orchestrator at startup.  Exists so
+# project config can constrain a parallel-friendly provider (e.g. drop
+# Anthropic from 10 to 2 on a Haiku-tier key) without threading the value
+# through every ``get_model_info()`` call site.  The env var
+# ``QF_MAX_CONCURRENCY`` still takes precedence — see ``get_model_info``.
+_max_concurrency_override: int | None = None
+
+
+def _resolve_max_concurrency(provider_lower: str) -> int:
+    """Resolve the concurrency cap using the documented precedence chain.
+
+    Precedence: ``QF_MAX_CONCURRENCY`` env > project.yaml override >
+    per-provider default. A non-positive or malformed env value falls
+    through rather than silently being clamped — an operator setting
+    ``QF_MAX_CONCURRENCY=0`` is far more likely trying to disable
+    concurrency than to pin it to 1, and silently rewriting their input
+    would surprise.
+    """
+    env_concurrency = os.environ.get("QF_MAX_CONCURRENCY")
+    if env_concurrency is not None:
+        try:
+            parsed = int(env_concurrency)
+        except ValueError:
+            parsed = None
+        if parsed is not None and parsed > 0:
+            return parsed
+        # Malformed or non-positive env — fall through to the next tier.
+    if _max_concurrency_override is not None:
+        return _max_concurrency_override
+    return _PROVIDER_MAX_CONCURRENCY.get(provider_lower, 2)
+
+
+def set_max_concurrency_override(value: int | None) -> None:
+    """Set the process-global concurrency override.
+
+    Pass ``None`` to clear (revert to env var / per-provider default). Pass a
+    positive int to apply. Non-positive values are coerced to ``None`` since
+    a 0 or negative cap would deadlock every parallel call site.
+    """
+    global _max_concurrency_override
+    _max_concurrency_override = None if value is None or value <= 0 else value
+
+
 def get_model_info(provider: str, model: str) -> ModelInfo:
     """Get model information from known values or defaults.
 
@@ -215,17 +259,12 @@ def get_model_info(provider: str, model: str) -> ModelInfo:
         supports_vision = False
         supports_tools = True  # Default to True for unknown models
 
-    # Concurrency: env var override > provider default > fallback
-    env_concurrency = os.environ.get("QF_MAX_CONCURRENCY")
-    if env_concurrency is not None:
-        try:
-            max_concurrency = int(env_concurrency)
-            if max_concurrency <= 0:
-                max_concurrency = 1
-        except ValueError:
-            max_concurrency = _PROVIDER_MAX_CONCURRENCY.get(provider_lower, 2)
-    else:
-        max_concurrency = _PROVIDER_MAX_CONCURRENCY.get(provider_lower, 2)
+    # Concurrency precedence (#1581):
+    #   QF_MAX_CONCURRENCY env > project.yaml override > per-provider default
+    # A malformed env var falls through to the next tier (override, then
+    # default) — silently bypassing the override on bad input would surprise
+    # the operator who set both.
+    max_concurrency = _resolve_max_concurrency(provider_lower)
 
     return ModelInfo(
         context_window=context_window,

--- a/src/questfoundry/providers/rate_limit.py
+++ b/src/questfoundry/providers/rate_limit.py
@@ -1,0 +1,262 @@
+"""Rate-limit classification and backoff helpers for LLM providers.
+
+The classifier and helper here exist so transport-level HTTP 429 errors do
+not burn a slot in the per-stage *semantic* retry budget. Issue #1581: a bare
+``except Exception`` in the validation/repair loops was routing rate-limit
+errors through the schema-repair path, appending an apology ``HumanMessage``
+and immediately retrying with no backoff — making the rate-limit pressure
+worse and exhausting the retry budget on transport errors.
+
+The module exports two pieces:
+
+- ``classify_rate_limit_error(exc)`` — walk the exception ``__cause__`` /
+  ``__context__`` chain and return a ``ProviderRateLimitError`` (with
+  ``retry_after_seconds``) if any layer looks like a rate-limit. Returns
+  ``None`` otherwise.
+- ``ainvoke_with_rate_limit_retry(model, messages, *, config)`` — wrap a
+  LangChain ``model.ainvoke`` call. On rate-limit, sleep and retry without
+  consuming the caller's semantic-retry budget. On any other exception,
+  re-raise immediately. After exceeding the total wait budget, raise
+  ``ProviderRateLimitError`` so the caller surfaces a hard transport failure.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import random
+from typing import TYPE_CHECKING, Any
+
+from questfoundry.observability.logging import get_logger
+from questfoundry.providers.base import ProviderRateLimitError
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+    from langchain_core.messages import BaseMessage
+
+log = get_logger(__name__)
+
+
+SINGLE_WAIT_CAP_SECONDS: float = 60.0
+"""Maximum seconds to sleep on any single backoff. Caps a runaway header
+value (provider could legally say "wait 600s") so the helper never blocks
+a stage for that long without the caller getting a chance to surface it."""
+
+TOTAL_WAIT_CAP_SECONDS: float = 300.0
+"""Maximum cumulative sleep across one ``ainvoke`` call. Beyond this we give
+up and raise ``ProviderRateLimitError`` so the caller can decide what to do
+(typically: fail the stage cleanly, with a message that says transport, not
+schema)."""
+
+DEFAULT_INITIAL_WAIT_SECONDS: float = 5.0
+"""Base delay for exponential backoff when the provider sends a 429 with no
+``Retry-After`` header. Doubles on each consecutive rate-limit until either
+``SINGLE_WAIT_CAP_SECONDS`` is hit or we exit."""
+
+_MAX_BACKOFF_ATTEMPTS: int = 12
+"""Hard ceiling on backoff loop iterations — prevents an infinite loop when
+both the total-wait cap math and the provider behave pathologically."""
+
+_JITTER_FRACTION: float = 0.10
+"""±10% jitter applied to every sleep so parallel callers don't stampede the
+same reset window."""
+
+
+def classify_rate_limit_error(exc: BaseException) -> ProviderRateLimitError | None:
+    """Return a ``ProviderRateLimitError`` if ``exc`` (or any wrapped cause)
+    is a rate-limit, else ``None``.
+
+    Recognises:
+    - ``anthropic.RateLimitError`` and ``openai.RateLimitError`` (both expose
+      a ``.response`` attribute with status 429 and a ``Retry-After`` header).
+    - ``google.api_core.exceptions.ResourceExhausted`` by class name.
+    - Any exception with a ``.response`` whose ``.status_code == 429``
+      (catches ``httpx.HTTPStatusError`` and any LangChain wrapper that
+      preserves ``.response``).
+    - Any exception with ``.status_code == 429`` directly on the instance.
+    """
+    seen: set[int] = set()
+    cur: BaseException | None = exc
+    while cur is not None and id(cur) not in seen:
+        seen.add(id(cur))
+        info = _classify_single(cur)
+        if info is not None:
+            return info
+        cur = cur.__cause__ or cur.__context__
+    return None
+
+
+def _classify_single(exc: BaseException) -> ProviderRateLimitError | None:
+    """Classify one exception (no chain walk)."""
+    name = type(exc).__name__
+    module = type(exc).__module__
+
+    # google.api_core.exceptions.ResourceExhausted — class-name match because
+    # the package is optional in this project (only present when google extras
+    # are installed). Gate on module prefix so a third-party class that happens
+    # to share the name isn't misclassified as a Google rate-limit.
+    if name == "ResourceExhausted" and (
+        module.startswith("google") or module.startswith("langchain_google")
+    ):
+        return ProviderRateLimitError("google", str(exc) or "ResourceExhausted")
+
+    # Provider-specific RateLimitError classes (anthropic + openai both name
+    # them this and both expose .response). Match by name + module-prefix to
+    # avoid colliding with any future custom subclass that happens to share
+    # the suffix.
+    if name == "RateLimitError" and (module.startswith("anthropic") or module.startswith("openai")):
+        provider = _provider_from_module(module)
+        retry_after = _read_retry_after(getattr(exc, "response", None))
+        return ProviderRateLimitError(provider, str(exc) or "rate_limit", retry_after)
+
+    # Generic 429 via response object (httpx.HTTPStatusError, LangChain wraps).
+    response = getattr(exc, "response", None)
+    if response is not None and getattr(response, "status_code", None) == 429:
+        provider = _provider_from_module(module)
+        retry_after = _read_retry_after(response)
+        return ProviderRateLimitError(provider, str(exc) or "rate_limit", retry_after)
+
+    # status_code on the exception itself (some thin wrappers).
+    if getattr(exc, "status_code", None) == 429:
+        provider = _provider_from_module(module)
+        return ProviderRateLimitError(provider, str(exc) or "rate_limit")
+
+    return None
+
+
+def _provider_from_module(module: str) -> str:
+    """Map a Python module name to a provider tag (best-effort)."""
+    if module.startswith("anthropic") or module.startswith("langchain_anthropic"):
+        return "anthropic"
+    if module.startswith("openai") or module.startswith("langchain_openai"):
+        return "openai"
+    if module.startswith("google") or module.startswith("langchain_google"):
+        return "google"
+    return "unknown"
+
+
+def _read_retry_after(response: Any) -> float | None:
+    """Extract ``Retry-After`` seconds from a response's headers, if present.
+
+    Provider quirks the helper ignores deliberately:
+    - HTTP-date format for ``Retry-After`` (e.g. ``Wed, 21 Oct 2026 07:28:00 GMT``)
+      — accepted by the spec but rare in practice for 429s. We fall back to
+      our exponential default if the value isn't a parseable float.
+    - Anthropic's ``anthropic-ratelimit-*-reset`` headers — expressed as
+      seconds-until-reset *or* an absolute timestamp depending on header.
+      ``Retry-After`` is always present alongside on a 429, so reading just
+      that is sufficient and avoids per-provider parsing.
+    """
+    if response is None:
+        return None
+    headers = getattr(response, "headers", None)
+    if not headers:
+        return None
+    raw = headers.get("retry-after") or headers.get("Retry-After")
+    if not raw:
+        return None
+    try:
+        seconds = float(raw)
+    except (TypeError, ValueError):
+        return None
+    if seconds < 0:
+        return None
+    return seconds
+
+
+def _next_backoff(retry_after_hint: float | None, consecutive: int) -> float:
+    """Compute the next sleep duration, with jitter, respecting the cap."""
+    if retry_after_hint is not None and retry_after_hint > 0:
+        base = retry_after_hint
+    else:
+        # 5, 10, 20, 40, 60, 60... seconds
+        base = DEFAULT_INITIAL_WAIT_SECONDS * (2 ** max(0, consecutive - 1))
+
+    capped = min(base, SINGLE_WAIT_CAP_SECONDS)
+    jitter = capped * _JITTER_FRACTION * (random.random() * 2 - 1)
+    return max(0.0, capped + jitter)
+
+
+async def ainvoke_with_rate_limit_retry(
+    model: Any,
+    messages: Sequence[BaseMessage],
+    *,
+    config: Any = None,
+) -> Any:
+    """Invoke ``model.ainvoke(messages, config=config)`` with rate-limit-aware
+    retry.
+
+    Behaviour:
+    - On success, return the result.
+    - On a classified rate-limit error, sleep ``retry_after`` seconds (jittered,
+      capped at ``SINGLE_WAIT_CAP_SECONDS``) and retry. This does NOT count
+      toward the caller's semantic-retry budget — that budget is reserved for
+      schema/validation failures.
+    - On any other exception, re-raise immediately so the caller's existing
+      ``except ValidationError`` / ``except Exception`` paths run unchanged.
+    - If cumulative sleep would exceed ``TOTAL_WAIT_CAP_SECONDS``, raise the
+      classified ``ProviderRateLimitError`` so the caller surfaces a clear
+      transport-level failure (and does not append a schema-repair message).
+    """
+    total_waited = 0.0
+    consecutive = 0
+    last_classified: ProviderRateLimitError | None = None
+
+    for attempt in range(1, _MAX_BACKOFF_ATTEMPTS + 1):
+        try:
+            return await model.ainvoke(messages, config=config)
+        except (KeyboardInterrupt, asyncio.CancelledError):
+            raise
+        except Exception as exc:
+            classified = classify_rate_limit_error(exc)
+            if classified is None:
+                raise
+            consecutive += 1
+            last_classified = classified
+            wait = _next_backoff(classified.retry_after_seconds, consecutive)
+
+            if total_waited + wait > TOTAL_WAIT_CAP_SECONDS:
+                log.error(
+                    "rate_limit_total_wait_exceeded",
+                    provider=classified.provider,
+                    total_waited=total_waited,
+                    next_wait=wait,
+                    cap=TOTAL_WAIT_CAP_SECONDS,
+                    attempt=attempt,
+                )
+                raise classified from exc
+
+            # INFO, not WARNING: the helper detected a 429 and handled it
+            # correctly. CLAUDE.md reserves WARNING for "this worked but
+            # someone should look at it". The two error-level logs above
+            # (``rate_limit_total_wait_exceeded`` / ``_attempts_exhausted``)
+            # are the failure paths — those re-raise.
+            log.info(
+                "rate_limit_backoff",
+                provider=classified.provider,
+                wait_seconds=round(wait, 2),
+                attempt=attempt,
+                total_waited=round(total_waited, 2),
+                retry_after_hint=classified.retry_after_seconds,
+            )
+            await asyncio.sleep(wait)
+            total_waited += wait
+
+    # Iteration ceiling reached without success.  ``last_classified`` is set
+    # because every loop iteration either returns, re-raises a non-rate-limit
+    # exception, or assigns ``last_classified`` before retrying — and an empty
+    # iteration range is impossible (range(1, 13)).
+    log.error(
+        "rate_limit_attempts_exhausted",
+        attempts=_MAX_BACKOFF_ATTEMPTS,
+        total_waited=round(total_waited, 2),
+    )
+    # Explicit guard rather than ``assert`` — assertions are stripped under
+    # ``python -O``, which would turn a broken invariant into ``raise None``
+    # (a confusing TypeError instead of a real diagnostic).
+    if last_classified is None:  # pragma: no cover — invariant from loop above
+        raise RuntimeError(
+            f"rate_limit_attempts_exhausted: no classified error captured after "
+            f"{_MAX_BACKOFF_ATTEMPTS} iterations"
+        )
+    raise last_classified

--- a/src/questfoundry/providers/rate_limit.py
+++ b/src/questfoundry/providers/rate_limit.py
@@ -53,9 +53,12 @@ DEFAULT_INITIAL_WAIT_SECONDS: float = 5.0
 ``Retry-After`` header. Doubles on each consecutive rate-limit until either
 ``SINGLE_WAIT_CAP_SECONDS`` is hit or we exit."""
 
-_MAX_BACKOFF_ATTEMPTS: int = 12
-"""Hard ceiling on backoff loop iterations — prevents an infinite loop when
-both the total-wait cap math and the provider behave pathologically."""
+_MAX_BACKOFF_ATTEMPTS: int = 600
+"""Hard ceiling on backoff loop iterations — defensive only. The real
+give-up gate is ``TOTAL_WAIT_CAP_SECONDS``. Set high enough that a provider
+returning ``Retry-After: 1`` (the smallest realistic short hint) can still
+exhaust the full 300s budget before this cap fires; an earlier value of 12
+silently capped runs at ~12s on short hints, defeating the time budget."""
 
 _JITTER_FRACTION: float = 0.10
 """±10% jitter applied to every sleep so parallel callers don't stampede the
@@ -245,7 +248,7 @@ async def ainvoke_with_rate_limit_retry(
     # Iteration ceiling reached without success.  ``last_classified`` is set
     # because every loop iteration either returns, re-raises a non-rate-limit
     # exception, or assigns ``last_classified`` before retrying — and an empty
-    # iteration range is impossible (range(1, 13)).
+    # iteration range is impossible (range(1, _MAX_BACKOFF_ATTEMPTS + 1)).
     log.error(
         "rate_limit_attempts_exhausted",
         attempts=_MAX_BACKOFF_ATTEMPTS,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,7 @@
 """Pytest configuration and shared fixtures."""
 
 import os
+from collections.abc import Generator
 from pathlib import Path
 
 import pytest
@@ -15,6 +16,23 @@ def disable_langsmith_tracing() -> None:
     """
     if os.environ.get("LANGSMITH_TEST_TRACING", "").lower() != "true":
         os.environ["LANGSMITH_TRACING"] = "false"
+
+
+@pytest.fixture(autouse=True)
+def _reset_max_concurrency_override() -> Generator[None, None, None]:
+    """Reset the process-global concurrency override around every test.
+
+    The orchestrator constructor mutates this global from project.yaml. Without
+    a reset, a leak from one test's orchestrator would change the result of
+    ``get_model_info()`` in unrelated tests run later in the same session.
+    Pinned at the suite level (#1581 review) rather than per-file so the
+    invariant doesn't depend on which file owns the override.
+    """
+    from questfoundry.providers.model_info import set_max_concurrency_override
+
+    set_max_concurrency_override(None)
+    yield
+    set_max_concurrency_override(None)
 
 
 @pytest.fixture

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -8,6 +8,8 @@ from unittest.mock import patch
 if TYPE_CHECKING:
     from pathlib import Path
 
+    import pytest
+
 from questfoundry.pipeline.config import (
     DEFAULT_MODEL,
     DEFAULT_PROVIDER,
@@ -221,6 +223,67 @@ class TestProvidersConfig:
 
         with patch.dict("os.environ", {"QF_IMAGE_PROVIDER": "placeholder"}):
             assert config.get_image_provider() == "openai/gpt-image-1"
+
+    def test_from_dict_with_max_concurrency(self) -> None:
+        """providers.max_concurrency parses as an int (#1581)."""
+        config = ProvidersConfig.from_dict(
+            {"default": "anthropic/claude-haiku-4-5-20251001", "max_concurrency": 2}
+        )
+
+        assert config.max_concurrency == 2
+
+    def test_from_dict_max_concurrency_default_none(self) -> None:
+        """max_concurrency is optional — absent means 'use per-provider default'."""
+        config = ProvidersConfig.from_dict({"default": "ollama/qwen3:4b-instruct-32k"})
+
+        assert config.max_concurrency is None
+
+    def test_from_dict_max_concurrency_invalid_falls_back(self) -> None:
+        """Non-positive max_concurrency is rejected (treated as None)."""
+        config = ProvidersConfig.from_dict(
+            {"default": "ollama/qwen3:4b-instruct-32k", "max_concurrency": 0}
+        )
+
+        assert config.max_concurrency is None
+
+    def test_from_dict_max_concurrency_rejects_bool(self) -> None:
+        """``True`` / ``False`` are not valid concurrency caps even though
+        ``isinstance(True, int)`` is true in Python."""
+        config = ProvidersConfig.from_dict(
+            {"default": "ollama/qwen3:4b-instruct-32k", "max_concurrency": True}
+        )
+
+        assert config.max_concurrency is None
+
+    def test_from_dict_max_concurrency_logs_warning_on_invalid_input(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Invalid types (string, float) emit a warning so users catch typos."""
+        import logging
+
+        with caplog.at_level(logging.WARNING):
+            config = ProvidersConfig.from_dict(
+                {"default": "ollama/qwen3:4b-instruct-32k", "max_concurrency": "two"}
+            )
+
+        assert config.max_concurrency is None
+        # structlog routes through stdlib logging; the event name appears in
+        # the rendered message regardless of whether stdlib or structlog
+        # formatting is active.
+        assert any("invalid_max_concurrency" in record.getMessage() for record in caplog.records)
+
+    def test_from_dict_max_concurrency_no_warning_when_absent(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """A missing ``max_concurrency`` is not invalid input — no warning."""
+        import logging
+
+        with caplog.at_level(logging.WARNING):
+            ProvidersConfig.from_dict({"default": "ollama/qwen3:4b-instruct-32k"})
+
+        assert not any(
+            "invalid_max_concurrency" in record.getMessage() for record in caplog.records
+        )
 
 
 # --- Tests for ProjectConfig with hybrid providers ---

--- a/tests/unit/test_model_info.py
+++ b/tests/unit/test_model_info.py
@@ -9,7 +9,11 @@ from questfoundry.providers.model_info import (
     ModelInfo,
     ModelProperties,
     get_model_info,
+    set_max_concurrency_override,
 )
+
+# The autouse fixture in tests/conftest.py resets the concurrency override
+# around every test, so no per-file fixture is needed here.
 
 
 class TestModelInfoDefaults:
@@ -51,6 +55,44 @@ class TestModelInfoDefaults:
         with patch.dict("os.environ", {"QF_MAX_CONCURRENCY": "10"}):
             info = get_model_info("ollama", "qwen3:4b-instruct-32k")
             assert info.max_concurrency == 10
+
+    def test_global_override_via_set_max_concurrency_override(self) -> None:
+        """set_max_concurrency_override() affects subsequent get_model_info() calls."""
+        set_max_concurrency_override(3)
+        info = get_model_info("anthropic", "claude-haiku-4-5-20251001")
+        assert info.max_concurrency == 3
+
+    def test_env_var_takes_precedence_over_global_override(self) -> None:
+        """Precedence: env QF_MAX_CONCURRENCY > project config override > per-provider default."""
+        set_max_concurrency_override(3)
+        with patch.dict("os.environ", {"QF_MAX_CONCURRENCY": "7"}):
+            info = get_model_info("anthropic", "claude-haiku-4-5-20251001")
+            assert info.max_concurrency == 7
+
+    def test_global_override_cleared_with_none(self) -> None:
+        """Setting the override to None reverts to per-provider default."""
+        set_max_concurrency_override(3)
+        set_max_concurrency_override(None)
+        info = get_model_info("anthropic", "claude-haiku-4-5-20251001")
+        assert info.max_concurrency == 10  # Anthropic default
+
+    def test_malformed_env_falls_through_to_override(self) -> None:
+        """A non-integer QF_MAX_CONCURRENCY does not silently bypass the override."""
+        set_max_concurrency_override(3)
+        with patch.dict("os.environ", {"QF_MAX_CONCURRENCY": "not-a-number"}):
+            info = get_model_info("anthropic", "claude-haiku-4-5-20251001")
+            assert info.max_concurrency == 3  # override, not anthropic default of 10
+
+    def test_zero_or_negative_env_falls_through_to_override(self) -> None:
+        """A non-positive QF_MAX_CONCURRENCY is treated as 'unset', not clamped to 1.
+
+        Silently rewriting ``0`` to ``1`` would surprise operators trying to
+        disable concurrency.
+        """
+        set_max_concurrency_override(3)
+        with patch.dict("os.environ", {"QF_MAX_CONCURRENCY": "0"}):
+            info = get_model_info("anthropic", "claude-haiku-4-5-20251001")
+            assert info.max_concurrency == 3  # override, not 1
 
 
 class TestModelInfoDataclass:

--- a/tests/unit/test_rate_limit.py
+++ b/tests/unit/test_rate_limit.py
@@ -91,6 +91,36 @@ class TestClassifierRecognizesWrappedHttpx:
         assert classify_rate_limit_error(exc) is None
 
 
+class TestClassifierRecognizesGoogleResourceExhausted:
+    def test_google_resource_exhausted_by_class_name_and_module(self) -> None:
+        """``google.api_core.exceptions.ResourceExhausted`` is detected by
+        class-name + module-prefix gating, without requiring the optional
+        ``google-api-core`` package to be installed."""
+        fake_cls = type(
+            "ResourceExhausted",
+            (Exception,),
+            {"__module__": "google.api_core.exceptions"},
+        )
+        exc = fake_cls("quota exceeded")
+
+        classified = classify_rate_limit_error(exc)
+
+        assert classified is not None
+        assert classified.provider == "google"
+
+    def test_other_module_with_same_classname_not_classified(self) -> None:
+        """A class named ``ResourceExhausted`` from an unrelated module is NOT
+        classified — the module-prefix gate is the safeguard."""
+        fake_cls = type(
+            "ResourceExhausted",
+            (Exception,),
+            {"__module__": "some.unrelated.package"},
+        )
+        exc = fake_cls("not actually rate-limited")
+
+        assert classify_rate_limit_error(exc) is None
+
+
 class TestClassifierWalksExceptionChain:
     def test_walks_cause_chain(self) -> None:
         """Classifier finds rate-limit deeper in __cause__."""
@@ -207,6 +237,49 @@ class TestAinvokeWithRateLimitRetryGivesUp:
         # Some sleeps should have happened before giving up.
         assert sum(slept) <= TOTAL_WAIT_CAP_SECONDS + SINGLE_WAIT_CAP_SECONDS
         assert len(slept) >= 1
+
+
+class TestBudgetCapDominatesIterationCap:
+    @pytest.mark.asyncio
+    async def test_short_retry_after_uses_full_time_budget(self) -> None:
+        """A provider sending ``Retry-After: 1`` should be retried until the
+        full ``TOTAL_WAIT_CAP_SECONDS`` budget is spent, not capped at the
+        iteration ceiling.
+
+        Regression for the iteration-cap-vs-budget interaction: an earlier
+        ``_MAX_BACKOFF_ATTEMPTS`` of 12 silently bounded short-hint retries to
+        ~12 seconds even though the time budget was 300s.
+        """
+        import anthropic
+
+        response = _build_httpx_response(429, {"retry-after": "1"})
+
+        class _Model:
+            calls = 0
+
+            async def ainvoke(self, _messages: list[Any], **_kwargs: Any) -> str:
+                _Model.calls += 1
+                raise anthropic.RateLimitError("rate", response=response, body=None)
+
+        slept: list[float] = []
+
+        async def _fake_sleep(seconds: float) -> None:
+            slept.append(seconds)
+
+        with (
+            patch("questfoundry.providers.rate_limit.asyncio.sleep", _fake_sleep),
+            pytest.raises(ProviderRateLimitError),
+        ):
+            await ainvoke_with_rate_limit_retry(_Model(), [], config=None)
+
+        # With ``Retry-After: 1`` and ±10% jitter, expect roughly TOTAL_WAIT_CAP / 1
+        # iterations before the helper gives up — far more than the historical
+        # ceiling of 12.
+        assert _Model.calls >= 50, (
+            f"short Retry-After should let the helper retry many times before the "
+            f"time budget is spent — got only {_Model.calls} attempts"
+        )
+        assert sum(slept) <= TOTAL_WAIT_CAP_SECONDS + SINGLE_WAIT_CAP_SECONDS
 
 
 class TestBackoffPolicy:

--- a/tests/unit/test_rate_limit.py
+++ b/tests/unit/test_rate_limit.py
@@ -1,0 +1,493 @@
+"""Tests for providers.rate_limit module — classifier + backoff helper.
+
+Verifies that transport-level rate-limit errors (HTTP 429) are recognized,
+backed off respecting Retry-After, and surfaced as ProviderRateLimitError —
+NOT routed through the semantic-retry / schema-repair path.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import patch
+
+import httpx
+import pytest
+
+from questfoundry.providers.base import ProviderRateLimitError
+from questfoundry.providers.rate_limit import (
+    DEFAULT_INITIAL_WAIT_SECONDS,
+    SINGLE_WAIT_CAP_SECONDS,
+    TOTAL_WAIT_CAP_SECONDS,
+    ainvoke_with_rate_limit_retry,
+    classify_rate_limit_error,
+)
+
+
+def _build_httpx_response(status: int, headers: dict[str, str] | None = None) -> httpx.Response:
+    """Build a real httpx.Response so .headers / .status_code behave naturally."""
+    return httpx.Response(
+        status_code=status,
+        headers=headers or {},
+        request=httpx.Request("POST", "https://example.test/v1"),
+    )
+
+
+class TestClassifierRecognizesAnthropic:
+    def test_anthropic_rate_limit_error(self) -> None:
+        import anthropic
+
+        response = _build_httpx_response(429, {"retry-after": "7"})
+        exc = anthropic.RateLimitError("rate limited", response=response, body=None)
+
+        classified = classify_rate_limit_error(exc)
+
+        assert classified is not None
+        assert classified.provider == "anthropic"
+        assert classified.retry_after_seconds == pytest.approx(7.0)
+
+    def test_anthropic_without_retry_after_header(self) -> None:
+        import anthropic
+
+        response = _build_httpx_response(429, {})
+        exc = anthropic.RateLimitError("rate limited", response=response, body=None)
+
+        classified = classify_rate_limit_error(exc)
+
+        assert classified is not None
+        assert classified.provider == "anthropic"
+        assert classified.retry_after_seconds is None
+
+
+class TestClassifierRecognizesOpenAI:
+    def test_openai_rate_limit_error(self) -> None:
+        import openai
+
+        response = _build_httpx_response(429, {"retry-after": "12"})
+        exc = openai.RateLimitError("rate limited", response=response, body=None)
+
+        classified = classify_rate_limit_error(exc)
+
+        assert classified is not None
+        assert classified.provider == "openai"
+        assert classified.retry_after_seconds == pytest.approx(12.0)
+
+
+class TestClassifierRecognizesWrappedHttpx:
+    def test_wrapped_httpx_status_429(self) -> None:
+        """A bare httpx.HTTPStatusError with 429 status is classified as rate-limit."""
+        response = _build_httpx_response(429, {"retry-after": "3"})
+        exc = httpx.HTTPStatusError("429", request=response.request, response=response)
+
+        classified = classify_rate_limit_error(exc)
+
+        assert classified is not None
+        assert classified.retry_after_seconds == pytest.approx(3.0)
+
+    def test_non_429_httpx_status_not_classified(self) -> None:
+        """A 500 httpx error is NOT a rate-limit error."""
+        response = _build_httpx_response(500)
+        exc = httpx.HTTPStatusError("500", request=response.request, response=response)
+
+        assert classify_rate_limit_error(exc) is None
+
+
+class TestClassifierWalksExceptionChain:
+    def test_walks_cause_chain(self) -> None:
+        """Classifier finds rate-limit deeper in __cause__."""
+        import anthropic
+
+        response = _build_httpx_response(429, {"retry-after": "4"})
+        inner = anthropic.RateLimitError("inner", response=response, body=None)
+        try:
+            raise RuntimeError("LangChain wrapped this") from inner
+        except RuntimeError as outer:
+            classified = classify_rate_limit_error(outer)
+
+        assert classified is not None
+        assert classified.retry_after_seconds == pytest.approx(4.0)
+
+
+class TestClassifierIgnoresNonRateLimit:
+    def test_validation_error_returns_none(self) -> None:
+        from pydantic import BaseModel, ValidationError
+
+        class M(BaseModel):
+            x: int
+
+        try:
+            M.model_validate({"x": "not-an-int"})
+        except ValidationError as exc:
+            assert classify_rate_limit_error(exc) is None
+        else:  # pragma: no cover
+            pytest.fail("Pydantic should have raised ValidationError")
+
+    def test_value_error_returns_none(self) -> None:
+        assert classify_rate_limit_error(ValueError("nope")) is None
+
+
+class TestAinvokeWithRateLimitRetrySucceeds:
+    @pytest.mark.asyncio
+    async def test_returns_immediately_on_success(self) -> None:
+        """When ainvoke succeeds first try, no sleep, return value passes through."""
+
+        class _Model:
+            calls = 0
+
+            async def ainvoke(self, _messages: list[Any], **_kwargs: Any) -> str:
+                _Model.calls += 1
+                return "ok"
+
+        result = await ainvoke_with_rate_limit_retry(_Model(), [], config=None)
+        assert result == "ok"
+        assert _Model.calls == 1
+
+    @pytest.mark.asyncio
+    async def test_retries_on_rate_limit_then_succeeds(self) -> None:
+        """A single rate-limit error sleeps then retries successfully."""
+        import anthropic
+
+        response = _build_httpx_response(429, {"retry-after": "0.01"})
+
+        class _Model:
+            calls = 0
+
+            async def ainvoke(self, _messages: list[Any], **_kwargs: Any) -> str:
+                _Model.calls += 1
+                if _Model.calls == 1:
+                    raise anthropic.RateLimitError("rate", response=response, body=None)
+                return "ok"
+
+        result = await ainvoke_with_rate_limit_retry(_Model(), [], config=None)
+        assert result == "ok"
+        assert _Model.calls == 2
+
+
+class TestAinvokeWithRateLimitRetryReraises:
+    @pytest.mark.asyncio
+    async def test_non_rate_limit_propagates_immediately(self) -> None:
+        """Non-rate-limit exceptions are re-raised without sleep."""
+
+        class _Model:
+            calls = 0
+
+            async def ainvoke(self, _messages: list[Any], **_kwargs: Any) -> str:
+                _Model.calls += 1
+                raise ValueError("schema mismatch")
+
+        with pytest.raises(ValueError, match="schema mismatch"):
+            await ainvoke_with_rate_limit_retry(_Model(), [], config=None)
+        assert _Model.calls == 1
+
+
+class TestAinvokeWithRateLimitRetryGivesUp:
+    @pytest.mark.asyncio
+    async def test_raises_provider_rate_limit_after_total_cap(self) -> None:
+        """If sustained rate-limits exceed TOTAL_WAIT_CAP_SECONDS, raise."""
+        import anthropic
+
+        # Force each retry to want the full single-wait cap so we hit total cap fast.
+        response = _build_httpx_response(429, {"retry-after": str(SINGLE_WAIT_CAP_SECONDS)})
+
+        class _Model:
+            async def ainvoke(self, _messages: list[Any], **_kwargs: Any) -> str:
+                raise anthropic.RateLimitError("rate", response=response, body=None)
+
+        # Patch asyncio.sleep so the test runs fast.
+        slept: list[float] = []
+
+        async def _fake_sleep(seconds: float) -> None:
+            slept.append(seconds)
+
+        with (
+            patch("questfoundry.providers.rate_limit.asyncio.sleep", _fake_sleep),
+            pytest.raises(ProviderRateLimitError),
+        ):
+            await ainvoke_with_rate_limit_retry(_Model(), [], config=None)
+
+        # Some sleeps should have happened before giving up.
+        assert sum(slept) <= TOTAL_WAIT_CAP_SECONDS + SINGLE_WAIT_CAP_SECONDS
+        assert len(slept) >= 1
+
+
+class TestBackoffPolicy:
+    @pytest.mark.asyncio
+    async def test_uses_retry_after_header_when_present(self) -> None:
+        """When the response has Retry-After, the helper sleeps approximately that long."""
+        import anthropic
+
+        response = _build_httpx_response(429, {"retry-after": "3"})
+
+        class _Model:
+            calls = 0
+
+            async def ainvoke(self, _messages: list[Any], **_kwargs: Any) -> str:
+                _Model.calls += 1
+                if _Model.calls == 1:
+                    raise anthropic.RateLimitError("rate", response=response, body=None)
+                return "ok"
+
+        slept: list[float] = []
+
+        async def _fake_sleep(seconds: float) -> None:
+            slept.append(seconds)
+
+        with patch("questfoundry.providers.rate_limit.asyncio.sleep", _fake_sleep):
+            await ainvoke_with_rate_limit_retry(_Model(), [], config=None)
+
+        # Hint was 3s; with ±10% jitter, expect ~2.7..3.3s
+        assert slept and 2.5 <= slept[0] <= 3.5
+
+    @pytest.mark.asyncio
+    async def test_falls_back_to_default_when_no_retry_after(self) -> None:
+        """When no Retry-After header, helper uses DEFAULT_INITIAL_WAIT_SECONDS."""
+        import anthropic
+
+        response = _build_httpx_response(429, {})  # no retry-after
+
+        class _Model:
+            calls = 0
+
+            async def ainvoke(self, _messages: list[Any], **_kwargs: Any) -> str:
+                _Model.calls += 1
+                if _Model.calls == 1:
+                    raise anthropic.RateLimitError("rate", response=response, body=None)
+                return "ok"
+
+        slept: list[float] = []
+
+        async def _fake_sleep(seconds: float) -> None:
+            slept.append(seconds)
+
+        with patch("questfoundry.providers.rate_limit.asyncio.sleep", _fake_sleep):
+            await ainvoke_with_rate_limit_retry(_Model(), [], config=None)
+
+        assert slept
+        # Default with ±10% jitter
+        lower = DEFAULT_INITIAL_WAIT_SECONDS * 0.85
+        upper = DEFAULT_INITIAL_WAIT_SECONDS * 1.15
+        assert lower <= slept[0] <= upper
+
+    @pytest.mark.asyncio
+    async def test_single_sleep_capped(self) -> None:
+        """Even when Retry-After says 600s, the helper caps a single sleep."""
+        import anthropic
+
+        response = _build_httpx_response(429, {"retry-after": "600"})
+
+        class _Model:
+            calls = 0
+
+            async def ainvoke(self, _messages: list[Any], **_kwargs: Any) -> str:
+                _Model.calls += 1
+                if _Model.calls == 1:
+                    raise anthropic.RateLimitError("rate", response=response, body=None)
+                return "ok"
+
+        slept: list[float] = []
+
+        async def _fake_sleep(seconds: float) -> None:
+            slept.append(seconds)
+
+        with patch("questfoundry.providers.rate_limit.asyncio.sleep", _fake_sleep):
+            await ainvoke_with_rate_limit_retry(_Model(), [], config=None)
+
+        assert slept and slept[0] <= SINGLE_WAIT_CAP_SECONDS * 1.15
+
+
+class TestProviderRateLimitErrorShape:
+    """ProviderRateLimitError carries provider + retry_after_seconds (issue #1581)."""
+
+    def test_has_retry_after_attribute(self) -> None:
+        err = ProviderRateLimitError("anthropic", "throttled", retry_after_seconds=7.0)
+        assert err.provider == "anthropic"
+        assert err.retry_after_seconds == 7.0
+
+    def test_retry_after_optional(self) -> None:
+        err = ProviderRateLimitError("openai", "throttled")
+        assert err.provider == "openai"
+        assert err.retry_after_seconds is None
+
+    def test_message_format(self) -> None:
+        err = ProviderRateLimitError("anthropic", "throttled", retry_after_seconds=2.0)
+        assert "anthropic" in str(err)
+        assert "throttled" in str(err)
+
+
+def test_module_constants_have_sane_values() -> None:
+    """Sanity: caps and defaults are positive and ordered correctly."""
+    assert 0 < DEFAULT_INITIAL_WAIT_SECONDS < SINGLE_WAIT_CAP_SECONDS
+    assert SINGLE_WAIT_CAP_SECONDS <= TOTAL_WAIT_CAP_SECONDS
+
+
+# -----------------------------------------------------------------------------
+# Integration: rate-limit error does NOT consume the semantic-retry budget,
+# and does NOT append a schema-repair HumanMessage.  Issue #1581 acceptance
+# criteria: "no `serialize_error` events with `attempt>=N` in logs are caused
+# by 429s — only by genuine validation/parse failures".
+# -----------------------------------------------------------------------------
+
+
+class TestSerializeRetryLoopHonoursRateLimit:
+    @pytest.mark.asyncio
+    async def test_rate_limit_does_not_decrement_semantic_budget(self) -> None:
+        """A 429 followed by a valid result returns on attempt 1 (no semantic
+        retry consumed) — and the retry helper is what handled the 429."""
+        from unittest.mock import AsyncMock, MagicMock
+
+        from pydantic import BaseModel, Field
+
+        from questfoundry.agents.serialize import serialize_to_artifact
+
+        class _Schema(BaseModel):
+            title: str = Field(min_length=1)
+            count: int = Field(ge=1)
+
+        import anthropic
+
+        response = _build_httpx_response(429, {"retry-after": "0.0"})
+        rate_limit_exc = anthropic.RateLimitError("rate", response=response, body=None)
+
+        mock_model = MagicMock()
+        # First call: 429.  Second call: valid result.  If the retry loop
+        # treated the 429 as a semantic error, max_retries would have to be >= 2
+        # to succeed.  We pass max_retries=1 to prove the rate-limit retry
+        # didn't burn that single semantic slot.
+        mock_invoke = AsyncMock(side_effect=[rate_limit_exc, {"title": "Valid", "count": 5}])
+        mock_model.with_structured_output.return_value.ainvoke = mock_invoke
+
+        async def _instant_sleep(_seconds: float) -> None:
+            return None
+
+        with patch("questfoundry.providers.rate_limit.asyncio.sleep", _instant_sleep):
+            artifact, _tokens, attempts_made = await serialize_to_artifact(
+                mock_model,
+                "A test brief",
+                _Schema,
+                max_retries=1,
+            )
+
+        assert artifact.title == "Valid"
+        # Critical: only one *semantic* attempt happened.
+        assert attempts_made == 1
+        # Two underlying ainvoke calls occurred (one 429, one success).
+        assert mock_invoke.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_grow_rate_limit_does_not_decrement_semantic_budget(self) -> None:
+        """A 429 in GROW's _grow_llm_call must not consume the semantic-retry slot.
+
+        GROW has a unique ``continue`` branch (semantic-validator hits >50%
+        phantom IDs) that re-runs the loop body — the rate-limit retry must
+        not interact with this counter.
+        """
+        from unittest.mock import AsyncMock, MagicMock
+
+        import anthropic
+
+        from questfoundry.models.grow import Phase4aOutput, SceneTypeTag
+        from questfoundry.pipeline.stages.grow import GrowStage
+
+        response = _build_httpx_response(429, {"retry-after": "0.0"})
+        rate_limit_exc = anthropic.RateLimitError("rate", response=response, body=None)
+
+        valid_output = Phase4aOutput(
+            tags=[
+                SceneTypeTag(
+                    beat_id="beat::a",
+                    scene_type="scene",
+                    narrative_function="introduce",
+                    exit_mood="tense anticipation",
+                )
+            ]
+        )
+
+        mock_structured = AsyncMock()
+        mock_structured.ainvoke = AsyncMock(side_effect=[rate_limit_exc, valid_output])
+
+        mock_model = MagicMock()
+        mock_model.with_structured_output = MagicMock(return_value=mock_structured)
+
+        stage = GrowStage()
+
+        async def _instant_sleep(_seconds: float) -> None:
+            return None
+
+        with patch("questfoundry.providers.rate_limit.asyncio.sleep", _instant_sleep):
+            _result, llm_calls, _tokens = await stage._grow_llm_call(
+                model=mock_model,
+                template_name="grow_phase4a_scene_types",
+                context={
+                    "beat_summaries": "test",
+                    "valid_beat_ids": "beat::a",
+                    "beat_count": "1",
+                },
+                output_schema=Phase4aOutput,
+                max_retries=1,
+            )
+
+        # Only one *semantic* attempt happened (max_retries=1) — the 429 retry
+        # was absorbed by the rate-limit helper, not by the schema-repair loop.
+        assert llm_calls == 1
+        assert mock_structured.ainvoke.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_rate_limit_does_not_append_humanmessage(self) -> None:
+        """A 429 retry must not append a schema-repair HumanMessage.
+
+        The schema-repair feedback is only appropriate for semantic failures.
+        Appending it on rate-limit grows the prompt and worsens the next call's
+        rate-limit pressure — exactly the failure mode in issue #1581.
+
+        Snapshot the messages list inside the side_effect because the
+        production code passes the same list object to every ainvoke call —
+        ``call_args_list`` would alias the post-mutation list otherwise.
+        """
+        from unittest.mock import MagicMock
+
+        from langchain_core.messages import HumanMessage
+        from pydantic import BaseModel, Field
+
+        from questfoundry.agents.serialize import serialize_to_artifact
+
+        class _Schema(BaseModel):
+            title: str = Field(min_length=1)
+            count: int = Field(ge=1)
+
+        import anthropic
+
+        response = _build_httpx_response(429, {"retry-after": "0.0"})
+        rate_limit_exc = anthropic.RateLimitError("rate", response=response, body=None)
+
+        snapshots: list[list[Any]] = []
+
+        async def _ainvoke(messages: list[Any], config: Any = None) -> dict[str, Any]:
+            del config  # unused — only the messages snapshot matters here
+            snapshots.append(list(messages))
+            if len(snapshots) == 1:
+                raise rate_limit_exc
+            return {"title": "Valid", "count": 5}
+
+        mock_model = MagicMock()
+        mock_model.with_structured_output.return_value.ainvoke = _ainvoke
+
+        async def _instant_sleep(_seconds: float) -> None:
+            return None
+
+        with patch("questfoundry.providers.rate_limit.asyncio.sleep", _instant_sleep):
+            await serialize_to_artifact(
+                mock_model,
+                "A test brief",
+                _Schema,
+                max_retries=1,
+            )
+
+        # Two calls happened (one 429, one success). The HumanMessage count in
+        # the second call must equal the first — i.e. no schema-repair message
+        # was appended between them.
+        assert len(snapshots) == 2
+        first_humans = sum(1 for m in snapshots[0] if isinstance(m, HumanMessage))
+        second_humans = sum(1 for m in snapshots[1] if isinstance(m, HumanMessage))
+        assert first_humans == second_humans, (
+            "Schema-repair HumanMessage must NOT be appended on rate-limit retry "
+            f"(first={first_humans}, second={second_humans})"
+        )


### PR DESCRIPTION
Closes #1581.

## Summary

- Transport-level 429s were absorbed by the bare `except Exception` in stage retry loops, routed through the schema-repair path, burned the semantic-retry budget, and retried immediately with no backoff. A stage that hit a temporary rate limit failed permanently after 3 attempts.
- New `providers/rate_limit.py` adds `classify_rate_limit_error()` (walks the exception chain, recognises anthropic/openai `RateLimitError`, google `ResourceExhausted`, wrapped httpx 429) and `ainvoke_with_rate_limit_retry()` (provider-aware backoff with jitter, capped at 60s per sleep / 300s cumulative). Wired into all five retry loops (`serialize`, `fill`, `dress`, `grow`, `polish`) with `except ProviderRateLimitError: raise` placed before the existing `except Exception` / `except (ValidationError, TypeError)`.
- `ProviderRateLimitError` extended with `retry_after_seconds` — no longer dead code.
- New `providers.max_concurrency` field in `project.yaml`. Orchestrator threads it to a process-global consulted in `get_model_info`. Precedence: `QF_MAX_CONCURRENCY` env > project.yaml > per-provider default. Non-positive or malformed values fall through.

## Acceptance criteria

- [x] No `serialize_error` events with `attempt>=N` caused by 429s.
- [x] `ProviderRateLimitError` raised on the rate-limit path (no longer dead code).
- [x] Unit tests cover anthropic/openai/wrapped-httpx 429.
- [x] Unit test confirms rate-limit doesn't decrement semantic-retry budget AND doesn't append feedback `HumanMessage` (covered for both `serialize` and `grow` loops).
- [x] Concurrency cap configurable via `project.yaml` with documented per-provider default.

## Test plan

- [x] `uv run pytest tests/unit/test_rate_limit.py` — 22 new unit tests pass (classifier per-provider, chain walk, non-rate-limit ignore, helper backoff success/retry/give-up/cap, integration with serialize and grow loops).
- [x] `uv run pytest tests/unit/` — 4072 unit tests pass (1 unrelated network-flaky test deselected).
- [x] `uv run mypy src/` and `uv run ruff check src/ tests/` — both clean.
- [ ] Manual repro on `projects/murder-haiku2` against rate-limited Anthropic key — completes (slowly) instead of failing with `stage_failed`.

## Local review circus

- pr-review-toolkit:code-reviewer: clean (after 3 rounds of fixes)
- superpowers:code-reviewer: clean (after 2 rounds of fixes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)