### PR TITLE
fix(grow): remove alphabetical interleave heuristics — concurrent contributes zero Phase 4a edges

### DIFF
--- a/docs/design/procedures/grow.md
+++ b/docs/design/procedures/grow.md
@@ -163,11 +163,11 @@ R-2.8. Intersection rejection due to the invariant is logged at INFO with the ca
 
 #### Base DAG Simulation
 
-**What:** Build a simulated DAG using all non-hint ordering edges — serial/wraps relationships plus heuristic commit-ordering edges for concurrent dilemmas. This is the substrate against which temporal hints are tested.
+**What:** Build a simulated DAG using all non-hint ordering edges from `serial` and `wraps` Dilemma relationships. This is the substrate against which temporal hints are tested. `concurrent` relationships contribute no base-DAG edges by design — concurrent has no mandatory ordering, so the base DAG remains permissive and any acyclic schedule that respects `serial` + `wraps` is correct.
 
 **Rules:**
 
-R-3.1. Base DAG uses deterministic ordering from Dilemma ordering relationships (`wraps`, `concurrent`, `serial`) only. Temporal hints are excluded from base.
+R-3.1. Base DAG contains only the deterministic ordering edges implied by `serial` and `wraps` Dilemma relationships (plus any predecessor edges already on the graph from earlier phases). `concurrent` relationships contribute no edges to the base DAG. Temporal hints are excluded from base.
 
 **Violations:**
 
@@ -244,7 +244,7 @@ This phase produces a structurally complete and minimally annotated beat DAG. Na
 
 ### 4a — Interleave
 
-**Purpose:** Apply cross-dilemma ordering edges to weave the per-dilemma Y-shapes into a single DAG. Use the Dilemma ordering relationships (`wraps`/`concurrent`/`serial`) plus the surviving temporal hints from Phase 3. No cycles possible — Phase 3 guaranteed acyclicity.
+**Purpose:** Apply cross-dilemma ordering edges across the per-dilemma Y-shapes. Use the mandatory ordering implied by `wraps` and `serial` Dilemma relationships plus the surviving temporal hints from Phase 3. `concurrent` contributes no edges. The output is *any* acyclic predecessor DAG that satisfies the constraints — no further ordering is invented. No cycles possible — Phase 3 guaranteed acyclicity.
 
 #### Input Contract
 
@@ -254,7 +254,7 @@ This phase produces a structurally complete and minimally annotated beat DAG. Na
 
 ##### Cross-Dilemma Ordering Edge Creation
 
-**What:** Add `predecessor` edges between beats of different Dilemmas according to `wraps`/`concurrent`/`serial` plus temporal hints. Each edge reflects "beat X must come before beat Y in any arc that traverses both."
+**What:** Add `predecessor` edges between beats of different Dilemmas as required by `serial` / `wraps` Dilemma relationships and surviving temporal hints. Each edge reflects "beat X must come before beat Y in any arc that traverses both." `concurrent` adds no edges — its contract is "either order is valid," so Phase 4a leaves concurrent pairs unordered. The result is *any* acyclic schedule that satisfies the mandatory edges; Phase 4a does not invent additional ordering to reach a preferred shape.
 
 **Rules:**
 
@@ -262,11 +262,13 @@ R-4a.1. `serial` Dilemmas: the last beat of Dilemma A precedes the first beat of
 
 R-4a.2. `wraps` Dilemmas (A wraps B): A's introduction beats precede B's introduction beats; B's final beats precede A's commit beats.
 
-R-4a.3. `concurrent` Dilemmas: no mandatory ordering from the relationship itself; interleaving is governed by temporal hints and heuristics.
+R-4a.3. `concurrent` Dilemmas contribute zero `predecessor` edges in Phase 4a. Concurrent has no mandatory ordering, and Phase 4a does not synthesize ordering that the spec does not require. Temporal hints between the two Dilemmas (R-4a.4) are the only mechanism that may emit edges between concurrent pairs.
 
 R-4a.4. Temporal hints that survived Phase 3 are applied as `predecessor` edges.
 
 R-4a.5. No cycles are introduced. If a cycle would be introduced, the input from Phase 3 was faulty — this is a hard failure, not a silent skip.
+
+R-4a.6. Phase 4a output may have multiple beat-DAG roots when no `serial` / `wraps` / hint relationship orders them. This is by design under R-4a.3 — root unification, if needed by a downstream stage, is a downstream concern (tracked in #1584), not a Phase 4a edge to invent.
 
 **Violations:**
 
@@ -477,11 +479,11 @@ R-6.4. If a soft Dilemma **with two explored paths** has no structural convergen
 
 #### Arc Enumeration and Integrity Checks
 
-**What:** For each combination of one path per explored Dilemma, walk the DAG from root, following the successor matching the arc's selected path at each Y-fork. The traversal is the arc's beat sequence. Validate it.
+**What:** For each combination of one path per explored Dilemma (the Cartesian product of paths across dilemmas), collect the union of beats belonging to any constituent path and topologically sort that union to produce the arc's beat sequence. Validate it. The topological-sort step handles multi-root beat DAGs (R-4a.6) implicitly: the union of paths is a single connected acyclic subgraph, and topo-sort yields a deterministic linear sequence regardless of root count.
 
 **Rules:**
 
-R-7.1. Arc traversal starts at the DAG root and walks `predecessor` successors. At each Y-fork, the traversal follows the successor matching the arc's selected path for that Dilemma.
+R-7.1. An arc is the topological sort of the union of beats belonging to one selected path per explored Dilemma. The sort is over the beat union as a single subgraph; multi-root structure (R-4a.6) is absorbed by the sort and does not require per-root walking.
 
 R-7.2. Arcs are computed on demand, not stored as graph nodes. If materialized for debugging, they must use the `materialized_` prefix.
 
@@ -489,7 +491,7 @@ R-7.3. Every computed arc reaches a terminal beat (no dead ends).
 
 R-7.4. Every arc traverses exactly one commit beat per explored Dilemma.
 
-R-7.5. Every beat in the graph is reachable from the root via at least one arc. Unreachable beats are pruning candidates (Phase 8) — not errors at this stage, but logged at INFO.
+R-7.5. Every beat in the graph is reachable from at least one root via at least one arc. Unreachable beats are pruning candidates (Phase 8) — not errors at this stage, but logged at INFO.
 
 R-7.6. No cycles in `predecessor` edges.
 
@@ -551,7 +553,7 @@ R-8.4. Pruning never deletes a beat that has `belongs_to` to an explored Path �
 
 ## Stage Output Contract
 
-1. The beat DAG is acyclic: every beat node has either ≥1 predecessor or is the root; ≥1 successor or is a terminal.
+1. The beat DAG is acyclic: every beat node has either ≥1 predecessor or is a root; ≥1 successor or is a terminal. Multi-root output is permitted per R-4a.6 — root unification, if any, is the responsibility of a downstream stage (see #1584).
 2. Every computed arc from root to terminal is complete — no dead ends.
 3. Every arc includes exactly one commit beat per explored Dilemma.
 4. Zero or more Intersection Group nodes exist. No group contains two beats from the same Dilemma.
@@ -564,7 +566,7 @@ R-8.4. Pruning never deletes a beat that has `belongs_to` to an explored Path �
 11. Every hard Dilemma has `converges_at: null` and `convergence_payoff: null`.
 12. No Passage, Choice, variant passage, residue beat, or character arc metadata exists.
 13. No cycles in `predecessor` edges.
-14. No orphan beats (all reachable from root by at least one arc).
+14. No orphan beats (all reachable from at least one root by at least one arc).
 15. Setup beats from SEED persist (structural, zero `belongs_to`, zero `dilemma_impacts`) — GROW does not add to or remove from them.
 16. Epilogue beats from SEED persist (structural, zero `belongs_to`, zero `dilemma_impacts`) — GROW does not add to or remove from them.
 17. Every beat has `scene_type`, `narrative_function`, and `exit_mood` populated by Phase 4b. Partial coverage (LLM missed some beats) emits a WARNING; downstream consumers handle absent fields via the R-4b.1 fallback (default `scene_type` to `"scene"`).
@@ -610,7 +612,7 @@ R-2.5: `belongs_to` edges never modified by intersection assignment.
 R-2.6: Intersection Groups carry resolved scene context.
 R-2.7: No-Conditional-Prerequisites Invariant: `paths(B) ⊇ paths(A_post_intersection)`.
 R-2.8: Intersection rejections logged at INFO.
-R-3.1: Base DAG excludes temporal hints.
+R-3.1: Base DAG contains only `serial` + `wraps` edges; concurrent and temporal hints are excluded.
 R-3.2: Hints cycling alone are mandatory drops.
 R-3.3: Mandatory drops logged with reason.
 R-3.4: Swap pairs resolved by LLM with context.
@@ -619,9 +621,10 @@ R-3.6: Swap resolutions logged.
 R-3.7: After Phase 3, surviving hints + base DAG are acyclic (hard invariant).
 R-4a.1: Serial: last beat of A precedes first beat of B.
 R-4a.2: Wraps: A's intros precede B's; B's finals precede A's commits.
-R-4a.3: Concurrent: no mandatory ordering from relationship alone.
+R-4a.3: Concurrent contributes zero Phase 4a edges; only temporal hints can order concurrent pairs.
 R-4a.4: Surviving temporal hints applied as edges.
 R-4a.5: No cycles in Phase 4a output; no silent skip.
+R-4a.6: Multi-root beat DAG is permitted output of Phase 4a; root unification is downstream.
 R-4b.1: Every beat receives `scene_type ∈ {scene, sequel, micro_beat}`; partial coverage emits WARNING.
 R-4b.2: Every beat receives `narrative_function ∈ {introduce, develop, complicate, confront, resolve}`.
 R-4b.3: Every beat receives `exit_mood` (2–40 character descriptor).
@@ -642,7 +645,7 @@ R-6.1: `converges_at` computed from DAG reachability.
 R-6.2: `convergence_payoff` is min exclusive-beat count per path.
 R-6.3: Hard Dilemmas have both fields null.
 R-6.4: Soft Dilemma with TWO explored paths and no structural convergence → halt (classification error). Single-path soft Dilemmas are out of scope.
-R-7.1: Arc traversal walks `predecessor` successors; follows path at forks.
+R-7.1: Arc = topological sort of the union of beats from one selected path per Dilemma; multi-root absorbed by sort.
 R-7.2: Arcs computed, not stored (materialized uses `materialized_` prefix).
 R-7.3: Every arc reaches a terminal beat.
 R-7.4: Every arc has exactly one commit per explored Dilemma.
@@ -734,7 +737,7 @@ No temporal hints in this run; acyclicity trivially holds.
 
 ### Phase 4a
 
-Cross-dilemma `predecessor` edges added per `concurrent` interleaving heuristic.
+`concurrent` contributes no `predecessor` edges (R-4a.3). With only one concurrent relationship in the run and no temporal hints, Phase 4a creates zero cross-dilemma edges and exits cleanly. The two Y-shapes remain independent roots in the beat DAG, to be unified at POLISH time.
 
 ### Phase 4b
 

--- a/docs/design/story-graph-ontology.md
+++ b/docs/design/story-graph-ontology.md
@@ -329,7 +329,7 @@ temporal_hint:
 - `before_introduce` — this beat should be placed before `relative_to`'s first beat
 - `after_introduce` — this beat should be placed after `relative_to`'s first beat
 
-Temporal hints are optional. A beat with no hint has no constraint on its placement relative to other dilemmas — GROW places it using structural heuristics and dilemma ordering relationships alone. Hints that conflict with dilemma ordering relationships (e.g., a hint saying "after B's commit" when A wraps B and A's commit comes first) are treated as advisory — GROW resolves the conflict in favor of the ordering relationship.
+Temporal hints are optional. A beat with no hint has no constraint on its placement relative to other dilemmas — GROW places it using dilemma ordering relationships (`serial` / `wraps`) alone. `concurrent` adds no Phase 4a edges (per `procedures/grow.md` R-4a.3), so beats whose only cross-dilemma relationship is concurrent are left unordered relative to those dilemmas; any acyclic schedule is correct. Hints that conflict with dilemma ordering relationships (e.g., a hint saying "after B's commit" when A wraps B and A's commit comes first) are treated as advisory — GROW resolves the conflict in favor of the ordering relationship.
 
 ### The 2^N Law in Graph Terms
 

--- a/src/questfoundry/graph/grow_algorithms.py
+++ b/src/questfoundry/graph/grow_algorithms.py
@@ -2646,11 +2646,17 @@ def _iter_temporal_hint_edges(
 def detect_temporal_hint_conflicts(graph: Graph) -> list[TemporalHintConflict]:
     """Simulate temporal hint edge application and return hints that would create cycles.
 
-    Replicates the full edge-building logic of ``interleave_cross_path_beats``
-    (serial, wraps, and concurrent including heuristic commit-ordering edges)
-    without committing any edges to the graph.  Hints that would be
-    skipped as cycle-creating are returned as ``TemporalHintConflict`` objects
+    Tests each temporal hint against the cumulative ``serial`` + ``wraps``
+    base DAG (R-3.1 / R-4a.3 — concurrent contributes no edges).  Hints whose
+    edges would close a cycle are returned as ``TemporalHintConflict`` objects
     for LLM resolution before interleave runs.
+
+    The simulation is two-pass: every non-hint mandatory edge is added first,
+    then concurrent pairs' hints are tested against the fully-built base.
+    This means hints that only conflict transitively with mandatory edges from
+    a *later* dilemma pair are caught at detection time rather than crashing
+    apply.  Iteration order is no longer load-bearing; the function's behavior
+    matches ``_build_hint_base_dag`` (used by ``build_hint_conflict_graph``).
 
     Returns:
         List of conflicting hints.  Empty if all hints are consistent.
@@ -2703,7 +2709,7 @@ def detect_temporal_hint_conflicts(graph: Graph) -> list[TemporalHintConflict]:
         return not from_groups.intersection(to_groups)
 
     def _sim_add(from_b: str, to_b: str) -> bool:
-        """Simulate adding a non-hint edge (serial/wraps/heuristic), updating state."""
+        """Simulate adding a non-hint mandatory edge (serial/wraps), updating state."""
         if not _is_valid_edge_candidate(from_b, to_b):
             return False
         if _would_create_cycle(from_b, to_b, successors, beat_set):
@@ -2714,26 +2720,33 @@ def detect_temporal_hint_conflicts(graph: Graph) -> list[TemporalHintConflict]:
 
     conflicts: list[TemporalHintConflict] = []
 
-    # Collect ALL relationship edges in the same order as interleave_cross_path_beats.
+    # Two-pass simulation matching the new contract:
+    #   Pass 1 — pre-load all non-hint mandatory edges (serial + wraps).  This
+    #   builds the same base DAG that `_build_hint_base_dag` uses, so a hint
+    #   targeting a concurrent pair is tested against the cumulative ordering
+    #   from every relationship in the graph (R-3.1).
+    #   Pass 2 — for each concurrent pair, generate hint edges and test each
+    #   against the fully-built base; a hint that cycles is reported.
     relationship_edges: list[tuple[str, str, str]] = []
-    for ordering in ("concurrent", "wraps", "serial"):
+    for ordering in ("serial", "wraps", "concurrent"):
         for edge in graph.get_edges(from_id=None, to_id=None, edge_type=ordering):
             a = edge["from"]
             b = edge["to"]
             if a in dilemma_paths and b in dilemma_paths:
                 relationship_edges.append((a, b, ordering))
 
+    # Pass 1: serial + wraps edges.
     for dilemma_a, dilemma_b, ordering in relationship_edges:
+        if ordering == "concurrent":
+            continue
         paths_a = dilemma_paths.get(dilemma_a, [])
         paths_b = dilemma_paths.get(dilemma_b, [])
         if not paths_a or not paths_b:
             continue
-
         ordered_a = [_get_path_beats_ordered(graph, p, path_beats_map) for p in paths_a]
         ordered_b = [_get_path_beats_ordered(graph, p, path_beats_map) for p in paths_b]
         all_beats_a = [b for seq in ordered_a for b in seq]
         all_beats_b = [b for seq in ordered_b for b in seq]
-
         if not all_beats_a or not all_beats_b:
             continue
 
@@ -2743,8 +2756,7 @@ def detect_temporal_hint_conflicts(graph: Graph) -> list[TemporalHintConflict]:
             for last_a in sorted(last_beats_a):
                 for first_b in sorted(first_beats_b):
                     _sim_add(first_b, last_a)
-
-        elif ordering == "wraps":
+        else:  # wraps
             first_beats_a = {seq[0] for seq in ordered_a if seq}
             first_beats_b = {seq[0] for seq in ordered_b if seq}
             last_beats_b = {seq[-1] for seq in ordered_b if seq}
@@ -2756,78 +2768,50 @@ def detect_temporal_hint_conflicts(graph: Graph) -> list[TemporalHintConflict]:
                 for commit_a in sorted(commits_a):
                     _sim_add(commit_a, last_b)
 
-        elif ordering == "concurrent":
-            # Temporal hints first (same order as interleave_cross_path_beats)
-            for hint_edge in _iter_temporal_hint_edges(
-                all_beats_a + all_beats_b,
-                beat_nodes,
-                dilemma_a,
-                dilemma_b,
-                all_beats_a,
-                ordered_a,
-                all_beats_b,
-                ordered_b,
-                beat_id_to_dilemmas,
-            ):
-                from_b, to_b = hint_edge.from_beat, hint_edge.to_beat
-                if not _is_valid_edge_candidate(from_b, to_b):
-                    continue
-                if _would_create_cycle(from_b, to_b, successors, beat_set):
-                    conflicts.append(
-                        TemporalHintConflict(
-                            beat_id=hint_edge.beat_id,
-                            hint_relative_to=hint_edge.relative_to,
-                            hint_position=hint_edge.position,
-                            from_beat=from_b,
-                            to_beat=to_b,
-                            beat_summary=beat_nodes.get(hint_edge.beat_id, {}).get("summary", ""),
-                        )
+    # Pass 2: concurrent pairs.  Concurrent contributes no edges (R-4a.3); only
+    # surviving temporal hints can introduce ordering between concurrent pairs.
+    for dilemma_a, dilemma_b, ordering in relationship_edges:
+        if ordering != "concurrent":
+            continue
+        paths_a = dilemma_paths.get(dilemma_a, [])
+        paths_b = dilemma_paths.get(dilemma_b, [])
+        if not paths_a or not paths_b:
+            continue
+        ordered_a = [_get_path_beats_ordered(graph, p, path_beats_map) for p in paths_a]
+        ordered_b = [_get_path_beats_ordered(graph, p, path_beats_map) for p in paths_b]
+        all_beats_a = [b for seq in ordered_a for b in seq]
+        all_beats_b = [b for seq in ordered_b for b in seq]
+        if not all_beats_a or not all_beats_b:
+            continue
+
+        for hint_edge in _iter_temporal_hint_edges(
+            all_beats_a + all_beats_b,
+            beat_nodes,
+            dilemma_a,
+            dilemma_b,
+            all_beats_a,
+            ordered_a,
+            all_beats_b,
+            ordered_b,
+            beat_id_to_dilemmas,
+        ):
+            from_b, to_b = hint_edge.from_beat, hint_edge.to_beat
+            if not _is_valid_edge_candidate(from_b, to_b):
+                continue
+            if _would_create_cycle(from_b, to_b, successors, beat_set):
+                conflicts.append(
+                    TemporalHintConflict(
+                        beat_id=hint_edge.beat_id,
+                        hint_relative_to=hint_edge.relative_to,
+                        hint_position=hint_edge.position,
+                        from_beat=from_b,
+                        to_beat=to_b,
+                        beat_summary=beat_nodes.get(hint_edge.beat_id, {}).get("summary", ""),
                     )
-                else:
-                    existing.add((from_b, to_b))
-                    successors[to_b].add(from_b)
-
-            # Heuristic commit-ordering edges — MUST match interleave_cross_path_beats
-            # so later concurrent pairs see the same graph state.
-            commits_a = set(_commits_beats_for_dilemma(all_beats_a, dilemma_a, beat_nodes))
-            commits_b = set(_commits_beats_for_dilemma(all_beats_b, dilemma_b, beat_nodes))
-            if commits_a and commits_b:
-                if dilemma_a < dilemma_b:
-                    prereq_commits, dependent_commits = commits_a, commits_b
-                else:
-                    prereq_commits, dependent_commits = commits_b, commits_a
-                for prereq in sorted(prereq_commits):
-                    for dependent in sorted(dependent_commits):
-                        _sim_add(dependent, prereq)
-            # Entry-beat ordering across dilemmas is intentionally omitted from
-            # the simulated DAG. Entry-beat edges in interleave_cross_path_beats
-            # are added as soft heuristics via `_add_predecessor(...,
-            # from_hint=False)`, which soft-skip cycle conflicts with previously-
-            # applied hints. Including them in the simulated base DAG would
-            # promote the heuristic to a hard constraint, causing valid
-            # hints that override the heuristic to be classified as mandatory
-            # solo drops. The peer function `_build_hint_base_dag` makes the
-            # same omission for the same reason.
-
-    # Order entry beats within the alphabetically first dilemma —
-    # MUST match interleave_cross_path_beats (#1192).
-    # Note: the early-return above (len(dilemma_paths) < 2) means this block
-    # is only reached for multi-dilemma stories. interleave_cross_path_beats
-    # has the same guard, so single-dilemma stories skip intra-dilemma
-    # ordering in both functions. This is acceptable because single-dilemma
-    # stories are not a production scenario (every story has >= 2 dilemmas).
-    first_dilemma = sorted(dilemma_paths.keys())[0]
-    first_paths = dilemma_paths[first_dilemma]
-    first_entry_beats: list[str] = []
-    for p in first_paths:
-        seq = _get_path_beats_ordered(graph, p, path_beats_map)
-        if seq:
-            first_entry_beats.append(seq[0])
-    if len(first_entry_beats) > 1:
-        first_entry_beats.sort()
-        # Chain alphabetically: beat[0] is root, beat[i+1] requires beat[i]
-        for i in range(len(first_entry_beats) - 1):
-            _sim_add(first_entry_beats[i + 1], first_entry_beats[i])
+                )
+            else:
+                existing.add((from_b, to_b))
+                successors[to_b].add(from_b)
 
     return conflicts
 
@@ -3018,18 +3002,14 @@ def _build_hint_base_dag(
 ) -> tuple[set[tuple[str, str]], dict[str, set[str]]]:
     """Build the base DAG for hint conflict detection/postcondition checking.
 
-    Pre-loads non-hint heuristic edges (predecessor + serial + wraps + concurrent
-    commit-ordering) from all relationship pairs into the base DAG.  Hints are
-    NOT included.  This is the shared DAG construction used by both
+    Pre-loads non-hint mandatory edges (existing ``predecessor`` edges + ``serial``
+    + ``wraps``) from all relationship pairs into the base DAG.  ``concurrent``
+    relationships contribute no edges per R-3.1 / R-4a.3 — concurrent has no
+    mandatory ordering, and the base DAG mirrors Phase 4a's semantics so that
+    hint conflict detection and Phase 4a apply produce consistent results.
+    Hints are NOT included.  This shared construction is used by both
     ``build_hint_conflict_graph`` (detection) and ``verify_hints_acyclic``
-    (postcondition), ensuring they produce consistent results.
-
-    Concurrent entry-beat ordering is intentionally absent from this base DAG.
-    Entry-beat ordering is a soft heuristic that must yield to hints rather than
-    block them.  Cycle-safety is preserved at apply time: in
-    ``interleave_cross_path_beats`` the entry-beat heuristic is added with
-    ``from_hint=False``, so cycle conflicts with previously-applied hints are
-    soft-skipped rather than rejecting the hint.
+    (postcondition).
 
     Args:
         graph: The story graph.
@@ -3092,18 +3072,10 @@ def _build_hint_base_dag(
             for last_b in sorted({seq[-1] for seq in ordered_b if seq}):
                 for commit_a in sorted(commits_a):
                     _sim(commit_a, last_b)
-        elif ordering == "concurrent":
-            # Heuristic commit-ordering only (no hints applied here)
-            commits_a = set(_commits_beats_for_dilemma(all_beats_a, dilemma_a, beat_nodes))
-            commits_b = set(_commits_beats_for_dilemma(all_beats_b, dilemma_b, beat_nodes))
-            if commits_a and commits_b:
-                if dilemma_a < dilemma_b:
-                    prereq_commits, dependent_commits = commits_a, commits_b
-                else:
-                    prereq_commits, dependent_commits = commits_b, commits_a
-                for prereq in sorted(prereq_commits):
-                    for dependent in sorted(dependent_commits):
-                        _sim(dependent, prereq)
+        # R-3.1: concurrent contributes no edges to the base DAG.
+        # The base DAG against which hints are tested is exactly the closure of
+        # serial + wraps edges (plus pre-existing predecessor edges). Phase 4a
+        # mirrors this: concurrent pairs are unordered there too.
 
     return existing, succ
 
@@ -3114,8 +3086,9 @@ def build_hint_conflict_graph(graph: Graph) -> HintConflictResult:
     Unlike ``detect_temporal_hint_conflicts`` (single-pass, cascade-blind),
     this function:
 
-    1. Builds a *base DAG* by simulating all non-hint edges (serial, wraps,
-       heuristic commit-ordering) without any hints.
+    1. Builds a *base DAG* by simulating all non-hint mandatory edges (serial,
+       wraps) without any hints.  Concurrent contributes no edges per R-3.1 /
+       R-4a.3.
     2. Tests each hint alone against the base DAG — hints that cycle alone
        are mandatory drops.
     3. Runs a greedy minimum-drop-set (MDS) loop using
@@ -3572,17 +3545,18 @@ def interleave_cross_path_beats(graph: Graph) -> int:
     """Create predecessor edges between beats from different dilemma paths.
 
     Reads dilemma relationship edges (concurrent/wraps/serial) and applies
-    cross-path ordering rules:
+    cross-path ordering rules per ``docs/design/procedures/grow.md`` R-4a:
 
     - ``serial`` (A before B): Last beats of every A path must precede first
-      beats of every B path.
+      beats of every B path (R-4a.1).
     - ``wraps`` (A wraps B): A's intro beats precede B's intro beats; B's
-      last beats precede A's commit beats.
-    - ``concurrent``: Temporal hints on beats drive specific orderings; without
-      hints, commit beats of one dilemma are ordered before commit beats of the
-      other to ensure pacing.
+      last beats precede A's commit beats (R-4a.2).
+    - ``concurrent``: contributes zero ordering edges (R-4a.3). Surviving
+      temporal hints (R-4a.4) are the only mechanism that orders concurrent
+      pairs; pairs with no hints stay unordered. The output may be multi-root
+      (R-4a.6) — root unification, if any, is downstream.
 
-    Any edge that would create a cycle raises GrowContractError (R-3.7 / R-4.5).
+    Any edge that would create a cycle raises GrowContractError (R-3.7 / R-4a.5).
     resolve_temporal_hints must prevent hint-induced cycles before this phase runs.
 
     Args:
@@ -3640,19 +3614,15 @@ def interleave_cross_path_beats(graph: Graph) -> int:
         return 0
 
     # Initialise the cycle-detection DAG from the same base as detection/postcondition.
-    # _build_hint_base_dag pre-loads non-hint heuristic edges (serial, wraps, commit-ordering)
-    # so that a hint accepted by build_hint_conflict_graph cannot create a cycle here
-    # due to a narrower incremental DAG (#1147).  Entry-beat ordering is intentionally
-    # absent from _build_hint_base_dag — it is a soft heuristic that must yield to hints
-    # rather than block them.  Below, the entry-beat heuristic is applied with
-    # ``from_hint=False``, so cycle conflicts with previously-applied hints soft-skip
-    # the heuristic edge instead of rejecting the hint.
+    # _build_hint_base_dag pre-loads non-hint mandatory edges (serial + wraps) so that a
+    # hint accepted by build_hint_conflict_graph cannot create a cycle here due to a
+    # narrower incremental DAG (#1147).  Concurrent contributes no edges per R-3.1 /
+    # R-4a.3, so detection and apply share an identical base.
     #
-    # ``_base_edges`` contains real graph edges + simulated heuristic edges.
     # ``successors`` is derived from the full base and is used for cycle detection.
     # ``existing_predecessors`` tracks only edges actually written to the graph —
-    # initialised from real graph edges so that simulated edges are still written
-    # by _add_predecessor (avoiding silent drops of valid edges).
+    # initialised from real graph edges so that the apply loop doesn't double-count
+    # edges already on the graph.
     _, successors = _build_hint_base_dag(
         graph,
         beat_nodes,
@@ -3709,16 +3679,20 @@ def interleave_cross_path_beats(graph: Graph) -> int:
             )
             return False
         if _would_create_cycle(from_beat, to_beat, successors, beat_set):
-            # Per R-3.7 / R-4.5: any cycle detected at interleave time is a
+            # Per R-3.7 / R-4a.5: any cycle detected at interleave time is a
             # hard pipeline failure — Silent Degradation policy forbids silent
-            # skip.  Hint-induced cycles should have been cleared by
-            # resolve_temporal_hints; heuristic-induced cycles indicate that
-            # Phase 3's acyclicity guarantee was not upheld.
+            # skip.  Possible sources:
+            #   - "temporal hint": resolve_temporal_hints (Phase 3) was meant
+            #     to clear cyclic hints; reaching here means R-3.7 was
+            #     violated.
+            #   - "wraps/serial": SEED produced a contradictory dilemma
+            #     relationship graph (e.g. wraps + serial that admit no
+            #     acyclic schedule); not a Phase 3 issue.
             from questfoundry.graph.grow_validation import (
                 GrowContractError,  # local to avoid circular import
             )
 
-            source = "temporal hint" if from_hint else "heuristic"
+            source = "temporal hint" if from_hint else "wraps/serial"
             log.error(
                 "interleave_cycle_skipped",
                 from_beat=from_beat,
@@ -3726,9 +3700,12 @@ def interleave_cross_path_beats(graph: Graph) -> int:
                 source=source,
             )
             raise GrowContractError(
-                f"R-3.7 / R-4.5: interleave would close a cycle "
+                f"R-3.7 / R-4a.5: interleave would close a cycle "
                 f"({from_beat!r} → {to_beat!r}, source={source!r}). "
-                f"Phase 3's acyclicity guarantee was violated. Halting."
+                f"Halting per Silent Degradation policy. If source is "
+                f"'wraps/serial', the SEED dilemma relationship graph is "
+                f"contradictory; if 'temporal hint', Phase 3's acyclicity "
+                f"guarantee was violated."
             )
         graph.add_edge("predecessor", from_beat, to_beat)
         existing_predecessors.add((from_beat, to_beat))
@@ -3786,7 +3763,9 @@ def interleave_cross_path_beats(graph: Graph) -> int:
                     _add_predecessor(commit_a, last_b)
 
         elif ordering == "concurrent":
-            # Apply temporal hints first
+            # R-4a.3: concurrent contributes no commit-/entry-beat ordering edges.
+            # The only Phase 4a edges between concurrent pairs come from surviving
+            # temporal hints (R-4a.4).
             hints_applied = 0
             for hint_edge in _iter_temporal_hint_edges(
                 all_beats_a + all_beats_b,
@@ -3809,56 +3788,6 @@ def interleave_cross_path_beats(graph: Graph) -> int:
                     dilemma_b=dilemma_b,
                     count=hints_applied,
                 )
-
-            # Heuristic fallback for concurrent: commits of A before commits of B
-            # (deterministic: use alphabetical dilemma ordering to pick direction)
-            commits_a = set(_commits_beats_for_dilemma(all_beats_a, dilemma_a, beat_nodes))
-            commits_b = set(_commits_beats_for_dilemma(all_beats_b, dilemma_b, beat_nodes))
-            if commits_a and commits_b:
-                # Alphabetically earlier dilemma's commits go first as a stable heuristic
-                if dilemma_a < dilemma_b:
-                    # A commits before B commits
-                    for ca in sorted(commits_a):
-                        for cb in sorted(commits_b):
-                            _add_predecessor(cb, ca)
-                else:
-                    # B commits before A commits
-                    for cb in sorted(commits_b):
-                        for ca in sorted(commits_a):
-                            _add_predecessor(ca, cb)
-
-            # Entry beats follow the same relative ordering as commit beats:
-            # whichever dilemma's commits go first also has its entry beats first.
-            # This ensures the beat DAG has a single root even when all dilemmas
-            # are concurrent (no serial/wraps edges) — fixing #1186.
-            first_beats_a = {seq[0] for seq in ordered_a if seq}
-            first_beats_b = {seq[0] for seq in ordered_b if seq}
-            if first_beats_a and first_beats_b:
-                if dilemma_a < dilemma_b:
-                    # A entry beats before B entry beats (consistent with A commits first)
-                    for fa in sorted(first_beats_a):
-                        for fb in sorted(first_beats_b):
-                            _add_predecessor(fb, fa)
-                else:
-                    # B entry beats before A entry beats (consistent with B commits first)
-                    for fb in sorted(first_beats_b):
-                        for fa in sorted(first_beats_a):
-                            _add_predecessor(fa, fb)
-
-    # Order entry beats within the alphabetically first dilemma to ensure
-    # a single DAG root when that dilemma has multiple paths (#1192).
-    first_dilemma = sorted(dilemma_paths.keys())[0]
-    first_paths = dilemma_paths[first_dilemma]
-    first_entry_beats: list[str] = []
-    for p in first_paths:
-        seq = _get_path_beats_ordered(graph, p, path_beats_map)
-        if seq:
-            first_entry_beats.append(seq[0])
-    if len(first_entry_beats) > 1:
-        first_entry_beats.sort()
-        # Chain alphabetically: beat[0] is root, beat[i+1] requires beat[i]
-        for i in range(len(first_entry_beats) - 1):
-            _add_predecessor(first_entry_beats[i + 1], first_entry_beats[i])
 
     log.info(
         "interleave_cross_path_beats_complete",

--- a/src/questfoundry/graph/grow_validation.py
+++ b/src/questfoundry/graph/grow_validation.py
@@ -854,11 +854,22 @@ def _build_beat_dilemma_map(graph: Graph) -> dict[str, set[str]]:
 
 
 def check_single_root_beat(graph: Graph) -> ValidationCheck:
-    """Verify the beat DAG has exactly one root beat.
+    """Diagnostic helper: report whether the beat DAG has exactly one root beat.
 
     A root beat is a beat with no prerequisites — it does not appear as
-    ``from_id`` in any predecessor edge. The beat DAG must have exactly one
-    root for POLISH to produce a single start passage.
+    ``from_id`` in any predecessor edge.
+
+    .. note::
+       Post-#1583 (R-4a.3 / R-4a.6 in ``docs/design/procedures/grow.md``)
+       multi-root output from GROW Phase 4a is permitted by design: a
+       ``concurrent`` dilemma pair with no temporal hint contributes no
+       cross-dilemma edges, and the resulting per-dilemma chains stay
+       independent. As a result this function is **not wired into
+       ``run_grow_checks()``** and is retained as an ad-hoc / unit-test
+       diagnostic only. A ``"fail"`` result no longer indicates a pipeline
+       error — it merely reports the multi-root state. Whether downstream
+       stages (POLISH passage formation) require single-root is a separate
+       policy decision tracked in #1584.
 
     Synthetic beat roles (micro_beat, residue_beat, false_branch_beat) are
     excluded since they are created by POLISH, not GROW.
@@ -867,8 +878,9 @@ def check_single_root_beat(graph: Graph) -> ValidationCheck:
         graph: The story graph to validate.
 
     Returns:
-        A ValidationCheck with severity "pass" if exactly one root beat
-        exists, or "fail" if zero or multiple roots are found.
+        A ValidationCheck with severity ``"pass"`` if exactly one root beat
+        exists, or ``"fail"`` if zero or multiple roots are found. Under
+        R-4a.6 the latter is informational, not an invariant violation.
     """
     beat_nodes = graph.get_nodes_by_type("beat")
     if not beat_nodes:

--- a/src/questfoundry/graph/grow_validation.py
+++ b/src/questfoundry/graph/grow_validation.py
@@ -1420,8 +1420,15 @@ def run_grow_checks(graph: Graph) -> ValidationReport:
             ]
         )
 
+    # check_single_root_beat is intentionally NOT in this list. R-4a.6 of
+    # docs/design/procedures/grow.md (added with #1583) explicitly permits
+    # multi-root beat-DAG output from Phase 4a when no serial / wraps / hint
+    # relationship orders the dilemmas. Root unification — if any — is
+    # downstream. The validator is retained as a public diagnostic helper
+    # (callable ad-hoc and exercised by unit tests) but is no longer wired
+    # into ``run_grow_checks`` / ``run_all_checks``. See #1584 for the
+    # deliberate downstream-unification policy decision.
     checks: list[ValidationCheck] = [
-        check_single_root_beat(graph),
         check_single_start(graph),
         check_passage_dag_cycles(graph),
         check_spine_arc_exists(graph),

--- a/tests/unit/test_grow_algorithms.py
+++ b/tests/unit/test_grow_algorithms.py
@@ -4289,9 +4289,9 @@ def _make_three_dilemma_serial_concurrent_graph() -> Graph:
 
     Dilemmas: alpha, beta, gamma. Each has one canonical path with two
     beats (intro + commit). Relationships:
-        serial:    alpha → beta (alpha_commit ≺ beta_intro)
-        concurrent: alpha ↔ gamma (alpha_commit ≺ gamma_commit by the
-                    alphabetical heuristic)
+        serial:    alpha → beta (alpha_commit ≺ beta_intro — base DAG edge)
+        concurrent: alpha ↔ gamma (no Phase 4a edges; only temporal hints
+                    can introduce ordering between this pair, per R-4a.3)
 
     No temporal hints attached — callers add their specific hint with
     ``graph.update_node(beat_id, temporal_hint=...)`` after construction.
@@ -4405,14 +4405,16 @@ class TestInterleavecrossPathBeats:
         errors = validate_beat_dag(graph)
         assert errors == []
 
-    def test_concurrent_commit_ordering_applied(self) -> None:
-        """Concurrent ordering: commit beats from one dilemma ordered before the other."""
+    def test_concurrent_with_no_hints_creates_no_edges(self) -> None:
+        """R-4a.3: concurrent contributes zero Phase 4a edges absent temporal hints.
 
+        Concurrent has no mandatory ordering, and Phase 4a does not invent any.
+        With no temporal hints attached, interleave should leave the per-dilemma
+        chains untouched and return 0 created edges.
+        """
         graph = _make_two_dilemma_graph_with_relationship("concurrent")
         count = interleave_cross_path_beats(graph)
-
-        # Should create at least one commit ordering edge
-        assert count > 0
+        assert count == 0
 
     def test_concurrent_result_is_acyclic(self) -> None:
         """After concurrent interleaving, the beat DAG remains acyclic."""
@@ -4468,19 +4470,13 @@ class TestInterleavecrossPathBeats:
     def test_temporal_hint_after_commit_applied(self) -> None:
         """Temporal hint 'after_commit' creates edge from this beat to commit beat (#1114).
 
-        Dilemma names are chosen so that the heuristic commit-ordering goes in the
-        SAME direction as the hint, avoiding a pre-loaded cycle in the base DAG
-        (which detection would drop the hint for).
-
-        Dilemmas: a_mentor < b_artifact alphabetically.
-        Concurrent edge (a_mentor → b_artifact): A commits before B →
-          predecessor(b_commit, a_commit) = a_commit before b_commit.
-        Hint on b_intro: after_commit of a_mentor →
-          predecessor(b_intro, a_commit) = a_commit before b_intro.
-        Chain: a_commit → b_intro → b_commit.  No cycle with heuristic.
+        Concurrent contributes no Phase 4a edges (R-4a.3); the hint is the
+        sole mechanism that orders the two dilemmas.  The hint
+        ``ba_intro after_commit a_mentor`` adds ``predecessor(ba_intro,
+        am_commit)`` = am_commit ≺ ba_intro.  Combined with the within-path
+        edges, the resulting chain is am_commit ≺ ba_intro ≺ ba_commit.
         """
         graph = Graph.empty()
-        # Use alphabetically ordered names so a_mentor < b_artifact
         for _dil, dil_id in (("a_mentor", "a_mentor"), ("b_artifact", "b_artifact")):
             graph.create_node(f"dilemma::{dil_id}", {"type": "dilemma", "raw_id": dil_id})
         for dil, path_id in (("a_mentor", "am_path"), ("b_artifact", "ba_path")):
@@ -4540,7 +4536,8 @@ class TestInterleavecrossPathBeats:
         graph.add_edge("belongs_to", "beat::ba_commit", "path::ba_path")
         graph.add_edge("predecessor", "beat::ba_commit", "beat::ba_intro")
 
-        # a_mentor concurrent with b_artifact (a < b → a commits before b)
+        # a_mentor concurrent with b_artifact — concurrent adds no Phase 4a
+        # edges; the hint below is what produces the cross-dilemma ordering.
         graph.add_edge("concurrent", "dilemma::a_mentor", "dilemma::b_artifact")
 
         # ba_intro should come after a_mentor's commit beat
@@ -4590,36 +4587,38 @@ class TestInterleavecrossPathBeats:
         assert count1 > 0
         assert count2 == 0  # No new edges on second run
 
-    def test_cycle_inducing_heuristic_edge_raises(self) -> None:
-        """R-3.7 / R-4.5: heuristic interleave edge that would create a cycle
-        raises GrowContractError — silent skip (interleave_cycle_skipped) is
-        forbidden per the Silent Degradation policy.
+    def test_cycle_inducing_wraps_edge_raises(self) -> None:
+        """R-3.7 / R-4a.5: any interleave edge that would close a cycle raises
+        GrowContractError. Silent skip (interleave_cycle_skipped) is forbidden
+        per the Silent Degradation policy.
 
-        Alphabetically "dilemma::artifact_quest" < "dilemma::mentor_trust" ('a' < 'm'),
-        so dilemma_a=mentor_trust, dilemma_b=artifact_quest. The heuristic 'else' branch
-        runs: artifact_quest (B) commits before mentor_trust (A).
-        It calls _add_predecessor(mt_commit, aq_commit) = aq_commit before mt_commit in topo.
+        Concurrent no longer contributes commit-/entry-beat ordering edges
+        (R-4a.3), so the regression scenario must come from a mandatory edge.
+        A ``wraps`` relationship requires ``B's last beat ≺ A's commit beat``
+        (R-4a.2); pre-loading the graph with the opposite ordering forces the
+        wraps edge to close a cycle when interleave applies it.
 
-        We pre-add predecessor(aq_intro, mt_commit) so that mt_commit executes before
-        aq_intro in topo. Via the within-path edge aq_intro → aq_commit, the topo chain
-        becomes: mt_commit → aq_intro → aq_commit.
-        Now aq_commit IS reachable from mt_commit in the successor graph.
-        _would_create_cycle(mt_commit, aq_commit) detects the cycle — must raise,
-        not silently skip.
+        Setup with ``mentor_trust WRAPS artifact_quest``:
+          wraps emits ``predecessor(mt_commit, aq_commit)`` — mt_commit has
+          aq_commit as predecessor → aq_commit ≺ mt_commit.
+          We pre-add ``predecessor(aq_commit, mt_commit)`` (a real cross-path
+          predecessor not from interleave), so mt_commit ≺ aq_commit already
+          holds in the partial DAG. The wraps edge would close the cycle, and
+          must raise rather than soft-skip.
         """
         import pytest
 
         from questfoundry.graph.grow_validation import GrowContractError
 
-        graph = _make_two_dilemma_graph_with_relationship("concurrent")
+        graph = _make_two_dilemma_graph_with_relationship("wraps")
 
-        # Pre-add: aq_intro requires mt_commit (mt_commit before aq_intro in topo).
-        # Creates topo chain: mt_commit → aq_intro → aq_commit (via within-path edge).
-        # Heuristic tries _add_predecessor(mt_commit, aq_commit) = aq_commit before mt_commit.
-        # _would_create_cycle: BFS from mt_commit reaches aq_commit → CYCLE → raise.
-        graph.add_edge("predecessor", "beat::aq_intro", "beat::mt_commit")
+        # Pre-add a predecessor that contradicts the wraps requirement. Wraps
+        # will try predecessor(mt_commit, aq_commit) = aq_commit ≺ mt_commit.
+        # The pre-existing predecessor(aq_commit, mt_commit) gives mt_commit ≺
+        # aq_commit, so adding the wraps edge closes the cycle.
+        graph.add_edge("predecessor", "beat::aq_commit", "beat::mt_commit")
 
-        with pytest.raises(GrowContractError, match=r"R-3\.7 / R-4\.5"):
+        with pytest.raises(GrowContractError, match=r"R-3\.7 / R-4a\.5"):
             interleave_cross_path_beats(graph)
 
     def test_phase_interleave_beats_completes(self) -> None:
@@ -4758,10 +4757,6 @@ class TestInterleavecrossPathBeats:
         its own dilemma in a temporal hint would create a within-dilemma predecessor
         edge, which is illegal for intersections (conditional prerequisite invariant).
         The hint must be discarded and no intra-dilemma predecessor edge created.
-
-        Note: the entry-beat heuristic (#1186) legitimately creates a cross-dilemma
-        edge involving aq_intro (predecessor(mt_intro, aq_intro)) — that is correct
-        behaviour and is NOT what this test is guarding against.
         """
         graph = _make_two_dilemma_graph_with_relationship("concurrent")
 
@@ -4857,7 +4852,7 @@ class TestInterleavecrossPathBeats:
             },
         )
 
-        with pytest.raises(GrowContractError, match=r"R-3\.7 / R-4\.5"):
+        with pytest.raises(GrowContractError, match=r"R-3\.7 / R-4a\.5"):
             interleave_cross_path_beats(graph)
 
     def test_hint_accepted_by_detection_does_not_raise_at_apply_time(self) -> None:
@@ -4868,12 +4863,12 @@ class TestInterleavecrossPathBeats:
           - Dilemma B (beta) concurrent with Dilemma C (gamma)
           - Beat b_intro has temporal hint "before_commit" of gamma
 
-        relationship_edges order is concurrent first, then serial.  In the OLD
-        incremental approach, when the concurrent pair (beta, gamma) was processed
-        the serial-pair heuristic edges (alpha→beta) were not yet in the DAG.
-        This could produce a working DAG inconsistent with the one used by
-        detection, potentially causing a hint accepted by detection to raise a
-        RuntimeError at apply time.
+        relationship_edges order is concurrent first, then serial.  In the
+        OLD incremental approach, when the concurrent pair (beta, gamma) was
+        processed the serial-pair edges (alpha→beta) were not yet in the
+        working DAG.  This could produce a working DAG inconsistent with
+        the one used by detection, potentially causing a hint accepted by
+        detection to raise a RuntimeError at apply time.
 
         After the fix, interleave initialises its working DAG from
         _build_hint_base_dag (same as detection), so both sites agree and no
@@ -4883,7 +4878,6 @@ class TestInterleavecrossPathBeats:
 
         graph = Graph.empty()
 
-        # Three dilemmas: alpha < beta < gamma (alphabetical order)
         for dil in ("alpha", "beta", "gamma"):
             graph.create_node(f"dilemma::{dil}", {"type": "dilemma", "raw_id": dil})
 
@@ -4930,10 +4924,10 @@ class TestInterleavecrossPathBeats:
         graph.add_edge("concurrent", "dilemma::beta", "dilemma::gamma")
 
         # Temporal hint on beta_intro: should come before gamma's commit.
-        # This hint is accepted by detection (full base includes alpha→beta serial
-        # heuristic edges).  With the old incremental code the base DAG at
+        # This hint is accepted by detection (full base includes alpha→beta
+        # serial edges).  With the old incremental code the working DAG at
         # concurrent-pair processing time lacked the serial edges, potentially
-        # producing a cycle check result inconsistent with detection.
+        # producing a cycle-check result inconsistent with detection.
         graph.update_node(
             "beat::beta_intro",
             temporal_hint={
@@ -4948,27 +4942,16 @@ class TestInterleavecrossPathBeats:
         assert count > 0, "Expected at least one cross-path predecessor edge"
         assert validate_beat_dag(graph) == [], "DAG must remain acyclic after interleave"
 
-    def test_concurrent_all_dilemmas_produces_single_root_beat(self) -> None:
-        """All-concurrent dilemmas must yield a single DAG root after interleaving (#1186).
+    def test_concurrent_only_relationships_leave_dilemma_chains_independent(self) -> None:
+        """R-4a.3: concurrent-only relationships add no Phase 4a edges.
 
-        When every dilemma relationship is 'concurrent' the commit-beat heuristic
-        alone leaves entry beats (_beat_01 equivalents) as independent DAG roots —
-        one per path — causing POLISH to fail with 'Multiple start passages'.
-
-        The fix adds entry-beat ordering in the same direction as commit-beat ordering
-        so the resulting DAG has exactly one root.
-
-        Graph: two dilemmas (a_alpha, b_beta), each with one path and three beats:
-          a_alpha: a_entry → a_mid → a_commit
-          b_beta:  b_entry → b_mid → b_commit
-        Dilemmas linked by a 'concurrent' edge (a_alpha → b_beta).
-        After interleave, exactly one beat must have no predecessor edges where it
-        appears as the 'from' side (i.e. no prerequisites).
+        Each dilemma's intra-path chain is independent of the other's; the beat
+        DAG therefore has one root *per dilemma* (multi-root output is permitted
+        per R-4a.6). Root unification, when needed by a downstream stage, is
+        that stage's concern — not Phase 4a's.
         """
         graph = Graph.empty()
 
-        # Use alphabetically ordered dilemma IDs so the heuristic direction is
-        # deterministic: a_alpha < b_beta → a's commits/entries go first.
         for dil in ("a_alpha", "b_beta"):
             graph.create_node(f"dilemma::{dil}", {"type": "dilemma", "raw_id": dil})
 
@@ -4983,7 +4966,6 @@ class TestInterleavecrossPathBeats:
                 },
             )
 
-        # a_alpha beats: a_entry → a_mid → a_commit
         for raw_id, effect, path_id in (
             ("a_entry", "advances", "aa_path"),
             ("a_mid", "advances", "aa_path"),
@@ -4999,11 +4981,9 @@ class TestInterleavecrossPathBeats:
                 },
             )
             graph.add_edge("belongs_to", f"beat::{raw_id}", f"path::{path_id}")
-        # Within-path ordering (commit requires mid requires entry)
         graph.add_edge("predecessor", "beat::a_mid", "beat::a_entry")
         graph.add_edge("predecessor", "beat::a_commit", "beat::a_mid")
 
-        # b_beta beats: b_entry → b_mid → b_commit
         for raw_id, effect, path_id in (
             ("b_entry", "advances", "bb_path"),
             ("b_mid", "advances", "bb_path"),
@@ -5022,14 +5002,8 @@ class TestInterleavecrossPathBeats:
         graph.add_edge("predecessor", "beat::b_mid", "beat::b_entry")
         graph.add_edge("predecessor", "beat::b_commit", "beat::b_mid")
 
-        # Concurrent relationship: a_alpha concurrent with b_beta
         graph.add_edge("concurrent", "dilemma::a_alpha", "dilemma::b_beta")
 
-        # Pre-fix state: the intra-path predecessor edges above only chain the three
-        # beats within each dilemma.  Both a_entry and b_entry are DAG roots (they have
-        # no predecessor edges pointing at them).  The concurrent commit-beat heuristic
-        # links commit beats (a_commit ← b_commit) but leaves entry beats untouched,
-        # so without the fix len(root_beats) == 2 and this assertion would fail.
         all_beat_ids = {
             "beat::a_entry",
             "beat::a_mid",
@@ -5039,75 +5013,42 @@ class TestInterleavecrossPathBeats:
             "beat::b_commit",
         }
 
-        # Run interleave
+        # No hints, so concurrent contributes zero edges.
         count = interleave_cross_path_beats(graph)
-        assert count > 0, "Expected cross-path predecessor edges to be created"
+        assert count == 0, (
+            f"Concurrent-only with no hints must add zero edges per R-4a.3; got {count}"
+        )
 
-        # Find root beats: beats that appear as 'from' side of NO predecessor edge
-        # (i.e. they have no prerequisites themselves).
+        # The two dilemma chains remain independent: one root per dilemma.
         beats_with_prereqs: set[str] = {
             edge["from"]
             for edge in graph.get_edges(edge_type="predecessor")
             if edge["from"] in all_beat_ids
         }
         root_beats = all_beat_ids - beats_with_prereqs
-
-        assert len(root_beats) == 1, (
-            f"Expected exactly 1 root beat, got {len(root_beats)}: {sorted(root_beats)}"
+        assert root_beats == {"beat::a_entry", "beat::b_entry"}, (
+            f"Expected one root per dilemma; got {sorted(root_beats)}"
         )
 
-        # All other beats must be reachable from the single root via predecessor edges.
-        # predecessor(from, to): 'from' requires 'to' as prerequisite.
-        # To traverse forward: from root, find beats where root is their prerequisite,
-        # i.e. edges where edge["to"] == root → edge["from"] comes after root.
-        root = next(iter(root_beats))
-        reachable: set[str] = {root}
-        frontier = {root}
-        while frontier:
-            next_frontier: set[str] = set()
-            for beat in frontier:
-                # Find beats that require 'beat' (i.e. come after it in narrative)
-                for edge in graph.get_edges(edge_type="predecessor"):
-                    if (
-                        edge["to"] == beat
-                        and edge["from"] in all_beat_ids
-                        and edge["from"] not in reachable
-                    ):
-                        reachable.add(edge["from"])
-                        next_frontier.add(edge["from"])
-            frontier = next_frontier
+        # DAG remains acyclic.
+        assert validate_beat_dag(graph) == [], "Beat DAG must remain acyclic"
 
-        assert reachable == all_beat_ids, (
-            f"Not all beats reachable from root {root!r}. "
-            f"Unreachable: {sorted(all_beat_ids - reachable)}"
-        )
+    def test_concurrent_multi_path_dilemmas_leave_dilemma_chains_independent(self) -> None:
+        """R-4a.3: multi-path dilemmas under a pre-Y-shape fixture stay multi-root.
 
-        # DAG must remain acyclic
-        assert validate_beat_dag(graph) == [], "Beat DAG must remain acyclic after interleave"
-
-    def test_concurrent_multi_path_dilemmas_produces_single_root_beat(self) -> None:
-        """Multi-path dilemmas must yield a single DAG root after interleaving (#1192).
-
-        Real projects have 2 paths per dilemma (one per explored answer).
-        With 1 path per dilemma, the cross-dilemma entry-beat ordering alone
-        produces a single root. With 2 paths, the first dilemma has 2 entry
-        beats that both become roots unless intra-dilemma ordering is applied.
-
-        Graph: two dilemmas (a_alpha, b_beta), each with TWO paths and three
-        beats per path:
-          a_alpha: a1_entry → a1_mid → a1_commit  (path aa_path1)
-                   a2_entry → a2_mid → a2_commit  (path aa_path2)
-          b_beta:  b1_entry → b1_mid → b1_commit  (path bb_path1)
-                   b2_entry → b2_mid → b2_commit  (path bb_path2)
-        Dilemmas linked by a 'concurrent' edge.
-        After interleave, exactly one beat must have no predecessor edges.
+        Real projects after the Y-shape ratification (#1206) collapse a dilemma's
+        per-path entry beats into a shared pre-commit chain — a single root per
+        dilemma. This pre-Y-shape fixture (each path with its own _entry beat
+        and no shared pre-commit beats) intentionally exercises the case
+        ``#1192`` was filed for. Under R-4a.3 the fixture is now legitimately
+        multi-root: Phase 4a does not invent edges to chain entry beats, and
+        whatever single-root requirement downstream stages need is their concern.
         """
         graph = Graph.empty()
 
         for dil in ("a_alpha", "b_beta"):
             graph.create_node(f"dilemma::{dil}", {"type": "dilemma", "raw_id": dil})
 
-        # Two paths per dilemma
         for dil, paths in (
             ("a_alpha", ("aa_path1", "aa_path2")),
             ("b_beta", ("bb_path1", "bb_path2")),
@@ -5125,7 +5066,6 @@ class TestInterleavecrossPathBeats:
 
         all_beat_ids: set[str] = set()
 
-        # Create beats for each path: entry → mid → commit
         for dil, path_id, prefix in (
             ("a_alpha", "aa_path1", "a1"),
             ("a_alpha", "aa_path2", "a2"),
@@ -5149,53 +5089,32 @@ class TestInterleavecrossPathBeats:
                 graph.add_edge("belongs_to", f"beat::{raw_id}", f"path::{path_id}")
                 all_beat_ids.add(f"beat::{raw_id}")
 
-            # Intra-path predecessor chain: commit requires mid requires entry
             graph.add_edge("predecessor", f"beat::{prefix}_mid", f"beat::{prefix}_entry")
             graph.add_edge("predecessor", f"beat::{prefix}_commit", f"beat::{prefix}_mid")
 
-        # Concurrent relationship
         graph.add_edge("concurrent", "dilemma::a_alpha", "dilemma::b_beta")
 
-        # Run interleave
+        # No hints, no wraps/serial → no Phase 4a edges.
         count = interleave_cross_path_beats(graph)
-        assert count > 0, "Expected cross-path predecessor edges to be created"
+        assert count == 0, (
+            f"Concurrent-only with no hints must add zero edges per R-4a.3; got {count}"
+        )
 
-        # Find root beats: beats with no predecessor edge where they are 'from'
+        # Each path's entry beat is its own root: 4 paths → 4 roots.
         beats_with_prereqs: set[str] = {
             edge["from"]
             for edge in graph.get_edges(edge_type="predecessor")
             if edge["from"] in all_beat_ids
         }
         root_beats = all_beat_ids - beats_with_prereqs
+        assert root_beats == {
+            "beat::a1_entry",
+            "beat::a2_entry",
+            "beat::b1_entry",
+            "beat::b2_entry",
+        }, f"Expected one root per path; got {sorted(root_beats)}"
 
-        assert len(root_beats) == 1, (
-            f"Expected exactly 1 root beat, got {len(root_beats)}: {sorted(root_beats)}"
-        )
-
-        # All beats reachable from root
-        root = next(iter(root_beats))
-        reachable: set[str] = {root}
-        frontier = {root}
-        while frontier:
-            next_frontier: set[str] = set()
-            for beat in frontier:
-                for edge in graph.get_edges(edge_type="predecessor"):
-                    if (
-                        edge["to"] == beat
-                        and edge["from"] in all_beat_ids
-                        and edge["from"] not in reachable
-                    ):
-                        reachable.add(edge["from"])
-                        next_frontier.add(edge["from"])
-            frontier = next_frontier
-
-        assert reachable == all_beat_ids, (
-            f"Not all beats reachable from root {root!r}. "
-            f"Unreachable: {sorted(all_beat_ids - reachable)}"
-        )
-
-        # DAG must remain acyclic
-        assert validate_beat_dag(graph) == [], "Beat DAG must remain acyclic after interleave"
+        assert validate_beat_dag(graph) == [], "Beat DAG must remain acyclic"
 
 
 class TestDetectTemporalHintConflicts:
@@ -5245,7 +5164,7 @@ class TestDetectTemporalHintConflicts:
         # This creates: mt_commit → aq_intro (aq after mt commit)
         # Combined with: aq_commit → mt_intro (mt after aq commit)
         # and: mt_intro → mt_commit (within mt path)
-        # → cycle: aq_commit → mt_intro → mt_commit → [heuristic] ... potential cycle
+        # → cycle: aq_commit → mt_intro → mt_commit → aq_intro → aq_commit
         graph.update_node(
             "beat::aq_intro",
             temporal_hint={
@@ -5263,44 +5182,31 @@ class TestDetectTemporalHintConflicts:
         conflicts = detect_temporal_hint_conflicts(graph)
         assert len(conflicts) >= 1
 
-    def test_heuristic_edges_from_prior_pair_expose_conflict_in_later_pair(self) -> None:
-        """Heuristic commit-ordering from earlier pairs exposes a cycle in a later pair.
+    def test_serial_edges_from_prior_pair_expose_conflict_in_later_pair(self) -> None:
+        """Serial edges from earlier pairs surface a cycle in a later concurrent pair.
 
-        Regression test for the bug where detect_temporal_hint_conflicts only simulated
-        concurrent hint edges, missing heuristic commit-ordering edges added after each
-        concurrent pair. The heuristic edges accumulate across pairs and can make a
-        hint in a later pair create a cycle that the old simulation would not detect.
+        Under R-3.1 the base DAG contains only ``serial`` + ``wraps`` edges.
+        ``detect_temporal_hint_conflicts`` must simulate those edges (not just
+        the hints) so that a hint targeting a concurrent pair sees the cumulative
+        ordering from prior serial relationships.
 
-        Graph: three dilemmas alpha < beta < gamma, three concurrent pairs processed
-        in insertion order: (alpha, beta), (beta, gamma), (alpha, gamma).
+        Setup (3 dilemmas):
+          alpha SERIAL beta  → alpha_commit ≺ beta_intro
+          beta  SERIAL gamma → beta_commit  ≺ gamma_intro
+          alpha CONCURRENT gamma  (the hint pair)
 
-        Heuristic edges added by the NEW simulation (alphabetical ordering):
-            Pair 1 (alpha, beta): alpha_commit ≺ beta_commit
-            Pair 2 (beta, gamma): beta_commit ≺ gamma_commit
-
-        Chain after pairs 1 & 2: alpha_commit → beta_commit → gamma_commit.
-
-        Hint in pair 3 (alpha, gamma):
-            alpha_intro after_commit of gamma → predecessor(alpha_intro, gamma_commit)
-            i.e., gamma_commit must precede alpha_intro.
-
-        NEW code sees the cycle:
-            alpha_intro → alpha_commit → beta_commit → gamma_commit → alpha_intro
-
-        OLD code (no heuristic edges simulated) misses it:
-            BFS from alpha_intro reaches only alpha_commit (within-path),
-            then nothing — gamma_commit is unreachable, no cycle reported.
+        With no hints attached, no conflicts exist.  With a hint on
+        ``alpha_intro`` (``after_commit gamma`` → gamma_commit ≺ alpha_intro),
+        the cycle alpha_intro → alpha_commit → beta_intro → beta_commit →
+        gamma_intro → gamma_commit → alpha_intro is only visible if the
+        simulator pre-loads the serial-chain edges before testing the hint.
         """
         from questfoundry.graph.grow_algorithms import detect_temporal_hint_conflicts
 
         graph = Graph.empty()
 
-        # Three dilemmas
         for dil in ("alpha", "beta", "gamma"):
             graph.create_node(f"dilemma::{dil}", {"type": "dilemma", "raw_id": dil})
-
-        # Canonical paths and beats for each dilemma
-        for dil in ("alpha", "beta", "gamma"):
             graph.create_node(
                 f"path::{dil}_path",
                 {
@@ -5332,33 +5238,24 @@ class TestDetectTemporalHintConflicts:
             graph.add_edge("belongs_to", f"beat::{dil}_commit", f"path::{dil}_path")
             graph.add_edge("predecessor", f"beat::{dil}_commit", f"beat::{dil}_intro")
 
-        # Three concurrent pairs — insertion order determines processing order.
-        # Pairs 1 & 2 have no hints; their heuristics build the chain
-        # alpha_commit → beta_commit → gamma_commit.
-        # Pair 3 is where the hint lives.
-        graph.add_edge("concurrent", "dilemma::alpha", "dilemma::beta")
-        graph.add_edge("concurrent", "dilemma::beta", "dilemma::gamma")
+        graph.add_edge("serial", "dilemma::alpha", "dilemma::beta")
+        graph.add_edge("serial", "dilemma::beta", "dilemma::gamma")
         graph.add_edge("concurrent", "dilemma::alpha", "dilemma::gamma")
 
-        # No hints anywhere → no conflicts
+        # No hints → no conflicts
         assert detect_temporal_hint_conflicts(graph) == []
 
-        # Hint on alpha_intro: must come after gamma's commit.
-        # predecessor(alpha_intro, gamma_commit): gamma_commit ≺ alpha_intro ≺ alpha_commit.
-        # This completes the cycle via the heuristic chain:
-        #   alpha_commit → beta_commit → gamma_commit → alpha_intro → alpha_commit
         graph.update_node(
             "beat::alpha_intro",
             temporal_hint={"relative_to": "dilemma::gamma", "position": "after_commit"},
         )
 
-        # With the fix: heuristic edges from pairs 1 & 2 are simulated before pair 3,
-        # so detect_temporal_hint_conflicts catches this cycle.
         conflicts = detect_temporal_hint_conflicts(graph)
         assert len(conflicts) >= 1, (
             "Expected detect_temporal_hint_conflicts to catch the cycle "
-            "alpha_commit→beta_commit→gamma_commit→alpha_intro→alpha_commit, "
-            "which is only visible when heuristic edges from prior pairs are simulated."
+            "alpha_intro → alpha_commit → beta_intro → beta_commit → gamma_intro "
+            "→ gamma_commit → alpha_intro; only visible when serial-chain edges "
+            "from prior pairs are simulated before testing the hint."
         )
 
     def test_serial_edges_are_simulated(self) -> None:
@@ -5419,9 +5316,9 @@ class TestDetectTemporalHintConflicts:
         assert detect_temporal_hint_conflicts(graph) == []
 
         # Hint: extra_intro after_commit mentor_trust → mt_commit ≺ extra_intro.
-        # Serial already establishes mt_commit ≺ aq_intro. Concurrent heuristic
-        # (artifact_quest < extra): aq_commit ≺ extra_commit.
-        # This is consistent; no cycle expected.
+        # Serial already establishes mt_commit ≺ aq_intro.  No cross-pair
+        # cycle path exists (concurrent contributes no edges per R-4a.3); the
+        # hint is consistent with the base DAG.
         graph.update_node(
             "beat::extra_intro",
             temporal_hint={
@@ -5469,20 +5366,25 @@ class TestDetectTemporalHintConflicts:
     def test_intersection_group_skip_in_simulation(self) -> None:
         """Intersection-group guard prevents edges between co-grouped beats.
 
-        If two beats share an intersection group, _sim_add skips the edge
-        (they co-occur in a scene and have no ordering). Exercises the
-        intersection-group index building and the guard path in _is_valid_edge_candidate.
+        Beats sharing an intersection group co-occur in a single scene and
+        have no ordering between them.  ``_is_valid_edge_candidate`` rejects
+        any candidate edge between two co-grouped beats so it is never
+        simulated.  Exercises the guard against a ``wraps``-induced candidate
+        edge between the wrap-target's last beat and the wrapper's commit
+        beat — placing those two beats in the same intersection group means
+        the wraps edge gets skipped and the simulation produces no conflicts.
         """
         from questfoundry.graph.grow_algorithms import detect_temporal_hint_conflicts
 
-        graph = _make_two_dilemma_graph_with_relationship("concurrent")
-        # Put mt_commit and aq_commit in the same intersection group so the
-        # heuristic _sim_add(aq_commit, mt_commit) is skipped.
+        graph = _make_two_dilemma_graph_with_relationship("wraps")
+        # Wraps emits a candidate edge predecessor(mt_commit, aq_commit) —
+        # i.e. aq_commit ≺ mt_commit.  Putting both in one intersection group
+        # makes _is_valid_edge_candidate reject the candidate; the simulation
+        # silently moves on without raising, and produces no conflicts.
         graph.create_node("intersection_group::shared", {"type": "intersection_group"})
         graph.add_edge("intersection", "beat::mt_commit", "intersection_group::shared")
         graph.add_edge("intersection", "beat::aq_commit", "intersection_group::shared")
 
-        # No hints — no conflicts; the heuristic edge is skipped but that's fine.
         conflicts = detect_temporal_hint_conflicts(graph)
         assert conflicts == []
 
@@ -5511,11 +5413,15 @@ class TestDetectTemporalHintConflicts:
         conflicts = detect_temporal_hint_conflicts(graph)
         assert conflicts == []
 
-    def test_no_conflicts_when_dilemma_has_no_commit_beats(self) -> None:
-        """Heuristic is skipped when a dilemma has no commit-effect beats.
+    def test_wraps_skipped_when_wrap_target_has_no_commit_beats(self) -> None:
+        """Wraps simulation skips the commit-edge step when the wrapper has no
+        commit-effect beats.
 
-        Exercises the `if commits_a and commits_b` False branch in the
-        concurrent heuristic section.
+        Exercises the ``if not commits_a`` early-out in the wraps branch of
+        ``_build_hint_base_dag`` / ``detect_temporal_hint_conflicts``.  With
+        no commit beats on the wrapper dilemma, the wraps relationship still
+        emits its intro→intro edge but skips the last_b→commit_a step;
+        no conflicts arise.
         """
         from questfoundry.graph.grow_algorithms import detect_temporal_hint_conflicts
 
@@ -5543,9 +5449,9 @@ class TestDetectTemporalHintConflicts:
             )
             graph.add_edge("belongs_to", f"beat::{dil}_intro", f"path::{dil}_path")
 
-        graph.add_edge("concurrent", "dilemma::mentor_trust", "dilemma::artifact_quest")
+        graph.add_edge("wraps", "dilemma::mentor_trust", "dilemma::artifact_quest")
 
-        # Neither dilemma has commit beats → heuristic is skipped entirely.
+        # Wrapper has no commit beats → commit-edge step is skipped; no conflicts.
         conflicts = detect_temporal_hint_conflicts(graph)
         assert conflicts == []
 
@@ -5608,25 +5514,20 @@ class TestBuildHintConflictGraph:
     def test_mandatory_solo_drop_detected(self) -> None:
         """A hint that cycles alone against the base DAG is a mandatory drop.
 
-        Set up a situation where the base DAG (heuristic commit-ordering) already
-        forces aq_commit ≺ mt_intro.  Adding a hint that requires mt_intro ≺ aq_commit
-        creates a cycle against the base DAG alone.
-
-        Since artifact_quest < mentor_trust alphabetically, the heuristic adds:
-          predecessor(aq_commit, mt_commit) → mt_commit ≺ aq_commit in successors.
-
-        We manually add a predecessor edge mt_commit ≺ mt_intro (within-path style)
-        and then hint mt_intro after_commit artifact_quest → aq_commit ≺ mt_intro.
-        The base DAG already has mt_intro ≺ mt_commit ≺ aq_commit (within-path edge),
-        so adding aq_commit ≺ mt_intro closes the cycle.
+        Concurrent contributes no Phase 4a edges (R-4a.3), so the base DAG
+        ordering must come from a pre-existing predecessor edge for the
+        cycle scenario. We manually add a predecessor that puts mt_intro ≺
+        aq_commit, then attach a hint on aq_commit that wants mt_commit ≺
+        aq_commit. The within-path edge mt_intro ≺ mt_commit makes the
+        chain mt_intro ≺ mt_commit ≺ aq_commit reachable, so adding the
+        hint's edge closes the cycle.
         """
         from questfoundry.graph.grow_algorithms import build_hint_conflict_graph
 
         graph = _make_two_dilemma_graph_with_relationship("concurrent")
-        # Base DAG: aq_commit ≺ mt_intro (manually added), mt_intro ≺ mt_commit (within-path).
-        # Hint: aq_commit after_commit mentor_trust → mt_commit ≺ aq_commit.
-        # Cycle: mt_commit reachable from aq_commit via mt_intro → mt_commit,
-        # so adding mt_commit ≺ aq_commit closes the cycle → mandatory drop.
+        # Pre-existing predecessor edge stands in for any prior-pair base
+        # DAG ordering: mt_intro ≺ aq_commit. Combined with within-path
+        # mt_intro ≺ mt_commit, the hint mt_commit ≺ aq_commit closes a cycle.
         graph.add_edge("predecessor", "beat::mt_intro", "beat::aq_commit")
         graph.update_node(
             "beat::aq_commit",
@@ -5643,77 +5544,101 @@ class TestBuildHintConflictGraph:
         )
         assert any(c.mandatory for c in result.conflicts)
 
-    def test_mandatory_drop_when_both_hints_conflict(self) -> None:
-        """When one hint cycles alone against the base DAG it is a mandatory drop.
+    def test_mandatory_drop_when_one_hint_cycles_against_base_other_does_not(self) -> None:
+        """One hint cycles alone, the other does not → only the cyclic one is a mandatory drop.
 
-        With the ``_make_two_dilemma_graph_with_relationship("concurrent")`` fixture:
-        - dilemma IDs are ``artifact_quest`` and ``mentor_trust`` (``aq < mt`` alphabetically).
-        - Heuristic commit-ordering (base DAG): ``aq_commit ≺ mt_commit``.
-        - Within-path: ``mt_intro ≺ mt_commit`` and ``aq_intro ≺ aq_commit``.
+        Under R-3.1 the base DAG comes from ``serial`` + ``wraps`` edges only;
+        ``build_hint_conflict_graph`` evaluates hints between dilemmas linked
+        by ``concurrent``.  The setup therefore mixes a serial chain with a
+        concurrent pair.
 
-        Hint 1 — ``mt_intro after_commit artifact_quest``:
-          Wants ``aq_commit ≺ mt_intro``.
-          Base DAG reaches ``aq_commit`` from ``mt_intro`` via within-path
-          ``mt_intro → mt_commit`` and heuristic ``mt_commit`` … actually
-          ``aq_commit`` is the *source* of the heuristic edge ``aq_commit ≺ mt_commit``,
-          not reachable from ``mt_intro``.  So hint 1 is **consistent** alone.
+        Setup:
+          alpha SERIAL beta:  alpha_commit ≺ beta_intro ≺ beta_commit
+          beta  SERIAL gamma: beta_commit  ≺ gamma_intro ≺ gamma_commit
+          alpha CONCURRENT gamma  (hint pair)
 
-        Hint 2 — ``aq_intro after_commit mentor_trust``:
-          Wants ``mt_commit ≺ aq_intro``.
-          Base DAG: ``aq_intro ≺ aq_commit ≺ mt_commit`` (within-path + heuristic).
-          Cycle: ``mt_commit → aq_intro → aq_commit → mt_commit``.  This hint is a
-          **mandatory solo drop** against the base DAG.
+          Hint H1 on alpha_intro: after_commit gamma →
+            wants gamma_commit ≺ alpha_intro.  Combined with the serial chain
+            ``alpha_intro ≺ alpha_commit ≺ … ≺ gamma_commit``, this cycles.
+            Mandatory solo drop.
+          Hint H2 on gamma_intro: after_commit alpha →
+            wants alpha_commit ≺ gamma_intro.  The serial chain already
+            implies ``alpha_commit ≺ gamma_intro`` transitively, so the hint
+            is consistent.  NOT a mandatory drop.
 
-        Expected outcome: aq_intro is mandatory_drops; mt_intro is not.
-        The ``build_hint_conflict_graph`` algorithm is correct to report this as
-        mandatory rather than a swap pair, because the cycle exists regardless of
-        whether the other hint is present.
+        Expected: H1 (alpha_intro) is the mandatory drop; H2 (gamma_intro) is
+        not.
         """
         from questfoundry.graph.grow_algorithms import build_hint_conflict_graph
 
-        graph = _make_two_dilemma_graph_with_relationship("concurrent")
+        graph = Graph.empty()
+        for dil in ("alpha", "beta", "gamma"):
+            graph.create_node(f"dilemma::{dil}", {"type": "dilemma", "raw_id": dil})
+            graph.create_node(
+                f"path::{dil}_path",
+                {
+                    "type": "path",
+                    "raw_id": f"{dil}_path",
+                    "dilemma_id": f"dilemma::{dil}",
+                    "is_canonical": True,
+                },
+            )
+            graph.create_node(
+                f"beat::{dil}_intro",
+                {
+                    "type": "beat",
+                    "raw_id": f"{dil}_intro",
+                    "summary": f"{dil} intro.",
+                    "dilemma_impacts": [{"dilemma_id": f"dilemma::{dil}", "effect": "advances"}],
+                },
+            )
+            graph.create_node(
+                f"beat::{dil}_commit",
+                {
+                    "type": "beat",
+                    "raw_id": f"{dil}_commit",
+                    "summary": f"{dil} commit.",
+                    "dilemma_impacts": [{"dilemma_id": f"dilemma::{dil}", "effect": "commits"}],
+                },
+            )
+            graph.add_edge("belongs_to", f"beat::{dil}_intro", f"path::{dil}_path")
+            graph.add_edge("belongs_to", f"beat::{dil}_commit", f"path::{dil}_path")
+            graph.add_edge("predecessor", f"beat::{dil}_commit", f"beat::{dil}_intro")
+
+        graph.add_edge("serial", "dilemma::alpha", "dilemma::beta")
+        graph.add_edge("serial", "dilemma::beta", "dilemma::gamma")
+        graph.add_edge("concurrent", "dilemma::alpha", "dilemma::gamma")
+
         graph.update_node(
-            "beat::mt_intro",
-            temporal_hint={
-                "relative_to": "dilemma::artifact_quest",
-                "position": "after_commit",
-            },
+            "beat::alpha_intro",
+            temporal_hint={"relative_to": "dilemma::gamma", "position": "after_commit"},
         )
         graph.update_node(
-            "beat::aq_intro",
-            temporal_hint={
-                "relative_to": "dilemma::mentor_trust",
-                "position": "after_commit",
-            },
+            "beat::gamma_intro",
+            temporal_hint={"relative_to": "dilemma::alpha", "position": "after_commit"},
         )
 
         result = build_hint_conflict_graph(graph)
-        # aq_intro cycles against base DAG alone (mandatory drop)
-        assert "beat::aq_intro" in result.mandatory_drops
-        # mt_intro is consistent against base DAG — not a mandatory drop
-        assert "beat::mt_intro" not in result.mandatory_drops
-        # minimum_drop_set contains aq_intro
-        assert "beat::aq_intro" in result.minimum_drop_set
+        assert "beat::alpha_intro" in result.mandatory_drops
+        assert "beat::gamma_intro" not in result.mandatory_drops
+        assert "beat::alpha_intro" in result.minimum_drop_set
 
     def test_swap_pair_when_hints_only_conflict_together(self) -> None:
         """Two hints form a swap pair when neither cycles alone but both cycle together.
 
-        To avoid the heuristic commit-ordering creating a solo cycle, we use
-        an 'introduce' hint so the heuristic (commit-ordering) does not pre-block it.
+        Use ``introduce`` hints so neither edge alone cycles against the
+        base DAG (concurrent contributes no edges per R-4a.3).
 
-        Setup using the two-dilemma fixture (aq < mt alphabetically):
-        - Base heuristic: aq_commit ≺ mt_commit.
-        - Hint on mt_intro: ``before_introduce artifact_quest``
-          Wants ``mt_intro ≺ aq_intro`` (mt_intro before aq's first beat).
-          predecessor(aq_intro, mt_intro): mt_intro ≺ aq_intro.
-          Base DAG has no path from aq_intro back to mt_intro, so no solo cycle.
-        - Hint on aq_intro: ``before_introduce mentor_trust``
-          Wants ``aq_intro ≺ mt_intro`` (aq_intro before mt's first beat).
-          predecessor(mt_intro, aq_intro): aq_intro ≺ mt_intro.
-          Base DAG has no path from mt_intro back to aq_intro, so no solo cycle.
+        Setup using the two-dilemma fixture (concurrent):
+        - Base DAG contains only the within-path edges.
+        - Hint on mt_intro: ``before_introduce artifact_quest`` →
+          predecessor(aq_intro, mt_intro) — mt_intro ≺ aq_intro. Acyclic alone.
+        - Hint on aq_intro: ``before_introduce mentor_trust`` →
+          predecessor(mt_intro, aq_intro) — aq_intro ≺ mt_intro. Acyclic alone.
         - Together: mt_intro ≺ aq_intro AND aq_intro ≺ mt_intro → cycle.
 
-        Expected: both beats in result.swap_pairs; neither in mandatory_drops.
+        Expected: both beats appear in ``result.swap_pairs``; neither in
+        ``mandatory_drops``.
         """
         from questfoundry.graph.grow_algorithms import build_hint_conflict_graph
 
@@ -5758,16 +5683,26 @@ class TestBuildHintConflictGraph:
     def test_mandatory_solo_drop_three_dilemma_chain(self) -> None:
         """A hint that cycles alone against the base DAG is a mandatory solo drop.
 
-        This tests the mandatory-drop detection path using a three-dilemma chain,
-        which is a common setup where the heuristic commit-ordering creates a
-        transitive chain that a long-range hint will violate.
+        Under R-3.1 the base DAG contains only `serial` and `wraps` edges
+        (concurrent contributes none).  This test sets up a serial chain
+        ``alpha SERIAL beta SERIAL gamma`` to seed the base DAG, then attaches
+        a hint on a beat in the ``alpha CONCURRENT gamma`` pair (the only pair
+        whose hints `build_hint_conflict_graph` evaluates) that cycles against
+        the chain.
 
-        Construct: three dilemmas alpha < beta < gamma.
-          Base DAG heuristic: alpha_commit ≺ beta_commit ≺ gamma_commit.
-          Hint H1 on alpha_intro: after_commit gamma → gamma_commit ≺ alpha_intro.
-          This cycles with base: alpha_intro ≺ alpha_commit ≺ … ≺ gamma_commit → cycle.
+        Setup:
+          alpha SERIAL beta:  alpha_commit ≺ beta_intro
+          beta  SERIAL gamma: beta_commit  ≺ gamma_intro
+          alpha CONCURRENT gamma  (the hint pair)
 
-        H1 is a mandatory solo drop. No swap pair needed.
+          Hint H1 on alpha_intro: after_commit gamma →
+            predecessor(alpha_intro, gamma_commit) = gamma_commit ≺ alpha_intro.
+          Within-path: alpha_intro ≺ alpha_commit (so alpha_commit is in
+            successor[alpha_intro]).
+          Serial chain: alpha_commit → beta_intro → beta_commit → gamma_intro
+            → gamma_commit (each step in successor).
+          Adding gamma_commit ≺ alpha_intro closes the cycle alpha_intro →
+            … → gamma_commit → alpha_intro → mandatory solo drop.
         """
         from questfoundry.graph.grow_algorithms import build_hint_conflict_graph
 
@@ -5805,14 +5740,12 @@ class TestBuildHintConflictGraph:
             graph.add_edge("belongs_to", f"beat::{dil}_commit", f"path::{dil}_path")
             graph.add_edge("predecessor", f"beat::{dil}_commit", f"beat::{dil}_intro")
 
-        graph.add_edge("concurrent", "dilemma::alpha", "dilemma::beta")
-        graph.add_edge("concurrent", "dilemma::beta", "dilemma::gamma")
+        # Serial chain seeds the base DAG: alpha → beta → gamma.
+        graph.add_edge("serial", "dilemma::alpha", "dilemma::beta")
+        graph.add_edge("serial", "dilemma::beta", "dilemma::gamma")
+        # Concurrent pair carries the hint to be evaluated.
         graph.add_edge("concurrent", "dilemma::alpha", "dilemma::gamma")
 
-        # H1: alpha_intro after_commit gamma → gamma_commit ≺ alpha_intro.
-        # Base heuristic (alpha<beta<gamma): alpha_commit≺beta_commit≺gamma_commit.
-        # Within-path: alpha_intro ≺ alpha_commit.
-        # Cycle: alpha_intro → alpha_commit → beta_commit → gamma_commit → alpha_intro.
         graph.update_node(
             "beat::alpha_intro",
             temporal_hint={"relative_to": "dilemma::gamma", "position": "after_commit"},
@@ -5821,7 +5754,7 @@ class TestBuildHintConflictGraph:
         result = build_hint_conflict_graph(graph)
         assert "beat::alpha_intro" in result.mandatory_drops, (
             "alpha_intro must be a mandatory solo drop — its hint cycles against "
-            "the base DAG heuristic chain."
+            "the serial-chain base DAG (alpha → beta → gamma)."
         )
 
     def test_genuine_cascade_two_hints_only_conflict_together(self) -> None:
@@ -5836,8 +5769,8 @@ class TestBuildHintConflictGraph:
         The conflict-graph approach tests each hint against the *base DAG only*
         (no other hints applied), so it correctly identifies this as a swap pair.
 
-        Setup (using the two-dilemma fixture, aq < mt alphabetically):
-          Base heuristic: aq_commit ≺ mt_commit.
+        Setup (two-dilemma fixture, concurrent — base DAG contains only the
+        within-path edges since concurrent adds none per R-4a.3):
           H1 on mt_intro: before_introduce artifact_quest → mt_intro ≺ aq_intro.
             Alone: base DAG has no path aq_intro → mt_intro, so no solo cycle.
           H2 on aq_intro: before_introduce mentor_trust → aq_intro ≺ mt_intro.
@@ -6029,14 +5962,13 @@ class TestBuildHintConflictGraph:
         Setup (built by `_make_three_dilemma_serial_concurrent_graph`):
           - 3 dilemmas: alpha, beta, gamma
           - alpha → beta serial: alpha_commit ≺ beta_intro
-          - alpha ↔ gamma concurrent: alpha_commit ≺ gamma_commit
-            (heuristic; alpha < gamma alphabetically)
+          - alpha ↔ gamma concurrent: contributes no Phase 4a edges
+            (R-4a.3); only temporal hints can order this pair
 
         Hint on gamma_intro: before_commit alpha
-          → predecessor(alpha_commit, gamma_intro), i.e. gamma_intro
-          ≺ alpha_commit. The base has gamma_intro ≺ gamma_commit and
-          alpha_commit ≺ gamma_commit, but no path from alpha_commit
-          back to gamma_intro, so no cycle.
+          → predecessor(alpha_commit, gamma_intro), i.e. gamma_intro ≺
+          alpha_commit. The base DAG (within-path + serial) has no path from
+          alpha_commit back to gamma_intro, so no solo cycle.
 
         Detection should produce no conflicts; verify_hints_acyclic with
         the hint kept should report no cycles. The presence of the serial
@@ -6069,25 +6001,70 @@ class TestBuildHintConflictGraph:
         )
 
     def test_serial_plus_concurrent_mix_cyclic_hint_detected(self) -> None:
-        """Companion to the agreement test: a hint that DOES cycle in a
-        serial+concurrent mix is detected as a mandatory drop, and
-        `verify_hints_acyclic` confirms the cycle when re-applied.
+        """A hint that cycles in a serial+concurrent mix is detected as a mandatory drop.
 
-        Same setup as the agreement test (alpha → beta serial, alpha ↔
-        gamma concurrent). Hint on alpha_intro: after_commit gamma
-          → predecessor(alpha_intro, gamma_commit), i.e. gamma_commit
-          ≺ alpha_intro.
-          Cycle: alpha_intro ≺ alpha_commit (within-path) ≺ gamma_commit
-          (concurrent heuristic) ≺ alpha_intro (the new hint edge).
-          `_would_create_cycle` catches this because gamma_commit is
-          reachable from alpha_intro in the base successors.
+        Under R-3.1 the base DAG comes from ``serial`` + ``wraps`` only —
+        concurrent contributes nothing.  To produce a hint that cycles
+        against the base DAG, the serial chain must reach from the hint's
+        ``from_beat`` to its ``to_beat``.
+
+        Setup:
+          alpha SERIAL beta  (alpha_commit ≺ beta_intro ≺ beta_commit)
+          beta  SERIAL gamma (beta_commit  ≺ gamma_intro ≺ gamma_commit)
+          alpha CONCURRENT gamma  (the pair `build_hint_conflict_graph`
+            evaluates hints across)
+
+          Hint on alpha_intro: ``after_commit gamma`` wants
+          ``gamma_commit ≺ alpha_intro``.  Cycle: ``alpha_intro ≺
+          alpha_commit ≺ beta_intro ≺ beta_commit ≺ gamma_intro ≺
+          gamma_commit ≺ alpha_intro``.  Mandatory solo drop.
+
+          ``verify_hints_acyclic`` must agree: with the hint dropped, no
+          cycle remains; with the hint surviving, the same cycle reappears.
         """
         from questfoundry.graph.grow_algorithms import (
             build_hint_conflict_graph,
             verify_hints_acyclic,
         )
 
-        graph = _make_three_dilemma_serial_concurrent_graph()
+        graph = Graph.empty()
+        for dil in ("alpha", "beta", "gamma"):
+            graph.create_node(f"dilemma::{dil}", {"type": "dilemma", "raw_id": dil})
+            graph.create_node(
+                f"path::{dil}_path",
+                {
+                    "type": "path",
+                    "raw_id": f"{dil}_path",
+                    "dilemma_id": f"dilemma::{dil}",
+                    "is_canonical": True,
+                },
+            )
+            graph.create_node(
+                f"beat::{dil}_intro",
+                {
+                    "type": "beat",
+                    "raw_id": f"{dil}_intro",
+                    "summary": f"{dil} intro.",
+                    "dilemma_impacts": [{"dilemma_id": f"dilemma::{dil}", "effect": "advances"}],
+                },
+            )
+            graph.create_node(
+                f"beat::{dil}_commit",
+                {
+                    "type": "beat",
+                    "raw_id": f"{dil}_commit",
+                    "summary": f"{dil} commit.",
+                    "dilemma_impacts": [{"dilemma_id": f"dilemma::{dil}", "effect": "commits"}],
+                },
+            )
+            graph.add_edge("belongs_to", f"beat::{dil}_intro", f"path::{dil}_path")
+            graph.add_edge("belongs_to", f"beat::{dil}_commit", f"path::{dil}_path")
+            graph.add_edge("predecessor", f"beat::{dil}_commit", f"beat::{dil}_intro")
+
+        graph.add_edge("serial", "dilemma::alpha", "dilemma::beta")
+        graph.add_edge("serial", "dilemma::beta", "dilemma::gamma")
+        graph.add_edge("concurrent", "dilemma::alpha", "dilemma::gamma")
+
         graph.update_node(
             "beat::alpha_intro",
             temporal_hint={"relative_to": "dilemma::gamma", "position": "after_commit"},
@@ -6095,12 +6072,10 @@ class TestBuildHintConflictGraph:
 
         result = build_hint_conflict_graph(graph)
         assert "beat::alpha_intro" in result.mandatory_drops, (
-            f"alpha_intro's hint must be a mandatory solo drop "
-            f"(cycles against concurrent heuristic in serial+concurrent mix); "
-            f"got mandatory_drops={result.mandatory_drops}"
+            f"alpha_intro's hint must be a mandatory solo drop (cycles against "
+            f"the alpha → beta → gamma serial chain); got "
+            f"mandatory_drops={result.mandatory_drops}"
         )
-        # Mirror the assertion shape used by other mandatory-drop tests in
-        # this class for completeness (see test_mandatory_solo_drop_detected).
         assert result.swap_pairs == [], f"Expected no swap pairs; got {result.swap_pairs}"
         assert result.minimum_drop_set == {"beat::alpha_intro"}, (
             f"Expected minimum_drop_set == {{'beat::alpha_intro'}}; got {result.minimum_drop_set}"
@@ -6108,16 +6083,13 @@ class TestBuildHintConflictGraph:
 
         cyclic_beats = verify_hints_acyclic(graph, surviving_beat_ids=set())
         assert cyclic_beats == [], (
-            f"Detection identified alpha_intro as the drop. "
-            f"verify_hints_acyclic with no surviving hints must report no "
-            f"cycles; got {cyclic_beats}"
+            f"With the hint dropped, verify_hints_acyclic must report no cycles; got {cyclic_beats}"
         )
 
         cyclic_with_hint = verify_hints_acyclic(graph, surviving_beat_ids={"beat::alpha_intro"})
         assert cyclic_with_hint, (
-            "Re-applying the dropped hint must produce a cycle "
-            "verify_hints_acyclic detects — otherwise detection found a "
-            "false-positive mandatory drop."
+            "Re-applying the dropped hint must reproduce the cycle; otherwise "
+            "detection produced a false-positive mandatory drop."
         )
 
     def test_cycles_alone_with_self_loop_beat(self) -> None:
@@ -6162,32 +6134,87 @@ class TestBuildHintConflictGraph:
         assert result.conflicts == []
 
     def test_cycles_with_hints_applied_skip_hint_self_loop(self) -> None:
-        """Test _cycles_with_hints_applied: applied hint with from_beat == to_beat is skipped."""
+        """One hint cycles alone, another is safe — only the cyclic one is mandatory.
+
+        Under R-3.1 the base DAG comes from ``serial`` + ``wraps`` edges only.
+        The cycle must come from a serial chain (since concurrent adds nothing),
+        and ``build_hint_conflict_graph`` only evaluates hints between dilemmas
+        linked by ``concurrent``.
+
+        Setup:
+          alpha SERIAL beta:  alpha_commit ≺ beta_intro ≺ beta_commit
+          beta  SERIAL gamma: beta_commit  ≺ gamma_intro ≺ gamma_commit
+          alpha CONCURRENT gamma  (the hint pair)
+
+          Hint H1 on alpha_intro: after_commit gamma →
+            wants gamma_commit ≺ alpha_intro.  Cycles via the serial chain.
+            Mandatory solo drop.
+          Hint H2 on gamma_intro: before_commit alpha →
+            wants gamma_intro ≺ alpha_commit.  This contradicts the serial
+            chain (alpha_commit ≺ … ≺ gamma_intro), but evaluating it alone
+            against the base DAG also cycles.  Mandatory solo drop too.
+
+        Use a different second hint that is safe on its own:
+          Hint H2 on gamma_commit: after_introduce alpha →
+            wants alpha_intro ≺ gamma_commit.  The serial chain already
+            implies alpha_commit ≺ gamma_commit transitively, but
+            ``alpha_intro ≺ gamma_commit`` is a strictly weaker statement
+            still consistent with the chain.  Safe — not a mandatory drop.
+        """
         from questfoundry.graph.grow_algorithms import build_hint_conflict_graph
 
-        graph = _make_two_dilemma_graph_with_relationship("concurrent")
-        # Add two hints
+        graph = Graph.empty()
+        for dil in ("alpha", "beta", "gamma"):
+            graph.create_node(f"dilemma::{dil}", {"type": "dilemma", "raw_id": dil})
+            graph.create_node(
+                f"path::{dil}_path",
+                {
+                    "type": "path",
+                    "raw_id": f"{dil}_path",
+                    "dilemma_id": f"dilemma::{dil}",
+                    "is_canonical": True,
+                },
+            )
+            graph.create_node(
+                f"beat::{dil}_intro",
+                {
+                    "type": "beat",
+                    "raw_id": f"{dil}_intro",
+                    "summary": f"{dil} intro.",
+                    "dilemma_impacts": [{"dilemma_id": f"dilemma::{dil}", "effect": "advances"}],
+                },
+            )
+            graph.create_node(
+                f"beat::{dil}_commit",
+                {
+                    "type": "beat",
+                    "raw_id": f"{dil}_commit",
+                    "summary": f"{dil} commit.",
+                    "dilemma_impacts": [{"dilemma_id": f"dilemma::{dil}", "effect": "commits"}],
+                },
+            )
+            graph.add_edge("belongs_to", f"beat::{dil}_intro", f"path::{dil}_path")
+            graph.add_edge("belongs_to", f"beat::{dil}_commit", f"path::{dil}_path")
+            graph.add_edge("predecessor", f"beat::{dil}_commit", f"beat::{dil}_intro")
+
+        graph.add_edge("serial", "dilemma::alpha", "dilemma::beta")
+        graph.add_edge("serial", "dilemma::beta", "dilemma::gamma")
+        graph.add_edge("concurrent", "dilemma::alpha", "dilemma::gamma")
+
+        # Cycle-causing hint
         graph.update_node(
-            "beat::mt_intro",
-            temporal_hint={
-                "relative_to": "dilemma::artifact_quest",
-                "position": "before_introduce",
-            },
+            "beat::alpha_intro",
+            temporal_hint={"relative_to": "dilemma::gamma", "position": "after_commit"},
         )
+        # Safe hint
         graph.update_node(
-            "beat::aq_intro",
-            temporal_hint={
-                "relative_to": "dilemma::mentor_trust",
-                "position": "after_commit",
-            },
+            "beat::gamma_commit",
+            temporal_hint={"relative_to": "dilemma::alpha", "position": "after_introduce"},
         )
+
         result = build_hint_conflict_graph(graph)
-        # aq_intro hint (after_commit mentor_trust → mt_commit ≺ aq_intro) cycles alone
-        # because the base DAG already has aq_intro ≺ mt_commit via within-path ordering.
-        # mt_intro hint (before_introduce artifact_quest → mt_intro ≺ aq_intro) is safe alone.
-        # The conflict result must be valid; aq_intro is a mandatory solo drop.
-        assert "beat::aq_intro" in result.mandatory_drops
-        assert "beat::mt_intro" not in result.mandatory_drops
+        assert "beat::alpha_intro" in result.mandatory_drops
+        assert "beat::gamma_commit" not in result.mandatory_drops
 
     def test_cycles_with_hints_applied_duplicate_edge(self) -> None:
         """Test _cycles_with_hints_applied: applied hint already in ext_existing is skipped."""
@@ -6378,19 +6405,18 @@ class TestBuildHintConflictGraph:
             "Expected branch beat to be preferred drop over canonical beat"
         )
 
-    def test_build_base_dag_with_heuristic_commit_ordering(self) -> None:
-        """Test _build_base_dag applies heuristic commit-ordering for concurrent dilemmas.
+    def test_build_base_dag_with_concurrent_only_relationship(self) -> None:
+        """R-3.1: concurrent contributes no edges to the base DAG.
 
-        For concurrent dilemmas, the base DAG should add prerequisite edges
-        between commit beats using alphabetical ordering heuristic.
+        With only a concurrent relationship and no temporal hints, the
+        base DAG built by ``_build_hint_base_dag`` should contain no
+        cross-dilemma edges, and ``build_hint_conflict_graph`` therefore
+        reports no conflicts and no mandatory drops.
         """
         from questfoundry.graph.grow_algorithms import build_hint_conflict_graph
 
         graph = _make_two_dilemma_graph_with_relationship("concurrent")
-        # artifact_quest < mentor_trust alphabetically
-        # So heuristic should add: aq_commit ≺ mt_commit (mt_commit ← aq_commit)
         result = build_hint_conflict_graph(graph)
-        # No hints, so no conflicts expected
         assert result.conflicts == []
         assert result.mandatory_drops == set()
 
@@ -6456,10 +6482,10 @@ class TestBuildHintConflictGraph:
         Beat structure per dilemma (D):
             D_intro → D_commit  (within-path predecessor edge)
 
-        Heuristic commit-ordering in base DAG (alpha < beta < gamma):
-            alpha_commit ≺ beta_commit  (from alpha-beta concurrent pair)
-            alpha_commit ≺ gamma_commit (from alpha-gamma concurrent pair)
-            beta_commit ≺ gamma_commit  (from beta-gamma concurrent pair)
+        Base DAG: only the within-path predecessor edges (concurrent
+        contributes no edges per R-4a.3, so there are no cross-dilemma
+        ordering edges in the base graph).  Cycles in tests using this
+        fixture are driven by temporal hints, not by the fixture itself.
         """
         graph = Graph.empty()
         for dil in ("alpha", "beta", "gamma"):
@@ -6724,8 +6750,8 @@ class TestBuildHintConflictGraph:
           H_am: beta_intro before_introduce alpha
                 → beta_intro ≺ alpha_intro (opposing direction → mutual conflict pair 1)
           H_bc: gamma_intro before_introduce beta
-                → gamma_intro ≺ beta_intro (with existing beta>gamma heuristic order,
-                  creates a back-edge that conflicts)
+                → gamma_intro ≺ beta_intro (creates a third independent
+                  conflict via base-DAG ordering)
 
         Rather than reasoning about exact edge algebra, use the two-dilemma graph
         directly to create TWO independent mutual conflicts that share no hints:
@@ -6928,152 +6954,17 @@ class TestBuildHintConflictGraph:
     # ------------------------------------------------------------------ #
 
     def test_greedy_mandatory_drop_no_swap_partner(self) -> None:
-        """Dropping the candidate resolves the conflict but no accepted hint is
-        an alternative resolution → candidate is a true mandatory drop (not swap).
+        """Drop set survives MDS resolution when no accepted hint is a swap partner.
 
-        Covers lines 3116-3133: the ``if not new_conflict_set`` branch where the
-        loop over ``accepted_ids`` finds no alternative drop → ``else`` mandatory.
-
-        Setup: three dilemmas (alpha, beta, gamma). Two hints form a transitive
-        cycle together with the heuristic DAG so that only the specific candidate
-        is causally responsible, while accepted hints all still conflict when
-        individually dropped (i.e., removing them does NOT clear conflicts).
-
-        Concrete arrangement using three-dilemma graph:
-          H_ab: alpha_intro before_introduce beta → alpha_intro ≺ beta_intro
-          H_ba: beta_intro  before_introduce alpha → beta_intro ≺ alpha_intro
-
-        Together these two form a direct mutual conflict (each causes the other to
-        cycle). But we only assign a hint to ONE of the two beats, and construct
-        the scenario so that the sequential simulation rejects only beta_intro's
-        hint, and dropping it resolves all conflicts. Then we verify that alpha_intro
-        is NOT in accepted_ids (it has no hint), so the ``for acc_id`` loop is empty
-        → swap_partner = None → mandatory drop path executes.
-
-        Actually the most direct path: use only ONE hint that cycles solo (mandatory
-        drop from Phase 1). Phase 2 starts with no survivors → conflict_set is empty
-        → the while loop never runs. That doesn't hit the target branch.
-
-        Instead, use the three-hint transitive cycle but where the sequential
-        simulation rejects exactly ONE hint (the lexicographically last one), and
-        dropping that one hint resolves the conflict. At that point accepted_ids
-        contains only hints that, when individually dropped, do NOT resolve the
-        remaining conflict (because the transitive chain still cycles without them).
-
-        The simplest scenario that hits the "no swap partner" path is:
-          3-hint cycle: H_ab (alpha_intro ≺ beta_intro), H_bg (beta_intro ≺
-          gamma_intro), H_ga (gamma_intro ≺ alpha_intro). Sequential simulation
-          rejects the last-processed conflicting hint. Dropping it resolves the
-          set. We check if any accepted hint also resolves the set — in a simple
-          3-cycle removing any single edge breaks the cycle, so each accepted hint
-          WOULD resolve it. This means we'd get a swap pair, not a mandatory drop.
-
-        To get "no swap partner", we need a scenario where the candidate is the
-        ONLY hint that, when dropped, resolves the conflict. This happens when the
-        conflict is one-sided:
-          H1: alpha_commit before_introduce beta → creates alpha_commit ≺ beta_intro
-              (with base DAG: beta_intro ≺ beta_commit ≺ gamma_commit ≺ alpha_commit
-               via heuristic, and alpha_intro ≺ alpha_commit via predecessor)
-
-        The base DAG heuristic (alpha < beta < gamma) in the three-dilemma graph
-        establishes: alpha_commit ≺ beta_commit ≺ gamma_commit.
-
-        If we add H_ga: gamma_commit before_introduce alpha →
-            gamma_commit ≺ alpha_intro (edge: alpha_intro must follow gamma_commit)
-            But alpha_intro ≺ alpha_commit already exists, so:
-            gamma_commit ≺ alpha_intro ≺ alpha_commit ≺ beta_commit ≺ gamma_commit
-            → cycle! H_ga cycles solo → Phase 1 mandatory drop. Not useful.
-
-        Simplest working approach: construct a scenario with exactly one conflicting
-        hint in conflict_set where accepted_ids is empty (no accepted hints exist
-        after Phase 1 removes all others). This is guaranteed to hit the
-        ``else`` (swap_partner is None) path because the loop over accepted_ids
-        is empty.
-
-        Use a graph with hints such that Phase 1 ejects all but one hint (leaving
-        a single survivor), and that single survivor still conflicts sequentially
-        against the base DAG alone — which means it would have been caught in
-        Phase 1. So that can't work either.
-
-        The reliable approach: use a three-dilemma graph with two independent
-        mutual-conflict pairs where the initial conflict_set has ≥2 elements.
-        In the first iteration the greedy picks the weakest; dropping it resolves
-        the conflict; accepted_ids has the other members of the conflict_set but
-        when we test them individually, dropping them alone does NOT resolve the
-        full conflict (because their counterpart is still present). This gives
-        swap_partner = None → mandatory drop.
-
-        Concrete: two independent mutual-conflict pairs sharing NO beats:
-          Pair 1 (two-dilemma subgraph): mt_intro ↔ aq_intro mutual conflict.
-          Pair 2 (alpha-beta): alpha_intro ↔ beta_intro mutual conflict.
-
-        BUT the two-dilemma and three-dilemma graphs are separate fixtures. Build
-        a four-dilemma graph inline.
-
-        Simpler: use the three-dilemma graph. Create three hints:
-          H1: alpha_commit (before_introduce beta) → weak [strength=1]
-          H2: beta_intro   (before_introduce alpha) → creates cycle with H1
-          H3: alpha_commit cycles with H2 once H1 is applied (H3 is a second cycle).
-
-        This is getting complex. Let's use a simpler and more direct test: call
-        build_hint_conflict_graph with a scenario where conflict_set resolves to
-        empty after dropping the candidate, but accepted_ids is EMPTY (because
-        there are no other survivors). This happens when there is exactly ONE
-        survivor that conflicts (cycle_set = [that_survivor]). Dropping it gives
-        new_conflict_set = []. accepted_ids = {} (empty, since it was the only
-        survivor). Loop finds no swap partner → mandatory drop.
-
-        To get exactly one survivor that conflicts sequentially: needs a survivor
-        whose hint edge conflicts with the BASE DAG alone (not with other hints).
-        But such a hint would be caught in Phase 1 (cycles alone → mandatory drop
-        from Phase 1), so it never reaches Phase 2.
-
-        CONCLUSION: the "no swap partner" else-branch is only reachable when
-        conflict_set has one element, accepted_ids is non-empty, BUT none of the
-        accepted hints individually resolve the conflict. This requires multiple
-        survivors where some are accepted and the conflicting one depends on them.
-
-        Use an asymmetric transitive chain:
-          H_ab: alpha_intro ≺ beta_intro  (alpha_intro before_introduce beta)
-          H_bc: beta_intro  ≺ gamma_intro (beta_intro  before_introduce gamma)
-
-        No cycle yet. Now add:
-          H_ga: gamma_intro ≺ alpha_intro (gamma_intro before_introduce alpha)
-
-        Together: alpha_intro ≺ beta_intro ≺ gamma_intro ≺ alpha_intro → 3-cycle.
-        Sequential sim (alphabetical order: alpha_intro, beta_intro, gamma_intro):
-          - alpha_intro: adds alpha_intro ≺ beta_intro (no cycle). Accepted.
-          - beta_intro:  adds beta_intro ≺ gamma_intro (no cycle). Accepted.
-          - gamma_intro: would add gamma_intro ≺ alpha_intro. Cycle! Rejected.
-
-        conflict_set = [H_ga] (only gamma_intro).
-        accepted_ids = {alpha_intro, beta_intro} (both were accepted).
-
-        Greedy picks H_ga (only one in conflict_set). Drops it: new_conflict_set=[].
-        Now checks accepted_ids: {alpha_intro, beta_intro}.
-          - Try dropping alpha_intro: simulate [H_bc, H_ga]. H_bc: beta ≺ gamma
-            (ok). H_ga: gamma ≺ alpha (no cycle without alpha ≺ beta). Accepted.
-            new_conflict = []. → swap_partner = alpha_intro. SWAP PAIR found!
-
-        That hits the swap pair path, not the mandatory drop path.
-
-        Let me try making H_ga depend on a unique edge not shared:
-          H_ga only cycles because of the chain alpha_intro ≺ beta_intro ≺ gamma_intro.
-          Without H_ab, beta_intro ≺ gamma_intro alone → dropping alpha_intro
-          leaves [H_bc, H_ga] which still cycles (beta ≺ gamma ≺ alpha ≺ beta... wait,
-          alpha is not in the remaining set. H_ga: gamma_intro ≺ alpha_intro. Without
-          H_ab, there's no path from alpha_intro back to gamma_intro. So no cycle!
-          dropping alpha_intro resolves → swap pair.
-
-        The "no swap partner" path requires that dropping NONE of the accepted hints
-        individually resolves the conflict. This can only happen with entangled cycles
-        where multiple accepted hints together create the conflict.
-
-        Given the complexity of constructing this artificially via the public API,
-        use ``build_hint_conflict_graph`` with the four-hint four-dilemma scenario
-        from ``test_multipass_greedy_residual_two_element_conflict`` which exercises
-        multiple iterations and may hit the mandatory-drop else path in iteration 2+.
-        We verify the else path is covered transitively by the multi-pair test.
+        Three hints on the three-dilemma concurrent fixture. H1 and H2 form a
+        direct mutual conflict between alpha_intro and beta_intro
+        (each `before_introduce` the other's dilemma); H3 is an additional
+        `before_introduce` from gamma_intro. After MDS resolution, at least
+        one of alpha_intro / beta_intro must end up in ``minimum_drop_set``,
+        and ``verify_hints_acyclic`` over the survivors must report no
+        cycles. The test does not assert which specific code path inside
+        ``build_hint_conflict_graph`` was taken — only that the public
+        contract holds.
         """
         # This test documents that the no-swap-partner mandatory-drop path is
         # exercised via test_multipass_greedy_residual_two_element_conflict
@@ -7096,17 +6987,9 @@ class TestBuildHintConflictGraph:
             "beat::beta_intro",
             temporal_hint={"relative_to": "dilemma::alpha", "position": "before_introduce"},
         )
-        # H3: gamma_commit ≺ alpha_commit — using after_commit on gamma, pointing at alpha.
-        # gamma_commit (before_introduce alpha) → target = alpha_intro
-        # edge: predecessor(alpha_intro, gamma_commit) → gamma_commit ≺ alpha_intro
-        # With base DAG: alpha_commit ≺ beta_commit ≺ gamma_commit →
-        # gamma_commit ≺ alpha_intro ≺ alpha_commit ≺ … ≺ gamma_commit → cycle!
-        # This would be caught in Phase 1 (cycles solo). Use a weaker hint.
-        # H3: gamma_intro before_introduce alpha → gamma_intro ≺ alpha_intro
-        # No solo cycle (gamma_intro is not reachable from alpha_intro in base DAG).
-        # Together with H1: alpha_intro ≺ beta_intro and base heuristic
-        # (alpha_commit ≺ beta_commit ≺ gamma_commit), no additional cycle.
-        # H3 is an independent non-conflicting hint, so it ends up in accepted_ids.
+        # H3: gamma_intro before_introduce alpha → gamma_intro ≺ alpha_intro.
+        # Acyclic alone against the base DAG (concurrent contributes no edges
+        # per R-4a.3, so gamma_intro is not reachable from alpha_intro).
         graph.update_node(
             "beat::gamma_intro",
             temporal_hint={"relative_to": "dilemma::alpha", "position": "before_introduce"},
@@ -7330,10 +7213,12 @@ class TestBuildHintConflictGraph:
         To get initial conflict_set of size 3, add a third independent pair:
           Pair 3: alpha_commit ↔ gamma_commit (mutual conflict, higher strength=2)
 
-        But alpha_commit and gamma_commit have commit-effect, and the base DAG
-        heuristic already orders them (alpha_commit ≺ beta_commit ≺ gamma_commit
-        ≺ delta_commit). So alpha_commit ≺ gamma_commit is already in the base DAG,
-        and adding gamma_commit ≺ alpha_commit cycles SOLO → Phase 1 mandatory drop.
+        (Historical note: an older implementation of this PR drove this
+        construction via an alphabetical commit-ordering heuristic in the
+        base DAG, which was removed in #1583. The construction below uses
+        independent pairs of intro hints instead, which works under R-4a.3
+        without depending on any base-DAG ordering between concurrent
+        dilemmas.)
 
         Alternative: use six dilemmas, three independent pairs. Too complex.
 
@@ -7663,10 +7548,11 @@ class TestBuildHintConflictGraph:
         # Relationship: alpha concurrent with beta
         graph.add_edge("concurrent", "dilemma::alpha", "dilemma::beta")
 
-        # The crucial setup edge: a_commit requires b2_commit (b2_commit ≺ a_commit).
-        # This makes b2_commit → a_commit in the base succ graph.
-        # The heuristic alpha_commit ≺ b2_commit would cycle against this and is
-        # therefore skipped by _build_hint_base_dag, leaving succ[b2_commit]={a_commit}.
+        # The crucial setup edge: a_commit requires b2_commit (b2_commit ≺
+        # a_commit).  This pre-existing predecessor edge stands in for any
+        # ordering between a_commit and b2_commit and populates
+        # succ[b2_commit] = {a_commit} in the base DAG; concurrent itself
+        # contributes no edges per R-4a.3.
         graph.add_edge("predecessor", "beat::a_commit", "beat::b2_commit")
 
         # Add the temporal hint on a_commit: "before_commit dilemma::beta"
@@ -7807,8 +7693,8 @@ class TestBuildHintConflictGraph:
             graph.add_edge("belongs_to", beat_id, "path::single_q1")
         graph.add_edge("predecessor", "beat::single_commit", "beat::single_intro")
 
-        # Dilemma relationship: multipath ↔ single concurrent
-        # Alphabetical: multipath < single → multipath commits ≺ single commits.
+        # Dilemma relationship: multipath ↔ single concurrent (no Phase 4a
+        # edges per R-4a.3 — the cycle below is driven entirely by the hints).
         graph.add_edge("concurrent", "dilemma::multipath", "dilemma::single")
 
         # Hint A: single_intro before_introduce multipath


### PR DESCRIPTION
## Summary

Closes #1583. Related: #1584 (deferred POLISH single-start-passage policy follow-up).

GROW Phase 4a's alphabetical commit-ordering and entry-beat heuristics were implementation gap-fillers, not spec requirements. The spec (`docs/design/procedures/grow.md` R-4a.3) says `concurrent` has "no mandatory ordering from the relationship itself" — but the implementation volunteered transitive constraints that occasionally collided with explicit `wraps` / `serial` edges from SEED, halting GROW on cycles even when a satisfying schedule existed (`projects/murder-haiku2`, 2026-04-29).

This PR removes the heuristic in three places (`interleave_cross_path_beats`, `_build_hint_base_dag`, `detect_temporal_hint_conflicts`), aligns the spec to make the multi-root output explicit (R-4a.6), and unwires `check_single_root_beat` (which guarded the now-vestigial single-root invariant from #1193) from GROW Phase 10 with a tracker reference to #1584 for the deliberate downstream policy.

## Highlights

- **`interleave_cross_path_beats` concurrent branch:** only temporal hints (R-4a.4) emit edges. The alphabetical commit-ordering, cross-dilemma entry-beat ordering (#1186 vestige), and within-first-dilemma chain (#1192 vestige) are gone. Concurrent contributes zero Phase 4a edges.
- **`_build_hint_base_dag` and `detect_temporal_hint_conflicts`:** mirror the same contract. `detect_temporal_hint_conflicts` is restructured into a two-pass simulator (serial+wraps mandatory edges first; then concurrent-pair hint cycle tests against the fully-built base). Iteration order is no longer load-bearing.
- **`check_single_root_beat` unwired from `run_grow_checks()`:** the validator was added in #1193 specifically as a hard guard for the heuristic-derived single-root invariant. Under R-4a.6 multi-root output is permitted; the guard contradicts the new spec. The function is retained as a public diagnostic helper (still unit-tested). #1584 tracks the POLISH-side policy decision.
- **Spec updates:** R-3.1, R-4a.3, R-7.1, R-7.5 rewritten; R-4a.6 added; Stage Output Contract items 1 & 14 + Phase 7 What + Worked Example aligned to Cartesian-product topo-sort semantics; `story-graph-ontology.md` "structural heuristics" claim removed.
- **`interleave_cycle_skipped` log/error label:** distinguishes `"temporal hint"` (Phase 3 acyclicity guarantee violated) from `"wraps/serial"` (contradictory SEED relationship graph) — the deleted heuristic source is gone.
- **Tests:** scenarios pinned to the alphabetical heuristic are rewritten to drive cycles via `serial` chains or pre-existing predecessor edges. Single-root assertions in tests for #1186 / #1192 are converted to multi-root assertions matching R-4a.6. Vacuous tests targeting the deleted code branches are repurposed against the surviving `wraps` paths. ~180-line accumulated docstring on `test_greedy_mandatory_drop_no_swap_partner` collapsed to a focused contract description.

## Verification (matches the issue's verification block)

```bash
# 1. Alphabetical heuristic gone from interleave
! rg -n "Alphabetically earlier dilemma's commits go first" src/questfoundry/graph/grow_algorithms.py
! rg -n "single DAG root when that dilemma has multiple paths" src/questfoundry/graph/grow_algorithms.py
! rg -n "Entry beats follow the same relative ordering as commit beats" src/questfoundry/graph/grow_algorithms.py

# 2. Heuristic gone from base-DAG construction
! rg -n "Heuristic commit-ordering only" src/questfoundry/graph/grow_algorithms.py

# 3. Spec / ontology no longer mention heuristic commit-ordering or "structural heuristics"
! rg -n "heuristic commit-ordering|structural heuristics" docs/design/procedures/grow.md docs/design/story-graph-ontology.md

# 4. check_single_root_beat unwired from run_grow_checks
! rg -n "check_single_root_beat\(graph\)" src/questfoundry/graph/grow_validation.py

# 5. Targeted unit tests pass
uv run pytest tests/unit/test_grow_algorithms.py tests/unit/test_grow_validation.py -q
```

All five verifications pass locally; 574 cross-stage tests pass (grow + polish unit suites).

## Test plan

- [x] Targeted unit tests: `uv run pytest tests/unit/test_grow_algorithms.py tests/unit/test_grow_validation.py -q` — 334 passed
- [x] Cross-stage regression: `uv run pytest tests/unit/test_grow_*.py tests/unit/test_polish_*.py -q` — 574 passed
- [x] Lint clean: `uv run ruff check`, `uv run ruff format --check`
- [x] Type clean: `uv run mypy src/questfoundry/graph/grow_algorithms.py src/questfoundry/graph/grow_validation.py`
- [ ] CI (claude-review + workflows) on this draft push
- [ ] Empirical: rerun GROW from `projects/murder-haiku2/snapshots/pre-grow.db` once #1584 lands the POLISH-side decision (cycle no longer triggers in Phase 4a; multi-root output is now expected)

## Out of scope (separate trackers)

- POLISH `_check_start_passage` (R-7.2) policy under multi-root beat DAGs — deliberate design decision, tracked in #1584. This PR makes the question visible by halting Phase 4a's invented constraints; it doesn't pre-decide the answer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)